### PR TITLE
feat(a11y): skip annotated preview helpers

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -204,6 +204,7 @@ def select_variants(
     * Scroll / animation captures (``@ScrollingPreview`` /
       ``@AnimatedPreview``) — see [is_dynamic_preview]. Functions whose
       ONLY variants are dynamic drop out of the report entirely.
+    * Visual-only helpers carrying ``@PreviewHelper(includeInA11y = false)``.
     * Previews with no entry in a ``partial`` report — a narrowed
       ``compose-preview a11y --id X`` run only checked what it was asked
       for, so the rest were never checked and listing them with empty
@@ -224,6 +225,8 @@ def select_variants(
         if kind != "COMPOSE":
             continue
         if is_dynamic_preview(preview):
+            continue
+        if preview.get("includeInA11y", True) is False:
             continue
         by_fn.setdefault(preview["functionName"], []).append(preview)
 

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -155,6 +155,47 @@ class SelectVariantsTest(unittest.TestCase):
         rows = ar.select_variants(manifest, {})
         self.assertEqual(rows, [])
 
+    def test_filters_out_color_scheme_specimen_helper(self):
+        specimen = _preview(
+            id="x.ColorSchemeSpecimenPreview",
+            function="ColorSchemeSpecimenPreview",
+            render="renders/ColorSchemeSpecimenPreview.png",
+        )
+        specimen["includeInA11y"] = False
+        manifest = {
+            "module": "app",
+            "previews": [
+                specimen,
+                _preview(
+                    id="x.ButtonPreview",
+                    function="ButtonPreview",
+                    render="renders/ButtonPreview.png",
+                ),
+            ],
+        }
+
+        rows = ar.select_variants(manifest, {})
+
+        self.assertEqual([r["functionName"] for r in rows], ["ButtonPreview"])
+
+    def test_older_manifest_includes_unannotated_specimens(self):
+        manifest = {
+            "module": "app",
+            "previews": [
+                _preview(
+                    id="x.ColorSchemeSpecimenPreview",
+                    function="ColorSchemeSpecimenPreview",
+                ),
+            ],
+        }
+
+        rows = ar.select_variants(manifest, {})
+
+        self.assertEqual(
+            [r["functionName"] for r in rows],
+            ["ColorSchemeSpecimenPreview"],
+        )
+
     def test_merges_a11y_for_chosen_variant(self):
         manifest = {
             "module": "sample-wear",

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewHelper.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/PreviewHelper.kt
@@ -1,0 +1,20 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Marks a `@Preview` as tooling/helper UI rather than application UI.
+ *
+ * Helper previews are still rendered and published normally. [includeInA11y] controls whether the
+ * accessibility pipeline audits their canned content. Set it to `false` for visual-only specimens
+ * whose intentionally repetitive labels would otherwise produce findings about the helper itself.
+ *
+ * ```
+ * @Preview
+ * @PreviewHelper(includeInA11y = false)
+ * @Composable
+ * fun ColorSchemeSpecimenPreview() { /* ... */ }
+ * ```
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class PreviewHelper(val includeInA11y: Boolean = true)

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -205,6 +205,8 @@ data class PreviewInfo(
    * `compose-preview show --json`, contrib scripting, and MCP readers. False for ordinary previews.
    */
   val fixedTheme: Boolean = false,
+  /** Mirrors discovery's `@PreviewHelper(includeInA11y = false)` manifest flag. */
+  val includeInA11y: Boolean = true,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
@@ -53,6 +53,9 @@ class A11yReportRenderer(private val fileSystem: FileSystem = SystemFileSystem) 
    */
   private var partialModules: Set<String> = emptySet()
 
+  /** Preview keys explicitly opted out via `@PreviewHelper(includeInA11y = false)`. */
+  private var excludedPreviewKeys: Set<String> = emptySet()
+
   override fun load(
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
     verbose: Boolean,
@@ -60,7 +63,11 @@ class A11yReportRenderer(private val fileSystem: FileSystem = SystemFileSystem) 
     val out = mutableMapOf<String, AccessibilityEntry>()
     val enabled = mutableSetOf<String>()
     val partial = mutableSetOf<String>()
+    val excluded = mutableSetOf<String>()
     for ((module, manifest) in manifests) {
+      manifest.previews
+        .filterNot { it.includeInA11y }
+        .mapTo(excluded) { "${module.gradlePath}/${it.id}" }
       // Prefer the manifest pointer when a producer stamped one (legacy gradle-aggregated reports,
       // future daemon-stamped pointer); fall back to the conventional `accessibility.json`
       // location so a freshly-written daemon-aggregated report is still picked up even when no
@@ -100,12 +107,15 @@ class A11yReportRenderer(private val fileSystem: FileSystem = SystemFileSystem) 
     a11yByKey = out
     enabledModules = enabled
     partialModules = partial
+    excludedPreviewKeys = excluded
     return enabled
   }
 
   override fun annotate(result: PreviewResult, module: PreviewModule): PreviewResult {
     if (module.gradlePath !in enabledModules) return result
-    val listed = a11yByKey["${module.gradlePath}/${result.id}"]
+    val key = "${module.gradlePath}/${result.id}"
+    if (key in excludedPreviewKeys) return result
+    val listed = a11yByKey[key]
     // A preview the report doesn't list, in a module whose report only covers part of its previews,
     // was never checked — leave the carrier off so `a11yEntry()` reads null ("checks didn't run")
     // rather than manufacturing a clean row for a preview ATF never saw (issue #3742).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -2205,6 +2205,10 @@ open class ReportCommand(args: List<String>, private val extensionId: String) : 
     val consumerIds = mutableListOf<String>()
     val requested = mutableListOf<RequestedPreview>()
     for (preview in manifest.previews) {
+      // A visual-only `@PreviewHelper` opted out at its declaration. Exclude it from both the
+      // daemon fan-out and this report's coverage universe: it was intentionally not checked, not
+      // missed by a narrowed request.
+      if (extensionId == "a11y" && !preview.includeInA11y) continue
       // Fetch order within a preview is load-bearing: the daemon keys its artefacts by preview id,
       // so each permutation's overlay lands on top of the last. [RequestedPreview] production keeps
       // the declared preview *first* here, and `DaemonA11yFetcher` reverses that so the base render

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
@@ -233,6 +233,25 @@ class A11yCommandTest {
   }
 
   @Test
+  fun `preview helper opted out of a11y never reaches the daemon work list`() {
+    val cmd = TestableReportCommand(emptyList())
+    val (module, original) = manifest("app", "ColorSchemeSpecimenPreview", "ButtonPreview")
+    val annotated =
+      original.copy(
+        previews =
+          original.previews.map {
+            if (it.id == "ColorSchemeSpecimenPreview") it.copy(includeInA11y = false) else it
+          }
+      )
+
+    val request = cmd.requestsFor(listOf(module to annotated)).single()
+
+    assertEquals(listOf("ButtonPreview"), request.previews.map { it.entryId })
+    assertEquals(listOf("ButtonPreview"), request.consumerPreviewIds)
+    assertFalse(request.narrowed, "an intentional helper exclusion is not partial coverage")
+  }
+
+  @Test
   fun `filter narrows the per-preview fan-out and marks the report partial`() {
     // The bug: `a11y --filter Alpha` used to fetch ATF for all three previews — a per-preview
     // daemon render each — to print one row. The render half was narrowed in #3734; this is the

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
@@ -49,11 +49,14 @@ class A11yReportRendererTest {
 
   private fun module(): PreviewModule = PreviewModule(gradlePath = "sample", projectDir = moduleDir)
 
-  private fun manifest(reportsView: Map<String, String> = mapOf("a11y" to "accessibility.json")) =
+  private fun manifest(
+    reportsView: Map<String, String> = mapOf("a11y" to "accessibility.json"),
+    previews: List<PreviewInfo> = emptyList(),
+  ) =
     PreviewManifest(
       module = "sample",
       variant = "debug",
-      previews = emptyList(),
+      previews = previews,
       dataExtensionReports = reportsView,
     )
 
@@ -132,6 +135,33 @@ class A11yReportRendererTest {
     val bar = renderer.annotate(previewResult("Bar"), module())
     assertNull(bar.dataExtensions["a11y"], "an unchecked preview gets no carrier")
     assertFalse(renderer.hasData(bar), "null a11yEntry is the established 'checks didn't run'")
+  }
+
+  @Test
+  fun `an opted out preview helper receives no a11y carrier`() {
+    writeReport(
+      """
+      {
+        "module": "sample",
+        "entries": [{"previewId": "ButtonPreview", "findings": []}]
+      }
+      """
+        .trimIndent()
+    )
+    val helper =
+      PreviewInfo(
+        id = "ColorSchemeSpecimenPreview",
+        functionName = "ColorSchemeSpecimenPreview",
+        className = "com.example.PreviewsKt",
+        includeInA11y = false,
+      )
+    val renderer = A11yReportRenderer()
+    renderer.load(listOf(module() to manifest(previews = listOf(helper))), verbose = false)
+
+    val result = renderer.annotate(previewResult(helper.id), module())
+
+    assertNull(result.dataExtensions["a11y"])
+    assertFalse(renderer.hasData(result))
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1094,6 +1094,11 @@ data class PreviewInfo(
    * False for every ordinary preview, so older manifests and unannotated modules are unchanged.
    */
   val fixedTheme: Boolean = false,
+  /**
+   * `@PreviewHelper(includeInA11y = false)` — this preview is visual/tooling-only content that the
+   * accessibility pipeline must not audit. True for ordinary previews and older manifests.
+   */
+  val includeInA11y: Boolean = true,
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -270,6 +270,9 @@ object PreviewDiscovery {
   // "this preview's subject IS a theme — never re-render it under a themeProvider override". A
   // marker with no parameters, matched by FQN like its siblings. See `FixedTheme.kt`.
   private const val FIXED_THEME_FQN = "ee.schimke.composeai.preview.FixedTheme"
+  // Tooling/helper preview metadata. Visual-only specimens can opt out of A11y auditing while
+  // remaining ordinary renderable previews everywhere else. See `PreviewHelper.kt`.
+  private const val PREVIEW_HELPER_FQN = "ee.schimke.composeai.preview.PreviewHelper"
   private const val LAUNCHER_WIDGET_PREVIEW_FQN =
     "ee.schimke.composeai.preview.LauncherWidgetPreview"
   // `@OverrideVariant` — repeatable; emits one extra synthetic preview per variant with
@@ -4177,6 +4180,11 @@ object PreviewDiscovery {
       // one of them. Reading it here also covers the built-in multi-preview expansion path, which
       // never sees a real `@Preview` [AnnotationInfo].
       fixedTheme = method.annotationInfo.any { it.name == FIXED_THEME_FQN },
+      includeInA11y =
+        method.annotationInfo
+          .firstOrNull { it.name == PREVIEW_HELPER_FQN }
+          ?.let { annBoolean(it, "includeInA11y", default = true) }
+          ?: true,
     )
   }
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1434,6 +1434,57 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover carries PreviewHelper a11y opt out`() {
+    val projectDir = createCmpTestProject()
+    val annDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    annDir.mkdirs()
+    File(annDir, "PreviewHelper.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class PreviewHelper(val includeInA11y: Boolean = true)
+        """
+          .trimIndent()
+      )
+    File(projectDir, "src/main/kotlin/test/Helpers.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+        import ee.schimke.composeai.preview.PreviewHelper
+
+        @PreviewHelper(includeInA11y = false)
+        @Preview @Composable fun ColorSchemeSpecimenPreview() {}
+
+        @Preview @Composable fun ContactRow() {}
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    val byFn = manifest.previews.associateBy { it.functionName }
+    assertThat(byFn.getValue("ColorSchemeSpecimenPreview").includeInA11y).isFalse()
+    assertThat(byFn.getValue("ContactRow").includeInA11y).isTrue()
+  }
+
+  @Test
   fun `composePreviewDiscover warns when a preview installs a theme under declared theme catalogs`() {
     val projectDir = createCmpTestProject()
 

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/ColorGallery.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/ColorGallery.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.composeai.preview.PreviewHelper
 import ee.schimke.composeai.preview.color.ColorSchemeSpecimen
 import ee.schimke.composeai.preview.color.ColorSpecimen
 
@@ -21,6 +22,7 @@ import ee.schimke.composeai.preview.color.ColorSpecimen
  * `TypographyGallery`'s specimen sheets.
  */
 @Preview(name = "ColorScheme specimen — light", widthDp = 360, heightDp = 1760)
+@PreviewHelper(includeInA11y = false)
 @Composable
 fun ColorSchemeSpecimenLightPreview() {
   MaterialTheme(colorScheme = lightColorScheme()) {
@@ -29,6 +31,7 @@ fun ColorSchemeSpecimenLightPreview() {
 }
 
 @Preview(name = "ColorScheme specimen — dark", widthDp = 360, heightDp = 1760)
+@PreviewHelper(includeInA11y = false)
 @Composable
 fun ColorSchemeSpecimenDarkPreview() {
   MaterialTheme(colorScheme = darkColorScheme()) {


### PR DESCRIPTION
## Summary

- add `@PreviewHelper(includeInA11y = false)` as source-level metadata for visual-only helper previews
- carry the flag through preview discovery and the public preview manifest model
- exclude opted-out helpers before daemon ATF fetching and prevent synthetic clean A11y carriers
- annotate the light and dark ColorScheme specimen previews

## Why

The ColorScheme specimen intentionally repeats decorative sample labels such as `Aa`. Auditing that helper as application UI produces `DuplicateSpeakableTextCheck` findings about the preview tool itself. A function-name denylist in the report would be late and brittle; the preview declaration is the durable source of truth.

Older manifests remain compatible because `includeInA11y` defaults to `true`.

## Validation

- `python3 .github/actions/lib/test_a11y_report.py -v` (50 tests)
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.A11yCommandTest --tests ee.schimke.composeai.cli.A11yReportRendererTest`
- `./gradlew -p gradle-plugin functionalTest --tests 'ee.schimke.composeai.plugin.DiscoveryFunctionalTest.composePreviewDiscover carries PreviewHelper a11y opt out'`
- `ANDROID_HOME=/Users/yschimke/Library/Android/sdk ./gradlew :samples:android:compileDebugKotlin`
- `./gradlew ktfmtFormatAll`
- `git diff --check`

Visual evidence is not applicable: this changes A11y audit selection and manifest plumbing, not rendered pixels.