### PR TITLE
fix(rc-player): resolve ColorTheme indices and modes in every player

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -81,6 +81,13 @@ internal object RcJvmServerRenderer {
     spec: RcJvmRenderSpec,
     seeds: Map<String, RemoteNamedValue> = emptyMap(),
     format: Format = Format.PNG,
+    /**
+     * Which branch a `ColorTheme` operation selects. Defaults to light rather than to the machine's
+     * desktop setting: this renderer is headless, so "the host's theme" is not a real question, and
+     * a render that changed colour with the build machine's OS would not be reproducible. Documents
+     * with no `ColorTheme` are unaffected either way.
+     */
+    theme: RenderTheme = RenderTheme.LIGHT,
   ): RenderResult {
     val cp = classpath()
     if (cp.isEmpty()) return RenderResult.Unavailable(unavailableReason())
@@ -99,7 +106,14 @@ internal object RcJvmServerRenderer {
     // cold would double the cost of every document that cannot be drawn.
     pool(cp)?.let { pool ->
       val pooled =
-        pool.render(docBytes, spec, seedLines(seeds).joinToString("\n"), format, secondsLeft())
+        pool.render(
+          docBytes,
+          spec,
+          seedLines(seeds).joinToString("\n"),
+          format,
+          theme,
+          secondsLeft(),
+        )
       when (pooled) {
         is RcJvmWorkerPool.PoolResult.Ok -> return RenderResult.Ok(pooled.bytes)
         is RcJvmWorkerPool.PoolResult.Failed -> return RenderResult.Failed(pooled.reason)
@@ -118,7 +132,7 @@ internal object RcJvmServerRenderer {
       }
     }
 
-    return renderOneShot(cp, docBytes, spec, seeds, format, secondsLeft())
+    return renderOneShot(cp, docBytes, spec, seeds, format, theme, secondsLeft())
   }
 
   /**
@@ -133,6 +147,7 @@ internal object RcJvmServerRenderer {
     spec: RcJvmRenderSpec,
     seeds: Map<String, RemoteNamedValue>,
     format: Format,
+    theme: RenderTheme,
     timeoutSeconds: Long = RENDER_TIMEOUT_SECONDS,
   ): RenderResult {
     val input = File.createTempFile("rcjvm-in-", ".rc")
@@ -160,6 +175,8 @@ internal object RcJvmServerRenderer {
         add(spec.density.toString())
         add("--format")
         add(format.wire)
+        add("--theme")
+        add(theme.wire)
         if (seedsFile != null) {
           add("--seeds")
           add(seedsFile.absolutePath)
@@ -339,6 +356,20 @@ internal object RcJvmServerRenderer {
   enum class Format(val wire: String) {
     PNG("png"),
     SVG("svg"),
+  }
+
+  /**
+   * The `ColorTheme` branch a cmp-jvm render selects.
+   *
+   * Deliberately this module's own type rather than `remote-core`'s `Theme` int: the CLI drives the
+   * player as a subprocess and carries no compile dependency on it, which is what lets the worker's
+   * classpath be staged independently. [wire] and [frame] are the two forms that cross the boundary
+   * — a `--theme` argument on the one-shot path, and an int in the pooled worker's request frame,
+   * whose values `RcJvmRenderWorkerMain` mirrors.
+   */
+  enum class RenderTheme(val wire: String, val frame: Int) {
+    LIGHT("light", 0),
+    DARK("dark", 1),
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPool.kt
@@ -120,6 +120,12 @@ internal class RcJvmWorkerPool(
     seedsText: String,
     format: RcJvmServerRenderer.Format,
     /**
+     * The `ColorTheme` branch to select — see `RcJvmServerRenderer.render`. Light by default,
+     * matching that entry point: a headless render has no host theme to follow, and one that varied
+     * with the machine's desktop setting would not be reproducible.
+     */
+    theme: RcJvmServerRenderer.RenderTheme = RcJvmServerRenderer.RenderTheme.LIGHT,
+    /**
      * Budget for this render, so the caller can bound pool-attempt + fallback together rather than
      * letting each lane spend the full timeout in turn. Defaults to the pool's own timeout.
      */
@@ -148,6 +154,7 @@ internal class RcJvmWorkerPool(
           spec,
           seedsText,
           format,
+          theme,
           requestIds.incrementAndGet(),
           timeoutSeconds,
         )
@@ -352,6 +359,7 @@ internal class RcJvmWorkerPool(
       spec: RcJvmRenderSpec,
       seedsText: String,
       format: RcJvmServerRenderer.Format,
+      theme: RcJvmServerRenderer.RenderTheme,
       requestId: Int = 0,
       renderTimeoutSeconds: Long,
     ): PoolResult {
@@ -367,6 +375,9 @@ internal class RcJvmWorkerPool(
         toWorker.writeInt(
           if (format == RcJvmServerRenderer.Format.SVG) WIRE_FORMAT_SVG else WIRE_FORMAT_PNG
         )
+        // After `format`, matching `RcJvmRenderWorkerMain`. Both ends ship from the same build, so
+        // the frame is versioned by the build rather than negotiated.
+        toWorker.writeInt(theme.frame)
         toWorker.writeInt(seeds.size)
         toWorker.write(seeds)
         toWorker.writeInt(docBytes.size)
@@ -462,9 +473,12 @@ internal class RcJvmWorkerPool(
     const val MAGIC_HELLO = 0x52435731
     const val MAGIC_REQUEST = 0x52435131
     const val MAGIC_RESPONSE = 0x52435231
-    const val PROTOCOL_VERSION = 1
+    // 2 adds the per-request `theme` field; see `RcJvmRenderWorkerMain`'s frame layout.
+    const val PROTOCOL_VERSION = 2
     const val STATUS_OK = 0
     const val STATUS_FAILED = 1
+    const val WIRE_THEME_LIGHT = 0
+    const val WIRE_THEME_DARK = 1
     const val WIRE_FORMAT_PNG = 0
     const val WIRE_FORMAT_SVG = 1
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5306,13 +5306,24 @@ class ServeHttpServer(
           )
           .params
       )
+    // `?uiMode=dark` selects the document's dark `ColorTheme` branch. This lane replays stored
+    // `.rc`
+    // bytes rather than waking the daemon, so the mode is a *player* setting here — it is the only
+    // thing `uiMode` can mean for an already-captured document, and without it a dark request would
+    // silently render the light branch.
+    val theme =
+      if (call.request.queryParameters["uiMode"]?.lowercase() == "dark") {
+        RcJvmServerRenderer.RenderTheme.DARK
+      } else {
+        RcJvmServerRenderer.RenderTheme.LIGHT
+      }
     val result =
       withContext(Dispatchers.IO) {
         if (!renderSemaphore.tryAcquire(RENDER_QUEUE_WAIT_SECONDS, TimeUnit.SECONDS)) {
           null
         } else {
           try {
-            RcJvmServerRenderer.render(doc, spec, seeds, format)
+            RcJvmServerRenderer.render(doc, spec, seeds, format, theme)
           } finally {
             renderSemaphore.release()
           }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolStub.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolStub.kt
@@ -41,10 +41,10 @@ import kotlin.system.exitProcess
  *   `System.out` to stderr for exactly this reason; the stub proves the pool would notice if it
  *   ever stopped.
  *
- * The artifact for `ok` is `"<width>x<height>@<density>:<format>:<seeds>:<docLen>#<n>"`, where `n`
- * counts the requests **this process** has served. That lets a test assert the whole request
- * survived the wire, and — via `n` — distinguish a reused warm worker from a freshly spawned one,
- * which is the entire property the pool exists to provide.
+ * The artifact for `ok` is `"<width>x<height>@<density>:<format>:<theme>:<seeds>:<docLen>#<n>"`,
+ * where `n` counts the requests **this process** has served. That lets a test assert the whole
+ * request survived the wire, and — via `n` — distinguish a reused warm worker from a freshly
+ * spawned one, which is the entire property the pool exists to provide.
  */
 object RcJvmWorkerPoolStub {
 
@@ -81,6 +81,7 @@ object RcJvmWorkerPoolStub {
       val height = input.readInt()
       val density = Float.fromBits(input.readInt())
       val format = input.readInt()
+      val theme = input.readInt()
       val seeds = String(input.readPayload(), Charsets.UTF_8)
       val doc = input.readPayload()
 
@@ -97,7 +98,9 @@ object RcJvmWorkerPoolStub {
 
       served++
       val formatName = if (format == RcJvmWorkerPool.WIRE_FORMAT_SVG) "svg" else "png"
-      val payload = "${width}x$height@$density:$formatName:$seeds:${doc.size}#$served".toByteArray()
+      val themeName = if (theme == RcJvmWorkerPool.WIRE_THEME_DARK) "dark" else "light"
+      val payload =
+        "${width}x$height@$density:$formatName:$themeName:$seeds:${doc.size}#$served".toByteArray()
       val status =
         if (mode == "failed") RcJvmWorkerPool.STATUS_FAILED else RcJvmWorkerPool.STATUS_OK
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RcJvmWorkerPoolTest.kt
@@ -42,10 +42,10 @@ class RcJvmWorkerPoolTest {
       val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
 
       // The spec, format and document length all survived the wire.
-      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#1", first.text())
       // `#2` is the point of the pool: the second document was drawn by the same process, so it
       // paid no JVM boot. A fresh worker would report `#1` again.
-      assertEquals("640x480@2.0:png::${DOC.size}#2", second.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#2", second.text())
     }
   }
 
@@ -53,7 +53,36 @@ class RcJvmWorkerPoolTest {
   fun seedsAndFormatReachTheWorker() {
     pool().use { pool ->
       val result = pool.render(DOC, SPEC, "float bmFtZQ== 1.5", RcJvmServerRenderer.Format.SVG)
-      assertEquals("640x480@2.0:svg:float bmFtZQ== 1.5:${DOC.size}#1", result.text())
+      assertEquals("640x480@2.0:svg:light:float bmFtZQ== 1.5:${DOC.size}#1", result.text())
+    }
+  }
+
+  @Test
+  fun theRequestedThemeReachesTheWorker() {
+    // The `ColorTheme` branch is a per-request property, not a property of the worker: one warm
+    // process serves light and dark requests in turn. A theme pinned at spawn — or dropped from the
+    // frame, which is what happened before it was carried — renders every document in one mode
+    // while the caller believes it asked for the other.
+    pool().use { pool ->
+      val dark =
+        pool.render(
+          DOC,
+          SPEC,
+          "",
+          RcJvmServerRenderer.Format.PNG,
+          RcJvmServerRenderer.RenderTheme.DARK,
+        )
+      val light =
+        pool.render(
+          DOC,
+          SPEC,
+          "",
+          RcJvmServerRenderer.Format.PNG,
+          RcJvmServerRenderer.RenderTheme.LIGHT,
+        )
+
+      assertEquals("640x480@2.0:png:dark::${DOC.size}#1", dark.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#2", light.text())
     }
   }
 
@@ -111,8 +140,8 @@ class RcJvmWorkerPoolTest {
       val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
       // Both report `#1`: the budget of one retired the first worker, so the second render was
       // served by a fresh process. This is what bounds a native leak.
-      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
-      assertEquals("640x480@2.0:png::${DOC.size}#1", second.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#1", first.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#1", second.text())
     }
   }
 
@@ -123,8 +152,8 @@ class RcJvmWorkerPoolTest {
       val first = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
       now += 5_000
       val second = pool.render(DOC, SPEC, "", RcJvmServerRenderer.Format.PNG)
-      assertEquals("640x480@2.0:png::${DOC.size}#1", first.text())
-      assertEquals("640x480@2.0:png::${DOC.size}#1", second.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#1", first.text())
+      assertEquals("640x480@2.0:png:light::${DOC.size}#1", second.text())
     }
   }
 

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -322,12 +322,13 @@ private fun RcComposePlayerResolved(
   systemColorLookup: (name: String) -> Int?,
 ) {
   val latestEventSink by rememberUpdatedState(onEvent)
+  val latestSystemColorLookup by rememberUpdatedState(systemColorLookup)
   val latestHapticFeedback by rememberUpdatedState(LocalHapticFeedback.current)
   var invalidationVersion by remember { mutableIntStateOf(0) }
   var wakeIntervalSeconds by remember(document) { mutableStateOf<Float?>(null) }
   var nextFrameRequestVersion by remember(document) { mutableIntStateOf(0) }
   val state =
-    remember(document, namedValues, systemColorLookup) {
+    remember(document, namedValues) {
       RcPlayerState(
         document,
         namedValues,
@@ -346,7 +347,12 @@ private fun RcComposePlayerResolved(
             RcPlayerEffect.NextFrame -> nextFrameRequestVersion += 1
           }
         },
-        systemColorLookup = systemColorLookup,
+        // Read through `latestSystemColorLookup`, never captured directly: a host's lookup is
+        // usually a capturing lambda, so a parent recomposition hands us a fresh instance. Keying
+        // the state on it would rebuild `RcPlayerState` — discarding variables an action changed,
+        // touch-expression state and running animation timelines — because a colour callback that
+        // resolves the same palette happened to be reallocated.
+        systemColorLookup = { name -> latestSystemColorLookup(name) },
       )
     }
   val needsContinuousFrames =

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -276,23 +276,50 @@ import org.jetbrains.skia.ImageInfo
 public fun RcComposePlayer(
   bytes: ByteArray,
   modifier: Modifier = Modifier,
-  theme: Int = RcTheme.UNSPECIFIED,
+  theme: Int = RcTheme.SYSTEM,
   namedValues: Map<String, RcNamedValue> = emptyMap(),
   onEvent: (RcPlayerEvent) -> Unit = {},
   fontFamilies: Map<String, RcFontFaces> = emptyMap(),
+  systemColorLookup: (name: String) -> Int? = { null },
 ) {
   val document = remember(bytes) { RcDocumentCodec.decode(bytes) }
-  RcComposePlayer(document, modifier, theme, namedValues, onEvent, fontFamilies)
+  RcComposePlayer(document, modifier, theme, namedValues, onEvent, fontFamilies, systemColorLookup)
 }
 
 @Composable
 public fun RcComposePlayer(
   document: RcDocument,
   modifier: Modifier = Modifier,
-  theme: Int = RcTheme.UNSPECIFIED,
+  theme: Int = RcTheme.SYSTEM,
   namedValues: Map<String, RcNamedValue> = emptyMap(),
   onEvent: (RcPlayerEvent) -> Unit = {},
   fontFamilies: Map<String, RcFontFaces> = emptyMap(),
+  systemColorLookup: (name: String) -> Int? = { null },
+) {
+  // Resolve once, at the only place that can: `SYSTEM` and `UNSPECIFIED` are questions for the
+  // host, and everything below this point — section gating, and every `ColorTheme` selection —
+  // needs a concrete answer. See [rcResolveSystemTheme] for why leaving them unresolved is not a
+  // neutral default.
+  RcComposePlayerResolved(
+    document,
+    modifier,
+    rcResolveSystemTheme(theme),
+    namedValues,
+    onEvent,
+    fontFamilies,
+    systemColorLookup,
+  )
+}
+
+@Composable
+private fun RcComposePlayerResolved(
+  document: RcDocument,
+  modifier: Modifier,
+  theme: Int,
+  namedValues: Map<String, RcNamedValue>,
+  onEvent: (RcPlayerEvent) -> Unit,
+  fontFamilies: Map<String, RcFontFaces>,
+  systemColorLookup: (name: String) -> Int?,
 ) {
   val latestEventSink by rememberUpdatedState(onEvent)
   val latestHapticFeedback by rememberUpdatedState(LocalHapticFeedback.current)
@@ -300,7 +327,7 @@ public fun RcComposePlayer(
   var wakeIntervalSeconds by remember(document) { mutableStateOf<Float?>(null) }
   var nextFrameRequestVersion by remember(document) { mutableIntStateOf(0) }
   val state =
-    remember(document, namedValues) {
+    remember(document, namedValues, systemColorLookup) {
       RcPlayerState(
         document,
         namedValues,
@@ -319,6 +346,7 @@ public fun RcComposePlayer(
             RcPlayerEffect.NextFrame -> nextFrameRequestVersion += 1
           }
         },
+        systemColorLookup = systemColorLookup,
       )
     }
   val needsContinuousFrames =

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcSystemTheme.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcSystemTheme.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.rcplayer.compose
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import ee.schimke.composeai.rcplayer.protocol.RcTheme
+
+/**
+ * Turn a requested theme into the concrete mode a `ColorTheme` selects with.
+ *
+ * [RcTheme.LIGHT] and [RcTheme.DARK] pass through — the caller has said which it wants.
+ * [RcTheme.SYSTEM] and [RcTheme.UNSPECIFIED] are both *questions*: one asks for the host's setting,
+ * the other says nothing at all. Neither is a mode, and both are answered here from
+ * [isSystemInDarkTheme].
+ *
+ * **Why they cannot be left alone.** Every consumer of a resolved theme branches the same way a
+ * `ColorTheme` operation does: light when the value is `LIGHT`, dark otherwise. That is a *branch*,
+ * not a default — pass `UNSPECIFIED` through it and the document renders dark, silently, without
+ * anything having decided that. A player whose caller did not name a mode should follow the
+ * platform, which is what a user changing their system theme expects and what the light/dark pair
+ * in the document is recorded for.
+ *
+ * `isSystemInDarkTheme` rather than an Android `Configuration` read: it is the Compose-level answer
+ * and it exists on every target this player runs on, so desktop, iOS, wasm and Android all resolve
+ * `SYSTEM` the same way instead of the JVM lanes quietly falling to one side.
+ */
+@Composable
+public fun rcResolveSystemTheme(theme: Int): Int =
+  when (theme) {
+    RcTheme.SYSTEM,
+    RcTheme.UNSPECIFIED -> if (isSystemInDarkTheme()) RcTheme.DARK else RcTheme.LIGHT
+    else -> theme
+  }

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcAndroidSystemColors.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcAndroidSystemColors.kt
@@ -1,0 +1,240 @@
+package ee.schimke.composeai.rcplayer.protocol
+
+/**
+ * The `android.R.color` resources a [RcColorTheme]'s light/dark **resource indices** name.
+ *
+ * A `ColorTheme` records four values per colour: a light and a dark resource index, and a light and
+ * a dark literal fallback. The fallback is what a host with no palette draws; the index is what a
+ * host *with* one is supposed to resolve. Nothing in the document says which `android.R.color` an
+ * index means — the mapping is this ordered list, and it is a wire contract, so entries are only
+ * ever appended.
+ *
+ * ## Why this is transcribed rather than derived
+ *
+ * The obvious shortcut is to read the creation-side constants (`Rc.AndroidColors`) reflectively and
+ * lowercase the field names. At `remote-compose` 1.0.0-alpha17 that is wrong for **21 of the 196
+ * indices**, and wrong silently:
+ * - `SYSTEM_ACCENT2_200` is `30`, colliding with `SYSTEM_ACCENT2_1000`, so index `31` has no
+ *   constant at all and index `30` resolves to whichever of the two the reflection order happens to
+ *   yield — a real resource, and the wrong colour.
+ * - Twenty names are misspelled against the resource they select: index `62` is `SYSTEM_ERROR_620`
+ *   where the resource is `system_error_10`, and the whole `system_neutral1_*` run (indices 78–90)
+ *   is spelled `SYSTEM_NEUTRAL78_0`, `SYSTEM_NEUTRAL79_790`, and so on. Those names match no
+ *   resource, so they resolve to nothing and the colour quietly stays on its fallback.
+ *
+ * The list below is the **player-side** table (`ThemeSupport.AndroidColors` in `remote-player-view`
+ * 1.0.0-alpha17), which is what actually resolves a document's indices on a device, and is
+ * therefore the authority regardless of what the creation-side constants are named.
+ */
+public object RcAndroidSystemColors {
+  /** The colour group a `ColorTheme` names to select this table — `Rc.AndroidColors.GROUP`. */
+  public const val GROUP: String = "android"
+
+  /** `android.R.color` resource names, indexed by the resource index a document records. */
+  public val NAMES: List<String> =
+    listOf(
+      "background_dark", // 0
+      "background_light", // 1
+      "black", // 2
+      "darker_gray", // 3
+      "holo_blue_bright", // 4
+      "holo_blue_dark", // 5
+      "holo_blue_light", // 6
+      "holo_green_dark", // 7
+      "holo_green_light", // 8
+      "holo_orange_dark", // 9
+      "holo_orange_light", // 10
+      "holo_purple", // 11
+      "holo_red_dark", // 12
+      "holo_red_light", // 13
+      "system_accent1_0", // 14
+      "system_accent1_10", // 15
+      "system_accent1_100", // 16
+      "system_accent1_1000", // 17
+      "system_accent1_200", // 18
+      "system_accent1_300", // 19
+      "system_accent1_400", // 20
+      "system_accent1_50", // 21
+      "system_accent1_500", // 22
+      "system_accent1_600", // 23
+      "system_accent1_700", // 24
+      "system_accent1_800", // 25
+      "system_accent1_900", // 26
+      "system_accent2_0", // 27
+      "system_accent2_10", // 28
+      "system_accent2_100", // 29
+      "system_accent2_1000", // 30
+      "system_accent2_200", // 31
+      "system_accent2_300", // 32
+      "system_accent2_400", // 33
+      "system_accent2_50", // 34
+      "system_accent2_500", // 35
+      "system_accent2_600", // 36
+      "system_accent2_700", // 37
+      "system_accent2_800", // 38
+      "system_accent2_900", // 39
+      "system_accent3_0", // 40
+      "system_accent3_10", // 41
+      "system_accent3_100", // 42
+      "system_accent3_1000", // 43
+      "system_accent3_200", // 44
+      "system_accent3_300", // 45
+      "system_accent3_400", // 46
+      "system_accent3_50", // 47
+      "system_accent3_500", // 48
+      "system_accent3_600", // 49
+      "system_accent3_700", // 50
+      "system_accent3_800", // 51
+      "system_accent3_900", // 52
+      "system_background_dark", // 53
+      "system_background_light", // 54
+      "system_control_activated_dark", // 55
+      "system_control_activated_light", // 56
+      "system_control_highlight_dark", // 57
+      "system_control_highlight_light", // 58
+      "system_control_normal_dark", // 59
+      "system_control_normal_light", // 60
+      "system_error_0", // 61
+      "system_error_10", // 62
+      "system_error_100", // 63
+      "system_error_1000", // 64
+      "system_error_200", // 65
+      "system_error_300", // 66
+      "system_error_400", // 67
+      "system_error_50", // 68
+      "system_error_500", // 69
+      "system_error_600", // 70
+      "system_error_700", // 71
+      "system_error_800", // 72
+      "system_error_900", // 73
+      "system_error_container_dark", // 74
+      "system_error_container_light", // 75
+      "system_error_dark", // 76
+      "system_error_light", // 77
+      "system_neutral1_0", // 78
+      "system_neutral1_10", // 79
+      "system_neutral1_100", // 80
+      "system_neutral1_1000", // 81
+      "system_neutral1_200", // 82
+      "system_neutral1_300", // 83
+      "system_neutral1_400", // 84
+      "system_neutral1_50", // 85
+      "system_neutral1_500", // 86
+      "system_neutral1_600", // 87
+      "system_neutral1_700", // 88
+      "system_neutral1_800", // 89
+      "system_neutral1_900", // 90
+      "system_neutral2_0", // 91
+      "system_neutral2_10", // 92
+      "system_neutral2_100", // 93
+      "system_neutral2_1000", // 94
+      "system_neutral2_200", // 95
+      "system_neutral2_300", // 96
+      "system_neutral2_400", // 97
+      "system_neutral2_50", // 98
+      "system_neutral2_500", // 99
+      "system_neutral2_600", // 100
+      "system_neutral2_700", // 101
+      "system_neutral2_800", // 102
+      "system_neutral2_900", // 103
+      "system_on_background_dark", // 104
+      "system_on_background_light", // 105
+      "system_on_error_container_dark", // 106
+      "system_on_error_container_light", // 107
+      "system_on_error_dark", // 108
+      "system_on_error_light", // 109
+      "system_on_primary_container_dark", // 110
+      "system_on_primary_container_light", // 111
+      "system_on_primary_dark", // 112
+      "system_on_primary_fixed", // 113
+      "system_on_primary_fixed_variant", // 114
+      "system_on_primary_light", // 115
+      "system_on_secondary_container_dark", // 116
+      "system_on_secondary_container_light", // 117
+      "system_on_secondary_dark", // 118
+      "system_on_secondary_fixed", // 119
+      "system_on_secondary_fixed_variant", // 120
+      "system_on_secondary_light", // 121
+      "system_on_surface_dark", // 122
+      "system_on_surface_disabled", // 123
+      "system_on_surface_light", // 124
+      "system_on_surface_variant_dark", // 125
+      "system_on_surface_variant_light", // 126
+      "system_on_tertiary_container_dark", // 127
+      "system_on_tertiary_container_light", // 128
+      "system_on_tertiary_dark", // 129
+      "system_on_tertiary_fixed", // 130
+      "system_on_tertiary_fixed_variant", // 131
+      "system_on_tertiary_light", // 132
+      "system_outline_dark", // 133
+      "system_outline_disabled", // 134
+      "system_outline_light", // 135
+      "system_outline_variant_dark", // 136
+      "system_outline_variant_light", // 137
+      "system_palette_key_color_neutral_dark", // 138
+      "system_palette_key_color_neutral_light", // 139
+      "system_palette_key_color_neutral_variant_dark", // 140
+      "system_palette_key_color_neutral_variant_light", // 141
+      "system_palette_key_color_primary_dark", // 142
+      "system_palette_key_color_primary_light", // 143
+      "system_palette_key_color_secondary_dark", // 144
+      "system_palette_key_color_secondary_light", // 145
+      "system_palette_key_color_tertiary_dark", // 146
+      "system_palette_key_color_tertiary_light", // 147
+      "system_primary_container_dark", // 148
+      "system_primary_container_light", // 149
+      "system_primary_dark", // 150
+      "system_primary_fixed", // 151
+      "system_primary_fixed_dim", // 152
+      "system_primary_light", // 153
+      "system_secondary_container_dark", // 154
+      "system_secondary_container_light", // 155
+      "system_secondary_dark", // 156
+      "system_secondary_fixed", // 157
+      "system_secondary_fixed_dim", // 158
+      "system_secondary_light", // 159
+      "system_surface_bright_dark", // 160
+      "system_surface_bright_light", // 161
+      "system_surface_container_dark", // 162
+      "system_surface_container_high_dark", // 163
+      "system_surface_container_high_light", // 164
+      "system_surface_container_highest_dark", // 165
+      "system_surface_container_highest_light", // 166
+      "system_surface_container_light", // 167
+      "system_surface_container_low_dark", // 168
+      "system_surface_container_low_light", // 169
+      "system_surface_container_lowest_dark", // 170
+      "system_surface_container_lowest_light", // 171
+      "system_surface_dark", // 172
+      "system_surface_dim_dark", // 173
+      "system_surface_dim_light", // 174
+      "system_surface_disabled", // 175
+      "system_surface_light", // 176
+      "system_surface_variant_dark", // 177
+      "system_surface_variant_light", // 178
+      "system_tertiary_container_dark", // 179
+      "system_tertiary_container_light", // 180
+      "system_tertiary_dark", // 181
+      "system_tertiary_fixed", // 182
+      "system_tertiary_fixed_dim", // 183
+      "system_tertiary_light", // 184
+      "system_text_hint_inverse_dark", // 185
+      "system_text_hint_inverse_light", // 186
+      "system_text_primary_inverse_dark", // 187
+      "system_text_primary_inverse_disable_only_dark", // 188
+      "system_text_primary_inverse_disable_only_light", // 189
+      "system_text_primary_inverse_light", // 190
+      "system_text_secondary_and_tertiary_inverse_dark", // 191
+      "system_text_secondary_and_tertiary_inverse_disabled_dark", // 192
+      "system_text_secondary_and_tertiary_inverse_disabled_light", // 193
+      "system_text_secondary_and_tertiary_inverse_light", // 194
+      "tab_indicator_text", // 195
+    )
+
+  /**
+   * The resource name at [index], or `null` when there is none — a negative index, which is how a
+   * document says "no resource for this mode", or an index past the end, which is a document
+   * written against a newer table than this player carries. Both mean "keep the fallback".
+   */
+  public fun nameAt(index: Int): String? = NAMES.getOrNull(index)
+}

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -550,13 +550,14 @@ public class RcPlayerState(
     val light = requestedTheme == RcTheme.LIGHT
     val index = if (light) operation.lightModeIndex else operation.darkModeIndex
     val fallback = if (light) operation.lightModeFallback else operation.darkModeFallback
+    // The group must resolve, by name, to the one whose table this is. An index means nothing
+    // without knowing whose table it indexes, so a document that names another vendor's group — or
+    // names none at all, which is how `colorGroupId = 0` reads — keeps its fallbacks rather than
+    // being recoloured out of Android's. `GenerateBaselineFixture` writes exactly such an
+    // operation, and the embedded player requires the name too, so anything looser would also make
+    // the two players disagree on the same bytes.
     val resolved =
-      if (
-        operation.colorGroupId != 0 &&
-          colorGroupName(operation.colorGroupId) != RcAndroidSystemColors.GROUP
-      ) {
-        // A group this player has no table for. An index means nothing without knowing whose table
-        // it indexes, so resolving it against the Android one would invent a colour.
+      if (colorGroupName(operation.colorGroupId) != RcAndroidSystemColors.GROUP) {
         null
       } else {
         RcAndroidSystemColors.nameAt(index)?.let(systemColorLookup)

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.rcplayer.runtime
 
+import ee.schimke.composeai.rcplayer.protocol.RcAndroidSystemColors
 import ee.schimke.composeai.rcplayer.protocol.RcBitmapData
 import ee.schimke.composeai.rcplayer.protocol.RcBooleanConstant
 import ee.schimke.composeai.rcplayer.protocol.RcClickArea
@@ -84,6 +85,13 @@ public class RcPlayerState(
   private val onInvalidated: () -> Unit = {},
   private val effectSink: (RcPlayerEffect) -> Unit = {},
   private val timeSource: RcTimeSource = RcTimeSource.System,
+  /**
+   * Host resolution for a `ColorTheme`'s recorded resource indices — see [applyColorTheme]. The
+   * default resolves nothing, which is correct for a host with no system palette to offer (a
+   * desktop JVM, a browser): every themed colour then renders as its captured fallback, exactly as
+   * it did before this parameter existed.
+   */
+  private val systemColorLookup: (name: String) -> Int? = { null },
 ) {
   private val floats = mutableMapOf<Int, Float>()
   private val componentValues =
@@ -523,13 +531,47 @@ public class RcPlayerState(
     setColor(operation.outId, result)
   }
 
+  /**
+   * Resolve one themed colour for [requestedTheme] and load it under the operation's output id.
+   *
+   * A `ColorTheme` carries, per mode, a **resource index** naming an `android.R.color` and a
+   * literal **fallback**. The fallback is what a host without that palette draws; the index is what
+   * a host with one is meant to read. [systemColorLookup] is that host — it maps a resource name to
+   * an ARGB value and returns `null` when the platform has no such resource, which is the ordinary
+   * case off Android and below API 34 rather than an error. When it returns `null` the captured
+   * fallback stands, so a document is never made worse by resolution being unavailable.
+   *
+   * [requestedTheme] must already be a concrete mode. `RcTheme.SYSTEM` and `RcTheme.UNSPECIFIED`
+   * mean "ask the host", and this is not the layer that can ask — resolve them before calling (the
+   * Compose player does it with `isSystemInDarkTheme`). Passing one through unresolved would select
+   * dark, because anything that is not `LIGHT` is dark here; that is the branch, not a default.
+   */
   public fun applyColorTheme(operation: RcColorTheme, requestedTheme: Int) {
-    setColor(
-      operation.outId,
-      if (requestedTheme == RcTheme.LIGHT) operation.lightModeFallback
-      else operation.darkModeFallback,
-    )
+    val light = requestedTheme == RcTheme.LIGHT
+    val index = if (light) operation.lightModeIndex else operation.darkModeIndex
+    val fallback = if (light) operation.lightModeFallback else operation.darkModeFallback
+    val resolved =
+      if (
+        operation.colorGroupId != 0 &&
+          colorGroupName(operation.colorGroupId) != RcAndroidSystemColors.GROUP
+      ) {
+        // A group this player has no table for. An index means nothing without knowing whose table
+        // it indexes, so resolving it against the Android one would invent a colour.
+        null
+      } else {
+        RcAndroidSystemColors.nameAt(index)?.let(systemColorLookup)
+      }
+    setColor(operation.outId, resolved ?: fallback)
   }
+
+  /**
+   * The colour group a themed colour names, or `null` when the document did not record one.
+   *
+   * The group reaches the wire as a text id rather than a string, so it is resolved the same way
+   * any other document text is.
+   */
+  private fun colorGroupName(colorGroupId: Int): String? =
+    texts[colorGroupId] ?: baseTexts[colorGroupId]
 
   public fun floatList(id: Int): RcFloatList? = floatLists[id]
 

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcColorThemeResolutionTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcColorThemeResolutionTest.kt
@@ -83,6 +83,27 @@ class RcColorThemeResolutionTest {
   }
 
   @Test
+  fun aDocumentThatNamesNoGroupIsLeftToItsFallbacks() {
+    // `colorGroupId = 0` is a document naming no table at all, not a document naming Android's.
+    // `GenerateBaselineFixture` writes exactly such an operation (group 0, index 0), so treating an
+    // absent group as Android would repaint it `background_dark` here while the embedded player —
+    // which requires the name — kept the fallback. Same bytes, two players, different colour.
+    val colorTheme =
+      RcColorTheme(
+        outId = 7,
+        colorGroupId = 0,
+        lightModeIndex = lightIndex,
+        darkModeIndex = darkIndex,
+        lightModeFallback = lightFallback,
+        darkModeFallback = darkFallback,
+      )
+    val state = state(colorTheme, lookup = lookup)
+    state.applyColorTheme(colorTheme, RcTheme.LIGHT)
+
+    assertEquals(lightFallback, state.color(colorTheme.outId))
+  }
+
+  @Test
   fun anUnresolvedThemeIsNotSilentlyDark() {
     // `SYSTEM` / `UNSPECIFIED` are questions for the host, and this layer cannot answer one, so the
     // Compose player resolves them before they arrive (`rcResolveSystemTheme`). This test states

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcColorThemeResolutionTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcColorThemeResolutionTest.kt
@@ -1,0 +1,121 @@
+package ee.schimke.composeai.rcplayer.runtime
+
+import ee.schimke.composeai.rcplayer.protocol.RcAndroidSystemColors
+import ee.schimke.composeai.rcplayer.protocol.RcColorTheme
+import ee.schimke.composeai.rcplayer.protocol.RcDocument
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
+import ee.schimke.composeai.rcplayer.protocol.RcOperation
+import ee.schimke.composeai.rcplayer.protocol.RcTextData
+import ee.schimke.composeai.rcplayer.protocol.RcTheme
+import ee.schimke.composeai.rcplayer.protocol.RcVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A `ColorTheme` records a resource *index* per mode as well as a literal fallback, and the index
+ * is the half a player has to ask its host about. These pin both halves: that the index is read at
+ * all, and that the mode chosen to read it for is the one the host asked for.
+ *
+ * The sentinels are colours nothing else in the document could produce, so "resolved the index" is
+ * distinguishable from "fell back" — which matters because falling back is *invisible*: the
+ * fallback is exactly what a host with no palette would have drawn, so a document that ignores its
+ * indices renders plausibly and silently stops following the system.
+ */
+class RcColorThemeResolutionTest {
+
+  private val lightSentinel = 0xFF00FF00.toInt()
+  private val darkSentinel = 0xFF0000FF.toInt()
+  private val lightFallback = 0xFF65558F.toInt()
+  private val darkFallback = 0xFFD0BCFF.toInt()
+
+  /** `system_primary_light` / `system_primary_dark`, the pair a Material 3 primary records. */
+  private val lightIndex = 153
+  private val darkIndex = 150
+
+  private val lookup: (String) -> Int? = { name ->
+    when (name) {
+      "system_primary_light" -> lightSentinel
+      "system_primary_dark" -> darkSentinel
+      else -> null
+    }
+  }
+
+  @Test
+  fun theTableNamesTheResourcesADocumentsIndicesRefersTo() {
+    // Order is a wire contract: a document records an index, so a shifted table recolours every
+    // themed document that has already been captured rather than failing loudly.
+    assertEquals(196, RcAndroidSystemColors.NAMES.size)
+    assertEquals("system_primary_light", RcAndroidSystemColors.nameAt(153))
+    assertEquals("system_primary_dark", RcAndroidSystemColors.nameAt(150))
+    assertEquals("system_surface_container_high_light", RcAndroidSystemColors.nameAt(164))
+    assertEquals("system_on_surface_dark", RcAndroidSystemColors.nameAt(122))
+    // The two entries the creation-side constants get wrong, pinned so a future "simplify this by
+    // reflecting over Rc.AndroidColors" reintroduces the bug loudly instead of silently.
+    assertEquals("system_accent2_1000", RcAndroidSystemColors.nameAt(30))
+    assertEquals("system_accent2_200", RcAndroidSystemColors.nameAt(31))
+    assertEquals("system_error_10", RcAndroidSystemColors.nameAt(62))
+    assertEquals("system_neutral1_0", RcAndroidSystemColors.nameAt(78))
+    // "No resource for this mode" and "written against a newer table" must both be quiet.
+    assertNull(RcAndroidSystemColors.nameAt(-1))
+    assertNull(RcAndroidSystemColors.nameAt(196))
+  }
+
+  @Test
+  fun eachModeResolvesItsOwnIndexThroughTheHost() {
+    assertEquals(lightSentinel, resolve(RcTheme.LIGHT, lookup))
+    assertEquals(darkSentinel, resolve(RcTheme.DARK, lookup))
+  }
+
+  @Test
+  fun anUnresolvableNameKeepsTheCapturedFallback() {
+    // The ordinary case off Android, and below API 34 on it. Not an error — the document must still
+    // render, in the colours it captured for exactly this situation.
+    assertEquals(lightFallback, resolve(RcTheme.LIGHT, { null }))
+    assertEquals(darkFallback, resolve(RcTheme.DARK, { null }))
+  }
+
+  @Test
+  fun anUnknownColorGroupIsLeftToItsFallbacks() {
+    // An index means nothing without knowing whose table it indexes. Resolving another vendor's
+    // group against the Android table would invent a colour rather than miss one.
+    assertEquals(lightFallback, resolve(RcTheme.LIGHT, lookup, group = "some-other-vendor"))
+  }
+
+  @Test
+  fun anUnresolvedThemeIsNotSilentlyDark() {
+    // `SYSTEM` / `UNSPECIFIED` are questions for the host, and this layer cannot answer one, so the
+    // Compose player resolves them before they arrive (`rcResolveSystemTheme`). This test states
+    // what the state layer does with one anyway — it takes the non-light branch — so that the
+    // reason resolution has to happen upstream stays written down: an unanswered question here is
+    // not a neutral default, it is a dark document.
+    assertEquals(darkSentinel, resolve(RcTheme.UNSPECIFIED, lookup))
+    assertEquals(darkSentinel, resolve(RcTheme.SYSTEM, lookup))
+  }
+
+  private fun resolve(
+    theme: Int,
+    systemColorLookup: (String) -> Int?,
+    group: String = RcAndroidSystemColors.GROUP,
+  ): Int {
+    val groupId = 43
+    val colorTheme =
+      RcColorTheme(
+        outId = 7,
+        colorGroupId = groupId,
+        lightModeIndex = lightIndex,
+        darkModeIndex = darkIndex,
+        lightModeFallback = lightFallback,
+        darkModeFallback = darkFallback,
+      )
+    val state = state(RcTextData(groupId, group), colorTheme, lookup = systemColorLookup)
+    state.applyColorTheme(colorTheme, theme)
+    return state.color(colorTheme.outId)
+  }
+
+  private fun state(vararg ops: RcOperation, lookup: (String) -> Int?) =
+    RcPlayerState(
+      RcDocument(RcHeader(RcVersion(1, 0, 0)), ops.toList()),
+      systemColorLookup = lookup,
+    )
+}

--- a/third_party/rc-embedded-player-jvm/build.gradle.kts
+++ b/third_party/rc-embedded-player-jvm/build.gradle.kts
@@ -58,6 +58,11 @@ val sharedPlayerSources =
     "androidx/compose/remote/player/compose/embedded/SnapshotRemoteComposeState.kt",
     // The platform-neutral `RemoteContext` — ported from `AndroidRemoteContext` minus `loadBitmap`.
     "androidx/compose/remote/player/compose/embedded/StoreBackedRemoteContext.kt",
+    // `ColorTheme` index -> `android.R.color` name table, plus the light/dark mode resolution both
+    // players share. Neutral: it names resources and resolves indices through a caller-supplied
+    // lookup, and never touches `Resources` itself — which is what lets this lane behave correctly
+    // (fallbacks, and a mode that was actually chosen) with no system palette to read.
+    "androidx/compose/remote/player/compose/embedded/ColorThemeResolution.kt",
     // Opaque image-loader handle, so the evaluator can carry one without naming `Drawable`.
     "androidx/compose/remote/player/compose/embedded/RcImageSource.kt",
     // The expression evaluator itself, and the composition locals the state path reads.

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFigmaSvgRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFigmaSvgRenderer.kt
@@ -19,6 +19,7 @@ package ee.schimke.composeai.rcembedded.jvm
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.remote.core.operations.Theme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
@@ -58,6 +59,8 @@ public fun renderRemoteDocumentToSvg(
   heightPx: Int,
   density: Float = 2f,
   seeds: Map<String, RcSeed> = emptyMap(),
+  theme: Int = Theme.LIGHT,
+  systemColorLookup: (name: String) -> Int? = { null },
 ): ByteArray {
   val rootDir = Files.createTempDirectory("rcjvm-svg-").toFile()
   val previewId = "rc-jvm"
@@ -75,7 +78,7 @@ public fun renderRemoteDocumentToSvg(
           )
         ) {
           val document = remember(bytes) { parseDocument(bytes) }
-          RcPlayerJvm(document, Modifier.fillMaxSize(), seeds)
+          RcPlayerJvm(document, Modifier.fillMaxSize(), seeds, theme, systemColorLookup)
         }
       }
     }

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderMain.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderMain.kt
@@ -16,6 +16,7 @@
 
 package ee.schimke.composeai.rcembedded.jvm
 
+import androidx.compose.remote.core.operations.Theme
 import java.io.File
 import kotlin.system.exitProcess
 
@@ -49,6 +50,10 @@ fun main(args: Array<String>) {
   val height = opts[ARG_HEIGHT]?.toIntOrNull()
   val density = opts[ARG_DENSITY]?.toFloatOrNull() ?: DEFAULT_DENSITY
   val format = opts[ARG_FORMAT]?.lowercase() ?: FORMAT_PNG
+  // `light` unless asked otherwise: a headless render has no desktop session whose theme it should
+  // follow, and one that changed colour with the build machine's OS setting would not be
+  // reproducible. `ColorTheme` is the only thing this selects — an unthemed document is unaffected.
+  val theme = if (opts[ARG_THEME]?.lowercase() == THEME_DARK) Theme.DARK else Theme.LIGHT
 
   if (input == null || output == null || width == null || height == null) {
     System.err.println(
@@ -87,8 +92,8 @@ fun main(args: Array<String>) {
   val artifact =
     try {
       when (format) {
-        FORMAT_SVG -> renderRemoteDocumentToSvg(bytes, width, height, density, seeds)
-        else -> renderRemoteDocumentToPng(bytes, width, height, density, seeds)
+        FORMAT_SVG -> renderRemoteDocumentToSvg(bytes, width, height, density, seeds, theme)
+        else -> renderRemoteDocumentToPng(bytes, width, height, density, seeds, theme)
       }
     } catch (t: Throwable) {
       // Any render failure — a malformed document, a missing native, an unsupported op — is
@@ -114,6 +119,8 @@ private const val ARG_HEIGHT = "--height"
 private const val ARG_DENSITY = "--density"
 private const val ARG_SEEDS = "--seeds"
 private const val ARG_FORMAT = "--format"
+private const val ARG_THEME = "--theme"
+private const val THEME_DARK = "dark"
 private const val FORMAT_PNG = "png"
 private const val FORMAT_SVG = "svg"
 private const val DEFAULT_DENSITY = 2f

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerMain.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerMain.kt
@@ -16,6 +16,7 @@
 
 package ee.schimke.composeai.rcembedded.jvm
 
+import androidx.compose.remote.core.operations.Theme
 import java.io.BufferedOutputStream
 import java.io.DataInputStream
 import java.io.DataOutputStream
@@ -55,7 +56,8 @@ import kotlin.system.exitProcess
  * pool -> worker, per request:
  *   int32 MAGIC_REQUEST, int32 requestId, int32 width, int32 height,
  *   int32 densityBits (Float.floatToIntBits), int32 format (0=png, 1=svg),
- *   int32 seedsLen, <seedsLen bytes UTF-8>, int32 docLen, <docLen bytes>
+ *   int32 theme (0=light, 1=dark), int32 seedsLen, <seedsLen bytes UTF-8>,
+ *   int32 docLen, <docLen bytes>
  * worker -> pool, per response:
  *   int32 MAGIC_RESPONSE, int32 requestId, int32 status (0=ok, 1=failed),
  *   int32 payloadLen, <payloadLen bytes>   // artifact bytes on ok, UTF-8 reason on failure
@@ -99,6 +101,11 @@ fun rcJvmRenderWorkerMain() {
     val height = input.readInt()
     val density = Float.fromBits(input.readInt())
     val format = input.readInt()
+    // Appended after `format` when the jvm player learned to select a `ColorTheme` mode. Both ends
+    // of this pipe are staged from the same build, so the frame is versioned by the build rather
+    // than negotiated — but the field is last so a frame read by an older worker would simply stop
+    // before it, which is the failure this ordering is chosen for.
+    val theme = if (input.readInt() == WIRE_THEME_DARK) Theme.DARK else Theme.LIGHT
     val seedsText = String(input.readPayload(), Charsets.UTF_8)
     val doc = input.readPayload()
 
@@ -108,8 +115,8 @@ fun rcJvmRenderWorkerMain() {
         val seeds = parseSeedText(seedsText)
         val artifact =
           when (format) {
-            WIRE_FORMAT_SVG -> renderRemoteDocumentToSvg(doc, width, height, density, seeds)
-            else -> renderRemoteDocumentToPng(doc, width, height, density, seeds)
+            WIRE_FORMAT_SVG -> renderRemoteDocumentToSvg(doc, width, height, density, seeds, theme)
+            else -> renderRemoteDocumentToPng(doc, width, height, density, seeds, theme)
           }
         Response(STATUS_OK, artifact)
       } catch (e: Exception) {
@@ -164,9 +171,16 @@ private fun DataInputStream.readPayload(): ByteArray {
 internal const val MAGIC_HELLO = 0x52435731
 internal const val MAGIC_REQUEST = 0x52435131
 internal const val MAGIC_RESPONSE = 0x52435231
-internal const val PROTOCOL_VERSION = 1
+// 2 adds the per-request `theme` field. The version is what makes a stale `lib-rcjvm/` sidecar fall
+// back to the one-shot path rather than mis-reading a frame it does not know the shape of, so it
+// has
+// to move whenever the frame does — a worker still speaking 1 would read `theme` as `seedsLen` and
+// desynchronise for good.
+internal const val PROTOCOL_VERSION = 2
 internal const val STATUS_OK = 0
 internal const val STATUS_FAILED = 1
+internal const val WIRE_THEME_LIGHT = 0
+internal const val WIRE_THEME_DARK = 1
 internal const val WIRE_FORMAT_PNG = 0
 internal const val WIRE_FORMAT_SVG = 1
 

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -33,6 +33,7 @@ import androidx.compose.remote.core.operations.ColorConstant
 import androidx.compose.remote.core.operations.ColorTheme
 import androidx.compose.remote.core.operations.FloatConstant
 import androidx.compose.remote.core.operations.NamedVariable
+import androidx.compose.remote.core.operations.Theme
 import androidx.compose.remote.core.operations.layout.Container
 import androidx.compose.remote.core.operations.layout.LayoutComponent
 import androidx.compose.remote.player.compose.embedded.GraphContext
@@ -49,6 +50,8 @@ import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
 import androidx.compose.remote.player.compose.embedded.recollectCollectionsReflection
 import androidx.compose.remote.player.compose.embedded.registerVariablesReflection
+import androidx.compose.remote.player.compose.embedded.resolveThemeMode
+import androidx.compose.remote.player.compose.embedded.resolveThemedColors
 import androidx.compose.remote.player.compose.embedded.updateTimeReflection
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -107,12 +110,14 @@ public fun renderRemoteDocumentToPng(
   heightPx: Int,
   density: Float = 2f,
   seeds: Map<String, RcSeed> = emptyMap(),
+  theme: Int = Theme.LIGHT,
+  systemColorLookup: (name: String) -> Int? = { null },
 ): ByteArray =
   Tracer.global.trace(category = RC_EMBEDDED_TRACE_DOCUMENT, name = "rcEmbedded:renderToPng") {
     val scene =
       ImageComposeScene(width = widthPx, height = heightPx, density = Density(density)) {
         val document = remember(bytes) { parseDocument(bytes) }
-        RcPlayerJvm(document, Modifier.fillMaxSize(), seeds)
+        RcPlayerJvm(document, Modifier.fillMaxSize(), seeds, theme, systemColorLookup)
       }
     try {
       // The composition, measure, layout and draw of the whole document all happen inside this
@@ -197,6 +202,8 @@ internal fun RcPlayerJvm(
   document: CoreDocument,
   modifier: Modifier = Modifier,
   seeds: Map<String, RcSeed> = emptyMap(),
+  theme: Int = Theme.LIGHT,
+  systemColorLookup: (name: String) -> Int? = { null },
 ) {
   val clock: RemoteClock =
     remember(document) { document.clock.takeUnless { it is SystemClock } ?: RemoteClock.SYSTEM }
@@ -207,7 +214,15 @@ internal fun RcPlayerJvm(
   val density = LocalDensity.current
   val remoteContext =
     remember(document) {
-      initDrawContext(document, clock, density.density, density.fontScale, seeds)
+      initDrawContext(
+        document,
+        clock,
+        density.density,
+        density.fontScale,
+        seeds,
+        theme,
+        systemColorLookup,
+      )
     }
 
   // Static capture: no frame loop. The time state is still provided so time-reading resolvers have
@@ -254,6 +269,8 @@ private fun initDrawContext(
   density: Float,
   fontScale: Float,
   seeds: Map<String, RcSeed>,
+  theme: Int,
+  systemColorLookup: (name: String) -> Int?,
 ): JvmRemoteContext =
   Tracer.global.trace(category = RC_EMBEDDED_TRACE_DOCUMENT, name = "rcEmbedded:initContext") {
     JvmRemoteContext(clock = clock).also { context ->
@@ -295,6 +312,22 @@ private fun initDrawContext(
           document.getOperationsReflection()
         }
       document.applyOperationsReflection(context, globalOps)
+
+      // Themed colours, before the `ColorTheme` ops in `constantOps` are applied — `ColorTheme`
+      // reads the fields resolution overwrites, so resolving afterwards is resolving too late.
+      //
+      // The mode is resolved rather than passed through: `SYSTEM`/`UNSPECIFIED` are questions, and
+      // `ColorTheme` treats anything that is not `LIGHT` as dark, so leaving one unanswered renders
+      // the document dark by accident. Headless, "the host's setting" is not a real question — this
+      // renderer has no desktop session whose theme it should follow, and a render that changed
+      // colour with the build machine's OS theme would not be reproducible — so `renderRemote
+      // DocumentToPng` defaults `theme` to `LIGHT` and a caller wanting dark asks for it.
+      //
+      // `systemColorLookup` defaults to resolving nothing, which is the honest answer here: there
+      // is no system palette off Android, so every themed colour keeps the fallback its document
+      // captured for exactly that case.
+      resolveThemedColors(document, systemColorLookup)
+      context.paintTheme = resolveThemeMode(theme, systemInDarkTheme = false)
 
       // Then every constant anywhere in the tree, so authored color/float defaults are in the
       // store before the data pass.

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerProtocolTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderWorkerProtocolTest.kt
@@ -134,6 +134,7 @@ class RcJvmRenderWorkerProtocolTest {
     toWorker.writeInt(HEIGHT)
     toWorker.writeInt(DENSITY.toRawBits())
     toWorker.writeInt(WIRE_FORMAT_PNG)
+    toWorker.writeInt(WIRE_THEME_LIGHT)
     toWorker.writeInt(seeds.size)
     toWorker.write(seeds)
     toWorker.writeInt(doc.size)

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -25,8 +25,9 @@ inside it. Vendoring is the only way to depend on it.
 ## What is vendored
 
 The player proper: the package root plus `layout/`, `modifier/`, and `state/` (42 upstream files,
-45 here — two local splits, `state/RcPlayerBitmapState.kt` and `RcPlayerShaders.kt`, plus the local
-`AndroidColorThemeResolver.kt`, each noted under "Local modifications" below). Upstream's
+46 here — two local splits, `state/RcPlayerBitmapState.kt` and `RcPlayerShaders.kt`, plus the local
+`AndroidColorThemeResolver.kt` and `ColorThemeResolution.kt`, each noted under "Local
+modifications" below). Upstream's
 `demos/`, `integration/previews/`, and the `androidx.wear.compose.remote.material3.previews` sample
 previews that live in the same source set are **not** vendored — they are demo/test scaffolding for
 the integration-test app, and they drag in Wear Material3 and `remote-creation-compose` capture.
@@ -84,12 +85,38 @@ the upstream tracking issue it was reported under.
   (`AndroidColorThemeResolver.kt`, `RcPlayer.kt`). Upstream's embedded player applies each
   `ColorTheme` operation but never performs the View player's preceding `ThemeSupport.mapColors`
   pass, so both light and dark branches retain their authored fallbacks. The embedded player now
-  maps the writer's `Rc.AndroidColors` indexes to framework `android.R.color` resources before its
-  first operation replay, retains the fallback for unknown groups or unavailable resources, and
-  exposes an explicit `theme` parameter that also reapplies colors when it changes. The paired
-  Robolectric conformance test authors one document through the public writer API and checks the
-  dark path against the AndroidX View player; light is deliberately excluded because alpha17's View
-  player has a separate cold-start light-theme bug.
+  maps the index to a framework `android.R.color` resource before its first operation replay,
+  retains the fallback for unknown groups or unavailable resources, and exposes an explicit `theme`
+  parameter that also reapplies colors when it changes. The paired Robolectric conformance test
+  authors one document through the public writer API and checks the dark path against the AndroidX
+  View player; light is deliberately excluded because alpha17's View player has a separate
+  cold-start light-theme bug.
+
+  Two follow-ups, both from not taking the AndroidX pieces on trust:
+
+  - **The index table is transcribed, not derived** (`ColorThemeResolution.kt`). Deriving it by
+    reflecting over `Rc.AndroidColors` and lowercasing the field names — which is how this started
+    — is wrong for **21 of the 196 indices** at alpha17. `SYSTEM_ACCENT2_200` is `30`, colliding
+    with `SYSTEM_ACCENT2_1000`, so index `31` has no constant and index `30` resolves to whichever
+    field reflection yields: a real resource, and the wrong colour. Twenty more are misspelled
+    against the resource they select (`SYSTEM_ERROR_620` at index `62`, where the resource is
+    `system_error_10`; the whole `system_neutral1_*` run at 78–90 spelled `SYSTEM_NEUTRAL78_0`,
+    `SYSTEM_NEUTRAL79_790`, …), so they match nothing and the colour keeps its fallback with no
+    diagnostic. The table now comes from `ThemeSupport.AndroidColors` in `remote-player-view`,
+    which is what actually resolves indices on a device. `AndroidColorTableDriftTest` keeps it
+    equal to the CMP player's copy in `:rc-player-protocol`.
+
+  - **`SYSTEM` / `UNSPECIFIED` are resolved to a real mode** (`resolveThemeMode`, used by
+    `RcPlayer` and the jvm renderer). `theme` used to default to `Theme.UNSPECIFIED` and be
+    assigned straight to `paintTheme`, and `ColorTheme.apply` selects light only for `Theme.LIGHT`
+    — so the default rendered every themed document *dark*, having just resolved the light palette
+    correctly. Measured on a themed document, the embedded lane drew `#292A2D`
+    (`system_surface_container_high_dark`) where the View lane drew `#E9E7EC`
+    (`…_high_light`); both now draw `#E9E7EC`. The default is `Theme.SYSTEM`, answered from
+    `isSystemInDarkTheme()` rather than from a `Configuration` read, so every player resolves it
+    the same way — the View player's own rule (an SDK-33-guarded `Configuration.isNightModeActive`,
+    with `UNSPECIFIED` falling through to dark) is where the divergence was found, not the
+    specification it was fixed against.
 
 ### Resolved: the two action-dispatch deltas (restored at alpha17)
 

--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -113,6 +113,20 @@ tasks.withType<Test>().configureEach {
   }
   // Robolectric's NATIVE graphics mode needs a real heap to rasterize into.
   maxHeapSize = "2g"
+
+  // `AndroidColorTableDriftTest` compares this module's `ColorTheme` index table against the CMP
+  // player's copy, which lives in another project and is therefore not otherwise an input to these
+  // tests. Without this the task stays UP-TO-DATE when only the sibling changes, and the guard
+  // silently stops guarding — which is the exact failure mode it exists to catch.
+  inputs
+    .file(
+      layout.settingsDirectory.file(
+        "rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/" +
+          "RcAndroidSystemColors.kt"
+      )
+    )
+    .withPropertyName("cmpAndroidColorTable")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
 }
 
 dependencies {

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/AndroidColorThemeResolver.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/AndroidColorThemeResolver.kt
@@ -16,38 +16,28 @@
 
 package androidx.compose.remote.player.compose.embedded
 
+import android.annotation.SuppressLint
 import android.content.Context
 import androidx.compose.remote.core.CoreDocument
 
-/** Resolves the indexed `android` ColorTheme group the same way the View player does. */
+/**
+ * Resolves the indexed `android` `ColorTheme` group against framework resources — the embedded
+ * player's equivalent of `ThemeSupport.AndroidColorEngine` in `remote-player-view`.
+ *
+ * Resolved by *name* rather than through `android.R.color.<name>`: the table spans resources
+ * introduced across API 31–34, so a name lookup degrades to "not found" on a device that predates
+ * one instead of tying this module to the compileSdk that first declared it.
+ */
+@SuppressLint("DiscouragedApi")
 internal fun resolveAndroidThemeColors(context: Context, document: CoreDocument) {
-  val indexedColorNames = runCatching {
-    Class.forName("androidx.compose.remote.creation.Rc\$AndroidColors")
-  }
-    .getOrNull()
-    ?.fields
-    ?.mapNotNull { field ->
-      if (field.type == Short::class.javaPrimitiveType) field.getShort(null).toInt() to field.name
-      else null
+  val resources = context.resources
+  resolveThemedColors(document) { name ->
+    when (val id = resources.getIdentifier(name, "color", "android")) {
+      0 -> null
+      // `getColor(id, null)`: these are plain colour resources, not theme attributes, so there is
+      // no theme to resolve against — and supplying one would let the *device's* night mode pick
+      // between them, which is the choice the document's own light/dark indices exist to make.
+      else -> runCatching { resources.getColor(id, null) }.getOrNull()
     }
-    ?.toMap()
-    .orEmpty()
-
-  document.themedColors.orEmpty().forEach { colorTheme ->
-    if (colorTheme.mColorGroupName != ANDROID_COLOR_GROUP) return@forEach
-
-    fun resolve(index: Short, fallback: Int): Int {
-      val name = indexedColorNames[index.toInt()]?.lowercase() ?: return fallback
-      return runCatching {
-          val resourceId = android.R.color::class.java.getField(name).getInt(null)
-          context.getColor(resourceId)
-        }
-        .getOrDefault(fallback)
-    }
-
-    colorTheme.mLightMode = resolve(colorTheme.mLightModeIndex, colorTheme.mLightModeFallback)
-    colorTheme.mDarkMode = resolve(colorTheme.mDarkModeIndex, colorTheme.mDarkModeFallback)
   }
 }
-
-private const val ANDROID_COLOR_GROUP = "android"

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ColorThemeResolution.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/ColorThemeResolution.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.operations.Theme
+
+/** The colour group whose indices [ANDROID_COLOR_NAMES] names. */
+internal const val ANDROID_COLOR_GROUP: String = "android"
+
+/**
+ * `android.R.color` resource names, indexed by the resource index a document records.
+ *
+ * Transcribed from `ThemeSupport.AndroidColors` in `remote-player-view` 1.0.0-alpha17 — the table
+ * the View player actually resolves a document's indices against, and therefore the authority.
+ *
+ * **Not derived from `Rc.AndroidColors` reflectively**, which is what this file did first and is
+ * the obvious-looking shortcut. At alpha17 those creation-side constants are wrong for 21 of the
+ * 196 indices, and wrong quietly: `SYSTEM_ACCENT2_200` is `30`, colliding with
+ * `SYSTEM_ACCENT2_1000`, so index `31` has no constant and index `30` resolves to whichever field
+ * reflection happens to yield — a real resource, and the wrong colour. Twenty more are misspelled
+ * against the resource they select (`SYSTEM_ERROR_620` at index `62`, where the resource is
+ * `system_error_10`; the entire `system_neutral1_*` run at 78–90 spelled `SYSTEM_NEUTRAL78_0`,
+ * `SYSTEM_NEUTRAL79_790`, …), so they match nothing and the colour silently keeps its fallback.
+ *
+ * Kept in sync with `RcAndroidSystemColors` in `:rc-player-protocol` by
+ * `AndroidColorTableDriftTest` — the two players must read a given index as the same resource, and
+ * the module boundary means the table cannot simply be shared.
+ */
+internal val ANDROID_COLOR_NAMES: List<String> =
+  listOf(
+    "background_dark", // 0
+    "background_light", // 1
+    "black", // 2
+    "darker_gray", // 3
+    "holo_blue_bright", // 4
+    "holo_blue_dark", // 5
+    "holo_blue_light", // 6
+    "holo_green_dark", // 7
+    "holo_green_light", // 8
+    "holo_orange_dark", // 9
+    "holo_orange_light", // 10
+    "holo_purple", // 11
+    "holo_red_dark", // 12
+    "holo_red_light", // 13
+    "system_accent1_0", // 14
+    "system_accent1_10", // 15
+    "system_accent1_100", // 16
+    "system_accent1_1000", // 17
+    "system_accent1_200", // 18
+    "system_accent1_300", // 19
+    "system_accent1_400", // 20
+    "system_accent1_50", // 21
+    "system_accent1_500", // 22
+    "system_accent1_600", // 23
+    "system_accent1_700", // 24
+    "system_accent1_800", // 25
+    "system_accent1_900", // 26
+    "system_accent2_0", // 27
+    "system_accent2_10", // 28
+    "system_accent2_100", // 29
+    "system_accent2_1000", // 30
+    "system_accent2_200", // 31
+    "system_accent2_300", // 32
+    "system_accent2_400", // 33
+    "system_accent2_50", // 34
+    "system_accent2_500", // 35
+    "system_accent2_600", // 36
+    "system_accent2_700", // 37
+    "system_accent2_800", // 38
+    "system_accent2_900", // 39
+    "system_accent3_0", // 40
+    "system_accent3_10", // 41
+    "system_accent3_100", // 42
+    "system_accent3_1000", // 43
+    "system_accent3_200", // 44
+    "system_accent3_300", // 45
+    "system_accent3_400", // 46
+    "system_accent3_50", // 47
+    "system_accent3_500", // 48
+    "system_accent3_600", // 49
+    "system_accent3_700", // 50
+    "system_accent3_800", // 51
+    "system_accent3_900", // 52
+    "system_background_dark", // 53
+    "system_background_light", // 54
+    "system_control_activated_dark", // 55
+    "system_control_activated_light", // 56
+    "system_control_highlight_dark", // 57
+    "system_control_highlight_light", // 58
+    "system_control_normal_dark", // 59
+    "system_control_normal_light", // 60
+    "system_error_0", // 61
+    "system_error_10", // 62
+    "system_error_100", // 63
+    "system_error_1000", // 64
+    "system_error_200", // 65
+    "system_error_300", // 66
+    "system_error_400", // 67
+    "system_error_50", // 68
+    "system_error_500", // 69
+    "system_error_600", // 70
+    "system_error_700", // 71
+    "system_error_800", // 72
+    "system_error_900", // 73
+    "system_error_container_dark", // 74
+    "system_error_container_light", // 75
+    "system_error_dark", // 76
+    "system_error_light", // 77
+    "system_neutral1_0", // 78
+    "system_neutral1_10", // 79
+    "system_neutral1_100", // 80
+    "system_neutral1_1000", // 81
+    "system_neutral1_200", // 82
+    "system_neutral1_300", // 83
+    "system_neutral1_400", // 84
+    "system_neutral1_50", // 85
+    "system_neutral1_500", // 86
+    "system_neutral1_600", // 87
+    "system_neutral1_700", // 88
+    "system_neutral1_800", // 89
+    "system_neutral1_900", // 90
+    "system_neutral2_0", // 91
+    "system_neutral2_10", // 92
+    "system_neutral2_100", // 93
+    "system_neutral2_1000", // 94
+    "system_neutral2_200", // 95
+    "system_neutral2_300", // 96
+    "system_neutral2_400", // 97
+    "system_neutral2_50", // 98
+    "system_neutral2_500", // 99
+    "system_neutral2_600", // 100
+    "system_neutral2_700", // 101
+    "system_neutral2_800", // 102
+    "system_neutral2_900", // 103
+    "system_on_background_dark", // 104
+    "system_on_background_light", // 105
+    "system_on_error_container_dark", // 106
+    "system_on_error_container_light", // 107
+    "system_on_error_dark", // 108
+    "system_on_error_light", // 109
+    "system_on_primary_container_dark", // 110
+    "system_on_primary_container_light", // 111
+    "system_on_primary_dark", // 112
+    "system_on_primary_fixed", // 113
+    "system_on_primary_fixed_variant", // 114
+    "system_on_primary_light", // 115
+    "system_on_secondary_container_dark", // 116
+    "system_on_secondary_container_light", // 117
+    "system_on_secondary_dark", // 118
+    "system_on_secondary_fixed", // 119
+    "system_on_secondary_fixed_variant", // 120
+    "system_on_secondary_light", // 121
+    "system_on_surface_dark", // 122
+    "system_on_surface_disabled", // 123
+    "system_on_surface_light", // 124
+    "system_on_surface_variant_dark", // 125
+    "system_on_surface_variant_light", // 126
+    "system_on_tertiary_container_dark", // 127
+    "system_on_tertiary_container_light", // 128
+    "system_on_tertiary_dark", // 129
+    "system_on_tertiary_fixed", // 130
+    "system_on_tertiary_fixed_variant", // 131
+    "system_on_tertiary_light", // 132
+    "system_outline_dark", // 133
+    "system_outline_disabled", // 134
+    "system_outline_light", // 135
+    "system_outline_variant_dark", // 136
+    "system_outline_variant_light", // 137
+    "system_palette_key_color_neutral_dark", // 138
+    "system_palette_key_color_neutral_light", // 139
+    "system_palette_key_color_neutral_variant_dark", // 140
+    "system_palette_key_color_neutral_variant_light", // 141
+    "system_palette_key_color_primary_dark", // 142
+    "system_palette_key_color_primary_light", // 143
+    "system_palette_key_color_secondary_dark", // 144
+    "system_palette_key_color_secondary_light", // 145
+    "system_palette_key_color_tertiary_dark", // 146
+    "system_palette_key_color_tertiary_light", // 147
+    "system_primary_container_dark", // 148
+    "system_primary_container_light", // 149
+    "system_primary_dark", // 150
+    "system_primary_fixed", // 151
+    "system_primary_fixed_dim", // 152
+    "system_primary_light", // 153
+    "system_secondary_container_dark", // 154
+    "system_secondary_container_light", // 155
+    "system_secondary_dark", // 156
+    "system_secondary_fixed", // 157
+    "system_secondary_fixed_dim", // 158
+    "system_secondary_light", // 159
+    "system_surface_bright_dark", // 160
+    "system_surface_bright_light", // 161
+    "system_surface_container_dark", // 162
+    "system_surface_container_high_dark", // 163
+    "system_surface_container_high_light", // 164
+    "system_surface_container_highest_dark", // 165
+    "system_surface_container_highest_light", // 166
+    "system_surface_container_light", // 167
+    "system_surface_container_low_dark", // 168
+    "system_surface_container_low_light", // 169
+    "system_surface_container_lowest_dark", // 170
+    "system_surface_container_lowest_light", // 171
+    "system_surface_dark", // 172
+    "system_surface_dim_dark", // 173
+    "system_surface_dim_light", // 174
+    "system_surface_disabled", // 175
+    "system_surface_light", // 176
+    "system_surface_variant_dark", // 177
+    "system_surface_variant_light", // 178
+    "system_tertiary_container_dark", // 179
+    "system_tertiary_container_light", // 180
+    "system_tertiary_dark", // 181
+    "system_tertiary_fixed", // 182
+    "system_tertiary_fixed_dim", // 183
+    "system_tertiary_light", // 184
+    "system_text_hint_inverse_dark", // 185
+    "system_text_hint_inverse_light", // 186
+    "system_text_primary_inverse_dark", // 187
+    "system_text_primary_inverse_disable_only_dark", // 188
+    "system_text_primary_inverse_disable_only_light", // 189
+    "system_text_primary_inverse_light", // 190
+    "system_text_secondary_and_tertiary_inverse_dark", // 191
+    "system_text_secondary_and_tertiary_inverse_disabled_dark", // 192
+    "system_text_secondary_and_tertiary_inverse_disabled_light", // 193
+    "system_text_secondary_and_tertiary_inverse_light", // 194
+    "tab_indicator_text", // 195
+  )
+
+/**
+ * Resolve [document]'s themed colours through [lookup], overwriting each operation's
+ * `mLightMode`/`mDarkMode` in place, and return how many modes resolved.
+ *
+ * Call this **before** the document's `ColorTheme` operations are applied: `ColorTheme.apply` reads
+ * `mLightMode`/`mDarkMode` — values its constructor seeded from the captured *fallbacks* — so
+ * resolving afterwards leaves the fallback already loaded into the context.
+ *
+ * [lookup] maps an `android.R.color` name to an ARGB value and returns `null` when the running
+ * platform has no such resource. `null`, a negative index (how a document says "no resource for
+ * this mode"), or an index past the end of the table all leave that mode's captured fallback in
+ * place, so resolution failing never makes a document render worse than it did before.
+ *
+ * Only the [ANDROID_COLOR_GROUP] group is resolved: an index means nothing without knowing whose
+ * table it indexes, so another vendor's group keeps its fallbacks rather than being resolved
+ * against Android's.
+ *
+ * Platform-neutral on purpose — the JVM lane shares this file and supplies its own [lookup] (or
+ * none, which is the honest answer for a headless renderer with no system palette).
+ */
+internal fun resolveThemedColors(document: CoreDocument, lookup: (name: String) -> Int?): Int {
+  var resolved = 0
+  document.themedColors.orEmpty().forEach { colorTheme ->
+    if (colorTheme.mColorGroupName != ANDROID_COLOR_GROUP) return@forEach
+    fun resolve(index: Short): Int? = ANDROID_COLOR_NAMES.getOrNull(index.toInt())?.let(lookup)
+    resolve(colorTheme.mLightModeIndex)?.let {
+      colorTheme.mLightMode = it
+      resolved++
+    }
+    resolve(colorTheme.mDarkModeIndex)?.let {
+      colorTheme.mDarkMode = it
+      resolved++
+    }
+  }
+  return resolved
+}
+
+/**
+ * Turn a requested theme into the concrete mode a `ColorTheme` selects with.
+ *
+ * [Theme.LIGHT] and [Theme.DARK] pass through. [Theme.SYSTEM] and [Theme.UNSPECIFIED] are not modes
+ * but questions — one asks for the host's setting, the other says nothing — and both are answered
+ * from [systemInDarkTheme].
+ *
+ * Neither may be passed through to the operation. `ColorTheme.apply` selects light only for
+ * `Theme.LIGHT` and dark for everything else, so an unanswered question renders the whole document
+ * dark with nothing having decided that — which is not a conservative default, it is a wrong one.
+ */
+internal fun resolveThemeMode(theme: Int, systemInDarkTheme: Boolean): Int =
+  when (theme) {
+    Theme.SYSTEM,
+    Theme.UNSPECIFIED -> if (systemInDarkTheme) Theme.DARK else Theme.LIGHT
+    else -> theme
+  }

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -32,6 +32,7 @@ import androidx.collection.ObjectIntMap
 import androidx.collection.emptyIntObjectMap
 import androidx.collection.emptyObjectIntMap
 import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.Limits
 import androidx.compose.remote.core.Operation
@@ -103,6 +104,11 @@ import java.io.ByteArrayInputStream
  * [theme] selects the `ColorTheme` light/dark branch. Indexed colors in the Android group are
  * resolved from framework resources before the first operation replay; unknown groups or missing
  * resources retain their authored fallback.
+ *
+ * [Theme.SYSTEM] — the default — and [Theme.UNSPECIFIED] are not modes, they are questions, and
+ * both are answered here from `isSystemInDarkTheme()`. They cannot be passed through: `ColorTheme`
+ * selects light only for `Theme.LIGHT` and dark for everything else, so an unanswered question
+ * renders the whole document dark without anything having chosen that.
  */
 @OptIn(ExperimentalRemotePlayerApi::class)
 @SuppressLint("RestrictedApiAndroidX")
@@ -111,7 +117,7 @@ import java.io.ByteArrayInputStream
 public fun RcPlayer(
   document: CoreDocument,
   modifier: Modifier = Modifier,
-  theme: Int = Theme.UNSPECIFIED,
+  theme: Int = Theme.SYSTEM,
   namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
   imageLoader: RcImageLoader? = null,
   isShaderValid: (shaderSource: String) -> Boolean = { true },
@@ -128,6 +134,11 @@ public fun RcPlayer(
       document.clock
     }
   }
+
+  // `SYSTEM` / `UNSPECIFIED` become a concrete mode here, once, before anything branches on them.
+  val systemInDarkTheme = isSystemInDarkTheme()
+  val resolvedTheme =
+    remember(theme, systemInDarkTheme) { resolveThemeMode(theme, systemInDarkTheme) }
 
   val density = LocalDensity.current
   val context = LocalContext.current
@@ -153,7 +164,7 @@ public fun RcPlayer(
       it.density = density.density
       document.initializeContext(it)
       resolveAndroidThemeColors(context, document)
-      it.paintTheme = theme
+      it.paintTheme = resolvedTheme
 
       // Register each bitmap's metadata (declared width/height for ImageAttribute, and
       // discoverability for the lazy decode) WITHOUT decoding the pixels. The costly decode
@@ -240,9 +251,9 @@ public fun RcPlayer(
     }
   }
 
-  LaunchedEffect(remoteContext, theme) {
-    document.themedColors.orEmpty().forEach { it.setTheme(remoteContext, theme) }
-    remoteContext.paintTheme = theme
+  LaunchedEffect(remoteContext, resolvedTheme) {
+    document.themedColors.orEmpty().forEach { it.setTheme(remoteContext, resolvedTheme) }
+    remoteContext.paintTheme = resolvedTheme
   }
 
   // Time and animations are driven on demand. A static document — no declared animations and no
@@ -468,7 +479,7 @@ public fun RcPlayer(
 public fun RcPlayer(
   capturedDocument: CapturedDocument,
   modifier: Modifier = Modifier,
-  theme: Int = Theme.UNSPECIFIED,
+  theme: Int = Theme.SYSTEM,
   namedColorOverrides: ObjectIntMap<String> = emptyObjectIntMap(),
   imageLoader: RcImageLoader? = null,
   isShaderValid: (shaderSource: String) -> Boolean = { true },

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/AndroidColorTableDriftTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/AndroidColorTableDriftTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The `ColorTheme` index → `android.R.color` name table exists twice, and the two copies must
+ * agree.
+ *
+ * A document records an *index*, so the table is how a player decides which resource that index
+ * meant. The embedded player carries it in `ColorThemeResolution.kt` and the CMP player carries it
+ * in `:rc-player-protocol`'s `RcAndroidSystemColors`; neither module can depend on the other (one
+ * is an Android library in a vendored AOSP package, the other is KMP with no Android target), so
+ * the duplication is structural. What must not be structural is *drift*: two players reading the
+ * same index as different resources would show up as a colour difference between render lanes, with
+ * nothing in either file looking wrong.
+ *
+ * Compared as source text rather than as loaded classes because only one of the two is on this
+ * module's classpath. Reading sources off disk is the same technique `PlatformNeutralSourcesTest`
+ * uses here.
+ */
+class AndroidColorTableDriftTest {
+
+  @Test
+  fun bothPlayersReadAnIndexAsTheSameResource() {
+    val embedded =
+      names(
+        repoFile(
+          "third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/" +
+            "compose/embedded/ColorThemeResolution.kt"
+        ),
+        marker = "internal val ANDROID_COLOR_NAMES",
+      )
+    val cmp =
+      names(
+        repoFile(
+          "rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/" +
+            "RcAndroidSystemColors.kt"
+        ),
+        marker = "public val NAMES",
+      )
+
+    assertTrue("embedded table looks empty — did the marker or the file move?", embedded.size > 100)
+    assertEquals("the two tables disagree on their length", embedded.size, cmp.size)
+    embedded.indices.forEach { index ->
+      assertEquals(
+        "index $index names a different resource in each player",
+        embedded[index],
+        cmp[index],
+      )
+    }
+  }
+
+  /**
+   * The quoted string literals of the `listOf(...)` that follows [marker]. Deliberately dumb: it
+   * reads the same characters a reviewer would, so a table edited in one file and not the other
+   * fails here rather than in a render.
+   */
+  private fun names(file: File, marker: String): List<String> {
+    val text = file.readText()
+    val start = text.indexOf(marker)
+    require(start >= 0) { "no `$marker` in ${file.path}" }
+    val open = text.indexOf("listOf(", start)
+    require(open >= 0) { "no listOf(...) after `$marker` in ${file.path}" }
+    // Balanced scan rather than a closing-brace pattern: the two files indent their tables
+    // differently, and a test that only works at one indentation is a test that stops running the
+    // first time someone reformats.
+    var depth = 0
+    var close = -1
+    for (i in text.indices.drop(open + "listOf".length)) {
+      when (text[i]) {
+        '(' -> depth++
+        ')' -> if (--depth == 0) close = i
+      }
+      if (close >= 0) break
+    }
+    require(close > open) { "unbalanced listOf(...) after `$marker` in ${file.path}" }
+    return Regex("\"([a-z0-9_]+)\"")
+      .findAll(text.substring(open, close))
+      .map { it.groupValues[1] }
+      .toList()
+  }
+
+  /**
+   * Walk up from the working directory to the repository root. Gradle runs unit tests with the
+   * *module* directory as the working directory, and this test reads a file from a sibling module.
+   */
+  private fun repoFile(relative: String): File {
+    var dir: File? = File("").absoluteFile
+    while (dir != null) {
+      val candidate = File(dir, relative)
+      if (candidate.isFile) return candidate
+      dir = dir.parentFile
+    }
+    throw AssertionError("could not locate $relative from ${File("").absolutePath}")
+  }
+}


### PR DESCRIPTION
A `ColorTheme` operation records, per mode, an `android.R.color` **resource index** and a literal **fallback**. #3952 taught the vendored embedded player to read the index. This carries that to the CMP player and the jvm renderer, and fixes three ways the reading was still wrong.

None of them is visible in isolation, which is why each needed measuring rather than reading: a document whose index does not resolve renders as its fallback, and the fallback is exactly what a host with no palette would have drawn.

## The index table is transcribed, not derived

`AndroidColorThemeResolver` built its index → name map by reflecting over the creation-side `Rc.AndroidColors` constants. Those are wrong for **21 of the 196 indices** at `1.0.0-alpha17`:

- `SYSTEM_ACCENT2_200` is `30`, colliding with `SYSTEM_ACCENT2_1000` — so index `31` has no constant at all, and index `30` resolves to whichever field reflection yields: a real resource, and the wrong colour.
- Twenty names are misspelled against the resource they select — `SYSTEM_ERROR_620` at index `62` where the resource is `system_error_10`, and the entire `system_neutral1_*` run at 78–90 spelled `SYSTEM_NEUTRAL78_0`, `SYSTEM_NEUTRAL79_790`, … Those match no resource, so the colour quietly keeps its fallback.

The table now comes from `ThemeSupport.AndroidColors` in `remote-player-view`, which is what actually resolves a document's indices on a device.

## `SYSTEM` / `UNSPECIFIED` are resolved to a real mode

`theme` defaulted to `Theme.UNSPECIFIED` and was assigned straight to `paintTheme`. `ColorTheme.apply` selects light only for `Theme.LIGHT` and dark for everything else — so the default rendered every themed document **dark**, immediately after resolving the light palette correctly. Same document, same host:

| lane | pixel | resource |
| --- | --- | --- |
| embedded, before #3952 | `#E6E0E9` | captured fallback — index never read |
| embedded, `main` today | `#292A2D` | `system_surface_container_high_dark` |
| view player | `#E9E7EC` | `system_surface_container_high_light` |
| **embedded, this PR** | **`#E9E7EC`** | `system_surface_container_high_light` |

`Theme.SYSTEM` is now the default and is answered from `isSystemInDarkTheme()`, so every player resolves it identically. The view player's own rule (an SDK-33-guarded `Configuration.isNightModeActive`, with `UNSPECIFIED` falling through to dark) is where the divergence was found, not the specification it was fixed against.

## The requested mode reaches the cmp-jvm lane

`renderRemoteDocumentToPng` gained a theme while `renderRemoteDocumentToSvg` did not, so the SVG path silently took the new light default with no way to override — and neither `RcJvmRenderSpec` nor the worker frame carried a mode at all, so a `?uiMode=dark` request rendered the light branch. It is threaded end to end now: `uiMode` in serve, through `RcJvmServerRenderer` and the worker pool, into the request frame, out to both render entry points, plus a `--theme` flag on the one-shot path.

Carrying it changes the frame, so `PROTOCOL_VERSION` moves 1 → 2. That is what makes a stale `lib-rcjvm/` sidecar fall back to the one-shot path rather than read `theme` as `seedsLen` and desynchronise for good.

## The other players

- **CMP player** (`RcPlayerState` / `RcComposePlayer`, desktop + iOS + wasm) resolved nothing at all — `applyColorTheme` read only the fallbacks. It now resolves through a host-supplied `systemColorLookup`, defaulting to resolving nothing, which is the honest answer where there is no system palette: the document keeps the fallbacks it captured for exactly that case. `rcResolveSystemTheme` answers `SYSTEM`/`UNSPECIFIED` the same way. The callback is read through `rememberUpdatedState` rather than keyed into the state's `remember`, so a host's capturing lambda cannot tear down player state on an unrelated recomposition.
- **jvm renderer** had no theme handling whatsoever. It now shares the neutral half of the resolution and defaults to `Theme.LIGHT` rather than following the build machine's desktop theme, so a headless render stays reproducible.

Resolution requires the document's colour group to resolve **by name** to `android`. `colorGroupId = 0` names no table at all rather than naming Android's, and `GenerateBaselineFixture` writes exactly such an operation (group 0, index 0) — treating it as Android would repaint it `background_dark` in the CMP player while the embedded player kept its fallbacks.

The table exists twice — the vendored module is an Android library in an AOSP package, `:rc-player-protocol` is KMP with no Android target, and neither can depend on the other. `AndroidColorTableDriftTest` compares the two, and the sibling file is declared as a task input so the guard cannot silently go stale (it was UP-TO-DATE and not guarding until that was added).

## Visual evidence

Not embeddable for this change, and the reason is itself a finding. The only fixture that exercises `ColorTheme` (`SystemThemeSwatchesRemote`) lays out as a **1-pixel sliver in both players** while its baked Compose PNG shows three full swatches — so the pixel comparison above is a single pixel, and a screenshot of it would show nothing. That layout defect is independent of this change (it predates it and affects the view lane identically) and is worth its own fix; until then the numbers above, taken from the rendered PNGs of all three lanes, are the evidence. The CMP/Wasm parity bot reports 44 unchanged and 0 regressions, which is the independent check that nothing else moved.

## Test plan

- [x] `RcColorThemeResolutionTest` (CMP): per-mode index resolution, fallback on an unresolvable name, unknown *and* absent colour group left alone, and the table's contract pinned — including the four entries reflection gets wrong, so a future "simplify this" reintroduces the bug loudly.
- [x] `AndroidColorTableDriftTest`: both tables agree; verified to actually fail when one is perturbed.
- [x] `RcJvmWorkerPoolTest`: a dark request served by a warm worker that serves a light one after it. The stub worker reads and echoes the theme, so a dropped field fails rather than passes.
- [x] `RcJvmRenderWorkerProtocolTest`: the hand-built frame carries the new field.
- [x] Render lanes on a real `ColorTheme` document: embedded and view now agree on `#E9E7EC`.
- [x] Suites green: `:rc-player-protocol`, `:rc-player-runtime`, `:rc-player-compose`, `:third-party-rc-embedded-player`, `:third-party-rc-embedded-player-jvm`, `:cli`.