### PR TITLE
feat(serve): answer replay-dropped overrides from the document, not an allow-list

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -254,6 +254,10 @@ dependencies {
   // (payload schema only; the alpha `androidx.compose.remote.*` deps live in the connector, not
   // here), so it stays off the renderer/daemon boundary the CLI guards.
   implementation(project(":data-remotecompose-core"))
+  // Reads a captured `.rc` document's override surface (`RcDocumentCapabilities`) so the serve
+  // layer can answer "does this override survive a replay?" per document instead of from a
+  // hand-maintained allow-list of axes. Pulls `:rc-player-protocol` transitively for the codec.
+  implementation(project(":rc-player-runtime"))
   // Public render-session library — the CLI consumes its own published API for daemon-driven
   // commands (`compose-preview a11y` etc.) instead of touching DaemonClient directly. We eat
   // our own dog food: anything the CLI can do, a third-party tooling consumer can do via the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLiveRouting.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.rcplayer.runtime.RcDocumentCapabilities
 
 /**
  * Shared override-routing logic for the two trusted-catalog live hosts:
@@ -123,64 +124,74 @@ internal object CatalogLiveRouting {
    * The overrides an **IR replay** of [previewId] cannot honour, named as the caller spelled them —
    * the daemon-lane counterpart of [droppedOverrideNames].
    *
-   * A schema-v5 IR-backed preview is redrawn by replaying a captured document, never by re-running
-   * the composable that authored it (`BundleIrReplayStore` / `RemoteComposeIrReplay`). So every
-   * axis whose *only* route to the pixels is a fresh composition is inert: the daemon renders,
-   * answers `200`, and hands back bytes byte-identical to the baked snapshot. That is the #3449
-   * failure mode wearing a successful render's clothes — worse than the baked case it was written
-   * for, because `generation=daemon` reads as proof the override was applied.
+   * A replayed preview is redrawn from its captured document, never by re-running the composable
+   * that authored it. So every axis whose only route to the pixels is a fresh composition is inert:
+   * the daemon renders, answers `200`, and hands back bytes byte-identical to the baked snapshot —
+   * the #3449 failure mode wearing a successful render's clothes, and worse than the baked case,
+   * because `generation=daemon` reads as proof the override was applied.
    *
-   * Deliberately a **narrow allow-list of the inert axes** rather than the inverse of what replay
-   * honours. Getting this set too wide turns working renders into refusals, so an axis earns its
-   * place here only by having **no representation in the document at all** — not merely by looking
-   * inert against one catalog:
-   * - `themeProvider` and the `knob.` named overrides — both are seeded *into* a composition
-   *   (`PreviewWrapperProvider` substitution, the named-override planner). There is no composition,
-   *   and neither has a document-side counterpart to fall back on.
+   * **[caps] is what makes this per document rather than per axis.** Support is a property of the
+   * bytes: of `remote-m3`'s 27 published documents 16 declare colour state a palette can move and
+   * 11 declare none, so no single answer for `themeProvider` is right even inside one catalog. Pass
+   * the document's [RcDocumentCapabilities] and the answer is read off its declarations; pass null
+   * (no document, or bytes that don't decode) and it falls back to the conservative answer, which
+   * is what this returned for every preview before it could check.
+   *
+   * Two axes stay named regardless, because they have **no representation in the document at all**:
+   * - `themeProvider`'s and the `knob.` overrides' only route is a composition — the
+   *   `PreviewWrapperProvider` substitution and the named-override planner both seed *into* one.
+   *   (`themeProvider` additionally lands as named colour seeds, which is the part [caps] answers.)
    * - `localeTag` — `stringResource()` resolved to a literal during capture and the text op holds
    *   that literal. Unlike the font/theme pair below, `RemoteContext` exposes no locale among its
-   *   system variables (`ID_*` covers time, window, touch, sensors, density, API level, font size,
-   *   dates), so a document has no way to defer the choice to the host.
-   * - **string** `rc.` named values. The rest of the Remote Compose facet does reach the replayed
-   *   document through the player's `StateUpdater` — `rc.shaderColor` and `rc.progress` both move
-   *   pixels on `remote-m3` — but a string seed does not land in the alpha player
-   *   (`RemoteContext.setNamedStringOverride` → `overrideText` → `RemoteComposeState.overrideData`
-   *   is structurally identical to the float path that works, so the divergence is downstream of
-   *   anything this repo controls). Reported as un-applied until the player honours it; the day it
-   *   does, this entry comes out and `IrReplayDroppedOverridesTest` is what notices.
+   *   system variables, so a document has no way to defer the choice to the host.
+   *
+   * A **string** `rc.` seed also stays named: the rest of the facet reaches the replayed document
+   * through the player's `StateUpdater`, but a string seed does not land in the alpha player
+   * (structurally identical to the float path that works, so the divergence is downstream of
+   * anything this repo controls). Reported as un-applied until the player honours it.
    *
    * **`fontScale` and `uiMode` are deliberately absent, and that is the subtle one.** They look
    * inert against `remote-m3` — every render there comes back byte-identical to the baked snapshot
    * — but that is a property of *those documents*, not of replay. A document can defer both to the
-   * host and resolve them at paint time, with no recomposition:
-   * `RemoteComposeView.getDefaultTextSize()` is `14f * density * Configuration.fontScale`, and
-   * `onDraw` derives the paint theme from `Configuration.isNightModeActive()` whenever the player's
-   * own theme is `THEME_UNSPECIFIED`. Both read the live Android `Configuration`, which
-   * `RenderEngine` already sets per render spec — so the wiring is end-to-end today and a document
-   * that reads the host values genuinely responds. The `remote-m3` catalog simply baked absolute
-   * text sizes and concrete colours at capture. Naming them here would 409 an override the replay
-   * can honour, which is exactly the false-refusal failure this list's narrowness exists to
-   * prevent. Their silence on a constant-folded document is authored behaviour, not a server lie.
+   * host and resolve them at paint time, with no recomposition. Naming them here would 409 an
+   * override the replay can honour, which is exactly the false-refusal this list's narrowness
+   * exists to prevent. Deciding them properly needs the player's execution semantics rather than
+   * its declarations, which is why [RcDocumentCapabilities] deliberately does not answer `uiMode`.
    *
    * The size / density / device family is **not** listed either: those reach the player through the
    * capture's `displayMetrics`, so a replay can answer them.
    *
-   * Still runs [withoutBakedNoOps] first, for the same reason [droppedOverrideNames] does. It is a
-   * no-op for the axes that remain — none of them is ever satisfied by baked pixels — but it keeps
-   * the two predicates honest about the same baseline if this list ever grows.
+   * Still runs [withoutBakedNoOps] first, for the same reason [droppedOverrideNames] does.
    */
-  fun irReplayDroppedOverrideNames(previewId: String, o: PreviewOverrides): List<String> {
+  fun irReplayDroppedOverrideNames(
+    previewId: String,
+    o: PreviewOverrides,
+    caps: RcDocumentCapabilities? = null,
+  ): List<String> {
     val dropped = withoutBakedNoOps(previewId, o)
     val names = mutableListOf<String>()
+    // Order is part of the contract — callers render these as a list, so it stays localeTag,
+    // themeProvider, knob.*, rc.* regardless of which of them the document can now answer.
     if (dropped.localeTag != null) names += "localeTag"
-    if (dropped.themeProvider != null) names += "themeProvider"
+    // A palette reaches a replay only as named colour seeds, so it lands exactly when the document
+    // declares colour slots. Without a document to read, keep the conservative answer this returned
+    // before it could check: dropped.
+    if (dropped.themeProvider != null && caps?.supportsThemeProvider != true) {
+      names += "themeProvider"
+    }
+    // Composition-only: the named-override planner seeds into a composition, and there is no
+    // document-side counterpart for [caps] to consult.
     dropped.namedOverrides?.keys?.sorted()?.forEach { names += "${ServeOverrides.KNOB_PREFIX}$it" }
-    dropped.remoteCompose
-      ?.namedValues
-      ?.filterValues { it is RemoteNamedValue.StringValue }
-      ?.keys
-      ?.sorted()
-      ?.forEach { names += "${ServeOverrides.RC_NAMED_PREFIX}$it" }
+    dropped.remoteCompose?.namedValues?.toSortedMap()?.forEach { (name, value) ->
+      // A string seed does not land in the alpha player whatever the document says (the float path
+      // with the identical shape does), so it stays named until that is fixed upstream.
+      val undrivableType = value is RemoteNamedValue.StringValue
+      // Beyond that, a seed lands only if the document declares the name at all — which the
+      // allow-list could never check, so an `rc.` seed aimed at a name no document carries was
+      // silently reported as applied.
+      val undeclared = caps != null && !caps.declaresNamedValue(name)
+      if (undrivableType || undeclared) names += "${ServeOverrides.RC_NAMED_PREFIX}$name"
+    }
     return names
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -8,6 +8,7 @@ import ee.schimke.composeai.data.layoutinspector.ExplodedSvg
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.designpages.DesignPage
+import ee.schimke.composeai.rcplayer.runtime.RcDocumentCapabilities
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
@@ -5116,11 +5117,39 @@ class ServeHttpServer(
       // A real render happened — and still could not apply everything, because this preview is
       // replayed from its captured document rather than recomposed. See
       // [CatalogLiveRouting.irReplayDroppedOverrideNames] for which axes that costs and why the
-      // list is narrow.
-      CatalogLiveRouting.irReplayDroppedOverrideNames(previewId, overrides)
+      // list is narrow. The document itself decides the axes it can: a palette lands only where
+      // the bytes declare colour slots, and an `rc.` seed only where they declare its name.
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        previewId,
+        overrides,
+        documentCapabilities(renderHost, previewId),
+      )
     } else {
       emptyList()
     }
+
+  /**
+   * [previewId]'s captured document read as an override surface, or null when the host carries no
+   * document or the bytes don't decode — both of which mean "cannot establish support", so the
+   * caller keeps its conservative answer rather than claiming an override applies.
+   *
+   * Memoised per preview: the documents are small (a few hundred bytes to a few KB) but this is on
+   * the render-response path, and the bytes for a given id do not change while the host is up.
+   */
+  private val documentCapabilityCache =
+    java.util.concurrent.ConcurrentHashMap<String, java.util.Optional<RcDocumentCapabilities>>()
+
+  private fun documentCapabilities(
+    renderHost: ServeHost,
+    previewId: String,
+  ): RcDocumentCapabilities? =
+    documentCapabilityCache
+      .computeIfAbsent(previewId) { id ->
+        java.util.Optional.ofNullable(
+          renderHost.remoteComposeDoc(id)?.let { RcDocumentCapabilities.of(it) }
+        )
+      }
+      .orElse(null)
 
   /**
    * Whether a refusal for [previewId] is **terminal** — retrying can never apply the override. True

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/IrReplayDroppedOverridesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/IrReplayDroppedOverridesTest.kt
@@ -6,6 +6,12 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import ee.schimke.composeai.rcplayer.protocol.RcDocument
+import ee.schimke.composeai.rcplayer.protocol.RcDocumentCodec
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
+import ee.schimke.composeai.rcplayer.protocol.RcNamedVariable
+import ee.schimke.composeai.rcplayer.protocol.RcVersion
+import ee.schimke.composeai.rcplayer.runtime.RcDocumentCapabilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -187,6 +193,111 @@ class IrReplayDroppedOverridesTest {
               namedValues = mapOf("text" to RemoteNamedValue.StringValue("body"))
             ),
         ),
+      ),
+    )
+  }
+
+  // ——— per-document answers (the capability argument) ———
+
+  /** A document's declarations, through the wire, exactly as the serve layer reads them. */
+  private fun capsOf(vararg named: Pair<String, Int>): RcDocumentCapabilities =
+    requireNotNull(
+      RcDocumentCapabilities.of(
+        RcDocumentCodec.encode(
+          RcDocument(
+            RcHeader(RcVersion(1, 0, 0)),
+            named.mapIndexed { i, (name, type) -> RcNamedVariable(i + 1, type, name) },
+          )
+        )
+      )
+    )
+
+  /**
+   * The finding that motivated reading the document: of `remote-m3`'s 27 published documents 16
+   * declare colour state a palette can move and 11 declare none, so no single answer for
+   * `themeProvider` is right even inside one catalog.
+   */
+  @Test
+  fun `themeProvider lands on a document that declares colour slots`() {
+    val overrides = PreviewOverrides(themeProvider = "coral")
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        overrides,
+        capsOf("USER:WearM3.onSurface" to RcNamedVariable.COLOR_TYPE),
+      ),
+    )
+    assertEquals(
+      listOf("themeProvider"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        overrides,
+        capsOf("USER:light.kitchen.is_on" to RcNamedVariable.INT_TYPE),
+      ),
+    )
+  }
+
+  /**
+   * No document to read means no claim that an override applies — the answer stays conservative.
+   */
+  @Test
+  fun `without a document the conservative answer is kept`() {
+    assertEquals(
+      listOf("themeProvider"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(themeProvider = "coral"),
+        caps = null,
+      ),
+    )
+  }
+
+  /**
+   * New precision the allow-list could not reach: a seed aimed at a name no document carries was
+   * reported as applied, because the list only knew about the value's *type*.
+   */
+  @Test
+  fun `an rc seed for an undeclared name is reported as dropped`() {
+    val overrides =
+      PreviewOverrides(
+        remoteCompose =
+          RemoteComposeOverride(
+            namedValues = mapOf("progress" to RemoteNamedValue.FloatValue(0.5f))
+          )
+      )
+    assertEquals(
+      emptyList(),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        overrides,
+        capsOf("USER:progress" to RcNamedVariable.FLOAT_TYPE),
+      ),
+    )
+    assertEquals(
+      listOf("rc.progress"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        overrides,
+        capsOf("USER:somethingElse" to RcNamedVariable.FLOAT_TYPE),
+      ),
+    )
+  }
+
+  /** A string seed stays named even where the document declares it — the gap is player-side. */
+  @Test
+  fun `a declared string seed is still dropped`() {
+    assertEquals(
+      listOf("rc.label"),
+      CatalogLiveRouting.irReplayDroppedOverrideNames(
+        lightId,
+        PreviewOverrides(
+          remoteCompose =
+            RemoteComposeOverride(
+              namedValues = mapOf("label" to RemoteNamedValue.StringValue("hi"))
+            )
+        ),
+        capsOf("USER:label" to RcNamedVariable.STRING_TYPE),
       ),
     )
   }


