### PR TITLE
test(serve): cover the typography table the harness doc claimed was covered

### DIFF
--- a/cli/serve-web/test/referenceCompareElement.test.ts
+++ b/cli/serve-web/test/referenceCompareElement.test.ts
@@ -11,6 +11,25 @@ import assert from "node:assert/strict";
 import { flush, resetDom } from "./setup.js";
 import "../src/components/ReferenceCompare.js";
 
+/**
+ * A second usage of the SAME token at a heavier weight, twice on the majority style and once on the
+ * override. `typographyDefaults` calls the most-used group the token's default, so the single
+ * heavier usage reads as a local override rather than a fidelity finding.
+ */
+const bold = (side: string) =>
+    [700, 400, 400].map((weight, i) => ({
+        kind: "typography",
+        role: `Heading ${side} ${i}`,
+        label: "Title",
+        bounds: { x: 10, y: 60 + i * 30, width: 60, height: 20 },
+        detail: {
+            token: "m3/title-medium",
+            fontSize: "20sp",
+            lineHeight: "24sp",
+            fontWeight: String(weight),
+        },
+    }));
+
 const ANNOTATIONS = {
     reference: [
         {
@@ -30,6 +49,7 @@ const ANNOTATIONS = {
                 lineHeight: "20sp",
             },
         },
+        ...bold("reference"),
     ],
     actual: [
         {
@@ -49,6 +69,7 @@ const ANNOTATIONS = {
                 lineHeight: "20sp",
             },
         },
+        ...bold("actual"),
     ],
 };
 
@@ -294,6 +315,46 @@ describe("<cp-reference-compare>", () => {
         assert.ok(lit() >= 2, "still lit for the keyboard");
         row.dispatchEvent(new Event("blur"));
         assert.equal(lit(), 0);
+    });
+
+    it("renders one row per style, with each side's usage count", async () => {
+        // The capture state `serve-reference-compare/annotated` held these three checks and nothing
+        // else did, so the harness doc's claim that they were covered here was wrong until now.
+        // The fixture carries three styles: a label pair, and a title token used twice at weight
+        // 400 with a single heavier usage that reads as an override off it.
+        stubResizeObserver();
+        stubCompare();
+        await mount();
+        await flush();
+        assert.equal(
+            document.querySelectorAll(".cp-typography-group").length,
+            3,
+            "one row per paired style, not one per usage",
+        );
+        const counts = Array.from(
+            document.querySelectorAll(".cp-typography-count"),
+        ).map((n) => n.textContent);
+        // Two sides per row. The singular/plural is the readout, so it is asserted as text.
+        assert.equal(counts.filter((c) => c === "2 usages").length, 2);
+        assert.equal(counts.filter((c) => c === "1 usage").length, 4);
+    });
+
+    it("marks a local override, and says which default it departed from", async () => {
+        // The distinction the whole table exists for: a fidelity finding is the render disagreeing
+        // with the design, an OVERRIDE is this usage departing from its own token's most-used
+        // group — on both sides equally, so it is not a defect at all. Marking one as the other
+        // would report a deliberate choice as a bug.
+        stubResizeObserver();
+        stubCompare();
+        await mount();
+        await flush();
+        const overrides = Array.from(
+            document.querySelectorAll(".cp-typography-override"),
+        ).map((n) => `${n.textContent}|${n.getAttribute("title")}`);
+        assert.deepEqual(overrides, [
+            "wght 700|Changed from titleMedium default",
+            "wght 700|Changed from titleMedium default",
+        ]);
     });
 
     it("marks the fields that differ between the two sides", async () => {

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -343,12 +343,24 @@ reading, because most of what they assert has a cheaper home:
   2px) — `cli/serve-web/src/zoom/viewport.ts` already has its own tests; the
   capture re-asserts them through a browser.
 - **Typography grouping** (`.cp-typography-group` count, `.cp-typography-count`
-  text, an override reading `wght 700`) — now covered directly by
-  `annotateTypography.test.ts` and `referenceCompareElement.test.ts`.
+  text, an override reading `wght 700`) — covered by
+  `referenceCompareElement.test.ts`. It was NOT, when this section first landed:
+  that test checked only that a group existed, and the claim here was wrong
+  until the coverage was actually written. Check before you move something.
 
-Two of them genuinely need a browser and should stay: `toBeVisible()`, which is
-a CSS question happy-dom cannot answer, and the design page's alignment check,
-which measures real laid-out geometry rather than the arithmetic behind it.
+THREE of them genuinely need a browser and should stay:
+
+- `toBeVisible()`, which is a CSS question happy-dom cannot answer;
+- the design page's alignment check, which measures real laid-out geometry
+  rather than the arithmetic behind it;
+- **`zoom-wheel`**, which reads the computed `outlineWidth` and `outlineOffset`
+  that `serve.css` produces and verifies the node marks counter-scale with
+  `--cp-page-zoom`. `viewport.test.ts` and `pageZoom.test.ts` cover the
+  arithmetic and the custom-property assignment, but neither evaluates the
+  stylesheet, so this is the only direct check that the marks stay hairlines at
+  high zoom instead of becoming slabs over the shape. Its own comment records an
+  earlier version that read `border` — always `0` on these nodes — and so
+  "passed however wrong the stylesheet was".
 
 ### The limit that matters most
 


### PR DESCRIPTION
Two review findings on #3982 — the harness doc — both correct, and the first is the worst kind of documentation error: **a false claim about coverage, in guidance telling people what is safe to delete.**

## The claim was wrong

#3982 said the `.cp-typography-group` count, the `.cp-typography-count` readout and the `wght 700` override were "now covered directly by `annotateTypography.test.ts` and `referenceCompareElement.test.ts`".

They were not. `annotateTypography.test.ts` covers the pure grouping helpers. `referenceCompareElement.test.ts` checked that *a* group existed, lit the highlight, and marked a changed size — and nothing else. The capture state `serve-reference-compare/annotated` was still the **sole holder** of all three checks, so anyone acting on that sentence would have deleted real coverage on my word.

Written now. It needed a fixture with the shape that makes an override an override: a token used twice at weight 400 plus a single heavier usage, so `typographyDefaults` calls the majority the default and the outlier reads as a local departure from it rather than a fidelity finding. Verified against what the element actually renders — three rows, counts of `2 usages`×2 and `1 usage`×4, and `wght 700` titled `Changed from titleMedium default` on both sides.

That distinction is the point of the table: a fidelity finding is the render disagreeing with the design; an override is this usage departing from its own token, **on both sides equally**, which is not a defect at all. Marking one as the other reports a deliberate choice as a bug.

## `zoom-wheel` was missing from the browser-bound list

The doc named two states as genuinely needing Chromium. There are three. `zoom-wheel` reads the computed `outlineWidth` and `outlineOffset` that `serve.css` produces and verifies the node marks counter-scale with `--cp-page-zoom`. `viewport.test.ts` and `pageZoom.test.ts` cover the arithmetic and the custom-property assignment, but neither evaluates the stylesheet — so it is the only direct check that marks stay hairlines at high zoom rather than becoming slabs over the shape they annotate.

Its own comment already records an earlier version that read `border`, which is `0` on those nodes, and so "passed however wrong the stylesheet was". A doc that implied it was movable was pointing at the one test in that group most worth keeping.

Both corrected in the README, with the obvious lesson added: check before you move something.

## Test plan

```
cd cli/serve-web && npm run verify     # 783 passing
```

No captures touched — this adds coverage rather than moving any.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vf7zeKSafCBxgGm3KsXHGe)_