### PR TITLE
fix(playground): preserve rejected lease state

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -567,6 +567,7 @@ class PlaygroundCompileService(
       // not compile or mutate IC state: report it without accepting the staged files/revision, so
       // the complete dirty set is retried on the next Run.
       if (compile.diagnostics.isCompileAdmissionFailure()) {
+        restoreStagedFiles(srcDir, accepted = lease.files, staged = desired)
         editLastCompileMillis = (System.nanoTime() - compileStarted) / 1_000_000
         renewEditLeaseLocked(lease)
         refreshEditHealthLocked()
@@ -802,6 +803,20 @@ class PlaygroundCompileService(
     val used = mutableSetOf<String>()
     return buildMap {
       files.forEach { file -> put(uniqueName(safeKtName(file.name), used), file.text) }
+    }
+  }
+
+  /** Restore the source tree after admission rejects a request before compilation starts. */
+  private fun restoreStagedFiles(
+    srcDir: Path,
+    accepted: Map<String, String>,
+    staged: Map<String, String>,
+  ) {
+    (staged.keys - accepted.keys).forEach { name ->
+      fileSystem.delete(srcDir / name, mustExist = false)
+    }
+    accepted.forEach { (name, text) ->
+      if (staged[name] != text) fileSystem.write(srcDir / name) { writeUtf8(text) }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1698,8 +1698,15 @@ class ServeHttpServer(
       withContext(Dispatchers.IO) {
         call.receiveStream().use { readCapped(it, MAX_PLAYGROUND_BYTES) }
       }
+        ?: run {
+          call.respondText(
+            "playground request exceeds ${MAX_PLAYGROUND_BYTES / 1024}KB",
+            status = HttpStatusCode.PayloadTooLarge,
+          )
+          return
+        }
     val request =
-      if (body == null || body.isEmpty()) PlaygroundEditLeaseAcquireRequest()
+      if (body.isEmpty()) PlaygroundEditLeaseAcquireRequest()
       else
         runCatching {
           JSON.decodeFromString(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -884,6 +884,85 @@ class PlaygroundCompileServiceTest {
   }
 
   @Test
+  fun `busy compiler restores the last accepted source tree`() {
+    data class Call(
+      val modified: List<String>,
+      val removed: List<String>,
+      val contents: Map<String, String>,
+    )
+
+    val calls = mutableListOf<Call>()
+    val compiler =
+      object : PlaygroundCompileService.Compiler {
+        override fun compile(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+        ) = emptyList<PlaygroundDiagnostic>()
+
+        override fun compileIncremental(
+          sources: List<Path>,
+          classpath: List<Path>,
+          outputDir: Path,
+          workingDir: Path,
+          modified: List<Path>,
+          removed: List<Path>,
+          firstBuild: Boolean,
+        ): PlaygroundCompileService.IncrementalCompileResult {
+          calls +=
+            Call(
+              modified.map { it.name },
+              removed.map { it.name },
+              sources.associate { it.name to fs.read(it) { readUtf8() } },
+            )
+          if (calls.size == 2) {
+            return PlaygroundCompileService.IncrementalCompileResult(
+              listOf(
+                PlaygroundDiagnostic(
+                  PlaygroundSeverity.ERROR,
+                  "the playground is busy compiling (all 1 compile slots in use) — try again shortly",
+                )
+              ),
+              incremental = false,
+            )
+          }
+          fs.createDirectories(outputDir)
+          fs.write(outputDir / "Snippet.class") { writeUtf8("compiled") }
+          return PlaygroundCompileService.IncrementalCompileResult(emptyList(), false)
+        }
+      }
+    val svc = service(compilerOverride = compiler, editLeasesEnabled = true)
+    val lease = svc.acquireEditLease("alice").lease!!
+    fun run(revision: Long, files: List<PlaygroundFile>) =
+      svc.run(
+        request(text = files.first().text)
+          .copy(
+            files = files,
+            editLease = lease,
+            revision = revision,
+          ),
+        true,
+        authenticatedOwner = "alice",
+      )
+
+    val accepted =
+      listOf(
+        PlaygroundFile("Snippet.kt", "@Preview fun P() = println(1)"),
+        PlaygroundFile("Theme.kt", "object Theme"),
+      )
+    assertNotNull(run(1, accepted).previewToken)
+    val busy = run(2, listOf(PlaygroundFile("Snippet.kt", "@Preview fun P() = println(2)")))
+    assertTrue(busy.diagnostics.single().message.startsWith("the playground is busy"))
+
+    assertNotNull(run(3, accepted).previewToken)
+    assertEquals(
+      Call(emptyList(), emptyList(), accepted.associate { it.name to it.text }),
+      calls[2],
+      "the retry sees the accepted files on disk even though its desired map is unchanged",
+    )
+  }
+
+  @Test
   fun `stale or foreign leased revisions are rejected before compilation`() {
     var compiles = 0
     val compiler =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -367,6 +367,22 @@ class PlaygroundRoutingTest {
   }
 
   @Test
+  fun `oversized edit lease acquisition is rejected`() {
+    val cookie = githubSessionCookie(githubRepoServer.port)
+
+    post(
+        "/api/1/compiler/edit-lease",
+        "x".repeat(256 * 1024 + 1),
+        githubRepoServer.port,
+        cookie,
+      )
+      .use { resp ->
+        assertEquals(413, resp.code)
+        assertTrue(resp.body!!.string().contains("exceeds 256KB"))
+      }
+  }
+
+  @Test
   fun `the editor page explains when the playground lane isn't enabled`() {
     get("/playground", plainServer.port).use { resp ->
       assertEquals(503, resp.code)


### PR DESCRIPTION
## What changed

- restore the last accepted source tree when incremental compiler admission returns busy
- reject oversized edit-lease acquisition bodies with `413 Payload Too Large`
- cover a modify/delete rejection followed by an unchanged retry
- cover the acquisition body cap over real HTTP

## Why

Follow-up to Codex review feedback on #4014:

- https://github.com/yschimke/compose-ai-tools/pull/4014#discussion_r3791848792
- https://github.com/yschimke/compose-ai-tools/pull/4014#discussion_r3791848793

A busy response happened after staging had already modified and deleted files, while the accepted in-memory file map remained unchanged. The next request could therefore treat missing or rejected disk contents as clean. Separately, a capped acquisition read returned `null`, which was interpreted as an empty legacy request.

## Validation

- `:cli:test --tests PlaygroundCompileServiceTest --tests PlaygroundRoutingTest` — passed
- `git diff --check`

`ktfmtCheckTest` currently also reports a pre-existing formatting issue in `ServeWebTest` on `main`; that unrelated line is intentionally excluded.