### PR TITLE
test(rc-embedded-player): pin the dynamic-colour diagnostic for the dropped badge

### DIFF
--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/DynamicColorDiagTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/DynamicColorDiagTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ee.schimke.composeai.rcembedded
+
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.Operation
+import androidx.compose.remote.core.RemoteClock
+import androidx.compose.remote.core.RemoteComposeBuffer
+import androidx.compose.remote.core.operations.layout.Container
+import androidx.compose.remote.core.operations.layout.LayoutComponent
+import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
+import androidx.compose.remote.player.compose.embedded.getOperationsReflection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.ByteArrayInputStream
+import java.io.File
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+/**
+ * Diagnostic for the embedded player's dropped dynamic-colour shapes (compose-ai-tools#3936, defect
+ * 1).
+ *
+ * A tinted badge whose background is a **literal** colour draws; an adjacent one whose background
+ * is a **dynamic** colour id (`flags=2, colorId=…`, produced by a `ColorExpression` ->
+ * `ColorAttribute` -> `ColorExpression` chain) renders as the card background instead. This prints
+ * where each op in that chain actually lives in the tree and whether the computed-op index the
+ * graph resolves through contains it — the fact a fix has to be built on, rather than another guess
+ * about which walk is short.
+ *
+ * Skips unless a document is staged, so it costs nothing in a normal run:
+ * ```
+ * ./gradlew :third-party-rc-embedded-player:testDebugUnitTest \
+ *   --tests '*DynamicColorDiagTest*' -Prc.embedded.input=<dir with the .rc files>
+ * ```
+ */
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [35])
+class DynamicColorDiagTest {
+
+  @Test
+  fun reportDynamicColourChain() {
+    val dir = System.getProperty("rc.embedded.input")?.let(::File)?.takeIf { it.isDirectory }
+    assumeTrue("no rc.embedded.input staged", dir != null)
+
+    val report = StringBuilder()
+    dir!!
+      .listFiles { f -> f.extension == "rc" }
+      ?.sortedBy { it.name }
+      ?.forEach { rc ->
+        val document =
+          CoreDocument(RemoteClock.SYSTEM).apply {
+            ByteArrayInputStream(rc.readBytes()).use {
+              initFromBuffer(RemoteComposeBuffer.fromInputStream(it))
+            }
+          }
+        val index = buildComputedOpIndex(document.getOperationsReflection())
+
+        // Where every op of interest actually sits: top level, inside a container, or only
+        // reachable
+        // through a component's canvas operations.
+        val located = LinkedHashMap<String, MutableList<String>>()
+        fun visit(ops: Collection<Operation>, path: String) {
+          for (op in ops) {
+            val name = op.javaClass.simpleName
+            if (name.startsWith("Color")) {
+              located.getOrPut(name) { mutableListOf() }.add(path)
+            }
+            if (op is Container) visit(op.getList(), "$path/container")
+            if (op is LayoutComponent) {
+              op.getCanvasOperations()?.let { visit(listOf(it), "$path/canvasOps") }
+            }
+          }
+        }
+        visit(document.getOperationsReflection(), "root")
+
+        report.appendLine("=== ${rc.name}")
+        report.appendLine("  computed-op index size = ${index.size}; ids = ${index.keys.sorted()}")
+        located.forEach { (name, paths) ->
+          val counts = paths.groupingBy { it }.eachCount()
+          report.appendLine("  $name -> $counts")
+        }
+        report.appendLine(
+          "  indexed op types = ${index.values.map { it.javaClass.simpleName }.toSortedSet()}"
+        )
+      }
+    // Written to a file rather than stdout: Gradle does not surface test stdout here, and the
+    // point of a diagnostic is that its output survives the harness.
+    File(dir, "diag.txt").writeText(report.toString())
+  }
+}


