### PR TITLE
fix(ci): compare shared CMP/Wasm render failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,8 +570,7 @@ jobs:
             --player "$GITHUB_WORKSPACE/cli/src/main/resources/rc-player/bundle.js" \
             --out "$RUNNER_TEMP/parity-out" \
             --system remote-m3 \
-            --cmp-wasm "$GITHUB_WORKSPACE/rc-player/wasm/build/wasmDist" \
-            --require-cmp-wasm
+            --cmp-wasm "$GITHUB_WORKSPACE/rc-player/wasm/build/wasmDist"
       # `tee` so the same report reaches the log, the job summary (the script appends it itself) and
       # the PR comment below — one text, three places, no chance of them disagreeing.
       - name: Compare against the base player


### PR DESCRIPTION
## Summary

- allow both the base and proposed CMP/Wasm players to finish rendering the fixed parity corpus
- defer the pass/fail decision to the existing baseline regression comparator

## Root cause

The proposed-player render used `--require-cmp-wasm`, while the base-player render did not. Six documents unsupported by both revisions therefore failed the proposed render early, skipped the baseline comparison, and made an unrelated player PR appear regressed.

The comparator already treats a document that rendered on the base but no longer renders on the proposal as a failure. Shared render failures are correctly ignored as pre-existing limitations.

## Validation

- `git diff --check`
- `node --test scripts/design-artifacts/rc-compare-regression.test.mjs`