### PR TITLE
feat(design-artifacts): publish all preview modules

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -711,6 +711,14 @@ jobs:
         working-directory: compose-ai-tools/scripts/design-artifacts
         run: npm ci --no-audit --no-fund --loglevel=warn
 
+      - name: Validate module selector
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.modules }}" ] && [ "${{ inputs.modules }}" != "all" ]; then
+            echo "::error title=modules input::modules supports only 'all'; use module for one Gradle path."
+            exit 1
+          fi
+
       # Repository-wide publication keeps one executable bundle per Gradle module. Discover the
       # module set once, order it deterministically, and prefer spec.module as the primary when the
       # authored catalog names one — that preserves the historical unqualified function-name winner
@@ -727,10 +735,6 @@ jobs:
           SPLIT_MODE: ${{ inputs.split-mode }}
         run: |
           set -euo pipefail
-          if [ -n "${{ inputs.modules }}" ] && [ "${{ inputs.modules }}" != "all" ]; then
-            echo "::error title=modules input::modules supports only 'all'; use module for one Gradle path."
-            exit 1
-          fi
           if [ -n "$EXTRA_MODULE" ]; then
             echo "::error title=all modules::extra-module is redundant with repository-wide discovery; omit it."
             exit 1
@@ -1168,8 +1172,9 @@ jobs:
           fi
           if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
             while IFS= read -r additional_bundle; do
+              module_index="$(basename "$additional_bundle" .png)"
               compose-preview bundle split "$additional_bundle" --view-only \
-                -o "$GITHUB_WORKSPACE/out/bundle/previews"
+                -o "$GITHUB_WORKSPACE/out/bundle/previews/modules/$module_index"
             done < <(find "$GITHUB_WORKSPACE/module-bundles" -type f -name '*.png' ! -name '0000.png' | sort -V)
           fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -14,7 +14,7 @@ name: Design Artifacts (reusable)
 #       with:
 #         system: your-system
 #         spec: catalog.spec.json
-#         module: ':app'
+#         module: ':app' # omit (or set modules: all) to publish every preview-enabled module
 #       secrets: inherit   # optional; only needed for buildfetch-ro-token
 #
 # The pipeline: install the released compose-preview CLI → validate the spec
@@ -25,7 +25,8 @@ name: Design Artifacts (reusable)
 #
 # Bespoke lanes some catalogs add (e.g. compose-m3's re-theme fold-in, a Wasm
 # tier) are intentionally out of scope — a caller that needs them keeps its own
-# workflow. This covers the common single-module (± one extra module) app catalog.
+# workflow. This covers single-module (± one extra module) catalogs and repository-wide baked
+# catalogs spanning every preview-enabled module.
 
 on:
   workflow_call:
@@ -39,9 +40,15 @@ on:
         required: true
         type: string
       module:
-        description: 'Gradle module path to render (e.g. ":app").'
-        required: true
+        description: 'Gradle module path to render (e.g. ":app"). Omit to discover and publish every module with the preview plugin applied.'
+        required: false
         type: string
+        default: ''
+      modules:
+        description: 'Set to "all" to discover and publish every preview-enabled Gradle module. Equivalent to omitting module; other values are rejected.'
+        required: false
+        type: string
+        default: ''
       # CodeQL reports "Checkout of untrusted code in a privileged context" (critical)
       # against the `actions/checkout` steps that consume this input and `driver-ref`
       # below. In THIS repo it is a false positive — dismissed, not fixed — and the
@@ -315,7 +322,7 @@ jobs:
   # it always has.
   shard-matrix:
     name: ${{ inputs.system }} · plan
-    if: ${{ inputs.render-shards > 1 }}
+    if: ${{ inputs.render-shards > 1 && inputs.module != '' && inputs.modules != 'all' }}
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 10
     permissions:
@@ -401,7 +408,7 @@ jobs:
 
   render-shard:
     name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
-    if: ${{ inputs.render-shards > 1 }}
+    if: ${{ inputs.render-shards > 1 && inputs.module != '' && inputs.modules != 'all' }}
     needs: [shard-matrix]
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -704,6 +711,52 @@ jobs:
         working-directory: compose-ai-tools/scripts/design-artifacts
         run: npm ci --no-audit --no-fund --loglevel=warn
 
+      # Repository-wide publication keeps one executable bundle per Gradle module. Discover the
+      # module set once, order it deterministically, and prefer spec.module as the primary when the
+      # authored catalog names one — that preserves the historical unqualified function-name winner
+      # if two modules declare the same preview function.
+      - name: Discover preview-enabled modules
+        if: ${{ inputs.module == '' || inputs.modules == 'all' }}
+        working-directory: ${{ inputs.working-directory || '.' }}
+        env:
+          SPEC: ${{ inputs.spec }}
+          EXTRA_MODULE: ${{ inputs.extra-module }}
+          RENDER_SHARDS: ${{ inputs.render-shards }}
+          PUBLISH_LIVE_BUNDLE: ${{ inputs.publish-live-bundle }}
+          SPLIT_PER_PREVIEW: ${{ inputs.split-per-preview }}
+          SPLIT_MODE: ${{ inputs.split-mode }}
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.modules }}" ] && [ "${{ inputs.modules }}" != "all" ]; then
+            echo "::error title=modules input::modules supports only 'all'; use module for one Gradle path."
+            exit 1
+          fi
+          if [ -n "$EXTRA_MODULE" ]; then
+            echo "::error title=all modules::extra-module is redundant with repository-wide discovery; omit it."
+            exit 1
+          fi
+          if [ "$RENDER_SHARDS" -gt 1 ]; then
+            echo "::error title=all modules::render-shards currently shards one module; use 1 when publishing all modules."
+            exit 1
+          fi
+          if [ "$PUBLISH_LIVE_BUNDLE" = "true" ]; then
+            echo "::error title=all modules::publish-live-bundle requires one executable module bundle; repository-wide catalogs publish baked/static bundles."
+            exit 1
+          fi
+          if [ "$SPLIT_PER_PREVIEW" = "true" ] && [ "$SPLIT_MODE" != "view-only" ]; then
+            echo "::error title=all modules::repository-wide per-preview splits must use split-mode: view-only because there is no single live classpath."
+            exit 1
+          fi
+          compose-preview list --json > "$GITHUB_WORKSPACE/discovered-previews.json"
+          preferred="$(node -e 'const fs=require("fs"); try { const s=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(s.module ?? ""); } catch {}' "$GITHUB_WORKSPACE/$SPEC")"
+          preferred_args=(); if [ -n "$preferred" ]; then preferred_args=(--preferred "$preferred"); fi
+          node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/preview-modules.mjs" \
+            --input "$GITHUB_WORKSPACE/discovered-previews.json" \
+            --output "$GITHUB_WORKSPACE/preview-modules.txt" \
+            "${preferred_args[@]}"
+          echo "Publishing $(wc -l < "$GITHUB_WORKSPACE/preview-modules.txt" | tr -d ' ') preview-enabled module(s):"
+          sed 's/^/  /' "$GITHUB_WORKSPACE/preview-modules.txt"
+
       # Fast, build-free pre-flight: resolve every spec `preview` against the
       # module's @Preview functions BEFORE the (long) render, so a mistyped or
       # renamed name fails here in seconds instead of as a late "missing" entry.