### PR DESCRIPTION
Second step of #3936, and the first consumer of `RcDocumentCapabilities` (#3947).

## Why

`CatalogLiveRouting.irReplayDroppedOverrideNames` decided which overrides an IR replay cannot honour from a hand-maintained list of axes. Support is a property of the **document**, not of the axis — of `remote-m3`'s 27 published documents 16 declare colour state a palette can move and 11 declare none, so no single answer for `themeProvider` is right even inside one catalog.

## What changes

It now takes the preview's `RcDocumentCapabilities`, read off the captured `.rc`:

| axis | before | now |
|---|---|---|
| `themeProvider` | always dropped | dropped only where the document declares no colour slots |
| `rc.<name>` | dropped when the *value* is a string | that, **plus** dropped when the document doesn't declare the name |

The second row is new precision the list could not reach. An `rc.` seed aimed at a name no document carries was reported as applied — a silent false success, which is the exact failure this predicate exists to catch.

Null capabilities (no document, or bytes that don't decode) keep the conservative answer the list gave for every preview before it could check, so nothing claims an override applies on evidence it doesn't have.

## Deliberately unchanged

- `localeTag` and `knob.*` seed into a composition and have no document-side counterpart for the capabilities to consult.
- A **string** `rc.` seed stays named even where the document declares it — that gap is in the alpha player, not the document.
- `fontScale` and `uiMode` stay absent. Deciding them needs the player's *execution* semantics rather than its declarations, which is why `RcDocumentCapabilities` deliberately does not answer `uiMode` (see #3947).

## Test plan

- `:cli:test` green in full; `IrReplayDroppedOverridesTest` at 12 tests, 4 new: `themeProvider` landing vs dropped on two documents that differ only in their declarations, the null-capabilities fallback, an `rc.` seed for an undeclared name, and a declared string seed still dropped.
- Fixtures go through `RcDocumentCodec.encode`, so they exercise the same read path the serve layer uses rather than a hand-built object.
- An existing test caught a real regression in the first cut: the result order is part of the contract (callers render it as a list), and regrouping the axes broke `localeTag, themeProvider, knob.*, rc.*`. Restored, and the ordering is now stated in the code.

Capabilities are memoised per preview id — the documents are small, but this sits on the render-response path.

Text-only change; no rendered surface is affected, so there is no visual evidence to embed.

## Not in this PR

Routing a `?rcPlayer=` request through replay so the player choice actually takes effect for a catalog whose previews recompose. That is the remaining half of goal 1 on #3936, and it is where the answer to "does this override survive?" gets used to decide 200-with-dropped vs refusal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYeKdEQJAhTrkmEx8CFQAw)_