### PR TITLE
fix(ci): repair main build failures

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -998,8 +998,7 @@ class ServeWebTest {
     )
     assertTrue(
       html.contains(
-        "var atSpecBaseline = el.disabled || " +
-          "el.getAttribute(\"data-theme-active\") !== \"1\";"
+        "var atSpecBaseline = el.disabled || " + "el.getAttribute(\"data-theme-active\") !== \"1\";"
       ),
       "a disabled control cannot move the initial spec verdict off baseline: $html",
     )

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -121,13 +121,11 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
           }
           lastIndex.value = tabIndex
         }
-        // `@FocusedPreview(pressed = true)` — after the focus walk lands, dispatch an
-        // indirect-pointer Press onto the focused composable so its `PressInteraction.Press` fires
-        // before the renderer captures pixels. Glimmer's `Modifier.onIndirectPointerGesture`
-        // observes this event on the focused-target path and emits the pressed-state interaction.
-        // If no indirect-pointer modifier consumes it, fall back to a focused DPAD_CENTER key-down:
-        // Wear M3 Button is built from `combinedClickable`, which has no indirect-pointer handler,
-        // but does own the normal focused-key press path. See [dispatchPress] for the rationale.
+        // `@FocusedPreview(pressed = true)` — after the focus walk lands, dispatch a Press onto the
+        // focused composable so its `PressInteraction.Press` fires before the renderer captures
+        // pixels. Prefer the normal focused-key path used by clickable components (including Wear
+        // M3 Button), then fall back to indirect-pointer input for Glimmer-specific gestures. See
+        // [dispatchPress] for the platform rationale.
         // The matching Release is held off
         // until the NEXT capture's LaunchedEffect runs (above) — held-press across the capture
         // window is exactly the "finger held on touchpad" shape we want pixels to show.
@@ -163,10 +161,15 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
 }
 
 /**
- * Dispatches a held Press through the focused component's real input path. It first sends an
+ * Dispatches a held Press through the focused component's real input path. It first sends a focused
+ * DPAD_CENTER key-down, which covers Compose components built from `clickable` or
+ * `combinedClickable`, including Wear M3 Button. When that event is unhandled, it falls back to an
  * indirect-pointer event through Compose UI's `AndroidComposeView.sendIndirectPointerEvent` — the
- * same channel real XR Glasses touchpads use. When that event is unhandled, it falls back to a
- * focused DPAD_CENTER key-down, which covers Wear components built from `combinedClickable`.
+ * same channel real XR Glasses touchpads use.
+ *
+ * Key input must be tried first. `AndroidComposeView.sendIndirectPointerEvent` can report that the
+ * root handled an event even when the focused component has no indirect-pointer modifier; treating
+ * that result as proof of a component Press prevented the key fallback from ever reaching Wear M3.
  *
  * The matching Release isn't sent here — it's deferred to the next capture's `LaunchedEffect` pass
  * (via the `pressHeld` flag) so the composable stays in its pressed state for *this* capture window
@@ -196,9 +199,9 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
  */
 @OptIn(ExperimentalIndirectPointerApi::class)
 private fun View.dispatchPress(): PressChannel {
-  if (sendIndirectPointer(MotionEvent.ACTION_DOWN)) return PressChannel.IndirectPointer
-  dispatchKeyPress()
-  return PressChannel.Key
+  if (dispatchKeyPress()) return PressChannel.Key
+  sendIndirectPointer(MotionEvent.ACTION_DOWN)
+  return PressChannel.IndirectPointer
 }
 
 /**
@@ -245,9 +248,8 @@ private fun View.sendIndirectPointer(action: Int): Boolean {
  * turns its down/up pair into the same held `PressInteraction.Press` / release lifecycle as a
  * physical button press.
  */
-private fun View.dispatchKeyPress() {
+private fun View.dispatchKeyPress(): Boolean =
   dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_CENTER))
