### PR TITLE
fix(preview-annotations): expose design-kit variant mappings

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
@@ -31,6 +31,9 @@ package ee.schimke.composeai.preview
  * * [referenceContentsOnly] defaults to true. Set it to false only when the referenced Figma node
  *   intentionally relies on overlapping sheet content, such as an authored backdrop. Keeping this
  *   next to [reference] avoids changing unrelated previews on the same component sheet.
+ * * [kitAxis] defaults to empty. Set it when every override variant on this component uses the same
+ *   design-kit property, so individual [OverrideVariant] cells only need to name exceptional axes
+ *   or values.
  *
  * ```kotlin
  * @file:CatalogGroup("Buttons")
@@ -115,6 +118,8 @@ annotation class CatalogComponent(
   val referenceSet: String = "",
   val noReference: String = "",
   val referenceContentsOnly: Boolean = true,
+  /** Default design-kit variant property for this component's override-variant cells. */
+  val kitAxis: String = "",
 )
 
 /**

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -89,6 +89,22 @@ package ee.schimke.composeai.preview
  *
  * Resolution walks the whole meta-annotation closure, so an annotation class that is itself tagged
  * with another one contributes both sets.
+ *
+ * ## Design-kit correspondence
+ *
+ * [kitAxis] names the design-kit variant property that the seeded knob represents when its name is
+ * different or ambiguous. [kitValue] optionally names this cell's kit-side value too. Both are
+ * metadata only: they do not change the preview override seed. A component whose cells all use the
+ * same property can declare the default once with [CatalogComponent.kitAxis].
+ *
+ * ```
+ * @OverrideVariant(
+ *   name = "avatar",
+ *   strings = ["content=avatar"],
+ *   kitAxis = "Show avatar",
+ *   kitValue = "True",
+ * )
+ * ```
  */
 @Repeatable
 @Retention(AnnotationRetention.BINARY)
@@ -123,6 +139,10 @@ annotation class OverrideVariant(
   val floats: Array<String> = [],
   /** Colour knob seeds, each `"key=#AARRGGBB"` (or `#RRGGBB`; or `"key#index=…"`). */
   val colors: Array<String> = [],
+  /** Design-kit variant property this cell maps to; empty keeps downstream name matching. */
+  val kitAxis: String = "",
+  /** Design-kit value this cell maps to; empty keeps downstream value matching. */
+  val kitValue: String = "",
 )
 
 /** Harness-driven state for an addressable [OverrideVariant]. */

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -171,6 +171,8 @@ data class CatalogEntry(
    * would see one component where the published catalog has several.
    */
   val perBreakpoint: Boolean = false,
+  /** COMPONENT: default design-kit variant property for override-variant cells. */
+  val kitAxis: String? = null,
 )
 
 @Serializable

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/CatalogEntryWireTest.kt
@@ -21,6 +21,7 @@ class CatalogEntryWireTest {
               "role": "COMPONENT",
               "componentId": "Button/Filled",
               "parallel": "FilledButton",
+              "kitAxis": "Configuration",
               "referenceContentsOnly": false
             }
           }]
@@ -30,6 +31,7 @@ class CatalogEntryWireTest {
       )
 
     assertEquals("FilledButton", manifest.previews.single().catalog?.parallel)
