### PR TITLE
fix(serve): filter unavailable historic preview revisions

### DIFF
--- a/.github/actions/apply/lib/push-branch.sh
+++ b/.github/actions/apply/lib/push-branch.sh
@@ -19,6 +19,8 @@
 #   DELTA_ON_TIP_PATHS   — whitespace-separated paths this invocation owns. On every retry start
 #                          from the fetched tip and replace only these paths (index publisher mode).
 #   REMOTE_URL           — test seam; defaults to the authenticated GitHub repository URL.
+#   REVISION_PREVIEW_INDEX — "1" to roll preview-index.json forward from catalog.json at the
+#                            fetched parent. Intended for design-artifact catalog branches.
 #
 # Exits 0 on success / skip, non-zero on push failure.
 set -euo pipefail
@@ -32,6 +34,8 @@ SHA_OUTPUT_FILE="${SHA_OUTPUT_FILE:-}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
 CARRY_FORWARD_PATHS="${CARRY_FORWARD_PATHS:-}"
 DELTA_ON_TIP_PATHS="${DELTA_ON_TIP_PATHS:-}"
+REVISION_PREVIEW_INDEX="${REVISION_PREVIEW_INDEX:-0}"
+HELPER_DIR=$(cd "$(dirname "$0")" && pwd)
 
 if [ -n "$CARRY_FORWARD_PATHS" ] && [ -n "$DELTA_ON_TIP_PATHS" ]; then
   echo "CARRY_FORWARD_PATHS and DELTA_ON_TIP_PATHS are mutually exclusive." >&2
@@ -88,6 +92,38 @@ tree_for_parent() {
   echo "$TREE"
 }
 
+with_revision_preview_index() {
+  candidate="$1"
+  parent="$2"
+  [ "$REVISION_PREVIEW_INDEX" = "1" ] || { echo "$candidate"; return; }
+
+  scratch=$(mktemp -d)
+  git show "${candidate}:catalog.json" > "$scratch/catalog.json"
+  if [ -n "$parent" ] && git show "${parent}:preview-index.json" > "$scratch/prior.json" 2>/dev/null; then
+    node "$HELPER_DIR/../../../../scripts/design-artifacts/revision-preview-index.mjs" \
+      --catalog "$scratch/catalog.json" --prior "$scratch/prior.json" --parent "$parent" \
+      --out "$scratch/preview-index.json"
+  else
+    node "$HELPER_DIR/../../../../scripts/design-artifacts/revision-preview-index.mjs" \
+      --catalog "$scratch/catalog.json" --parent "$parent" \
+      --out "$scratch/preview-index.json"
+  fi
+  blob=$(git hash-object -w "$scratch/preview-index.json")
+  git read-tree "$candidate"
+  git update-index --add --cacheinfo "100644,$blob,preview-index.json"
+  indexed=$(git write-tree)
+  rm -rf "$scratch"
+  echo "$indexed"
+}
+
+carry_parent_preview_index() {
+  candidate="$1"
+  parent="$2"
+  git read-tree "$candidate"
+  git restore --source="$parent" --staged -- preview-index.json
+  git write-tree
+}
+
 # Retry loop handles the push race when two PRs finish concurrently
 # against the same shared branch. Per-PR concurrency in the workflow
 # serialises a single PR's pushes, but different PRs push to the same
@@ -101,6 +137,18 @@ while :; do
     PARENT_TREE=$(git rev-parse "${PARENT}^{tree}")
   fi
   CANDIDATE_TREE=$(tree_for_parent "$PARENT")
