### PR TITLE
test(serve): pin asymmetric typography coverage

### DIFF
--- a/cli/serve-web/test/referenceCompareElement.test.ts
+++ b/cli/serve-web/test/referenceCompareElement.test.ts
@@ -17,18 +17,20 @@ import "../src/components/ReferenceCompare.js";
  * heavier usage reads as a local override rather than a fidelity finding.
  */
 const bold = (side: string) =>
-    [700, 400, 400].map((weight, i) => ({
-        kind: "typography",
-        role: `Heading ${side} ${i}`,
-        label: "Title",
-        bounds: { x: 10, y: 60 + i * 30, width: 60, height: 20 },
-        detail: {
-            token: "m3/title-medium",
-            fontSize: "20sp",
-            lineHeight: "24sp",
-            fontWeight: String(weight),
-        },
-    }));
+    (side === "reference" ? [700, 400, 400] : [700, 400, 400, 400]).map(
+        (weight, i) => ({
+            kind: "typography",
+            role: `Heading ${side} ${i}`,
+            label: "Title",
+            bounds: { x: 10, y: 60 + i * 30, width: 60, height: 20 },
+            detail: {
+                token: "m3/title-medium",
+                fontSize: "20sp",
+                lineHeight: "24sp",
+                fontWeight: String(weight),
+            },
+        }),
+    );
 
 const ANNOTATIONS = {
     reference: [
@@ -331,12 +333,20 @@ describe("<cp-reference-compare>", () => {
             3,
             "one row per paired style, not one per usage",
         );
-        const counts = Array.from(
-            document.querySelectorAll(".cp-typography-count"),
-        ).map((n) => n.textContent);
-        // Two sides per row. The singular/plural is the readout, so it is asserted as text.
-        assert.equal(counts.filter((c) => c === "2 usages").length, 2);
-        assert.equal(counts.filter((c) => c === "1 usage").length, 4);
+        const countsByRow = Array.from(
+            document.querySelectorAll(".cp-typography-group"),
+        ).map((row) =>
+            Array.from(row.querySelectorAll(".cp-typography-count")).map(
+                (count) => count.textContent,
+            ),
+        );
+        // Preserve row and side association: the title default is used twice in the reference but
+        // three times in the actual, while both the label and heavier override are singular per side.
+        assert.deepEqual(countsByRow, [
+            ["1 usage", "1 usage"],
+            ["1 usage", "1 usage"],
+            ["2 usages", "3 usages"],
+        ]);
     });
 
     it("marks a local override, and says which default it departed from", async () => {

--- a/vscode-extension/preview-harness/README.md
+++ b/vscode-extension/preview-harness/README.md
@@ -77,7 +77,7 @@ A few specifics that come up:
   build, not the headless shell).
 - **Live XR capture** (`spatial-xr-real`): the committed spatial fixtures wrap
   the `spatial-rich` proxy (per-panel renders assembled offline). To diff the
-  *actual* `composePreviewRenderXr` output, the `render-xr-composite` CI job
+  _actual_ `composePreviewRenderXr` output, the `render-xr-composite` CI job
   generates a fixture from the real render dir with
   [`fixtures/spatial-xr-real.gen.mjs`](fixtures/spatial-xr-real.gen.mjs)
   (`--render-dir <renders/<id>> --texture-base /spatial-fixtures/spatial-xr-real/`),
@@ -134,9 +134,9 @@ rather than booting `scenario.html` and replaying messages.
   test `ServeWebFixtureTest`, which also fails CI if the committed HTML drifts
   from `ServeWeb`. Refresh after a serve-UI change with:
 
-  ```sh
-  UPDATE_SERVE_WEB_FIXTURES=true ./gradlew :cli:test --tests '*ServeWebFixtureTest*'
-  ```
+    ```sh
+    UPDATE_SERVE_WEB_FIXTURES=true ./gradlew :cli:test --tests '*ServeWebFixtureTest*'
+    ```
 
 The `snapshot` path filter in `harness:snapshot` matches this spec too, so these
 land in `out/` alongside the panel fixtures and need no separate CI wiring.
@@ -327,12 +327,12 @@ maintenance for an answer that does not involve pixels.
 
 Measured on this suite:
 
-| | count |
-| --- | --- |
-| `FIXTURE_STATES` entries | 59 |
-| …carrying any `expect()` | 9 |
-| …pure captures | 50 |
-| `cli/serve-web` tests | 743 in 51 files (19 element, 32 pure) |
+|                          | count                                 |
+| ------------------------ | ------------------------------------- |
+| `FIXTURE_STATES` entries | 59                                    |
+| …carrying any `expect()` | 9                                     |
+| …pure captures           | 50                                    |
+| `cli/serve-web` tests    | 743 in 51 files (19 element, 32 pure) |
 
 The 50 pure captures are the harness doing its job. The 9 hybrids are worth
 reading, because most of what they assert has a cheaper home:
@@ -348,7 +348,8 @@ reading, because most of what they assert has a cheaper home:
   that test checked only that a group existed, and the claim here was wrong
   until the coverage was actually written. Check before you move something.
 
-THREE of them genuinely need a browser and should stay:
+FOUR `FIXTURE_STATES` entries genuinely need a browser and should stay, covering
+three categories of checks:
 
 - `toBeVisible()`, which is a CSS question happy-dom cannot answer;
 - the design page's alignment check, which measures real laid-out geometry
@@ -377,7 +378,7 @@ fixture costs a baseline. That is not a theoretical concern:
 
 Both shipped, both were found by reading code rather than by ~500 captures. A
 decision whose inputs are expensive to vary is under-covered by construction, so
-coverage of *decisions* belongs where inputs are free.
+coverage of _decisions_ belongs where inputs are free.
 
 ### Cost, for calibration
 
@@ -391,7 +392,7 @@ There are 58 page fixtures.
 3. Keep the capture for what is left: the picture.
 
 The same brittleness exists one layer down. Six Kotlin assertions that grepped
-`viewer.js` / `format-compare.js` for the *spelling* of an expression broke
+`viewer.js` / `format-compare.js` for the _spelling_ of an expression broke
 during the TypeScript migration without any behaviour changing; each was
 retargeted at the seam, with the rule itself driven by a real test. A test that
 pins source text is a screenshot of code.


### PR DESCRIPTION
## Summary

- make the reference/actual typography fixture deliberately asymmetric
- assert per-row, per-side usage-count text instead of flattened totals
- document the four browser-only fixture states as three categories

This follows up the remaining Codex review findings on #4010 and confirms the earlier #3982 coverage concerns are now represented directly.

## Verification

- `npm run typecheck` (`cli/serve-web`)
- `npm test` (`cli/serve-web`): 783 passing
- `git diff --check`