### PR TITLE
fix(playground): qualify expanded theme wrappers

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -339,7 +339,7 @@ object PlaygroundSourceCleaner {
       else applySubstitute(out, rules, addedImports)
     out = applyInline(out, rules, addedImports)
     out = applyDrop(out, rules, residue)
-    out = applyMaterial3SystemTheme(out, rules, addedImports)
+    out = applyMaterial3SystemTheme(out, rules)
     out = applyRename(out, rules, addedImports)
     if (isEntry) out = stampPreview(out, rules, addedImports)
     // Residue: declared scaffolding that survived. With a parse, every *call* is visible however it
@@ -528,11 +528,7 @@ object PlaygroundSourceCleaner {
    * argument-free trailing-lambda call. `StickerFrame(tokens) { … }` may encode more than the
    * reusable stock light/dark policy; leaving it as residue is the safe and honest outcome.
    */
-  private fun applyMaterial3SystemTheme(
-    text: String,
-    rules: UsageRules,
-    addedImports: MutableSet<String>,
-  ): String {
+  private fun applyMaterial3SystemTheme(text: String, rules: UsageRules): String {
     var out = text
     for ((name, scaffold) in rules.scaffolds) {
       if (
@@ -540,15 +536,23 @@ object PlaygroundSourceCleaner {
           scaffold.special != UsageRules.MATERIAL3_SYSTEM_THEME
       )
         continue
-      var changed = false
+      // The expansion is fully qualified on purpose. A preserved component body may already use a
+      // different MaterialTheme (or colour-scheme helper) by simple name; injecting AndroidX
+      // imports would make that otherwise valid source ambiguous.
       for (at in wordOccurrences(out, name).asReversed()) {
         var next = at + name.length
         while (next < out.length && out[next].isWhitespace()) next++
+        var replaceEnd = at + name.length
+        if (out.getOrNull(next) == '(') {
+          val close = matchParen(out, next) ?: continue
+          if (out.substring(next + 1, close).isNotBlank()) continue
+          replaceEnd = close + 1
+          next = close + 1
+          while (next < out.length && out[next].isWhitespace()) next++
+        }
         if (out.getOrNull(next) != '{') continue
-        out = out.replaceRange(at, at + name.length, MATERIAL3_SYSTEM_THEME_CALL)
-        changed = true
+        out = out.replaceRange(at, replaceEnd, MATERIAL3_SYSTEM_THEME_CALL)
       }
-      if (changed) addedImports.addAll(scaffold.imports)
     }
     return out
   }
@@ -834,7 +838,7 @@ object PlaygroundSourceCleaner {
   private const val MAX_REWRITES = 64
 
   private const val MATERIAL3_SYSTEM_THEME_CALL =
-    "MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme())"
+    "androidx.compose.material3.MaterialTheme(colorScheme = if (androidx.compose.foundation.isSystemInDarkTheme()) androidx.compose.material3.darkColorScheme() else androidx.compose.material3.lightColorScheme())"
 
   private data class Call(val start: Int, val argsStart: Int, val argsEnd: Int)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -245,25 +245,106 @@ class PlaygroundSourceCleanerTest {
 
     assertTrue(
       result.text.contains(
-        "MaterialTheme(colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()) {"
+        "androidx.compose.material3.MaterialTheme(colorScheme = if (androidx.compose.foundation.isSystemInDarkTheme()) androidx.compose.material3.darkColorScheme() else androidx.compose.material3.lightColorScheme()) {"
       ),
       result.text,
     )
     assertTrue(result.text.contains("Text(\"Card\")"), result.text)
-    assertTrue(
-      result.text.contains("import androidx.compose.foundation.isSystemInDarkTheme"),
-      result.text,
-    )
-    assertTrue(result.text.contains("import androidx.compose.material3.MaterialTheme"), result.text)
-    assertTrue(
-      result.text.contains("import androidx.compose.material3.darkColorScheme"),
-      result.text,
-    )
-    assertTrue(
-      result.text.contains("import androidx.compose.material3.lightColorScheme"),
-      result.text,
-    )
+    assertFalse(result.text.contains("import androidx.compose.foundation.isSystemInDarkTheme"))
+    assertFalse(result.text.contains("import androidx.compose.material3.MaterialTheme"))
     assertFalse(result.text.contains("import com.example.catalog.Sticker"), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  @Test
+  fun `a system Material 3 theme wrapper accepts an empty argument list`() {
+    val source =
+      """
+      package com.example.catalog
+
+      import androidx.compose.runtime.Composable
+      import com.example.catalog.Sticker
+
+      @Composable
+      fun CardPreview() = Sticker() { Unit }
+      """
+        .trimIndent()
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = UsageRules.MATERIAL3_SYSTEM_THEME,
+              )
+          )
+      )
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source,
+          source.lines().indexOfFirst { it.contains("Unit") } + 1,
+          rules,
+        )
+      )
+
+    assertFalse(result.text.contains("Sticker"), result.text)
+    assertTrue(result.text.contains("androidx.compose.material3.MaterialTheme("), result.text)
+    assertEquals(emptyList(), result.residue)
+  }
+
+  @Test
+  fun `a system Material 3 expansion cannot collide with retained simple imports`() {
+    val source =
+      """
+      package com.example.catalog
+
+      import com.example.brand.MaterialTheme
+      import com.example.catalog.Sticker
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CardPreview() = Sticker { MaterialTheme { Unit } }
+      """
+        .trimIndent()
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = UsageRules.MATERIAL3_SYSTEM_THEME,
+                addImports =
+                  listOf(
+                    "androidx.compose.material3.MaterialTheme",
+                    "androidx.compose.material3.darkColorScheme",
+                    "androidx.compose.material3.lightColorScheme",
+                    "androidx.compose.foundation.isSystemInDarkTheme",
+                  ),
+              )
+          )
+      )
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source,
+          source.lines().indexOfFirst { it.contains("MaterialTheme { Unit") } + 1,
+          rules,
+        )
+      )
+
+    assertTrue(result.text.contains("import com.example.brand.MaterialTheme"), result.text)
+    assertFalse(
+      result.text.contains("import androidx.compose.material3.MaterialTheme"),
+      result.text,
+    )
+    assertTrue(result.text.contains("MaterialTheme { Unit }"), result.text)
     assertEquals(emptyList(), result.residue)
   }
 


### PR DESCRIPTION
## Summary

- recognize argument-free theme wrappers written as `Sticker() { ... }`
- replace the empty call and preserve its trailing lambda
- fully qualify the generated Material 3 theme and color-scheme calls
- avoid injecting imports that can collide with declarations retained from the component body

This follows up both remaining Codex review findings on #3988.

## Verification

- `:cli:ktfmtCheck`
- `:cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundSourceCleanerTest`
- `git diff --check`