+  PREVIEW_INDEX_CARRIED=0
+  if [ "$REVISION_PREVIEW_INDEX" = "1" ] && [ -n "$PARENT" ] && \
+      git cat-file -e "${PARENT}:preview-index.json" 2>/dev/null; then
+    # Compare with the parent's unchanged index first. Otherwise an identical catalog would appear
+    # changed merely because the generated staging directory does not itself carry the rolling
+    # index, manufacturing an empty publish on every run.
+    CANDIDATE_TREE=$(carry_parent_preview_index "$CANDIDATE_TREE" "$PARENT")
+    PREVIEW_INDEX_CARRIED=1
+  else
+    # First indexed publish: adding the index is itself a real branch change.
+    CANDIDATE_TREE=$(with_revision_preview_index "$CANDIDATE_TREE" "$PARENT")
+  fi
   if [ -n "$PARENT" ]; then
     if [ "$SKIP_IF_UNCHANGED" = "1" ] && [ "$CANDIDATE_TREE" = "$PARENT_TREE" ]; then
       echo "Tree unchanged vs ${TARGET_BRANCH}; skipping push."
@@ -109,6 +157,10 @@ while :; do
       fi
       exit 0
     fi
+  fi
+
+  if [ "$PREVIEW_INDEX_CARRIED" = "1" ]; then
+    CANDIDATE_TREE=$(with_revision_preview_index "$CANDIDATE_TREE" "$PARENT")
   fi
 
   if [ -n "$PARENT" ]; then

--- a/.github/actions/apply/lib/test-push-branch.sh
+++ b/.github/actions/apply/lib/test-push-branch.sh
@@ -58,4 +58,46 @@ publish "$render" CARRY_FORWARD_PATHS
 publish "$index" DELTA_ON_TIP_PATHS
 assert_tip render-v3 issues-newer
 
+# A catalog publish carries the prior index forward and promotes its `current` inventory under the
+# actual parent SHA. The staging directory intentionally has no preview-index.json: the helper owns
+# that generated branch metadata.
+indexed="$ROOT/indexed"
+mkdir -p "$indexed"
+printf '%s\n' '{"components":[{"images":[{"path":"images/old/ideal.png"}]}]}' > "$indexed/catalog.json"
+(
+  cd "$indexed"
+  env TARGET_BRANCH=design-artifacts/index REPO=local/test GITHUB_TOKEN_INLINE=test MSG=first \
+    REMOTE_URL="$REMOTE" REVISION_PREVIEW_INDEX=1 "$HELPER"
+)
+first=$(git --git-dir="$REMOTE" rev-parse refs/heads/design-artifacts/index)
+indexed2="$ROOT/indexed2"
+mkdir -p "$indexed2"
+printf '%s\n' '{"components":[{"images":[{"path":"images/new/ideal.png"}]}]}' > "$indexed2/catalog.json"
+(
+  cd "$indexed2"
+  env TARGET_BRANCH=design-artifacts/index REPO=local/test GITHUB_TOKEN_INLINE=test MSG=second \
+    REMOTE_URL="$REMOTE" REVISION_PREVIEW_INDEX=1 "$HELPER"
+)
+index_check="$ROOT/index-check"
+git clone -q --branch design-artifacts/index "$REMOTE" "$index_check"
+node -e '
+  const fs = require("fs");
+  const index = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (index.current.join() !== "new__ideal") throw new Error("new current missing");
+  const prior = index.revisions.find((entry) => entry.commit === process.argv[2]);
+  if (!prior || prior.previews.join() !== "old__ideal") throw new Error("prior current not promoted");
+' "$index_check/preview-index.json" "$first"
+
+indexed3="$ROOT/indexed3"
+mkdir -p "$indexed3"
+cp "$indexed2/catalog.json" "$indexed3/catalog.json"
+before=$(git --git-dir="$REMOTE" rev-parse refs/heads/design-artifacts/index)
+(
+  cd "$indexed3"
+  env TARGET_BRANCH=design-artifacts/index REPO=local/test GITHUB_TOKEN_INLINE=test MSG=unchanged \
+    REMOTE_URL="$REMOTE" REVISION_PREVIEW_INDEX=1 SKIP_IF_UNCHANGED=1 "$HELPER"
+)
+after=$(git --git-dir="$REMOTE" rev-parse refs/heads/design-artifacts/index)
+test "$before" = "$after"
+
 echo "push-branch race tests passed"

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1396,6 +1396,7 @@ jobs:
           MSG="chore(design-artifacts): regenerate ${SYSTEM} catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
           CARRY_FORWARD_PATHS='parity/issues.json' \
