### PR TITLE
fix(rc-player): resolve embedded theme colors

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -25,8 +25,8 @@ inside it. Vendoring is the only way to depend on it.
 ## What is vendored
 
 The player proper: the package root plus `layout/`, `modifier/`, and `state/` (42 upstream files,
-44 here — two local splits, `state/RcPlayerBitmapState.kt` and `RcPlayerShaders.kt`, each noted
-under "Local modifications" below). Upstream's
+45 here — two local splits, `state/RcPlayerBitmapState.kt` and `RcPlayerShaders.kt`, plus the local
+`AndroidColorThemeResolver.kt`, each noted under "Local modifications" below). Upstream's
 `demos/`, `integration/previews/`, and the `androidx.wear.compose.remote.material3.previews` sample
 previews that live in the same source set are **not** vendored — they are demo/test scaffolding for
 the integration-test app, and they drag in Wear Material3 and `remote-creation-compose` capture.
@@ -79,6 +79,17 @@ the upstream tracking issue it was reported under.
   from an explicit `COLOR` operation. `RcPlayerPaintTest` pins the player default and
   `ComposePathColorFilterRobolectricReproTest` independently demonstrates the SrcIn behaviour using
   only standard Compose drawing.
+
+- **Indexed Android `ColorTheme` values resolved at cold start**
+  (`AndroidColorThemeResolver.kt`, `RcPlayer.kt`). Upstream's embedded player applies each
+  `ColorTheme` operation but never performs the View player's preceding `ThemeSupport.mapColors`
+  pass, so both light and dark branches retain their authored fallbacks. The embedded player now
+  maps the writer's `Rc.AndroidColors` indexes to framework `android.R.color` resources before its
+  first operation replay, retains the fallback for unknown groups or unavailable resources, and
+  exposes an explicit `theme` parameter that also reapplies colors when it changes. The paired
+  Robolectric conformance test authors one document through the public writer API and checks the
+  dark path against the AndroidX View player; light is deliberately excluded because alpha17's View
+  player has a separate cold-start light-theme bug.
 
 ### Resolved: the two action-dispatch deltas (restored at alpha17)
 

