### PR TITLE
docs(serve): correct what the spec-baseline attribute read actually guards

### DIFF
--- a/cli/serve-web/src/components/SpecCompare.ts
+++ b/cli/serve-web/src/components/SpecCompare.ts
@@ -188,11 +188,22 @@ export class SpecCompare extends LitElement {
         this.bakedBand = this.chip?.getAttribute("data-spec-match") ?? "";
         this.referenceUrl = this.compare.getAttribute("data-reference") ?? "";
 
-        // Read rather than wait to be told. `viewer.js` publishes the baseline on the stage as it
-        // refreshes the links, but the two scripts do not have a guaranteed order — and a deep
-        // link that already names a theme (`?themeProvider=…`) is served with the baked verdict
-        // on the chip, so a first paint that trusted the served label would show the wrong number
-        // for however long the other script took to arrive.
+        // Read rather than wait to be told — for the installs that happen after `viewer.js` has
+        // spoken, not for the first one.
+        //
+        // The order is in fact fixed, and it is the unhelpful way round: `ServeWeb` emits
+        // `serve-components.js` immediately before `viewer.js`, both classic scripts, so this
+        // element upgrades and installs while the attribute is still absent. A themed deep link
+        // (`?themeProvider=…`) is served with the baked verdict on the chip, so this read falls
+        // back to `true` and the chip keeps that verdict — until `viewer.js` runs `syncSpecBaseline`
+        // moments later and pushes the correction through `baseline()`. Nothing is painted in
+        // between: two consecutive classic scripts give the browser no opportunity, so the wrong
+        // number is never on screen.
+        //
+        // What the read does buy is every install that is NOT that one — the `whenParsed()` retry
+        // above, and any re-connect — where `viewer.js` has already published and the pushed call
+        // has been and gone. Those would otherwise start from `true` with nobody left to correct
+        // them.
         this.atBaseline = this.root.getAttribute("data-spec-baseline") !== "0";
         if (!this.atBaseline) this.setChipVerdict(null);
 

--- a/cli/serve-web/src/components/SpecCompare.ts
+++ b/cli/serve-web/src/components/SpecCompare.ts
@@ -188,22 +188,28 @@ export class SpecCompare extends LitElement {
         this.bakedBand = this.chip?.getAttribute("data-spec-match") ?? "";
         this.referenceUrl = this.compare.getAttribute("data-reference") ?? "";
 
-        // Read rather than wait to be told — for the installs that happen after `viewer.js` has
-        // spoken, not for the first one.
+        // Read rather than wait to be told — but this does NOT cover the first install, and the
+        // ordering is worth stating precisely because it is the unhelpful way round.
         //
-        // The order is in fact fixed, and it is the unhelpful way round: `ServeWeb` emits
-        // `serve-components.js` immediately before `viewer.js`, both classic scripts, so this
-        // element upgrades and installs while the attribute is still absent. A themed deep link
-        // (`?themeProvider=…`) is served with the baked verdict on the chip, so this read falls
-        // back to `true` and the chip keeps that verdict — until `viewer.js` runs `syncSpecBaseline`
-        // moments later and pushes the correction through `baseline()`. Nothing is painted in
-        // between: two consecutive classic scripts give the browser no opportunity, so the wrong
-        // number is never on screen.
+        // `ServeWeb` emits `serve-components.js` ahead of `viewer.js`, so this element upgrades and
+        // installs while `data-spec-baseline` is still absent and the read falls back to `true`. On
+        // a themed deep link (`?themeProvider=…`), which is served with the baked verdict on the
+        // chip, that is the wrong answer, and it stands until `viewer.js` runs `syncSpecBaseline`
+        // and pushes the correction through `baseline()`.
         //
-        // What the read does buy is every install that is NOT that one — the `whenParsed()` retry
+        // That gap is not instantaneous. The two tags are not adjacent — an inline theme script,
+        // the presence script and `format-compare.js` sit between them, and `format-compare.js` is
+        // emitted on precisely the pages that have a spec chip. Classic scripts fix execution
+        // ORDER, they do not stop the browser painting markup it has already parsed while it waits
+        // on a fetch. So on a cold or slow load a themed deep link can show the baked verdict
+        // briefly before the correction lands. Closing that properly means publishing the baseline
+        // ahead of this script, which needs the URL read where the page can do it early rather than
+        // this element guessing.
+        //
+        // What the read does buy is every install that is NOT the first — the `whenParsed()` retry
         // above, and any re-connect — where `viewer.js` has already published and the pushed call
-        // has been and gone. Those would otherwise start from `true` with nobody left to correct
-        // them.
+        // has been and gone. Those would otherwise start from `true` with nothing left to correct
+        // them at all.
         this.atBaseline = this.root.getAttribute("data-spec-baseline") !== "0";
         if (!this.atBaseline) this.setChipVerdict(null);
 

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -643,10 +643,12 @@
   }
   // Pushed to the lane AND published on the stage, and the two carry different weight.
   //
-  // The push is what corrects the first paint. `serve-components.js` is emitted immediately before
-  // this file, so `<cp-spec-compare>` has already installed by the time we run and has already
-  // defaulted itself to the baked verdict; this call is what moves it off. Both are classic scripts
-  // running back to back, so that correction lands before the browser paints either state.
+  // The push is what corrects the FIRST install. `serve-components.js` is emitted ahead of this
+  // file, so `<cp-spec-compare>` has already installed by the time we run, and has already fallen
+  // back to the baked verdict because the attribute did not exist yet; this call is what moves it
+  // off. It is a correction and not a guarantee: the tags are not adjacent, and a browser is free
+  // to paint parsed markup while it fetches what sits between them, so on a cold load a themed
+  // deep link can show the baked verdict for the interval before we get here.
   //
   // The attribute is for the installs that come later — the element's deferred retry, or a
   // re-connect — which have no push to wait for and read the stage instead.

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -641,8 +641,15 @@
     }
     return true;
   }
