### PR TITLE
fix(serve): publish themed spec baseline early

### DIFF
--- a/cli/serve-web/src/components/SpecCompare.ts
+++ b/cli/serve-web/src/components/SpecCompare.ts
@@ -188,28 +188,9 @@ export class SpecCompare extends LitElement {
         this.bakedBand = this.chip?.getAttribute("data-spec-match") ?? "";
         this.referenceUrl = this.compare.getAttribute("data-reference") ?? "";
 
-        // Read rather than wait to be told — but this does NOT cover the first install, and the
-        // ordering is worth stating precisely because it is the unhelpful way round.
-        //
-        // `ServeWeb` emits `serve-components.js` ahead of `viewer.js`, so this element upgrades and
-        // installs while `data-spec-baseline` is still absent and the read falls back to `true`. On
-        // a themed deep link (`?themeProvider=…`), which is served with the baked verdict on the
-        // chip, that is the wrong answer, and it stands until `viewer.js` runs `syncSpecBaseline`
-        // and pushes the correction through `baseline()`.
-        //
-        // That gap is not instantaneous. The two tags are not adjacent — an inline theme script,
-        // the presence script and `format-compare.js` sit between them, and `format-compare.js` is
-        // emitted on precisely the pages that have a spec chip. Classic scripts fix execution
-        // ORDER, they do not stop the browser painting markup it has already parsed while it waits
-        // on a fetch. So on a cold or slow load a themed deep link can show the baked verdict
-        // briefly before the correction lands. Closing that properly means publishing the baseline
-        // ahead of this script, which needs the URL read where the page can do it early rather than
-        // this element guessing.
-        //
-        // What the read does buy is every install that is NOT the first — the `whenParsed()` retry
-        // above, and any re-connect — where `viewer.js` has already published and the pushed call
-        // has been and gone. Those would otherwise start from `true` with nothing left to correct
-        // them at all.
+        // ServeWeb's inline theme bootstrap publishes this before the component bundle loads, so
+        // the first install does not briefly show the baked verdict for a themed deep link.
+        // viewer.js keeps it current after controls change, and reconnects read the latest value.
         this.atBaseline = this.root.getAttribute("data-spec-baseline") !== "0";
         if (!this.atBaseline) this.setChipVerdict(null);
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3797,6 +3797,14 @@ $noteBlock        <div class="cp-site-footer-links">
           el.setAttribute("data-theme-active", "1");
         }
       } catch (e) {}
+      // Publish the design-score baseline before the component bundle upgrades the comparison
+      // control. A chosen theme changes the rendered side of the comparison, so the
+      // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
+      // sync after controls change; this early write makes the element's initial read authoritative.
+      if (root) {
+        var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+        root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
+      }
       // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite
       // uiMode never lands a transparent sticker on a clashing surface. The server seeds
       // data-bg-theme from the baked variant (or the dark-first default); a light/dark Theme choice
@@ -9655,11 +9663,14 @@ $rows
       <!-- Remembers which control drawers this visitor left open (`cp-grp.<id>` per
            `details.cp-group[data-cp-group]`). Renders nothing; `serve.css` hides the tag. -->
       <cp-group-memory></cp-group-memory>
+      <!-- Resolve a deep-linked or remembered theme and publish the design-score baseline before
+           the component bundle upgrades the comparison control. -->
+      <script>${viewerThemeStickyScript(themeStorageKey(sessionId, basePath))}</script>
       ${scriptTag("serve-components.js")}
       <!-- The viewer's drawers, the phone row order, the theme toggle's value and the component
            filter. Renders nothing; `serve.css` hides the tag. -->
       <cp-viewer-drawers></cp-viewer-drawers>
-      <script>${viewerThemeStickyScript(themeStorageKey(sessionId, basePath))}</script>${presenceScriptTag(presenceUrl)}
+      ${presenceScriptTag(presenceUrl)}
       $compareScriptTags${scriptTag("viewer.js")}
       """
         .trimIndent()

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/viewer.js
@@ -645,17 +645,9 @@
     }
     return true;
   }
-  // Pushed to the lane AND published on the stage, and the two carry different weight.
-  //
-  // The push is what corrects the FIRST install. `serve-components.js` is emitted ahead of this
-  // file, so `<cp-spec-compare>` has already installed by the time we run, and has already fallen
-  // back to the baked verdict because the attribute did not exist yet; this call is what moves it
-  // off. It is a correction and not a guarantee: the tags are not adjacent, and a browser is free
-  // to paint parsed markup while it fetches what sits between them, so on a cold load a themed
-  // deep link can show the baked verdict for the interval before we get here.
-  //
-  // The attribute is for the installs that come later — the element's deferred retry, or a
-  // re-connect — which have no push to wait for and read the stage instead.
+  // The inline theme bootstrap publishes the initial value before serve-components.js upgrades
+  // the spec element. Keep both the stage attribute and the installed element current from here on:
+  // the attribute serves reconnects, while the push updates the existing install immediately.
   function syncSpecBaseline() {
     var at = specAtBaseline();
     root.setAttribute("data-spec-baseline", at ? "1" : "0");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -1068,12 +1068,19 @@ class ServeWebTest {
     // Load order is load-bearing: `viewer.js` calls `window.cpSpecCompare` on the way into the
     // lane, and `<cp-spec-compare>` draws every surface from format-compare.js's primitives. The
     // element wires itself up as its tag upgrades, so the components bundle has to be requested
-    // before viewer.js, and the tag itself before the bundle that defines it.
+    // before viewer.js, and the tag itself before the bundle that defines it. The inline theme
+    // bootstrap must publish the baseline before that upgrade too: otherwise a cold themed deep
+    // link can paint the baked verdict while the parser waits for the later scripts.
     val tag = html.indexOf("<cp-spec-compare>")
+    val baseline = html.indexOf("root.setAttribute(\"data-spec-baseline\"")
     val components = html.indexOf("serve-components.js")
     val formatCompare = html.indexOf("format-compare.js")
     val viewer = html.indexOf("/viewer.js")
     assertTrue(tag in 1 until components, "the tag is parsed before the bundle upgrades it")
+    assertTrue(
+      baseline in (tag + 1) until components,
+      "the inline theme bootstrap publishes the baseline before the component upgrades",
+    )
     assertTrue(components in 1 until viewer, "the components bundle precedes viewer.js")
     assertTrue(formatCompare in 1 until viewer, "format-compare.js precedes viewer.js")
   }


### PR DESCRIPTION
## Summary

- resolve deep-linked or remembered theme state before `serve-components.js` upgrades the spec comparison control
- publish `data-spec-baseline` during that inline bootstrap so the first chip paint cannot show the server-baked verdict for a themed render
- retain `viewer.js` baseline synchronization for later control changes and reconnects
- pin the load-order contract in `ServeWebTest`

## Root cause

The spec comparison element installed before `viewer.js` first published the baseline. On a cold themed deep link, the missing attribute fell back to the baked default verdict, which could paint while later parser-blocking assets loaded.

## Verification

`JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeWebTest' --no-daemon`

Fixes #3989