### PR TITLE
fix(samples): adopt Material 3 alpha26 ripple API

### DIFF
--- a/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
+++ b/samples/android-alpha/src/main/kotlin/com/example/samplealpha/FocusRingPreviews.kt
@@ -45,7 +45,7 @@ private fun WithRippleConfig(config: RippleThemeConfiguration, content: @Composa
 @Composable
 fun InsetFocusRingFanOutPreview() {
   MaterialTheme {
-    WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
+    WithRippleConfig(RippleDefaults.InsetFocusRingThemeConfiguration) { ButtonRow() }
   }
 }
 
@@ -62,22 +62,20 @@ fun InsetFocusRingFanOutPreview() {
 @Composable
 fun InsetFocusRingMovingPreview() {
   MaterialTheme {
-    WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
+    WithRippleConfig(RippleDefaults.InsetFocusRingThemeConfiguration) { ButtonRow() }
   }
 }
 
 /**
- * Opacity-focus baseline: the same row drawn under
- * `RippleDefaults.OpacityFocusRippleThemeConfiguration`. Pair-render with the inset-ring fan-out to
- * see the visual delta between the two focus-indication strategies.
+ * Opacity-focus baseline: the same row drawn under `RippleDefaults.OpacityFocusThemeConfiguration`.
+ * Pair-render with the inset-ring fan-out to see the visual delta between the two focus-indication
+ * strategies.
  */
 @Preview(name = "Opacity Focus", widthDp = 480, heightDp = 96, showBackground = true)
 @FocusedPreview(indices = [1])
 @Composable
 fun OpacityFocusPreview() {
-  MaterialTheme {
-    WithRippleConfig(RippleDefaults.OpacityFocusRippleThemeConfiguration) { ButtonRow() }
-  }
+  MaterialTheme { WithRippleConfig(RippleDefaults.OpacityFocusThemeConfiguration) { ButtonRow() } }
 }
 
 /**
@@ -94,7 +92,7 @@ fun OpacityFocusPreview() {
 @Composable
 fun FocusTraversalPreview() {
   MaterialTheme {
-    WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
+    WithRippleConfig(RippleDefaults.InsetFocusRingThemeConfiguration) { ButtonRow() }
   }
 }
 
@@ -109,6 +107,6 @@ fun FocusTraversalPreview() {
 @Composable
 fun FocusOverlayPreview() {
   MaterialTheme {
-    WithRippleConfig(RippleDefaults.InsetFocusRingRippleThemeConfiguration) { ButtonRow() }
+    WithRippleConfig(RippleDefaults.InsetFocusRingThemeConfiguration) { ButtonRow() }
   }
 }

--- a/samples/design-catalog-m3-android/src/main/kotlin/com/example/designcatalogm3android/FocusRing.kt
+++ b/samples/design-catalog-m3-android/src/main/kotlin/com/example/designcatalogm3android/FocusRing.kt
@@ -22,10 +22,10 @@ import ee.schimke.composeai.preview.FocusedPreview
 
 /**
  * Android-only catalog theme that opts into the Material 3 **inset focus ring** — via
- * [RippleDefaults.InsetFocusRingRippleThemeConfiguration] over [LocalRippleThemeConfiguration]
- * (material3 1.5.0-alpha+) — the keyboard-focus indicator the design system ships. CMP `material3`
- * has no equivalent yet, so the focus-ring stickers are rendered here (Robolectric) and folded into
- * the otherwise-CMP `compose-m3` catalog by the design-artifacts generator.
+ * [RippleDefaults.InsetFocusRingThemeConfiguration] over [LocalRippleThemeConfiguration] (material3
+ * 1.5.0-alpha+) — the keyboard-focus indicator the design system ships. CMP `material3` has no
+ * equivalent yet, so the focus-ring stickers are rendered here (Robolectric) and folded into the
+ * otherwise-CMP `compose-m3` catalog by the design-artifacts generator.
  *
  * Mirrors the ring-colour override the CMP-era catalog used: the stroke goes `primary` (outer) over
  * `surface` (inner gap) instead of the stock muted `secondary`/`onSecondary`, so the ring stays
@@ -37,7 +37,7 @@ private fun FocusRingSticker(content: @Composable () -> Unit) {
   val colorScheme = if (dark) darkColorScheme() else lightColorScheme()
   MaterialTheme(colorScheme = colorScheme) {
     CompositionLocalProvider(
-      LocalRippleThemeConfiguration provides RippleDefaults.InsetFocusRingRippleThemeConfiguration,
+      LocalRippleThemeConfiguration provides RippleDefaults.InsetFocusRingThemeConfiguration,
       LocalRippleConfiguration provides
         RippleConfiguration(
           focus =


### PR DESCRIPTION
## What changed

- migrate the Android alpha focus-ring previews to the Material 3 alpha26 ripple configuration names
- update the Android Material 3 catalog's focus-ring configuration and KDoc
- keep Material 3 pinned at `1.5.0-alpha26`

## Root cause

Material 3 `1.5.0-alpha26` renamed `RippleDefaults.InsetFocusRingRippleThemeConfiguration` and `RippleDefaults.OpacityFocusRippleThemeConfiguration`. The dependency update landed while both sample modules still referenced the alpha25 names, leaving `:samples:android-alpha` and `:samples:design-catalog-m3-android` unable to compile.

## Impact

Both alpha26-dependent samples build again, and their inset-ring and opacity-focus previews continue to render through the replacement API.

## Validation

- `./gradlew :samples:android-alpha:ktfmtCheck :samples:design-catalog-m3-android:ktfmtCheck :samples:android-alpha:composePreviewRenderAll :samples:design-catalog-m3-android:composePreviewRenderAll --no-daemon`
- `./gradlew :samples:android-alpha:build :samples:design-catalog-m3-android:build --no-daemon`