### PR TITLE
fix(rc-embedded-player): isolate bitmap decode failures

### DIFF
--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -45,6 +45,7 @@ import androidx.compose.remote.player.compose.embedded.LocalRemoteContext
 import androidx.compose.remote.player.compose.embedded.RcPlayerRawDocument
 import androidx.compose.remote.player.compose.embedded.RcPlayerRootLayoutComponent
 import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
+import androidx.compose.remote.player.compose.embedded.applyDataOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.applyOperationsReflection
 import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
@@ -289,13 +290,16 @@ private fun initDrawContext(
       context.loadFloat(RemoteContext.ID_FONT_SIZE, 14f * fontScale * density)
       context.loadFloat(RemoteContext.ID_DENSITY, density)
       context.density = density
-      document.initializeContext(context)
+      // Bind/reset the context without CoreDocument's eager applyDataOperations pass. Images are
+      // registered below and decoded only when a draw actually requests them.
+      document.initializeContext(context, emptyMap())
 
       // Register each bitmap's metadata (id + declared size) WITHOUT decoding pixels; the decode
       // is deferred to first draw (resolveImage drives BitmapData.apply -> loadBitmap).
       val bitmaps = ArrayList<BitmapData>()
       findBitmaps(document.getOperationsReflection(), bitmaps)
       bitmaps.forEach { bitmap -> context.putObject(bitmap.mImageId, bitmap) }
+      document.applyDataOperationsWithoutBitmaps(context)
 
       document.setLayoutCallback {}
       document.updateTimeReflection(context)
@@ -311,7 +315,7 @@ private fun initDrawContext(
         } else {
           document.getOperationsReflection()
         }
-      document.applyOperationsReflection(context, globalOps)
+      document.applyOperationsReflection(context, globalOps.withoutBitmaps())
 
       // Themed colours, before the `ColorTheme` ops in `constantOps` are applied — `ColorTheme`
       // reads the fields resolution overwrites, so resolving afterwards is resolving too late.
@@ -345,7 +349,7 @@ private fun initDrawContext(
 
       val dataOps = ArrayList<Operation>()
       document.rootLayoutComponent?.getData(dataOps, true)
-      document.applyOperationsReflection(context, dataOps)
+      document.applyOperationsReflection(context, dataOps.withoutBitmaps())
     }
   }
 
@@ -393,6 +397,10 @@ private fun findBitmaps(operations: Collection<Operation>, list: MutableList<Bit
     if (op is Container) findBitmaps(op.getList(), list)
   }
 }
