### PR TITLE
fix(playground): retain last editing revision

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -117,6 +117,7 @@ class PlaygroundCompileService(
   private var editCompileAttempts = 0L
   private var editIncrementalCompiles = 0L
   private var editFullFallbacks = 0L
+  private var editLastRevision: Long? = null
   private var editLastCompileMillis: Long? = null
   @Volatile
   private var editHealthSnapshot =
@@ -476,7 +477,9 @@ class PlaygroundCompileService(
         enabled = editLeasesEnabled,
         active = lease != null,
         expiresAtEpochMs = lease?.expiresAt,
-        lastRevision = lease?.lastRevision?.takeIf { it > 0 },
+        // Process-lifetime soak telemetry, like the neighboring counters: retain the last accepted
+        // revision after its lease releases or expires so operators can inspect a completed trial.
+        lastRevision = editLastRevision,
         acquisitions = editLeaseAcquisitions,
         compileAttempts = editCompileAttempts,
         incrementalCompiles = editIncrementalCompiles,
@@ -595,6 +598,7 @@ class PlaygroundCompileService(
       editLastCompileMillis = (System.nanoTime() - compileStarted) / 1_000_000
       lease.files = desired
       lease.lastRevision = request.revision
+      editLastRevision = request.revision
       refreshEditHealthLocked()
 
       val diagnostics = compile.diagnostics

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -647,6 +647,34 @@ class PlaygroundCompileServiceTest {
   }
 
   @Test
+  fun `last accepted revision survives lease expiry and release`() {
+    var now = 1_000L
+    val svc =
+      service(
+        editLeasesEnabled = true,
+        editLeaseTtlMillis = 5_000L,
+        nowMillis = { now },
+      )
+    val alice = svc.acquireEditLease("alice").lease!!
+    val response =
+      svc.run(
+        request().copy(editLease = alice, revision = 7),
+        isSecurityChecked = true,
+        authenticatedOwner = "alice",
+      )
+    assertNotNull(response.previewToken)
+
+    now = 6_001L
+    val bob = svc.acquireEditLease("bob").lease!! // Purges Alice's expired lease.
+    assertEquals(7, svc.editLeaseHealth().lastRevision)
+
+    assertTrue(svc.releaseEditLease("bob", bob))
+    val completed = svc.editLeaseHealth()
+    assertFalse(completed.active)
+    assertEquals(7, completed.lastRevision)
+  }
+
+  @Test
   fun `an abandoned editing lease deletes its workspace at the idle deadline`() {
     var now = 1_000L
     val scheduled = mutableListOf<Pair<Long, () -> Unit>>()


### PR DESCRIPTION
## Summary

- retain the last accepted Playground editing revision after lease release or expiry
- keep `/status.json` soak telemetry process-lifetime, matching the neighboring counters
- cover both expiry-driven replacement and explicit release

## Root cause

`playground.editing.lastRevision` was projected directly from the active lease. Clearing the lease therefore erased the most recent revision precisely when an operator might inspect a completed production soak.

## Behavior

The service now tracks the last accepted revision independently of the active lease. Busy admission failures remain excluded because the value updates only when the lease's source/revision baseline is accepted.

## Validation

- `./gradlew :cli:ktfmtCheckMain :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundCompileServiceTest`
- regression coverage for revision retention across expiry and release
- `git diff --check origin/main...HEAD`
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD`

Note: current `main` has an unrelated pre-existing `:cli:ktfmtCheckTest` failure in `ServeWebTest.kt`; this PR does not modify that file.
