### PR TITLE
fix(playground): release idle editing leases

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import java.security.SecureRandom
 import java.util.Base64
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import okio.FileSystem
 import okio.Path
 
@@ -100,6 +102,10 @@ class PlaygroundCompileService(
   val editLeasesEnabled: Boolean = false,
   private val editLeaseTtlMillis: Long = DEFAULT_EDIT_LEASE_TTL_MILLIS,
   private val nowMillis: () -> Long = System::currentTimeMillis,
+  /** Schedules idle-lease reclamation; injectable so expiry behavior is deterministic in tests. */
+  private val scheduleEditLeaseExpiry: (Long, () -> Unit) -> Unit = { delayMillis, task ->
+    EDIT_LEASE_EXPIRY_EXECUTOR.schedule(task, delayMillis, TimeUnit.MILLISECONDS)
+  },
 ) {
 
   private val editLock = Any()
@@ -324,7 +330,7 @@ class PlaygroundCompileService(
       val existing = editLease
       if (existing != null) {
         if (existing.owner == owner) {
-          existing.expiresAt = nowMillis() + editLeaseTtlMillis
+          renewEditLeaseLocked(existing)
           refreshEditHealthLocked()
           return@synchronized existing.response("You already hold the live-edit lease.")
         }
@@ -353,6 +359,7 @@ class PlaygroundCompileService(
         )
       editLease = lease
       editLeaseAcquisitions++
+      scheduleEditLeaseExpiryLocked(lease)
       refreshEditHealthLocked()
       lease.response("Live editing acquired.")
     }
@@ -396,6 +403,30 @@ class PlaygroundCompileService(
     editLease = null
     cleanup(lease.workDir)
     refreshEditHealthLocked()
+  }
+
+  private fun renewEditLeaseLocked(lease: EditLease) {
+    lease.expiresAt = nowMillis() + editLeaseTtlMillis
+    scheduleEditLeaseExpiryLocked(lease)
+  }
+
+  private fun scheduleEditLeaseExpiryLocked(lease: EditLease) {
+    val leaseId = lease.id
+    val deadline = lease.expiresAt
+    scheduleEditLeaseExpiry((deadline - nowMillis()).coerceAtLeast(0L)) {
+      synchronized(editLock) {
+        val current = editLease ?: return@synchronized
+        // A release/reacquire or renewal supersedes this particular deadline's task.
+        if (current.id != leaseId || current.expiresAt != deadline) return@synchronized
+        if (current.expiresAt <= nowMillis()) {
+          purgeExpiredEditLeaseLocked()
+        } else {
+          // Wall-clock adjustment or an early scheduler wakeup: retain the lease and try again at
+          // the remaining deadline rather than leaking its workspace.
+          scheduleEditLeaseExpiryLocked(current)
+        }
+      }
+    }
   }
 
   private fun refreshEditHealthLocked() {
@@ -443,7 +474,7 @@ class PlaygroundCompileService(
             else "catalog '$catalog' cannot serve mode ${mode.name} on this host"
           )
 
-      lease.expiresAt = nowMillis() + editLeaseTtlMillis
+      renewEditLeaseLocked(lease)
       refreshEditHealthLocked()
       val config = mode to catalog
       if (lease.config != null && lease.config != config) {
@@ -474,15 +505,21 @@ class PlaygroundCompileService(
       editCompileAttempts++
       refreshEditHealthLocked()
       var compile =
-        compiler.compileIncremental(
-          sources = sources,
-          classpath = classpath.entries,
-          outputDir = classesDir,
-          workingDir = icDir,
-          modified = modified,
-          removed = removed,
-          firstBuild = firstBuild,
-        )
+        try {
+          compiler.compileIncremental(
+            sources = sources,
+            classpath = classpath.entries,
+            outputDir = classesDir,
+            workingDir = icDir,
+            modified = modified,
+            removed = removed,
+            firstBuild = firstBuild,
+          )
+        } catch (t: Throwable) {
+          renewEditLeaseLocked(lease)
+          refreshEditHealthLocked()
+          throw t
+        }
       // An internal BTA/IC failure has no source position. Reset only this lease and retry the same
       // revision through the proven full path; ordinary source diagnostics stay incremental.
       if (compile.diagnostics.isInfrastructureCompileFailure()) {
@@ -508,6 +545,8 @@ class PlaygroundCompileService(
 
       val diagnostics = compile.diagnostics
       if (diagnostics.any { it.severity == PlaygroundSeverity.ERROR }) {
+        renewEditLeaseLocked(lease)
+        refreshEditHealthLocked()
         return@synchronized PlaygroundRunResponse(
           diagnostics = diagnostics,
           errors = PlaygroundErrorsWire.project(diagnostics),
@@ -521,26 +560,32 @@ class PlaygroundCompileService(
       // bytecode. Snapshot the successful revision into an ordinary token-owned work directory.
       val revisionWorkDir = newWorkDir()
       val revisionClasses = revisionWorkDir / "classes"
-      try {
-        fileSystem.createDirectories(revisionClasses)
-        copyDirectory(classesDir, revisionClasses)
-        publishCompiled(
-            mode = mode,
-            classpath = classpath,
-            classesDir = revisionClasses,
-            workDir = revisionWorkDir,
-            diagnostics = diagnostics,
-            isSecurityChecked = isSecurityChecked,
-          )
-          .copy(
-            editLease = lease.id,
-            revision = request.revision,
-            incremental = compile.incremental,
-          )
-      } catch (t: Throwable) {
-        cleanup(revisionWorkDir)
-        failure("playground revision snapshot failed: ${t.message ?: t.javaClass.simpleName}")
-      }
+      val response =
+        try {
+          fileSystem.createDirectories(revisionClasses)
+          copyDirectory(classesDir, revisionClasses)
+          publishCompiled(
+              mode = mode,
+              classpath = classpath,
+              classesDir = revisionClasses,
+              workDir = revisionWorkDir,
+              diagnostics = diagnostics,
+              isSecurityChecked = isSecurityChecked,
+            )
+            .copy(
+              editLease = lease.id,
+              revision = request.revision,
+              incremental = compile.incremental,
+            )
+        } catch (t: Throwable) {
+          cleanup(revisionWorkDir)
+          failure("playground revision snapshot failed: ${t.message ?: t.javaClass.simpleName}")
+        }
+      // The TTL is an idle timeout. Give a continuously active owner a full window after
+      // compilation, discovery, snapshotting and first-frame rendering finish.
+      renewEditLeaseLocked(lease)
+      refreshEditHealthLocked()
+      response
     }
 
   private fun compileAndMint(
@@ -741,6 +786,10 @@ class PlaygroundCompileService(
     const val DEFAULT_EDIT_LEASE_TTL_MILLIS: Long = 15 * 60 * 1000L
 
     private val EDIT_LEASE_RANDOM = SecureRandom()
+    private val EDIT_LEASE_EXPIRY_EXECUTOR =
+      Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "playground-edit-lease-expiry").apply { isDaemon = true }
+      }
 
     private fun newEditLeaseId(): String {
       val bytes = ByteArray(18)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4613,6 +4613,29 @@ $noteBlock        <div class="cp-site-footer-links">
       var suffix = ${jsString(querySuffix)};
       var editLease = null;
       var editRevision = 0;
+      function releaseEditLeaseOnDiscard() {
+        if (!editLease) return;
+        var body = JSON.stringify({ lease: editLease });
+        var url = "/api/1/compiler/edit-lease/release" + suffix;
+        editLease = null;
+        if (navigator.sendBeacon) {
+          navigator.sendBeacon(url, new Blob([body], { type: "application/json" }));
+        } else {
+          fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: body,
+            credentials: "same-origin",
+            keepalive: true
+          }).catch(function () {});
+        }
+      }
+      window.addEventListener("pagehide", function (event) {
+        // A bfcache page is still alive and may be restored; an actually discarded page should
+        // surrender the one host-wide lease immediately. Delivery remains best-effort, with the
+        // server TTL as the hard fallback.
+        if (!event.persisted) releaseEditLeaseOnDiscard();
+      });
       function setEditLease(value, message, expiresAt) {
         editLease = value;
         editRevision = 0;

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -37,6 +37,7 @@ class PlaygroundCompileServiceTest {
     editLeasesEnabled: Boolean = false,
     editLeaseTtlMillis: Long = PlaygroundCompileService.DEFAULT_EDIT_LEASE_TTL_MILLIS,
     nowMillis: () -> Long = { 1_000L },
+    scheduleEditLeaseExpiry: (Long, () -> Unit) -> Unit = { _, _ -> },
   ) =
     PlaygroundCompileService(
       catalogClasspath = { mode, _ -> classpathFor(mode) },
@@ -51,6 +52,7 @@ class PlaygroundCompileServiceTest {
       editLeasesEnabled = editLeasesEnabled,
       editLeaseTtlMillis = editLeaseTtlMillis,
       nowMillis = nowMillis,
+      scheduleEditLeaseExpiry = scheduleEditLeaseExpiry,
     )
 
   private fun request(
@@ -587,6 +589,76 @@ class PlaygroundCompileServiceTest {
     assertTrue(svc.acquireEditLease("bob").acquired, "release makes the single slot available")
     now = 8_000L
     assertFalse(svc.editLeaseHealth().active, "status observes idle expiry without taking the lock")
+  }
+
+  @Test
+  fun `an abandoned editing lease deletes its workspace at the idle deadline`() {
+    var now = 1_000L
+    val scheduled = mutableListOf<Pair<Long, () -> Unit>>()
+    val svc =
+      service(
+        editLeasesEnabled = true,
+        editLeaseTtlMillis = 5_000L,
+        nowMillis = { now },
+        scheduleEditLeaseExpiry = { delay, task -> scheduled += delay to task },
+      )
+
+    val lease = svc.acquireEditLease("alice")
+    assertTrue(lease.acquired)
+    assertTrue(fs.metadataOrNull("/work/run1".toPath())?.isDirectory == true)
+    assertEquals(5_000L, scheduled.single().first)
+
+    now = 6_000L
+    scheduled.single().second.invoke()
+
+    assertFalse(svc.editLeaseHealth().active)
+    assertNull(fs.metadataOrNull("/work/run1".toPath()), "expiry reclaims the IC workspace")
+  }
+
+  @Test
+  fun `leased compile refreshes the idle deadline after work finishes`() {
+    var now = 1_000L
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ) = emptyList<PlaygroundDiagnostic>()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult {
+          now = 8_000L // The compile outlives the deadline established when it started.
+          fs.createDirectories(outputDir)
+          fs.write(outputDir / "Snippet.class") { writeUtf8("compiled") }
+          return PlaygroundCompileService.IncrementalCompileResult(emptyList(), true)
+        }
+      }
+    val svc =
+      service(
+        compilerOverride = compiler,
+        editLeasesEnabled = true,
+        editLeaseTtlMillis = 5_000L,
+        nowMillis = { now },
+      )
+    val lease = svc.acquireEditLease("alice").lease!!
+
+    svc.run(
+      request().copy(editLease = lease, revision = 1),
+      isSecurityChecked = true,
+      authenticatedOwner = "alice",
+    )
+
+    val health = svc.editLeaseHealth()
+    assertTrue(health.active)
+    assertEquals(13_000L, health.expiresAtEpochMs)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
@@ -78,6 +78,9 @@ class ServeWebPlaygroundCatalogTest {
     assertTrue(html.contains("Acquire editing lease"))
     assertTrue(html.contains("/api/1/compiler/edit-lease"))
     assertTrue(html.contains("editLease: editLease"))
+    assertTrue(html.contains("window.addEventListener(\"pagehide\""))
+    assertTrue(html.contains("navigator.sendBeacon(url"))
+    assertTrue(html.contains("if (!event.persisted) releaseEditLeaseOnDiscard()"))
   }
 
   @Test


### PR DESCRIPTION
## Summary

- best-effort release the single Playground editing lease when its browser page is discarded
- reclaim an abandoned lease workspace at its server-side idle deadline without waiting for another request
- refresh the idle deadline after compilation, snapshotting, and rendering finish

## Root cause

The editor only released its lease from the explicit button. Closing the tab left the lease held until another lease operation lazily noticed expiry, and the workspace could remain on disk indefinitely if no later request arrived. The deadline was also set before potentially long compile/render work, shortening the documented idle window.

## Behavior

`pagehide` now sends the authenticated release request when the page is actually discarded; bfcache navigation retains the lease. Browser teardown delivery is inherently best-effort, so a daemon scheduled cleanup remains the authoritative fallback at the configured TTL.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundCompileServiceTest --tests ee.schimke.composeai.cli.serve.ServeWebPlaygroundCatalogTest`
- fake-clock coverage for workspace reclamation at expiry
- fake-clock coverage for a compile outliving its original deadline and receiving a fresh idle window afterward