+
+/** Bitmap pixels are resolved on first draw; setup passes must only apply the other data ops. */
+private fun Collection<Operation>.withoutBitmaps(): ArrayList<Operation> =
+  filterTo(ArrayList(size)) { it !is BitmapData }
 
 /** Collect every constant-like op in the tree. Mirrors `RcPlayer.kt`'s inline constant walk. */
 private fun collectConstants(operations: Collection<Operation>, out: MutableList<Operation>) {

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/CoreDataAccessors.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/CoreDataAccessors.kt
@@ -18,8 +18,14 @@
 
 package androidx.compose.remote.player.compose.embedded
 
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.Operation
+import androidx.compose.remote.core.RemoteContext
+import androidx.compose.remote.core.VariableSupport
+import androidx.compose.remote.core.operations.BitmapData
 import androidx.compose.remote.core.operations.BitmapFontData
 import androidx.compose.remote.core.operations.ClipPath
+import androidx.compose.remote.core.operations.ComponentData
 import androidx.compose.remote.core.operations.ConditionalOperations
 import androidx.compose.remote.core.operations.DrawBitmapFontText
 import androidx.compose.remote.core.operations.DrawBitmapFontTextOnPath
@@ -34,6 +40,8 @@ import androidx.compose.remote.core.operations.FloatFunctionCall
 import androidx.compose.remote.core.operations.ParticlesCreate
 import androidx.compose.remote.core.operations.ParticlesLoop
 import androidx.compose.remote.core.operations.TouchExpression
+import androidx.compose.remote.core.operations.layout.Component
+import androidx.compose.remote.core.operations.layout.Container
 import androidx.compose.remote.core.operations.layout.LayoutComponent
 import androidx.compose.remote.core.operations.layout.LayoutComponentContent
 import androidx.compose.remote.core.operations.layout.LoopOperation
@@ -404,6 +412,46 @@ internal fun androidx.compose.remote.core.CoreDocument.applyOperationsReflection
   operations: ArrayList<androidx.compose.remote.core.Operation>,
 ) {
   docApplyOperationsMethod.invoke(this, context, operations)
+}
+
+/**
+ * The core's data initialization pass, except that [BitmapData] remains metadata until first draw.
+ *
+ * This deliberately mirrors `CoreDocument.applyDataOperations`: its context mode, time update,
+ * variable registration, recursive component updates, dirty/op-count bookkeeping, and operation
+ * ordering are all observable by animations and interactions. Calling the two-argument
+ * `initializeContext` and merely omitting this pass breaks those behaviors; calling the stock pass
+ * eagerly decodes every bitmap.
+ */
+internal fun CoreDocument.applyDataOperationsWithoutBitmaps(context: RemoteContext) {
+  val operations = getOperationsReflection()
+  context.mode = RemoteContext.ContextMode.DATA
+  try {
+    updateTimeReflection(context)
+    registerVariablesReflection(context, operations)
+    applyOperationsWithoutBitmaps(context, operations)
+  } finally {
+    context.mode = RemoteContext.ContextMode.UNSET
+  }
+}
+
+private fun applyOperationsWithoutBitmaps(
+  context: RemoteContext,
+  operations: Collection<Operation>,
+) {
+  operations.forEach { operation ->
+    if (operation is BitmapData) return@forEach
+    if (operation is VariableSupport) operation.updateVariables(context)
+    if (operation is Component) operation.updateVariables(context)
+    operation.markNotDirty()
+    context.incrementOpCount()
+    if (operation is Container) {
+      if (operation is ComponentData) operation.apply(context)
+      applyOperationsWithoutBitmaps(context, operation.getList())
+    } else {
+      operation.apply(context)
+    }
+  }
 }
 
 private val docOperationsField =

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -162,9 +162,10 @@ public fun RcPlayer(
       it.loadFloat(RemoteContext.ID_FONT_SIZE, 14f * density.fontScale * density.density)
       it.loadFloat(RemoteContext.ID_DENSITY, density.density)
       it.density = density.density
-      document.initializeContext(it)
-      resolveAndroidThemeColors(context, document)
-      it.paintTheme = resolvedTheme
+      // Use the overload that only binds/reset the context. The one-argument overload immediately
+      // calls applyDataOperations(), which walks every top-level operation and eagerly applies
+      // BitmapData (decoding every image before the document can compose).
+      document.initializeContext(it, emptyMap())
 
       // Register each bitmap's metadata (declared width/height for ImageAttribute, and
       // discoverability for the lazy decode) WITHOUT decoding the pixels. The costly decode
@@ -175,6 +176,10 @@ public fun RcPlayer(
       val bitmaps = ArrayList<BitmapData>()
       findBitmaps(document.getOperationsReflection(), bitmaps)
       bitmaps.forEach { bitmap -> it.putObject(bitmap.mImageId, bitmap) }
+      document.applyDataOperationsWithoutBitmaps(it)
+
+      resolveAndroidThemeColors(context, document)
+      it.paintTheme = resolvedTheme
 
       document.setLayoutCallback {}
 
@@ -209,7 +214,7 @@ public fun RcPlayer(
         } else {
           document.getOperationsReflection()
         }
-      document.applyOperationsReflection(it, globalOps)
+      document.applyOperationsReflection(it, globalOps.withoutBitmaps())
 
       val constantOps = ArrayList<Operation>()
       fun walk(ops: Collection<Operation>) {
@@ -247,7 +252,7 @@ public fun RcPlayer(
 
       val dataOps = ArrayList<Operation>()
       document.rootLayoutComponent?.getData(dataOps, true)
-      document.applyOperationsReflection(it, dataOps)
+      document.applyOperationsReflection(it, dataOps.withoutBitmaps())
     }
   }
 
@@ -542,6 +547,10 @@ private fun findBitmaps(operations: Collection<Operation>, list: MutableList<Bit
     }
   }
 }
