### PR TITLE
feat(design-catalog-remote-m3): add a ColorTheme sticker for the second theming path

### DIFF
--- a/samples/design-catalog-remote-m3/catalog.spec.json
+++ b/samples/design-catalog-remote-m3/catalog.spec.json
@@ -100,7 +100,8 @@
       "name": "Theme",
       "components": [
         { "componentId": "Theme/Typography", "preview": "TypographyRemote", "parallel": "Typography", "caption": "A type ramp read from RemoteMaterialTheme.typography." },
-        { "componentId": "Theme/ColorScheme", "preview": "ColorSchemeRemote", "parallel": "ColorScheme", "caption": "Colour-scheme swatches read from RemoteMaterialTheme.colorScheme." }
+        { "componentId": "Theme/ColorScheme", "preview": "ColorSchemeRemote", "parallel": "ColorScheme", "caption": "Colour-scheme swatches read from RemoteMaterialTheme.colorScheme." },
+        { "componentId": "Theme/SystemThemeSwatches", "preview": "SystemThemeSwatchesRemote", "caption": "System-theme swatches — the catalog's only document carrying ColorTheme operations, where a light and a dark colour live in the document and the player selects between them." }
       ]
     },
     {

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/SystemThemePreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/SystemThemePreviews.kt
@@ -1,0 +1,129 @@
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package com.example.designcatalogremotem3
+
+import androidx.compose.remote.creation.Rc
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.RemoteConstantCacheKey
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
+/**
+ * The catalog's coverage of the **second** Remote Compose colour-theming mechanism.
+ *
+ * A document can carry theming two unrelated ways, and until this sticker the published catalogs
+ * only exercised one:
+ * - **named colour state** (`USER:WearM3.<role>`) — a slot the host overwrites outright, which is
+ *   what every themed sticker in [CatalogPreviews] uses and what a `themeProvider` request seeds
+ *   into. 16 of the catalog's documents declare it.
+ * - **`ColorTheme` operations** — a light and a dark colour captured *in the document*, which the
+ *   player picks between from the requested theme. **No published document emitted one**, so
+ *   everything downstream that reads it — `RcDocumentCapabilities`, and the replay-override routing
+ *   built on it (compose-ai-tools#3936) — had only synthetic fixtures to test against.
+ *
+ * `homeassistant-remotecompose` now ships both: its Wear widgets take the named path and its
+ * launcher widgets take this one, via Android's system theme resources. This sticker is the
+ * catalog's copy of that second shape so the parity and capability work has a real document.
+ *
+ * The two are deliberately *not* interchangeable. A `ColorTheme` op holds its colours inline, so a
+ * palette override has no slot to write into; it answers light/dark and nothing else. That
+ * distinction is the one this sticker exists to keep honest.
+ */
+/**
+ * A colour the **host** resolves from Android's system theme, written into the document as a
+ * `ColorTheme` operation and referenced by id.
+ *
+ * Built without a constant value, and that is load-bearing. `BackgroundModifier` branches on
+ * `hasConstantValue`: a colour carrying one is written as literal red/green/blue by
+ * `SolidBackgroundModifier` and its id provider is never asked for. Subclassing
+ * `RemoteColor(fallbackArgb)` and overriding `writeToDocument` therefore emits **no** `ColorTheme`
+ * operation at all — the first two revisions of this sticker did exactly that, rendered three
+ * correct-looking swatches, and produced a document with zero themed colours in it. The fallback
+ * that wins is the light value a host without the resources would draw anyway, so the loss is
+ * invisible in pixels and only the decoded document shows it. `homeassistant-remotecompose` shipped
+ * the same mistake in its launcher palette (yschimke/homeassistant-remotecompose#573).
+ *
+ * The id-provider constructor and `RemoteConstantCacheKey` are `internal` upstream — there is no
+ * public route to a document-written colour at `remote-compose` 1.0.0-alpha17 — hence the
+ * file-level suppression.
+ */
+private fun systemThemeColor(
+  lightResource: Short,
+  darkResource: Short,
+  lightFallback: Color,
+  darkFallback: Color,
+): RemoteColor {
+  val lightArgb = lightFallback.toArgb()
+  val darkArgb = darkFallback.toArgb()
+  return RemoteColor(
+    RemoteConstantCacheKey("SystemTheme:$lightResource/$darkResource:$lightArgb/$darkArgb")
+  ) { creationState ->
+    creationState.document
+      .addThemedColor(Rc.AndroidColors.GROUP, lightResource, darkResource, lightArgb, darkArgb)
+      .toInt()
+  }
+}
+
+/**
+ * Three swatches painted from system-theme resources rather than named state, so the document
+ * carries `ColorTheme` operations and no colour-typed `NamedVariable`.
+ *
+ * The fallbacks are what a host without the resources draws, and are what this sticker's baked PNG
+ * shows — the point of the fixture is the operations in the bytes, not the pixels.
+ */
+@CatalogRemoteModes
+@Composable
+fun SystemThemeSwatchesRemote() = RemoteSticker { RemoteColumn { RemoteRow { SwatchTriple() } } }
+
+@Composable
+private fun SwatchTriple() {
+  RemoteBoxSwatch(
+    systemThemeColor(
+      Rc.AndroidColors.SYSTEM_SURFACE_CONTAINER_HIGH_LIGHT,
+      Rc.AndroidColors.SYSTEM_SURFACE_CONTAINER_HIGH_DARK,
+      Color(0xFFE6E0E9),
+      Color(0xFF2B2930),
+    )
+  )
+  RemoteBoxSwatch(
+    systemThemeColor(
+      Rc.AndroidColors.SYSTEM_PRIMARY_LIGHT,
+      Rc.AndroidColors.SYSTEM_PRIMARY_DARK,
+      Color(0xFF65558F),
+      Color(0xFFD0BCFF),
+    )
+  )
+  RemoteBoxSwatch(
+    systemThemeColor(
+      Rc.AndroidColors.SYSTEM_ON_SURFACE_LIGHT,
+      Rc.AndroidColors.SYSTEM_ON_SURFACE_DARK,
+      Color(0xFF1D1B20),
+      Color(0xFFE6E0E9),
+    )
+  )
+}
+
+/**
+ * The `background(RemoteColor)` overload, deliberately — **not**
+ * `background(RemoteBrush.solidColor(color))`.
+ *
+ * They are not equivalent for a colour that writes itself into the document. The brush overload
+ * takes the colour's constant value, so a `SystemThemedRemoteColor` reaches the bytes as a baked
+ * `PaintData` and its `writeToDocument` is never called: the first cut of this sticker rendered
+ * three correct-looking swatches whose document contained zero `ColorTheme` operations. The
+ * `RemoteColor` overload resolves the colour through the document, which is what emits the op — and
+ * is what `cardChrome` in `homeassistant-remotecompose` uses on the launcher path.
+ */
+@Composable
+private fun RemoteBoxSwatch(color: RemoteColor) =
+  androidx.compose.remote.creation.compose.layout.RemoteBox(
+    modifier = RemoteModifier.size(44.rdp).background(color),
+    content = {},
+  )

--- a/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/SystemThemePreviews.kt
+++ b/samples/design-catalog-remote-m3/src/main/kotlin/com/example/designcatalogremotem3/SystemThemePreviews.kt
@@ -88,7 +88,11 @@ private fun SwatchTriple() {
     systemThemeColor(
       Rc.AndroidColors.SYSTEM_SURFACE_CONTAINER_HIGH_LIGHT,
       Rc.AndroidColors.SYSTEM_SURFACE_CONTAINER_HIGH_DARK,
-      Color(0xFFE6E0E9),
+      // M3 baseline light `surfaceContainerHigh`. `0xFFE6E0E9` is one step up the ramp
+      // (`surfaceContainerHighest`) and was the wrong neutral to pair with this resource — a
+      // fallback should be what the named resource would have given, since that is the whole
+      // point of carrying one.
+      Color(0xFFECE6F0),
       Color(0xFF2B2930),
     )
   )


### PR DESCRIPTION
A document can carry theming two unrelated ways, and the published catalogs only exercised one:

- **named colour state** (`USER:WearM3.<role>`) — a slot the host overwrites outright. 16 of the catalog's documents declare it, and it is what a `themeProvider` request seeds into.
- **`ColorTheme` operations** — a light and a dark colour held *inline*, which the player picks between from the requested theme. **No published document emitted one.**

That gap is why #3962's bugs survived as long as they did: with no rendered document carrying a `ColorTheme`, the visual-diff bot had nothing to regress-test. This sticker gives the path a real document, so the next change to it gets before/after coverage for free.

## The sticker

!``[SystemThemeSwatchesRemote](https://raw.githubusercontent.com/yschimke/compose-ai-tools/7c43ea1897d60791ef4221677f0d3e7fe4ba731d/renders/samples:design-catalog-remote-m3/SystemThemeSwatchesRemote_width_200dp_height_200dp_dpi_320-c8673ea8.png)``

Three swatches — `surfaceContainerHigh`, `primary`, `onSurface` — each resolved from an `android.R.color` resource pair recorded in the document.

## It must not be built the obvious way

`RemoteColor`'s ordinary constructor sets a constant value, and `BackgroundModifier` branches on `hasConstantValue` — a colour that has one is written as literal RGB and its `writeToDocument` is never called. So subclassing `RemoteColor(lightFallback)` and overriding `writeToDocument` produces a document containing **no `ColorTheme` operation at all**, while rendering perfectly plausibly: the constant it falls back to is the light fallback a host without the resources would have drawn anyway.

`background(RemoteBrush.solidColor(color))` is the same trap from the other side — the brush overload reads the colour's constant instead of resolving it through the document.

This sticker uses the id-provider constructor and the `RemoteColor` overload of `background`. Both choices are commented at the point where they are made, because both look like free stylistic variation and neither is.

## Verified on the bytes, not the pixels

A fallback-only document renders identically to a correct one, so the assertion that matters is on the emitted operations. The captured `.rc` carries three `ColorTheme` operations with the expected resource indices:

| role | light / dark index | resource |
| --- | --- | --- |
| `surfaceContainerHigh` | 164 / 163 | `system_surface_container_high_light` / `_dark` |
| `primary` | 153 / 150 | `system_primary_light` / `system_primary_dark` |
| `onSurface` | 124 / 122 | `system_on_surface_light` / `system_on_surface_dark` |

## Player parity

Played back through both Remote Compose players at 400×400 / density 2, the document agrees **pixel-for-pixel — 0 differing pixels of 160000** between the embedded player and the `remote-player-view` lane, both resolving the system palette to `#1B1B1F` / `#445E91` / `#E9E7EC`. That is the property #3962 established, and this fixture is what will now guard it.

## Review follow-ups (both confirmed)

- **Registered in `catalog.spec.json`.** Only referenced previews become catalog components on export; `validate-catalog-spec.mjs` reported the sticker as unlisted, so the published catalog and its parity runs would have omitted it — defeating the coverage this PR exists to add. Validator is now clean (0 warnings, 0 errors).
- **Light fallback corrected** to `0xFFECE6F0`. `0xFFE6E0E9` is the M3 baseline for `surfaceContainerHighest`, one step up the neutral ramp from the resource it was paired with. The baked PNG is byte-identical before and after — under Robolectric the resources resolve, so the fallback is not what gets drawn. It matters only on a host predating them, which is precisely where it cannot be observed, and why it was worth fixing rather than shrugging at.

## Test plan

- [x] Decoded the rendered `.rc`: 3 `ColorTheme` operations, indices as tabulated.
- [x] Baked PNG: 23232 opaque px across three 88×88 swatches.
- [x] Embedded vs view player on the same document: 0 differing px of 160000.
- [x] `validate-catalog-spec.mjs`: 0 warnings, 0 errors.
- [x] `:samples:design-catalog-remote-m3:composePreviewRenderAll` green.