### PR TITLE
fix(playground): harden editing lease state

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -96,11 +96,21 @@ data class PlaygroundEditLeaseResponse(
   val acquired: Boolean,
   val lease: String? = null,
   val expiresAtEpochMs: Long? = null,
+  /** Last revision accepted by this lease, so a reattached editor can continue monotonically. */
+  val revision: Long = 0,
   val message: String,
 )
 
+/** Body for `POST /api/{version}/compiler/edit-lease`. [client] is unique to one browser tab. */
+@Serializable data class PlaygroundEditLeaseAcquireRequest(val client: String = "")
+
 /** Body for `POST /api/{version}/compiler/edit-lease/release`. */
-@Serializable data class PlaygroundEditLeaseReleaseRequest(val lease: String = "")
+@Serializable
+data class PlaygroundEditLeaseReleaseRequest(
+  val lease: String = "",
+  /** Empty preserves the original whole-lease release contract for non-browser API callers. */
+  val client: String = "",
+)
 
 /**
  * One entry in the editor's catalog selector (`GET /api/{version}/compiler/catalogs`).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -2,7 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import java.security.SecureRandom
 import java.util.Base64
-import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import okio.FileSystem
 import okio.Path
@@ -103,13 +103,16 @@ class PlaygroundCompileService(
   private val editLeaseTtlMillis: Long = DEFAULT_EDIT_LEASE_TTL_MILLIS,
   private val nowMillis: () -> Long = System::currentTimeMillis,
   /** Schedules idle-lease reclamation; injectable so expiry behavior is deterministic in tests. */