+
+/** Bitmap pixels are resolved on first draw; setup passes must only apply the other data ops. */
+private fun Collection<Operation>.withoutBitmaps(): ArrayList<Operation> =
+  filterTo(ArrayList(size)) { it !is BitmapData }
 
 private fun findComponentValues(
   operations: Collection<Operation>,

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerImagePlatform.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerImagePlatform.kt
@@ -67,12 +67,22 @@ import androidx.compose.ui.graphics.asImageBitmap
 internal fun resolveBitmap(remoteContext: RemoteContext, id: Int): Bitmap? {
   val cached = remoteContext.mRemoteComposeState.getFromId(id)
   if (cached is Bitmap) return cached
+  if (cached === FailedBitmapDecode) return null
   // Not decoded yet: find the registered BitmapData and decode it now (apply = putObject +
   // loadBitmap, which caches the decoded Bitmap under the id).
   val data = remoteContext.mRemoteComposeState.getObject(id) as? BitmapData ?: return null
-  data.apply(remoteContext)
+  try {
+    data.apply(remoteContext)
+  } catch (_: Exception) {
+    // A bad or unresolvable image costs one image slot, not the whole document. Remember the
+    // failure so a recomposition/draw loop does not retry the same broken reference every frame.
+    remoteContext.mRemoteComposeState.cacheData(id, FailedBitmapDecode)
+    return null
+  }
   return remoteContext.mRemoteComposeState.getFromId(id) as? Bitmap
 }
+
+private object FailedBitmapDecode
 
 /** [resolveBitmap] projected to a Compose [ImageBitmap]; null when there is no bitmap. */
 internal fun resolveImage(remoteContext: RemoteContext, id: Int): ImageBitmap? =

--- a/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerBitmapFailureTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerBitmapFailureTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("RestrictedApiAndroidX")
+
+package androidx.compose.remote.player.compose.embedded
+
+import androidx.compose.remote.core.operations.BitmapData
+import androidx.compose.remote.player.core.platform.AndroidRemoteContext
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class RcPlayerBitmapFailureTest {
+
+  @Test
+  fun relativeUriLeavesBitmapSlotEmpty() {
+    val context = AndroidRemoteContext()
+    val state = SnapshotRemoteComposeState()
+    context.mRemoteComposeState = state
+    context.putObject(
+      IMAGE_ID,
+      BitmapData(
+        IMAGE_ID,
+        BitmapData.TYPE_PNG,
+        64,
+        BitmapData.ENCODING_URL,
+        64,
+        "camera/current".toByteArray(),
+      ),
+    )
+
+    assertNull(resolveBitmap(context, IMAGE_ID))
+    // The failed decode is memoized, so another frame remains empty without retrying or throwing.
+    assertNull(resolveBitmap(context, IMAGE_ID))
+  }
+
+  private companion object {
+    const val IMAGE_ID = 42
+  }
+}


### PR DESCRIPTION
## What changed

- initialize embedded Android and JVM contexts without the eager core bitmap pass
- preserve the core data-initialization semantics for every non-bitmap operation
- keep bitmap metadata registered for layout while deferring pixel decode until first use
- turn an unresolvable bitmap into a memoized empty slot instead of aborting the document
- add a regression test for the relative-URI failure

## Root cause

The one-argument `CoreDocument.initializeContext` immediately calls `applyDataOperations`, which applies every `BitmapData` before the player's lazy registration path runs. A relative URI reaches `URI.toURL()` during that eager pass and throws. Later setup passes could also re-apply bitmap operations.

## Validation

- `:third-party-rc-embedded-player:testDebugUnitTest` (full module)
- focused JVM parser, bitmap-context, and renderer tests
- module ktfmt checks

Fixes #3993