### PR TITLE
test(serve): move two capture assertions to where they can be exhaustive

### DIFF
--- a/cli/serve-web/test/pageZoom.test.ts
+++ b/cli/serve-web/test/pageZoom.test.ts
@@ -331,10 +331,10 @@ describe("<cp-page-zoom>", () => {
         // The published scale goes back to 1 as well. The stylesheet counter-scales every node's
         // mark by it, so a reset that restored the view and left the variable behind would draw
         // hairlines at the old zoom over a sheet at 1:1 — a residue no view assertion can see.
-        assert.equal(
-            parseFloat(stage.style.getPropertyValue("--cp-page-zoom")) || 1,
-            1,
-        );
+        // Compared as the published STRING, with no `|| 1` fallback: a reset that published `0`,
+        // an empty value or `NaN` would parse-or-default its way past a numeric check while the
+        // counter-scaling stayed broken.
+        assert.equal(stage.style.getPropertyValue("--cp-page-zoom"), "1");
     });
 
     it("resets from a WHEEL zoom too, not only from a framed section", async () => {

--- a/cli/serve-web/test/pageZoom.test.ts
+++ b/cli/serve-web/test/pageZoom.test.ts
@@ -326,12 +326,30 @@ describe("<cp-page-zoom>", () => {
         await flush();
         assert.deepEqual(view(), { scale: 1, x: 0, y: 0 });
         assert.equal(el<HTMLElement>("cp-page-zoom").hidden, true);
+        const stage = el<HTMLElement>(".cp-page-stage");
+        assert.equal(stage.classList.contains("cp-page-zoomed"), false);
+        // The published scale goes back to 1 as well. The stylesheet counter-scales every node's
+        // mark by it, so a reset that restored the view and left the variable behind would draw
+        // hairlines at the old zoom over a sheet at 1:1 — a residue no view assertion can see.
         assert.equal(
-            el<HTMLElement>(".cp-page-stage").classList.contains(
-                "cp-page-zoomed",
-            ),
-            false,
+            parseFloat(stage.style.getPropertyValue("--cp-page-zoom")) || 1,
+            1,
         );
+    });
+
+    it("resets from a WHEEL zoom too, not only from a framed section", async () => {
+        // The capture that used to assert this could only afford one route in. Reset is reachable
+        // from a continuous wheel zoom as well as a discrete double-click frame, and the two arrive
+        // at the view through different code — `zoomAbout` versus `frameRect`.
+        await mount();
+        wheel(at(320, 215), -120, true);
+        wheel(at(320, 215), -120, true);
+        await flush();
+        assert.ok(view().scale > 1, "the wheel zoomed");
+        el<HTMLButtonElement>("[data-cp-page-zoom-reset]").click();
+        await flush();
+        assert.deepEqual(view(), { scale: 1, x: 0, y: 0 });
+        assert.equal(el<HTMLElement>("cp-page-zoom").hidden, true);
     });
 
     it("zooms in and out a notch from the corner buttons", async () => {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1875,6 +1875,28 @@ class ServeWebFixtureTest {
         version = version,
       )
 
+    // A node with code behind it is an ANCHOR, not a button or a bare div. That is what makes
+    // clicking it navigate, a middle click open a tab, a modifier click do what the reader's
+    // platform says, and the status bar preview the destination — none of which a `<button>` with a
+    // click handler gives you, and all of which a screenshot passes without.
+    //
+    // Asserted here rather than in the harness because it is server-rendered markup: the capture
+    // that used to hold it had to hover a node, wait for a tooltip and evaluate in a browser to
+    // read two attributes off the emitted HTML.
+    assertTrue(
+      Regex("""<a class="cp-page-node" [^>]*href="[^"]*/p/[^"]*"""")
+        .containsMatchIn(designPageHtml),
+      "a node with a renderable preview is emitted as an anchor to it",
+    )
+    // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
+    // tag is the same; only the target differs, so a reader never meets a node that looks
+    // navigable and is not.
+    assertTrue(
+      designPageHtml.contains("""<a class="cp-page-node" """) &&
+        !designPageHtml.contains("""<span class="cp-page-node" """),
+      "an unlinked node still links out to the design file rather than becoming inert",
+    )
+
     val designPageIndex =
       ServeWeb.designPagesIndexPage(
         moduleLabel = "compose-m3",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1891,10 +1891,21 @@ class ServeWebFixtureTest {
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
     // tag is the same; only the target differs, so a reader never meets a node that looks
     // navigable and is not.
+    //
+    // Matched on THAT node (`1:6`, the fixture's unlinked shape) rather than on "some anchor
+    // exists and no span does": the renderable nodes satisfy a bare existence check on their own,
+    // so this one could regress to a div and go unnoticed.
+    val unlinkedNode =
+      Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:6"[^>]*>""").find(designPageHtml)
+    assertTrue(unlinkedNode != null, "the unlinked node 1:6 is emitted at all")
+    assertEquals(
+      "a",
+      unlinkedNode!!.groupValues[1],
+      "an unlinked node stays an anchor rather than becoming inert",
+    )
     assertTrue(
-      designPageHtml.contains("""<a class="cp-page-node" """) &&
-        !designPageHtml.contains("""<span class="cp-page-node" """),
-      "an unlinked node still links out to the design file rather than becoming inert",
+      unlinkedNode.value.contains("href=\"https://www.figma.com/"),
+      "…and its destination is the design file, the only link it has",
     )
 
     val designPageIndex =

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -478,14 +478,10 @@ const FIXTURE_STATES = [
             // the full state. An unlinked one would shoot the degenerate half of the same card.
             await page.hover('.cp-page-node[data-link="manifest"]');
             await page.waitForSelector(".cp-page-tip:not([hidden]) .cp-page-tip-card");
-            // The overlay is a real link now — that is what makes clicking it GO, and what makes a
-            // middle click, a modifier click and the status-bar preview work. A `<button>` here
-            // would pass every pixel assertion and none of that.
-            const tag = await page.locator('.cp-page-node[data-link="manifest"]').first().evaluate(
-                (el) => el.tagName.toLowerCase() + "|" + (el.getAttribute("href") || ""),
-            );
-            expect(tag.startsWith("a|")).toBe(true);
-            expect(tag).toContain("/p/");
+            // The overlay being a real anchor — which is what makes clicking it GO, and what makes
+            // a middle click, a modifier click and the status-bar preview work — is server-rendered
+            // markup, so it is asserted in `ServeWebFixtureTest` against the emitted HTML rather
+            // than by hovering a node and reading attributes back out of a browser.
         },
     },
     {
@@ -745,20 +741,11 @@ const FIXTURE_STATES = [
             });
             await page.evaluate(() => document.activeElement?.blur());
             await page.waitForFunction(() => document.querySelector("cp-page-zoom").hidden);
-            // Back to the IDENTITY, not merely to something small: a reset that left a residual
-            // translate would look right in a screenshot and mis-place every overlay measured after
-            // the next resize. Asserted on the computed transform rather than by comparing the
-            // canvas's box to the stage's — those legitimately differ by the stage's border.
-            const view = await page.evaluate(() => {
-                const canvas = document.querySelector(".cp-page-canvas");
-                const stage = document.querySelector(".cp-page-stage");
-                return {
-                    transform: getComputedStyle(canvas).transform,
-                    zoom: stage.style.getPropertyValue("--cp-page-zoom"),
-                };
-            });
-            expect(["none", "matrix(1, 0, 0, 1, 0, 0)"]).toContain(view.transform);
-            expect(parseFloat(view.zoom)).toBe(1);
+            // Returning to the IDENTITY — rather than merely to something small, which would look
+            // right here and mis-place every overlay measured after the next resize — is pinned in
+            // `cli/serve-web/test/pageZoom.test.ts`, which asserts the view state itself and covers
+            // reset from a wheel zoom as well as from a framed section. This state exists for the
+            // picture: the bar gone, the sheet back at 1:1.
         },
     },
     {


### PR DESCRIPTION
Applies the rule landed in #3982 to the two clearest cases — and deliberately not to two others, which matters as much.

Hybrid states carrying assertions: **9 → 7**. Both states keep their interaction and their screenshot; **24/24 design-page captures byte-identical**.

## `serve-design-page/selected`

Asserted that a node overlay is an `<a href>` containing `/p/` — which is the difference between clicking navigating, a middle click opening a tab, a modifier click doing what the platform says, and none of that.

That is **server-rendered markup**. The capture was hovering a node, waiting for a tooltip to appear, and evaluating in a browser to read two attributes back off HTML that `ServeWeb.designPage` had already produced. It now lives in `ServeWebFixtureTest`, against the emitted string.

Coverage went up rather than sideways: a second case covers the **unlinked** node, which still links out to the design file. The capture never reached it — its own comment says it deliberately picked a linked node because "an unlinked one would shoot the degenerate half of the same card". Correct for a screenshot; a needless gap for an assertion.

## `serve-design-page/zoom-reset`

Asserted an identity transform and `--cp-page-zoom === 1`.

`pageZoom.test.ts` already asserted `view()` deep-equals `{scale: 1, x: 0, y: 0}`, which is **stronger** — it checks the state the transform is derived from rather than the rendered string, and doesn't have to allow for `"none"` meaning the same thing as an identity matrix.

What it did *not* cover was the published `--cp-page-zoom`, so I added it. That is a real gap: the stylesheet counter-scales every node's mark by that variable, so a reset that restored the view and left the variable behind would draw hairlines at the old zoom over a sheet at 1:1 — a residue no view assertion can see.

Also added: **reset from a wheel zoom**, which the capture could not afford. It reaches the view through `zoomAbout` rather than `frameRect`, so it is a different path to the same button.

## What I did NOT move

`zoom-wheel` and `zoom-section` stay in the browser, and the doc's rule is why: they read **computed geometry under a real CSS transform** (`getComputedStyle(...).outlineWidth`, a measured alignment within 2px). happy-dom cannot answer either.

`zoom-wheel` also carries the best cautionary comment in the suite — an earlier version read `border`, which is `0` on these nodes, so it "passed however wrong the stylesheet was". Reading the property that actually paints is the whole test. That is a browser's job and it should keep it.

## Test plan

```
cd cli/serve-web && npm run verify     # 744 passing, 4 bundles in sync
./gradlew :cli:test :cli:ktfmtCheck    # full module
cd vscode-extension
HARNESS_FIXTURE=serve-design-page npx playwright test -c preview-harness/playwright.config.mjs pages-snapshot
# 24/24 captures byte-identical against main
```

Remaining hybrids if you want to keep going: `diff-lane` (7 assertions, the biggest — URL construction plus some DOM wiring), `zoom-wheel`/`zoom-section` (stay), `serve-reference-compare/annotated` (mostly covered now by `annotateTypography.test.ts` and `referenceCompareElement.test.ts`), and two single-assertion viewer states.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7zeKSafCBxgGm3KsXHGe)_