### PR TITLE
test(serve): make three assertions reject what they were meant to reject

### DIFF
--- a/cli/serve-web/test/pageZoom.test.ts
+++ b/cli/serve-web/test/pageZoom.test.ts
@@ -49,9 +49,13 @@ function view(): { scale: number; x: number; y: number } {
     // An EMPTY transform is the identity — that is how the element expresses 1:1, by clearing the
     // property rather than writing `translate(0px, 0px) scale(1)`.
     if (!transform || transform === "none") return { scale: 1, x: 0, y: 0 };
+    // ANCHORED. Unanchored, `translate(...) scale(...) rotate(180deg)` still matches its familiar
+    // substring, so the guard below would accept it and this fake layout would silently ignore an
+    // operation the browser is really applying — the zoom tests passing over a visibly different
+    // view.
     const match =
-        /translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/.exec(
-            transform,
+        /^translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)$/.exec(
+            transform.trim(),
         );
     // Anything else present but unreadable is a FAILURE, not an identity. Returning the identity
     // here — which this used to do — makes every assertion in this file fail open: a reset that

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1908,7 +1908,9 @@ class ServeWebFixtureTest {
     // relative to the current page and navigates nowhere near the preview — would have passed.
     assertEquals(
       "com.example.ProfileCardPreview",
-      Regex("""/p/([^/?#]+)""").find(manifestHref!!)?.groupValues?.get(1),
+      // The capture must be the FINAL segment. Unanchored, `/p/<id>/other` still yields `<id>` —
+      // and the server registers only the exact `/p/{name}` routes, so that URL navigates nowhere.
+      Regex("""/p/([^/?#]+)(?:[?#]|$)""").find(manifestHref!!)?.groupValues?.get(1),
       "…and its destination is THAT preview, on the preview route",
     )
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1896,11 +1896,20 @@ class ServeWebFixtureTest {
     )
     // The whole final segment, not a prefix: `/p/com.example.ProfileCardPreviewLegacy` contains
     // the id we mean and navigates somewhere else.
-    val manifestHref = Regex("""href="([^"]*)"""").find(manifestNode.value)!!.groupValues[1]
+    // `\shref=` and not `href=`: the latter also matches the tail of `data-href`, so swapping a
+    // real
+    // anchor for scripted navigation — precisely the inert-destination regression this is here to
+    // catch — would keep it green.
+    val hrefOf = { tag: String -> Regex("""\shref="([^"]*)"""").find(tag)?.groupValues?.get(1) }
+    val manifestHref = hrefOf(manifestNode.value)
+    assertTrue(manifestHref != null, "the manifest node carries a real href attribute")
+    // Matched through the route delimiter. `substringAfterLast` returns the WHOLE string when the
+    // delimiter is absent, so a bare `href="com.example.ProfileCardPreview"` — which resolves
+    // relative to the current page and navigates nowhere near the preview — would have passed.
     assertEquals(
       "com.example.ProfileCardPreview",
-      manifestHref.substringBefore('?').substringAfterLast("/p/"),
-      "…and its destination is THAT preview, not one whose id merely starts the same way",
+      Regex("""/p/([^/?#]+)""").find(manifestHref!!)?.groupValues?.get(1),
+      "…and its destination is THAT preview, on the preview route",
     )
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
     // tag is the same; only the target differs, so a reader never meets a node that looks
@@ -1920,10 +1929,9 @@ class ServeWebFixtureTest {
     // The WHOLE href, compared as one string. Checking parts independently loses whatever part is
     // not checked: a host check alone passes for the Figma homepage, and a key-plus-node check
     // alone passes for a relative URL or a different host carrying the same query.
-    val unlinkedHref = Regex("""href="([^"]*)"""").find(unlinkedNode.value)!!.groupValues[1]
     assertEquals(
       "https://www.figma.com/design/ocdacdEsnHipMJD3egzxKb?node-id=1-6",
-      unlinkedHref,
+      hrefOf(unlinkedNode.value),
       "…and its destination is THIS node in the catalog's design file",
     )
 


### PR DESCRIPTION
Review findings that arrived after #3990 merged. All three are the same failure in different clothes: **a pattern loose enough to match the thing it was supposed to refuse.**

Each is verified by feeding it the input it used to accept.

## `view()`'s regex was unanchored

```ts
/translate\((-?[\d.]+)px, (-?[\d.]+)px\) scale\(([\d.]+)\)/
```

`translate(0px, 0px) scale(1) rotate(180deg)` still matches that substring. So the "unreadable transform throws" guard I *added in #3990* accepted it, and the fake layout silently ignored an operation the browser really applies — the zoom tests passing over a visibly different view. That is a fail-open one layer deeper than the one #3990 set out to fix.

Anchored, and verified:

| transform | before | after |
| --- | --- | --- |
| `translate(0px, 0px) scale(1)` | parsed | parsed |
| `…scale(1) rotate(180deg)` | **parsed** | rejected |
| `translateX(40px)` | rejected | rejected |

## `href=` matches the tail of `data-href`

`Regex("""href="([^"]*)"""")` matches inside `data-href="…"`. So swapping a real anchor for `data-href` plus scripted navigation — **precisely the inert-destination regression these assertions exist to catch** — kept them both green. Now requires an attribute boundary:

| tag | before | after |
| --- | --- | --- |
| `<a … href="/p/Foo">` | `/p/Foo` | `/p/Foo` |
| `<a … data-href="/p/Foo">` | **`/p/Foo`** | rejected |

## `substringAfterLast` returns the whole string when the delimiter is missing

Kotlin's `substringAfterLast("/p/")` on `"com.example.ProfileCardPreview"` returns the input unchanged — so a bare relative `href`, which resolves against the current page and navigates nowhere near the preview route, compared equal to the expected id and passed. Matched through the delimiter instead:

| href | before | after |
| --- | --- | --- |
| `/m3/p/com.example.ProfileCardPreview?q=1` | id | id |
| `com.example.ProfileCardPreview` | **id** | rejected |
| `/m3/p/…PreviewLegacy` | `…Legacy` (fails) | `…Legacy` (fails) |

## The pattern, since it is now four rounds deep

Every one of these — including the two in #3990 and the two in #3985 — is me writing an assertion that *passes*, rather than asking what else would pass. Substring containment, an unanchored regex, a prefix check, a helper that defaults on failure: each reads as a check and functions as a decoration for the exact input it was written to exclude. The harness doc I landed this morning says a test that pins an incidental rendering fails for the same reason it never caught anything, and this is that, in the assertions rather than the fixtures.

## Test plan

```
cd cli/serve-web && npm run verify     # 766 passing, 4 bundles in sync
./gradlew :cli:test :cli:ktfmtCheck    # full module
```

Each pattern additionally driven over its accept/reject table directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7zeKSafCBxgGm3KsXHGe)_