### PR TITLE
fix(preview): carry and capture motion surfaces

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -530,6 +530,21 @@ abstract class BundlePreviewTask : DefaultTask() {
       resolvePreviewPng(preview)?.let { previewPngs[bundleIds.getValue(preview.id)] = it }
     }
 
+    // Motion captures are first-class baked artifacts too. Keep their renderer-owned leaf names:
+    // the bundled previews manifest points at `renders/<leaf>`, and catalog export deliberately
+    // joins that declaration to `previews/<leaf>` so animation/interaction siblings cannot be
+    // confused. Previously bundle pack carried only PNG stills, making every correctly rendered
+    // APNG/GIF disappear before publishing (issue #3922).
+    val motionFiles = LinkedHashMap<String, ByteArray>()
+    for (preview in selected) {
+      for ((path, bytes) in resolvePreviewMotion(preview)) {
+        val previous = motionFiles.put(path, bytes)
+        check(previous == null || previous.contentEquals(bytes)) {
+          "composePreviewBundle: two motion captures resolve to '$path' with different bytes"
+        }
+      }
+    }
+
     // (v8) Per-preview override sidecars: the editable knobs a preview declared via
     // `previewOverride*`,
     // captured during the render as `renders/<stem>.overrides.json`. Packed verbatim under
@@ -604,6 +619,7 @@ abstract class BundlePreviewTask : DefaultTask() {
         inlinedProjectJars = inlinedJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
         previewPngs = previewPngs,
+        motionFiles = motionFiles,
         irFiles = irZipFiles,
         dataExtensionFiles = dataExtensionZipFiles,
         overrideFiles = overrideFiles,
@@ -625,6 +641,7 @@ abstract class BundlePreviewTask : DefaultTask() {
       "composePreviewBundle — wrote ${outFile.name} (${outFile.length()} bytes)\n" +
         "  resolution:           ${classpath.resolution}\n" +
         "  previews baked:       ${previewPngs.size} / ${selected.size} (cover=$coverId)\n" +
+        "  motion captures:      ${motionFiles.size}\n" +
         "  IR-backed previews:   ${irEntries.size} (replayed from ir/, classes dropped)\n" +
         "  data extensions:      ${dataExtensionEntries.size} (carried under extensions/)\n" +
         "  entry classes:        ${report.entryClassFqns.size}\n" +
@@ -718,6 +735,23 @@ abstract class BundlePreviewTask : DefaultTask() {
       }
       ?.minByOrNull { it.name }
       ?.readBytes()
+  }
+
+  /** Motion capture bytes for [preview], keyed by their in-bundle `previews/<leaf>` path. */
+  private fun resolvePreviewMotion(preview: PreviewInfo): Map<String, ByteArray> {
+    val rendersRoot = rendersDir.orNull?.asFile ?: return emptyMap()
+    val previewsRoot = rendersRoot.parentFile ?: rendersRoot
+    val files = LinkedHashMap<String, ByteArray>()
+    for (capture in preview.captures) {
+      if (capture.interaction == null && capture.animation == null) continue
+      val rel = capture.renderOutput.takeIf { it.isNotEmpty() } ?: continue
+      val extension = rel.substringAfterLast('.', missingDelimiterValue = "").lowercase()
+      if (extension != "apng" && extension != "gif") continue
+      val source = File(previewsRoot, rel)
+      if (!source.isFile || source.length() <= 0) continue
+      files["$BUNDLE_PREVIEWS_DIR/${source.name}"] = source.readBytes()
+    }
+    return files
   }
 
   /**
@@ -1431,6 +1465,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     inlinedProjectJars: Map<String, File>,
     report: String,
     previewPngs: Map<String, ByteArray>,
+    motionFiles: Map<String, ByteArray>,
     irFiles: Map<String, ByteArray>,
     dataExtensionFiles: Map<String, ByteArray>,
     overrideFiles: Map<String, ByteArray>,
@@ -1442,6 +1477,8 @@ abstract class BundlePreviewTask : DefaultTask() {
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
       // One baked PNG per selected preview under the well-known `previews/` directory.
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
+      // Renderer-named APNG/GIF siblings consumed by catalog motion publishing and bundle readers.
+      motionFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // (v8) Per-preview override sidecars under `previews/<id>.overrides.json`.
       overrideFiles.forEach { (path, bytes) -> zip.writeFile(path, bytes) }
       // Per-sheet catalog-token sidecars under `previews/<id>.catalog.json` (issue #2167).

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
@@ -165,7 +165,9 @@ fun renderAnimatedPreview(
         }
 
         repeat(frameCount) {
-          collector.capture(captureRootPngBytes(), crop)
+          val frame = captureMotionSurfacePngBytes()
+          observeMotionRootBounds(bounds)
+          collector.capture(frame, crop)
           mainClock.advanceTimeBy(frameInterval.toLong())
         }
       }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRenderer.kt
@@ -151,7 +151,9 @@ fun renderInteractionPreview(
             onRoot().performTouchInput { if (event.down) down(centre) else up() }
             nextEvent++
           }
-          collector.capture(captureRootPngBytes(), crop)
+          val frame = captureMotionSurfacePngBytes()
+          observeMotionRootBounds(bounds)
+          collector.capture(frame, crop)
           mainClock.advanceTimeBy(frameInterval.toLong())
           elapsed += frameInterval
         }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
@@ -11,8 +11,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SkikoComposeUiTest
-import androidx.compose.ui.test.captureToImage
-import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import ee.schimke.composeai.scroll.ScrollGifEncoder
@@ -20,6 +19,7 @@ import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File
 import javax.imageio.ImageIO
+import kotlin.math.ceil
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image as SkiaImage
 
@@ -216,14 +216,34 @@ internal fun MotionPreviewProviders(
 }
 
 /**
- * Captures the rendered root as encoded PNG bytes.
+ * Captures the complete Skiko scene, including popup/dialog owners that are not descendants of the
+ * preview's main semantics root.
  *
- * Every frame of one capture comes back with the same width, height and colour type because the
- * scene is fixed-size — which is exactly the invariant [ApngEncoder] requires of its inputs.
+ * Compose Desktop paints those owners into the same scene surface even though `onRoot()` selects
+ * only the main owner. Capturing the surface is therefore the lossless source for motion frames;
+ * [MotionFrameCollector] still trims it to the measured capture bounds, so ordinary inline previews
+ * keep the same dimensions and byte cost they had before popup support.
  */
 @OptIn(ExperimentalTestApi::class)
-internal fun SkikoComposeUiTest.captureRootPngBytes(): ByteArray {
-  val bitmap = onRoot().captureToImage()
+internal fun SkikoComposeUiTest.captureMotionSurfacePngBytes(): ByteArray =
+  captureToImage().toPngBytes()
+
+/**
+ * Folds every active semantics owner's window bounds into [tracker]. Popups are separate roots, so
+ * the main content's `onMeasured` callback cannot see them. Observing roots after each rendered
+ * frame lets [recordMotionCapture] re-record at the union's required size when a gesture opens a
+ * menu, tooltip, dialog, or sheet beyond the resting sticker bounds.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun SkikoComposeUiTest.observeMotionRootBounds(tracker: MotionBoundsTracker) {
+  for (node in onAllNodes(isRoot()).fetchSemanticsNodes()) {
+    val bounds = node.boundsInWindow
+    tracker.observe(ceil(bounds.right).toInt(), ceil(bounds.bottom).toInt())
+  }
+}
+
+private fun androidx.compose.ui.graphics.ImageBitmap.toPngBytes(): ByteArray {
+  val bitmap = this
   val skiaImage = SkiaImage.makeFromBitmap(bitmap.asSkiaBitmap())
   try {
     val pngData =

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRendererTest.kt
@@ -190,6 +190,46 @@ class DesktopInteractionRendererTest {
   }
 
   @Test
+  fun `a popup owner is captured and expands wrapped motion bounds`() {
+    val output =
+      render(
+        "OpenPopupOnTap",
+        spec(targets = listOf(0)),
+        "popup-owner",
+        widthPx = 90,
+        heightPx = 30,
+        wrapWidth = true,
+        wrapHeight = true,
+      )
+
+    val frames = ApngFrames.read(output)
+    assertEquals("the popup owner expands capture to the 90px scene", 90, frames.last().width)
+    assertTrue(
+      "the separate popup owner is present in the encoded frame",
+      frames.last().isWhiteAt(55, 15),
+    )
+  }
+
+  @Test
+  fun `a real Material AlertDialog is captured from its separate owner`() {
+    val output =
+      render(
+        "OpenAlertDialogOnTap",
+        spec(targets = listOf(0)),
+        "alert-dialog-owner",
+        widthPx = 320,
+        heightPx = 240,
+        wrapWidth = true,
+        wrapHeight = true,
+      )
+
+    val last = ApngFrames.read(output).last()
+    assertEquals(320, last.width)
+    assertEquals(240, last.height)
+    assertTrue("the dialog/scrim paints the scene centre", last.alphaAt(160, 120) > 0)
+  }
+
+  @Test
   fun `an unwrapped capture keeps the requested frame`() {
     // The device-framed case still fills its sandbox — cropping is what a *wrapped* axis asks for,
     // and a `@Preview` that declared a device size means it.

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/InteractionRenderTestFixtures.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/InteractionRenderTestFixtures.kt
@@ -7,15 +7,22 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 
 /**
  * Test fixtures for [DesktopInteractionRendererTest].
@@ -81,6 +88,35 @@ fun ExpandOnTap() {
     Box(modifier = Modifier.size(30.dp).background(Color.DarkGray).clickable { expanded = true })
     if (expanded) {
       Box(modifier = Modifier.size(width = 60.dp, height = 30.dp).background(Color.White))
+    }
+  }
+}
+
+/** A real separate-owner popup, used to prove the motion surface includes platform-hosted UI. */
+@Composable
+fun OpenPopupOnTap() {
+  var open by remember { mutableStateOf(false) }
+  Box(modifier = Modifier.size(30.dp).background(Color.DarkGray).clickable { open = true })
+  if (open) {
+    Popup(alignment = Alignment.TopStart, offset = IntOffset(40, 0)) {
+      Box(modifier = Modifier.size(30.dp).background(Color.White))
+    }
+  }
+}
+
+/** The real Material dialog API, not a catalog-owned Surface reconstruction. */
+@Composable
+fun OpenAlertDialogOnTap() {
+  var open by remember { mutableStateOf(false) }
+  Box(modifier = Modifier.size(30.dp).background(Color.DarkGray).clickable { open = true })
+  if (open) {
+    MaterialTheme {
+      AlertDialog(
+        onDismissRequest = {},
+        title = { Text("Captured dialog") },
+        text = { Text("This content lives in the dialog owner.") },
+        confirmButton = { TextButton(onClick = {}) { Text("OK") } },
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

- carry rendered APNG/GIF motion captures through `composePreviewBundle` under their renderer-owned entry names
- capture the complete Skiko scene for desktop motion, including separate popup and dialog owners
- expand wrapped motion bounds when a popup/dialog root appears during an interaction
- cover both a raw `Popup` and the real Material 3 `AlertDialog`

## Root cause

Bundle packing baked only PNG stills, so correctly rendered motion artifacts disappeared before catalog publishing. Separately, desktop motion sampled only the main semantics root, while menus, tooltips, dialogs, sheets, and other popup-hosted surfaces render in separate owners.

## Impact

Published catalogs can now retain their motion entries, and interaction/animation recordings include popup-hosted Material surfaces instead of showing an apparently unresponsive anchor. This unblocks restoring the real popup-hosted comparisons removed by m3-catalog PR #124.

## Validation

- `./gradlew :renderer-desktop:test --tests ee.schimke.composeai.renderer.DesktopInteractionRendererTest --tests ee.schimke.composeai.renderer.DesktopAnimatedRendererTest :gradle-plugin:ktfmtCheck :renderer-desktop:ktfmtCheck`
- focused real `SwitchOn` catalog render produced two 114-frame APNGs
- focused `composePreviewBundle` packed both APNGs and reported `motion captures: 2`
- `git diff --check`

Closes #3922
Closes #3916