### PR TITLE
chore(renovate): pin daemon tracing to 1.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,7 +102,7 @@
       "allowedVersions": "/^1\\.13\\./"
     },
     {
-      "description": "androidx.tracing:tracing: keep the daemon-specific catalog alias on the 1.x line. The standalone Android daemon sidecar packages this implementation dependency's full runtime classpath, while 2.x adds kotlinx-coroutines-core and androidx.collection even though the daemon only uses Trace.beginSection/endSection. The separate 2.x player alias is intentionally unaffected; moving the daemon to 2.x is a manual packaging decision.",
+      "description": "androidx.tracing:tracing: keep the daemon-specific catalog alias on the 1.x line. The standalone Android daemon sidecar stages every runtime JAR, so 2.x would make every daemon user download and cache kotlinx-coroutines-core and androidx.collection and would enlarge the runtime classpath even though the daemon only uses Trace.beginSection/endSection. That is extra distribution weight and dependency surface with no daemon behavior benefit. The separate 2.x player alias is intentionally unaffected; moving the daemon to 2.x is a manual packaging decision.",
       "matchManagers": [
         "gradle"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,6 +102,17 @@
       "allowedVersions": "/^1\\.13\\./"
     },
     {
+      "description": "androidx.tracing:tracing: keep the daemon-specific catalog alias on the 1.x line. The standalone Android daemon sidecar packages this implementation dependency's full runtime classpath, while 2.x adds kotlinx-coroutines-core and androidx.collection even though the daemon only uses Trace.beginSection/endSection. The separate 2.x player alias is intentionally unaffected; moving the daemon to 2.x is a manual packaging decision.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "androidx.tracing:tracing"
+      ],
+      "matchCurrentValue": "/^1\\./",
+      "allowedVersions": "/^1\\./"
+    },
+    {
       "description": "compose-multiplatform: pin to the 1.10.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers. 1.11.0 ships ABI-breaking changes (non-Android `Shader` becomes a Compose wrapper type, `NativePaint`/`NativeCanvas` typealiases deprecated, `Paint.asFrameworkPaint`/`Canvas.nativeCanvas` replaced) and bumps the required Kotlin language/API to 2.2 — raising the floor is a manual decision. Keep `samples/cmp-shared`'s explicit `ui-tooling-preview` coord in lockstep so the plugin's compose-runtime compatibility check stays happy.",
       "matchManagers": [
         "gradle"


### PR DESCRIPTION
## Summary

- constrain the daemon-specific `androidx.tracing:tracing` catalog entry to the 1.x line
- document why 2.x is unsuitable for the standalone Android daemon sidecar
- leave the separate 2.x Remote Compose player alias unaffected

## Why

PR #3997 attempted to update the daemon alias to 2.x. `:cli:packageAndroidDaemon` stages the daemon's complete runtime classpath into a separately downloaded and cached sidecar. Because tracing 2.x introduces `kotlinx-coroutines-core` and `androidx.collection`, that upgrade would make every Android-daemon user download and retain those additional runtime JARs and would enlarge the daemon's dependency-resolution and classpath surface.

The daemon does not use any functionality that requires that closure: it only calls `Trace.beginSection` and `Trace.endSection`, which 1.3.0 already provides. The added distribution weight and dependency surface therefore have no daemon behavior benefit.

Matching `matchCurrentValue` against 1.x ensures this rule applies only to the daemon pin and does not constrain the existing 2.x player alias that shares the same Maven coordinate.

## Impact

Renovate can continue proposing 1.x updates for the daemon dependency, but will no longer reopen the unsuitable 2.x upgrade. Moving the daemon to 2.x remains an explicit packaging decision.

## Checks

- `jq empty .github/renovate.json`
- `git diff --check`