-}
 
 private fun View.dispatchKeyRelease() {
   dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DPAD_CENTER))

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
@@ -149,9 +149,14 @@ fun MediaControlButtonsPlaying() {
   var suffix = "?token=demo-token-fixture";
   var editLease = null;
   var editRevision = 0;
+  // One holder per document/tab: closing one tab must not tear down another tab's shared
+  // owner-wide incremental workspace.
+  var editClient = (window.crypto && typeof window.crypto.randomUUID === "function")
+    ? window.crypto.randomUUID()
+    : (Date.now().toString(36) + "-" + Math.random().toString(36).slice(2));
   function releaseEditLeaseOnDiscard() {
     if (!editLease) return;
-    var body = JSON.stringify({ lease: editLease });
+    var body = JSON.stringify({ lease: editLease, client: editClient });
     var url = "/api/1/compiler/edit-lease/release" + suffix;
     editLease = null;
     if (navigator.sendBeacon) {
@@ -172,9 +177,9 @@ fun MediaControlButtonsPlaying() {
     // server TTL as the hard fallback.
     if (!event.persisted) releaseEditLeaseOnDiscard();
   });
-  function setEditLease(value, message, expiresAt) {
+  function setEditLease(value, message, expiresAt, revision) {
     editLease = value;
-    editRevision = 0;
+    editRevision = value && Number.isFinite(revision) ? revision : 0;
     if (!editLeaseButton) return;
     editLeaseButton.disabled = false;
     editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
@@ -192,7 +197,9 @@ fun MediaControlButtonsPlaying() {
       editLeaseButton.disabled = true;
       if (!editLease) {
         fetch("/api/1/compiler/edit-lease" + suffix, {
-          method: "POST", headers: { "Accept": "application/json" }
+          method: "POST",
+          headers: { "Accept": "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({ client: editClient })
         })
           .then(function (r) {
             return r.json().then(function (body) {
@@ -201,7 +208,7 @@ fun MediaControlButtonsPlaying() {
             });
           })
           .then(function (body) {
-            setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+            setEditLease(body.lease, body.message, body.expiresAtEpochMs, body.revision);
           })
           .catch(function (e) {
             setEditLease(null, e.message || "Could not acquire editing lease.");
@@ -211,7 +218,7 @@ fun MediaControlButtonsPlaying() {
         fetch("/api/1/compiler/edit-lease/release" + suffix, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ lease: releasing })
+          body: JSON.stringify({ lease: releasing, client: editClient })
         })
           .then(function (r) {
             if (!r.ok) throw new Error("The editing lease has already expired.");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -144,9 +144,14 @@ fun Greeting() {
   var suffix = "?token=demo-token-fixture";
   var editLease = null;
   var editRevision = 0;
+  // One holder per document/tab: closing one tab must not tear down another tab's shared
+  // owner-wide incremental workspace.
+  var editClient = (window.crypto && typeof window.crypto.randomUUID === "function")
+    ? window.crypto.randomUUID()
+    : (Date.now().toString(36) + "-" + Math.random().toString(36).slice(2));
   function releaseEditLeaseOnDiscard() {
     if (!editLease) return;
-    var body = JSON.stringify({ lease: editLease });
+    var body = JSON.stringify({ lease: editLease, client: editClient });
     var url = "/api/1/compiler/edit-lease/release" + suffix;
     editLease = null;
     if (navigator.sendBeacon) {
@@ -167,9 +172,9 @@ fun Greeting() {
     // server TTL as the hard fallback.
     if (!event.persisted) releaseEditLeaseOnDiscard();
   });
-  function setEditLease(value, message, expiresAt) {
+  function setEditLease(value, message, expiresAt, revision) {
     editLease = value;
-    editRevision = 0;
+    editRevision = value && Number.isFinite(revision) ? revision : 0;
     if (!editLeaseButton) return;
     editLeaseButton.disabled = false;
     editLeaseButton.textContent = value ? "Release editing lease" : "Acquire editing lease";
@@ -187,7 +192,9 @@ fun Greeting() {
       editLeaseButton.disabled = true;
       if (!editLease) {
         fetch("/api/1/compiler/edit-lease" + suffix, {
-          method: "POST", headers: { "Accept": "application/json" }
+          method: "POST",
+          headers: { "Accept": "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({ client: editClient })
         })
           .then(function (r) {
             return r.json().then(function (body) {
@@ -196,7 +203,7 @@ fun Greeting() {
             });
           })
           .then(function (body) {
-            setEditLease(body.lease, body.message, body.expiresAtEpochMs);
+            setEditLease(body.lease, body.message, body.expiresAtEpochMs, body.revision);
           })
           .catch(function (e) {
             setEditLease(null, e.message || "Could not acquire editing lease.");
@@ -206,7 +213,7 @@ fun Greeting() {
         fetch("/api/1/compiler/edit-lease/release" + suffix, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ lease: releasing })
+          body: JSON.stringify({ lease: releasing, client: editClient })
         })
           .then(function (r) {
             if (!r.ok) throw new Error("The editing lease has already expired.");

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-axes-folded.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-axes-folded.html
@@ -308,7 +308,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -411,7 +411,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-palette.html
@@ -322,7 +322,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-cross-product.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-cross-product.html
@@ -285,7 +285,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-exploded.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-exploded.html
@@ -320,7 +320,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-focus.html
@@ -283,7 +283,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-gestures.html
@@ -281,7 +281,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history-local.html
@@ -264,7 +264,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-history.html
@@ -264,7 +264,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-inspect.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-inspect.html
@@ -279,7 +279,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-motion.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-motion.html
@@ -268,7 +268,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-nav-collapsed.html
@@ -284,7 +284,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-path.html
@@ -277,7 +277,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-pinned-lanes.html
@@ -289,7 +289,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-rc-players.html
@@ -318,7 +318,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions-open.html
@@ -275,7 +275,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-revisions.html
@@ -275,7 +275,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-signin.html
@@ -274,7 +274,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-source.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-source.html
@@ -276,7 +276,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-states.html
@@ -281,7 +281,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-theme-overflow.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-theme-overflow.html
@@ -292,7 +292,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-themes.html
@@ -273,7 +273,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-variants.html
@@ -283,7 +283,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm-live.html
@@ -276,7 +276,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wasm.html
@@ -267,7 +267,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-wear-screen.html
@@ -259,7 +259,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -326,7 +326,7 @@
   // server-baked score is already stale on the first paint. viewer.js keeps this attribute in
   // sync after controls change; this early write makes the element's initial read authoritative.
   if (root) {
-    var atSpecBaseline = el.getAttribute("data-theme-active") !== "1";
+    var atSpecBaseline = el.disabled || el.getAttribute("data-theme-active") !== "1";
     root.setAttribute("data-spec-baseline", atSpecBaseline ? "1" : "0");
   }
   // Keep the stage backing colour in step with the CHOSEN theme, so a re-render in the opposite


### PR DESCRIPTION
## What changed

- prefer focused DPAD input before indirect-pointer fallback for pressed preview captures
- regenerate stale playground and viewer HTML fixtures
- format the newly added disabled-theme ServeWeb regression test

## Root cause

The focused press dispatcher trusted the root-level indirect-pointer handled result, even when Wear Material 3's `combinedClickable` never received a press, so the DPAD fallback was skipped. Separately, recent `main` changes landed without regenerating their committed ServeWeb fixtures and with one Kotlin test outside ktfmt.

## Impact

Wear pressed previews now render their actual pressed state while Glimmer retains its indirect-pointer path. The committed browser fixtures again match ServeWeb output, allowing the CLI and module test jobs to pass.

## Validation

- `./gradlew :cli:build :bundle-viewer:build --no-daemon`
- `./gradlew :data-focus-connector:ktfmtCheck :data-focus-connector:testDebugUnitTest :samples:design-catalog-wear-m3:testDebugUnitTest --tests '*WearFocusedPressPixelTest*' --no-daemon`
- `./gradlew :samples:xr-glimmer:composePreviewRenderAll --no-daemon`

Addresses the failures from [Actions run 31946958107](https://github.com/yschimke/compose-ai-tools/actions/runs/31946958107).