### PR TITLE
fix(renderer): preserve capture timing while settling

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -722,28 +722,35 @@ class RenderEngine(
               "compose-ai-daemon: [render] phase=captureRoboImage.start outputBaseName=${spec.outputBaseName}"
             )
             trace.section("render:captureRoboImage") {
-              val visuallySettled =
-                ee.schimke.composeai.renderer.captureVisuallySettledFrame(
-                  file = outputFile,
-                  role = "daemon preview still",
-                  advanceFrame = {
-                    rule.mainClock.advanceTimeByFrame()
-                    rule.waitForIdle()
-                  },
-                ) { candidate ->
-                  resolveRenderedCaptureRoot(rule)
-                    .interaction
-                    .captureRoboImage(
-                      file = candidate,
-                      roborazziOptions = roborazziOptions,
-                    )
+              fun capture(candidate: File) {
+                resolveRenderedCaptureRoot(rule)
+                  .interaction
+                  .captureRoboImage(
+                    file = candidate,
+                    roborazziOptions = roborazziOptions,
+                  )
+              }
+
+              // An explicit captureAdvanceMs selects an exact animation phase. Sampling later
+              // frames would silently move that snapshot by 16–64ms, so only default-timed daemon
+              // stills use adaptive settling.
+              if (spec.captureAdvanceMs == null) {
+                val visuallySettled =
+                  ee.schimke.composeai.renderer.captureVisuallySettledFrame(
+                    file = outputFile,
+                    role = "daemon preview still",
+                    advanceFrame = { rule.mainClock.advanceTimeByFrame() },
+                    capture = ::capture,
+                  )
+                if (!visuallySettled) {
+                  System.err.println(
+                    "compose-ai-daemon: [render] frame did not become visually quiescent after " +
+                      "${ee.schimke.composeai.renderer.VISUAL_SETTLE_MAX_SAMPLES} samples; " +
+                      "using the latest frame."
+                  )
                 }
-              if (!visuallySettled) {
-                System.err.println(
-                  "compose-ai-daemon: [render] frame did not become visually quiescent after " +
-                    "${ee.schimke.composeai.renderer.VISUAL_SETTLE_MAX_SAMPLES} samples; " +
-                    "using the latest frame."
-                )
+              } else {
+                capture(outputFile)
               }
             }
             System.err.println(

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1537,7 +1537,15 @@ abstract class RobolectricRenderTestBase(
                   .thenBy { if (it is CaptureRenderJob && it.capture.animation != null) 1 else 0 }
               )
           var captureIndex = 0
-          jobs.forEach { job ->
+          jobs.forEachIndexed { jobIndex, job ->
+            // Pixel settling advances the shared paused clock. It is safe only for the final job
+            // in this composition; otherwise a later still/product/GIF would start after its
+            // requested time. Explicitly timed jobs are snapshots and must also remain exact.
+            val settleStillFrame =
+              shouldAdvanceClockForVisualSettling(
+                advanceTimeMillis = job.advanceTimeMillis,
+                hasFollowingJobs = jobIndex < jobs.lastIndex,
+              )
             // When the job has no explicit `advanceTimeMillis`, default
             // to `CAPTURE_ADVANCE_MS` *or* the current virtual time —
             // whichever is later. Internal advances (e.g. the
@@ -1645,13 +1653,14 @@ abstract class RobolectricRenderTestBase(
               scroll != null &&
                 scroll.mode == ScrollMode.LONG &&
                 scroll.axis == ScrollAxis.VERTICAL &&
-                handleLongCapture(
+                handleLongCaptureInternal(
                   rule = rule,
                   scroll = scroll,
                   previewId = preview.id,
                   heightDp = heightDp,
                   isRound = isRoundDevice(params.device) && params.kind == PreviewKind.COMPOSE,
                   outputFile = outputFile,
+                  settleFrames = settleStillFrame,
                 )
             if (forceLongFlatten) {
               rule.runOnUiThread {
@@ -1826,14 +1835,13 @@ abstract class RobolectricRenderTestBase(
               // only a changing preview spends the five-sample budget. Explicit time-sampled
               // captures stay single-shot: advancing their clock would change the frame the
               // annotation asked for. Animated/GIF paths were handled above and never reach here.
-              if (job.advanceTimeMillis == null) {
+              if (settleStillFrame) {
                 val visuallySettled =
                   captureVisuallySettledFrame(
                     file = outputFile,
                     role = "preview still",
                     advanceFrame = {
                       rule.mainClock.advanceTimeByFrame()
-                      rule.waitForIdle()
                       currentTime += VISUAL_SETTLE_FRAME_MS
                     },
                   ) { candidate ->
@@ -2282,7 +2290,16 @@ public fun handleLongCapture(
   heightDp: Int,
   isRound: Boolean,
   outputFile: File,
-): Boolean = handleLongCaptureInternal(rule, scroll, previewId, heightDp, isRound, outputFile)
+): Boolean =
+  handleLongCaptureInternal(
+    rule,
+    scroll,
+    previewId,
+    heightDp,
+    isRound,
+    outputFile,
+    settleFrames = true,
+  )
 
 /**
  * Drives `@ScrollingPreview(modes = [END])` — the mode that produces an ordinary single-frame PNG
@@ -2336,6 +2353,7 @@ private fun handleLongCaptureInternal(
   heightDp: Int,
   isRound: Boolean,
   outputFile: File,
+  settleFrames: Boolean,
 ): Boolean {
   val density = rule.activity.resources.displayMetrics.density
   val viewportLayoutPx = (heightDp * density).toInt().coerceAtLeast(1)
@@ -2400,25 +2418,30 @@ private fun handleLongCaptureInternal(
         maxScrollPx = scroll.maxScrollPx,
       ) { scrolledPx ->
         val sliceFile = File(slicesDir, "slice_${slices.size}.png")
-        val visuallySettled =
-          captureVisuallySettledFrame(
-            file = sliceFile,
-            role = "scroll LONG slice",
-            advanceFrame = {
-              rule.mainClock.advanceTimeByFrame()
-              rule.waitForIdle()
-            },
-          ) { candidate ->
-            stableDialogCrop.captureFrame(
-              rule = rule,
-              file = candidate,
-              roborazziOptions = sliceRoborazziOptions,
+        if (settleFrames) {
+          val visuallySettled =
+            captureVisuallySettledFrame(
+              file = sliceFile,
+              role = "scroll LONG slice",
+              advanceFrame = { rule.mainClock.advanceTimeByFrame() },
+            ) { candidate ->
+              stableDialogCrop.captureFrame(
+                rule = rule,
+                file = candidate,
+                roborazziOptions = sliceRoborazziOptions,
+              )
+            }
+          if (!visuallySettled) {
+            System.err.println(
+              "@ScrollingPreview(LONG) on '$previewId': slice ${slices.size} did not become " +
+                "visually quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
             )
           }
-        if (!visuallySettled) {
-          System.err.println(
-            "@ScrollingPreview(LONG) on '$previewId': slice ${slices.size} did not become " +
-              "visually quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
+        } else {
+          stableDialogCrop.captureFrame(
+            rule = rule,
+            file = sliceFile,
+            roborazziOptions = sliceRoborazziOptions,
           )
         }
         slices += SliceCapture(scrolledPx, sliceFile)
@@ -2452,25 +2475,30 @@ private fun handleLongCaptureInternal(
     // bar, FAB — whatever animates in at scroll-end) is always
     // present. Generic over layout: not Wear-specific.
     val finalFrameFile = File(slicesDir, "final_frame.png")
-    val visuallySettled =
-      captureVisuallySettledFrame(
-        file = finalFrameFile,
-        role = "scroll LONG final",
-        advanceFrame = {
-          rule.mainClock.advanceTimeByFrame()
-          rule.waitForIdle()
-        },
-      ) { candidate ->
-        stableDialogCrop.captureFrame(
-          rule = rule,
-          file = candidate,
-          roborazziOptions = sliceRoborazziOptions,
+    if (settleFrames) {
+      val visuallySettled =
+        captureVisuallySettledFrame(
+          file = finalFrameFile,
+          role = "scroll LONG final",
+          advanceFrame = { rule.mainClock.advanceTimeByFrame() },
+        ) { candidate ->
+          stableDialogCrop.captureFrame(
+            rule = rule,
+            file = candidate,
+            roborazziOptions = sliceRoborazziOptions,
+          )
+        }
+      if (!visuallySettled) {
+        System.err.println(
+          "@ScrollingPreview(LONG) on '$previewId': final frame did not become visually " +
+            "quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
         )
       }
-    if (!visuallySettled) {
-      System.err.println(
-        "@ScrollingPreview(LONG) on '$previewId': final frame did not become visually " +
-          "quiescent after $VISUAL_SETTLE_MAX_SAMPLES samples; using the latest frame."
+    } else {
+      stableDialogCrop.captureFrame(
+        rule = rule,
+        file = finalFrameFile,
+        roborazziOptions = sliceRoborazziOptions,
       )
     }
 
@@ -2523,6 +2551,15 @@ private const val POST_SCROLL_SETTLE_MS = 1000L
 public const val VISUAL_SETTLE_MAX_SAMPLES = 5
 internal const val VISUAL_SETTLE_SLOW_PATH_IDENTICAL_SAMPLES = 3
 internal const val VISUAL_SETTLE_FRAME_MS = 16L
+
+/**
+ * Whether visual settling may advance a preview's paused clock without changing another requested
+ * output. Timed captures are exact snapshots, and any following job shares this same clock.
+ */
+internal fun shouldAdvanceClockForVisualSettling(
+  advanceTimeMillis: Long?,
+  hasFollowingJobs: Boolean,
+): Boolean = advanceTimeMillis == null && !hasFollowingJobs
 
 /**
  * Captures [file] twice and returns immediately if both decoded frames have identical pixels. After

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
@@ -11,6 +11,28 @@ import org.junit.Test
 class CaptureVisuallySettledFrameTest {
 
   @Test
+  fun `settling may advance only an untimed final job`() {
+    assertTrue(
+      shouldAdvanceClockForVisualSettling(
+        advanceTimeMillis = null,
+        hasFollowingJobs = false,
+      )
+    )
+    assertFalse(
+      shouldAdvanceClockForVisualSettling(
+        advanceTimeMillis = 200L,
+        hasFollowingJobs = false,
+      )
+    )
+    assertFalse(
+      shouldAdvanceClockForVisualSettling(
+        advanceTimeMillis = null,
+        hasFollowingJobs = true,
+      )
+    )
+  }
+
+  @Test
   fun `fast path accepts the first two identical frames`() {
     val file = File.createTempFile("settled_final_", ".png").apply { deleteOnExit() }
     var captures = 0


### PR DESCRIPTION
## What changed

- skip adaptive daemon settling when `captureAdvanceMs` requests an exact animation phase
- allow clock-advancing settling only for the final untimed job in a shared standalone composition
- disable per-frame LONG settling when a later sibling job still needs the shared clock
- remove `waitForIdle()` from every visual-settling callback while `mainClock.autoAdvance` is disabled
- preserve the existing public `handleLongCapture` JVM signature
- add policy coverage for timed jobs and jobs with following siblings

## Why

This follows up on three late P1 review findings from #3938:

- https://github.com/yschimke/compose-ai-tools/pull/3938#discussion_r3789875842
- https://github.com/yschimke/compose-ai-tools/pull/3938#discussion_r3789875846
- https://github.com/yschimke/compose-ai-tools/pull/3938#discussion_r3789875847

The original settling loop could shift explicit daemon snapshots, advance a shared clock before later GIF/product jobs, and block on Compose idleness when an infinite animation continuously had pending frame work.

## Impact

Standalone/default final stills retain adaptive two-to-five-frame settling. Timed captures and non-final sibling jobs capture once so their requested phase and subsequent jobs remain deterministic. Manually advanced settling remains bounded even for infinite animations.

## Validation

- focused `CaptureVisuallySettledFrameTest` and `CaptureDecodableFrameTest`
- daemon Android compilation and ktfmt checks
- daemon `OverrideIntegrationTest.captureAdvanceMsOverrideThreadsThroughTheRenderPath`
- full `samples:android` Compose Preview render (154 previews, including animated fixtures)
- `samples:wear` `LongScrollPreviewPixelTest`
- visually inspected the combined LONG+GIF Wear output