### PR TITLE
fix(playground): make Material 3 themes follow night mode

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -329,8 +329,8 @@ object PlaygroundSourceCleaner {
     out = unqualifyScaffoldCalls(out, rules)
     // Order matters. UNWRAP first, so a wrapper takes its own arguments away with it before DROP
     // starts reasoning about which arguments mention a dropped binding. INLINE next, so a member
-    // substitution lands before DROP inspects the argument it sits in. DROP, then RENAME last —
-    // renaming early would hide a name the other passes match on.
+    // substitution lands before DROP inspects the argument it sits in. DROP, then semantic theme
+    // wrappers and RENAME last — rewriting early would hide a name the other passes match on.
     out = applyUnwrap(out, rules)
     // The parse settles argument binding, trailing-lambda calls and qualifiers; the text pass is
     // the fallback for a host with no staged sidecar (see [UsageSourceParser]).
@@ -339,6 +339,7 @@ object PlaygroundSourceCleaner {
       else applySubstitute(out, rules, addedImports)
     out = applyInline(out, rules, addedImports)
     out = applyDrop(out, rules, residue)
+    out = applyMaterial3SystemTheme(out, rules, addedImports)
     out = applyRename(out, rules, addedImports)
     if (isEntry) out = stampPreview(out, rules, addedImports)
     // Residue: declared scaffolding that survived. With a parse, every *call* is visible however it
@@ -510,11 +511,44 @@ object PlaygroundSourceCleaner {
   ): String {
     var out = text
     for ((name, scaffold) in rules.scaffolds) {
-      if (scaffold.kind != UsageRules.Kind.RENAME) continue
+      if (scaffold.kind != UsageRules.Kind.RENAME || scaffold.special != null) continue
       val to = scaffold.renameTo ?: continue
       if (!mentionsWord(out, name)) continue
       out = replaceWord(out, name, to)
       addedImports.addAll(scaffold.imports)
+    }
+    return out
+  }
+
+  /**
+   * `Sticker { … }` → a stock Material 3 theme which actually consumes the preview's `uiMode`.
+   *
+   * Only the helper name is replaced, so the trailing lambda — the component usage this cleaner is
+   * trying to preserve — stays byte-for-byte intact. The rewrite deliberately accepts only an
+   * argument-free trailing-lambda call. `StickerFrame(tokens) { … }` may encode more than the
+   * reusable stock light/dark policy; leaving it as residue is the safe and honest outcome.
+   */
+  private fun applyMaterial3SystemTheme(
+    text: String,
+    rules: UsageRules,
+    addedImports: MutableSet<String>,
+  ): String {
+    var out = text
+    for ((name, scaffold) in rules.scaffolds) {
+      if (
+        scaffold.kind != UsageRules.Kind.RENAME ||
+          scaffold.special != UsageRules.MATERIAL3_SYSTEM_THEME
+      )
+        continue
+      var changed = false
+      for (at in wordOccurrences(out, name).asReversed()) {
+        var next = at + name.length
+        while (next < out.length && out[next].isWhitespace()) next++
+        if (out.getOrNull(next) != '{') continue
+        out = out.replaceRange(at, at + name.length, MATERIAL3_SYSTEM_THEME_CALL)
+        changed = true
+      }
+      if (changed) addedImports.addAll(scaffold.imports)
     }
     return out
   }
@@ -798,6 +832,9 @@ object PlaygroundSourceCleaner {
   // ---------------------------------------------------------------------------------------------
 
   private const val MAX_REWRITES = 64
+
+  private const val MATERIAL3_SYSTEM_THEME_CALL =
+    "MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme())"
 
   private data class Call(val start: Int, val argsStart: Int, val argsEnd: Int)
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -93,6 +93,15 @@ data class UsageRules(
     @SerialName("kind") @Serializable(with = LenientKind::class) val kind: Kind = Kind.UNKNOWN,
     /** [Kind.RENAME] only: the plain-Compose name to call instead. */
     @SerialName("renameTo") val renameTo: String? = null,
+    /**
+     * Optional reusable semantics layered onto [Kind.RENAME].
+     *
+     * A string rather than another enum on purpose: an older server ignores this new JSON key and
+     * still performs the ordinary [renameTo], so a catalog may publish the special before every
+     * server has upgraded. This build recognises [MATERIAL3_SYSTEM_THEME]. An unrecognised value is
+     * left untouched and reported as residue rather than silently degraded to an incomplete rename.
+     */
+    @SerialName("special") val special: String? = null,
     /** An import the replacement needs, e.g. `androidx.compose.material3.MaterialTheme`. */
     @SerialName("addImport") val addImport: String? = null,
     /**
@@ -101,8 +110,9 @@ data class UsageRules(
      * delegation reads and which nothing in the snippet mentions by name.
      *
      * Applies alongside [addImport] to every kind that emits a replacement — RENAME, SUBSTITUTE,
-     * INLINE; see [imports]. DROP and UNWRAP write no new code, so an import declared on one of
-     * those has nothing to serve.
+     * INLINE; see [imports]. The [MATERIAL3_SYSTEM_THEME] special supplies its standard imports
+     * itself, so every catalog gets the same complete, runnable expansion. DROP and UNWRAP write no
+     * new code, so an import declared on one of those has nothing to serve.
      */
     @SerialName("addImports") val addImports: List<String> = emptyList(),
     /** [Kind.SUBSTITUTE] only: what the call reads as, with `$0`, `$1`… for its arguments. */
@@ -135,14 +145,19 @@ data class UsageRules(
      * failure the compile gate exists to catch.
      */
     val imports: List<String>
-      get() = if (addImport == null) addImports else addImports + addImport
+      get() = buildList {
+        addAll(addImports)
+        addImport?.let(::add)
+        if (special == MATERIAL3_SYSTEM_THEME) addAll(MATERIAL3_SYSTEM_THEME_IMPORTS)
+      }
+        .distinct()
   }
 
   enum class Kind {
     /**
-     * Call the plain-Compose equivalent instead. `Sticker { }` → `MaterialTheme { }`: the sticker
-     * frame *is* a `MaterialTheme` over the baseline scheme, so the rename is the honest reading —
-     * and unwrapping it instead would leave the snippet unthemed, which is worse than noisy.
+     * Call the plain-Compose equivalent instead. A purely structural `CatalogFrame { }` can become
+     * `Box { }`; a wrapper whose meaning includes a system-responsive Material 3 scheme should add
+     * the [MATERIAL3_SYSTEM_THEME] special rather than collapsing to bare `MaterialTheme { }`.
      */
     RENAME,
 
@@ -225,6 +240,25 @@ data class UsageRules(
   }
 
   companion object {
+    /**
+     * A [Scaffold.special] value for an argument-free wrapper that means "stock Material 3,
+     * following system night mode". The cleaner preserves its trailing lambda and emits:
+     * ```
+     * MaterialTheme(
+     *   colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme(),
+     * ) { … }
+     * ```
+     */
+    const val MATERIAL3_SYSTEM_THEME = "MATERIAL3_SYSTEM_THEME"
+
+    private val MATERIAL3_SYSTEM_THEME_IMPORTS =
+      listOf(
+        "androidx.compose.foundation.isSystemInDarkTheme",
+        "androidx.compose.material3.MaterialTheme",
+        "androidx.compose.material3.darkColorScheme",
+        "androidx.compose.material3.lightColorScheme",
+      )
+
     /** Every override knob takes `(key, default, index)`; the default is `$1`. */
     private val OVERRIDE_KNOB_PARAMS = listOf("key", "default", "index")
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -205,6 +205,110 @@ class PlaygroundSourceCleanerTest {
     assertEquals(emptyList(), result.residue)
   }
 
+  @Test
+  fun `a system Material 3 theme wrapper keeps its lambda and follows preview uiMode`() {
+    val source =
+      """
+      package com.example.catalog
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import com.example.catalog.Sticker
+
+      @Composable
+      fun CardPreview() = Sticker {
+        Text("Card")
+      }
+      """
+        .trimIndent()
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = UsageRules.MATERIAL3_SYSTEM_THEME,
+              )
+          )
+      )
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source,
+          source.lines().indexOfFirst { it.contains("Text(\"Card\")") } + 1,
+          rules,
+        )
+      )
+
+    assertTrue(
+      result.text.contains(
+        "MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()) {"
+      ),
+      result.text,
+    )
+    assertTrue(result.text.contains("Text(\"Card\")"), result.text)
+    assertTrue(
+      result.text.contains("import androidx.compose.foundation.isSystemInDarkTheme"),
+      result.text,
+    )
+    assertTrue(result.text.contains("import androidx.compose.material3.MaterialTheme"), result.text)
+    assertTrue(
+      result.text.contains("import androidx.compose.material3.darkColorScheme"),
+      result.text,
+    )
+    assertTrue(
+      result.text.contains("import androidx.compose.material3.lightColorScheme"),
+      result.text,
+    )
+    assertFalse(result.text.contains("import com.example.catalog.Sticker"), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  @Test
+  fun `a system Material 3 theme rule does not discard wrapper arguments`() {
+    val source =
+      """
+      package com.example.catalog
+
+      import androidx.compose.runtime.Composable
+      import com.example.catalog.Sticker
+
+      @Composable
+      fun CardPreview() = Sticker("brand") {
+        Unit
+      }
+      """
+        .trimIndent()
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = UsageRules.MATERIAL3_SYSTEM_THEME,
+              )
+          )
+      )
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source,
+          source.lines().indexOfFirst { it.contains("Unit") } + 1,
+          rules,
+        )
+      )
+
+    assertTrue(result.text.contains("Sticker(\"brand\")"), result.text)
+    assertEquals(listOf("Sticker"), result.residue)
+    assertFalse(result.text.contains("darkColorScheme"), result.text)
+  }
+
   /** Not one annotation from either annotation package may reach the editor. */
   @Test
   fun `catalog annotations and their imports are gone`() {
@@ -414,6 +518,67 @@ class PlaygroundSourceCleanerTest {
     assertEquals("MaterialTheme", rules.scaffolds["Sticker"]?.renameTo)
     assertEquals(UsageRules.Kind.DROP, rules.scaffolds["catalogButtonSize"]?.kind)
     assertEquals(UsageRules.Kind.UNKNOWN, rules.scaffolds["toggleable"]?.kind)
+  }
+
+  @Test
+  fun `the reusable system Material 3 theme special parses without catalog-authored imports`() {
+    val rules =
+      assertNotNull(
+        UsageRules.parse(
+          """{"scaffolds":{"Sticker":{"kind":"RENAME","renameTo":"MaterialTheme","special":"MATERIAL3_SYSTEM_THEME"}}}"""
+        )
+      )
+
+    val sticker = assertNotNull(rules.scaffolds["Sticker"])
+    assertEquals(UsageRules.Kind.RENAME, sticker.kind)
+    assertEquals(UsageRules.MATERIAL3_SYSTEM_THEME, sticker.special)
+    assertEquals(
+      listOf(
+        "androidx.compose.foundation.isSystemInDarkTheme",
+        "androidx.compose.material3.MaterialTheme",
+        "androidx.compose.material3.darkColorScheme",
+        "androidx.compose.material3.lightColorScheme",
+      ),
+      sticker.imports,
+    )
+  }
+
+  @Test
+  fun `an unknown rename special is residue instead of an incomplete rename`() {
+    val source =
+      """
+      import androidx.compose.runtime.Composable
+      import com.example.Sticker
+
+      @Composable
+      fun CardPreview() = Sticker { Unit }
+      """
+        .trimIndent()
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = "FUTURE_THEME_POLICY",
+              )
+          )
+      )
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source,
+          source.lines().indexOfFirst { it.contains("Unit") } + 1,
+          rules,
+        )
+      )
+
+    assertTrue(result.text.contains("Sticker { Unit }"), result.text)
+    assertFalse(result.text.contains("MaterialTheme"), result.text)
+    assertEquals(listOf("Sticker"), result.residue)
   }
 
   /**


### PR DESCRIPTION
## What changed

- add a reusable `MATERIAL3_SYSTEM_THEME` special for playground scaffold rename rules
- expand argument-free theme wrappers into a stock Material 3 theme that selects `darkColorScheme()` or `lightColorScheme()` with `isSystemInDarkTheme()`
- inject the required Foundation and Material 3 imports automatically
- preserve argument-bearing wrappers and unknown specials as residue instead of applying a lossy rename
- cover expansion, imports, parsing, and safe fallback behavior with focused tests

## Why

The playground honors the requested `uiMode`, but catalog usage rules could rename a system-responsive wrapper such as `Sticker` to bare `MaterialTheme`. Bare `MaterialTheme` does not select a dark color scheme, so generated examples remained light in night mode.

The special expands to ordinary Compose source rather than calling a compose-ai-tools runtime helper. This keeps snippets portable and avoids requiring an extra runtime artifact on every Material 3 catalog classpath.

## Impact

Catalogs can opt in with:

```json
{
  "kind": "RENAME",
  "renameTo": "MaterialTheme",
  "special": "MATERIAL3_SYSTEM_THEME"
}
```

Generated playground code then follows the preview's light/dark UI mode.

## Validation

- `./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.PlaygroundSourceCleanerTest'`
- `./gradlew :cli:ktfmtCheck`
- `git diff --check`