-  // Published on the stage as well as pushed to the lane, because the two scripts have no
-  // guaranteed order: `<cp-spec-compare>` reads the attribute when it installs, whenever that is.
+  // Pushed to the lane AND published on the stage, and the two carry different weight.
+  //
+  // The push is what corrects the first paint. `serve-components.js` is emitted immediately before
+  // this file, so `<cp-spec-compare>` has already installed by the time we run and has already
+  // defaulted itself to the baked verdict; this call is what moves it off. Both are classic scripts
+  // running back to back, so that correction lands before the browser paints either state.
+  //
+  // The attribute is for the installs that come later — the element's deferred retry, or a
+  // re-connect — which have no push to wait for and read the stage instead.
   function syncSpecBaseline() {
     var at = specAtBaseline();
     root.setAttribute("data-spec-baseline", at ? "1" : "0");


### PR DESCRIPTION
Follow-up to #3969. Comment-only; no behaviour change.

## What was wrong

Both sides of the baseline handshake documented a race that cannot happen, and used it to justify the attribute read:

- `SpecCompare.ts` — *"the two scripts do not have a guaranteed order … a first paint that trusted the served label would show the wrong number for however long the other script took to arrive"*
- `viewer.js` — *"because the two scripts have no guaranteed order"*

The order is fixed, and it is the opposite of what the comments assumed. `ServeWeb.kt` emits `serve-components.js` ahead of `viewer.js`, so `<cp-spec-compare>` upgrades and installs while `data-spec-baseline` is still absent; `getAttribute(…) !== "0"` falls back to `true` and the chip keeps the baked verdict. A themed deep link is served with that verdict on the chip, which is precisely the case the comment claimed the read was protecting. What corrects it is `syncSpecBaseline`'s pushed `baseline()` call from the second script.

## What the read is really for

Every install that is **not** the first — the element's `whenParsed()` retry, and any re-connect. Those run after `viewer.js` has published and the pushed call has been and gone, so they have nothing left to wait for and must read the stage instead. Without the read they would start from `true` with no correction coming at all.

## The residual window, now documented rather than denied

An earlier revision of this PR replaced the false race with a false guarantee, claiming the correction lands before any paint. Review caught it and it was wrong twice over:

- The tags are **not** adjacent. `<cp-viewer-drawers>`, the inline theme script, the presence script and `format-compare.js` sit between them — and `format-compare.js` is gated on `hasSvgExport || specRasterUrl != null`, so it is emitted on exactly the pages that carry a spec chip. There is an external fetch in the gap on every page this comment concerns.
- Classic scripts fix execution **order**, not rendering. A browser may paint markup it has already parsed while waiting on that fetch.

So on a cold or slow load, a themed deep link can show the baked verdict until `syncSpecBaseline` runs. Both comments now say so. Closing it for real means publishing the baseline ahead of `serve-components.js`, which needs the URL read somewhere the page can do it early rather than this element inferring it — noted in the comment, not attempted here. The flash is pre-existing behaviour from #3969, not introduced by this PR, and deserves its own change.

The server cannot supply the attribute at render time, incidentally: `viewerPage` receives no request query, and the viewer's deep-link state is applied client-side from `location.search`. A static `data-spec-baseline="1"` would only restate the default the read already falls back to.

## Why it is worth changing

The arrangement is order-robust either way — were the tags ever swapped, `window.cpSpecCompare` would not yet exist for the push, and the attribute read would cover it. Nothing is broken. But a comment that promises a guarantee the code does not provide invites the next person to lean on it, or to "simplify" the push away as redundant.

## Test plan

- `npm test` in `cli/serve-web` — 652 passing, unchanged.
- `npx tsc --noEmit` — clean.
- `npm run build` — bundle byte-identical, confirming the change is comment-only.