### PR TITLE
fix(serve): keep disabled themes at spec baseline

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3802,7 +3802,7 @@ $noteBlock        <div class="cp-site-footer-links">
       // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
       // sync after controls change; this early write makes the element's initial read authoritative.
       if (root) {
-        var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+        var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
         root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
       }
       // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -987,6 +987,25 @@ class ServeWebTest {
   }
 
   @Test
+  fun `a disabled theme control keeps the published spec verdict at baseline`() {
+    // Static viewers cannot apply either a URL-selected or remembered theme. The sticky bootstrap
+    // may still display that choice and mark it active, but it must not suppress a score for pixels
+    // that remain exactly the baked snapshot.
+    val html = chipHtmlFor(DesignReferenceMatch(percent = 99.6))
+    assertTrue(
+      Regex("<select id=\"cp-theme\"[^>]* disabled>").containsMatchIn(html),
+      "the static viewer's theme control is disabled: $html",
+    )
+    assertTrue(
+      html.contains(
+        "var atSpecBaseline = el.disabled || " +
+          "el.getAttribute(\"data-theme-active\") !== \"1\";"
+      ),
+      "a disabled control cannot move the initial spec verdict off baseline: $html",
+    )
+  }
+
+  @Test
   fun `the match band colours the chip without deciding whether the number shows`() {
     // Bands are read off the distribution a real catalog produces, not off round numbers: across
     // m3-catalog's 120 published pairs the median is 99.70%, so `match` is the quiet majority.


### PR DESCRIPTION
## Summary

- keep the server-baked spec verdict at baseline when the theme selector is disabled
- add regression coverage for static viewers whose URL or stored theme can still mark the selector active

## Root cause

The early baseline bootstrap added in #4001 checked only `data-theme-active`. Static viewers can display a URL-selected or remembered theme while their selector is disabled, so that flag does not mean the rendered pixels actually changed. This guard now mirrors `activeThemeChoice()` by treating disabled controls as unable to emit an override.

## Verification

`JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :cli:test --tests 'ee.schimke.composeai.cli.serve.ServeWebTest' --no-daemon`

Follow-up to the unresolved review feedback on #4001.