### PR DESCRIPTION
Reproduction and measurement for #3936 defect 1 — the embedded player dropping tinted badge circles. No behaviour change; this lands the diagnosis so the fix can be built on evidence rather than on the next plausible guess.

## What the issue described, and what is actually happening

The issue reports the badge as *dropped*, and notes as puzzling that "the blue sensor badge survives and the amber light-on badge does not — same card type, same layout, adjacent tiles."

Measured on the horizontal-stack document through both harnesses, the blue badge is **not** a survivor of a flaky paint path — it is a different path entirely:

| badge | background | embedded result |
| --- | --- | --- |
| blue sensor | literal (`flags=0`, explicit rgba) | drawn — `#D3EAFD` vs the view lane's `#D2EAFD`, one LSB of red |
| amber light-on | dynamic (`flags=2, colorId=59`) | absent — card background shows through |

So it is not "some circles don't draw". Every literal-coloured shape draws; every shape whose colour arrives as a computed id does not.

## Where it breaks

The obvious first guess is that one of the tree walks is short — the constant walk in `RcPlayer` descends into `LayoutComponent.getCanvasOperations()` and `buildComputedOpIndex` does not. **That guess is wrong, and the diagnostic is what shows it.** Every colour op in this document sits under nested `Container`s, which the existing walk already reaches:

```
computed-op index size = 16; ids = [48, 52, 53, 54, 55, 56, 57, 58, 59, 63, 64, 65, 71, 75, 76, 77]
ColorConstant  -> {root/container/container/container/container=2}
ColorExpression-> {root/container/container/container/container=2}
ColorAttribute -> {root/container/container/container/container=4}
```

Ids 53, 54, 56, 57, 58 and **59** are all present. I implemented the canvas-ops traversal anyway and measured it: **zero change** in differing-pixel counts on all three documents. Reverted.

Resolution therefore reaches `GraphContext.getColor`, which is:

```kotlin
if (isComputed(id)) (computedValue(id) as? Number)?.toInt() ?: 0 else super.getColor(id)
```

`?: 0` is fully transparent — precisely the observed symptom.

## The remaining link

`ColorAttribute` is a `PaintOperation`. It has no `apply` of its own; it emits its value from `paint(PaintContext)` via `loadFloat`. And `PaintOperation.apply` forwards to `paint(...)` **only when the context reports `ContextMode.PAINT`**:

```java
if (context.getMode() == ContextMode.PAINT) { context.getPaintContext()?.let { paint(it) } }
```

Evaluated through the graph, `apply` writes nothing, the capture is empty, the attribute reads as `0`, and the `ColorExpression` recombining those attributes yields a transparent colour.

`GraphContext`'s own comment anticipates exactly this — *"those ops aren't read through the scalar resolvers, but if one ever is, it degrades to a captured scalar / default"*. One **is**, on every dynamically-tinted background.

The view player never uses this graph; it runs the real paint pass, where `paint` is called, so the same bytes resolve correctly there.

## Why this is a test and not a fix

The fix is to evaluate `PaintOperation`s through a capture-only `PaintContext` so they emit into the same channel the scalar ops use. That changes the evaluation contract of a vendored player for *every* computed op, and it deserves to land with an assertion that pins the amber badge rather than as a second speculative edit — this session already produced one edit that measured as inert, and one measurement I trusted too readily.

## Cost

Skips unless a document is staged via `-Prc.embedded.input`, so a normal run is unaffected. Writes its report to a file rather than stdout, because Gradle does not surface test stdout for this module.

```
./gradlew :third-party-rc-embedded-player:testDebugUnitTest \
  --tests '*DynamicColorDiagTest*' -Prc.embedded.input=<dir with .rc files>
```

## Test plan

- [x] Skips cleanly with no property set.
- [x] Full `:third-party-rc-embedded-player` suite green with it present.
- [x] With a document staged, reports the index contents and each colour op's position in the tree (output quoted above).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYeKdEQJAhTrkmEx8CFQAw)_