### PR TITLE
fix(deps): update Wear Compose to 1.7.0-beta01

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -2277,7 +2277,7 @@ open class RobolectricHost(
         }
       // [GesturePreviewOverrideExtension] plans a [GestureOverrideExtension] whose composition
       // reaches `androidx.wear.compose.material3.onehandedgesture` (gesture API added in
-      // wear-compose 1.7.0-alpha). Gate registration on that package being loadable so
+      // wear-compose 1.7.0-beta). Gate registration on that package being loadable so
       // plain-Android
       // — or pre-1.7 Wear — consumers never resolve the gesture types. Mirrors the ambient gate.
       val gestureOverrides =

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/SandboxHoldingRunner.kt
@@ -229,7 +229,7 @@ internal fun isWearAmbientAvailable(loader: ClassLoader?): Boolean {
 /**
  * Returns `true` when the Wear one-handed-gesture API
  * (`androidx.wear.compose.material3.onehandedgesture.OneHandedGestureModifierKt`, added in
- * `wear-compose 1.7.0-alpha`) is on the supplied classloader. Gates `:data-gestures-connector`
+ * `wear-compose 1.7.0-beta`) is on the supplied classloader. Gates `:data-gestures-connector`
  * registration so a plain-Android consumer — or a Wear consumer still on `wear-compose 1.6.x` —
  * doesn't drive `GestureOverrideExtension`'s composition into unresolved gesture types.
  */

--- a/data/ambient/connector/build.gradle.kts
+++ b/data/ambient/connector/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.data.ambient.connector"
-  // wear-compose 1.7.0-alpha's AARs declare `minCompileSdk = 37`; compile against API 37 to link
+  // wear-compose 1.7.0-beta's AARs declare `minCompileSdk = 37`; compile against API 37 to link
   // against `androidx.wear.compose.foundation`. Override the conventions plugin's `compileSdk =
   // 36`.
   compileSdk = 37

--- a/data/gestures/connector/build.gradle.kts
+++ b/data/gestures/connector/build.gradle.kts
@@ -1,6 +1,6 @@
 // `:data-gestures-connector` glues `:data-gestures-core` (the wire-shape payload) to the daemon's
 // data-product / preview-override surface for the Wear OS one-handed-gesture framework
-// (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-alpha`). Ships:
+// (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-beta`). Ships:
 //
 //  - `GestureStateController` — process-static registry + state holder for the gesture handlers a
 //    preview reports, plus the enabled / hint / last-invoked state the data product serves.
@@ -28,7 +28,7 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.data.gestures.connector"
-  // The wear-compose 1.7.0-alpha AARs (`compose-material3`, `compose-foundation`,
+  // The wear-compose 1.7.0-beta AARs (`compose-material3`, `compose-foundation`,
   // `compose-material-core`) declare `minCompileSdk = 37`, so this module compiles against API 37
   // to see the gesture types directly. Override the conventions plugin's `compileSdk = 36` default.
   // Same pattern `:data-remotecompose-connector` / `:samples:remotecompose` use for their alpha
@@ -63,11 +63,11 @@ dependencies {
   api(project(":data-render-compose"))
 
   // `androidx.wear.compose.material3.onehandedgesture.*` — the real one-handed-gesture API the
-  // reporting seam wraps (`oneHandedGesture`, `OneHandedGestureClickIndicator`, `GestureAction`,
-  // `LocalOneHandedGestureEnabled`) plus `LocalContentColor`. `compileOnly` because consumers
-  // using the public reporting/indicator helpers are Wear apps that already pull
-  // wear-compose-material3 at runtime; `:daemon:android` can still link the connector without
-  // transitively publishing the alpha Wear stack.
+  // reporting seam wraps (`oneHandedGesture`, `OneHandedGestureClickIndicator`,
+  // `OneHandedGestureAction`, `LocalOneHandedGestureEnabled`) plus `LocalContentColor`.
+  // `compileOnly` because consumers using the public reporting/indicator helpers are Wear apps
+  // that already pull wear-compose-material3 at runtime; `:daemon:android` can still link the
+  // connector without transitively publishing the beta Wear stack.
   compileOnly(libs.wear.compose.material3)
   testImplementation(libs.wear.compose.material3)
 

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureIndicatorIcon.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureIndicatorIcon.kt
@@ -13,27 +13,26 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.LocalContentColor
-import androidx.wear.compose.material3.onehandedgesture.GestureAction
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureAction
 
 /**
  * Renders wear-compose-material3's shipped gesture-indicator AVD as a static, tinted peak frame.
  *
- * Alpha06's explicit indicator state triggers a finite animation and is reset by the real
- * indicator. Robolectric completes that animation during idle pre-roll, so [GestureHint] uses this
- * replica only for a forced still capture. Normal on-device rendering uses the real state-backed
- * indicator.
+ * The explicit indicator state triggers a finite animation and is reset by the real indicator.
+ * Robolectric completes that animation during idle pre-roll, so [GestureHint] uses this replica
+ * only for a forced still capture. Normal on-device rendering uses the real state-backed indicator.
  */
 @OptIn(ExperimentalAnimationGraphicsApi::class)
 @Composable
 fun GestureIndicatorIcon(
-  action: GestureAction,
+  action: OneHandedGestureAction,
   modifier: Modifier = Modifier,
   size: Dp = 40.dp,
   tint: Color = LocalContentColor.current,
 ) {
   val resId =
     when (action) {
-      GestureAction.Dismiss ->
+      OneHandedGestureAction.Dismiss ->
         androidx.wear.compose.material3.R.drawable
           .wear_one_handed_gesture_dismiss_indicator_animation
       else ->

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureReporting.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureReporting.kt
@@ -14,22 +14,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.wear.compose.material3.LocalContentColor
-import androidx.wear.compose.material3.onehandedgesture.GestureAction
-import androidx.wear.compose.material3.onehandedgesture.GestureIndicatorSize
 import androidx.wear.compose.material3.onehandedgesture.LocalOneHandedGestureEnabled
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureAction
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureConfiguration
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureIndicatorSize
 import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
 import ee.schimke.composeai.daemon.protocol.GestureKindOverride
 import kotlinx.coroutines.launch
 
 /**
- * Consumer-facing kind of one-handed gesture, mapped to the Wear framework [GestureAction] and the
- * `compose/gestures` wire spelling ([GestureKindOverride]). `SCROLL` and `PAGE` are
- * [GestureAction.Primary] gestures (the primary "double pinch" also drives scroll / paging per the
- * Wear design guide) but stay distinct in the data product so an agent can tell a play button from
- * a scroll surface.
+ * Consumer-facing kind of one-handed gesture, mapped to the Wear framework [OneHandedGestureAction]
+ * and the `compose/gestures` wire spelling ([GestureKindOverride]). `SCROLL` and `PAGE` are
+ * [OneHandedGestureAction.Primary] gestures (the primary "double pinch" also drives scroll / paging
+ * per the Wear design guide) but stay distinct in the data product so an agent can tell a play
+ * button from a scroll surface.
  */
 enum class GestureType(val wire: GestureKindOverride) {
   PRIMARY(GestureKindOverride.PRIMARY),
@@ -37,12 +37,12 @@ enum class GestureType(val wire: GestureKindOverride) {
   SCROLL(GestureKindOverride.SCROLL),
   PAGE(GestureKindOverride.PAGE);
 
-  fun toGestureAction(): GestureAction =
+  fun toGestureAction(): OneHandedGestureAction =
     when (this) {
       PRIMARY,
       SCROLL,
-      PAGE -> GestureAction.Primary
-      DISMISS -> GestureAction.Dismiss
+      PAGE -> OneHandedGestureAction.Primary
+      DISMISS -> OneHandedGestureAction.Dismiss
     }
 }
 
@@ -67,7 +67,8 @@ val LocalGestureRegistry: ProvidableCompositionLocal<GestureStateController> =
  * `renderNow.overrides.gestures.invoke` / an `input.gesture` recording event — neither of which the
  * framework's internal, Pixel-Watch-only registry exposes.
  *
- * @param type gesture kind (drives the framework [GestureAction] and the reported wire kind).
+ * @param type gesture kind (drives the framework [OneHandedGestureAction] and the reported wire
+ *   kind).
  * @param label accessibility / hint label, forwarded to `oneHandedGesture(onGestureLabel = …)` and
  *   used as the handler's identity in the data product.
  * @param gestureConfiguration persistent action/id/priority specification shared with the matching
@@ -128,7 +129,7 @@ fun GestureHint(
   indicatorState: OneHandedGestureClickIndicatorState,
   modifier: Modifier = Modifier,
   forceShow: Boolean = false,
-  gestureIndicatorSize: GestureIndicatorSize = GestureIndicatorSize.Medium,
+  gestureIndicatorSize: OneHandedGestureIndicatorSize = OneHandedGestureIndicatorSize.Medium,
   gestureIndicatorTint: Color = LocalContentColor.current,
   content: @Composable () -> Unit,
 ) {

--- a/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureStateController.kt
+++ b/data/gestures/connector/src/main/kotlin/ee/schimke/composeai/daemon/GestureStateController.kt
@@ -13,9 +13,10 @@ import java.util.concurrent.CopyOnWriteArrayList
 /**
  * Process-static state holder + registry for the Wear OS one-handed-gesture connector.
  *
- * The Wear gesture framework (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-alpha`) registers
- * handlers with an **internal**, on-device-only `GestureManager`; off a Pixel Watch it silently
- * no-ops and nothing is observable. This controller makes gestures observable + drivable two ways:
+ * The Wear gesture framework (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-beta`) registers
+ * handlers with an **internal**, on-device-only `OneHandedGestureManager`; off a Pixel Watch it
+ * silently no-ops and nothing is observable. This controller makes gestures observable + drivable
+ * two ways:
  * - **Opt-in, labelled** — a preview wires [reportedOneHandedGesture], which applies the real
  *   modifier *and* reports each handler here (with the author's label).
  * - **Zero-change, framework-level** — [ShadowSdkGestureInputManager] shadows the framework's

--- a/data/gestures/core/src/main/kotlin/ee/schimke/composeai/data/gestures/GestureModels.kt
+++ b/data/gestures/core/src/main/kotlin/ee/schimke/composeai/data/gestures/GestureModels.kt
@@ -21,7 +21,7 @@ object Material3GestureProduct {
  * gesture hints for this render ([hintsShown]), and — for interactive sessions — the label of the
  * handler last invoked via an `input.gesture` script event ([lastInvoked]).
  *
- * The gesture framework (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-alpha`) only dispatches
+ * The gesture framework (`Modifier.oneHandedGesture` in `wear-compose 1.7.0-beta`) only dispatches
  * on a Pixel Watch 3+; off-device it silently no-ops. This data product is what makes the otherwise
  * invisible gesture wiring observable under Robolectric / `@Preview`, and lets an agent invoke a
  * handler without the hardware.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,7 +108,7 @@ navigation-compose = "2.9.8"
 # 1.1.x is the current stable line; bump when the Glance team ships a 1.2.x with the planned
 # preview-DSL stabilisation.
 glance-appwidget = "1.2.0-rc01"
-wear-compose = "1.7.0-alpha07"
+wear-compose = "1.7.0-beta01"
 wear-tiles = "1.6.2"
 wear-protolayout = "1.4.2"
 wear-tooling-preview = "1.0.0"

--- a/renderers/android/build.gradle.kts
+++ b/renderers/android/build.gradle.kts
@@ -11,7 +11,7 @@ android {
   namespace = "ee.schimke.composeai.renderer"
   // The `composeai.maven-publishing` convention wires the `singleVariant("release")`
   // publication for us — don't declare it twice.
-  // wear-compose 1.7.0-alpha's AARs declare `minCompileSdk = 37`; compile against API 37 so the
+  // wear-compose 1.7.0-beta's AARs declare `minCompileSdk = 37`; compile against API 37 so the
   // `compileOnly` `wear.compose.foundation` types resolve. Override the conventions `compileSdk =
   // 36`.
   compileSdk = 37

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ShadowWearTimeSource.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/ShadowWearTimeSource.kt
@@ -16,7 +16,7 @@ import org.robolectric.annotation.Implements
  * currentTime({ currentTimeMillis() }, timeFormat).value
  * ```
  *
- * Neither major has an inspection-mode branch (checked through `1.7.0-alpha07`), so there is no
+ * Neither major has an inspection-mode branch (checked through `1.7.0-beta01`), so there is no
  * `LocalInspectionMode` seam here the way there is elsewhere: a preview gets a fixed clock only by
  * passing its own `TimeSource`, which an activity hero — rendering the app's real screen — has no
  * way to do. Hence a shadow.

--- a/runtimes/wear-preview/build.gradle.kts
+++ b/runtimes/wear-preview/build.gradle.kts
@@ -41,7 +41,7 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.wear.preview"
-  // wear-compose 1.7.0-alpha requires `compileSdk = 37` (mirrors :samples:design-catalog-wear-m3).
+  // wear-compose 1.7.0-beta requires `compileSdk = 37` (mirrors :samples:design-catalog-wear-m3).
   compileSdk = 37
 
   buildFeatures { compose = true }

--- a/samples/design-catalog-wear-m3/build.gradle.kts
+++ b/samples/design-catalog-wear-m3/build.gradle.kts
@@ -51,7 +51,7 @@ val wearCatalogAuthoredLocales: List<String> =
 
 android {
   namespace = "com.example.designcatalogwearm3"
-  // wear-compose 1.7.0-alpha requires `compileSdk = 37`; override the conventions `compileSdk =
+  // wear-compose 1.7.0-beta requires `compileSdk = 37`; override the conventions `compileSdk =
   // 36`.
   compileSdk = 37
 

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -20,7 +20,7 @@ composePreview {
 
 android {
   namespace = "com.example.samplewear"
-  // wear-compose 1.7.0-alpha (gesture API) requires `compileSdk = 37`; override the conventions
+  // wear-compose 1.7.0-beta (gesture API) requires `compileSdk = 37`; override the conventions
   // plugin's `compileSdk = 36` default. Robolectric still renders at SDK 35 (see `composePreview`).
   compileSdk = 37
 

--- a/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/GestureHintPreviews.kt
@@ -19,7 +19,7 @@ import androidx.wear.compose.material3.FilledTonalButton
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
-import androidx.wear.compose.material3.onehandedgesture.GestureAction
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureAction
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicator
 import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
 import androidx.wear.tooling.preview.devices.WearDevices
@@ -43,10 +43,10 @@ fun MediaGestureScreen(showIndicators: Boolean = false, onDismiss: () -> Unit = 
   val playSource = remember { MutableInteractionSource() }
   val backSource = remember { MutableInteractionSource() }
   val playConfiguration =
-    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:media-play")
+    rememberGestureConfiguration(OneHandedGestureAction.Primary, key = "samplewear:media-play")
   val playIndicatorState = rememberGestureIndicatorState(forceShow = showIndicators)
   val backConfiguration =
-    rememberGestureConfiguration(GestureAction.Dismiss, key = "samplewear:media-back")
+    rememberGestureConfiguration(OneHandedGestureAction.Dismiss, key = "samplewear:media-back")
   val backIndicatorState = rememberGestureIndicatorState(forceShow = showIndicators)
   val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
   ScreenScaffold {

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Gestures.kt
@@ -37,15 +37,15 @@ import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
-import androidx.wear.compose.material3.onehandedgesture.GestureAction
-import androidx.wear.compose.material3.onehandedgesture.GesturePriority
 import androidx.wear.compose.material3.onehandedgesture.LocalOneHandedGestureEnabled
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureAction
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureClickIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureConfiguration
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureDefaults
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureHorizontalPageIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGesturePageIndicatorState
+import androidx.wear.compose.material3.onehandedgesture.OneHandedGesturePriority
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureScrollIndicator
 import androidx.wear.compose.material3.onehandedgesture.OneHandedGestureScrollIndicatorState
 import androidx.wear.compose.material3.onehandedgesture.oneHandedGesture
@@ -86,9 +86,9 @@ object GestureRoutes {
 
 @Composable
 internal fun rememberGestureConfiguration(
-  action: GestureAction,
+  action: OneHandedGestureAction,
   key: String,
-  priority: GesturePriority = GesturePriority.Clickable,
+  priority: OneHandedGesturePriority = OneHandedGesturePriority.Clickable,
 ): OneHandedGestureConfiguration =
   rememberOneHandedGestureConfiguration(
     action = action,
@@ -245,7 +245,7 @@ private fun PlayGestureButton(forceHint: Boolean) {
   var playing by remember { mutableStateOf(false) }
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:play")
+    rememberGestureConfiguration(OneHandedGestureAction.Primary, key = "samplewear:play")
   val indicatorState = rememberGestureIndicatorState(forceShow = forceHint)
   val coroutineScope = rememberCoroutineScope()
   Button(
@@ -283,7 +283,7 @@ fun PrimaryActionScreen(forceHint: Boolean = false) {
 fun DismissActionScreen(onDismiss: () -> Unit = {}, forceHint: Boolean = false) {
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureAction.Dismiss, key = "samplewear:dismiss")
+    rememberGestureConfiguration(OneHandedGestureAction.Dismiss, key = "samplewear:dismiss")
   val indicatorState = rememberGestureIndicatorState(forceShow = forceHint)
   val coroutineScope = rememberCoroutineScope()
   GestureDemoScreen(
@@ -314,9 +314,9 @@ fun ScrollGestureScreen(forceHint: Boolean = false) {
   val coroutineScope = rememberCoroutineScope()
   val gestureConfiguration =
     rememberGestureConfiguration(
-      GestureAction.Primary,
+      OneHandedGestureAction.Primary,
       key = "samplewear:scroll",
-      priority = GesturePriority.Scrollable,
+      priority = OneHandedGesturePriority.Scrollable,
     )
   val indicatorState = rememberScrollGestureIndicatorState(forceHint)
   ScreenScaffold(scrollState = listState) { contentPadding ->
@@ -360,9 +360,9 @@ fun PageGestureScreen(forceHint: Boolean = false) {
   val coroutineScope = rememberCoroutineScope()
   val gestureConfiguration =
     rememberGestureConfiguration(
-      GestureAction.Primary,
+      OneHandedGestureAction.Primary,
       key = "samplewear:page",
-      priority = GesturePriority.Scrollable,
+      priority = OneHandedGesturePriority.Scrollable,
     )
   val indicatorState = rememberPageGestureIndicatorState(forceHint)
   ScreenScaffold {
@@ -405,7 +405,7 @@ fun PageGestureScreen(forceHint: Boolean = false) {
 fun DisabledGestureScreen() {
   val interactionSource = remember { MutableInteractionSource() }
   val gestureConfiguration =
-    rememberGestureConfiguration(GestureAction.Primary, key = "samplewear:disabled-play")
+    rememberGestureConfiguration(OneHandedGestureAction.Primary, key = "samplewear:disabled-play")
   CompositionLocalProvider(LocalOneHandedGestureEnabled provides false) {
     GestureDemoScreen(title = "Disabled", instruction = "Gestures off on this screen") {
       Button(
@@ -459,9 +459,9 @@ fun ScrollIndicatorStickerPreview() {
     val listState = rememberTransformingLazyColumnState()
     val gestureConfiguration =
       rememberGestureConfiguration(
-        GestureAction.Primary,
+        OneHandedGestureAction.Primary,
         key = "samplewear:scroll-sticker",
-        priority = GesturePriority.Scrollable,
+        priority = OneHandedGesturePriority.Scrollable,
       )
     OneHandedGestureScrollIndicator(
       gestureConfiguration = gestureConfiguration,
@@ -478,9 +478,9 @@ fun PageIndicatorStickerPreview() {
   GestureSticker {
     val gestureConfiguration =
       rememberGestureConfiguration(
-        GestureAction.Primary,
+        OneHandedGestureAction.Primary,
         key = "samplewear:page-sticker",
-        priority = GesturePriority.Scrollable,
+        priority = OneHandedGesturePriority.Scrollable,
       )
     OneHandedGestureHorizontalPageIndicator(
       gestureConfiguration = gestureConfiguration,


### PR DESCRIPTION
## Summary

- update Wear Compose from `1.7.0-alpha07` to `1.7.0-beta01`
- migrate the one-handed gesture integration and Wear samples to the beta API names
- refresh version-specific documentation across the renderer and preview modules

## Why

Wear Compose beta01 renamed the public gesture action, priority, and indicator-size types with the `OneHandedGesture` prefix. Updating the dependency without migrating those references caused unresolved symbols in the gesture connector and downstream Wear builds.

The internal `SdkGestureInputManagerImpl` bridge used by the Robolectric shadow remains unchanged, so framework-level gesture discovery and invocation continue to work.

## Impact

Wear samples and preview gesture support now build against the beta line while preserving the existing gesture behavior and preview data-product integration.

## Validation

- `./gradlew :data-gestures-connector:compileDebugKotlin :samples:wear:compileDebugKotlin`
- `./gradlew :data-gestures-connector:testDebugUnitTest :samples:wear:testDebugUnitTest`
- `./gradlew :data-gestures-connector:ktfmtCheck :samples:wear:ktfmtCheck`
- `git diff --check`