+          REVISION_PREVIEW_INDEX=1 \
           GIT_AUTHOR_NAME='${{ inputs.commit-user-name }}' \
           GIT_AUTHOR_EMAIL='${{ inputs.commit-user-email }}' \
           GIT_COMMITTER_NAME='${{ inputs.commit-user-name }}' \

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -552,6 +552,7 @@ jobs:
           GITHUB_TOKEN_INLINE="$GH_TOKEN" \
           MSG="chore(design-artifacts): regenerate $SYSTEM catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
+          REVISION_PREVIEW_INDEX=1 \
           GIT_AUTHOR_NAME='Yuri Schimke' \
           GIT_AUTHOR_EMAIL='yuri@schimke.ee' \
           GIT_COMMITTER_NAME='Yuri Schimke' \

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -151,6 +151,8 @@ class ServeBundleHost(
    * uploaded bundle, and for a catalog whose branch history couldn't be read.
    */
   val revisions: List<ServeCatalogRevision.Revision> = emptyList(),
+  /** Preview inventories precomputed by the publisher, keyed by historic delivery commit. */
+  private val revisionPreviewIds: Map<String, Set<String>>? = null,
   /**
    * Each design reference's path **on the delivery branch**, which is not the path the served
    * manifest carries: catalog import rewrites every raster to a server-owned `references/<id>.png`.
@@ -681,6 +683,10 @@ class ServeBundleHost(
    */
   fun pinnedCatalogIsAuthoritative(commit: String): Boolean =
     pinnedManifest?.forCommit(commit)?.catalogRead == true
+
+  /** Null means this branch or revision predates the generation-time index, so menus fail open. */
+  fun revisionContainsPreview(commit: String, previewId: String): Boolean? =
+    ServeCatalogRevision.normalize(commit)?.let { revisionPreviewIds?.get(it)?.contains(previewId) }
 
   /** [referenceId]'s canonical reference raster as published at [commit]. See [pinnedRender]. */
   fun pinnedReference(commit: String, referenceId: String): PinnedOutcome =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -317,6 +317,14 @@ class ServeCatalogStore(
         return Result.Failed(system, "could not parse catalog.json: $detail")
       }
 
+    // One compact file answers preview availability for the whole revision menu. Older branches
+    // have no index and deliberately fail open; the pinned catalog remains authoritative on click.
+    val revisionPreviewIds = runCatching {
+      ServeRevisionPreviewIndex.parse(fetchCatalogAsset(base + ServeRevisionPreviewIndex.FILE_NAME))
+        ?.previewsByCommit()
+    }
+      .getOrNull()
+
     // Stage the fetch so a re-load (ServeCatalogRefresher) can't turn a healthy catalog into 404s:
     // fetch the images into a sibling `.staging` dir and only swap it over the live `dir` once we
     // know we have a usable catalog (count > 0). A partial/failed fetch (e.g. images temporarily
@@ -741,6 +749,7 @@ class ServeCatalogStore(
           bakedBranchPaths = bakedPathById.toMap(),
           referenceBranchPaths = referenceBranchPaths,
           revisions = revisions,
+          revisionPreviewIds = revisionPreviewIds,
           // Same seam as `fetchBakedPng`: the host names a commit and a published path, the store
           // builds the URL and applies the fetch policy. Null repo ⇒ no pinned lane at all.
           fetchPinnedAsset = { commit, path ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2318,16 +2318,36 @@ class ServeHttpServer(
    * A session with no delivery branch behind it (an uploaded bundle, a local project) gets no
    * revision surface at all rather than an empty control.
    */
-  private fun RoutingContext.catalogRevisions(renderHost: ServeHost): ServeWeb.CatalogRevisions {
+  private fun RoutingContext.catalogRevisions(
+    renderHost: ServeHost,
+    previewId: String? = null,
+  ): ServeWeb.CatalogRevisions {
     val host = catalogBundleHost(renderHost) ?: return ServeWeb.CatalogRevisions.NONE
     if (!host.supportsPinnedRevisions) return ServeWeb.CatalogRevisions.NONE
     return ServeWeb.CatalogRevisions(
       pinned =
         ServeCatalogRevision.normalize(call.request.queryParameters[ServeCatalogRevision.PARAM]),
-      revisions = host.revisions,
+      revisions = if (previewId == null) host.revisions else availableRevisions(host, previewId),
       repo = host.provenance?.repo,
     )
   }
+
+  /**
+   * The catalog publishes as they apply to one preview, newest first.
+   *
+   * A delivery branch's feed is catalog-wide, so it includes commits from before a newly-added
+   * preview existed. Offering those as this preview's versions only manufactures links to honest
+   * 404s. The publisher rolls a compact preview index forward with every catalog generation, so
+   * this is an in-memory lookup rather than one historical `catalog.json` fetch per row. A missing
+   * index or entry fails open, keeping older publishers backward-compatible.
+   */
+  private fun availableRevisions(
+    host: ServeBundleHost,
+    previewId: String,
+  ): List<ServeCatalogRevision.Revision> =
+    host.revisions.filterIndexed { index, revision ->
+      index == 0 || host.revisionContainsPreview(revision.commit, previewId) != false
+    }
 
   /**
    * Answer one **pinned** image request: the published bytes at a delivery-branch commit, or a 404
@@ -2580,7 +2600,7 @@ class ServeHttpServer(
           repo = reportContext.repo,
           login = githubAuth?.currentLogin(call),
         )
-      val revisions = catalogRevisions(renderHost)
+      val revisions = catalogRevisions(renderHost, preview.id)
       val pinned = revisions.pinned != null
       markGeneration("static-page", pageCacheControl())
       call.respondText(
@@ -4451,7 +4471,7 @@ class ServeHttpServer(
       onMissing = { respondNotFoundHtml("That design system was not found on this server.") },
     ) { renderHost ->
       val previewId = call.parameters["name"]
-      val revisions = catalogRevisions(renderHost)
+      val revisions = catalogRevisions(renderHost, previewId)
       // Which catalog decides what this page is *about*. Unpinned it is the session's own list;
       // under a pin it is the revision's own catalog, asked FIRST — the same authority rule the
       // asset lanes follow, and for the same reason. Asking the tip first looks harmless while a
@@ -4480,7 +4500,32 @@ class ServeHttpServer(
           ?: if (revisionAnswers) null else renderHost.previews.firstOrNull { it.id == id }
       }
       if (preview == null) {
-        respondNotFoundHtml("That preview does not exist in this catalog.")
+        if (revisions.pinned != null && previewId != null) {
+          // The selected publish answered authoritatively that this id was absent. Keep the 404 —
+          // serving today's preview here would lie about the pin — but retain the revision menu so
+          // a catalog-wide publish that predates this preview is not a navigation dead end.
+          val skin = siteSkin()
+          call.respondText(
+            ServeWeb.unavailablePreviewRevisionPage(
+              previewId = previewId,
+              token = token,
+              sessionId = webSessionId,
+              basePath = basePath,
+              isPublic = isPublic,
+              revisions = revisions,
+              unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
+              version = BUNDLE_VERSION,
+              siteName = skin.first,
+              themeCss = skin.second,
+              themeStorageKey = skin.third,
+              sessionInOrigin = siteSystem() != null,
+            ),
+            ContentType.Text.Html,
+            HttpStatusCode.NotFound,
+          )
+        } else {
+          respondNotFoundHtml("That preview does not exist in this catalog.")
+        }
         return@withLeasedSession
       }
       // Offer the in-browser Wasm tier when this catalog session has a Wasm app registered.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndex.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndex.kt
@@ -1,0 +1,34 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Compact, generation-time inventory used to remove nonexistent historic versions from menus. */
+@Serializable
+data class ServeRevisionPreviewIndex(
+  val schema: String = "",
+  val current: List<String> = emptyList(),
+  val revisions: List<Entry> = emptyList(),
+) {
+  @Serializable data class Entry(val commit: String = "", val previews: List<String> = emptyList())
+
+  /** Null means this branch predates the index, so callers must fail open. */
+  fun previewsByCommit(): Map<String, Set<String>>? {
+    if (schema != SCHEMA) return null
+    return revisions
+      .mapNotNull { entry ->
+        ServeCatalogRevision.normalize(entry.commit)?.let { it to entry.previews.toSet() }
+      }
+      .toMap()
+  }
+
+  companion object {
+    const val FILE_NAME: String = "preview-index.json"
+    const val SCHEMA: String = "compose-preview-revision-index/v1"
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    fun parse(bytes: ByteArray?): ServeRevisionPreviewIndex? = bytes?.let {
+      runCatching { JSON.decodeFromString(serializer(), it.toString(Charsets.UTF_8)) }.getOrNull()
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4226,6 +4226,61 @@ object ServeWeb {
   }
 
   /**
+   * The honest landing page for a preview URL pinned to a publish that did not contain that
+   * preview.
+   *
+   * This remains a 404 — showing the current render under a historical URL would make the pin a lie
+   * — but unlike the generic [notFoundPage] it keeps the catalog's revision navigator. A preview
+   * can be added between publishes, so the catalog-wide revision menu can legitimately lead to a
+   * commit where its id is absent. Dropping the menu at that point strands the visitor on the first
+   * unavailable publish they try; keeping it lets them choose another historical publish or return
+   * to current without pretending this one had pixels it never published.
+   */
+  fun unavailablePreviewRevisionPage(
+    previewId: String,
+    token: String,
+    sessionId: String? = null,
+    basePath: String = "",
+    isPublic: Boolean = false,
+    revisions: CatalogRevisions,
+    unfurl: UnfurlMetadata? = null,
+    version: String? = null,
+    siteName: String = "",
+    themeCss: String = "",
+    themeStorageKey: String = "",
+    sessionInOrigin: Boolean = false,
+  ): String {
+    val linkSessionId = if (sessionInOrigin) null else sessionId
+    val idSeg = WebEscaping.urlEncodeSegment(previewId)
+    val query = querySuffix(linkQuery(token, linkSessionId, basePath, isPublic))
+    val hrefFor: (String?) -> String = { pin -> withPin("$basePath/p/$idSeg$query", pin) }
+    val revisionMenu = revisionsHtml(revisions, includeBanner = false, hrefFor = hrefFor)
+    val pin = revisions.pinned?.let(ServeCatalogRevision::short).orEmpty()
+    val message =
+      if (pin.isBlank()) "That preview does not exist in this catalog."
+      else "This preview was not published in catalog revision $pin."
+    val suffix = querySuffix(if (isPublic) "" else "token=" + WebEscaping.urlEncodeSegment(token))
+    return document(
+      title = "Preview unavailable — compose-preview",
+      unfurlDescription = message,
+      unfurl = unfurl,
+      version = version,
+      navSuffix = suffix,
+      siteName = siteName,
+      themeCss = themeCss,
+      themeStorageKey = themeStorageKey,
+      body =
+        """
+        <h1 class="cp-head">Preview unavailable</h1>
+        <p class="cp-sub">${WebEscaping.htmlEscape(message)} Choose another revision or return to the current catalog.</p>
+        $revisionMenu
+        <a class="cp-back" href="${WebEscaping.htmlEscape(hrefFor(null))}">← View current preview</a>
+        """
+          .trimIndent(),
+    )
+  }
+
+  /**
    * `GET /playground` — the **Stage-1 editor** for the Kotlin playground
    * (`docs/design/PLAYGROUND.md` §2). A code box + a mode selector + a Run button that POSTs to
    * `/api/{v}/compiler/run` and shows the compiler diagnostics, the first-frame render, and the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -54,6 +54,13 @@ class ServePinnedRevisionTest {
     """
       .trimIndent()
 
+  private val previewIndexJson =
+    """
+    {"schema":"compose-preview-revision-index/v1","current":["$previewId"],"revisions":[
+      {"commit":"$oldCommit","previews":["$previewId"]}]}
+    """
+      .trimIndent()
+
   private val feed =
     """
     <feed>
@@ -88,6 +95,8 @@ class ServePinnedRevisionTest {
       ServeCatalogRevision.commitsFeedUrl(repo, branch) -> feed.encodeToByteArray()
       "${tip}catalog.json",
       "${byBranch}catalog.json" -> catalogJson.encodeToByteArray()
+      "${tip}preview-index.json",
+      "${byBranch}preview-index.json" -> previewIndexJson.encodeToByteArray()
       "${tip}references/index.json",
       "${byBranch}references/index.json" -> referencesJson.encodeToByteArray()
       "${tip}references/button.png",
@@ -215,6 +224,26 @@ class ServePinnedRevisionTest {
     // the same bytes under a sha.
     assertFalse(page.contains("at=$newCommit"), page)
     assertTrue(page.contains("b34eff53"), page)
+  }
+
+  @Test
+  fun `a generated preview index removes revisions that did not publish this preview`() {
+    val tip = "https://raw.githubusercontent.com/$repo/$newCommit/"
+    val withoutPreview =
+      """
+      {"schema":"compose-preview-revision-index/v1","current":["$previewId"],"revisions":[
+        {"commit":"$oldCommit","previews":["some-other-preview"]}]}
+      """
+        .trimIndent()
+        .encodeToByteArray()
+    val port = startWith { url ->
+      if (url == "${tip}preview-index.json") withoutPreview else fetch(url)
+    }
+
+    val page = text("http://127.0.0.1:$port/$system/p/$previewId")
+
+    assertTrue(page.contains("cp-revisions"), page)
+    assertFalse(page.contains("at=$oldCommit"), page)
   }
 
   @Test
@@ -502,7 +531,17 @@ class ServePinnedRevisionTest {
       if (url == "${old}catalog.json") olderCatalog.encodeToByteArray() else fetch(url)
     }
 
-    assertEquals(404, get("http://127.0.0.1:$port/$system/p/$previewId?at=$oldCommit").first)
+    val unavailable = get("http://127.0.0.1:$port/$system/p/$previewId?at=$oldCommit")
+    assertEquals(404, unavailable.first)
+    val unavailablePage = unavailable.second.decodeToString()
+    // A catalog publish can predate one preview. That is still an honest 404, but it must not
+    // strand the visitor: the same revision control remains available to choose another publish,
+    // and current is a clean URL rather than today's pixels served under the historical pin.
+    assertTrue(unavailablePage.contains("Preview unavailable"), unavailablePage)
+    assertTrue(unavailablePage.contains("was not published in catalog revision"), unavailablePage)
+    assertTrue(unavailablePage.contains("class=\"cp-revisions\""), unavailablePage)
+    assertTrue(unavailablePage.contains("/p/$previewId"), unavailablePage)
+    assertTrue(unavailablePage.contains("at=$oldCommit"), unavailablePage)
     assertEquals(
       404,
       get("http://127.0.0.1:$port/$system/render/$previewId.png?at=$oldCommit").first,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndexTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndexTest.kt
@@ -1,0 +1,33 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ServeRevisionPreviewIndexTest {
+  @Test
+  fun `valid index maps historic commits to preview sets`() {
+    val index =
+      ServeRevisionPreviewIndex.parse(
+        """
+        {"schema":"compose-preview-revision-index/v1","current":["today"],"revisions":[
+          {"commit":"1111111","previews":["old","shared"]},
+          {"commit":"not-a-sha","previews":["ignored"]}]}
+        """
+          .trimIndent()
+          .encodeToByteArray()
+      )
+
+    assertEquals(mapOf("1111111" to setOf("old", "shared")), index?.previewsByCommit())
+  }
+
+  @Test
+  fun `missing malformed and unknown indexes fail open`() {
+    assertNull(ServeRevisionPreviewIndex.parse(null))
+    assertNull(ServeRevisionPreviewIndex.parse("nope".encodeToByteArray()))
+    assertNull(
+      ServeRevisionPreviewIndex.parse("""{"schema":"future","revisions":[]}""".encodeToByteArray())
+        ?.previewsByCommit()
+    )
+  }
+}

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -214,6 +214,13 @@ A run whose output tree is byte-identical to the tip pushes **nothing**
 (`SKIP_IF_UNCHANGED=1`), so the weekly cron doesn't accumulate empty commits —
 a commit on these branches always means the rendered output actually changed.
 
+The publisher also rolls `preview-index.json` forward atomically with the commit. Its `current`
+inventory names the previews in this publish; on the next publish that inventory is promoted under
+the actual parent SHA and the oldest entry is trimmed. The preview server can therefore omit
+catalog-wide revisions that predate a particular preview with one small manifest read, rather than
+fetching and parsing every historical `catalog.json`. The index is carried unchanged during the
+byte-identical check, so this derived metadata cannot manufacture an otherwise-empty publish.
+
 The storage cost is modest despite each commit being a full ~60 MB snapshot,
 because unchanged PNGs are the same blob and git stores them once.
 `compose-preview/main` is the worked example: 770 commits of a ~69 MB tree

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -354,6 +354,12 @@ comparison page, one row per publish, dated and labelled by the *source* commit 
 regenerated from. Opening one pins the page. On an ordinary page view the control is a single folded
 line:
 
+The rows are preview-specific even though the commit feed is catalog-wide. Each generated delivery
+branch carries a rolling `preview-index.json`; the server uses it to omit revisions that did not
+publish the preview on the page. Branches produced before this index existed fail open and retain
+their rows, while a direct link to a genuinely absent preview still returns a contextual `404` with
+a route back to the current preview.
+
 ![The viewer's folded Revisions disclosure](images/serve-revision-viewer.png)
 
 The rules the lane holds to, each of which exists because its opposite would make a permalink a lie:

--- a/scripts/design-artifacts/revision-preview-index.mjs
+++ b/scripts/design-artifacts/revision-preview-index.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+import { servePreviewId } from "./design-references.mjs";
+
+export const SCHEMA = "compose-preview-revision-index/v1";
+export const MAX_REVISIONS = 12;
+
+export function previewIds(catalog) {
+  return [...new Set(
+    (catalog?.components ?? []).flatMap((component) =>
+      (component?.images ?? [])
+        .map((image) => image?.path)
+        .filter((path) => typeof path === "string" && /^images\/.+\.png$/.test(path))
+        .map(servePreviewId),
+    ),
+  )].sort();
+}
+
+/**
+ * Roll a branch tip's index forward. The new commit cannot name itself inside its own tree, so its
+ * inventory lives under `current`; on the next publish it is promoted under the then-parent SHA.
+ */
+export function updateRevisionPreviewIndex(catalog, prior, parent, limit = MAX_REVISIONS) {
+  const revisions = [];
+  if (parent && prior?.schema === SCHEMA && Array.isArray(prior.current)) {
+    revisions.push({ commit: parent, previews: [...new Set(prior.current)].sort() });
+  }
+  if (prior?.schema === SCHEMA && Array.isArray(prior.revisions)) {
+    for (const entry of prior.revisions) {
+      if (
+        typeof entry?.commit !== "string" ||
+        !Array.isArray(entry?.previews) ||
+        revisions.some((candidate) => candidate.commit === entry.commit)
+      ) continue;
+      revisions.push({ commit: entry.commit, previews: [...new Set(entry.previews)].sort() });
+    }
+  }
+  return { schema: SCHEMA, current: previewIds(catalog), revisions: revisions.slice(0, limit - 1) };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values } = parseArgs({
+    options: {
+      catalog: { type: "string" },
+      prior: { type: "string" },
+      parent: { type: "string", default: "" },
+      out: { type: "string" },
+    },
+  });
+  if (!values.catalog || !values.out) {
+    throw new Error("usage: revision-preview-index.mjs --catalog <catalog.json> [--prior <preview-index.json>] [--parent <sha>] --out <preview-index.json>");
+  }
+  const catalog = JSON.parse(await readFile(values.catalog, "utf8"));
+  const prior = values.prior ? JSON.parse(await readFile(values.prior, "utf8")) : null;
+  const index = updateRevisionPreviewIndex(catalog, prior, values.parent);
+  await writeFile(values.out, `${JSON.stringify(index, null, 2)}\n`);
+}

--- a/scripts/design-artifacts/revision-preview-index.test.mjs
+++ b/scripts/design-artifacts/revision-preview-index.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SCHEMA, previewIds, updateRevisionPreviewIndex } from "./revision-preview-index.mjs";
+
+const catalog = (...paths) => ({ components: [{ images: paths.map((path) => ({ path })) }] });
+
+test("preview ids use the server route identity", () => {
+  assert.deepEqual(previewIds(catalog("images/dialog-list/ideal__icon.png", "not-an-image")), [
+    "dialog-list__ideal__icon",
+  ]);
+});
+
+test("the previous current inventory is promoted under the parent commit", () => {
+  const prior = {
+    schema: SCHEMA,
+    current: ["old", "shared"],
+    revisions: [{ commit: "aaaaaaa", previews: ["older"] }],
+  };
+  assert.deepEqual(updateRevisionPreviewIndex(catalog("images/new/ideal.png"), prior, "bbbbbbb"), {
+    schema: SCHEMA,
+    current: ["new__ideal"],
+    revisions: [
+      { commit: "bbbbbbb", previews: ["old", "shared"] },
+      { commit: "aaaaaaa", previews: ["older"] },
+    ],
+  });
+});
+
+test("a branch without an index starts with only current", () => {
+  assert.deepEqual(updateRevisionPreviewIndex(catalog("images/new/ideal.png"), null, "bbbbbbb"), {
+    schema: SCHEMA,
+    current: ["new__ideal"],
+    revisions: [],
+  });
+});


### PR DESCRIPTION
## Summary

- publish a rolling `preview-index.json` with each design catalog revision
- filter each preview's revision menu using that precomputed availability index
- show a contextual historical-unavailable page for direct links instead of a generic dead end
- retain fail-open compatibility for delivery branches created before the index existed

## Root cause

The revision selector was built from the catalog delivery branch's catalog-wide commit feed. A catalog publish can predate an individual preview, so the selector generated valid commit links for preview IDs that the selected revision's own `catalog.json` never published.

## Implementation

The publish helper now carries the existing preview index forward atomically. Its prior `current` inventory is promoted under the actual parent commit SHA, the newly generated catalog becomes `current`, and the history is trimmed to the same revision window as the UI. The update happens after resolving the push parent, so retry races remain correct. Unchanged catalogs compare with the carried index and still skip publication.

The server fetches and parses the compact index once during catalog loading. Indexed absences are removed from the menu without fetching every historical `catalog.json`; missing indexes and missing entries fail open.

## Validation

- `node --test scripts/design-artifacts/revision-preview-index.test.mjs`
- `bash .github/actions/apply/lib/test-push-branch.sh`
- `./gradlew :cli:ktfmtCheck`
- focused `ServePinnedRevisionTest`, `ServeRevisionPreviewIndexTest`, and `ServeCatalogStoreTest` runs
- `git diff --check`
