### PR TITLE
test(serve): make three assertions from #3985 actually discriminating

### DIFF
--- a/cli/serve-web/test/pageZoom.test.ts
+++ b/cli/serve-web/test/pageZoom.test.ts
@@ -46,12 +46,22 @@ function el<T extends Element>(selector: string): T {
 
 function view(): { scale: number; x: number; y: number } {
     const transform = el<HTMLElement>(".cp-page-canvas").style.transform;
+    // An EMPTY transform is the identity — that is how the element expresses 1:1, by clearing the
+    // property rather than writing `translate(0px, 0px) scale(1)`.
+    if (!transform || transform === "none") return { scale: 1, x: 0, y: 0 };
     const match =
         /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
             transform,
         );
-    if (!match) return { scale: 1, x: 0, y: 0 };
-    return { x: +match[1], y: +match[2], scale: +match[3] };
+    // Anything else present but unreadable is a FAILURE, not an identity. Returning the identity
+    // here — which this used to do — makes every assertion in this file fail open: a reset that
+    // emitted `translateX(...)`, or a scale that came out `NaN`, would satisfy
+    // `deepEqual(view(), { scale: 1, x: 0, y: 0 })` on a canvas that is nowhere near 1:1.
+    if (!match) throw new Error(`unreadable transform: ${transform}`);
+    const parsed = { x: +match[1], y: +match[2], scale: +match[3] };
+    if (!Object.values(parsed).every(Number.isFinite))
+        throw new Error(`non-finite transform: ${transform}`);
+    return parsed;
 }
 
 /** Where a user-unit point currently sits on screen. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1894,9 +1894,13 @@ class ServeWebFixtureTest {
       manifestNode!!.groupValues[1],
       "a node with a renderable preview is emitted as an anchor",
     )
-    assertTrue(
-      manifestNode.value.contains("/p/com.example.ProfileCardPreview"),
-      "…and its destination is THAT preview, not merely some /p/ URL",
+    // The whole final segment, not a prefix: `/p/com.example.ProfileCardPreviewLegacy` contains
+    // the id we mean and navigates somewhere else.
+    val manifestHref = Regex("""href="([^"]*)"""").find(manifestNode.value)!!.groupValues[1]
+    assertEquals(
+      "com.example.ProfileCardPreview",
+      manifestHref.substringBefore('?').substringAfterLast("/p/"),
+      "…and its destination is THAT preview, not one whose id merely starts the same way",
     )
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
     // tag is the same; only the target differs, so a reader never meets a node that looks
@@ -1913,12 +1917,13 @@ class ServeWebFixtureTest {
       unlinkedNode!!.groupValues[1],
       "an unlinked node stays an anchor rather than becoming inert",
     )
-    // The whole destination, not just its host: a regression to the Figma homepage, to another
-    // file, or to the wrong node all begin `https://www.figma.com/` and would pass a prefix check
-    // while node 1:6 no longer reaches its own design location.
-    assertTrue(
-      unlinkedNode.value.contains("ocdacdEsnHipMJD3egzxKb") &&
-        unlinkedNode.value.contains("node-id=1-6"),
+    // The WHOLE href, compared as one string. Checking parts independently loses whatever part is
+    // not checked: a host check alone passes for the Figma homepage, and a key-plus-node check
+    // alone passes for a relative URL or a different host carrying the same query.
+    val unlinkedHref = Regex("""href="([^"]*)"""").find(unlinkedNode.value)!!.groupValues[1]
+    assertEquals(
+      "https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-6",
+      unlinkedHref,
       "…and its destination is THIS node in the catalog's design file",
     )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1883,10 +1883,20 @@ class ServeWebFixtureTest {
     // Asserted here rather than in the harness because it is server-rendered markup: the capture
     // that used to hold it had to hover a node, wait for a tooltip and evaluate in a browser to
     // read two attributes off the emitted HTML.
+    // Matched on the manifest-linked node itself (`1:1`), not on "some /p/ anchor exists": the
+    // fixture carries several renderable nodes, so an existence check stays green while this
+    // particular overlay regresses to a span or points somewhere else.
+    val manifestNode =
+      Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:1"[^>]*>""").find(designPageHtml)
+    assertTrue(manifestNode != null, "the manifest-linked node 1:1 is emitted at all")
+    assertEquals(
+      "a",
+      manifestNode!!.groupValues[1],
+      "a node with a renderable preview is emitted as an anchor",
+    )
     assertTrue(
-      Regex("""<a class="cp-page-node" [^>]*href="[^"]*/p/[^"]*"""")
-        .containsMatchIn(designPageHtml),
-      "a node with a renderable preview is emitted as an anchor to it",
+      manifestNode.value.contains("/p/com.example.ProfileCardPreview"),
+      "…and its destination is THAT preview, not merely some /p/ URL",
     )
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
     // tag is the same; only the target differs, so a reader never meets a node that looks
@@ -1903,9 +1913,13 @@ class ServeWebFixtureTest {
       unlinkedNode!!.groupValues[1],
       "an unlinked node stays an anchor rather than becoming inert",
     )
+    // The whole destination, not just its host: a regression to the Figma homepage, to another
+    // file, or to the wrong node all begin `https://www.figma.com/` and would pass a prefix check
+    // while node 1:6 no longer reaches its own design location.
     assertTrue(
-      unlinkedNode.value.contains("href=\"https://www.figma.com/"),
-      "…and its destination is the design file, the only link it has",
+      unlinkedNode.value.contains("ocdacdEsnHipMJD3egzxKb") &&
+        unlinkedNode.value.contains("node-id=1-6"),
+      "…and its destination is THIS node in the catalog's design file",
     )
 
     val designPageIndex =


### PR DESCRIPTION
Review caught three weak assertions in #3985 after it merged. All three were correct findings, and in a PR arguing that assertions should be exhaustive rather than incidental, which is the joke.

## `view()` failed open — the one that matters

```ts
if (!match) return { scale: 1, x: 0, y: 0 };
```

This helper backs most of `pageZoom.test.ts`, and it returned **the identity** whenever it could not parse the canvas transform. So a reset that emitted `translateX(...)`, or a scale that came out `NaN`, satisfied `assert.deepEqual(view(), { scale: 1, x: 0, y: 0 })` on a canvas nowhere near 1:1 — including the new wheel-reset case I added. The browser assertion I removed in #3985 rejected everything except `none` or an identity matrix, so on that specific point my replacement was genuinely weaker than what it replaced.

An empty transform is still the identity — that is how the element expresses 1:1, by clearing the property rather than writing `translate(0px, 0px) scale(1)`. Anything *present and unreadable* now throws, and non-finite components throw too.

This is a pre-existing helper, so the fail-open predates #3985; it just wasn't load-bearing until an assertion leaned on it.

## Two node assertions that matched too much

| assertion | matched | now |
| --- | --- | --- |
| manifest node is an anchor to its preview | any `<a class="cp-page-node" … href="…/p/…">` — the fixture has several renderable nodes, so the manifest overlay could regress to a span and stay green | node `1:1` specifically, tag checked, destination pinned to `/p/com.example.ProfileCardPreview` |
| unlinked node links to the design file | any URL starting `https://www.figma.com/` — the homepage, another file, or the wrong node all pass | node `1:6` specifically, destination pinned to the catalog's file key **and** `node-id=1-6` |

The second one is the more instructive failure. Review flagged exactly this shape on the unlinked node in the previous round, I fixed it there, and left the identical flaw in the assertion three lines above untouched. Fixing half a problem without checking whether the other half shares it is the actual mistake.

While pinning the destination I found my first attempt asserted `/m3/p/…` — a guessed `basePath`. It fails; the test now pins the preview id, which is the part that carries meaning, rather than a path prefix it would be coupled to for no benefit.

## Verified rather than assumed

`view()`'s new behaviour was checked by setting an unparseable transform on the canvas and confirming it throws instead of reading as identity. The two node assertions were checked by them failing on a wrong guess before being corrected.

## Test plan

```
cd cli/serve-web && npm run verify     # 744 passing, 4 bundles in sync
./gradlew :cli:test :cli:ktfmtCheck    # full module
```

No behaviour change, no captures touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7zeKSafCBxgGm3KsXHGe)_