### PR TITLE
fix(release): keep action refs on release tag

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -30,8 +30,7 @@ runs:
         echo "::warning::a11y-report is deprecated; call ./.github/actions/apply with only=a11y + a11y-module=<module> instead. See apply/action.yml for the input mapping."
 
     # This public action intentionally follows its own release tag; release-please updates it atomically.
-    # x-release-please-version
-    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # zizmor: ignore[unpinned-uses]
+    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
       with:
         mode: ${{ inputs.mode }}
         only: 'a11y'

--- a/.github/actions/apply/action.yml
+++ b/.github/actions/apply/action.yml
@@ -690,8 +690,7 @@ runs:
     - name: Install CLI from source
       if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version == 'source')
       # The released action intentionally composes the matching released helper.
-      # x-release-please-version
-      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v1.8.0 # zizmor: ignore[unpinned-uses]
+      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
 
     # `cli-version: 'none'` is the third install state — install is skipped
     # entirely. Compose / resources pipelines must then run with
@@ -701,8 +700,7 @@ runs:
       id: install-release
       if: steps.resolve.outputs.phase != 'publish' && (steps.scope.outputs.mode != 'skip' && steps.clivers.outputs.version != 'source' && steps.clivers.outputs.version != 'none')
       # The released action intentionally composes the matching released helper.
-      # x-release-please-version
-      uses: yschimke/compose-ai-tools/.github/actions/install@v1.8.0 # zizmor: ignore[unpinned-uses]
+      uses: yschimke/compose-ai-tools/.github/actions/install@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
       with:
         version: ${{ steps.clivers.outputs.version }}
         catalog-path: ${{ inputs.catalog-path }}

--- a/.github/actions/notification-previews/action.yml
+++ b/.github/actions/notification-previews/action.yml
@@ -34,8 +34,7 @@ runs:
         echo "::warning::notification-previews is deprecated; call ./.github/actions/apply with only=notifications + notifications-module=<module> instead. See apply/action.yml for the input mapping."
 
     # This public action intentionally follows its own release tag; release-please updates it atomically.
-    # x-release-please-version
-    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # zizmor: ignore[unpinned-uses]
+    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
       with:
         mode: ${{ inputs.mode }}
         only: 'notifications'

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -44,8 +44,7 @@ runs:
         echo "::warning::preview-baselines is deprecated; call ./.github/actions/apply with mode=baseline + only=compose,resources instead. See apply/action.yml for the input mapping."
 
     # This public action intentionally follows its own release tag; release-please updates it atomically.
-    # x-release-please-version
-    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # zizmor: ignore[unpinned-uses]
+    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
       with:
         mode: baseline
         only: 'compose,resources'

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -47,8 +47,7 @@ runs:
         echo "::warning::preview-comment is deprecated; call ./.github/actions/apply with mode=comment + only=compose,resources instead. See apply/action.yml for the input mapping."
 
     # This public action intentionally follows its own release tag; release-please updates it atomically.
-    # x-release-please-version
-    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # zizmor: ignore[unpinned-uses]
+    - uses: yschimke/compose-ai-tools/.github/actions/apply@v1.8.0 # x-release-please-version; zizmor: ignore[unpinned-uses]
       with:
         mode: comment
         only: 'compose,resources'


### PR DESCRIPTION
## What changed

Move each `x-release-please-version` annotation onto the same YAML line as the action reference it controls.

## Why

Follow-up to the latest Codex review on #3966:

https://github.com/yschimke/compose-ai-tools/pull/3966#discussion_r3791849437

Release Please's Generic updater replaces version values on the annotated line. The previous standalone marker comments therefore left the public wrappers delegating to `apply@v1.8.0`, and `apply` composing its v1.8.0 install helpers, while the manifest advanced to 1.9.0.

Official behavior: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files

## Validation

- parsed all five composite action files as YAML
- verified every `x-release-please-version` line contains its semantic action tag
- `git diff --check`

The two missing changelog entries on #3966 require release-note commit overrides or a direct release-branch update; they are intentionally separate from this reusable configuration fix.