### PR TITLE
fix(glimmer): address environment render feedback

### DIFF
--- a/data/glimmer-environment/connector/src/main/kotlin/ee/schimke/composeai/glimmer/GlimmerEnvironmentCompositor.kt
+++ b/data/glimmer-environment/connector/src/main/kotlin/ee/schimke/composeai/glimmer/GlimmerEnvironmentCompositor.kt
@@ -20,11 +20,14 @@ enum class GlimmerEnvironment {
  *
  * The source capture is never treated as alpha: black is additive zero and each colour channel is
  * saturated independently. [applyToPng] preserves the source next to the composited result as
- * `<basename>.raw.png`.
+ * `<basename>.raw.png` unless the caller supplies a distinct preservation path.
  */
 object GlimmerEnvironmentCompositor {
-  fun applyToPng(file: File, environment: GlimmerEnvironment): File {
-    val raw = file.resolveSibling("${file.nameWithoutExtension}.raw.png")
+  fun applyToPng(
+    file: File,
+    environment: GlimmerEnvironment,
+    raw: File = file.resolveSibling("${file.nameWithoutExtension}.raw.png"),
+  ): File {
     file.copyTo(raw, overwrite = true)
     val capture = ImageIO.read(raw) ?: error("Unable to decode Glimmer capture: $raw")
     ImageIO.write(composite(capture, environment), "png", file)

--- a/data/glimmer-environment/connector/src/test/kotlin/ee/schimke/composeai/glimmer/GlimmerEnvironmentCompositorTest.kt
+++ b/data/glimmer-environment/connector/src/test/kotlin/ee/schimke/composeai/glimmer/GlimmerEnvironmentCompositorTest.kt
@@ -37,4 +37,32 @@ class GlimmerEnvironmentCompositorTest {
       dir.deleteRecursively()
     }
   }
+
+  @Test
+  fun `png application can preserve raw capture without overwriting another processor artifact`() {
+    val dir = createTempDirectory("glimmer-composite-distinct-raw-").toFile()
+    try {
+      val file = File(dir, "capture.png")
+      val focusRaw = File(dir, "capture.raw.png")
+      val glimmerRaw = File(dir, "capture.glimmer.raw.png")
+      val source = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
+      source.setRGB(0, 0, 0xffffffff.toInt())
+      ImageIO.write(source, "png", file)
+      focusRaw.writeText("pre-focus-overlay")
+
+      val raw =
+        GlimmerEnvironmentCompositor.applyToPng(
+          file,
+          GlimmerEnvironment.Dark,
+          raw = glimmerRaw,
+        )
+
+      assertThat(raw).isEqualTo(glimmerRaw)
+      assertThat(glimmerRaw.exists()).isTrue()
+      assertThat(focusRaw.readText()).isEqualTo("pre-focus-overlay")
+      assertThat(file.readBytes().contentEquals(glimmerRaw.readBytes())).isFalse()
+    } finally {
+      dir.deleteRecursively()
+    }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -2284,18 +2284,21 @@ internal object ComposePreviewTasks {
   /**
    * `<stem>.raw.<png|gif>` lives next to a clean output registered in the manifest. PNG siblings
    * are produced by `@FocusedPreview(overlay = true)`; GIF siblings are the additive RGB source
-   * preserved by `@GlimmerEnvironmentPreview` before connector compositing. Same preservation shape
-   * as [isA11ySiblingOfExpected] — match by mechanical suffix-strip, not by re-checking the
-   * manifest's overlay flag, so a `.raw.png` whose clean sibling has been removed is still garbage.
+   * preserved by `@GlimmerEnvironmentPreview` before connector compositing. When those two PNG
+   * processors are combined, `<stem>.glimmer.raw.png` additionally preserves the overlayed,
+   * pre-environment capture. Same preservation shape as [isA11ySiblingOfExpected] — match by
+   * mechanical suffix-strip, not by re-checking manifest flags, so raw artifacts whose clean
+   * sibling has been removed are still garbage.
    */
   internal fun isRawSiblingOfExpected(rel: String, expectedRelPaths: Set<String>): Boolean {
-    val extension =
+    val (suffix, extension) =
       when {
-        rel.endsWith(".raw.png") -> ".png"
-        rel.endsWith(".raw.gif") -> ".gif"
+        rel.endsWith(".glimmer.raw.png") -> ".glimmer.raw" to ".png"
+        rel.endsWith(".raw.png") -> ".raw" to ".png"
+        rel.endsWith(".raw.gif") -> ".raw" to ".gif"
         else -> return false
       }
-    val cleanSibling = rel.removeSuffix(".raw$extension") + extension
+    val cleanSibling = rel.removeSuffix("$suffix$extension") + extension
     return cleanSibling in expectedRelPaths
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -41,6 +41,25 @@ class CleanStaleRendersTest {
   }
 
   @Test
+  fun `keeps raw siblings of registered renders`() {
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("Foo.raw.png", expected)).isTrue()
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("Foo.glimmer.raw.png", expected)).isTrue()
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("sub/Bar.raw.png", expected)).isTrue()
+    assertThat(
+        ComposePreviewTasks.isRawSiblingOfExpected("Animation.raw.gif", setOf("Animation.gif"))
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `drops raw artifacts with no clean sibling`() {
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("Removed.raw.png", expected)).isFalse()
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("Removed.glimmer.raw.png", expected))
+      .isFalse()
+    assertThat(ComposePreviewTasks.isRawSiblingOfExpected("Removed.raw.gif", expected)).isFalse()
+  }
+
+  @Test
   fun `prunes catalog-token sidecars for sheets absent from the manifest`() {
     val catalogDir = tempDir.root.resolve("build/compose-previews/data/catalog-tokens")
     catalogDir.mkdirs()

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1736,6 +1736,7 @@ abstract class RobolectricRenderTestBase(
                     isRound = isRoundDevice(params.device) && params.kind == PreviewKind.COMPOSE,
                     outputFile = outputFile,
                     curveCapture = animationCurveCapture,
+                    glimmerEnvironment = job.capture.glimmerEnvironment?.toConnectorEnvironment(),
                   )
                   .also { handled ->
                     // The clock has been driven well past `currentTime`
@@ -1957,9 +1958,18 @@ abstract class RobolectricRenderTestBase(
                 job.capture.glimmerEnvironment != null &&
                 outputFile.extension.equals("png", ignoreCase = true)
             ) {
+              // FocusOverlay owns `<basename>.raw.png` as its pre-overlay artifact. Preserve the
+              // overlayed, pre-environment Glimmer source separately when both processors apply.
+              val glimmerRaw =
+                if (focus?.overlay == true) {
+                  outputFile.resolveSibling("${outputFile.nameWithoutExtension}.glimmer.raw.png")
+                } else {
+                  outputFile.resolveSibling("${outputFile.nameWithoutExtension}.raw.png")
+                }
               GlimmerEnvironmentCompositor.applyToPng(
                 outputFile,
                 job.capture.glimmerEnvironment.toConnectorEnvironment(),
+                raw = glimmerRaw,
               )
             }
 
@@ -2923,6 +2933,7 @@ private fun handleAnimatedCapture(
   isRound: Boolean,
   outputFile: File,
   curveCapture: SlotTreeCapture?,
+  glimmerEnvironment: ConnectorGlimmerEnvironment? = null,
 ): Boolean {
   val framesDir = File(outputFile.parentFile, "${outputFile.nameWithoutExtension}_anim_frames")
   framesDir.deleteRecursively()
@@ -3089,9 +3100,9 @@ private fun handleAnimatedCapture(
     // when there are no tracks (e.g. showCurves = false, or the
     // inspector found nothing — which can happen on a static
     // preview accidentally annotated).
-    val composedFrames: List<BufferedImage> =
+    fun composePresentationFrames(screenshots: List<BufferedImage>): List<BufferedImage> =
       if (tracks.isNotEmpty()) {
-        rawFrames.mapIndexed { i, screenshot ->
+        screenshots.mapIndexed { i, screenshot ->
           AnimationCurvePlotter.composeFrameWithCurves(
             screenshot = screenshot,
             tracks = tracks,
@@ -3100,21 +3111,37 @@ private fun handleAnimatedCapture(
           )
         }
       } else {
-        rawFrames
+        screenshots
       }
+
+    val rawComposedFrames = composePresentationFrames(rawFrames)
 
     // Hold the first frame for [HOLD_START_MS] and the last for
     // [HOLD_END_MS] so the GIF reads as "pre-state → animation → settled
     // state" rather than instantly looping back. Single-frame GIFs
     // collapse to one long-hold image.
     val frameDelays =
-      IntArray(composedFrames.size) { i ->
+      IntArray(rawComposedFrames.size) { i ->
         when (i) {
           0 -> HOLD_START_ANIM_MS
-          composedFrames.lastIndex -> HOLD_END_ANIM_MS
+          rawComposedFrames.lastIndex -> HOLD_END_ANIM_MS
           else -> frameIntervalMs
         }
       }
+    val composedFrames =
+      glimmerEnvironment?.let { environment ->
+        val rawOutput = outputFile.resolveSibling("${outputFile.nameWithoutExtension}.raw.gif")
+        ScrollGifEncoder.encode(
+          frames = rawComposedFrames,
+          outputFile = rawOutput,
+          frameDelaysMs = frameDelays,
+        ) ?: return false
+        // Composite only the captured Glimmer surface. Curve panels are renderer-owned UI and
+        // should retain their ordinary colours rather than receiving the simulated environment.
+        composePresentationFrames(
+          rawFrames.map { GlimmerEnvironmentCompositor.composite(it, environment) }
+        )
+      } ?: rawComposedFrames
     val written =
       ScrollGifEncoder.encode(
         frames = composedFrames,

--- a/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
+++ b/samples/xr-glimmer/src/main/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuPreviews.kt
@@ -3,6 +3,7 @@ package com.example.samplexrglimmer
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -10,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import androidx.xr.glimmer.GlimmerTheme
 import androidx.xr.glimmer.ListItem
 import androidx.xr.glimmer.Text
+import ee.schimke.composeai.preview.AnimatedPreview
 import ee.schimke.composeai.preview.FocusedPreview
 import ee.schimke.composeai.preview.GlimmerEnvironment
 import ee.schimke.composeai.preview.GlimmerEnvironmentPreview
@@ -22,7 +24,10 @@ import ee.schimke.composeai.preview.GlimmerEnvironmentPreview
 @Composable
 fun GlimmerMenu() {
   GlimmerTheme {
-    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    Column(
+      modifier = Modifier.fillMaxWidth().padding(24.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
       ListItem(onClick = {}) { Text("Next track") }
       ListItem(onClick = {}) { Text("Previous track") }
       ListItem(onClick = {}) { Text("Add to favourites") }
@@ -74,3 +79,25 @@ fun GlimmerXrMenuBusy() = GlimmerMenu()
 @FocusedPreview(indices = [0, 1, 2, 3], gif = true)
 @Composable
 fun GlimmerXrMenuVeniceCanalCats() = GlimmerMenu()
+
+@Preview(
+  name = "Animated Light",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@GlimmerEnvironmentPreview(GlimmerEnvironment.Light)
+@AnimatedPreview(durationMs = 100, frameIntervalMs = 50, showCurves = false)
+@Composable
+fun GlimmerXrMenuAnimated() = GlimmerMenu()
+
+@Preview(
+  name = "Overlay Light",
+  device = AI_GLASSES_DEVICE_SPEC,
+  showBackground = true,
+  backgroundColor = ADDITIVE_ZERO_BACKGROUND,
+)
+@GlimmerEnvironmentPreview(GlimmerEnvironment.Light)
+@FocusedPreview(indices = [0], overlay = true)
+@Composable
+fun GlimmerXrMenuOverlay() = GlimmerMenu()

--- a/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuTest.kt
+++ b/samples/xr-glimmer/src/test/kotlin/com/example/samplexrglimmer/GlimmerInteractiveMenuTest.kt
@@ -85,4 +85,29 @@ class GlimmerInteractiveMenuTest {
     files.forEach { assertThat(it.exists()).isTrue() }
     assertThat(files.map { it.readBytes().contentHashCode() }.toSet()).hasSize(1)
   }
+
+  @Test
+  fun `animated Glimmer capture preserves raw GIF and composites its environment`() {
+    val base = "GlimmerXrMenuAnimated_Animated_Light"
+    val gif = renderFile(rendersDir, base, ext = "gif")
+    val raw = renderFile(rendersDir, base, suffix = ".raw", ext = "gif")
+
+    assertThat(gif.exists()).isTrue()
+    assertThat(raw.exists()).isTrue()
+    assertThat(gif.readBytes().contentEquals(raw.readBytes())).isFalse()
+  }
+
+  @Test
+  fun `focus overlay and environment retain distinct raw PNG artifacts`() {
+    val base = "GlimmerXrMenuOverlay_Overlay_Light"
+    val composited = renderFile(rendersDir, base)
+    val preOverlay = renderFile(rendersDir, base, suffix = ".raw")
+    val preEnvironment = renderFile(rendersDir, base, suffix = ".glimmer.raw")
+
+    assertThat(composited.exists()).isTrue()
+    assertThat(preOverlay.exists()).isTrue()
+    assertThat(preEnvironment.exists()).isTrue()
+    assertThat(preOverlay.readBytes().contentEquals(preEnvironment.readBytes())).isFalse()
+    assertThat(preEnvironment.readBytes().contentEquals(composited.readBytes())).isFalse()
+  }
 }


### PR DESCRIPTION
Follow-up to #4003 and #3670.

## What changed

- composite `@AnimatedPreview` GIF frames when a Glimmer environment is selected and preserve the additive source as `.raw.gif`
- keep focus-overlay and Glimmer raw PNG artifacts separate as `.raw.png` and `.glimmer.raw.png`
- preserve the new nested raw artifact during stale-render cleanup
- restore the Glimmer menu's 24dp viewport inset
- format the connector source that failed CI
- add rendered-preview and cleanup regression coverage

## Root cause

The initial environment post-processing only handled ordinary PNGs and focus-walk GIFs. Animated GIFs bypassed it, while static focus-overlay and environment processors both claimed the same `.raw.png` path. The sample container's inset was also dropped during extraction, and one connector file had not been run through ktfmt.

## Validation

- `:gradle-plugin:test --tests ee.schimke.composeai.plugin.CleanStaleRendersTest`
- `:data-glimmer-environment-connector:test`
- `:renderer-android:compileDebugKotlin`
- `:samples:xr-glimmer:composePreviewRenderAll`
- `:samples:xr-glimmer:testDebugUnitTest`
- ktfmt checks for all four affected modules