@@ -717,12 +770,23 @@ jobs:
           WORKDIR: ${{ inputs.working-directory }}
           LIVE_BUNDLE: ${{ inputs.publish-live-bundle }}
           LIVE_SOURCE: ${{ inputs.live-rerender-source }}
+          ALL_MODULES: ${{ inputs.module == '' || inputs.modules == 'all' }}
         run: |
           set -euo pipefail
           # Gradle path (":app", "a:b") → directory ("app", "a/b"), under the
           # build's directory when the caller is a multi-build monorepo.
           to_dir() { printf '%s' "${WORKDIR:+$WORKDIR/}${1#:}" | tr ':' '/'; }
-          args=(--spec "$SPEC" --module-dir "$(to_dir "$MODULE")")
+          args=(--spec "$SPEC")
+          if [ "$ALL_MODULES" = "true" ]; then
+            while IFS= read -r discovered_module; do
+              [ -n "$discovered_module" ] && args+=(--src "$(to_dir "$discovered_module")")
+            done < "$GITHUB_WORKSPACE/preview-modules.txt"
+            # One source.module cannot describe a repository-wide catalog. Keep validation honest:
+            # deferred coverage must not pass on a live path the generate step intentionally omits.
+            LIVE_SOURCE=false
+          else
+            args+=(--module-dir "$(to_dir "$MODULE")")
+          fi
           # A catalog whose previews span the primary + one extra module must
           # resolve names against BOTH, or the extra module's previews read as
           # "missing" and fail the pre-flight.
@@ -772,8 +836,11 @@ jobs:
           SPEC: ${{ inputs.spec }}
         run: |
           set -euo pipefail
-          compose-preview list --json --module "${{ inputs.module }}" \
-            > "$GITHUB_WORKSPACE/discovered-previews.json"
+          module_args=()
+          if [ -n "${{ inputs.module }}" ] && [ "${{ inputs.modules }}" != "all" ]; then
+            module_args=(--module "${{ inputs.module }}")
+          fi
+          compose-preview list --json "${module_args[@]}" > "$GITHUB_WORKSPACE/discovered-previews.json"
           node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/deferred-preview-ids.mjs" \
             --spec "$GITHUB_WORKSPACE/$SPEC" \
             --previews "$GITHUB_WORKSPACE/discovered-previews.json" \
@@ -880,12 +947,40 @@ jobs:
         run: |
           set -euo pipefail
           run() { if [ "${{ inputs.desktop-render }}" = "true" ]; then xvfb-run -a -s "-screen 0 2000x1400x24" "$@"; else "$@"; fi; }
+          run_without_filter() {
+            if [ "${{ inputs.desktop-render }}" = "true" ]; then
+              env -u 'ORG_GRADLE_PROJECT_composePreview.filter' xvfb-run -a -s "-screen 0 2000x1400x24" "$@"
+            else
+              env -u 'ORG_GRADLE_PROJECT_composePreview.filter' "$@"
+            fi
+          }
           embed=(); if [ "${{ inputs.embed-deps }}" = "true" ]; then embed=(--embed-deps); fi
           exclude=(); if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS"); fi
           if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
-          run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
-            "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \
-            --timeout ${{ inputs.render-timeout }}
+          if [ -f "$GITHUB_WORKSPACE/preview-modules.txt" ]; then
+            mkdir -p "$GITHUB_WORKSPACE/module-bundles"
+            index=0
+            while IFS= read -r discovered_module; do
+              [ -z "$discovered_module" ] && continue
+              output="$GITHUB_WORKSPACE/module-bundles/$(printf '%04d' "$index").png"
+              # The authored render filter belongs to the preferred/primary module. Every later
+              # module is fallback inventory and must render in full; applying the primary's
+              # function names there can fail on no match or silently thin unrelated previews.
+              if [ "$index" -eq 0 ]; then
+                run compose-preview bundle pack --module "$discovered_module" --with-semantics --progress \
+                  "${embed[@]}" "${exclude[@]}" -o "$output" --timeout ${{ inputs.render-timeout }}
+              else
+                run_without_filter compose-preview bundle pack --module "$discovered_module" --with-semantics --progress \
+                  "${embed[@]}" -o "$output" --timeout ${{ inputs.render-timeout }}
+              fi
+              index=$((index + 1))
+            done < "$GITHUB_WORKSPACE/preview-modules.txt"
+            cp "$GITHUB_WORKSPACE/module-bundles/0000.png" "$GITHUB_WORKSPACE/bundle.png"
+          else
+            run compose-preview bundle pack --module "${{ inputs.module }}" --with-semantics --progress \
+              "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \
+              --timeout ${{ inputs.render-timeout }}
+          fi
 
       - name: Download shard renders
         if: ${{ inputs.render-shards > 1 }}
@@ -990,10 +1085,20 @@ jobs:
           set -euo pipefail
           extra=()
           if [ -n "${{ inputs.extra-module }}" ]; then extra=(--extra-renders "$GITHUB_WORKSPACE/extra-bundle.png"); fi
+          additional=()
+          fallback=()
+          if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
+            fallback=(--generate-fallbacks)
+            while IFS= read -r additional_bundle; do
+              additional+=(--additional-renders "$additional_bundle")
+            done < <(find "$GITHUB_WORKSPACE/module-bundles" -type f -name '*.png' ! -name '0000.png' | sort -V)
+          fi
           source_args=()
-          if [ "${{ inputs.live-rerender-source }}" = "true" ]; then
+          if [ "${{ inputs.live-rerender-source }}" = "true" ] && [ ! -f "$GITHUB_WORKSPACE/preview-modules.txt" ]; then
             source_ref="${RENDERED_REF:-$GITHUB_REF_NAME}"
             source_args=(--source-repo "${GITHUB_REPOSITORY}" --source-ref "${source_ref}" --source-module "${{ inputs.module }}")
+          elif [ "${{ inputs.live-rerender-source }}" = "true" ]; then
+            echo "::notice title=All-module catalog::live-rerender-source is omitted because one source.module cannot represent multiple Gradle modules; baked previews are still published."
           fi
           incomplete=()
           if [ "${{ inputs.allow-incomplete }}" = "true" ]; then incomplete=(--allow-incomplete); fi
@@ -1014,6 +1119,8 @@ jobs:
             --spec "${{ inputs.spec }}" \
             --renders "$GITHUB_WORKSPACE/bundle.png" \
             "${extra[@]}" \
+            "${additional[@]}" \
+            "${fallback[@]}" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
             "${source_args[@]}" \
@@ -1058,6 +1165,12 @@ jobs:
           else
             compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/bundle.png" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
