### PR TITLE
fix(playground): show compile errors inline

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4501,8 +4501,8 @@ object ServeWeb {
           </div>
           <textarea id="pg-source" class="cp-pg-source" spellcheck="false"
             aria-label="Kotlin source">$sample</textarea>
-          <div id="pg-status" class="cp-pg-status" hidden></div>
-          <ul id="pg-diagnostics" class="cp-pg-diags" hidden></ul>
+          <div id="pg-status" class="cp-pg-status" role="status" hidden></div>
+          <ul id="pg-diagnostics" class="cp-pg-diags" aria-live="polite" hidden></ul>
           <div id="pg-result" class="cp-doc-result cp-pg-result" hidden>
             <p id="pg-preview-note" class="cp-pg-status" hidden></p>
             <img id="pg-image" class="cp-pg-image" alt="Rendered first frame" hidden>
@@ -4674,6 +4674,55 @@ object ServeWeb {
       function writeSource(text) {
         if (editor) editor.setValue(text); else source.value = text;
       }
+      // CodeMirror diagnostics are deliberately drawn by this page instead of depending on its
+      // optional lint addon: the compiler already returns exact 0-based locations, and keeping the
+      // tiny renderer here preserves the editor's plain-textarea fallback. The list below the
+      // editor remains the accessible summary; these widgets put each message beside the code that
+      // caused it, which is where it is useful while fixing a failed compile.
+      var editorDiags = [];
+      var latestDiags = [];
+      function clearEditorDiags() {
+        if (!editor) return;
+        editorDiags.forEach(function (entry) {
+          if (entry.widget) entry.widget.clear();
+          if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+          if (entry.mark) entry.mark.clear();
+        });
+        editorDiags = [];
+      }
+      function renderEditorDiags() {
+        clearEditorDiags();
+        if (!editor) return;
+        var file = files[active];
+        latestDiags.forEach(function (d) {
+          if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
+          var severity = d.severity || "info";
+          var lineClass = "cp-pg-line-" + severity;
+          editor.addLineClass(d.line, "background", lineClass);
+          var message = document.createElement("div");
+          message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
+          // The live summary below already announces the same diagnostic. Keep this visual copy
+          // out of the accessibility tree so a compile failure is not read twice.
+          message.setAttribute("aria-hidden", "true");
+          message.textContent = d.message;
+          var widget = editor.addLineWidget(d.line, message, { coverGutter: false, noHScroll: true });
+          var mark = null;
+          if (d.ch != null) {
+            var lineText = editor.getLine(d.line) || "";
+            var start = Math.max(0, Math.min(d.ch, lineText.length));
+            var endLine = d.endLine == null ? d.line : Math.max(d.line, d.endLine);
+            var endCh = d.endCh == null ? Math.min(lineText.length, start + 1) : d.endCh;
+            if (endLine !== d.line || endCh > start) {
+              mark = editor.markText(
+                { line: d.line, ch: start },
+                { line: endLine, ch: endCh },
+                { className: "cp-pg-range-" + severity }
+              );
+            }
+          }
+          editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+        });
+      }
       // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
       // buffer, `active` is the one the textarea is showing. A single-file snippet keeps exactly
       // the old shape, so nothing about the common case changes.
@@ -4730,6 +4779,8 @@ object ServeWeb {
         statusEl.textContent = text;
       }
       function clearOut() {
+        latestDiags = [];
+        clearEditorDiags();
         diags.hidden = true; diags.innerHTML = "";
         result.hidden = true; image.hidden = true; image.removeAttribute("src"); openRow.hidden = true;
         note.hidden = true; note.textContent = "";
@@ -4745,11 +4796,14 @@ object ServeWeb {
         active = i;
         writeSource(files[active].text);
         renderFiles();
+        renderEditorDiags();
       }
       function renderDiags(list) {
-        if (!list || !list.length) return;
+        latestDiags = list || [];
+        renderEditorDiags();
+        if (!latestDiags.length) return;
         diags.hidden = false;
-        list.forEach(function (d) {
+        latestDiags.forEach(function (d) {
           var li = document.createElement("li");
           li.className = "cp-pg-diag cp-pg-" + (d.severity || "info");
           // With several buffers open, "unresolved reference at line 5" is useless without the
@@ -4761,8 +4815,15 @@ object ServeWeb {
           li.textContent = (d.severity || "info") + ": " + d.message + loc;
           if (owner >= 0) {
             li.style.cursor = "pointer";
-            li.title = "Show " + d.file;
-            li.addEventListener("click", function () { showFile(owner); });
+            li.title = "Show " + d.file + (d.line != null ? ":" + (d.line + 1) : "");
+            li.addEventListener("click", function () {
+              showFile(owner);
+              if (editor && d.line != null) {
+                editor.setCursor({ line: d.line, ch: d.ch || 0 });
+                editor.scrollIntoView({ line: d.line, ch: d.ch || 0 }, 80);
+                editor.focus();
+              }
+            });
           }
           diags.appendChild(li);
         });

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/playground.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/playground.css
@@ -50,6 +50,23 @@
 .cp-pg-error { background: var(--md-sys-color-error-container);
   color: var(--md-sys-color-on-error-container); }
 .cp-pg-warning { background: light-dark(#ffdfb0, #4a3000); color: light-dark(#573100, #ffd8a3); }
+/* Compiler locations stay visible in the editor while their full, accessible summary remains in
+   the list below it. A line tint makes the location scannable; the widget carries the actual
+   message immediately beneath the offending line. */
+.cp-pg-line-error { background: color-mix(in srgb, var(--md-sys-color-error-container) 55%, transparent); }
+.cp-pg-line-warning { background: light-dark(#fff4df, #362600); }
+.cp-pg-inline-diag { padding: 4px 12px; border-left: 3px solid currentcolor;
+  font-family: var(--md-sys-typescale-mono-font); font-size: 12.5px; line-height: 1.45; }
+.cp-pg-inline-error { background: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container); }
+.cp-pg-inline-warning { background: light-dark(#ffdfb0, #4a3000);
+  color: light-dark(#573100, #ffd8a3); }
+.cp-pg-inline-info { background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface); }
+.cp-pg-range-error { text-decoration: underline wavy var(--md-sys-color-error) 1.5px;
+  text-underline-offset: 2px; }
+.cp-pg-range-warning { text-decoration: underline wavy light-dark(#8a4f00, #ffb95c) 1.5px;
+  text-underline-offset: 2px; }
 .cp-pg-result { display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
 .cp-pg-image { max-width: 100%; border-radius: var(--md-sys-shape-corner-medium); border: 0;
   background: var(--md-sys-color-surface-container-lowest);

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -3551,6 +3551,13 @@ class ServeWebFixtureTest {
       playground.contains("d.file") && playground.contains("indexOfFile"),
       "diagnostics name their file and can jump to it",
     )
+    assertTrue(
+      playground.contains("editor.addLineWidget") &&
+        playground.contains("editor.addLineClass") &&
+        playground.contains("editor.markText") &&
+        assetText("playground.css").contains(".cp-pg-inline-error"),
+      "located compiler errors are shown inline beside the source as well as in the summary",
+    )
     // The terminal status stays exactly "Done." — the e2e polls on it, so the preview note lives
     // in its own element rather than being appended to the status text.
     assertTrue(

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
@@ -115,8 +115,8 @@
 fun MediaControlButtonsPlaying() {
   MediaControlButtons(onPlayButtonClick = {}, playing = true)
 }</textarea>
-          <div id="pg-status" class="cp-pg-status" hidden></div>
-          <ul id="pg-diagnostics" class="cp-pg-diags" hidden></ul>
+          <div id="pg-status" class="cp-pg-status" role="status" hidden></div>
+          <ul id="pg-diagnostics" class="cp-pg-diags" aria-live="polite" hidden></ul>
           <div id="pg-result" class="cp-doc-result cp-pg-result" hidden>
             <p id="pg-preview-note" class="cp-pg-status" hidden></p>
             <img id="pg-image" class="cp-pg-image" alt="Rendered first frame" hidden>
@@ -266,6 +266,55 @@ fun MediaControlButtonsPlaying() {
   function writeSource(text) {
     if (editor) editor.setValue(text); else source.value = text;
   }
+  // CodeMirror diagnostics are deliberately drawn by this page instead of depending on its
+  // optional lint addon: the compiler already returns exact 0-based locations, and keeping the
+  // tiny renderer here preserves the editor's plain-textarea fallback. The list below the
+  // editor remains the accessible summary; these widgets put each message beside the code that
+  // caused it, which is where it is useful while fixing a failed compile.
+  var editorDiags = [];
+  var latestDiags = [];
+  function clearEditorDiags() {
+    if (!editor) return;
+    editorDiags.forEach(function (entry) {
+      if (entry.widget) entry.widget.clear();
+      if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+      if (entry.mark) entry.mark.clear();
+    });
+    editorDiags = [];
+  }
+  function renderEditorDiags() {
+    clearEditorDiags();
+    if (!editor) return;
+    var file = files[active];
+    latestDiags.forEach(function (d) {
+      if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
+      var severity = d.severity || "info";
+      var lineClass = "cp-pg-line-" + severity;
+      editor.addLineClass(d.line, "background", lineClass);
+      var message = document.createElement("div");
+      message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
+      // The live summary below already announces the same diagnostic. Keep this visual copy
+      // out of the accessibility tree so a compile failure is not read twice.
+      message.setAttribute("aria-hidden", "true");
+      message.textContent = d.message;
+      var widget = editor.addLineWidget(d.line, message, { coverGutter: false, noHScroll: true });
+      var mark = null;
+      if (d.ch != null) {
+        var lineText = editor.getLine(d.line) || "";
+        var start = Math.max(0, Math.min(d.ch, lineText.length));
+        var endLine = d.endLine == null ? d.line : Math.max(d.line, d.endLine);
+        var endCh = d.endCh == null ? Math.min(lineText.length, start + 1) : d.endCh;
+        if (endLine !== d.line || endCh > start) {
+          mark = editor.markText(
+            { line: d.line, ch: start },
+            { line: endLine, ch: endCh },
+            { className: "cp-pg-range-" + severity }
+          );
+        }
+      }
+      editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+    });
+  }
   // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
   // buffer, `active` is the one the textarea is showing. A single-file snippet keeps exactly
   // the old shape, so nothing about the common case changes.
@@ -322,6 +371,8 @@ fun MediaControlButtonsPlaying() {
     statusEl.textContent = text;
   }
   function clearOut() {
+    latestDiags = [];
+    clearEditorDiags();
     diags.hidden = true; diags.innerHTML = "";
     result.hidden = true; image.hidden = true; image.removeAttribute("src"); openRow.hidden = true;
     note.hidden = true; note.textContent = "";
@@ -337,11 +388,14 @@ fun MediaControlButtonsPlaying() {
     active = i;
     writeSource(files[active].text);
     renderFiles();
+    renderEditorDiags();
   }
   function renderDiags(list) {
-    if (!list || !list.length) return;
+    latestDiags = list || [];
+    renderEditorDiags();
+    if (!latestDiags.length) return;
     diags.hidden = false;
-    list.forEach(function (d) {
+    latestDiags.forEach(function (d) {
       var li = document.createElement("li");
       li.className = "cp-pg-diag cp-pg-" + (d.severity || "info");
       // With several buffers open, "unresolved reference at line 5" is useless without the
@@ -353,8 +407,15 @@ fun MediaControlButtonsPlaying() {
       li.textContent = (d.severity || "info") + ": " + d.message + loc;
       if (owner >= 0) {
         li.style.cursor = "pointer";
-        li.title = "Show " + d.file;
-        li.addEventListener("click", function () { showFile(owner); });
+        li.title = "Show " + d.file + (d.line != null ? ":" + (d.line + 1) : "");
+        li.addEventListener("click", function () {
+          showFile(owner);
+          if (editor && d.line != null) {
+            editor.setCursor({ line: d.line, ch: d.ch || 0 });
+            editor.scrollIntoView({ line: d.line, ch: d.ch || 0 }, 80);
+            editor.focus();
+          }
+        });
       }
       diags.appendChild(li);
     });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -108,8 +108,8 @@ fun Greeting() {
         Text(&quot;Hello, Compose!&quot;)
     }
 }</textarea>
-          <div id="pg-status" class="cp-pg-status" hidden></div>
-          <ul id="pg-diagnostics" class="cp-pg-diags" hidden></ul>
+          <div id="pg-status" class="cp-pg-status" role="status" hidden></div>
+          <ul id="pg-diagnostics" class="cp-pg-diags" aria-live="polite" hidden></ul>
           <div id="pg-result" class="cp-doc-result cp-pg-result" hidden>
             <p id="pg-preview-note" class="cp-pg-status" hidden></p>
             <img id="pg-image" class="cp-pg-image" alt="Rendered first frame" hidden>
@@ -259,6 +259,55 @@ fun Greeting() {
   function writeSource(text) {
     if (editor) editor.setValue(text); else source.value = text;
   }
+  // CodeMirror diagnostics are deliberately drawn by this page instead of depending on its
+  // optional lint addon: the compiler already returns exact 0-based locations, and keeping the
+  // tiny renderer here preserves the editor's plain-textarea fallback. The list below the
+  // editor remains the accessible summary; these widgets put each message beside the code that
+  // caused it, which is where it is useful while fixing a failed compile.
+  var editorDiags = [];
+  var latestDiags = [];
+  function clearEditorDiags() {
+    if (!editor) return;
+    editorDiags.forEach(function (entry) {
+      if (entry.widget) entry.widget.clear();
+      if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+      if (entry.mark) entry.mark.clear();
+    });
+    editorDiags = [];
+  }
+  function renderEditorDiags() {
+    clearEditorDiags();
+    if (!editor) return;
+    var file = files[active];
+    latestDiags.forEach(function (d) {
+      if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
+      var severity = d.severity || "info";
+      var lineClass = "cp-pg-line-" + severity;
+      editor.addLineClass(d.line, "background", lineClass);
+      var message = document.createElement("div");
+      message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
+      // The live summary below already announces the same diagnostic. Keep this visual copy
+      // out of the accessibility tree so a compile failure is not read twice.
+      message.setAttribute("aria-hidden", "true");
+      message.textContent = d.message;
+      var widget = editor.addLineWidget(d.line, message, { coverGutter: false, noHScroll: true });
+      var mark = null;
+      if (d.ch != null) {
+        var lineText = editor.getLine(d.line) || "";
+        var start = Math.max(0, Math.min(d.ch, lineText.length));
+        var endLine = d.endLine == null ? d.line : Math.max(d.line, d.endLine);
+        var endCh = d.endCh == null ? Math.min(lineText.length, start + 1) : d.endCh;
+        if (endLine !== d.line || endCh > start) {
+          mark = editor.markText(
+            { line: d.line, ch: start },
+            { line: endLine, ch: endCh },
+            { className: "cp-pg-range-" + severity }
+          );
+        }
+      }
+      editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+    });
+  }
   // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
   // buffer, `active` is the one the textarea is showing. A single-file snippet keeps exactly
   // the old shape, so nothing about the common case changes.
@@ -315,6 +364,8 @@ fun Greeting() {
     statusEl.textContent = text;
   }
   function clearOut() {
+    latestDiags = [];
+    clearEditorDiags();
     diags.hidden = true; diags.innerHTML = "";
     result.hidden = true; image.hidden = true; image.removeAttribute("src"); openRow.hidden = true;
     note.hidden = true; note.textContent = "";
@@ -330,11 +381,14 @@ fun Greeting() {
     active = i;
     writeSource(files[active].text);
     renderFiles();
+    renderEditorDiags();
   }
   function renderDiags(list) {
-    if (!list || !list.length) return;
+    latestDiags = list || [];
+    renderEditorDiags();
+    if (!latestDiags.length) return;
     diags.hidden = false;
-    list.forEach(function (d) {
+    latestDiags.forEach(function (d) {
       var li = document.createElement("li");
       li.className = "cp-pg-diag cp-pg-" + (d.severity || "info");
       // With several buffers open, "unresolved reference at line 5" is useless without the
@@ -346,8 +400,15 @@ fun Greeting() {
       li.textContent = (d.severity || "info") + ": " + d.message + loc;
       if (owner >= 0) {
         li.style.cursor = "pointer";
-        li.title = "Show " + d.file;
-        li.addEventListener("click", function () { showFile(owner); });
+        li.title = "Show " + d.file + (d.line != null ? ":" + (d.line + 1) : "");
+        li.addEventListener("click", function () {
+          showFile(owner);
+          if (editor && d.line != null) {
+            editor.setCursor({ line: d.line, ch: d.ch || 0 });
+            editor.scrollIntoView({ line: d.line, ch: d.ch || 0 }, 80);
+            editor.focus();
+          }
+        });
       }
       diags.appendChild(li);
     });

--- a/vscode-extension/preview-harness/playground.spec.mjs
+++ b/vscode-extension/preview-harness/playground.spec.mjs
@@ -150,6 +150,35 @@ test("compiles the default Android snippet to a first frame + live /pg/ handoff"
   ).toMatch(/^data:image\/png/);
 });
 
+test("shows compile errors beside the offending source line", async ({ page }) => {
+  requirePlayground();
+  await page.goto(`/playground${q}`, { waitUntil: "domcontentloaded" });
+  await page.selectOption("#pg-mode", ANDROID_MODE);
+  await setSource(
+    page,
+    [
+      "import androidx.compose.runtime.Composable",
+      "import androidx.compose.ui.tooling.preview.Preview",
+      "",
+      "@Preview",
+      "@Composable",
+      "fun Broken() {",
+      "    MissingSymbol()",
+      "}",
+    ].join("\n"),
+  );
+
+  expect(await runAndAwaitTerminal(page)).toBe("Compilation failed.");
+  const summary = page.locator("#pg-diagnostics .cp-pg-error");
+  await expect(summary, "compile-error summary").toContainText("MissingSymbol");
+
+  // The summary remains useful to screen readers and to the textarea fallback, but a normal
+  // CodeMirror run also paints the bad line and puts the compiler's message directly beneath it.
+  const inline = page.locator(".cp-pg-inline-error");
+  await expect(inline, "inline compile error").toContainText("MissingSymbol");
+  await expect(page.locator(".cp-pg-line-error"), "highlighted source line").toHaveCount(1);
+});
+
 test("a multi-file snippet compiles as one module and offers every preview it declared", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- render compiler diagnostics inline beneath their source lines in the playground
- highlight diagnostic lines and ranges while retaining the accessible summary below the editor
- support multi-file navigation and clear stale markers before subsequent runs
- add fixture coverage and a browser-harness compile-failure scenario

## Why

Compile failures were only visible in the diagnostics list below the editor, forcing users to correlate file and line numbers manually. The compile API already returns CodeMirror-compatible zero-based locations, but the playground frontend did not render them in the editor.

## Impact

Errors and warnings now appear beside the code that caused them. Clicking a diagnostic summary jumps to the matching file, line, and column. The plain-textarea fallback continues to use the summary list.

## Validation

- `./gradlew :cli:test --tests '*ServeWebFixtureTest*'`
- `node --check vscode-extension/preview-harness/playground.spec.mjs`
- parsed generated fixture inline scripts with Node `vm.Script`
- `git diff --check`