### PR TITLE
docs: bind npm trusted publishing to the entry-point workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,8 +333,14 @@ jobs:
     # Same posture as `publish-vscode-extension`: a registry outage must not strand the drafted
     # release, since `finalize-release` gates on this whole run succeeding. Unlike the VSIX there is
     # no GitHub Release asset to fall back on, so a tolerated failure here means the version simply
-    # is not on npm — recover by re-dispatching this workflow for the tag, which republishes
-    # idempotently (the step below skips a version that is already up).
+    # is not on npm — recover by RE-RUNNING THIS FAILED JOB in the original `release-please.yml`
+    # run, which republishes idempotently (the step below skips a version that is already up).
+    #
+    # Not by re-dispatching release.yml for the tag: npm's Trusted Publisher matches the OIDC
+    # token's ENTRY-POINT workflow, which is `release-please.yml` for the automatic chain and
+    # `release.yml` for a dispatch — and npm allows only one binding per package. A dispatched
+    # run therefore cannot authenticate to npm no matter how the tag resolves. Re-running the
+    # job keeps the entry point (and the tag) exactly as they were. See docs/RELEASING.md.
     continue-on-error: true
     permissions:
       contents: read
@@ -368,6 +374,9 @@ jobs:
           # npm's provenance generator would attest a commit that did not produce the tarball. A
           # package with no attestation is a gap, one with a false attestation is a lie. The
           # workflow_call path runs on the release commit the tag names, so provenance stays on.