+          fi
+          if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
+            while IFS= read -r additional_bundle; do
+              compose-preview bundle split "$additional_bundle" --view-only \
+                -o "$GITHUB_WORKSPACE/out/bundle/previews"
+            done < <(find "$GITHUB_WORKSPACE/module-bundles" -type f -name '*.png' ! -name '0000.png' | sort -V)
           fi
           if [ -n "${{ inputs.extra-module }}" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
             if [ "${{ inputs.extra-split-mode }}" = "full" ]; then

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -294,6 +294,30 @@ jobs:
 Author the spec with `init-catalog-spec` and check it with `validate-catalog-spec`
 (see below) before the first run.
 
+To publish every Gradle module that applies `ee.schimke.composeai.preview`, omit `module` (or set
+`modules: all` explicitly):
+
+```yaml
+    with:
+      system: your-system
+      spec: catalog.spec.json
+      modules: all
+```
+
+The workflow discovers the same repository-wide module set as `compose-preview list`, then packs
+one bundle per module. The authored spec and `@CatalogComponent` annotations remain the curation and
+metadata overrides. Every remaining still-backed preview receives a generated entry grouped first
+by Gradle module (catalog section) and then by `@Preview(group = …)` (`Previews` when no group was
+declared). Animated/interaction captures attached to those previews travel with the generated
+entry, including GIF/APNG artifacts. If two modules use the same preview function name, the
+spec-preferred/primary module keeps the unqualified name and later modules receive a stable
+`<module>::<function>` join key.
+
+Repository-wide mode publishes baked artifacts because executable bundles retain distinct module
+classpaths. Consequently it currently requires `render-shards: 1`, does not combine with
+`extra-module` or `publish-live-bundle`, and permits per-preview splitting only with
+`split-mode: view-only`. Supplying `module` keeps the existing single-module/live-bundle behavior.
+
 For the two bespoke needs a catalog like MeshCore has, the reusable workflow
 exposes generic hooks rather than forcing a copy: `stage-font-globs` stages
 bundled faces into fontconfig before rendering (so a desktop render resolves

--- a/scripts/design-artifacts/catalog-motion.mjs
+++ b/scripts/design-artifacts/catalog-motion.mjs
@@ -52,22 +52,25 @@ export function motionPreviewFor(component) {
  */
 export function motionArtifactsFor(bundle, functionName) {
   const out = [];
-  for (const preview of bundle?.previews ?? []) {
-    if ((preview.functionName ?? preview.id) !== functionName) continue;
-    for (const capture of preview.captures ?? []) {
-      const declaration = motionDeclarationOf(capture);
-      if (!declaration) continue;
-      const path = bundleEntryFor(bundle, preview.id, capture.renderOutput);
-      if (!path) continue;
-      out.push({
-        path,
-        // Kept until `foldMotion`: a separately named motion function has a different filename
-        // stem from the still, so its position in the function's preview fan-out is the only
-        // reliable bridge back to the already-resolved static axes.
-        previewId: preview.id,
-        kind: declaration.kind,
-        ...(declaration.caption ? { caption: declaration.caption } : {}),
-      });
+  const bundles = Array.isArray(bundle) ? bundle : [bundle];
+  for (const renderBundle of bundles) {
+    for (const preview of renderBundle?.previews ?? []) {
+      if ((preview.functionName ?? preview.id) !== functionName) continue;
+      for (const capture of preview.captures ?? []) {
+        const declaration = motionDeclarationOf(capture);
+        if (!declaration) continue;
+        const path = bundleEntryFor(renderBundle, preview.id, capture.renderOutput);
+        if (!path) continue;
+        out.push({
+          path,
+          // Kept until `foldMotion`: a separately named motion function has a different filename
+          // stem from the still, so its position in the function's preview fan-out is the only
+          // reliable bridge back to the already-resolved static axes.
+          previewId: preview.id,
+          kind: declaration.kind,
+          ...(declaration.caption ? { caption: declaration.caption } : {}),
+        });
+      }
     }
   }
   return out;

--- a/scripts/design-artifacts/catalog-motion.test.mjs
+++ b/scripts/design-artifacts/catalog-motion.test.mjs
@@ -98,6 +98,22 @@ test("a declared capture the render never wrote is dropped, not published as a 4
   assert.deepEqual(motionArtifactsFor(bundle, "SwitchOn"), []);
 });
 
+test("artifacts are collected from every module bundle", () => {
+  const one = {
+    previews: [
+      { id: "One", functionName: "One", captures: [animationCapture("renders/One.gif", "one")] },
+    ],
+    entries: { "previews/One.gif": {} },
+  };
+  const two = {
+    previews: [
+      { id: "Two", functionName: "Two", captures: [animationCapture("renders/Two.gif", "two")] },
+    ],
+    entries: { "previews/Two.gif": {} },
+  };
+  assert.equal(motionArtifactsFor([one, two], "Two")[0].path, "previews/Two.gif");
+});
+
 test("a function carrying both annotations keeps its two captures apart by renderOutput", () => {
   // This is the case the plain `previews/<id>.<ext>` fallback cannot answer: both artifacts belong
   // to one preview id, and only the manifest says which file is the interaction.

--- a/scripts/design-artifacts/figma-code-connect-target.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.mjs
@@ -70,9 +70,20 @@ export function targetsByFunction(bundle) {
       out.set(fn, target);
     }
   };
+  const parsedPreviews = bundle?.previews ?? [];
   // Parsed previews first (the common path when the reader preserves `targets`)…
-  ingest(bundle?.previews);
-  // …then the raw manifest, so a reader that dropped the field still yields targets.
-  if (out.size === 0) ingest(parsePreviewsEntry(bundle));
+  ingest(parsedPreviews);
+  // …then the raw manifest, so a reader that dropped the field still yields targets. Reuse the
+  // parsed preview's function identity by id: repository-wide publication namespaces duplicate
+  // functions on the parsed bundle, while the embedded previews.json intentionally stays raw.
+  const parsedFunctionById = new Map(
+    parsedPreviews.map((preview) => [preview.id, preview.functionName ?? preview.id]),
+  );
+  ingest(
+    parsePreviewsEntry(bundle).map((preview) => ({
+      ...preview,
+      functionName: parsedFunctionById.get(preview.id) ?? preview.functionName,
+    })),
+  );
   return out;
 }

--- a/scripts/design-artifacts/figma-code-connect-target.test.mjs
+++ b/scripts/design-artifacts/figma-code-connect-target.test.mjs
@@ -96,6 +96,26 @@ test("targetsByFunction falls back to the raw previews.json entry when parsing d
   assert.equal(byFn.get("CardPreview").confidence, "HIGH");
 });
 
+test("raw target metadata keeps a namespaced parsed function identity", () => {
+  const raw = JSON.stringify({
+    previews: [
+      {
+        id: "feature.BtnPreview",
+        functionName: "BtnPreview",
+        targets: [{ functionName: "Button", sourceFile: "Button.kt" }],
+      },
+    ],
+  });
+  const bundle = {
+    previews: [{ id: "feature.BtnPreview", functionName: ":feature::BtnPreview" }],
+    entries: { "previews.json": new TextEncoder().encode(raw) },
+  };
+
+  const byFn = targetsByFunction(bundle);
+  assert.equal(byFn.has("BtnPreview"), false);
+  assert.equal(byFn.get(":feature::BtnPreview").functionName, "Button");
+});
+
 test("targetsByFunction carries the target's parameters and className", () => {
   const bundle = {
     previews: [

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -140,6 +140,12 @@ import { previewIdAliases } from "./preview-id-alias.mjs";
 import { selectComponentImages, selectOf } from "./catalog-select.mjs";
 import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.mjs";
 import { completenessFailure } from "./completeness-gate.mjs";
+import {
+  claimedPreviewFunctions,
+  combinedBundleEntries,
+  generatedFallbackGroups,
+  namespaceModuleRecords,
+} from "./multi-module-catalog.mjs";
 
 /**
  * Best-effort fetch + parse of a JSON URL, with a short timeout. Returns null on
@@ -728,6 +734,12 @@ const { values } = parseArgs({
     // `FilledButtonFocused`, and this replaces the CMP module's ring-less render of
     // that function so the keyboard-focus variant shows the real ring.
     "extra-renders": { type: "string" },
+    // Additional independent module bundles for repository-wide publication. Unlike
+    // `--extra-renders`, these do not override the primary module: their candidates are appended,
+    // duplicate function names are namespaced deterministically, and uncurated renders receive a
+    // generated module/preview-group inventory.
+    "additional-renders": { type: "string", multiple: true },
+    "generate-fallbacks": { type: "boolean", default: false },
     // When set, copy the `--renders` executable bundle onto the branch under
     // `out/bundle/<file>` and record `liveBundle: {path, file}` in catalog.json.
     // `compose-preview serve --catalogs --allow-render-trusted` then fetches that
@@ -811,10 +823,15 @@ if (effectiveBreakpoints !== undefined) spec.breakpoints = effectiveBreakpoints;
 // the join folds a function's theme/size multipreview variants (whose ids differ
 // only by an appended `_<mode>`) onto one component. See `loadCandidates` (which
 // also works around the published null-widthDp crash) and the vendored join.
-const { candidates, bundle } = await loadCandidates(
-  rendersPath,
-  spec.breakpoints,
-);
+const primaryRecord = await loadCandidates(rendersPath, spec.breakpoints);
+const additionalRecords = [];
+for (const path of values["additional-renders"] ?? []) {
+  additionalRecords.push(await loadCandidates(resolve(path), spec.breakpoints));
+}
+const moduleRecords = namespaceModuleRecords(primaryRecord, additionalRecords);
+let { candidates, bundle } = moduleRecords[0];
+const additionalBundles = moduleRecords.slice(1).map((record) => record.bundle);
+candidates = moduleRecords.flatMap((record) => record.candidates);
 
 // Fold a supplementary render bundle in, overriding same-named functions. Lets an
 // Android-only render (the material3 1.5.0-alpha inset focus ring, which CMP can't
@@ -860,6 +877,8 @@ if (values["extra-renders"]) {
   }
 }
 
+const allBundles = [bundle, extraBundle, ...additionalBundles].filter(Boolean);
+
 // Annotation-derived inventory (compose-ai-tools Phase 2): components discovery
 // resolved from `@CatalogComponent` / `@CatalogVariant` / `@CatalogGroup` travel on
 // each preview's `catalog` field in `previews.json`. Build the inventory from them
@@ -879,7 +898,7 @@ if (values["extra-renders"]) {
 // `candidates` above — so its `@CatalogComponent` must reach the inventory as well,
 // or the component would render but never enter `spec.groups`. Primary previews come
 // first, so a component present in both dedupes to the primary's annotation.
-const inventoryPreviews = [...bundle.previews, ...(extraBundle?.previews ?? [])];
+const inventoryPreviews = allBundles.flatMap((renderBundle) => renderBundle.previews ?? []);
 const { groups: annotationGroups, orphanVariants, withoutBreakpoints } =
   inventoryFromPreviews(inventoryPreviews, { breakpoints: catalogBreakpoints(spec) });
 if (withoutBreakpoints.length > 0) {
@@ -914,6 +933,25 @@ if (annotationGroups.length > 0) {
   );
 }
 
+// Repository-wide mode publishes every rendered preview, even when the hand-authored spec curates
+// only a primary catalog module. Annotation/spec entries stay authoritative; generated entries are
+// added only for function names neither inventory names. Single-module and legacy extra-module
+// calls never enter this block, so their output remains byte-for-byte shaped as before.
+if (values["generate-fallbacks"]) {
+  const fallbackGroups = generatedFallbackGroups(
+    moduleRecords,
+    claimedPreviewFunctions(spec.groups ?? []),
+  );
+  if (fallbackGroups.length > 0) {
+    spec.groups = [...(spec.groups ?? []), ...fallbackGroups];
+    const count = fallbackGroups.reduce((n, group) => n + group.components.length, 0);
+    console.log(
+      `[${spec.system}] generated ${count} fallback component(s) across ` +
+        `${fallbackGroups.length} module/preview group(s)`,
+    );
+  }
+}
+
 // Zero effective inventory: the spec declares no `groups` AND the render carried no
 // `@CatalogComponent` annotations (an author forgot them, or the render ran with a CLI/plugin that
 // predates catalog metadata). Fail here with a clear, actionable message rather than letting the
@@ -936,7 +974,7 @@ if (!Array.isArray(spec.groups) || spec.groups.length === 0) {
 // when `groupOrder` is absent, so catalogs that don't set it are unchanged.
 spec.groups = applyGroupOrder(spec.groups, spec.groupOrder);
 
-const renderFailures = renderFailuresFromBundles([bundle, extraBundle], spec);
+const renderFailures = renderFailuresFromBundles(allBundles, spec);
 if (renderFailures.length > 0) {
   const signatures = new Set(renderFailures.map((f) => `${f.errorClass}\u0000${f.message}`));
   console.warn(
@@ -1057,15 +1095,14 @@ const { catalog, missing, noSticker, withoutSemantics, deferred } =
     // Every daemon preview id per function, from the bundles' FULL preview lists — including the
     // deferred palettes whose render was skipped (#2966), which is how their live-only coverage still
     // gets declared even though no image of them exists to fold.
-    previewIdsByFunction: daemonPreviewIdsByFunction([bundle, extraBundle]),
+    previewIdsByFunction: daemonPreviewIdsByFunction(allBundles),
     // The same fan-outs with their render parameters. A separately named motion function may
     // declare annotations in a different order, so theme inheritance joins by axis identity rather
     // than zipping the two id arrays.
-    previewCellsByFunction: daemonPreviewCellsByFunction([bundle, extraBundle]),
-    // The bundle motion artifacts are read from. The primary only: a motion capture is published
-    // by the module that owns the component, and a supplementary render exists to fill in stills
-    // the primary could not produce.
-    motionBundle: bundle,
+    previewCellsByFunction: daemonPreviewCellsByFunction(allBundles),
+    // Motion artifacts are read from every catalog module. Keep the legacy extra-render supplement
+    // out: it fills in stills the primary could not produce and does not own motion captures.
+    motionBundle: [bundle, ...additionalBundles],
   });
 
 // Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0
@@ -1325,7 +1362,11 @@ if (values["publish-live-bundle"]) {
   // Re-stamp each component's module-relative `sourceFile` (dropped by the pinned
   // buildCatalog) from the bundle's discovery previews, so the preview server can link a
   // preview to its source on GitHub. No-op when discovery recorded no paths.
-  const stampedSources = applySourceFiles(manifest, spec, sourceByFunction(bundle));
+  const sourcesByFunction = new Map();
+  for (const renderBundle of allBundles) {
+    for (const [fn, source] of sourceByFunction(renderBundle)) sourcesByFunction.set(fn, source);
+  }
+  const stampedSources = applySourceFiles(manifest, spec, sourcesByFunction);
   if (stampedSources > 0) {
     console.log(
       `[${spec.system}] stamped sourceFile on ${stampedSources} component(s) from discovery`,
@@ -1370,7 +1411,7 @@ if (values["publish-live-bundle"]) {
   //     mode-deferred record already names its theme and stays 1:1. `previewIds` stays, as the
   //     function's full list, for a consumer that wants the wider view.
   if (deferred.length > 0) {
-    const idsByFunction = daemonPreviewIdsByFunction([bundle, extraBundle]);
+    const idsByFunction = daemonPreviewIdsByFunction(allBundles);
     // Drift guard: re-derive every BAKED image's path and compare against what `buildCatalog`
     // actually wrote. A mismatch means the exporter's naming has moved out from under
     // `catalogImagePath`, so the derived deferred paths would point at routes no sticker will ever
@@ -1387,7 +1428,7 @@ if (values["publish-live-bundle"]) {
           `updated to match.`,
       );
     }
-    const records = expandDeferredRecords(deferred, spec, [bundle, extraBundle]);
+    const records = expandDeferredRecords(deferred, spec, allBundles);
     manifest.deferred = records.map((record) => {
       const ids = idsByFunction.get(record.preview) ?? [];
       return {
@@ -1426,7 +1467,7 @@ if (values["publish-live-bundle"]) {
     bridgeLivePreviewIds(
       manifest,
       spec,
-      [bundle, extraBundle],
+      allBundles,
       overriddenFunctions,
     );
     // The shared live daemon opens only the primary bundle. An extra-only image renders through a
@@ -1436,7 +1477,7 @@ if (values["publish-live-bundle"]) {
     // advertise them without eagerly parsing every supplement bundle.
     const stampedDeclarations = applyCatalogPreviewDeclarations(
       manifest,
-      [bundle, extraBundle],
+      allBundles,
     );
     if (stampedDeclarations > 0) {
       console.log(
@@ -1444,7 +1485,7 @@ if (values["publish-live-bundle"]) {
       );
     }
   }
-  stampPreviewDensities(manifest, spec, [bundle, extraBundle]);
+  stampPreviewDensities(manifest, spec, allBundles);
 
   // Publish the motion axis' bytes onto the branch, under `motion/`, and repoint each declaration
   // at where they landed.
@@ -1460,11 +1501,12 @@ if (values["publish-live-bundle"]) {
   // whose name each artifact inherits — see catalog-motion-publish.mjs), and because the rewritten
   // paths have to reach the `writeFile` that closes this block. Reading the bytes from the PRIMARY
   // bundle only mirrors `motionBundle` in the join above: a motion capture is published from the
-  // bundle that rendered it, and the `--extra-renders` supplement carries none.
+  // bundle that rendered it. Repository-wide publication therefore merges the entry views with
+  // deterministic primary-first precedence before copying the bytes.
   {
     const { published, unresolved, missing } = await publishMotionArtifacts(
       manifest,
-      bundle.entries,
+      combinedBundleEntries(allBundles),
       outPath,
     );
     if (published > 0 || missing.length > 0) {
@@ -1503,9 +1545,10 @@ if (values["publish-live-bundle"]) {
 // that ADDS a function (not just overrides a same-named one) carries its own layout tree + editable
 // figma-svg, which must land in the catalog too — otherwise a screen rendered from a second module is
 // PNG-only. Extra wins on a name clash, matching the candidate fold above.
-const layoutByFn = layoutByFunction(bundle);
-if (extraBundle)
-  for (const [fn, v] of layoutByFunction(extraBundle)) layoutByFn.set(fn, v);
+const layoutByFn = new Map();
+for (const renderBundle of allBundles) {
+  for (const [fn, value] of layoutByFunction(renderBundle)) layoutByFn.set(fn, value);
+}
 const fnByComponentId = new Map(
   spec.groups.flatMap((g) =>
     g.components.map((c) => [c.componentId, c.preview]),
@@ -1563,7 +1606,7 @@ const indexManifest = JSON.parse(
 // this is the *design* SVG — a designer imports it into Figma for an editable
 // component rather than a flat screenshot. Written under figma/<slug>.svg; the
 // index links it. Components whose render produced no drawing layers are skipped.
-const figmaSvgByFn = figmaSvgByFunctions([bundle, extraBundle]);
+const figmaSvgByFn = figmaSvgByFunctions(allBundles);
 const figmaDir = join(outPath, "figma");
 await mkdir(figmaDir, { recursive: true });
 const figmaSvgSlugs = new Set();
@@ -1584,12 +1627,11 @@ for (const component of catalog.components) {
   // figma/<slug>.svg (per-slug avoids <node>.png name collisions across components).
   // A hybrid sticker's raster crops live in whichever bundle carried its figma-svg; an id is unique
   // to one bundle, so merging both is safe (the other returns empty).
-  const rasters = extraBundle
-    ? new Map([
-        ...figmaRastersForId(bundle, carried.id),
-        ...figmaRastersForId(extraBundle, carried.id),
-      ])
-    : figmaRastersForId(bundle, carried.id);
+  const rasters = new Map(
+    allBundles.flatMap((renderBundle) => [
+      ...figmaRastersForId(renderBundle, carried.id),
+    ]),
+  );
   if (rasters.size) {
     figmaSvgHybridSlugs.add(componentSlug);
     const rasterDir = `${componentSlug}.figma-raster`;
@@ -1639,7 +1681,7 @@ for (const component of catalog.components) {
 // they are, since index.html, compare.html, design-parity's FIGMA_IMPORT.md and the
 // meshcore-mobile seeding runbook all reference that path today. The per-variant set
 // lives in a `figma/<slug>/` *directory*, so the two never collide.
-const figmaSvgsById = figmaSvgByIds([bundle, extraBundle]);
+const figmaSvgsById = figmaSvgByIds(allBundles);
 let figmaVariantSvgCount = 0;
 let figmaVariantGapCount = 0;
 const figmaVariantSvgPaths = new Set();
@@ -1674,12 +1716,11 @@ for (const component of indexManifest.components ?? []) {
     // Same two-bundle merge as the back-compat loop: a hybrid sticker's crops live in
     // whichever bundle carried its figma-svg, and a preview id belongs to one bundle,
     // so merging is safe (the other side returns empty).
-    const rasters = extraBundle
-      ? new Map([
-          ...figmaRastersForId(bundle, image.previewId),
-          ...figmaRastersForId(extraBundle, image.previewId),
-        ])
-      : figmaRastersForId(bundle, image.previewId);
+    const rasters = new Map(
+      allBundles.flatMap((renderBundle) => [
+        ...figmaRastersForId(renderBundle, image.previewId),
+      ]),
+    );
     if (rasters.size) {
       // Hybrid crops get a sibling dir keyed by the *variant* basename, not the slug:
       // a component's light and dark vectors share one `figma/<slug>/` dir and each
@@ -1715,8 +1756,8 @@ for (const component of indexManifest.components ?? []) {
   // live lane does not exist.
   const tags = catalogTagIndex(
     indexManifest,
-    [bundle, extraBundle],
-    resolveSemanticsIds(indexManifest, spec, [bundle, extraBundle]),
+    allBundles,
+    resolveSemanticsIds(indexManifest, spec, allBundles),
   );
   const tagsDir = join(outPath, "tags");
   await mkdir(tagsDir, { recursive: true });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -141,7 +141,10 @@ import { selectComponentImages, selectOf } from "./catalog-select.mjs";
 import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.mjs";
 import { completenessFailure } from "./completeness-gate.mjs";
 import {
+  additionalBundleLiveConflict,
+  claimedComponentIds,
   claimedPreviewFunctions,
+  combinedBundleMap,
   combinedBundleEntries,
   generatedFallbackGroups,
   namespaceModuleRecords,
@@ -793,6 +796,16 @@ if (!values.spec || !values.renders || !values.out) {
   process.exit(2);
 }
 
+const additionalLiveConflicts = additionalBundleLiveConflict(values);
+if (additionalLiveConflicts) {
+  console.error(
+    `--additional-renders cannot be combined with ${additionalLiveConflicts.join(" or ")} — ` +
+      `repository-wide catalogs publish baked module bundles and have no single executable ` +
+      `live bundle or source module.`,
+  );
+  process.exit(2);
+}
+
 // Fail loudly rather than publish a catalog whose extra-only stickers claim a live lane
 // nothing can serve. Both prerequisites are silent when violated: with no --extra-renders
 // there is no second bundle to alias against, and with no --publish-live-bundle serve
@@ -941,6 +954,7 @@ if (values["generate-fallbacks"]) {
   const fallbackGroups = generatedFallbackGroups(
     moduleRecords,
     claimedPreviewFunctions(spec.groups ?? []),
+    claimedComponentIds(spec.groups ?? []),
   );
   if (fallbackGroups.length > 0) {
     spec.groups = [...(spec.groups ?? []), ...fallbackGroups];
@@ -1800,10 +1814,10 @@ const codeConnect = buildCodeConnectManifest({
   components: catalog.components,
   fnByComponentId,
   componentByComponentId,
-  targetByFn: targetsByFunction(bundle),
+  targetByFn: combinedBundleMap(allBundles, targetsByFunction),
   slug,
   figmaSvgSlugs,
-  sourceByFn: sourceByFunction(bundle),
+  sourceByFn: combinedBundleMap(allBundles, sourceByFunction),
   system: spec.system,
   title: spec.title,
   source: {

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -91,6 +91,34 @@ export function claimedPreviewFunctions(groups) {
   );
 }
 
+/** Component identities already owned by authored or annotation-derived inventory. */
+export function claimedComponentIds(groups) {
+  return new Set(
+    (groups ?? []).flatMap((group) =>
+      (group.components ?? []).map((component) => component.componentId).filter(Boolean),
+    ),
+  );
+}
+
+/** Merge per-bundle discovery metadata using the same later-bundle-wins precedence as renders. */
+export function combinedBundleMap(bundles, mapBundle) {
+  const combined = new Map();
+  for (const bundle of bundles ?? []) {
+    for (const [key, value] of mapBundle(bundle)) combined.set(key, value);
+  }
+  return combined;
+}
+
+/** Additional module bundles are baked-only until publication carries a real per-module live lane. */
+export function additionalBundleLiveConflict(values) {
+  if (!(values?.["additional-renders"]?.length > 0)) return null;
+  const conflicts = [
+    values["publish-live-bundle"] && "--publish-live-bundle",
+    values["source-module"] && "--source-module",
+  ].filter(Boolean);
+  return conflicts.length > 0 ? conflicts : null;
+}
+
 function componentId(module, fn) {
   const modulePart = module.replace(/^:/, "").replaceAll(":", "/") || "root";
   return `${modulePart}/${fn}`;
@@ -104,7 +132,11 @@ function componentId(module, fn) {
  * metadata-only and GIF-only previews have no sticker for the catalog exporter to anchor, while a
  * normal `@AnimatedPreview` that also carries a still is included and publishes its motion axis.
  */
-export function generatedFallbackGroups(records, claimed = new Set()) {
+export function generatedFallbackGroups(
+  records,
+  claimed = new Set(),
+  reservedComponentIds = new Set(),
+) {
   const groups = new Map();
   for (const record of records ?? []) {
     const module = record.module ?? bundleModulePath(record.bundle);
@@ -126,11 +158,18 @@ export function generatedFallbackGroups(records, claimed = new Set()) {
         group = { name, section: module, components: [] };
         groups.set(key, group);
       }
+      const generatedId = componentId(module, fn);
+      if (reservedComponentIds.has(generatedId)) {
+        throw new Error(
+          `generated fallback componentId '${generatedId}' collides with authored or generated inventory`,
+        );
+      }
       group.components.push({
-        componentId: componentId(module, fn),
+        componentId: generatedId,
         preview: fn,
         ...(preview?.params?.name ? { caption: preview.params.name } : {}),
       });
+      reservedComponentIds.add(generatedId);
       claimed.add(fn);
     }
   }

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -1,0 +1,149 @@
+/**
+ * Multi-module catalog helpers.
+ *
+ * A preview bundle is deliberately a one-module executable unit.  Publishing a repository-wide
+ * catalog therefore keeps the bundles separate and combines their catalog candidates instead of
+ * pretending their classpaths can be merged.  These helpers provide the small identity layer the
+ * catalog join needs: deterministic duplicate-function names and generated groups for renders the
+ * authored spec did not curate.
+ */
+
+/** The Gradle module that produced a bundle. */
+export function bundleModulePath(bundle, fallback = ":unknown") {
+  return bundle?.manifest?.modulePath ?? bundle?.manifest?.module ?? fallback;
+}
+
+/** The candidate/spec join key. */
+function candidateFunction(candidate) {
+  return candidate?.functionName ?? candidate?.componentId;
+}
+
+/** The preview record's function name. */
+function previewFunction(preview) {
+  return preview?.functionName ?? preview?.id;
+}
+
+/**
+ * Namespace duplicate function names across module bundles.
+ *
+ * The primary record wins the familiar unqualified name, preserving authored specs. Additional
+ * records are sorted by Gradle path and use `<module>::<function>` only when an earlier module has
+ * already claimed that function. Unique names stay untouched. Bundle entry ids are not rewritten:
+ * they are normally class-qualified already, and keeping them intact preserves daemon addressing.
+ */
+export function namespaceModuleRecords(primary, additional = []) {
+  const ordered = [
+    primary,
+    ...additional.toSorted((a, b) =>
+      bundleModulePath(a.bundle).localeCompare(bundleModulePath(b.bundle)),
+    ),
+  ];
+  const claimed = new Map();
+  return ordered.map((record) => {
+    const module = bundleModulePath(record.bundle);
+    const keyByFunction = new Map();
+    for (const preview of record.bundle?.previews ?? []) {
+      const fn = previewFunction(preview);
+      if (keyByFunction.has(fn)) continue;
+      const owner = claimed.get(fn);
+      const key = owner && owner !== module ? `${module}::${fn}` : fn;
+      keyByFunction.set(fn, key);
+      if (!owner) claimed.set(fn, module);
+    }
+    for (const candidate of record.candidates ?? []) {
+      const fn = candidateFunction(candidate);
+      if (!keyByFunction.has(fn)) {
+        const owner = claimed.get(fn);
+        const key = owner && owner !== module ? `${module}::${fn}` : fn;
+        keyByFunction.set(fn, key);
+        if (!owner) claimed.set(fn, module);
+      }
+    }
+    const previews = (record.bundle?.previews ?? []).map((preview) => ({
+      ...preview,
+      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+    }));
+    const candidates = (record.candidates ?? []).map((candidate) => ({
+      ...candidate,
+      functionName:
+        keyByFunction.get(candidateFunction(candidate)) ?? candidateFunction(candidate),
+      module,
+    }));
+    return {
+      ...record,
+      module,
+      candidates,
+      bundle: { ...record.bundle, previews },
+    };
+  });
+}
+
+/** Preview functions already represented by the effective authored/annotation inventory. */
+export function claimedPreviewFunctions(groups) {
+  return new Set(
+    (groups ?? []).flatMap((group) =>
+      (group.components ?? []).flatMap((component) => [
+        component.preview,
+        component.motionPreview,
+        ...(component.variants ?? []).map((variant) => variant.preview),
+      ]),
+    ).filter(Boolean),
+  );
+}
+
+function componentId(module, fn) {
+  const modulePart = module.replace(/^:/, "").replaceAll(":", "/") || "root";
+  return `${modulePart}/${fn}`;
+}
+
+/**
+ * Generate spec-shaped fallback groups for every unclaimed rendered function.
+ *
+ * A module becomes the top-level section and `@Preview(group = …)` becomes its group. Functions
+ * with no preview group land under `Previews`. Only candidates with a static image participate;
+ * metadata-only and GIF-only previews have no sticker for the catalog exporter to anchor, while a
+ * normal `@AnimatedPreview` that also carries a still is included and publishes its motion axis.
+ */
+export function generatedFallbackGroups(records, claimed = new Set()) {
+  const groups = new Map();
+  for (const record of records ?? []) {
+    const module = record.module ?? bundleModulePath(record.bundle);
+    const previewByFunction = new Map();
+    for (const preview of record.bundle?.previews ?? []) {
+      const fn = previewFunction(preview);
+      if (!previewByFunction.has(fn)) previewByFunction.set(fn, preview);
+    }
+    const seen = new Set();
+    for (const candidate of record.candidates ?? []) {
+      const fn = candidateFunction(candidate);
+      if (!fn || claimed.has(fn) || seen.has(fn) || !(candidate.images?.length > 0)) continue;
+      seen.add(fn);
+      const preview = previewByFunction.get(fn);
+      const name = preview?.params?.group?.trim() || "Previews";
+      const key = `${module}\u0000${name}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { name, section: module, components: [] };
+        groups.set(key, group);
+      }
+      group.components.push({
+        componentId: componentId(module, fn),
+        preview: fn,
+        ...(preview?.params?.name ? { caption: preview.params.name } : {}),
+      });
+      claimed.add(fn);
+    }
+  }
+  return [...groups.values()];
+}
+
+/** First bundle wins on an entry collision, matching the candidate/spec precedence. */
+export function combinedBundleEntries(bundles) {
+  const entries = {};
+  for (const bundle of bundles ?? []) {
+    for (const [path, bytes] of Object.entries(bundle?.entries ?? {})) {
+      if (!(path in entries)) entries[path] = bytes;
+    }
+  }
+  return entries;
+}

--- a/scripts/design-artifacts/multi-module-catalog.test.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  claimedPreviewFunctions,
+  combinedBundleEntries,
+  generatedFallbackGroups,
+  namespaceModuleRecords,
+} from "./multi-module-catalog.mjs";
+
+const record = (module, functions) => ({
+  bundle: {
+    manifest: { modulePath: module },
+    previews: functions.map((fn) => ({
+      id: `${module}.${fn}`,
+      functionName: fn,
+      params: { group: fn === "Grouped" ? "Controls" : null, name: `${fn} caption` },
+    })),
+    entries: { [`${module}.entry`]: module },
+  },
+  candidates: functions.map((fn) => ({ componentId: fn, images: [{ path: `${fn}.png` }] })),
+});
+
+test("additional modules are sorted and duplicate functions are deterministically namespaced", () => {
+  const [primary, a, z] = namespaceModuleRecords(
+    record(":catalog", ["Shared", "CatalogOnly"]),
+    [record(":z", ["Shared"]), record(":a", ["Shared", "AOnly"])],
+  );
+  assert.equal(primary.module, ":catalog");
+  assert.equal(a.module, ":a");
+  assert.equal(z.module, ":z");
+  assert.deepEqual(primary.candidates.map((it) => it.functionName), ["Shared", "CatalogOnly"]);
+  assert.deepEqual(a.candidates.map((it) => it.functionName), [":a::Shared", "AOnly"]);
+  assert.deepEqual(z.candidates.map((it) => it.functionName), [":z::Shared"]);
+});
+
+test("fallback inventory groups by Gradle module and preview group and skips curated previews", () => {
+  const records = namespaceModuleRecords(
+    record(":catalog", ["Curated"]),
+    [record(":feature", ["Grouped", "Plain"])],
+  );
+  const claimed = claimedPreviewFunctions([
+    { name: "Authored", components: [{ componentId: "curated", preview: "Curated" }] },
+  ]);
+  assert.deepEqual(generatedFallbackGroups(records, claimed), [
+    {
+      name: "Controls",
+      section: ":feature",
+      components: [
+        {
+          componentId: "feature/Grouped",
+          preview: "Grouped",
+          caption: "Grouped caption",
+        },
+      ],
+    },
+    {
+      name: "Previews",
+      section: ":feature",
+      components: [
+        { componentId: "feature/Plain", preview: "Plain", caption: "Plain caption" },
+      ],
+    },
+  ]);
+});
+
+test("combined entries keep primary bytes on collisions", () => {
+  assert.deepEqual(
+    combinedBundleEntries([
+      { entries: { same: "primary", a: "a" } },
+      { entries: { same: "additional", b: "b" } },
+    ]),
+    { same: "primary", a: "a", b: "b" },
+  );
+});

--- a/scripts/design-artifacts/multi-module-catalog.test.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  additionalBundleLiveConflict,
+  claimedComponentIds,
   claimedPreviewFunctions,
+  combinedBundleMap,
   combinedBundleEntries,
   generatedFallbackGroups,
   namespaceModuleRecords,
@@ -72,4 +75,54 @@ test("combined entries keep primary bytes on collisions", () => {
     ]),
     { same: "primary", a: "a", b: "b" },
   );
+});
+
+test("fallback inventory rejects a generated component ID already owned by authored inventory", () => {
+  const records = namespaceModuleRecords(record(":feature", ["Foo"]));
+  assert.throws(
+    () => generatedFallbackGroups(records, new Set(), new Set(["feature/Foo"])),
+    /generated fallback componentId 'feature\/Foo' collides/,
+  );
+});
+
+test("claimed component IDs include authored and annotation-derived inventory", () => {
+  assert.deepEqual(
+    claimedComponentIds([
+      { components: [{ componentId: "one" }, { componentId: "two" }] },
+      { components: [{ componentId: "three" }] },
+    ]),
+    new Set(["one", "two", "three"]),
+  );
+});
+
+test("combined bundle metadata uses later-bundle precedence", () => {
+  const bundles = [
+    { metadata: new Map([["Shared", "primary"]]) },
+    {
+      metadata: new Map([
+        ["Shared", "extra"],
+        ["Only", "additional"],
+      ]),
+    },
+  ];
+  assert.deepEqual(
+    combinedBundleMap(bundles, (bundle) => bundle.metadata),
+    new Map([
+      ["Shared", "extra"],
+      ["Only", "additional"],
+    ]),
+  );
+});
+
+test("additional renders reject primary-only live publication modes", () => {
+  assert.deepEqual(
+    additionalBundleLiveConflict({
+      "additional-renders": ["feature.png"],
+      "publish-live-bundle": true,
+      "source-module": ":app",
+    }),
+    ["--publish-live-bundle", "--source-module"],
+  );
+  assert.equal(additionalBundleLiveConflict({ "additional-renders": ["feature.png"] }), null);
+  assert.equal(additionalBundleLiveConflict({ "publish-live-bundle": true }), null);
 });

--- a/scripts/design-artifacts/preview-modules.mjs
+++ b/scripts/design-artifacts/preview-modules.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/** Extract the deterministic module list from `compose-preview list --json`. */
+import { readFile, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+export function previewModules(response, preferred) {
+  const modules = [...new Set((response?.previews ?? []).map((p) => p?.module).filter(Boolean))]
+    .sort((a, b) => a.localeCompare(b));
+  if (preferred && modules.includes(preferred)) {
+    modules.splice(modules.indexOf(preferred), 1);
+    modules.unshift(preferred);
+  }
+  return modules;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { values } = parseArgs({
+    options: {
+      input: { type: "string" },
+      output: { type: "string" },
+      preferred: { type: "string" },
+    },
+  });
+  if (!values.input || !values.output) {
+    console.error("usage: preview-modules.mjs --input <list.json> --output <modules.txt> [--preferred <:module>]");
+    process.exit(2);
+  }
+  const modules = previewModules(JSON.parse(await readFile(values.input, "utf8")), values.preferred);
+  if (modules.length === 0) {
+    console.error("preview-modules: discovery returned no preview-enabled modules");
+    process.exit(1);
+  }
+  await writeFile(values.output, `${modules.join("\n")}\n`, "utf8");
+}

--- a/scripts/design-artifacts/preview-modules.mjs
+++ b/scripts/design-artifacts/preview-modules.mjs
@@ -7,9 +7,12 @@ import { parseArgs } from "node:util";
 export function previewModules(response, preferred) {
   const modules = [...new Set((response?.previews ?? []).map((p) => p?.module).filter(Boolean))]
     .sort((a, b) => a.localeCompare(b));
-  if (preferred && modules.includes(preferred)) {
-    modules.splice(modules.indexOf(preferred), 1);
-    modules.unshift(preferred);
+  const normalizedPreferred = preferred?.replace(/^:/, "");
+  const preferredIndex = modules.findIndex(
+    (module) => module.replace(/^:/, "") === normalizedPreferred,
+  );
+  if (normalizedPreferred && preferredIndex >= 0) {
+    modules.unshift(...modules.splice(preferredIndex, 1));
   }
   return modules;
 }

--- a/scripts/design-artifacts/preview-modules.test.mjs
+++ b/scripts/design-artifacts/preview-modules.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { previewModules } from "./preview-modules.mjs";
+
+test("preview modules are unique and sorted", () => {
+  assert.deepEqual(
+    previewModules({ previews: [{ module: ":z" }, { module: ":a" }, { module: ":z" }] }),
+    [":a", ":z"],
+  );
+});
+
+test("preferred spec module is first when present", () => {
+  assert.deepEqual(
+    previewModules({ previews: [{ module: ":feature" }, { module: ":catalog" }] }, ":catalog"),
+    [":catalog", ":feature"],
+  );
+});

--- a/scripts/design-artifacts/preview-modules.test.mjs
+++ b/scripts/design-artifacts/preview-modules.test.mjs
@@ -15,3 +15,10 @@ test("preferred spec module is first when present", () => {
     [":catalog", ":feature"],
   );
 });
+
+test("preferred spec module matches discovery without a leading colon", () => {
+  assert.deepEqual(
+    previewModules({ previews: [{ module: "feature" }, { module: "catalog" }] }, ":catalog"),
+    ["catalog", "feature"],
+  );
+});


### PR DESCRIPTION
Closes #3978.

## Summary

- make `module` optional in the reusable design-artifacts workflow and add the explicit `modules: all` spelling
- discover every Gradle module that applies the preview plugin and pack one bundle per module
- merge module candidates into one catalog while preserving authored spec and annotation curation
- generate deterministic fallback sections by Gradle module and `@Preview` group
- namespace duplicate function names by module and publish motion, layout, semantics, and Figma sidecars across all bundles
- retain the existing single-module and legacy `extra-module` behavior

## Root cause

Repository-wide preview discovery was already the CLI default, but the reusable publisher required exactly one primary module and the catalog generator rejected any render without authored spec or catalog-annotation inventory. As a result, valid previews in other plugin-enabled modules never reached the published catalog.

## User impact

Consumers can now omit `module` or pass `modules: all` to publish all preview-enabled modules. Explicit spec entries remain metadata/curation overrides, while otherwise unlisted previews receive generated module/group organization. Static and attached GIF/APNG captures are published together.

Repository-wide output is baked because each Gradle module retains an independent executable classpath. The workflow rejects incompatible live-bundle, extra-module, and multi-shard combinations with actionable errors.

## Test plan

- `node --test scripts/design-artifacts/multi-module-catalog.test.mjs scripts/design-artifacts/preview-modules.test.mjs scripts/design-artifacts/catalog-motion.test.mjs scripts/design-artifacts/catalog-inventory.test.mjs` (45 passing)
- parse `.github/workflows/design-artifacts-reusable.yml` as YAML
- run `bash -n` over every workflow `run:` block after expression substitution
- `node --check scripts/design-artifacts/generate-design-catalog.mjs`
- `git diff --check`

This changes workflow/data-product plumbing only; there is no visual UI change requiring before/after screenshots.