### PR TITLE
feat(playground): add incremental editing lease

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -158,6 +158,8 @@ internal object CliFlagValidation {
             "--playground-caller-concurrency",
             "--playground-catalog-limit",
             "--playground-compile-slots",
+            "--playground-editing",
+            "--playground-edit-lease-ttl",
             "--playground-rate-limit",
             "--playground-sandbox",
             "--playground-sandbox-cpus",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -84,6 +84,7 @@ internal object CliFlags {
       "--playground-catalog-limit",
       "--playground-rate-limit",
       "--playground-caller-concurrency",
+      "--playground-edit-lease-ttl",
       "--extra-maven-repos",
       "--trust-store",
       "--catalogs",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -397,6 +397,13 @@ class ServeCommand(args: List<String>) : Command(args) {
   private val playgroundCallerConcurrency: Int =
     args.flagValue("--playground-caller-concurrency")?.toIntOrNull()?.takeIf { it > 0 } ?: 1
 
+  /** Authenticated, explicitly acquired, single-host stateful BTA editing trial. Off by default. */
+  private val playgroundEditing: Boolean = "--playground-editing" in args
+
+  private val playgroundEditLeaseTtlSeconds: Long =
+    args.flagValue("--playground-edit-lease-ttl")?.toLongOrNull()?.takeIf { it > 0 }
+      ?: PlaygroundCompileService.DEFAULT_EDIT_LEASE_TTL_MILLIS / 1000
+
   /**
    * `--trust-forwarded-for`: rate-limit an anonymous caller by the **last** `X-Forwarded-For` entry
    * rather than the socket peer.
@@ -1578,7 +1585,20 @@ class ServeCommand(args: List<String>) : Command(args) {
             ?.doc
             ?.path
         },
+        editLeasesEnabled = playgroundEditing && repoAccessGated,
+        editLeaseTtlMillis = playgroundEditLeaseTtlSeconds * 1000,
       )
+    if (playgroundEditing && !repoAccessGated) {
+      System.err.println(
+        "serve: --playground-editing requested without GitHub auth; the authenticated editing " +
+          "lease is disabled."
+      )
+    } else if (service.editLeasesEnabled) {
+      System.err.println(
+        "serve: playground live editing trial enabled — one authenticated lease, " +
+          "${playgroundEditLeaseTtlSeconds}s idle TTL"
+      )
+    }
     // No mode survived gating (e.g. an Android-only host whose daemon sidecar / android.jar is
     // absent, so every classpath gated to null): don't enable a lane that would render an empty
     // mode selector and mint dead tokens on Run. Disable it, like the no-source case above.
@@ -1686,6 +1706,7 @@ class ServeCommand(args: List<String>) : Command(args) {
               )
             }
           },
+        editing = { service.editLeaseHealth() },
       )
     }
     return PlaygroundLane(compile = service, redeem = redeem, health = health)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -81,7 +81,26 @@ data class PlaygroundRunRequest(
    * the wrong thing.
    */
   val catalog: String = "",
+  /**
+   * Optional single-user editing lease. Empty keeps the original stateless, one-shot compile.
+   * Non-empty values are accepted only from the authenticated owner that acquired the lease.
+   */
+  val editLease: String = "",
+  /** Monotonic client revision within [editLease]. Required to increase on every leased compile. */
+  val revision: Long = 0,
 )
+
+/** Result of explicitly acquiring the host's one stateful Playground editing lease. */
+@Serializable
+data class PlaygroundEditLeaseResponse(
+  val acquired: Boolean,
+  val lease: String? = null,
+  val expiresAtEpochMs: Long? = null,
+  val message: String,
+)
+
+/** Body for `POST /api/{version}/compiler/edit-lease/release`. */
+@Serializable data class PlaygroundEditLeaseReleaseRequest(val lease: String = "")
 
 /**
  * One entry in the editor's catalog selector (`GET /api/{version}/compiler/catalogs`).
@@ -192,6 +211,12 @@ data class PlaygroundRunResponse(
   val documentUrl: String? = null,
   val previewId: String? = null,
   val previews: List<String> = emptyList(),
+  /** Echoed only for stateful editing compiles. */
+  val editLease: String? = null,
+  /** The accepted stateful revision. Null on the original one-shot path. */
+  val revision: Long? = null,
+  /** True when this revision used BTA incremental compilation rather than the full fallback. */
+  val incremental: Boolean = false,
 )
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.nio.file.Path as NioPath
 import okio.Path
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
 import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
 
@@ -55,12 +56,7 @@ class PlaygroundBtaCompiler(
     classpath: List<Path>,
     outputDir: Path,
   ): List<PlaygroundDiagnostic> {
-    val collector = DiagnosticCollector()
-    return try {
-      // Non-incremental on purpose: a playground compiles a *fresh* snippet against a stable
-      // catalog classpath, so IC's per-entry classpath snapshotting is pure overhead — and it would
-      // throw on the catalog's leading `classes/` **directory** entry (it treats every entry as a
-      // JAR). The non-incremental path accepts directory entries and needs no icWorkingDir writes.
+    return compileWithCollector { collector ->
       session.compile(
         sources = sources.map { it.toNioPath() },
         compileClasspath = classpath.map { it.toNioPath() },
@@ -68,6 +64,53 @@ class PlaygroundBtaCompiler(
         compilerPlugins = compilerPlugins,
         diagnosticListener = collector,
       )
+    }
+  }
+
+  override fun compileIncremental(
+    sources: List<Path>,
+    classpath: List<Path>,
+    outputDir: Path,
+    workingDir: Path,
+    modified: List<Path>,
+    removed: List<Path>,
+    firstBuild: Boolean,
+  ): PlaygroundCompileService.IncrementalCompileResult {
+    val diagnostics = compileWithCollector { collector ->
+      session.compileIncremental(
+        sources = sources.map { it.toNioPath() },
+        compileClasspath = classpath.map { it.toNioPath() },
+        outputDir = outputDir.toNioPath(),
+        compilerPlugins = compilerPlugins,
+        sourcesChanges =
+          if (firstBuild) SourcesChanges.Unknown
+          else
+            SourcesChanges.Known(
+              modified.map { java.io.File(it.toString()) },
+              removed.map { java.io.File(it.toString()) },
+            ),
+        diagnosticListener = collector,
+        workingDir = workingDir.toNioPath(),
+      )
+    }
+    // The first call seeds BTA's IC state but cannot reuse any previous compilation. Report only
+    // subsequent calls as incremental so the UI and soak counters measure an actual warm edit.
+    return PlaygroundCompileService.IncrementalCompileResult(
+      diagnostics,
+      incremental = !firstBuild,
+    )
+  }
+
+  private inline fun compileWithCollector(
+    block: (DiagnosticCollector) -> Unit
+  ): List<PlaygroundDiagnostic> {
+    val collector = DiagnosticCollector()
+    return try {
+      // The ordinary path stays non-incremental: a playground compiles a *fresh* snippet against a
+      // stable catalog classpath, so retaining per-run IC state would be pure overhead. Leased
+      // editing calls the incremental entry point above, including for a catalog's `classes/`
+      // directory.
+      block(collector)
       // A clean compile: DiagnosticCollector only captures errors, so success yields no
       // diagnostics.
       emptyList()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import java.security.SecureRandom
 import java.util.Base64
 import okio.FileSystem
 import okio.Path
@@ -95,7 +96,40 @@ class PlaygroundCompileService(
    * a pin-only host the answer is yes for precisely this system and no for every other one.
    */
   private val pinnedCatalogSystem: (PlaygroundMode) -> String? = { null },
+  /** Explicitly opt in the one-host-wide authenticated stateful editing lease. */
+  val editLeasesEnabled: Boolean = false,
+  private val editLeaseTtlMillis: Long = DEFAULT_EDIT_LEASE_TTL_MILLIS,
+  private val nowMillis: () -> Long = System::currentTimeMillis,
 ) {
+
+  private val editLock = Any()
+  private var editLease: EditLease? = null
+  private var editLeaseAcquisitions = 0L
+  private var editCompileAttempts = 0L
+  private var editIncrementalCompiles = 0L
+  private var editFullFallbacks = 0L
+  private var editLastCompileMillis: Long? = null
+  @Volatile
+  private var editHealthSnapshot =
+    PlaygroundHealth.Editing(
+      enabled = editLeasesEnabled,
+      active = false,
+      acquisitions = 0,
+      compileAttempts = 0,
+      incrementalCompiles = 0,
+      fullFallbacks = 0,
+    )
+
+  private data class EditLease(
+    val id: String,
+    val owner: String,
+    val workDir: Path,
+    var expiresAt: Long,
+    var lastRevision: Long = 0,
+    var config: Pair<PlaygroundMode, String?>? = null,
+    var files: Map<String, String> = emptyMap(),
+    var incrementalReady: Boolean = false,
+  )
 
   /**
    * True when `--playground` put a runtime catalog selector on this host, whether or not any
@@ -200,7 +234,27 @@ class PlaygroundCompileService(
       classpath: List<Path>,
       outputDir: Path,
     ): List<PlaygroundDiagnostic>
+
+    /**
+     * Stateful variant. Implementations without BTA IC support retain correctness by doing a full
+     * compile; callers surface [IncrementalCompileResult.incremental] so trials can distinguish it.
+     */
+    fun compileIncremental(
+      sources: List<Path>,
+      classpath: List<Path>,
+      outputDir: Path,
+      workingDir: Path,
+      modified: List<Path>,
+      removed: List<Path>,
+      firstBuild: Boolean,
+    ): IncrementalCompileResult =
+      IncrementalCompileResult(compile(sources, classpath, outputDir), incremental = false)
   }
+
+  data class IncrementalCompileResult(
+    val diagnostics: List<PlaygroundDiagnostic>,
+    val incremental: Boolean,
+  )
 
   /**
    * Finds the `@Preview` id(s) in freshly compiled [classesDir]; empty ⇒ the snippet declared none.
@@ -214,7 +268,18 @@ class PlaygroundCompileService(
    * audit marker forwarded to [PlaygroundTokenStore.add]: the route passes `true` only once the
    * request has cleared the playground gate.
    */
-  fun run(request: PlaygroundRunRequest, isSecurityChecked: Boolean): PlaygroundRunResponse {
+  fun run(
+    request: PlaygroundRunRequest,
+    isSecurityChecked: Boolean,
+    authenticatedOwner: String? = null,
+  ): PlaygroundRunResponse {
+    if (request.editLease.isNotEmpty()) {
+      return try {
+        runWithEditLease(request, isSecurityChecked, authenticatedOwner)
+      } catch (t: Throwable) {
+        failure("playground live edit failed: ${t.message ?: t.javaClass.simpleName}")
+      }
+    }
     val files = request.files.filter { it.text.isNotBlank() }
     if (files.isEmpty()) return failure("no source files supplied")
 
@@ -241,6 +306,243 @@ class PlaygroundCompileService(
     }
   }
 
+  fun acquireEditLease(owner: String): PlaygroundEditLeaseResponse =
+    synchronized(editLock) {
+      if (!editLeasesEnabled) {
+        return@synchronized PlaygroundEditLeaseResponse(
+          false,
+          message = "Live editing is disabled.",
+        )
+      }
+      if (owner.isBlank()) {
+        return@synchronized PlaygroundEditLeaseResponse(
+          false,
+          message = "GitHub sign-in is required for live editing.",
+        )
+      }
+      purgeExpiredEditLeaseLocked()
+      val existing = editLease
+      if (existing != null) {
+        if (existing.owner == owner) {
+          existing.expiresAt = nowMillis() + editLeaseTtlMillis
+          refreshEditHealthLocked()
+          return@synchronized existing.response("You already hold the live-edit lease.")
+        }
+        return@synchronized PlaygroundEditLeaseResponse(
+          acquired = false,
+          expiresAtEpochMs = existing.expiresAt,
+          message = "The live-edit lease is in use. Try again after it expires.",
+        )
+      }
+      val workDir =
+        try {
+          newWorkDir().also(fileSystem::createDirectories)
+        } catch (t: Throwable) {
+          return@synchronized PlaygroundEditLeaseResponse(
+            acquired = false,
+            message =
+              "Live editing could not allocate its workspace: ${t.message ?: t.javaClass.simpleName}",
+          )
+        }
+      val lease =
+        EditLease(
+          id = newEditLeaseId(),
+          owner = owner,
+          workDir = workDir,
+          expiresAt = nowMillis() + editLeaseTtlMillis,
+        )
+      editLease = lease
+      editLeaseAcquisitions++
+      refreshEditHealthLocked()
+      lease.response("Live editing acquired.")
+    }
+
+  /** Cheap, owner-free and lock-free projection: status polling never waits behind a compile. */
+  fun editLeaseHealth(): PlaygroundHealth.Editing {
+    val snapshot = editHealthSnapshot
+    return if (
+      snapshot.active &&
+        snapshot.expiresAtEpochMs != null &&
+        snapshot.expiresAtEpochMs <= nowMillis()
+    ) {
+      snapshot.copy(active = false, expiresAtEpochMs = null)
+    } else {
+      snapshot
+    }
+  }
+
+  fun releaseEditLease(owner: String, id: String): Boolean =
+    synchronized(editLock) {
+      purgeExpiredEditLeaseLocked()
+      val lease = editLease ?: return@synchronized false
+      if (lease.owner != owner || lease.id != id) return@synchronized false
+      editLease = null
+      cleanup(lease.workDir)
+      refreshEditHealthLocked()
+      true
+    }
+
+  private fun EditLease.response(message: String) =
+    PlaygroundEditLeaseResponse(
+      acquired = true,
+      lease = id,
+      expiresAtEpochMs = expiresAt,
+      message = message,
+    )
+
+  private fun purgeExpiredEditLeaseLocked() {
+    val lease = editLease ?: return
+    if (lease.expiresAt > nowMillis()) return
+    editLease = null
+    cleanup(lease.workDir)
+    refreshEditHealthLocked()
+  }
+
+  private fun refreshEditHealthLocked() {
+    val lease = editLease?.takeIf { it.expiresAt > nowMillis() }
+    editHealthSnapshot =
+      PlaygroundHealth.Editing(
+        enabled = editLeasesEnabled,
+        active = lease != null,
+        expiresAtEpochMs = lease?.expiresAt,
+        lastRevision = lease?.lastRevision?.takeIf { it > 0 },
+        acquisitions = editLeaseAcquisitions,
+        compileAttempts = editCompileAttempts,
+        incrementalCompiles = editIncrementalCompiles,
+        fullFallbacks = editFullFallbacks,
+        lastCompileMillis = editLastCompileMillis,
+      )
+  }
+
+  private fun runWithEditLease(
+    request: PlaygroundRunRequest,
+    isSecurityChecked: Boolean,
+    owner: String?,
+  ): PlaygroundRunResponse =
+    synchronized(editLock) {
+      if (!editLeasesEnabled) return@synchronized failure("Live editing is disabled.")
+      purgeExpiredEditLeaseLocked()
+      val lease = editLease ?: return@synchronized failure("The live-edit lease has expired.")
+      if (owner.isNullOrBlank() || lease.owner != owner || lease.id != request.editLease) {
+        return@synchronized failure("This live-edit lease is not yours.")
+      }
+      if (request.revision <= lease.lastRevision) {
+        return@synchronized failure(
+          "Revision ${request.revision} is stale; the lease is already at ${lease.lastRevision}."
+        )
+      }
+      val files = request.files.filter { it.text.isNotBlank() }
+      if (files.isEmpty()) return@synchronized failure("no source files supplied")
+
+      val mode = PlaygroundMode.fromConfType(request.confType)
+      val catalog = request.catalog.trim().takeIf { it.isNotEmpty() }
+      val classpath =
+        catalogClasspath(mode, catalog)
+          ?: return@synchronized failure(
+            if (catalog == null) "mode ${mode.name} is not available on this host"
+            else "catalog '$catalog' cannot serve mode ${mode.name} on this host"
+          )
+
+      lease.expiresAt = nowMillis() + editLeaseTtlMillis
+      refreshEditHealthLocked()
+      val config = mode to catalog
+      if (lease.config != null && lease.config != config) {
+        cleanup(lease.workDir)
+        fileSystem.createDirectories(lease.workDir)
+        lease.files = emptyMap()
+        lease.incrementalReady = false
+      }
+      lease.config = config
+
+      val srcDir = lease.workDir / "src"
+      val classesDir = lease.workDir / "classes"
+      val icDir = lease.workDir / "bta-ic"
+      fileSystem.createDirectories(srcDir)
+      fileSystem.createDirectories(classesDir)
+      val desired = stagedFileMap(files)
+      val removed = (lease.files.keys - desired.keys).map { srcDir / it }
+      val modified =
+        desired
+          .filter { (name, text) -> lease.files[name] != text }
+          .map { (name, text) ->
+            (srcDir / name).also { path -> fileSystem.write(path) { writeUtf8(text) } }
+          }
+      removed.forEach { fileSystem.delete(it, mustExist = false) }
+      val sources = desired.keys.map { srcDir / it }
+      val firstBuild = !lease.incrementalReady
+      val compileStarted = System.nanoTime()
+      editCompileAttempts++
+      refreshEditHealthLocked()
+      var compile =
+        compiler.compileIncremental(
+          sources = sources,
+          classpath = classpath.entries,
+          outputDir = classesDir,
+          workingDir = icDir,
+          modified = modified,
+          removed = removed,
+          firstBuild = firstBuild,
+        )
+      // An internal BTA/IC failure has no source position. Reset only this lease and retry the same
+      // revision through the proven full path; ordinary source diagnostics stay incremental.
+      if (compile.diagnostics.isInfrastructureCompileFailure()) {
+        editFullFallbacks++
+        refreshEditHealthLocked()
+        fileSystem.deleteRecursively(classesDir, mustExist = false)
+        fileSystem.deleteRecursively(icDir, mustExist = false)
+        fileSystem.createDirectories(classesDir)
+        compile =
+          IncrementalCompileResult(
+            compiler.compile(sources, classpath.entries, classesDir),
+            incremental = false,
+          )
+        lease.incrementalReady = false
+      } else {
+        lease.incrementalReady = true
+      }
+      if (compile.incremental) editIncrementalCompiles++
+      editLastCompileMillis = (System.nanoTime() - compileStarted) / 1_000_000
+      lease.files = desired
+      lease.lastRevision = request.revision
+      refreshEditHealthLocked()
+
+      val diagnostics = compile.diagnostics
+      if (diagnostics.any { it.severity == PlaygroundSeverity.ERROR }) {
+        return@synchronized PlaygroundRunResponse(
+          diagnostics = diagnostics,
+          errors = PlaygroundErrorsWire.project(diagnostics),
+          editLease = lease.id,
+          revision = request.revision,
+          incremental = compile.incremental,
+        )
+      }
+
+      // BTA needs a mutable output directory for the next edit. Preview tokens need immutable
+      // bytecode. Snapshot the successful revision into an ordinary token-owned work directory.
+      val revisionWorkDir = newWorkDir()
+      val revisionClasses = revisionWorkDir / "classes"
+      try {
+        fileSystem.createDirectories(revisionClasses)
+        copyDirectory(classesDir, revisionClasses)
+        publishCompiled(
+            mode = mode,
+            classpath = classpath,
+            classesDir = revisionClasses,
+            workDir = revisionWorkDir,
+            diagnostics = diagnostics,
+            isSecurityChecked = isSecurityChecked,
+          )
+          .copy(
+            editLease = lease.id,
+            revision = request.revision,
+            incremental = compile.incremental,
+          )
+      } catch (t: Throwable) {
+        cleanup(revisionWorkDir)
+        failure("playground revision snapshot failed: ${t.message ?: t.javaClass.simpleName}")
+      }
+    }
+
   private fun compileAndMint(
     request: PlaygroundRunRequest,
     files: List<PlaygroundFile>,
@@ -264,6 +566,24 @@ class PlaygroundCompileService(
       )
     }
 
+    return publishCompiled(
+      mode = mode,
+      classpath = classpath,
+      classesDir = classesDir,
+      workDir = workDir,
+      diagnostics = diagnostics,
+      isSecurityChecked = isSecurityChecked,
+    )
+  }
+
+  private fun publishCompiled(
+    mode: PlaygroundMode,
+    classpath: Classpath,
+    classesDir: Path,
+    workDir: Path,
+    diagnostics: List<PlaygroundDiagnostic>,
+    isSecurityChecked: Boolean,
+  ): PlaygroundRunResponse {
     val renderClasspath = classpath.entries + classesDir
     // Sorted, so the same snippet renders the same preview on every run: ClassGraph's scan order
     // over the snippet's classes is not a guaranteed order, and a multi-file snippet routinely
@@ -375,6 +695,38 @@ class PlaygroundCompileService(
     }
   }
 
+  private fun stagedFileMap(files: List<PlaygroundFile>): Map<String, String> {
+    val used = mutableSetOf<String>()
+    return buildMap {
+      files.forEach { file -> put(uniqueName(safeKtName(file.name), used), file.text) }
+    }
+  }
+
+  private fun copyDirectory(from: Path, to: Path) {
+    check(fileSystem.metadataOrNull(from)?.isDirectory == true) {
+      "compiled classes directory is missing: $from"
+    }
+    fileSystem.createDirectories(to)
+    fileSystem.list(from).forEach { source ->
+      val target = to / source.name
+      if (fileSystem.metadata(source).isDirectory) {
+        copyDirectory(source, target)
+      } else {
+        fileSystem.copy(source, target)
+      }
+    }
+  }
+
+  private fun List<PlaygroundDiagnostic>.isInfrastructureCompileFailure(): Boolean =
+    size == 1 &&
+      single().file == null &&
+      (single().message.startsWith("compilation failed:") ||
+        single().message.startsWith("compile sandbox error:") ||
+        single().message.startsWith("compile sandbox failed:") ||
+        single().message.startsWith("could not launch the compile sandbox") ||
+        single().message.startsWith("the compile sandbox produced no result") ||
+        single().message.startsWith("unreadable compile report:"))
+
   private fun cleanup(workDir: Path) {
     try {
       fileSystem.deleteRecursively(workDir, mustExist = false)
@@ -386,6 +738,16 @@ class PlaygroundCompileService(
   private fun failure(message: String) = PlaygroundRunResponse(exception = message)
 
   companion object {
+    const val DEFAULT_EDIT_LEASE_TTL_MILLIS: Long = 15 * 60 * 1000L
+
+    private val EDIT_LEASE_RANDOM = SecureRandom()
+
+    private fun newEditLeaseId(): String {
+      val bytes = ByteArray(18)
+      EDIT_LEASE_RANDOM.nextBytes(bytes)
+      return "pge_" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
     /**
      * Reduce a client-supplied name to a safe `.kt` filename (last segment, printable, non-empty).
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundHealth.kt
@@ -65,6 +65,8 @@ data class PlaygroundHealth(
    * declare a backend this host cannot render.
    */
   val catalogSelector: (() -> CatalogSelector)? = null,
+  /** Stateful editing trial state and cumulative process-lifetime counters. */
+  val editing: (() -> Editing)? = null,
 ) {
   /**
    * A wired playground mode. "Wired" means configured with a bundle source *and* backed by an
@@ -95,5 +97,17 @@ data class PlaygroundHealth(
     val resolved: Int,
     /** `--playground-catalog-limit`. At [resolved] == [limit] a new catalog is refused. */
     val limit: Int,
+  )
+
+  data class Editing(
+    val enabled: Boolean,
+    val active: Boolean,
+    val expiresAtEpochMs: Long? = null,
+    val lastRevision: Long? = null,
+    val acquisitions: Long,
+    val compileAttempts: Long,
+    val incrementalCompiles: Long,
+    val fullFallbacks: Long,
+    val lastCompileMillis: Long? = null,
   )
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundJailedCompiler.kt
@@ -75,6 +75,43 @@ class PlaygroundJailedCompiler(
     classpath: List<Path>,
     outputDir: Path,
   ): List<PlaygroundDiagnostic> {
+    return launchCompile(sources, classpath, outputDir)
+  }
+
+  override fun compileIncremental(
+    sources: List<Path>,
+    classpath: List<Path>,
+    outputDir: Path,
+    workingDir: Path,
+    modified: List<Path>,
+    removed: List<Path>,
+    firstBuild: Boolean,
+  ): PlaygroundCompileService.IncrementalCompileResult =
+    PlaygroundCompileService.IncrementalCompileResult(
+      diagnostics =
+        launchCompile(
+          sources,
+          classpath,
+          outputDir,
+          incrementalWorkingDir = workingDir,
+          modified = modified,
+          removed = removed,
+          firstBuild = firstBuild,
+        ),
+      // The child is cold, but it uses the persistent IC/output state and therefore is genuinely
+      // incremental. A future warm worker removes the remaining toolchain-bootstrap cost.
+      incremental = !firstBuild,
+    )
+
+  private fun launchCompile(
+    sources: List<Path>,
+    classpath: List<Path>,
+    outputDir: Path,
+    incrementalWorkingDir: Path? = null,
+    modified: List<Path> = emptyList(),
+    removed: List<Path> = emptyList(),
+    firstBuild: Boolean = false,
+  ): List<PlaygroundDiagnostic> {
     // The snippet's work dir — the one path the jail leaves writable, and the parent of both the
     // staged sources and the class output. Everything the compile writes (classes, the IC dir, this
     // request file) therefore lands inside the directory the token store deletes.
@@ -87,8 +124,12 @@ class PlaygroundJailedCompiler(
         outputDir = outputDir.toString(),
         btaImplJars = btaImplJars,
         compilerPluginJars = compilerPluginJars,
-        icWorkingDir = File(workDir, "bta-ic").absolutePath,
+        icWorkingDir = incrementalWorkingDir?.toString() ?: File(workDir, "bta-ic").absolutePath,
         moduleName = moduleName,
+        incremental = incrementalWorkingDir != null,
+        modified = modified.map { it.toString() },
+        removed = removed.map { it.toString() },
+        firstBuild = firstBuild,
       )
     // Admission control BEFORE the fork: without it, every concurrent POST is another whole JVM
     // holding another whole memory budget, and the per-process caps say nothing about the total.
@@ -307,6 +348,10 @@ data class PlaygroundCompileRequest(
   val compilerPluginJars: List<String>,
   val icWorkingDir: String,
   val moduleName: String,
+  val incremental: Boolean = false,
+  val modified: List<String> = emptyList(),
+  val removed: List<String> = emptyList(),
+  val firstBuild: Boolean = false,
 )
 
 /** What it answers: the same diagnostics an in-process compile would have returned. */
@@ -340,11 +385,26 @@ object PlaygroundCompileMain {
             icWorkingDir = File(request.icWorkingDir).toPath(),
             moduleName = request.moduleName,
           )
-          .compile(
-            sources = request.sources.map { it.toPath() },
-            classpath = request.classpath.map { it.toPath() },
-            outputDir = request.outputDir.toPath(),
-          )
+          .let { compiler ->
+            if (request.incremental)
+              compiler
+                .compileIncremental(
+                  sources = request.sources.map { it.toPath() },
+                  classpath = request.classpath.map { it.toPath() },
+                  outputDir = request.outputDir.toPath(),
+                  workingDir = request.icWorkingDir.toPath(),
+                  modified = request.modified.map { it.toPath() },
+                  removed = request.removed.map { it.toPath() },
+                  firstBuild = request.firstBuild,
+                )
+                .diagnostics
+            else
+              compiler.compile(
+                sources = request.sources.map { it.toPath() },
+                classpath = request.classpath.map { it.toPath() },
+                outputDir = request.outputDir.toPath(),
+              )
+          }
       } catch (t: Throwable) {
         listOf(
           PlaygroundDiagnostic(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -771,6 +771,12 @@ class ServeHttpServer(
         if (playgroundService != null) {
           val svc = playgroundService
           post("/api/{version}/compiler/run") { handlePlaygroundRun(svc) }
+          if (svc.editLeasesEnabled) {
+            post("/api/{version}/compiler/edit-lease") { handlePlaygroundEditLeaseAcquire(svc) }
+            post("/api/{version}/compiler/edit-lease/release") {
+              handlePlaygroundEditLeaseRelease(svc)
+            }
+          }
           // The runtime catalog selector's list. Fetched by the editor on load rather than only
           // baked into the page: catalogs are fetched in the background *after* the server is up,
           // so
@@ -1479,6 +1485,7 @@ class ServeHttpServer(
         pinnedCatalogSystems = service.pinnedCatalogSystems,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
         version = BUNDLE_VERSION,
+        editingLeaseEnabled = service.editLeasesEnabled && githubAuth?.currentLogin(call) != null,
       ),
       ContentType.Text.Html,
     )
@@ -1659,11 +1666,74 @@ class ServeHttpServer(
       )
       return
     }
-    val response = withContext(Dispatchers.IO) { service.run(request, isSecurityChecked = true) }
+    val response =
+      withContext(Dispatchers.IO) {
+        service.run(
+          request,
+          isSecurityChecked = true,
+          authenticatedOwner = githubAuth?.currentLogin(call),
+        )
+      }
     call.respondText(
       JSON.encodeToString(PlaygroundRunResponse.serializer(), response),
       ContentType.Application.Json,
     )
+  }
+
+  private suspend fun RoutingContext.handlePlaygroundEditLeaseAcquire(
+    service: PlaygroundCompileService
+  ) {
+    if (rejectBadToken()) return
+    if (rejectMissingGithubAuth(api = true)) return
+    if (rejectMissingGithubRepoAccess(api = true)) return
+    val owner = githubAuth?.currentLogin(call)
+    if (owner == null) {
+      call.respondText(
+        "GitHub sign-in is required for live editing.",
+        status = HttpStatusCode.Unauthorized,
+      )
+      return
+    }
+    val result = withContext(Dispatchers.IO) { service.acquireEditLease(owner) }
+    call.respondText(
+      JSON.encodeToString(PlaygroundEditLeaseResponse.serializer(), result),
+      ContentType.Application.Json,
+      if (result.acquired) HttpStatusCode.OK else HttpStatusCode.Conflict,
+    )
+  }
+
+  private suspend fun RoutingContext.handlePlaygroundEditLeaseRelease(
+    service: PlaygroundCompileService
+  ) {
+    if (rejectBadToken()) return
+    if (rejectMissingGithubAuth(api = true)) return
+    if (rejectMissingGithubRepoAccess(api = true)) return
+    val owner = githubAuth?.currentLogin(call)
+    if (owner == null) {
+      call.respondText(
+        "GitHub sign-in is required for live editing.",
+        status = HttpStatusCode.Unauthorized,
+      )
+      return
+    }
+    val body =
+      withContext(Dispatchers.IO) {
+        call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
+      }
+    val request = body?.let {
+      runCatching {
+        JSON.decodeFromString(
+          PlaygroundEditLeaseReleaseRequest.serializer(),
+          it.decodeToString(),
+        )
+      }
+        .getOrNull()
+    }
+    if (request == null || !service.releaseEditLease(owner, request.lease)) {
+      call.respondText("Live-edit lease not found.", status = HttpStatusCode.NotFound)
+      return
+    }
+    call.respondText("{\"released\":true}", ContentType.Application.Json)
   }
 
   /** `GET /d/{id}`: the permalink page. An expired (or unknown) id is a styled 404, not a hint. */
@@ -3776,6 +3846,20 @@ class ServeHttpServer(
                   RateLimitDto(
                     activeCallers = it.activeCallers(),
                     trackedCallers = it.trackedCallers(),
+                  )
+                },
+              editing =
+                h.editing?.invoke()?.let {
+                  EditingDto(
+                    enabled = it.enabled,
+                    active = it.active,
+                    expiresAtEpochMs = it.expiresAtEpochMs,
+                    lastRevision = it.lastRevision,
+                    acquisitions = it.acquisitions,
+                    compileAttempts = it.compileAttempts,
+                    incrementalCompiles = it.incrementalCompiles,
+                    fullFallbacks = it.fullFallbacks,
+                    lastCompileMillis = it.lastCompileMillis,
                   )
                 },
             )
@@ -6346,6 +6430,21 @@ private data class PlaygroundDto(
   val catalogSelector: CatalogSelectorDto? = null,
   /** The per-caller compile budget, or null when the lane is unmetered. */
   val rateLimit: RateLimitDto? = null,
+  /** Authenticated single-lease incremental editing trial, or null on older/unwired lanes. */
+  val editing: EditingDto? = null,
+)
+
+@Serializable
+private data class EditingDto(
+  val enabled: Boolean,
+  val active: Boolean,
+  val expiresAtEpochMs: Long? = null,
+  val lastRevision: Long? = null,
+  val acquisitions: Long,
+  val compileAttempts: Long,
+  val incrementalCompiles: Long,
+  val fullFallbacks: Long,
+  val lastCompileMillis: Long? = null,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4288,6 +4288,8 @@ object ServeWeb {
      * span.
      */
     version: String? = null,
+    /** Show the authenticated, server-enabled single stateful editing lease control. */
+    editingLeaseEnabled: Boolean = false,
   ): String {
     val suffix = querySuffix(queryString(token, sessionId = null, isPublic = isPublic))
     val sample = WebEscaping.htmlEscape(seed?.text ?: PLAYGROUND_SAMPLE)
@@ -4470,6 +4472,16 @@ object ServeWeb {
           PlaygroundCatalogsResponse(catalogs),
         )
       )
+    val editLeaseButton =
+      if (!editingLeaseEnabled) ""
+      else
+        """
+            <button id="pg-edit-lease" class="cp-doc-btn" type="button">Acquire editing lease</button>"""
+    val editLeaseNote =
+      if (!editingLeaseEnabled) ""
+      else
+        """
+          <p id="pg-edit-lease-note" class="cp-pg-status" hidden></p>"""
     return document(
       title = "Playground — compose-preview",
       unfurlDescription = "Compile a Compose snippet against the live catalog and open a preview.",
@@ -4489,8 +4501,8 @@ object ServeWeb {
             <select id="pg-mode" class="cp-pg-mode">
               $options
             </select>
-            <button id="pg-run" class="cp-doc-btn cp-pg-run" type="button">Run</button>
-          </div>
+            <button id="pg-run" class="cp-doc-btn cp-pg-run" type="button">Run</button>$editLeaseButton
+          </div>$editLeaseNote
           <div id="pg-files" class="cp-pg-files" role="tablist" aria-label="Snippet files">
             <button class="cp-pg-file" type="button" role="tab" aria-current="true"
               data-pg-file="${WebEscaping.htmlEscape(fileName)}">${
@@ -4536,6 +4548,8 @@ object ServeWeb {
       var mode = document.getElementById("pg-mode");
       var catalog = document.getElementById("pg-catalog");
       var run = document.getElementById("pg-run");
+      var editLeaseButton = document.getElementById("pg-edit-lease");
+      var editLeaseNote = document.getElementById("pg-edit-lease-note");
       var fileBar = document.getElementById("pg-files");
       var addFile = document.getElementById("pg-add-file");
       var removeFile = document.getElementById("pg-remove-file");
@@ -4548,6 +4562,57 @@ object ServeWeb {
       var note = document.getElementById("pg-preview-note");
       var previewList = document.getElementById("pg-previews");
       var suffix = ${jsString(querySuffix)};
+      var editLease = null;
+      var editRevision = 0;
+      function setEditLease(value, message, expiresAt) {
+        editLease = value;
+        editRevision = 0;
+        if (!editLeaseButton) return;
+        editLeaseButton.disabled = false;
+        editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
+        editLeaseButton.setAttribute("aria-pressed", value ? "true" : "false");
+        editLeaseNote.hidden = !message;
+        editLeaseNote.textContent = message || "";
+        if (value && expiresAt) {
+          editLeaseButton.title = "Lease expires " + new Date(expiresAt).toLocaleTimeString();
+        } else {
+          editLeaseButton.removeAttribute("title");
+        }
+      }
+      if (editLeaseButton) {
+        editLeaseButton.addEventListener("click", function () {
+          editLeaseButton.disabled = true;
+          if (!editLease) {
+            fetch("/api/1/compiler/edit-lease" + suffix, {
+              method: "POST", headers: { "Accept": "application/json" }
+            })
+              .then(function (r) {
+                return r.json().then(function (body) {
+                  if (!r.ok) throw new Error(body.message || "The editing lease is busy.");
+                  return body;
+                });
+              })
+              .then(function (body) {
+                setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+              })
+              .catch(function (e) {
+                setEditLease(null, e.message || "Could not acquire editing lease.");
+              });
+          } else {
+            var releasing = editLease;
+            fetch("/api/1/compiler/edit-lease/release" + suffix, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ lease: releasing })
+            })
+              .then(function (r) {
+                if (!r.ok) throw new Error("The editing lease has already expired.");
+                setEditLease(null, "Editing lease released.");
+              })
+              .catch(function (e) { setEditLease(null, e.message); });
+          }
+        });
+      }
       // The catalog selector. Each entry carries its own mode list because a catalog's bundle
       // backend picks the renderer — selecting `compose-m3` (desktop) and selecting an Android
       // catalog are not the same choice with a different classpath, they are different modes.
@@ -4779,7 +4844,9 @@ object ServeWeb {
         var body = JSON.stringify({
           confType: mode.value,
           catalog: catalog ? catalog.value : "",
-          files: files
+          files: files,
+          editLease: editLease || "",
+          revision: editLease ? ++editRevision : 0
         });
         fetch("/api/1/compiler/run" + suffix, {
           method: "POST",
@@ -4795,10 +4862,23 @@ object ServeWeb {
           .then(function (res) {
             if (myId !== reqId) return;
             run.disabled = false;
+            if (editLeaseButton) editLeaseButton.disabled = false;
             renderDiags(res.diagnostics);
             var hasError = (res.diagnostics || []).some(function (d) { return d.severity === "error"; });
-            if (res.exception) { setStatus(res.exception, true); return; }
-            if (hasError) { setStatus("Compilation failed.", true); return; }
+            if (res.exception) {
+              if (res.exception.indexOf("live-edit lease") >= 0) setEditLease(null, res.exception);
+              setStatus(res.exception, true); return;
+            }
+            if (hasError) {
+              setStatus(
+                res.revision != null
+                  ? ("Compilation failed at revision " + res.revision +
+                    (res.incremental ? " (incremental)." : " (full fallback)."))
+                  : "Compilation failed.",
+                true
+              );
+              return;
+            }
             result.hidden = false;
             if (res.image) { image.hidden = false; image.src = res.image; }
             var link = res.documentUrl || res.previewUrl;
@@ -4839,10 +4919,16 @@ object ServeWeb {
               });
             }
             setStatus("Done.", false);
+            if (res.revision != null && editLeaseNote) {
+              editLeaseNote.hidden = false;
+              editLeaseNote.textContent = "Revision " + res.revision +
+                (res.incremental ? " compiled incrementally." : " used a full compile.");
+            }
           })
           .catch(function (e) {
             if (myId !== reqId) return;
             run.disabled = false;
+            if (editLeaseButton) editLeaseButton.disabled = false;
             setStatus(e.message || "run failed", true);
           });
       });

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -33,10 +33,14 @@ class PlaygroundCompileServiceTest {
     render: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
     capture: (PlaygroundTokenStore.PlaygroundSnippet) -> ByteArray? = { null },
     publish: (String, ByteArray, Boolean) -> String? = { _, _, _ -> null },
+    compilerOverride: PlaygroundCompileService.Compiler? = null,
+    editLeasesEnabled: Boolean = false,
+    editLeaseTtlMillis: Long = PlaygroundCompileService.DEFAULT_EDIT_LEASE_TTL_MILLIS,
+    nowMillis: () -> Long = { 1_000L },
   ) =
     PlaygroundCompileService(
       catalogClasspath = { mode, _ -> classpathFor(mode) },
-      compiler = PlaygroundCompileService.Compiler(compile),
+      compiler = compilerOverride ?: PlaygroundCompileService.Compiler(compile),
       discoverer = PlaygroundCompileService.PreviewDiscoverer(discover),
       tokenStore = tokenStore,
       newWorkDir = { "/work/run${++workDirs}".toPath() },
@@ -44,6 +48,9 @@ class PlaygroundCompileServiceTest {
       renderFirstFrame = render,
       captureRemoteDocument = capture,
       publishRemoteDocument = publish,
+      editLeasesEnabled = editLeasesEnabled,
+      editLeaseTtlMillis = editLeaseTtlMillis,
+      nowMillis = nowMillis,
     )
 
   private fun request(
@@ -550,5 +557,229 @@ class PlaygroundCompileServiceTest {
     )
     assertNull(resp.previewToken)
     assertTrue(tokenStore.snapshot().isEmpty())
+  }
+
+  @Test
+  fun `one authenticated editing lease is exclusive, renewable, and owner-released`() {
+    var now = 1_000L
+    val svc =
+      service(
+        editLeasesEnabled = true,
+        editLeaseTtlMillis = 5_000L,
+        nowMillis = { now },
+      )
+
+    val alice = svc.acquireEditLease("alice")
+    assertTrue(alice.acquired)
+    assertNotNull(alice.lease)
+    assertEquals(6_000L, alice.expiresAtEpochMs)
+
+    val bob = svc.acquireEditLease("bob")
+    assertFalse(bob.acquired)
+    assertNull(bob.lease, "a busy response never discloses the capability")
+    assertFalse(svc.releaseEditLease("bob", alice.lease!!), "ownership is checked")
+
+    now = 2_000L
+    val renewed = svc.acquireEditLease("alice")
+    assertEquals(alice.lease, renewed.lease)
+    assertEquals(7_000L, renewed.expiresAtEpochMs)
+    assertTrue(svc.releaseEditLease("alice", alice.lease!!))
+    assertTrue(svc.acquireEditLease("bob").acquired, "release makes the single slot available")
+    now = 8_000L
+    assertFalse(svc.editLeaseHealth().active, "status observes idle expiry without taking the lock")
+  }
+
+  @Test
+  fun `leased revisions send precise source changes and mint immutable class snapshots`() {
+    data class Call(
+      val modified: List<String>,
+      val removed: List<String>,
+      val first: Boolean,
+    )
+    val calls = mutableListOf<Call>()
+    var generation = 0
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ): List<PlaygroundDiagnostic> = emptyList()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult {
+          calls += Call(modified.map { it.name }, removed.map { it.name }, firstBuild)
+          fs.createDirectories(outputDir)
+          fs.write(outputDir / "Snippet.class") { writeUtf8("generation-${++generation}") }
+          return PlaygroundCompileService.IncrementalCompileResult(emptyList(), true)
+        }
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+
+    fun leased(revision: Long, files: List<PlaygroundFile>) =
+      svc.run(
+        PlaygroundRunRequest(
+          files = files,
+          confType = "compose-cmp",
+          editLease = lease,
+          revision = revision,
+        ),
+        isSecurityChecked = true,
+        authenticatedOwner = "alice",
+      )
+
+    val first =
+      leased(
+        1,
+        listOf(
+          PlaygroundFile("Snippet.kt", "@Preview fun P() = Unit"),
+          PlaygroundFile("Theme.kt", "object Theme"),
+        ),
+      )
+    val second = leased(2, listOf(PlaygroundFile("Snippet.kt", "@Preview fun P() = println(2)")))
+
+    assertEquals(Call(listOf("Snippet.kt", "Theme.kt"), emptyList(), true), calls[0])
+    assertEquals(Call(listOf("Snippet.kt"), listOf("Theme.kt"), false), calls[1])
+    assertEquals(1L, first.revision)
+    assertEquals(2L, second.revision)
+    assertTrue(first.incremental)
+    val firstClasses = tokenStore.get(first.previewToken!!)!!.snippet.classesDir
+    val secondClasses = tokenStore.get(second.previewToken!!)!!.snippet.classesDir
+    assertTrue(firstClasses != secondClasses, "each token owns an immutable revision snapshot")
+    assertEquals("generation-1", fs.read(firstClasses / "Snippet.class") { readUtf8() })
+    assertEquals("generation-2", fs.read(secondClasses / "Snippet.class") { readUtf8() })
+    val health = svc.editLeaseHealth()
+    assertTrue(health.active)
+    assertEquals(1, health.acquisitions)
+    assertEquals(2, health.compileAttempts)
+    assertEquals(2, health.incrementalCompiles)
+    assertEquals(0, health.fullFallbacks)
+  }
+
+  @Test
+  fun `stale or foreign leased revisions are rejected before compilation`() {
+    var compiles = 0
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ) = emptyList<PlaygroundDiagnostic>()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult {
+          compiles++
+          fs.createDirectories(outputDir)
+          return PlaygroundCompileService.IncrementalCompileResult(emptyList(), true)
+        }
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+    val req = request().copy(editLease = lease, revision = 1)
+
+    assertTrue(svc.run(req, true, authenticatedOwner = "bob").exception!!.contains("not yours"))
+    svc.run(req, true, authenticatedOwner = "alice")
+    assertTrue(svc.run(req, true, authenticatedOwner = "alice").exception!!.contains("stale"))
+    assertEquals(1, compiles)
+  }
+
+  @Test
+  fun `an incremental infrastructure failure retries once through full compile`() {
+    var fullCompiles = 0
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ): List<PlaygroundDiagnostic> {
+          fullCompiles++
+          fs.createDirectories(outputDir)
+          fs.write(outputDir / "Snippet.class") { writeUtf8("full") }
+          return emptyList()
+        }
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ) =
+          PlaygroundCompileService.IncrementalCompileResult(
+            listOf(
+              PlaygroundDiagnostic(
+                PlaygroundSeverity.ERROR,
+                "compilation failed: broken IC cache",
+              )
+            ),
+            true,
+          )
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+    val response =
+      svc.run(
+        request().copy(editLease = lease, revision = 1),
+        isSecurityChecked = true,
+        authenticatedOwner = "alice",
+      )
+
+    assertEquals(1, fullCompiles)
+    assertFalse(response.incremental)
+    assertNotNull(response.previewToken)
+    assertEquals(1, svc.editLeaseHealth().fullFallbacks)
+  }
+
+  @Test
+  fun `an unexpected leased compiler failure still returns the JSON contract`() {
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ) = emptyList<PlaygroundDiagnostic>()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult = error("compiler vanished")
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+
+    val response =
+      svc.run(
+        request().copy(editLease = lease, revision = 1),
+        isSecurityChecked = true,
+        authenticatedOwner = "alice",
+      )
+
+    assertTrue(response.exception!!.contains("compiler vanished"))
+    assertNull(response.previewToken)
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -51,6 +51,23 @@ class PlaygroundRoutingTest {
       fileSystem = fs,
     )
 
+  private val editingPlayground =
+    PlaygroundCompileService(
+      catalogClasspath = { mode, _ ->
+        if (mode == PlaygroundMode.CMP) {
+          PlaygroundCompileService.Classpath("compose-m3", listOf("/cat/app.jar".toPath()))
+        } else {
+          null
+        }
+      },
+      compiler = PlaygroundCompileService.Compiler { _, _, _ -> emptyList() },
+      discoverer = PlaygroundCompileService.PreviewDiscoverer { _, _ -> listOf("com.example.P") },
+      tokenStore = tokenStore,
+      newWorkDir = { "/work/edit${++workN}".toPath() },
+      fileSystem = fs,
+      editLeasesEnabled = true,
+    )
+
   private val registry = ServeSessionRegistry(open = { null })
 
   // Materialize always succeeds (a real daemon isn't in scope here) so redemption reaches its Live
@@ -137,7 +154,7 @@ class PlaygroundRoutingTest {
         sessions = registry,
         defaultSessionId = "none",
         isPublic = true,
-        playgroundService = playground,
+        playgroundService = editingPlayground,
         githubAuth = githubAuth(repositoryAccess = true),
       )
       .also { it.start() }
@@ -165,6 +182,16 @@ class PlaygroundRoutingTest {
           .build()
       )
       .execute()
+
+  private fun post(path: String, body: String, port: Int, cookie: String? = null): Response {
+    val request =
+      Request.Builder()
+        .url("http://127.0.0.1:$port$path")
+        .post(body.toRequestBody("application/json".toMediaType()))
+        .apply { cookie?.let { header("Cookie", it) } }
+        .build()
+    return client.newCall(request).execute()
+  }
 
   @Test
   fun `a clean compile returns a preview token over the run route`() {
@@ -294,7 +321,29 @@ class PlaygroundRoutingTest {
     val cookie = githubSessionCookie(githubRepoServer.port)
     get("/playground", githubRepoServer.port, cookie).use { resp ->
       assertEquals(200, resp.code)
-      assertTrue(resp.body!!.string().contains("id=\"pg-source\""))
+      val html = resp.body!!.string()
+      assertTrue(html.contains("id=\"pg-source\""))
+      assertTrue(html.contains("id=\"pg-edit-lease\""))
+    }
+  }
+
+  @Test
+  fun `authenticated user acquires the single editing lease and compiles a revision`() {
+    val cookie = githubSessionCookie(githubRepoServer.port)
+    val lease =
+      post("/api/1/compiler/edit-lease", "{}", githubRepoServer.port, cookie).use { resp ->
+        assertEquals(200, resp.code)
+        Json.parseToJsonElement(resp.body!!.string()).jsonObject["lease"]!!.jsonPrimitive.content
+      }
+    val body =
+      """{"files":[{"name":"Snippet.kt","text":"@Preview fun P(){}"}],"confType":"compose-cmp","editLease":"$lease","revision":1}"""
+
+    post("/api/1/compiler/run", body, githubRepoServer.port, cookie).use { resp ->
+      assertEquals(200, resp.code)
+      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      assertEquals("1", json["revision"]?.jsonPrimitive?.content)
+      assertEquals(lease, json["editLease"]?.jsonPrimitive?.content)
+      assertTrue(json["previewToken"]?.jsonPrimitive?.content?.startsWith("pg_") == true)
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -69,6 +69,7 @@ class ServeStatusTest {
     catalogLoads: CatalogLoadTracker? = null,
     failedCatalogPreviews: List<String> = emptyList(),
     deferredCatalogPreviews: List<String> = emptyList(),
+    playgroundHealth: (() -> PlaygroundHealth)? = null,
   ): ServeHttpServer {
     registry.register(
       "default-mod",
@@ -117,6 +118,7 @@ class ServeStatusTest {
         trustStoreConfigured = true,
         catalogRefreshSeconds = 600,
         acceptBundlesEnabled = false,
+        playgroundHealth = playgroundHealth,
       )
       .also { it.start() }
   }
@@ -161,6 +163,48 @@ class ServeStatusTest {
     assertTrue(body.contains("\"catalogRefreshSeconds\":600"), body)
     // Static bundle catalogs run no daemon, so no live servers.
     assertTrue(body.contains("\"runningServers\":[]"), "static catalogs run no daemon: $body")
+  }
+
+  @Test
+  fun `status_json exposes owner-free editing soak counters`() {
+    server =
+      newServer(public = true, token = "unused") {
+        PlaygroundHealth(
+          admittedBy = "GitHub repository access",
+          sandboxProfile = "bwrap",
+          sandboxActive = true,
+          jailDropped = false,
+          sandboxMemoryMb = 1536,
+          sandboxCpus = 1.0,
+          sandboxTtlSeconds = 180,
+          probe = null,
+          compilerJailed = true,
+          compileSlots = 1,
+          modes = { emptyList() },
+          editing = {
+            PlaygroundHealth.Editing(
+              enabled = true,
+              active = true,
+              expiresAtEpochMs = 2_000,
+              lastRevision = 7,
+              acquisitions = 3,
+              compileAttempts = 12,
+              incrementalCompiles = 10,
+              fullFallbacks = 2,
+              lastCompileMillis = 418,
+            )
+          },
+        )
+      }
+
+    val (code, body) = get("/status.json")
+
+    assertEquals(200, code)
+    assertTrue(body.contains("\"editing\":{\"enabled\":true,\"active\":true"), body)
+    assertTrue(body.contains("\"lastRevision\":7"), body)
+    assertTrue(body.contains("\"incrementalCompiles\":10"), body)
+    assertTrue(body.contains("\"fullFallbacks\":2"), body)
+    assertFalse(body.contains("editLease"), "status must not expose the lease capability: $body")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2159,6 +2159,7 @@ class ServeWebFixtureTest {
         token,
         isPublic = false,
         version = version,
+        editingLeaseEnabled = true,
         catalogs =
           listOf(
             PlaygroundCatalogInfo(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
@@ -22,6 +22,7 @@ class ServeWebPlaygroundCatalogTest {
     seed: PlaygroundSeed? = null,
     preselectCatalog: String? = null,
     pinnedCatalogSystems: Set<String> = emptySet(),
+    editingLeaseEnabled: Boolean = false,
   ) =
     ServeWeb.playgroundPage(
       token = "t",
@@ -31,6 +32,7 @@ class ServeWebPlaygroundCatalogTest {
       seed = seed,
       preselectCatalog = preselectCatalog,
       pinnedCatalogSystems = pinnedCatalogSystems,
+      editingLeaseEnabled = editingLeaseEnabled,
     )
 
   private val previewSeed =
@@ -67,6 +69,16 @@ class ServeWebPlaygroundCatalogTest {
       modes = listOf(PlaygroundMode.ANDROID, PlaygroundMode.REMOTE_COMPOSE),
       resolved = false,
     )
+
+  @Test
+  fun `the explicit editing lease control is rendered only when enabled`() {
+    assertFalse(page(listOf(m3)).contains("id=\"pg-edit-lease\""))
+    val html = page(listOf(m3), editingLeaseEnabled = true)
+    assertTrue(html.contains("id=\"pg-edit-lease\""))
+    assertTrue(html.contains("Acquire editing lease"))
+    assertTrue(html.contains("/api/1/compiler/edit-lease"))
+    assertTrue(html.contains("editLease: editLease"))
+  }
 
   @Test
   fun `a seeded page opens on the preview's own source, in its own catalog`() {

--- a/daemon/bta-host/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompiler.kt
+++ b/daemon/bta-host/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompiler.kt
@@ -130,7 +130,6 @@ class BtaCompiler(
     workingDir.toFile().mkdirs()
     val cpSnapshotsDir = workingDir.resolve("cp-snapshots").also { it.toFile().mkdirs() }
     val icWorkingDir = workingDir.resolve("ic").also { it.toFile().mkdirs() }
-    val shrunkClasspathSnapshot = workingDir.resolve("shrunk-classpath-snapshot.bin")
 
     val jvm = toolchains.getToolchain<JvmPlatformToolchain>()
     toolchains.createBuildSession().use { session ->
@@ -153,7 +152,6 @@ class BtaCompiler(
             icWorkingDir,
             sourcesChanges,
             snapshotFiles,
-            shrunkClasspathSnapshot,
           )
           .build()
       builder.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)

--- a/daemon/bta-host/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaCompilerIncrementalTest.kt
+++ b/daemon/bta-host/src/test/kotlin/ee/schimke/composeai/daemon/bta/BtaCompilerIncrementalTest.kt
@@ -46,6 +46,10 @@ class BtaCompilerIncrementalTest {
     val workingDir = tmp.newFolder("ic-work").toPath()
     val outputDir1 = tmp.newFolder("out-pass-1").toPath()
     val outputDir2 = tmp.newFolder("out-pass-2").toPath()
+    // Served catalogs lead with an extracted classes directory rather than a JAR. Even empty, this
+    // pins the BTA API shape and our directory content-hashing path on both passes.
+    val catalogClasses = tmp.newFolder("catalog-classes").toPath()
+    val compileClasspath = listOf(catalogClasses) + fx.compileClasspath
 
     val compiler = BtaCompiler(implClasspath = fx.implClasspath)
 
@@ -55,7 +59,7 @@ class BtaCompilerIncrementalTest {
     val pass1 =
       compiler.compileIncremental(
         sources = fx.sources,
-        compileClasspath = fx.compileClasspath,
+        compileClasspath = compileClasspath,
         outputDir = outputDir1,
         workingDir = workingDir,
         compilerPlugins = listOf(fx.composePlugin),
@@ -74,12 +78,6 @@ class BtaCompilerIncrementalTest {
       "BTA's IC working directory $icDir wasn't populated; classpath-snapshot wiring is wrong",
       icDir.toFile().exists() && icDir.toFile().list().orEmpty().isNotEmpty(),
     )
-    val shrunk = workingDir.resolve("shrunk-classpath-snapshot.bin")
-    assertTrue(
-      "Expected shrunk-classpath-snapshot.bin written at $shrunk after pass 1",
-      shrunk.exists(),
-    )
-
     // Modify one source — flip the greeting prefix. BTA's IC should pick this up via mtime.
     val modified = fx.sources.first { it.fileName.toString() == "Greeting.kt" }
     modified.writeText(
@@ -96,7 +94,7 @@ class BtaCompilerIncrementalTest {
     val pass2 =
       compiler.compileIncremental(
         sources = fx.sources,
-        compileClasspath = fx.compileClasspath,
+        compileClasspath = compileClasspath,
         outputDir = outputDir2,
         workingDir = workingDir,
         compilerPlugins = listOf(fx.composePlugin),

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
@@ -3,6 +3,7 @@
 package ee.schimke.composeai.daemon.bta
 
 import java.net.URLClassLoader
+import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
 import kotlin.io.path.exists
@@ -105,8 +106,8 @@ class BtaCompileSession(
    *   rebuild invalidates the cache automatically.
    * - [sourcesChanges] defaults to [SourcesChanges.ToBeCalculated]; callers with a file watcher
    *   pass [SourcesChanges.Known] for tighter incrementality.
-   * - The BTA IC working directory is [icWorkingDir]/`ic/`; the shrunk classpath snapshot is
-   *   written to [icWorkingDir]/`shrunk-classpath-snapshot.bin`.
+   * - The BTA IC working directory is [icWorkingDir]/`ic/`; the current API owns any reduced
+   *   classpath state inside that directory rather than requiring a separate snapshot path.
    */
   fun compileIncremental(
     sources: List<Path>,
@@ -121,12 +122,13 @@ class BtaCompileSession(
      * Defaults to the session's constructor-supplied [logger].
      */
     diagnosticListener: KotlinLogger? = null,
+    /** Override for callers that share one loaded toolchain across isolated editing sessions. */
+    workingDir: Path = icWorkingDir,
   ): List<Path> {
     outputDir.toFile().mkdirs()
-    icWorkingDir.toFile().mkdirs()
-    val cpSnapshotsDir = icWorkingDir.resolve("cp-snapshots").also { it.toFile().mkdirs() }
-    val icDir = icWorkingDir.resolve("ic").also { it.toFile().mkdirs() }
-    val shrunkClasspathSnapshot = icWorkingDir.resolve("shrunk-classpath-snapshot.bin")
+    workingDir.toFile().mkdirs()
+    val cpSnapshotsDir = workingDir.resolve("cp-snapshots").also { it.toFile().mkdirs() }
+    val icDir = workingDir.resolve("ic").also { it.toFile().mkdirs() }
 
     val jvm = toolchains.getToolchain<JvmPlatformToolchain>()
     toolchains.createBuildSession().use { session ->
@@ -134,7 +136,7 @@ class BtaCompileSession(
         // Content-hash the JAR rather than path-hashing — production needs to survive in-place
         // AAR rebuilds where the JAR's path stays stable but its contents move. Reuses the
         // existing snapshot when the SHA-256 matches.
-        val sha = sha256OfFile(jar)
+        val sha = sha256OfPath(jar)
         val cached = cpSnapshotsDir.resolve("$sha.bin")
         if (!cached.exists()) {
           val snapshotOp = jvm.classpathSnapshottingOperationBuilder(jar).build()
@@ -151,7 +153,6 @@ class BtaCompileSession(
             icDir,
             sourcesChanges,
             snapshotFiles,
-            shrunkClasspathSnapshot,
           )
           .build()
       builder.set(JvmCompilationOperation.INCREMENTAL_COMPILATION, icConfig)
@@ -192,18 +193,32 @@ class BtaCompileSession(
       .map { it.toPath() }
       .toList()
 
-  private fun sha256OfFile(path: Path): String {
-    // Streamed SHA — works on the gradle-cache page-cache hot path without buffering the
-    // whole JAR. The block size is small on purpose: AAR JARs can be 10s of MB and we don't
-    // want a 64 KB allocation per call.
+  private fun sha256OfPath(path: Path): String {
+    // BTA snapshots both JARs and classes directories. Hash directory entries in stable relative
+    // path order so an extracted catalog `classes/` directory gets the same content-addressed
+    // cache semantics as a JAR rebuilt in place.
     val md = MessageDigest.getInstance("SHA-256")
     val buf = ByteArray(8 * 1024)
-    path.toFile().inputStream().use { stream ->
-      while (true) {
-        val n = stream.read(buf)
-        if (n <= 0) break
-        md.update(buf, 0, n)
+    fun hashFile(file: Path, relative: String) {
+      md.update(relative.toByteArray(Charsets.UTF_8))
+      md.update(0)
+      Files.newInputStream(file).use { stream ->
+        while (true) {
+          val n = stream.read(buf)
+          if (n <= 0) break
+          md.update(buf, 0, n)
+        }
       }
+    }
+    if (Files.isDirectory(path)) {
+      Files.walk(path).use { paths ->
+        paths
+          .filter { Files.isRegularFile(it) }
+          .sorted(compareBy { path.relativize(it).toString() })
+          .forEach { hashFile(it, path.relativize(it).toString()) }
+      }
+    } else {
+      hashFile(path, path.fileName.toString())
     }
     return md.digest().joinToString("") { "%02x".format(it) }
   }

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -220,6 +220,26 @@ SERVE_PLAYGROUND_BUNDLE=compose-m3
 SERVE_PLAYGROUND_COMPILE_SLOTS=1
 ```
 
+For the opt-in incremental-editing trial, enable the single whole-host lease:
+
+```bash
+SERVE_PLAYGROUND_EDITING=1
+SERVE_PLAYGROUND_EDIT_LEASE_TTL=900   # idle seconds; optional, default 15 minutes
+```
+
+This knob is ignored unless GitHub auth is configured. A signed-in user explicitly presses
+**Acquire editing lease**; while they hold it, Run reuses that lease's source tree, class output,
+and Kotlin Build Tools API incremental state. Exactly one user can hold the lease across the host,
+and each successful revision still gets an immutable preview-token snapshot. Release it from the
+same button or let the idle TTL expire.
+
+The trial is deliberately easy to observe at `/status.json` → `playground.editing`: `active`,
+`lastRevision`, `acquisitions`, `compileAttempts`, `incrementalCompiles`, `fullFallbacks`, and
+`lastCompileMillis` are process-lifetime signals suitable for a production soak. No login or lease
+capability is exposed there. With a configured sandbox, compilation remains in the capped child;
+the current trial reuses its on-disk IC state but still starts a child for each Run. A recycled warm
+jailed worker is the next latency step, not a prerequisite for safely collecting correctness data.
+
 `SERVE_PLAYGROUND_BUNDLE` takes either a **served catalog system id** (as above) or a local
 `.bundle` path (`/config/playground-cmp.bundle`); a value with a path separator, a `.bundle`/`.png`
 suffix, or one that names an existing file is read as a path, anything else as a system id. Prefer

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -166,6 +166,9 @@ services:
       # compiles/minute, 1 concurrent); set SERVE_PLAYGROUND_RATE_LIMIT=0 to disable the limiter.
       SERVE_PLAYGROUND_RATE_LIMIT: "${SERVE_PLAYGROUND_RATE_LIMIT:-}"
       SERVE_PLAYGROUND_CALLER_CONCURRENCY: "${SERVE_PLAYGROUND_CALLER_CONCURRENCY:-}"
+      # Experimental: one explicit GitHub-authenticated stateful editing lease for the whole host.
+      SERVE_PLAYGROUND_EDITING: "${SERVE_PLAYGROUND_EDITING:-0}"
+      SERVE_PLAYGROUND_EDIT_LEASE_TTL: "${SERVE_PLAYGROUND_EDIT_LEASE_TTL:-}"
       # Attribute a request to the X-Forwarded-For peer rather than the proxy's own address, so the
       # per-caller budget above counts real visitors instead of lumping them under Caddy. ONLY safe
       # behind a proxy that appends the peer address it saw — which the `caddy` service below is.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -270,6 +270,10 @@ fi
   args+=(--playground-rate-limit "${SERVE_PLAYGROUND_RATE_LIMIT}")
 [[ -n "${SERVE_PLAYGROUND_CALLER_CONCURRENCY:-}" ]] &&
   args+=(--playground-caller-concurrency "${SERVE_PLAYGROUND_CALLER_CONCURRENCY}")
+# Experimental stateful BTA editing: exactly one GitHub-authenticated lease across the host.
+[[ "${SERVE_PLAYGROUND_EDITING:-0}" == "1" ]] && args+=(--playground-editing)
+[[ -n "${SERVE_PLAYGROUND_EDIT_LEASE_TTL:-}" ]] &&
+  args+=(--playground-edit-lease-ttl "${SERVE_PLAYGROUND_EDIT_LEASE_TTL}")
 [[ -n "${SERVE_TRUST_FORWARDED_FOR:-}" && "${SERVE_TRUST_FORWARDED_FOR}" != "0" ]] &&
   args+=(--trust-forwarded-for)
 

--- a/docs/design/PLAYGROUND.md
+++ b/docs/design/PLAYGROUND.md
@@ -554,6 +554,167 @@ the stage-2 in-process BTA compile targets < 1 s warm on desktop. The playground
 rides the daemon path, so the warm edit→pixel loop is in that range, not the
 cold-fork range.
 
+### 7.2 Optional stateful editing — use BTA incrementally, keep one-shot as the default
+
+The API is **BTA**, Kotlin's experimental **Build Tools API** (not BTS). The
+playground already uses it: [`PlaygroundBtaCompiler`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt)
+drives the same [`BtaCompileSession`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt)
+that backs the editor daemon. The default one-shot Run still does not retain BTA
+incremental state: it is staged into a fresh work directory, and a sandboxed Run
+starts a fresh compiler JVM. The explicit lease added below supplies the previous
+source tree, output directory, and IC cache that incremental compilation needs.
+
+**Decision: ship a stateful trial as an opt-in layer over the existing one-shot
+contract.** It is now behind `--playground-editing`, requires configured GitHub
+authentication, and exposes exactly one explicit whole-host lease. BTA is the
+right compiler API for it, but BTA alone is not the feature. The trial also needs
+an editing-session lifetime, mutable source and output state, and immutable
+successful revisions for preview tokens; a warm bounded compiler worker remains
+the next latency step. The current Run button remains the simple and robust
+default; **Acquire editing lease** opts into the additional state. The trial
+keeps explicit Run so it can soak in production before debounce or cancellation
+changes the interaction model.
+
+#### What the newer BTA gives us
+
+The direction is now substantially less speculative than when this document was
+written:
+
+- Kotlin/JVM compilation in KGP uses BTA by default since Kotlin 2.3.20, so the
+  JVM path is exercised by normal Gradle builds ([Kotlin 2.3.20 notes](https://kotlinlang.org/docs/whatsnew2320.html#kotlin-jvm-compilation-uses-build-tools-api-by-default)).
+- BTA exposes snapshot-based JVM incremental compilation, known modified and
+  removed files (`SourcesChanges.Known`), compiler plugins, cancellable build
+  operations, and build metrics. Kotlin's proposal defines classpath
+  snapshotting over a **classes directory or JAR**, so the extracted catalog
+  `classes/` entry is not a fundamental blocker
+  ([KEEP-421 proposal](https://github.com/Kotlin/KEEP/blob/build-tools-api/proposals/extensions/build-tools-api.md#jvmplatformtoolchain)).
+- Kotlin 2.4 adds tracking for non-source configuration inputs, a structured
+  compiler-message rendering hook, and more consistent Compose incremental
+  compilation across files
+  ([Kotlin 2.4 BTA notes](https://kotlinlang.org/docs/whatsnew24.html#build-tools-api)).
+- This repo's existing `BtaCompilerIncrementalTest` passes on Kotlin 2.4.10. On
+  the 2026-08-16 development machine its three-file Compose fixture took
+  **9.943 s cold** (toolchain bootstrap + first compile) and **606 ms warm**
+  after one source edit. That is a viability measurement, not a Playground SLO:
+  the real catalog classpaths and render leg still need their own benchmark.
+
+Two caveats remain load-bearing. First, JetBrains still marks BTA experimental
+and says direct third-party build-tool integration is not yet a public contract
+([BTA documentation](https://kotlinlang.org/docs/build-tools-api.html)); we must
+pin API and implementation versions together and keep a full-compile fallback.
+Second, BTA is a **build** API, not the Kotlin Analysis API. It can produce class
+files and diagnostics faster; it does not provide completion, hover, go-to
+definition, rename, or refactoring. Those would be a separate LSP/Analysis API
+project and must not be implied by the "Live editing" label.
+
+"Full editing" therefore needs a precise boundary. This proposal supports a
+full **playground module**: multiple user-owned Kotlin files may be added,
+renamed, removed, and incrementally recompiled against one selected catalog.
+It does not make the catalog's repository into a browser IDE. Editing an
+arbitrary Gradle/Android project would additionally require source-set and
+variant modelling, resources and generated sources, Java mixed compilation,
+KSP/KAPT, dependency resolution, and build-script execution. BTA accepts the
+resolved inputs to a Kotlin compilation; it does not discover or safely execute
+that project build model for us.
+
+#### Session and compile shape
+
+Keep `/api/{version}/compiler/run` backward compatible. An ordinary request is
+unchanged. An opted-in client adds an unguessable `editLease` and a monotonically
+increasing `revision`; the server derives the known modified/removed file set by
+reconciling the posted module. The response echoes the lease and revision. The
+existing frontend's monotonic-run fence then
+also discards a slow response for an older revision.
+
+Each editing session owns:
+
+| State | Lifetime / rule |
+|---|---|
+| Staged source tree | Mutable until session TTL; filenames remain server-validated and relative. |
+| IC working directory | Private to exactly one session + catalog + mode + compiler configuration. Never share it across users or catalogs. |
+| Mutable compiler output | Reused by BTA across revisions; never handed directly to a preview token. |
+| Successful revision snapshot | Immutable classes directory copied or hard-linked after a clean compile; this is what render and preview tokens use. |
+| Last accepted revision | Reject duplicate/out-of-order writes so concurrent tabs cannot roll source state backwards. |
+
+The immutable snapshot distinction matters. A preview token minted at revision 4
+must keep rendering revision 4 after revision 5 compiles; pointing tokens at the
+incremental compiler's mutable output directory would silently change an already
+shared link. Failed compiles publish no snapshot and leave the last successful
+preview intact. If BTA reports an internal/IC fault, discard that session's IC
+state and retry the same revision as a full compile into a clean output directory;
+only a second failure reaches the user as an infrastructure error.
+
+The compiler process and IC state have different sharing boundaries:
+
+```
+warm compiler worker (toolchain + Compose plugin, keyed by Kotlin version)
+  ├─ catalog classpath snapshots (read-only, content addressed)
+  └─ current single lease → sources + output + IC cache
+```
+
+The one-lease trial intentionally avoids multi-tenant IC state. If measurement
+justifies multiple leases later, each must retain its own sources, output, and IC
+cache beneath the same worker boundary.
+
+Refactor `BtaCompileSession` accordingly: the expensive loaded
+`KotlinToolchains` belongs to the worker, while module name, output directory,
+IC directory, source changes, and compiler configuration belong to a per-edit
+session operation. Do not create one `BtaCompileSession` as currently shaped per
+browser session; that would reload the expensive toolchain for every editor and
+erase most of the win.
+
+#### Containment and capacity
+
+A warm compiler worker is compatible with the security argument in §6.3: it
+loads source into the compiler but does not execute snippet bytecode, annotation
+processors, or user-selected compiler plugins. It must still run inside the
+configured jail with the existing heap, CPU, pid, filesystem, and wall-clock
+bounds because malicious source can attack compiler resources.
+
+Make the worker protocol narrower than the current arbitrary-path child request:
+session ids and relative file changes in, diagnostics/metrics out; the parent
+chooses every host path and classpath. Recycle a worker on any of: hard timeout,
+OOM/non-zero exit, maximum compile count, maximum age, or memory watermark.
+BTA cancellation is useful for superseded revisions but is explicitly
+best-effort, so cancellation never replaces the sandbox deadline or process
+recycle. Existing per-caller rate/concurrency limits continue to apply to every
+compile, incremental or not.
+
+#### Delivery sequence and graduation gate
+
+1. **Classpath/IC correctness spike.** Teach the production snapshot cache to
+   content-hash directories as well as files, move off BTA's deprecated
+   `shrunkClasspathSnapshot` builder overload, and test edit/add/remove/rename,
+   compile-error recovery, Compose cross-file invalidation, catalog change, and
+   a classes-directory dependency.
+2. **Local opt-in.** Add stateful sessions behind a serve flag for the existing
+   in-process development posture. Keep explicit Run; this isolates compiler and
+   token semantics from debounce/UI questions.
+3. **Warm jailed worker.** Replace the authenticated public lane's disposable
+   compiler fork with a capped, recycled worker or small pool. The trial keeps
+   today's capped child-per-Run boundary and reuses only its session-owned disk
+   state, so this step improves latency without weakening the current containment
+   probe or resource accounting.
+4. **Live-edit UX.** Add the visible opt-in, 350–500 ms debounce, superseded-build
+   cancellation, "compiling revision N" state, and last-good-preview behaviour.
+   Explicit Run remains available and is the accessibility/fallback path.
+5. **Measure before defaulting.** Benchmark 1/10/50-file snippets against real
+   CMP and Android catalog classpaths. Record cold bootstrap, warm body edit,
+   ABI edit, add/remove/rename, error→fix, snapshot copy, first-frame render,
+   p50/p95, heap growth, and worker recycle. Graduate only if warm compile p95 is
+   under 1 s, materially beats a warm non-incremental compile, and 100-edit soak
+   tests show bounded memory and revision-correct preview tokens.
+
+Steps 1–2 and the explicit opt-in part of step 4 are implemented. Production
+soak counters live at `/status.json` → `playground.editing`; the lease owner and
+unguessable capability are intentionally absent. Steps 3 and the automatic UX
+remain follow-ups, and the feature remains off by default.
+
+This sequence also gives a cheap exit: if real snippets are too small for IC to
+beat the already measured 0.3–0.5 s warm non-incremental in-process compile, ship
+the **warm jailed worker** alone. It removes the public lane's repeated 3+ second
+toolchain bootstrap without taking on editing-session or IC-cache complexity.
+
 ---
 
 ## 8. Open questions — resolved

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
@@ -133,6 +133,8 @@ fun MediaControlButtonsPlaying() {
   var mode = document.getElementById("pg-mode");
   var catalog = document.getElementById("pg-catalog");
   var run = document.getElementById("pg-run");
+  var editLeaseButton = document.getElementById("pg-edit-lease");
+  var editLeaseNote = document.getElementById("pg-edit-lease-note");
   var fileBar = document.getElementById("pg-files");
   var addFile = document.getElementById("pg-add-file");
   var removeFile = document.getElementById("pg-remove-file");
@@ -145,6 +147,57 @@ fun MediaControlButtonsPlaying() {
   var note = document.getElementById("pg-preview-note");
   var previewList = document.getElementById("pg-previews");
   var suffix = "?token=demo-token-fixture";
+  var editLease = null;
+  var editRevision = 0;
+  function setEditLease(value, message, expiresAt) {
+    editLease = value;
+    editRevision = 0;
+    if (!editLeaseButton) return;
+    editLeaseButton.disabled = false;
+    editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
+    editLeaseButton.setAttribute("aria-pressed", value ? "true" : "false");
+    editLeaseNote.hidden = !message;
+    editLeaseNote.textContent = message || "";
+    if (value && expiresAt) {
+      editLeaseButton.title = "Lease expires " + new Date(expiresAt).toLocaleTimeString();
+    } else {
+      editLeaseButton.removeAttribute("title");
+    }
+  }
+  if (editLeaseButton) {
+    editLeaseButton.addEventListener("click", function () {
+      editLeaseButton.disabled = true;
+      if (!editLease) {
+        fetch("/api/1/compiler/edit-lease" + suffix, {
+          method: "POST", headers: { "Accept": "application/json" }
+        })
+          .then(function (r) {
+            return r.json().then(function (body) {
+              if (!r.ok) throw new Error(body.message || "The editing lease is busy.");
+              return body;
+            });
+          })
+          .then(function (body) {
+            setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+          })
+          .catch(function (e) {
+            setEditLease(null, e.message || "Could not acquire editing lease.");
+          });
+      } else {
+        var releasing = editLease;
+        fetch("/api/1/compiler/edit-lease/release" + suffix, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lease: releasing })
+        })
+          .then(function (r) {
+            if (!r.ok) throw new Error("The editing lease has already expired.");
+            setEditLease(null, "Editing lease released.");
+          })
+          .catch(function (e) { setEditLease(null, e.message); });
+      }
+    });
+  }
   // The catalog selector. Each entry carries its own mode list because a catalog's bundle
   // backend picks the renderer — selecting `compose-m3` (desktop) and selecting an Android
   // catalog are not the same choice with a different classpath, they are different modes.
@@ -371,7 +424,9 @@ fun MediaControlButtonsPlaying() {
     var body = JSON.stringify({
       confType: mode.value,
       catalog: catalog ? catalog.value : "",
-      files: files
+      files: files,
+      editLease: editLease || "",
+      revision: editLease ? ++editRevision : 0
     });
     fetch("/api/1/compiler/run" + suffix, {
       method: "POST",
@@ -387,10 +442,23 @@ fun MediaControlButtonsPlaying() {
       .then(function (res) {
         if (myId !== reqId) return;
         run.disabled = false;
+        if (editLeaseButton) editLeaseButton.disabled = false;
         renderDiags(res.diagnostics);
         var hasError = (res.diagnostics || []).some(function (d) { return d.severity === "error"; });
-        if (res.exception) { setStatus(res.exception, true); return; }
-        if (hasError) { setStatus("Compilation failed.", true); return; }
+        if (res.exception) {
+          if (res.exception.indexOf("live-edit lease") >= 0) setEditLease(null, res.exception);
+          setStatus(res.exception, true); return;
+        }
+        if (hasError) {
+          setStatus(
+            res.revision != null
+              ? ("Compilation failed at revision " + res.revision +
+                (res.incremental ? " (incremental)." : " (full fallback)."))
+              : "Compilation failed.",
+            true
+          );
+          return;
+        }
         result.hidden = false;
         if (res.image) { image.hidden = false; image.src = res.image; }
         var link = res.documentUrl || res.previewUrl;
@@ -431,10 +499,16 @@ fun MediaControlButtonsPlaying() {
           });
         }
         setStatus("Done.", false);
+        if (res.revision != null && editLeaseNote) {
+          editLeaseNote.hidden = false;
+          editLeaseNote.textContent = "Revision " + res.revision +
+            (res.incremental ? " compiled incrementally." : " used a full compile.");
+        }
       })
       .catch(function (e) {
         if (myId !== reqId) return;
         run.disabled = false;
+        if (editLeaseButton) editLeaseButton.disabled = false;
         setStatus(e.message || "run failed", true);
       });
   });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -88,7 +88,9 @@
               <option value="remote-compose">Remote Compose</option>
             </select>
             <button id="pg-run" class="cp-doc-btn cp-pg-run" type="button">Run</button>
+            <button id="pg-edit-lease" class="cp-doc-btn" type="button">Acquire editing lease</button>
           </div>
+          <p id="pg-edit-lease-note" class="cp-pg-status" hidden></p>
           <div id="pg-files" class="cp-pg-files" role="tablist" aria-label="Snippet files">
             <button class="cp-pg-file" type="button" role="tab" aria-current="true"
               data-pg-file="Snippet.kt">Snippet.kt</button>
@@ -126,6 +128,8 @@ fun Greeting() {
   var mode = document.getElementById("pg-mode");
   var catalog = document.getElementById("pg-catalog");
   var run = document.getElementById("pg-run");
+  var editLeaseButton = document.getElementById("pg-edit-lease");
+  var editLeaseNote = document.getElementById("pg-edit-lease-note");
   var fileBar = document.getElementById("pg-files");
   var addFile = document.getElementById("pg-add-file");
   var removeFile = document.getElementById("pg-remove-file");
@@ -138,6 +142,57 @@ fun Greeting() {
   var note = document.getElementById("pg-preview-note");
   var previewList = document.getElementById("pg-previews");
   var suffix = "?token=demo-token-fixture";
+  var editLease = null;
+  var editRevision = 0;
+  function setEditLease(value, message, expiresAt) {
+    editLease = value;
+    editRevision = 0;
+    if (!editLeaseButton) return;
+    editLeaseButton.disabled = false;
+    editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
+    editLeaseButton.setAttribute("aria-pressed", value ? "true" : "false");
+    editLeaseNote.hidden = !message;
+    editLeaseNote.textContent = message || "";
+    if (value && expiresAt) {
+      editLeaseButton.title = "Lease expires " + new Date(expiresAt).toLocaleTimeString();
+    } else {
+      editLeaseButton.removeAttribute("title");
+    }
+  }
+  if (editLeaseButton) {
+    editLeaseButton.addEventListener("click", function () {
+      editLeaseButton.disabled = true;
+      if (!editLease) {
+        fetch("/api/1/compiler/edit-lease" + suffix, {
+          method: "POST", headers: { "Accept": "application/json" }
+        })
+          .then(function (r) {
+            return r.json().then(function (body) {
+              if (!r.ok) throw new Error(body.message || "The editing lease is busy.");
+              return body;
+            });
+          })
+          .then(function (body) {
+            setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+          })
+          .catch(function (e) {
+            setEditLease(null, e.message || "Could not acquire editing lease.");
+          });
+      } else {
+        var releasing = editLease;
+        fetch("/api/1/compiler/edit-lease/release" + suffix, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ lease: releasing })
+        })
+          .then(function (r) {
+            if (!r.ok) throw new Error("The editing lease has already expired.");
+            setEditLease(null, "Editing lease released.");
+          })
+          .catch(function (e) { setEditLease(null, e.message); });
+      }
+    });
+  }
   // The catalog selector. Each entry carries its own mode list because a catalog's bundle
   // backend picks the renderer — selecting `compose-m3` (desktop) and selecting an Android
   // catalog are not the same choice with a different classpath, they are different modes.
@@ -364,7 +419,9 @@ fun Greeting() {
     var body = JSON.stringify({
       confType: mode.value,
       catalog: catalog ? catalog.value : "",
-      files: files
+      files: files,
+      editLease: editLease || "",
+      revision: editLease ? ++editRevision : 0
     });
     fetch("/api/1/compiler/run" + suffix, {
       method: "POST",
@@ -380,10 +437,23 @@ fun Greeting() {
       .then(function (res) {
         if (myId !== reqId) return;
         run.disabled = false;
+        if (editLeaseButton) editLeaseButton.disabled = false;
         renderDiags(res.diagnostics);
         var hasError = (res.diagnostics || []).some(function (d) { return d.severity === "error"; });
-        if (res.exception) { setStatus(res.exception, true); return; }
-        if (hasError) { setStatus("Compilation failed.", true); return; }
+        if (res.exception) {
+          if (res.exception.indexOf("live-edit lease") >= 0) setEditLease(null, res.exception);
+          setStatus(res.exception, true); return;
+        }
+        if (hasError) {
+          setStatus(
+            res.revision != null
+              ? ("Compilation failed at revision " + res.revision +
+                (res.incremental ? " (incremental)." : " (full fallback)."))
+              : "Compilation failed.",
+            true
+          );
+          return;
+        }
         result.hidden = false;
         if (res.image) { image.hidden = false; image.src = res.image; }
         var link = res.documentUrl || res.previewUrl;
@@ -424,10 +494,16 @@ fun Greeting() {
           });
         }
         setStatus("Done.", false);
+        if (res.revision != null && editLeaseNote) {
+          editLeaseNote.hidden = false;
+          editLeaseNote.textContent = "Revision " + res.revision +
+            (res.incremental ? " compiled incrementally." : " used a full compile.");
+        }
       })
       .catch(function (e) {
         if (myId !== reqId) return;
         run.disabled = false;
+        if (editLeaseButton) editLeaseButton.disabled = false;
         setStatus(e.message || "run failed", true);
       });
   });


### PR DESCRIPTION
## Summary

- add an explicit, single whole-host Playground editing lease for GitHub-authenticated users
- retain multi-file source, class output, and Kotlin Build Tools API incremental state across leased revisions
- snapshot every successful revision into immutable preview-token classes and fall back to a clean full compile when IC infrastructure fails
- expose acquire/release controls, revision status, deployment flags, and owner-free production soak counters under `playground.editing`
- update the Playground design notes, deployment documentation, and HTML fixtures

## Why

The existing Playground invokes BTA as a fresh one-shot compile. That is robust, but it cannot reuse the source tree, output, or classpath/IC state needed for an editing loop. This introduces a deliberately narrow production trial: one authenticated user explicitly acquires the only lease, while ordinary Run requests remain stateless and unchanged.

The single-lease boundary makes the experiment easy to contain and measure before considering multiple sessions or automatic debounce compilation.

## Production impact

The feature is off by default. Enable it with:

```bash
SERVE_PLAYGROUND_EDITING=1
SERVE_PLAYGROUND_EDIT_LEASE_TTL=900
```

It is ignored when GitHub auth is not configured. `/status.json` reports process-lifetime acquisitions, compile attempts, incremental compiles, full fallbacks, last revision, and last compile duration without exposing the user or lease capability.

Sandboxed compiles retain their existing capped child-process boundary. The trial reuses disk/IC state but still starts a child per Run; a recycled warm jailed worker remains a follow-up latency improvement.

## Validation

- `./gradlew :cli:ktfmtCheck :daemon:core:ktfmtCheck :daemon:bta-host:ktfmtCheck`
- focused service, authenticated HTTP routing, status JSON, Playground UI/fixture, BTA compiler, and jailed compiler tests
- `:daemon:core:test` and `:daemon:bta-host:test`
- BTA incremental test now covers a catalog-style classes-directory classpath entry
- `git diff --check`

The deployment passthrough script requires Bash 4 `mapfile`; this macOS host only provides Bash 3.2. The new entrypoint and Compose mappings were checked directly.