--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -162,6 +162,10 @@ dependencies {
   // `remote-player-view`-backed `RemoteDocumentPlayer` in an identical harness, so a divergence can
   // be attributed to the embedded player rather than to software-canvas rasterization.
   testImplementation(libs.compose.remote.player.view)
+  // ColorTheme conformance fixtures are authored through the same public writer API applications
+  // use. Keeping this explicit makes the test's creation-side contract visible even though the
+  // player dependencies currently bring it in transitively.
+  testImplementation(libs.compose.remote.creation)
   // `RcFigmaSvgExportTest` — runs the production `compose/figma-svg` export over each player's
   // captured tree, so it needs the producers themselves (`ComposeSemanticsDataProducer`,
   // `LayoutInspectorDataProducer`, `ComposeFigmaSvgDataProducer`). The connector `api`-exposes

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/AndroidColorThemeResolver.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/AndroidColorThemeResolver.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import android.content.Context
+import androidx.compose.remote.core.CoreDocument
+
+/** Resolves the indexed `android` ColorTheme group the same way the View player does. */
+internal fun resolveAndroidThemeColors(context: Context, document: CoreDocument) {
+  val indexedColorNames = runCatching {
+    Class.forName("androidx.compose.remote.creation.Rc\$AndroidColors")
+  }
+    .getOrNull()
+    ?.fields
+    ?.mapNotNull { field ->
+      if (field.type == Short::class.javaPrimitiveType) field.getShort(null).toInt() to field.name
+      else null
+    }
+    ?.toMap()
+    .orEmpty()
+
+  document.themedColors.orEmpty().forEach { colorTheme ->
+    if (colorTheme.mColorGroupName != ANDROID_COLOR_GROUP) return@forEach
+
+    fun resolve(index: Short, fallback: Int): Int {
+      val name = indexedColorNames[index.toInt()]?.lowercase() ?: return fallback
+      return runCatching {
+          val resourceId = android.R.color::class.java.getField(name).getInt(null)
+          context.getColor(resourceId)
+        }
+        .getOrDefault(fallback)
+    }
+
+    colorTheme.mLightMode = resolve(colorTheme.mLightModeIndex, colorTheme.mLightModeFallback)
+    colorTheme.mDarkMode = resolve(colorTheme.mDarkModeIndex, colorTheme.mDarkModeFallback)
+  }
+}
+
+private const val ANDROID_COLOR_GROUP = "android"

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ExperimentalRemoteDocumentPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ExperimentalRemoteDocumentPlayer.kt
@@ -20,6 +20,7 @@ package androidx.compose.remote.player.compose.embedded
 
 import androidx.collection.ObjectIntMap
 import androidx.collection.emptyObjectIntMap
+import androidx.compose.remote.core.operations.Theme
 import androidx.compose.remote.player.compose.ExperimentalRemotePlayerApi
 import androidx.compose.remote.player.core.RemoteDocument
 import androidx.compose.remote.player.core.state.StateUpdater
@@ -35,6 +36,7 @@ import androidx.compose.ui.Modifier
 public fun ExperimentalRemoteDocumentPlayer(
   document: RemoteDocument,
   modifier: Modifier = Modifier,
+  theme: Int = Theme.UNSPECIFIED,
   namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
   imageLoader: RcImageLoader? = null,
   isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -44,6 +46,7 @@ public fun ExperimentalRemoteDocumentPlayer(
   RcPlayer(
     document = document.document,
     modifier = modifier,
+    theme = theme,
     namedColorOverrides = namedColorOverrides,
     imageLoader = imageLoader,
     isShaderValid = isShaderValid,

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -48,6 +48,7 @@ import androidx.compose.remote.core.operations.Header
 import androidx.compose.remote.core.operations.NamedVariable
 import androidx.compose.remote.core.operations.ParticlesCompare
 import androidx.compose.remote.core.operations.ParticlesLoop
+import androidx.compose.remote.core.operations.Theme
 import androidx.compose.remote.core.operations.Utils
 import androidx.compose.remote.core.operations.WakeIn
 import androidx.compose.remote.core.operations.layout.Component
@@ -74,6 +75,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.positionOnScreen
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.preferredFrameRate
 import androidx.compose.ui.semantics.contentDescription
@@ -97,6 +99,10 @@ import java.io.ByteArrayInputStream
  * the embedded equivalent of the View player's `setColor(name, value)` — pass [namedColorOverrides]
  * (variable name -> ARGB int); each entry is applied via `setNamedColorOverride` after the
  * document's defaults.
+ *
+ * [theme] selects the `ColorTheme` light/dark branch. Indexed colors in the Android group are
+ * resolved from framework resources before the first operation replay; unknown groups or missing
+ * resources retain their authored fallback.
  */
 @OptIn(ExperimentalRemotePlayerApi::class)
 @SuppressLint("RestrictedApiAndroidX")
@@ -105,6 +111,7 @@ import java.io.ByteArrayInputStream
 public fun RcPlayer(
   document: CoreDocument,
   modifier: Modifier = Modifier,
+  theme: Int = Theme.UNSPECIFIED,
   namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
   imageLoader: RcImageLoader? = null,
   isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -123,6 +130,7 @@ public fun RcPlayer(
   }
 
   val density = LocalDensity.current
+  val context = LocalContext.current
   val remoteContext = remember {
     // Consider a Compose Clock
     AndroidRemoteContext(clock).also {
@@ -144,6 +152,8 @@ public fun RcPlayer(
       it.loadFloat(RemoteContext.ID_DENSITY, density.density)
       it.density = density.density
       document.initializeContext(it)
+      resolveAndroidThemeColors(context, document)
+      it.paintTheme = theme
 
       // Register each bitmap's metadata (declared width/height for ImageAttribute, and
       // discoverability for the lazy decode) WITHOUT decoding the pixels. The costly decode
@@ -228,6 +238,11 @@ public fun RcPlayer(
       document.rootLayoutComponent?.getData(dataOps, true)
       document.applyOperationsReflection(it, dataOps)
     }
+  }
+
+  LaunchedEffect(remoteContext, theme) {
+    document.themedColors.orEmpty().forEach { it.setTheme(remoteContext, theme) }
+    remoteContext.paintTheme = theme
   }
 
   // Time and animations are driven on demand. A static document — no declared animations and no
@@ -453,6 +468,7 @@ public fun RcPlayer(
 public fun RcPlayer(
   capturedDocument: CapturedDocument,
   modifier: Modifier = Modifier,
+  theme: Int = Theme.UNSPECIFIED,
   namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
   imageLoader: RcImageLoader? = null,
   isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -477,6 +493,7 @@ public fun RcPlayer(
   RcPlayer(
     document = coreDoc,
     modifier = modifier,
+    theme = theme,
     namedColorOverrides = namedColorOverrides,
     imageLoader = imageLoader,
     isShaderValid = isShaderValid,

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcColorThemePlayerTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/RcColorThemePlayerTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.view.View.MeasureSpec
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.remote.core.operations.Theme
+import androidx.compose.remote.core.operations.layout.managers.BoxLayout
+import androidx.compose.remote.creation.Rc
+import androidx.compose.remote.creation.RemoteComposeWriter
+import androidx.compose.remote.creation.modifiers.RecordingModifier
+import androidx.compose.remote.creation.profile.RcPlatformProfiles
+import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayer
+import androidx.compose.remote.player.core.RemoteDocument
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/** Cold-start coverage for ColorTheme's indexed Android system-color form. */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34], qualifiers = "night-xhdpi")
+class RcColorThemePlayerTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun viewPlayer_coldStart_darkTheme_resolvesSystemColors() {
+    assertThemeColorResolved(render(Player.VIEW))
+  }
+
+  @Test
+  fun embeddedPlayer_coldStart_darkTheme_resolvesSystemColors() {
+    assertThemeColorResolved(render(Player.EMBEDDED))
+  }
+
+  private fun assertThemeColorResolved(result: RenderResult) {
+    val expected = expectedDarkColor()
+    assertEquals("mapped dark system color", expected, result.mappedDarkColor)
+    assertEquals("color loaded into player state", expected, result.resolvedColor)
+  }
+
+  private fun render(player: Player): RenderResult {
+    val fixture = colorThemeDocument()
+    lateinit var remoteDocument: RemoteDocument
+    composeRule.setContent {
+      val density = LocalDensity.current
+      Box(Modifier.size(with(density) { WIDTH.toDp() }, with(density) { HEIGHT.toDp() })) {
+        val document = remember { RemoteDocument(fixture.bytes) }
+        remoteDocument = document
+        when (player) {
+          Player.VIEW ->
+            RemoteDocumentPlayer(
+              document = document.document,
+              documentWidth = WIDTH,
+              documentHeight = HEIGHT,
+            )
+          Player.EMBEDDED ->
+            ExperimentalRemoteDocumentPlayer(
+              document = document,
+              modifier = Modifier.fillMaxSize(),
+              theme = Theme.DARK,
+            )
+        }
+      }
+    }
+    composeRule.waitForIdle()
+
+    val root = composeRule.activity.findViewById<ViewGroup>(android.R.id.content)
+    root.measure(
+      MeasureSpec.makeMeasureSpec(WIDTH, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(HEIGHT, MeasureSpec.EXACTLY),
+    )
+    root.layout(0, 0, WIDTH, HEIGHT)
+    Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ARGB_8888).also { root.draw(Canvas(it)) }
+    val coreDocument = remoteDocument.document
+    return RenderResult(
+      mappedDarkColor = checkNotNull(coreDocument.themedColors).single().mDarkMode,
+      resolvedColor = coreDocument.remoteComposeState.getColor(fixture.colorId.toInt()),
+    )
+  }
+
+  private fun expectedDarkColor(): Int =
+    composeRule.activity.getColor(android.R.color.system_accent2_800)
+
+  private fun colorThemeDocument(): DocumentFixture {
+    val writer = RemoteComposeWriter.obtain(WIDTH, HEIGHT, RcPlatformProfiles.ANDROIDX)
+    val fallbackColor = 0xffff00ff.toInt()
+    val colorId =
+      writer.addThemedColor(
+        Rc.AndroidColors.GROUP,
+        Rc.AndroidColors.SYSTEM_ACCENT2_50,
+        Rc.AndroidColors.SYSTEM_ACCENT2_800,
+        fallbackColor,
+        fallbackColor,
+      )
+    writer.root {
+      writer.box(
+        RecordingModifier().backgroundId(colorId).fillMaxSize(),
+        BoxLayout.CENTER,
+        BoxLayout.CENTER,
+      ) {}
+    }
+    return DocumentFixture(writer.encodeToByteArray(), colorId)
+  }
+
+  private data class DocumentFixture(val bytes: ByteArray, val colorId: Short)
+
+  private data class RenderResult(
+    val mappedDarkColor: Int,
+    val resolvedColor: Int,
+  )
+
+  private enum class Player {
+    VIEW,
+    EMBEDDED,
+  }
+
+  private companion object {
+    const val WIDTH = 100
+    const val HEIGHT = 100
+  }
+}


### PR DESCRIPTION
## Summary

- resolve indexed Android `ColorTheme` entries against framework `android.R.color` resources before the embedded player's first operation replay
- expose and forward an explicit theme through both embedded-player entry points, including reapplication when it changes
- add dark-theme cold-start conformance coverage comparing the embedded and AndroidX View players

## Why

The embedded player applied `ColorTheme` operations without the View player's preceding `ThemeSupport.mapColors` pass. As a result, Android system-color indexes such as `SYSTEM_ACCENT2_800` retained their authored fallback instead of resolving to the platform color.

Unknown groups and unavailable resources still retain their fallbacks. Light-mode comparison is intentionally excluded because the pinned AndroidX Java player has a separate cold-start light-theme bug.

## Validation

- `ANDROID_HOME=/Users/yschimke/Library/Android/sdk ./gradlew :third-party-rc-embedded-player:testDebugUnitTest --tests ee.schimke.composeai.rcembedded.RcColorThemePlayerTest :third-party-rc-embedded-player:ktfmtCheck --no-build-cache`
