### PR TITLE
feat(serve): open Remote Compose previews on the embedded player

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -8766,10 +8766,22 @@ $rows
     // live/interactive, with its status dot as the live indicator. viewer.js drives both from one
     // lane value (`syncLaneSelect`), so the two can never disagree about what's on the stage.
     val rcEnabled = enabledRcPlayers.toSet()
-    // The lane the viewer opens on for a Remote Compose preview: the server-side `java` player when
-    // it's available (the default snapshot lane), else the client `js` canvas.
+    // The lane the viewer opens on for a Remote Compose preview: the server-side `cmp-android`
+    // (embedded) player when it's available, else `java`, else the client `js` canvas.
+    //
+    // The payoff is the data tier rather than the pixels (#3936). `java` is
+    // `AndroidView { RemoteComposePlayer }`, so a whole document reaches Compose as one interop
+    // leaf: `compose/figma-svg` exports it as a single raster wearing an `.svg` extension, and the
+    // semantics tree describes a black box. The embedded player emits real Compose nodes, so the
+    // same document exports editable geometry and describes the card.
+    //
+    // The two lanes were measured over all 164 documents of the homeassistant catalog before this
+    // moved (`renders/rc-embedded-lane-ab/`): 34 byte-identical, and the residual is overwhelmingly
+    // text rasterization — Skia and the Android canvas hint glyphs differently, which no amount of
+    // player work removes. `?rcPlayer=java` still selects the old lane for anything that needs it.
     val defaultRcBackend =
       when {
+        RcPlayerBackend.CMP_ANDROID.wire in rcEnabled -> RcPlayerBackend.CMP_ANDROID.wire
         RcPlayerBackend.JAVA.wire in rcEnabled -> RcPlayerBackend.JAVA.wire
         RcPlayerBackend.JS.wire in rcEnabled -> RcPlayerBackend.JS.wire
         else -> enabledRcPlayers.firstOrNull().orEmpty()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -635,14 +635,20 @@ class ServeWebTest {
     for (wire in listOf("js", "cmp-wasm", "java", "cmp-android", "cmp-jvm")) {
       assertTrue(html.contains("value=\"rc:$wire\""), "option for $wire present")
     }
-    // Java is the seeded default: both the combo's selection and the chip's opening label.
-    assertTrue(html.contains("data-rc-default=\"java\""), "java is the default player")
+    // CMP Android is the seeded default: both the combo's selection and the chip's opening label.
+    // It opens on the embedded player because that is the lane whose output is a real Compose tree
+    // — editable figma-svg geometry and a described semantics tree, rather than one interop leaf
+    // (#3936). `?rcPlayer=java` still selects the view player.
+    assertTrue(
+      html.contains("data-rc-default=\"cmp-android\""),
+      "cmp-android is the default player",
+    )
     assertTrue(html.contains("<option value=\"rc:java\">Java</option>"), html)
     // The combo itself rests on its placeholder — the chip is what names the current lane, and a
     // combo repeating that name beside it read as two controls arguing about the same fact.
     assertTrue(html.contains("<option value=\"\" selected>Switch renderer…</option>"), html)
     assertTrue(
-      html.contains("<span id=\"cp-live-toggle-label\">Java</span>"),
+      html.contains("<span id=\"cp-live-toggle-label\">CMP Android</span>"),
       "the chip names the lane it opens on",
     )
     // cmp-jvm is the disabled option (and says why in its own label); the enabled ones are not.

--- a/docs/design/evidence/rc-backend-selector/README.md
+++ b/docs/design/evidence/rc-backend-selector/README.md
@@ -26,7 +26,7 @@ selector only offers lanes that actually re-render.
 
 The images below are the exact chip markup + CSS the viewer emits (`ServeWeb.viewerPage`), rendered
 in the headless Chromium shipped in the agent environment. Two host shapes are shown: a daemon-backed
-Android host (js + java + cmp-android live, cmp-jvm disabled, default = java) and a static bundle host
+Android host (js + java + cmp-android live, cmp-jvm disabled, default = cmp-android) and a static bundle host
 (only the js canvas, default = js).
 
 ### Light

--- a/docs/design/evidence/renderer-picker/README.md
+++ b/docs/design/evidence/renderer-picker/README.md
@@ -37,6 +37,13 @@ flow — nobody reads a 200-character absolute URL.
 
 ## Kept diffed
 
-`serve-viewer-rc-players` is a committed page fixture with a `player-cmp-android` runtime state, so
+`serve-viewer-rc-players` is a committed page fixture with a *switched-player* runtime state, so
 the CI visual-diff bot renders and diffs both on every future PR — this page is a snapshot of the
 change, not the mechanism that keeps it covered.
+
+That state selects whichever lane is **not** the default, so it names the non-default player rather
+than a fixed one: it was `player-cmp-android` when the viewer opened on Java, and became
+`player-java` when #3936 flipped the default to the embedded player. The images above still show
+the Java-default era they were captured in — they document the chip-row collapse, which is what
+this page is about, and re-capturing them would only restate the same redesign with the two lane
+names swapped.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
@@ -88,11 +88,11 @@
       </div>
 
       <div class="cp-preview-primary" aria-label="Preview renderer">
-      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" data-default-lane-label="Java" title="Static snapshot — click for the live, interactive preview">
+      <button type="button" id="cp-live-toggle" class="cp-live-toggle" aria-pressed="false" data-default-lane-label="CMP Android" title="Static snapshot — click for the live, interactive preview">
             <span class="cp-live-dot" aria-hidden="true"></span>
-            <span id="cp-live-toggle-label">Java</span>
+            <span id="cp-live-toggle-label">CMP Android</span>
           </button>
-<select id="cp-lane-select" class="cp-lane-select" aria-label="Switch renderer" title="Draw this preview with a different renderer" data-default="rc:java" data-rc-default="java"><option value="" selected>Switch renderer…</option><option value="rc:js">JS</option><option value="rc:cmp-wasm">CMP Wasm</option><option value="rc:java">Java</option><option value="rc:cmp-android">CMP Android</option><option value="rc:cmp-jvm" disabled>CMP JVM (unavailable)</option></select>
+<select id="cp-lane-select" class="cp-lane-select" aria-label="Switch renderer" title="Draw this preview with a different renderer" data-default="rc:cmp-android" data-rc-default="cmp-android"><option value="" selected>Switch renderer…</option><option value="rc:js">JS</option><option value="rc:cmp-wasm">CMP Wasm</option><option value="rc:java">Java</option><option value="rc:cmp-android">CMP Android</option><option value="rc:cmp-jvm" disabled>CMP JVM (unavailable)</option></select>
 <a class="cp-format-link cp-compare-players" href="/remote-m3/compare?format=rc&preview=appcard__ideal__default__compact&token=demo-token-fixture" title="See every Remote Compose player's render of this screen side by side">compare players →</a>
 <button type="button" id="cp-svg-toggle" class="cp-fmt-toggle" aria-pressed="false" title="Show the vector (SVG) render">SVG</button>
 <button type="button" id="cp-explode-toggle" class="cp-fmt-toggle" aria-pressed="false" title="Show how the visible drawing layers are composed">3D</button>

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -281,7 +281,7 @@ const STYLED_FIXTURES = new Set([
     // captured document. The picker's whole claim is visual — one chip naming the current renderer
     // beside one combo of alternatives, where a row of six pressed-state chips used to be — so
     // captured bare it is an unstyled button next to an unstyled select and nothing about the
-    // simplification would move a baseline. `viewer.js` is needed too, for the `player-cmp-android`
+    // simplification would move a baseline. `viewer.js` is needed too, for the `player-java`
     // state below.
     "serve-viewer-rc-players",
     // The playground handoff this host cannot honour. Its whole claim is a NOTICE — an
@@ -1366,17 +1366,20 @@ const FIXTURE_STATES = [
     })),
     {
         // Switching player through the combo. The committed HTML always opens on the default
-        // (`Java`), so this is the only way the picker's *moved* state is diffed: the combo on
-        // `CMP Android`, and — the point of the whole control — the chip beside it renaming itself
-        // to match instead of the visitor having to read which of six chips lit up.
+        // (`CMP Android`), so this is the only way the picker's *moved* state is diffed: the combo
+        // on `Java`, and — the point of the whole control — the chip beside it renaming itself to
+        // match instead of the visitor having to read which of six chips lit up.
+        //
+        // It selects whichever lane is *not* the default, so it followed the default from
+        // `cmp-android` to `java` when #3936 flipped it. Selecting the default would leave the
+        // picker where it already is and diff nothing, which is the failure this note exists to
+        // prevent the next time the default moves.
         fixture: "serve-viewer-rc-players",
-        suffix: "player-cmp-android",
+        suffix: "player-java",
         apply: async (page) => {
-            await page.selectOption("#cp-lane-select", "rc:cmp-android");
+            await page.selectOption("#cp-lane-select", "rc:java");
             await page.waitForFunction(
-                () =>
-                    document.getElementById("cp-live-toggle-label")?.textContent ===
-                    "CMP Android",
+                () => document.getElementById("cp-live-toggle-label")?.textContent === "Java",
             );
         },
     },


### PR DESCRIPTION
Closes #3936 — step 3, the flip itself. The viewer's default lane for a Remote Compose preview moves from `java` (the view player) to `cmp-android` (the embedded Compose player).

## Why

The payoff is the data tier, not the pixels. `java` is `AndroidView { RemoteComposePlayer }`, so a whole document reaches Compose as **one interop leaf**: `compose/figma-svg` exports it as a single raster wearing an `.svg` extension, and the semantics tree describes a black box. The embedded player emits real Compose nodes, so the same document exports editable geometry and describes the card.

## What the lanes actually look like now

Step 2's bar was "re-run the A/B until the lanes agree, or until every remaining difference is understood and accepted." Measured over all 164 documents of the `homeassistant-remotecompose` catalog, both lanes on the same commit, scored with `scripts/rc-lane-ab/render-ab.sh` (pixelmatch with AA detection):

| result | at #3936 filing | now |
| --- | --- | --- |
| no differing pixels | 16 | **34** |
| differing, under 1% | 86 | 87 |
| differing, 1–5% | 59 | **40** |
| unrendered on the embedded lane | 2 | **0** |

Three defects the sweep found are fixed — #3977 (dynamic colours), #3995 (component-value expressions), #4008 (clip ordering) — and #4000 landed the bitmap isolation that keeps an unloadable image from costing the whole card.

**The residual is understood and is not player work.** It is overwhelmingly text rasterization: Compose's Skia stack and the Android canvas hint and fill glyphs differently. The worst-scoring document is visually indistinguishable between lanes. There is also a sub-LSB compositing difference on tinted fills where *neither* player is right (`#493C23` is the correct value; view paints `#493C22`, embedded `#4A3D23`). Full detail and images in `renders/rc-embedded-lane-ab/`.

One caution recorded there and worth repeating: the two `PictureEntity_AppMode` documents score as ~98% different, and that is the **embedded lane being more correct** — it draws the card with an empty image slot where the view player replaces the whole card with a black error panel. A parity score against the view lane is not the same thing as correctness.

## The change

One `when` branch in `ServeWeb.viewerPage`. `?rcPlayer=java` still selects the view player and `ServeOverrides` keeps accepting both spellings (`java`/`view`), so anything that needs the old lane can ask for it — the fallback order behind it (`java`, then `js`) is unchanged, so a host without the embedded lane behaves exactly as before.

## Fixtures and tests

- `ServeWebTest` — the two assertions that pinned `data-rc-default="java"` and the chip's opening label.
- `serve-viewer-rc-players.html` — regenerated with `UPDATE_SERVE_WEB_FIXTURES=true`; the diff is three lines, and `rc:java` remains an offered option.
- `pages-snapshot.spec.mjs` — the switched-player snapshot existed to diff the picker's *moved* state, so selecting the new default would have made it diff nothing. It now selects whichever lane is **not** the default (`java`), with a note so the next flip moves it again rather than quietly neutering it. Its baseline is renamed `player-java`.
- Two evidence READMEs that stated the default in prose.

## Test plan

`./gradlew :cli:test` green, including `ServeWebFixtureTest`'s sync assertion against the regenerated golden.

No new visual evidence in this body: the change is which lane the viewer *opens on*, and both lanes' rendered output is already captured side by side in `renders/rc-embedded-lane-ab/`. The picker's own appearance is unchanged apart from the chip's opening label, which the regenerated page fixture and its Playwright baseline cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYeKdEQJAhTrkmEx8CFQAw)_