+    assertEquals("Configuration", manifest.previews.single().catalog?.kitAxis)
     assertEquals(false, manifest.previews.single().catalog?.referenceContentsOnly)
   }
 

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
@@ -65,6 +65,10 @@ data class OverrideVariantSpec(
   val seeds: List<OverrideSeed> = emptyList(),
   val interaction: OverrideVariantInteraction? = null,
   val interactionIndex: Int = 0,
+  /** Explicit design-kit variant property for this cell; null keeps downstream name matching. */
+  val kitAxis: String? = null,
+  /** Explicit design-kit value for this cell; null keeps downstream value matching. */
+  val kitValue: String? = null,
 ) {
   /**
    * The seed map (keyed by [OverrideSeed.seedKey]) this variant applies — the exact shape

--- a/design-map/README.md
+++ b/design-map/README.md
@@ -25,9 +25,10 @@ Every field the projection reads is defined in this repository:
 
 | Field on `previews.json` | Declared by |
 | --- | --- |
-| `catalog.reference`, `referenceSet`, `noReference`, `referenceContentsOnly` | [`@CatalogComponent`](https://github.com/yschimke/compose-ai-tools/blob/main/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt) |
+| `catalog.reference`, `referenceSet`, `noReference`, `referenceContentsOnly`, `kitAxis` | [`@CatalogComponent`](https://github.com/yschimke/compose-ai-tools/blob/main/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt) |
 | `catalog.props`, `catalog.state` | `@CatalogVariant` |
 | `overrides.seeds`, `overrides.props` | `@OverrideVariant` / `@PreviewAxis` |
+| `overrides.kitAxis`, `overrides.kitValue` | `@OverrideVariant` |
 
 Rename one of those and the projection has to change in the same commit. Keeping the two on
 opposite sides of a repo boundary is how a manifest reader goes quietly stale — and the reference

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -961,6 +961,8 @@ data class CatalogEntry(
    * behaviour.
    */
   val perBreakpoint: Boolean = false,
+  /** COMPONENT only: default design-kit variant property for override-variant cells. */
+  val kitAxis: String? = null,
 )
 
 /** Kind of a seeded `previewOverride*` value — mirrors `PreviewOverrideValue`'s subtypes. */
@@ -1018,6 +1020,10 @@ data class OverrideVariantSpec(
    * with the value it already resolves to is a no-op.
    */
   val props: List<CatalogVariantProp> = emptyList(),
+  /** Explicit design-kit variant property for this cell; null keeps downstream name matching. */
+  val kitAxis: String? = null,
+  /** Explicit design-kit value for this cell; null keeps downstream value matching. */
+  val kitValue: String? = null,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1183,6 +1183,7 @@ object PreviewDiscovery {
       noReference = annStringOrNull(component, "noReference"),
       referenceContentsOnly = annBoolean(component, "referenceContentsOnly", default = true),
       parallel = annStringOrNull(component, "parallel"),
+      kitAxis = annStringOrNull(component, "kitAxis"),
       perBreakpoint = annBoolean(component, "perBreakpoint"),
     )
   }
@@ -2220,6 +2221,8 @@ object PreviewDiscovery {
           seeds = seeds,
           interaction = interaction,
           interactionIndex = interactionIndex,
+          kitAxis = (pv.getValue("kitAxis") as? String)?.takeIf { it.isNotBlank() },
+          kitValue = (pv.getValue("kitValue") as? String)?.takeIf { it.isNotBlank() },
         )
       val existing = specs.putIfAbsent(name, spec)
       // Only a *conflicting* duplicate is worth a warning. The same annotation reached twice — once

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -116,6 +116,43 @@ class PreviewDataTest {
   }
 
   @Test
