### PR TITLE
chore(deps): update Compose BOM to 2026.08.00

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ classgraph = "4.8.186"
 # `Compare previews` is exercised against. Renovate updates this freely;
 # the variant below (`compose-bom-compat`) is the older line that
 # renderer-android compiles its public API against.
-compose-bom-stable = "2026.06.01"
+compose-bom-stable = "2026.08.00"
 # renderer-android compiles its public API surface against this OLDER BOM so
 # the emitted bytecode only references Compose 1.9.x method signatures.
 # AndroidX honours binary-backward-compatibility within a major version, so

--- a/renderers/xr/build.gradle.kts
+++ b/renderers/xr/build.gradle.kts
@@ -26,8 +26,8 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.renderer.xr"
-  // `androidx.xr.compose` declares `minCompileSdk = 36`.
-  compileSdk = 36
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
   buildFeatures { compose = true }
   testOptions {
     unitTests.all {

--- a/samples/android-daemon-bench/build.gradle.kts
+++ b/samples/android-daemon-bench/build.gradle.kts
@@ -36,6 +36,8 @@ composePreview {
 
 android {
   namespace = "com.example.daemonbench"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.daemonbench"

--- a/samples/android-library/build.gradle.kts
+++ b/samples/android-library/build.gradle.kts
@@ -33,6 +33,8 @@ composePreview {
 
 android {
   namespace = "com.example.samplelibrary"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   buildFeatures { compose = true }
 

--- a/samples/android-live-lane/build.gradle.kts
+++ b/samples/android-live-lane/build.gradle.kts
@@ -29,6 +29,8 @@ composePreview {
 
 android {
   namespace = "com.example.androidlivelane"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.androidlivelane"

--- a/samples/android-screenshot-test/build.gradle.kts
+++ b/samples/android-screenshot-test/build.gradle.kts
@@ -37,6 +37,8 @@ composePreview {
 
 android {
   namespace = "com.example.sampleandroidscreenshot"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.sampleandroidscreenshot"

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 composePreview {
-  // Pin Robolectric to SDK 35 even though `composeai.android-conventions` sets
-  // `compileSdk = 36`. The plugin's default is auto-detection (`compileSdk` →
+  // Pin Robolectric to SDK 35 even though this module sets `compileSdk = 37` for Compose 1.12.
+  // The plugin's default is auto-detection (`compileSdk` →
   // `sdk=N` in `robolectric.properties`, see issue #1248), but the project's
   // toolchain is JDK 17 and Robolectric SDK 36 requires JDK 21+
   // (`DefaultSdkProvider.verifySupportedSdk`). The override demonstrates the
@@ -34,6 +34,8 @@ composePreview {
 
 android {
   namespace = "com.example.sampleandroid"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "com.example.sampleandroid"

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/CustomStyleAbiPreview.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/CustomStyleAbiPreview.kt
@@ -1,0 +1,26 @@
+package com.example.sampleandroid
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.style.CustomStyle
+import androidx.compose.foundation.style.ExperimentalFoundationStyleApi
+import androidx.compose.foundation.style.Style
+import androidx.compose.foundation.style.StyleScope
+import androidx.compose.foundation.style.apply
+import androidx.compose.foundation.style.styleable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationStyleApi::class)
+private val abiCustomStyle = CustomStyle<StyleScope> { background(Color.Magenta) }
+
+@OptIn(ExperimentalFoundationStyleApi::class)
+@Preview(name = "CustomStyle ABI", widthDp = 80, heightDp = 80)
+@Composable
+fun CustomStyleAbiPreview() {
+  val style = Style { apply(abiCustomStyle) }
+  Box(Modifier.size(80.dp).styleable(style = style))
+}

--- a/samples/sdk-matrix/build.gradle.kts
+++ b/samples/sdk-matrix/build.gradle.kts
@@ -127,7 +127,10 @@ tasks.withType(Test::class.java).configureEach {
 }
 
 dependencies {
-  implementation(platform(libs.compose.bom.stable))
+  // This matrix deliberately exercises compileSdk 35/36 clients too. Compose 1.12 itself requires
+  // compileSdk 37, so use compose-preview's supported compatibility floor here; the regular samples
+  // exercise the current stable BOM.
+  implementation(platform(libs.compose.bom.compat))
   implementation(libs.compose.ui)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui.tooling.preview)

--- a/samples/sdk21/android-metro-viewmodel/build.gradle.kts
+++ b/samples/sdk21/android-metro-viewmodel/build.gradle.kts
@@ -28,6 +28,8 @@ plugins {
 
 android {
   namespace = "com.example.metroviewmodel"
+  // Compose 1.12 (BOM 2026.08.00) publishes minCompileSdk 37 metadata.
+  compileSdk = 37
 
   buildFeatures { compose = true }
 

--- a/samples/xr-spatial/build.gradle.kts
+++ b/samples/xr-spatial/build.gradle.kts
@@ -21,11 +21,10 @@ plugins {
 // annotation KDoc and `SubspaceSceneRecorder`.
 
 composePreview {
-  // Pin Robolectric to SDK 35. `androidx.xr.compose:compose`'s AAR metadata
-  // declares `minCompileSdk = 36`, so the module compiles against 36, but
-  // Robolectric 4.16.1 needs JDK 21+ for an SDK 36 sandbox and the repo's
-  // toolchain stays on JDK 17. The 2D fallback path the previews exercise is
-  // pure Compose drawing (no API-36 platform symbol at render time), so SDK 35
+  // Pin Robolectric to SDK 35. Compose 1.12's AAR metadata requires this module to compile against
+  // 37, but a Robolectric SDK 36+ sandbox needs JDK 21 and the repo's toolchain stays on JDK 17.
+  // The 2D fallback path the previews exercise is
+  // pure Compose drawing (no API-36/37 platform symbol at render time), so SDK 35
   // captures it cleanly — the same escape hatch `:samples:remotecompose` and
   // `:samples:android-alpha` use to render compileSdk-37 modules under JDK 17.
   // Drop this override when the toolchain moves to JDK 21.
@@ -40,11 +39,8 @@ composePreview {
 android {
   namespace = "com.example.samplexrspatial"
 
-  // `androidx.xr.compose:compose` raises `minCompileSdk = 36` in its AAR
-  // metadata, so the module must compile against 36. That is the repo default
-  // from `composeai.android-conventions` (platform-36 is installed); unlike
-  // `:samples:xr-glimmer` no platform-37 bump is needed.
-  compileSdk = 36
+  // Compose 1.12 supersedes androidx.xr.compose's older minCompileSdk 36 requirement.
+  compileSdk = 37
 
   buildFeatures { compose = true }
 


### PR DESCRIPTION
## Summary

- update the repository's stable Compose BOM test line to `2026.08.00` / Compose 1.12
- raise affected sample and XR modules to `compileSdk 37`, as required by the new AndroidX AAR metadata
- add a focused preview that constructs and applies the new `CustomStyle<StyleScope>` ABI
- keep the SDK compatibility matrix on `compose-bom-compat` so compileSdk 35/36 and older Compose clients remain covered

## Why

Compose 1.12 introduces a binary- and source-incompatible experimental Style API shape around `CustomStyle`. The direct runtime probe confirms compose-preview renders code compiled against the new ABI successfully. The actual upgrade failure was earlier in the build: Compose 1.12 artifacts require compileSdk 37.

This does not raise compose-preview's consumer Compose floor. The compatibility BOM remains `2025.11.01`, and clients that do not adopt Compose 1.12 are not required to change compileSdk.

## Validation

- rendered the full `:samples:android` preview catalog on BOM `2026.08.00`
- rendered `CustomStyleAbiPreview` successfully and visually verified the magenta output
- passed affected modules' `checkDebugAarMetadata` tasks
- passed `:renderer-android:compileDebugKotlin`
- passed `:gradle-plugin:test`
- passed `:ktfmtCheckAll`
