### PR TITLE
docs(ci): record why the privileged-checkout alert is benign here

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -42,6 +42,27 @@ on:
         description: 'Gradle module path to render (e.g. ":app").'
         required: true
         type: string
+      # CodeQL reports "Checkout of untrusted code in a privileged context" (critical)
+      # against the `actions/checkout` steps that consume this input and `driver-ref`
+      # below. In THIS repo it is a false positive — dismissed, not fixed — and the
+      # reasoning is worth keeping so the next reader doesn't re-derive it:
+      #
+      #  - The rule treats a `workflow_run` trigger as privileged, because it usually
+      #    fires from a PR-triggered run whose head is untrusted. The one privileged
+      #    caller here is post-release-design-artifacts.yml → design-artifacts.yml,
+      #    and it hangs off release-please.yml, which runs only on `push` to `main`
+      #    and `workflow_dispatch`. No `pull_request`/`pull_request_target` anywhere
+      #    in that chain, so nothing a non-writer controls can start it.
+      #  - The rule treats a reusable workflow's inputs as attacker-controlled, because
+      #    a caller may pass anything. Both call sites in design-artifacts.yml pass
+      #    literals only and never set `ref` or `driver-ref`, so the checkouts resolve
+      #    to the default branch and the literal `main` respectively.
+      #
+      # An EXTERNAL caller is a different question: this workflow is meant to be called
+      # from other repos, and there the ref a caller passes is that repo's business —
+      # if you wire it into a privileged trigger, pass a ref you control, never one
+      # derived from PR head/branch/title. Re-check the first bullet before adding any
+      # new trigger to a caller in this repo.
       ref:
         description: 'Git ref of the CALLING repo to check out and render (branch, tag or SHA). Empty ⇒ the ref that triggered the caller — the normal push/PR case. Set this when the trigger cannot imply the right ref: a `schedule` run only fires for a workflow on the default branch and checks out that branch, so a catalog living on a side branch (e.g. `previews`) needs `ref: previews` here or the render finds no catalog.spec.json (issue #2963).'
         required: false
@@ -67,6 +88,8 @@ on:
         required: false
         type: string
         default: 'gradle/libs.versions.toml'
+      # Same CodeQL "privileged checkout" note as `ref` above — the default is a
+      # literal and no caller in this repo overrides it.
       driver-ref:
         description: 'compose-ai-tools ref checked out for the export driver (scripts/design-artifacts).'
         required: false


### PR DESCRIPTION
## Summary

#3959 put a `workflow_run` trigger in front of `design-artifacts.yml`, which made CodeQL report 3 critical **Checkout of untrusted code in a privileged context** alerts against the `actions/checkout` steps in `design-artifacts-reusable.yml` that consume `inputs.ref` / `inputs.driver-ref`.

They're false positives, and they're being dismissed rather than worked around. This records why, next to the inputs themselves, so the next person to hit it doesn't re-derive the analysis — or, worse, "fix" a workflow other repos call in order to quiet a rule that doesn't apply.

Both premises of the rule fail here:

- **`workflow_run` is privileged because it usually fires from a PR-triggered run.** The only privileged caller is `post-release-design-artifacts.yml` → `design-artifacts.yml`, hanging off `release-please.yml`, which runs solely on `push: branches: [main]` and `workflow_dispatch`. No `pull_request` / `pull_request_target` anywhere in the chain, so nothing a non-writer controls can start it, and anyone who can already has write access.
- **A reusable workflow's inputs are attacker-controlled because a caller may pass anything.** Both call sites in `design-artifacts.yml` (`wear-m3`, `remote-m3`) pass literals — `system`, `spec`, `module`, `cli-source`, split flags — and never set `ref` or `driver-ref`. They resolve to checkout's default (the default branch) and the literal `main`.

The comment also states the part that does **not** generalise: this workflow is designed to be called from other repos, and an external caller wiring it into a privileged trigger owns the ref it passes — it should pass one it controls, never one derived from a PR head, branch name, or title. It closes by pointing at the first bullet as the thing to re-check before adding a new trigger to any caller in this repo.

Comments only — no keys, defaults, or steps changed.

## Test plan

- `yaml.safe_load` on the file parses, and the two inputs still read `ref` default `''`, `driver-ref` default `'main'` — i.e. the comment insertion didn't disturb the schema.
- `git diff --stat`: 23 insertions, 0 deletions.
- No behaviour to exercise; nothing visual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uef5JBNLS3eAD76tW65U6J)_