### PR TITLE
fix(playground): keep diagnostics with edited buffers

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4837,7 +4837,7 @@ $noteBlock        <div class="cp-site-footer-links">
         if (!editor) return;
         editorDiags.forEach(function (entry) {
           if (entry.widget) entry.widget.clear();
-          if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+          if (entry.lineHandle) editor.removeLineClass(entry.lineHandle, "background", entry.lineClass);
           if (entry.mark) entry.mark.clear();
         });
         editorDiags = [];
@@ -4850,7 +4850,10 @@ $noteBlock        <div class="cp-site-footer-links">
           if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
           var severity = d.severity || "info";
           var lineClass = "cp-pg-line-" + severity;
-          editor.addLineClass(d.line, "background", lineClass);
+          // CodeMirror moves this handle with the line when edits are inserted above it. Keeping
+          // the original numeric index would clear whichever line later occupied that position and
+          // strand the actual diagnostic highlight after the next compile.
+          var lineHandle = editor.addLineClass(d.line, "background", lineClass);
           var message = document.createElement("div");
           message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
           // The live summary below already announces the same diagnostic. Keep this visual copy
@@ -4872,7 +4875,7 @@ $noteBlock        <div class="cp-site-footer-links">
               );
             }
           }
-          editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+          editorDiags.push({ widget: widget, lineHandle: lineHandle, lineClass: lineClass, mark: mark });
         });
       }
       // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
@@ -4923,6 +4926,10 @@ $noteBlock        <div class="cp-site-footer-links">
         active = Math.min(active, files.length - 1);
         writeSource(files[active].text);
         renderFiles();
+        // Removing the active file is also a tab transition. Repaint the retained diagnostics for
+        // the buffer that just became active instead of leaving its messages hidden until a click
+        // or another compile happens to refresh them.
+        renderEditorDiags();
       });
       renderFiles();
       function setStatus(text, isError) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -3629,9 +3629,17 @@ class ServeWebFixtureTest {
     assertTrue(
       playground.contains("editor.addLineWidget") &&
         playground.contains("editor.addLineClass") &&
+        playground.contains("removeLineClass(entry.lineHandle") &&
         playground.contains("editor.markText") &&
         assetText("playground.css").contains(".cp-pg-inline-error"),
-      "located compiler errors are shown inline beside the source as well as in the summary",
+      "located compiler errors are shown inline and cleared through CodeMirror's moving line handle",
+    )
+    assertTrue(
+      playground
+        .substringAfter("removeFile.addEventListener")
+        .substringBefore("renderFiles();\n      function setStatus")
+        .contains("renderEditorDiags();"),
+      "removing the active file repaints diagnostics for the buffer that replaces it",
     )
     // The terminal status stays exactly "Done." — the e2e polls on it, so the preview note lives
     // in its own element rather than being appended to the status text.

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
@@ -360,7 +360,7 @@ fun MediaControlButtonsPlaying() {
     if (!editor) return;
     editorDiags.forEach(function (entry) {
       if (entry.widget) entry.widget.clear();
-      if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+      if (entry.lineHandle) editor.removeLineClass(entry.lineHandle, "background", entry.lineClass);
       if (entry.mark) entry.mark.clear();
     });
     editorDiags = [];
@@ -373,7 +373,10 @@ fun MediaControlButtonsPlaying() {
       if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
       var severity = d.severity || "info";
       var lineClass = "cp-pg-line-" + severity;
-      editor.addLineClass(d.line, "background", lineClass);
+      // CodeMirror moves this handle with the line when edits are inserted above it. Keeping
+      // the original numeric index would clear whichever line later occupied that position and
+      // strand the actual diagnostic highlight after the next compile.
+      var lineHandle = editor.addLineClass(d.line, "background", lineClass);
       var message = document.createElement("div");
       message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
       // The live summary below already announces the same diagnostic. Keep this visual copy
@@ -395,7 +398,7 @@ fun MediaControlButtonsPlaying() {
           );
         }
       }
-      editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+      editorDiags.push({ widget: widget, lineHandle: lineHandle, lineClass: lineClass, mark: mark });
     });
   }
   // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
@@ -446,6 +449,10 @@ fun MediaControlButtonsPlaying() {
     active = Math.min(active, files.length - 1);
     writeSource(files[active].text);
     renderFiles();
+    // Removing the active file is also a tab transition. Repaint the retained diagnostics for
+    // the buffer that just became active instead of leaving its messages hidden until a click
+    // or another compile happens to refresh them.
+    renderEditorDiags();
   });
   renderFiles();
   function setStatus(text, isError) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -355,7 +355,7 @@ fun Greeting() {
     if (!editor) return;
     editorDiags.forEach(function (entry) {
       if (entry.widget) entry.widget.clear();
-      if (entry.line != null) editor.removeLineClass(entry.line, "background", entry.lineClass);
+      if (entry.lineHandle) editor.removeLineClass(entry.lineHandle, "background", entry.lineClass);
       if (entry.mark) entry.mark.clear();
     });
     editorDiags = [];
@@ -368,7 +368,10 @@ fun Greeting() {
       if (d.file !== file.name || d.line == null || d.line < 0 || d.line >= editor.lineCount()) return;
       var severity = d.severity || "info";
       var lineClass = "cp-pg-line-" + severity;
-      editor.addLineClass(d.line, "background", lineClass);
+      // CodeMirror moves this handle with the line when edits are inserted above it. Keeping
+      // the original numeric index would clear whichever line later occupied that position and
+      // strand the actual diagnostic highlight after the next compile.
+      var lineHandle = editor.addLineClass(d.line, "background", lineClass);
       var message = document.createElement("div");
       message.className = "cp-pg-inline-diag cp-pg-inline-" + severity;
       // The live summary below already announces the same diagnostic. Keep this visual copy
@@ -390,7 +393,7 @@ fun Greeting() {
           );
         }
       }
-      editorDiags.push({ widget: widget, line: d.line, lineClass: lineClass, mark: mark });
+      editorDiags.push({ widget: widget, lineHandle: lineHandle, lineClass: lineClass, mark: mark });
     });
   }
   // The snippet is a LIST of files compiled as one module, not one file: `files` holds every
@@ -441,6 +444,10 @@ fun Greeting() {
     active = Math.min(active, files.length - 1);
     writeSource(files[active].text);
     renderFiles();
+    // Removing the active file is also a tab transition. Repaint the retained diagnostics for
+    // the buffer that just became active instead of leaving its messages hidden until a click
+    // or another compile happens to refresh them.
+    renderEditorDiags();
   });
   renderFiles();
   function setStatus(text, isError) {


### PR DESCRIPTION
## Summary

- retain CodeMirror's moving line handle when applying diagnostic backgrounds
- clear the background through that handle after edits shift the source
- repaint retained diagnostics when removing the active file switches buffers
- regenerate both playground page fixtures

This follows up both remaining Codex review findings on #3980.

## Verification

- `:cli:ktfmtCheck`
- `:cli:test --tests ee.schimke.composeai.cli.serve.ServeWebFixtureTest` (29 tests)
- fixture regeneration followed by normal check-mode verification
- `git diff --check`