+  fun `design kit correspondence round-trips through preview manifest`() {
+    val preview =
+      PreviewInfo(
+        id = "test.Avatar_VARIANT_avatar",
+        functionName = "Avatar",
+        className = "test.CatalogKt",
+        catalog =
+          CatalogEntry(
+            role = CatalogRole.COMPONENT,
+            componentId = "Avatar",
+            kitAxis = "Configuration",
+          ),
+        overrides =
+          OverrideVariantSpec(
+            name = "avatar",
+            seeds =
+              listOf(
+                OverrideSeed(
+                  key = "content",
+                  kind = OverrideSeedKind.STRING,
+                  raw = "avatar",
+                )
+              ),
+            kitAxis = "Show avatar",
+            kitValue = "True",
+          ),
+      )
+    val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews.single().catalog?.kitAxis).isEqualTo("Configuration")
+    assertThat(decoded.previews.single().overrides?.kitAxis).isEqualTo("Show avatar")
+    assertThat(decoded.previews.single().overrides?.kitValue).isEqualTo("True")
+  }
+
+  @Test
   fun `gestureHint capture round-trips and defaults to null`() {
     // The renderer's `RenderPreviewCapture.gestureHint` mirror reads this shape out of
     // `previews.json`; a rename here would silently drop the `@GestureHintPreview` override.

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
@@ -93,6 +93,33 @@ class PreviewDiscoveryProjectJarTest {
     assertThat((outcome as PreviewDiscovery.Outcome.Success).manifest.previews).isEmpty()
   }
 
+  @Test
+  fun `catalog and override design kit correspondence is discovered`() {
+    val jar = File(tempDir.root, "kit-axis-classes.jar")
+    writeKitAxisPreviewClassJar(jar)
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = emptyList(),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":catalog",
+          variantName = "debug",
+          projectDirectory = tempDir.root,
+          failOnEmpty = true,
+          projectClassJars = listOf(jar),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    val base = outcome.manifest.previews.single { it.overrides == null }
+    val variant = outcome.manifest.previews.single { it.overrides != null }
+    assertThat(base.catalog?.kitAxis).isEqualTo("Configuration")
+    assertThat(variant.catalog?.kitAxis).isEqualTo("Configuration")
+    assertThat(variant.overrides?.kitAxis).isEqualTo("Show avatar")
+    assertThat(variant.overrides?.kitValue).isEqualTo("True")
+  }
+
   /**
    * Writes a JAR containing a single class with one parameterless `public static` method annotated
    * with `androidx.compose.ui.tooling.preview.Preview`. The annotation is emitted as a
@@ -121,6 +148,49 @@ class PreviewDiscoveryProjectJarTest {
     cw.visitEnd()
 
     jar.parentFile.mkdirs()
+    JarOutputStream(jar.outputStream()).use { jos ->
+      jos.putNextEntry(JarEntry("$internalName.class"))
+      jos.write(cw.toByteArray())
+      jos.closeEntry()
+    }
+  }
+
+  /** Writes the issue #3899 contract directly into CLASS-retained annotation tables. */
+  private fun writeKitAxisPreviewClassJar(jar: File) {
+    val internalName = "test/KitAxisPreviewKt"
+    val methodName = "Avatar"
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, methodName, "()V", null, null)
+    mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", false).visitEnd()
+    mv.visitAnnotation("Lee/schimke/composeai/preview/CatalogComponent;", false).apply {
+      visit("id", "Avatar")
+      visit("kitAxis", "Configuration")
+      visitEnd()
+    }
+    mv.visitAnnotation("Lee/schimke/composeai/preview/OverrideVariant;", false).apply {
+      visit("name", "avatar")
+      visit("kitAxis", "Show avatar")
+      visit("kitValue", "True")
+      visitArray("strings").apply {
+        visit(null, "content=avatar")
+        visitEnd()
+      }
+      visitEnd()
+    }
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
     JarOutputStream(jar.outputStream()).use { jos ->
       jos.putNextEntry(JarEntry("$internalName.class"))
       jos.write(cw.toByteArray())


### PR DESCRIPTION
## Summary

- add optional `kitAxis` metadata to `@CatalogComponent` as a component-wide default
- add optional `kitAxis` and `kitValue` metadata to `@OverrideVariant`
- carry the fields through discovery, `previews.json`, runtime/public wire mirrors, and documentation
- preserve existing heuristic matching when metadata is absent

## Root cause

Preview annotations carried override knob seeds but no explicit correspondence to differently named design-kit properties or values. Downstream consumers therefore had to guess that correspondence with component-specific alias tables and fuzzy matching.

## Validation

- `./gradlew :preview-data-api:test :preview-annotations:allTests :data-preview-overrides-core:test :gradle-plugin:preview-discovery:test`
- `./gradlew :preview-data-api:ktfmtCheck :preview-annotations:ktfmtCheck :data-preview-overrides-core:ktfmtCheck`
- ASM-level regression coverage for CLASS-retained annotation discovery

Fixes #3899