+          # Belt and braces only: a dispatched run is not the entry point npm's Trusted Publisher
+          # is bound to (see the job comment), so it fails to authenticate before provenance is
+          # ever generated. Kept so the flag is right if the binding ever moves to this file.
           IS_RECOVERY: ${{ github.event_name == 'workflow_dispatch' }}
         working-directory: design-map
         run: |

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -72,6 +72,14 @@ If the automatic chain ever leaves a release half-published (e.g. Maven Central 
 
 Both fallbacks share the same concurrency group as the primary path, so they can't race each other. The final upload step is idempotent — it uploads onto an existing Release (or creates one if none exists).
 
+**One exception: npm.** Neither fallback can publish `@yschimke/compose-design-map`, because both
+enter through `release.yml` and the npm trusted publisher is bound to `release-please.yml` (see the
+trusted-publishing note under "What the `release.yml` workflow does" — npm permits one binding per
+package). If `publish-design-map` failed, re-run *that job* in the original **Release PR** run
+instead: Actions → the run → **Re-run failed jobs**. An `E404 Not Found - PUT` from `npm publish`
+means the OIDC token did not match the trusted publisher, not that the package or version is
+missing.
+
 If the GitHub Release is public but `compose-preview update` still selects the
 previous version, check the original **Release PR** run's
 `verify-maven-readiness` job. Re-run that failed job after Central recovers, or
@@ -95,7 +103,7 @@ republishing the release.
    - `compose-preview-<ver>.{zip,tar.gz}` — the CLI; tarball already implementation-bundles `:mcp` and the desktop renderer.
    - `compose-preview-mcp-<ver>.{zip,tar.gz}` — the MCP server standalone for consumers who want to wire it into an MCP client without dragging the CLI in.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
-4. Publishes **`@yschimke/compose-design-map`** (the `design-map/` package — the annotations→`design-map.json` projection) to **npm**, at the tag's version. Uses npm Trusted Publishing (OIDC), so there is no npm token to rotate; provenance is attached except on a `workflow_dispatch` recovery, where the ref no longer names the built tree. Like the marketplace publishes it is tolerated rather than blocking, and it skips a version already on npm, so re-dispatching a tag is safe.
+4. Publishes **`@yschimke/compose-design-map`** (the `design-map/` package — the annotations→`design-map.json` projection) to **npm**, at the tag's version. Uses npm Trusted Publishing (OIDC), so there is no npm token to rotate; provenance is attached automatically. Like the marketplace publishes it is tolerated rather than blocking, and it skips a version already on npm, so re-running it is safe. Unlike the other steps, its recovery is **re-running the failed job in the original release run**, not a `workflow_dispatch` of `release.yml` — see the trusted-publisher note below.
 5. Uploads the CLI, MCP, XR compositor, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 
 Alongside `release.yml`, the automatic release chain starts
@@ -136,11 +144,24 @@ Required secrets on the repository:
 `GITHUB_TOKEN` is provided automatically and is used by the `release` job to upload assets onto the GitHub Release.
 
 npm needs **no secret**: `@yschimke/compose-design-map` publishes over OIDC Trusted Publishing,
-configured once on npmjs.com against this repository and the `release.yml` workflow filename. That
-binding is to the filename — renaming `release.yml` breaks npm publishing until the trusted
-publisher is reconfigured. The package's committed version is a placeholder (`0.0.0`); the release
-job stamps the tag onto it, exactly as `build-vscode-extension` does for the extension, so nothing
-in the tree needs bumping.
+configured once on npmjs.com against this repository and the **`release-please.yml`** workflow
+filename — the workflow that *starts* the run, not `release.yml`, which merely contains the
+`npm publish`. npm matches the OIDC token's entry-point workflow, so a `workflow_call` chain is
+validated against the caller; binding it to `release.yml` matches nothing and npm answers the
+publish with a bare `E404 Not Found - PUT` (it falls back to the empty `NODE_AUTH_TOKEN` and the
+registry will not admit that a package exists to an anonymous writer). The binding is to the
+filename — renaming `release-please.yml` breaks npm publishing until the trusted publisher is
+reconfigured. `id-token: write` is required on **both** ends of the chain: the `release` job in
+`release-please.yml` and `publish-design-map` in `release.yml`.
+
+npm allows only **one** trusted publisher per package, so the automatic chain owns the binding and
+a `workflow_dispatch` of `release.yml` cannot authenticate to npm — that dispatch remains the
+recovery path for Maven Central and the GitHub Release assets, but for npm the recovery is to
+**re-run the failed `publish-design-map` job in the original `release-please.yml` run** (Actions →
+the run → "Re-run failed jobs"). The step skips a version already on npm, so it is idempotent.
+
+The package's committed version is a placeholder (`0.0.0`); the release job stamps the tag onto it,
+exactly as `build-vscode-extension` does for the extension, so nothing in the tree needs bumping.
 
 Marketplace publishes are idempotent on re-runs: if the version is already published (e.g. on a `workflow_dispatch` retry for an existing tag), the step logs the "already published" message and exits 0 rather than failing.
 


### PR DESCRIPTION
## Summary

`publish-design-map` failed on the v1.8.0 release ([run 31912943700](https://github.com/yschimke/compose-ai-tools/actions/runs/31912943700/job/95080656597)) with:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@yschimke%2fcompose-design-map - Not found
```

The OIDC exchange never produced a credential, so `npm publish` fell back to the `.npmrc` `setup-node` writes (`_authToken=${NODE_AUTH_TOKEN}`, and there is deliberately no npm secret) and the registry answered the anonymous `PUT` with a 404. Compare the same step in `design-parity`, which publishes fine and logs `publish Signed provenance statement with source and build information from GitHub Actions` — that line is absent here.

Why the exchange failed: npm matches a Trusted Publisher against the OIDC token's **entry-point** workflow. The automatic chain enters through `release-please.yml`, which calls `release.yml` over `workflow_call`; `release.yml` only *contains* the `npm publish`. `docs/RELEASING.md` said the publisher was configured against `release.yml`, so the binding could not match any real release run. Per npm's docs: *"Some GitHub Actions workflows use `workflow_call` to invoke other workflows that run `npm publish` … validation checks the calling workflow's name instead of the workflow that actually contains the publish command."*

Docs and comments only — no workflow behaviour changes.

- `docs/RELEASING.md` — name `release-please.yml` as the trusted-publisher workflow, spell out the entry-point rule and the resulting 404 symptom, and note that `id-token: write` is needed on both ends of the chain.
- `docs/RELEASING.md` — record that npm permits **one** binding per package, which makes the documented "re-dispatch `release.yml` for the tag" recovery unusable for npm: a dispatched run's entry point is `release.yml`, so it cannot authenticate. Recovery is re-running the failed `publish-design-map` job in the original release run, which is already idempotent (the step skips a version that is up). Added the same caveat to the **Fallback paths** section, where a reader hits it first.
- `.github/workflows/release.yml` — the job comment pointed at that same broken recovery path; corrected, plus a note on why the `IS_RECOVERY` provenance flag is now belt-and-braces.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses.
- No visual surfaces touched; docs + YAML comments only.
- End-to-end verification is the npmjs.com side, which this PR cannot change: repoint `@yschimke/compose-design-map`'s Trusted Publisher to `release-please.yml`, then re-run `publish-design-map` in the v1.8.0 run and confirm the provenance line appears and `1.8.0` lands on npm (`npm view @yschimke/compose-design-map version` currently reports `0.0.0`, the hand-published bootstrap).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uef5JBNLS3eAD76tW65U6J)_