-  private val scheduleEditLeaseExpiry: (Long, () -> Unit) -> Unit = { delayMillis, task ->
-    EDIT_LEASE_EXPIRY_EXECUTOR.schedule(task, delayMillis, TimeUnit.MILLISECONDS)
+  private val scheduleEditLeaseExpiry: (Long, () -> Unit) -> (() -> Unit) = { delayMillis, task ->
+    val future = EDIT_LEASE_EXPIRY_EXECUTOR.schedule(task, delayMillis, TimeUnit.MILLISECONDS)
+    val cancel: () -> Unit = { future.cancel(false) }
+    cancel
   },
 ) {
 
   private val editLock = Any()
   private var editLease: EditLease? = null
+  private var cancelEditLeaseExpiry: (() -> Unit)? = null
   private var editLeaseAcquisitions = 0L
   private var editCompileAttempts = 0L
   private var editIncrementalCompiles = 0L
@@ -135,6 +138,7 @@ class PlaygroundCompileService(
     var config: Pair<PlaygroundMode, String?>? = null,
     var files: Map<String, String> = emptyMap(),
     var incrementalReady: Boolean = false,
+    val holders: MutableSet<String> = mutableSetOf(),
   )
 
   /**
@@ -312,7 +316,7 @@ class PlaygroundCompileService(
     }
   }
 
-  fun acquireEditLease(owner: String): PlaygroundEditLeaseResponse =
+  fun acquireEditLease(owner: String, client: String = ""): PlaygroundEditLeaseResponse =
     synchronized(editLock) {
       if (!editLeasesEnabled) {
         return@synchronized PlaygroundEditLeaseResponse(
@@ -326,10 +330,27 @@ class PlaygroundCompileService(
           message = "GitHub sign-in is required for live editing.",
         )
       }
+      if (client.length > MAX_EDIT_LEASE_CLIENT_LENGTH) {
+        return@synchronized PlaygroundEditLeaseResponse(
+          false,
+          message = "The live-edit client id is too long.",
+        )
+      }
       purgeExpiredEditLeaseLocked()
       val existing = editLease
       if (existing != null) {
         if (existing.owner == owner) {
+          if (
+            client.isNotBlank() &&
+              client !in existing.holders &&
+              existing.holders.size >= MAX_EDIT_LEASE_HOLDERS
+          ) {
+            return@synchronized PlaygroundEditLeaseResponse(
+              false,
+              message = "The live-edit lease already has too many browser tabs attached.",
+            )
+          }
+          if (client.isNotBlank()) existing.holders += client
           renewEditLeaseLocked(existing)
           refreshEditHealthLocked()
           return@synchronized existing.response("You already hold the live-edit lease.")
@@ -356,6 +377,7 @@ class PlaygroundCompileService(
           owner = owner,
           workDir = workDir,
           expiresAt = nowMillis() + editLeaseTtlMillis,
+          holders = mutableSetOf<String>().apply { if (client.isNotBlank()) add(client) },
         )
       editLease = lease
       editLeaseAcquisitions++
@@ -378,12 +400,20 @@ class PlaygroundCompileService(
     }
   }
 
-  fun releaseEditLease(owner: String, id: String): Boolean =
+  fun releaseEditLease(owner: String, id: String, client: String = ""): Boolean =
     synchronized(editLock) {
       purgeExpiredEditLeaseLocked()
       val lease = editLease ?: return@synchronized false
       if (lease.owner != owner || lease.id != id) return@synchronized false
+      if (client.isNotBlank()) {
+        if (!lease.holders.remove(client)) return@synchronized false
+        if (lease.holders.isNotEmpty()) {
+          refreshEditHealthLocked()
+          return@synchronized true
+        }
+      }
       editLease = null
+      cancelEditLeaseExpiryLocked()
       cleanup(lease.workDir)
       refreshEditHealthLocked()
       true
@@ -394,6 +424,7 @@ class PlaygroundCompileService(
       acquired = true,
       lease = id,
       expiresAtEpochMs = expiresAt,
+      revision = lastRevision,
       message = message,
     )
 
@@ -401,6 +432,7 @@ class PlaygroundCompileService(
     val lease = editLease ?: return
     if (lease.expiresAt > nowMillis()) return
     editLease = null
+    cancelEditLeaseExpiryLocked()
     cleanup(lease.workDir)
     refreshEditHealthLocked()
   }
@@ -411,22 +443,30 @@ class PlaygroundCompileService(
   }
 
   private fun scheduleEditLeaseExpiryLocked(lease: EditLease) {
+    cancelEditLeaseExpiryLocked()
     val leaseId = lease.id
     val deadline = lease.expiresAt
-    scheduleEditLeaseExpiry((deadline - nowMillis()).coerceAtLeast(0L)) {
-      synchronized(editLock) {
-        val current = editLease ?: return@synchronized
-        // A release/reacquire or renewal supersedes this particular deadline's task.
-        if (current.id != leaseId || current.expiresAt != deadline) return@synchronized
-        if (current.expiresAt <= nowMillis()) {
-          purgeExpiredEditLeaseLocked()
-        } else {
-          // Wall-clock adjustment or an early scheduler wakeup: retain the lease and try again at
-          // the remaining deadline rather than leaking its workspace.
-          scheduleEditLeaseExpiryLocked(current)
+    cancelEditLeaseExpiry =
+      scheduleEditLeaseExpiry((deadline - nowMillis()).coerceAtLeast(0L)) {
+        synchronized(editLock) {
+          val current = editLease ?: return@synchronized
+          // A release/reacquire or renewal supersedes this particular deadline's task.
+          if (current.id != leaseId || current.expiresAt != deadline) return@synchronized
+          cancelEditLeaseExpiry = null
+          if (current.expiresAt <= nowMillis()) {
+            purgeExpiredEditLeaseLocked()
+          } else {
+            // Wall-clock adjustment or an early scheduler wakeup: retain the lease and try again at
+            // the remaining deadline rather than leaking its workspace.
+            scheduleEditLeaseExpiryLocked(current)
+          }
         }
       }
-    }
+  }
+
+  private fun cancelEditLeaseExpiryLocked() {
+    cancelEditLeaseExpiry?.invoke()
+    cancelEditLeaseExpiry = null
   }
 
   private fun refreshEditHealthLocked() {
@@ -520,6 +560,20 @@ class PlaygroundCompileService(
           refreshEditHealthLocked()
           throw t
         }
+      // Admission happens before the jailed compiler is launched. A busy response therefore did
+      // not compile or mutate IC state: report it without accepting the staged files/revision, so
+      // the complete dirty set is retried on the next Run.
+      if (compile.diagnostics.isCompileAdmissionFailure()) {
+        editLastCompileMillis = (System.nanoTime() - compileStarted) / 1_000_000
+        renewEditLeaseLocked(lease)
+        refreshEditHealthLocked()
+        return@synchronized PlaygroundRunResponse(
+          diagnostics = compile.diagnostics,
+          errors = PlaygroundErrorsWire.project(compile.diagnostics),
+          editLease = lease.id,
+          revision = lease.lastRevision.takeIf { it > 0 },
+        )
+      }
       // An internal BTA/IC failure has no source position. Reset only this lease and retry the same
       // revision through the proven full path; ordinary source diagnostics stay incremental.
       if (compile.diagnostics.isInfrastructureCompileFailure()) {
@@ -772,6 +826,11 @@ class PlaygroundCompileService(
         single().message.startsWith("the compile sandbox produced no result") ||
         single().message.startsWith("unreadable compile report:"))
 
+  private fun List<PlaygroundDiagnostic>.isCompileAdmissionFailure(): Boolean =
+    size == 1 &&
+      single().file == null &&
+      single().message.startsWith("the playground is busy compiling")
+
   private fun cleanup(workDir: Path) {
     try {
       fileSystem.deleteRecursively(workDir, mustExist = false)
@@ -784,12 +843,19 @@ class PlaygroundCompileService(
 
   companion object {
     const val DEFAULT_EDIT_LEASE_TTL_MILLIS: Long = 15 * 60 * 1000L
+    private const val MAX_EDIT_LEASE_CLIENT_LENGTH = 128
+    private const val MAX_EDIT_LEASE_HOLDERS = 32
 
     private val EDIT_LEASE_RANDOM = SecureRandom()
     private val EDIT_LEASE_EXPIRY_EXECUTOR =
-      Executors.newSingleThreadScheduledExecutor { runnable ->
-        Thread(runnable, "playground-edit-lease-expiry").apply { isDaemon = true }
-      }
+      ScheduledThreadPoolExecutor(1) { runnable ->
+          Thread(runnable, "playground-edit-lease-expiry").apply { isDaemon = true }
+        }
+        .apply {
+          // Renewals cancel the old deadline; remove it immediately rather than retaining a
+          // cancelled task in the delayed queue until the original TTL elapses.
+          removeOnCancelPolicy = true
+        }
 
     private fun newEditLeaseId(): String {
       val bytes = ByteArray(18)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1694,7 +1694,25 @@ class ServeHttpServer(
       )
       return
     }
-    val result = withContext(Dispatchers.IO) { service.acquireEditLease(owner) }
+    val body =
+      withContext(Dispatchers.IO) {
+        call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
+      }
+    val request =
+      if (body == null || body.isEmpty()) PlaygroundEditLeaseAcquireRequest()
+      else
+        runCatching {
+          JSON.decodeFromString(
+            PlaygroundEditLeaseAcquireRequest.serializer(),
+            body.decodeToString(),
+          )
+        }
+          .getOrNull()
+    if (request == null) {
+      call.respondText("Invalid live-edit lease request.", status = HttpStatusCode.BadRequest)
+      return
+    }
+    val result = withContext(Dispatchers.IO) { service.acquireEditLease(owner, request.client) }
     call.respondText(
       JSON.encodeToString(PlaygroundEditLeaseResponse.serializer(), result),
       ContentType.Application.Json,
@@ -1729,7 +1747,9 @@ class ServeHttpServer(
       }
         .getOrNull()
     }
-    if (request == null || !service.releaseEditLease(owner, request.lease)) {
+    if (
+      request == null || !service.releaseEditLease(owner, request.lease, client = request.client)
+    ) {
       call.respondText("Live-edit lease not found.", status = HttpStatusCode.NotFound)
       return
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4621,9 +4621,14 @@ $noteBlock        <div class="cp-site-footer-links">
       var suffix = ${jsString(querySuffix)};
       var editLease = null;
       var editRevision = 0;
+      // One holder per document/tab: closing one tab must not tear down another tab's shared
+      // owner-wide incremental workspace.
+      var editClient = (window.crypto && typeof window.crypto.randomUUID === "function")
+        ? window.crypto.randomUUID()
+        : (Date.now().toString(36) + "-" + Math.random().toString(36).slice(2));
       function releaseEditLeaseOnDiscard() {
         if (!editLease) return;
-        var body = JSON.stringify({ lease: editLease });
+        var body = JSON.stringify({ lease: editLease, client: editClient });
         var url = "/api/1/compiler/edit-lease/release" + suffix;
         editLease = null;
         if (navigator.sendBeacon) {
@@ -4644,9 +4649,9 @@ $noteBlock        <div class="cp-site-footer-links">
         // server TTL as the hard fallback.
         if (!event.persisted) releaseEditLeaseOnDiscard();
       });
-      function setEditLease(value, message, expiresAt) {
+      function setEditLease(value, message, expiresAt, revision) {
         editLease = value;
-        editRevision = 0;
+        editRevision = value && Number.isFinite(revision) ? revision : 0;
         if (!editLeaseButton) return;
         editLeaseButton.disabled = false;
         editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
@@ -4664,7 +4669,9 @@ $noteBlock        <div class="cp-site-footer-links">
           editLeaseButton.disabled = true;
           if (!editLease) {
             fetch("/api/1/compiler/edit-lease" + suffix, {
-              method: "POST", headers: { "Accept": "application/json" }
+              method: "POST",
+              headers: { "Accept": "application/json", "Content-Type": "application/json" },
+              body: JSON.stringify({ client: editClient })
             })
               .then(function (r) {
                 return r.json().then(function (body) {
@@ -4673,7 +4680,7 @@ $noteBlock        <div class="cp-site-footer-links">
                 });
               })
               .then(function (body) {
-                setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+                setEditLease(body.lease, body.message, body.expiresAtEpochMs, body.revision);
               })
               .catch(function (e) {
                 setEditLease(null, e.message || "Could not acquire editing lease.");
@@ -4683,7 +4690,7 @@ $noteBlock        <div class="cp-site-footer-links">
             fetch("/api/1/compiler/edit-lease/release" + suffix, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ lease: releasing })
+              body: JSON.stringify({ lease: releasing, client: editClient })
             })
               .then(function (r) {
                 if (!r.ok) throw new Error("The editing lease has already expired.");

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -37,7 +37,7 @@ class PlaygroundCompileServiceTest {
     editLeasesEnabled: Boolean = false,
     editLeaseTtlMillis: Long = PlaygroundCompileService.DEFAULT_EDIT_LEASE_TTL_MILLIS,
     nowMillis: () -> Long = { 1_000L },
-    scheduleEditLeaseExpiry: (Long, () -> Unit) -> Unit = { _, _ -> },
+    scheduleEditLeaseExpiry: (Long, () -> Unit) -> (() -> Unit) = { _, _ -> {} },
   ) =
     PlaygroundCompileService(
       catalogClasspath = { mode, _ -> classpathFor(mode) },
@@ -592,6 +592,61 @@ class PlaygroundCompileServiceTest {
   }
 
   @Test
+  fun `renewing a lease cancels the superseded expiry task`() {
+    var scheduled = 0
+    var cancelled = 0
+    val svc =
+      service(
+        editLeasesEnabled = true,
+        scheduleEditLeaseExpiry = { _, _ ->
+          scheduled++
+          { cancelled++ }
+        },
+      )
+
+    val lease = svc.acquireEditLease("alice", client = "tab-a").lease!!
+    svc.acquireEditLease("alice", client = "tab-a")
+
+    assertEquals(2, scheduled)
+    assertEquals(1, cancelled, "renewal removes the old delayed task")
+    assertTrue(svc.releaseEditLease("alice", lease, client = "tab-a"))
+    assertEquals(2, cancelled, "release removes the active delayed task")
+  }
+
+  @Test
+  fun `one tab release retains a lease held by another tab`() {
+    val svc = service(editLeasesEnabled = true)
+    val first = svc.acquireEditLease("alice", client = "tab-a")
+    val second = svc.acquireEditLease("alice", client = "tab-b")
+
+    assertEquals(first.lease, second.lease)
+    assertTrue(svc.releaseEditLease("alice", first.lease!!, client = "tab-a"))
+    assertTrue(svc.editLeaseHealth().active)
+    assertTrue(fs.metadataOrNull("/work/run1".toPath())?.isDirectory == true)
+
+    assertTrue(svc.releaseEditLease("alice", first.lease!!, client = "tab-b"))
+    assertFalse(svc.editLeaseHealth().active)
+    assertNull(fs.metadataOrNull("/work/run1".toPath()))
+  }
+
+  @Test
+  fun `reattaching a tab reports the accepted server revision`() {
+    val svc = service(editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice", client = "tab-a").lease!!
+    val response =
+      svc.run(
+        request().copy(editLease = lease, revision = 7),
+        isSecurityChecked = true,
+        authenticatedOwner = "alice",
+      )
+    assertNotNull(response.previewToken)
+
+    val reattached = svc.acquireEditLease("alice", client = "tab-b")
+    assertEquals(lease, reattached.lease)
+    assertEquals(7, reattached.revision)
+  }
+
+  @Test
   fun `an abandoned editing lease deletes its workspace at the idle deadline`() {
     var now = 1_000L
     val scheduled = mutableListOf<Pair<Long, () -> Unit>>()
@@ -600,7 +655,10 @@ class PlaygroundCompileServiceTest {
         editLeasesEnabled = true,
         editLeaseTtlMillis = 5_000L,
         nowMillis = { now },
-        scheduleEditLeaseExpiry = { delay, task -> scheduled += delay to task },
+        scheduleEditLeaseExpiry = { delay, task ->
+          scheduled += delay to task
+          {}
+        },
       )
 
     val lease = svc.acquireEditLease("alice")
@@ -734,6 +792,67 @@ class PlaygroundCompileServiceTest {
     assertEquals(2, health.compileAttempts)
     assertEquals(2, health.incrementalCompiles)
     assertEquals(0, health.fullFallbacks)
+  }
+
+  @Test
+  fun `busy compiler does not accept files or revision and retries the full dirty set`() {
+    data class Call(val modified: List<String>, val firstBuild: Boolean)
+
+    val calls = mutableListOf<Call>()
+    var attempt = 0
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ) = emptyList<PlaygroundDiagnostic>()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult {
+          calls += Call(modified.map { it.name }, firstBuild)
+          attempt++
+          if (attempt == 1) {
+            return PlaygroundCompileService.IncrementalCompileResult(
+              diagnostics =
+                listOf(
+                  PlaygroundDiagnostic(
+                    PlaygroundSeverity.ERROR,
+                    "the playground is busy compiling (all 1 compile slots in use) — try again shortly",
+                  )
+                ),
+              incremental = false,
+            )
+          }
+          fs.createDirectories(outputDir)
+          fs.write(outputDir / "Snippet.class") { writeUtf8("compiled") }
+          return PlaygroundCompileService.IncrementalCompileResult(emptyList(), false)
+        }
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+    val edit = request(text = "@Preview fun P() = println(1)").copy(editLease = lease)
+
+    val busy = svc.run(edit.copy(revision = 1), true, authenticatedOwner = "alice")
+    assertTrue(busy.diagnostics.single().message.startsWith("the playground is busy"))
+    assertNull(busy.revision)
+    assertNull(svc.editLeaseHealth().lastRevision)
+
+    val retried = svc.run(edit.copy(revision = 2), true, authenticatedOwner = "alice")
+    assertNotNull(retried.previewToken)
+    assertEquals(
+      listOf(Call(listOf("Snippet.kt"), true), Call(listOf("Snippet.kt"), true)),
+      calls,
+      "the rejected attempt does not become the source or IC baseline",
+    )
+    assertEquals(2, svc.editLeaseHealth().lastRevision)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -331,10 +331,16 @@ class PlaygroundRoutingTest {
   fun `authenticated user acquires the single editing lease and compiles a revision`() {
     val cookie = githubSessionCookie(githubRepoServer.port)
     val lease =
-      post("/api/1/compiler/edit-lease", "{}", githubRepoServer.port, cookie).use { resp ->
-        assertEquals(200, resp.code)
-        Json.parseToJsonElement(resp.body!!.string()).jsonObject["lease"]!!.jsonPrimitive.content
-      }
+      post(
+          "/api/1/compiler/edit-lease",
+          """{"client":"tab-a"}""",
+          githubRepoServer.port,
+          cookie,
+        )
+        .use { resp ->
+          assertEquals(200, resp.code)
+          Json.parseToJsonElement(resp.body!!.string()).jsonObject["lease"]!!.jsonPrimitive.content
+        }
     val body =
       """{"files":[{"name":"Snippet.kt","text":"@Preview fun P(){}"}],"confType":"compose-cmp","editLease":"$lease","revision":1}"""
 
@@ -345,6 +351,19 @@ class PlaygroundRoutingTest {
       assertEquals(lease, json["editLease"]?.jsonPrimitive?.content)
       assertTrue(json["previewToken"]?.jsonPrimitive?.content?.startsWith("pg_") == true)
     }
+
+    post(
+        "/api/1/compiler/edit-lease",
+        """{"client":"tab-b"}""",
+        githubRepoServer.port,
+        cookie,
+      )
+      .use { resp ->
+        assertEquals(200, resp.code)
+        val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+        assertEquals(lease, json["lease"]?.jsonPrimitive?.content)
+        assertEquals("1", json["revision"]?.jsonPrimitive?.content)
+      }
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
@@ -81,6 +81,9 @@ class ServeWebPlaygroundCatalogTest {
     assertTrue(html.contains("window.addEventListener(\"pagehide\""))
     assertTrue(html.contains("navigator.sendBeacon(url"))
     assertTrue(html.contains("if (!event.persisted) releaseEditLeaseOnDiscard()"))
+    assertTrue(html.contains("JSON.stringify({ client: editClient })"))
+    assertTrue(html.contains("JSON.stringify({ lease: editLease, client: editClient })"))
+    assertTrue(html.contains("body.expiresAtEpochMs, body.revision"))
   }
 
   @Test


### PR DESCRIPTION
## Summary

- keep rejected busy-compilation attempts out of the incremental source and revision baseline
- attach browser tabs as distinct holders so closing one tab does not release another tab's lease
- return the server's accepted revision when a tab attaches and resume the client counter from it
- cancel and immediately remove superseded expiry tasks instead of retaining them for the full TTL

## Root cause

The initial production trial treated the authenticated owner as the browser holder, even though multiple tabs can share that owner and lease. It also modeled deadline renewal as append-only delayed callbacks and treated every compiler diagnostic as a completed compile, including admission failures produced before the jailed compiler starts.

## Behavior

The acquire/release protocol now carries a bounded per-tab client id. A tab release removes only that holder; the workspace is reclaimed when the last holder releases or the idle TTL expires. Reattachment reports `revision`, allowing the editor to continue monotonically. Busy admission returns diagnostics without advancing `files`, `lastRevision`, or IC readiness, so the full dirty set is retried.

Expiry renewal now cancels the previous scheduled future, and the shared scheduled executor removes cancelled tasks from its delayed queue immediately.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundCompileServiceTest --tests ee.schimke.composeai.cli.serve.PlaygroundRoutingTest --tests ee.schimke.composeai.cli.serve.ServeWebPlaygroundCatalogTest`
- regression coverage for busy retry state, multi-tab release, revision reattachment, and expiry-task cancellation
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD`
