### PR TITLE
fix(rc-embedded-player): skip nested bitmap setup

### DIFF
--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -46,6 +46,7 @@ import androidx.compose.remote.player.compose.embedded.RcPlayerRawDocument
 import androidx.compose.remote.player.compose.embedded.RcPlayerRootLayoutComponent
 import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
 import androidx.compose.remote.player.compose.embedded.applyDataOperationsWithoutBitmaps
+import androidx.compose.remote.player.compose.embedded.applyOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.applyOperationsReflection
 import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
@@ -315,7 +316,7 @@ private fun initDrawContext(
         } else {
           document.getOperationsReflection()
         }
-      document.applyOperationsReflection(context, globalOps.withoutBitmaps())
+      document.applyOperationsWithoutBitmaps(context, globalOps)
 
       // Themed colours, before the `ColorTheme` ops in `constantOps` are applied — `ColorTheme`
       // reads the fields resolution overwrites, so resolving afterwards is resolving too late.
@@ -349,7 +350,7 @@ private fun initDrawContext(
 
       val dataOps = ArrayList<Operation>()
       document.rootLayoutComponent?.getData(dataOps, true)
-      document.applyOperationsReflection(context, dataOps.withoutBitmaps())
+      document.applyOperationsWithoutBitmaps(context, dataOps)
     }
   }
 
@@ -397,10 +398,6 @@ private fun findBitmaps(operations: Collection<Operation>, list: MutableList<Bit
     if (op is Container) findBitmaps(op.getList(), list)
   }
 }
-
-/** Bitmap pixels are resolved on first draw; setup passes must only apply the other data ops. */
-private fun Collection<Operation>.withoutBitmaps(): ArrayList<Operation> =
-  filterTo(ArrayList(size)) { it !is BitmapData }
 
 /** Collect every constant-like op in the tree. Mirrors `RcPlayer.kt`'s inline constant walk. */
 private fun collectConstants(operations: Collection<Operation>, out: MutableList<Operation>) {

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/CoreDataAccessors.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/CoreDataAccessors.kt
@@ -435,7 +435,15 @@ internal fun CoreDocument.applyDataOperationsWithoutBitmaps(context: RemoteConte
   }
 }
 
-private fun applyOperationsWithoutBitmaps(
+/** Apply an operation tree while preserving containers and skipping every nested [BitmapData]. */
+internal fun CoreDocument.applyOperationsWithoutBitmaps(
+  context: RemoteContext,
+  operations: Collection<Operation>,
+) {
+  applyOperationsWithoutBitmapsRecursively(context, operations)
+}
+
+private fun applyOperationsWithoutBitmapsRecursively(
   context: RemoteContext,
   operations: Collection<Operation>,
 ) {
@@ -447,7 +455,7 @@ private fun applyOperationsWithoutBitmaps(
     context.incrementOpCount()
     if (operation is Container) {
       if (operation is ComponentData) operation.apply(context)
-      applyOperationsWithoutBitmaps(context, operation.getList())
+      applyOperationsWithoutBitmapsRecursively(context, operation.getList())
     } else {
       operation.apply(context)
     }

--- a/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayer.kt
@@ -214,7 +214,7 @@ public fun RcPlayer(
         } else {
           document.getOperationsReflection()
         }
-      document.applyOperationsReflection(it, globalOps.withoutBitmaps())
+      document.applyOperationsWithoutBitmaps(it, globalOps)
 
       val constantOps = ArrayList<Operation>()
       fun walk(ops: Collection<Operation>) {
@@ -252,7 +252,7 @@ public fun RcPlayer(
 
       val dataOps = ArrayList<Operation>()
       document.rootLayoutComponent?.getData(dataOps, true)
-      document.applyOperationsReflection(it, dataOps.withoutBitmaps())
+      document.applyOperationsWithoutBitmaps(it, dataOps)
     }
   }
 
@@ -551,10 +551,6 @@ private fun findBitmaps(operations: Collection<Operation>, list: MutableList<Bit
     }
   }
 }
-
-/** Bitmap pixels are resolved on first draw; setup passes must only apply the other data ops. */
-private fun Collection<Operation>.withoutBitmaps(): ArrayList<Operation> =
-  filterTo(ArrayList(size)) { it !is BitmapData }
 
 private fun findComponentValues(
   operations: Collection<Operation>,

--- a/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerBitmapFailureTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerBitmapFailureTest.kt
@@ -18,7 +18,12 @@
 
 package androidx.compose.remote.player.compose.embedded
 
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.Operation
+import androidx.compose.remote.core.RemoteContext
+import androidx.compose.remote.core.WireBuffer
 import androidx.compose.remote.core.operations.BitmapData
+import androidx.compose.remote.core.operations.layout.Container
 import androidx.compose.remote.player.core.platform.AndroidRemoteContext
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -50,6 +55,41 @@ class RcPlayerBitmapFailureTest {
     assertNull(resolveBitmap(context, IMAGE_ID))
     // The failed decode is memoized, so another frame remains empty without retrying or throwing.
     assertNull(resolveBitmap(context, IMAGE_ID))
+  }
+
+  @Test
+  fun nestedRelativeUriIsSkippedDuringSetupTraversal() {
+    val context = AndroidRemoteContext()
+    val state = SnapshotRemoteComposeState()
+    context.mRemoteComposeState = state
+    val bitmap = relativeUriBitmap()
+    context.putObject(IMAGE_ID, bitmap)
+    val operations = arrayListOf<Operation>(TestContainer(arrayListOf(bitmap)))
+
+    CoreDocument().applyOperationsWithoutBitmaps(context, operations)
+
+    assertNull("setup must not decode the nested bitmap", state.getFromId(IMAGE_ID))
+  }
+
+  private fun relativeUriBitmap(): BitmapData =
+    BitmapData(
+      IMAGE_ID,
+      BitmapData.TYPE_PNG,
+      64,
+      BitmapData.ENCODING_URL,
+      64,
+      "camera/current".toByteArray(),
+    )
+
+  private class TestContainer(private val operations: ArrayList<Operation>) :
+    Operation(), Container {
+    override fun getList(): ArrayList<Operation> = operations
+
+    override fun write(buffer: WireBuffer) = Unit
+
+    override fun apply(context: RemoteContext) = Unit
+
+    override fun deepToString(indent: String): String = "${indent}TestContainer"
   }
 
   private companion object {


### PR DESCRIPTION
## What changed

- expose the recursive bitmap-skipping operation traversal for setup subsets
- use it for the Android and JVM global/data setup passes
- remove the shallow top-level bitmap filters
- add a regression test with a relative-URI bitmap nested inside a container

## Why

Follow-up to #4000 and [review feedback](https://github.com/yschimke/compose-ai-tools/pull/4000#discussion_r3791675988). The original shallow filter removed direct `BitmapData` entries but retained containers, allowing the core traversal to recurse into nested bitmap operations and decode them eagerly.

## Impact

Nested unloadable images now remain lazy during every setup pass, matching the behavior already provided for top-level images. Other container operations retain their existing ordering and bookkeeping.

## Validation

- `:third-party-rc-embedded-player:testDebugUnitTest`
- focused JVM URL-bitmap parser, bitmap-context, and renderer tests
- module formatting and diff checks