### PR TITLE
fix(rc-harness): validate manifest-complete A/B runs

### DIFF
--- a/renders/rc-embedded-lane-ab/README.md
+++ b/renders/rc-embedded-lane-ab/README.md
@@ -68,8 +68,26 @@ lane is more correct, not less** — a caution about reading the table above as 
 
 ## Regenerating
 
+The committed sweep is pinned to `homeassistant-remotecompose` source
+`72c6d941f244d3d712c6029ba54d6de3147adc12`, published as design-artifact commit
+`7d22352e435c405b5ff1c25a19bd4106fa7a3231`. Stage those exact 164 documents first:
+
+```bash
+artifact=7d22352e435c405b5ff1c25a19bd4106fa7a3231
+curl -fL "https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/$artifact/bundle/bundle.png" \
+  -o /tmp/homeassistant-remotecompose-7d22352e.bundle.png
+npm --prefix scripts/design-artifacts ci
+node scripts/design-artifacts/rc-compare.mjs \
+  --bundle /tmp/homeassistant-remotecompose-7d22352e.bundle.png \
+  --player cli/src/main/resources/rc-player/bundle.js \
+  --out /tmp/rc-lane-ab-stage \
+  --stage-embedded /tmp/rc-lane-ab-input
 ```
-scripts/rc-lane-ab/render-ab.sh <dir with <id>.rc + manifest.json> [lane-output-dir]
+
+Then render, score, and compose the evidence:
+
+```bash
+scripts/rc-lane-ab/render-ab.sh /tmp/rc-lane-ab-input [lane-output-dir]
 ```
 
 That is the whole recipe — it renders both lanes, prints the table above, and rewrites every image

--- a/scripts/rc-lane-ab/render-ab.sh
+++ b/scripts/rc-lane-ab/render-ab.sh
@@ -47,6 +47,8 @@ if [ ! -f "$input_dir/manifest.json" ]; then
   exit 1
 fi
 
+node "$repo_root/scripts/rc-lane-ab/validate-stage.mjs" inputs "$input_dir"
+
 # Fail before the renders rather than after them. Composition is the last step and takes seconds;
 # discovering a missing dependency after minutes of Gradle is a bad trade.
 python3 -c 'import PIL' 2>/dev/null || {
@@ -72,21 +74,11 @@ echo "==> rendering both lanes"
   "-Prc.view.output=$lanes_dir/view" \
   "-Prc.embedded.output=$lanes_dir/embedded"
 
-# A lane that rendered nothing is the failure this check exists to make loud. Compare against the
-# document count rather than against zero, so a partial lane fails too. The embedded lane is
-# allowed to fall short by the documents it genuinely cannot render (issue #3993) — those leave an
-# `<id>.error`, so count PNG + error against the total.
-expected=$(find "$input_dir" -name '*.rc' | wc -l | tr -d ' ')
-for lane in view embedded; do
-  count=$(find "$lanes_dir/$lane" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
-  errors=$(find "$lanes_dir/$lane" -name '*.error' 2>/dev/null | wc -l | tr -d ' ')
-  echo "    $lane: $count/$expected png, $errors error"
-  if [ "$((count + errors))" -ne "$expected" ]; then
-    echo "    ^ $lane accounted for $((count + errors)) of $expected documents." >&2
-    [ "$count" -eq 0 ] && echo "      Zero usually means the input path was not absolute." >&2
-    exit 1
-  fi
-done
+# The manifest is the source of truth, not whatever `.rc` files happen to remain in a reused
+# directory. Every manifest id must have exactly one input and one result in each lane. Embedded
+# failures are explicit `.error` results; a view error is terminal because the scorer enumerates
+# view PNGs and would otherwise silently drop that document from the A/B.
+node "$repo_root/scripts/rc-lane-ab/validate-stage.mjs" results "$input_dir" "$lanes_dir"
 
 echo "==> scoring"
 node "$repo_root/scripts/design-artifacts/rc-lane-ab-score.mjs" \

--- a/scripts/rc-lane-ab/validate-stage.mjs
+++ b/scripts/rc-lane-ab/validate-stage.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+function die(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function filesWith(dir, extension) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(extension))
+    .map((entry) => entry.name.slice(0, -extension.length))
+    .sort();
+}
+
+function difference(left, right) {
+  const other = new Set(right);
+  return left.filter((value) => !other.has(value));
+}
+
+function manifestIds(inputDir) {
+  const manifestPath = path.join(inputDir, "manifest.json");
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    die(`cannot read ${manifestPath}: ${error.message}`);
+  }
+  if (!Array.isArray(manifest) || manifest.length === 0)
+    die("manifest.json must contain at least one document");
+  const ids = manifest.map((entry) => entry?.id);
+  if (ids.some((id) => typeof id !== "string" || id.length === 0))
+    die("every manifest entry must have a non-empty string id");
+  if (new Set(ids).size !== ids.length)
+    die("manifest.json contains duplicate ids");
+  return ids.sort();
+}
+
+function validateInputs(inputDir, ids) {
+  const inputs = filesWith(inputDir, ".rc");
+  const missing = difference(ids, inputs);
+  const extra = difference(inputs, ids);
+  if (missing.length || extra.length) {
+    die(
+      `staged .rc files do not match manifest` +
+        (missing.length ? `; missing: ${missing.join(", ")}` : "") +
+        (extra.length ? `; extra: ${extra.join(", ")}` : ""),
+    );
+  }
+  console.log(`inputs: ${ids.length}/${ids.length} manifest documents`);
+}
+
+function validateLane(lanesDir, lane, ids) {
+  const dir = path.join(lanesDir, lane);
+  const pngs = filesWith(dir, ".png");
+  const errors = filesWith(dir, ".error");
+  const known = new Set(ids);
+  const extras = [...pngs, ...errors].filter((id) => !known.has(id));
+  if (extras.length)
+    die(`${lane} has results outside the manifest: ${extras.join(", ")}`);
+
+  for (const id of ids) {
+    const hasPng = pngs.includes(id);
+    const hasError = errors.includes(id);
+    if (lane === "view" && hasError) die(`view failed to render ${id}`);
+    if (Number(hasPng) + Number(hasError) !== 1)
+      die(
+        `${lane} must have exactly one result for ${id}; found ` +
+          `${hasPng ? "png" : "no png"} and ${hasError ? "error" : "no error"}`,
+      );
+  }
+  console.log(
+    `    ${lane}: ${pngs.length}/${ids.length} png, ${errors.length} error`,
+  );
+}
+
+const [mode, inputDir, lanesDir] = process.argv.slice(2);
+if (
+  (mode !== "inputs" && mode !== "results") ||
+  !inputDir ||
+  (mode === "results" && !lanesDir)
+) {
+  die(
+    "usage: validate-stage.mjs inputs <input-dir> | results <input-dir> <lanes-dir>",
+  );
+}
+const ids = manifestIds(inputDir);
+validateInputs(inputDir, ids);
+if (mode === "results") {
+  validateLane(lanesDir, "view", ids);
+  validateLane(lanesDir, "embedded", ids);
+}

--- a/scripts/rc-lane-ab/validate-stage.test.mjs
+++ b/scripts/rc-lane-ab/validate-stage.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(new URL("./validate-stage.mjs", import.meta.url));
+const roots = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+function fixture(ids = ["one", "two"]) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "rc-lane-ab-"));
+  roots.push(root);
+  const input = path.join(root, "input");
+  const lanes = path.join(root, "lanes");
+  fs.mkdirSync(input);
+  fs.mkdirSync(path.join(lanes, "view"), { recursive: true });
+  fs.mkdirSync(path.join(lanes, "embedded"), { recursive: true });
+  fs.writeFileSync(
+    path.join(input, "manifest.json"),
+    JSON.stringify(ids.map((id) => ({ id, width: 1, height: 1 }))),
+  );
+  for (const id of ids) fs.writeFileSync(path.join(input, `${id}.rc`), "rc");
+  return { input, lanes, ids };
+}
+
+function run(mode, input, lanes) {
+  return spawnSync(
+    process.execPath,
+    [script, mode, input, ...(lanes ? [lanes] : [])],
+    {
+      encoding: "utf8",
+    },
+  );
+}
+
+test("accepts exactly the manifest inputs and one result per lane", () => {
+  const { input, lanes, ids } = fixture();
+  for (const id of ids) {
+    fs.writeFileSync(path.join(lanes, "view", `${id}.png`), "png");
+    fs.writeFileSync(path.join(lanes, "embedded", `${id}.png`), "png");
+  }
+  assert.equal(run("results", input, lanes).status, 0);
+});
+
+test("rejects missing and stale staged inputs", () => {
+  const { input } = fixture();
+  fs.rmSync(path.join(input, "one.rc"));
+  fs.writeFileSync(path.join(input, "stale.rc"), "rc");
+  const result = run("inputs", input);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /missing: one/);
+  assert.match(result.stderr, /extra: stale/);
+});
+
+test("rejects a view error instead of silently omitting it from scoring", () => {
+  const { input, lanes, ids } = fixture();
+  fs.writeFileSync(path.join(lanes, "view", "one.error"), "boom");
+  fs.writeFileSync(path.join(lanes, "view", "two.png"), "png");
+  for (const id of ids)
+    fs.writeFileSync(path.join(lanes, "embedded", `${id}.png`), "png");
+  const result = run("results", input, lanes);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /view failed to render one/);
+});
+
+test("allows one embedded error but rejects missing or duplicate results", () => {
+  const { input, lanes, ids } = fixture();
+  for (const id of ids)
+    fs.writeFileSync(path.join(lanes, "view", `${id}.png`), "png");
+  fs.writeFileSync(path.join(lanes, "embedded", "one.error"), "boom");
+  fs.writeFileSync(path.join(lanes, "embedded", "two.png"), "png");
+  assert.equal(run("results", input, lanes).status, 0);
+
+  fs.writeFileSync(path.join(lanes, "embedded", "one.png"), "png");
+  const duplicate = run("results", input, lanes);
+  assert.equal(duplicate.status, 1);
+  assert.match(duplicate.stderr, /exactly one result for one/);
+});


### PR DESCRIPTION
## Summary

- pin the exact 164-document homeassistant catalog artifact and source revisions used by the committed A/B
- document the complete staging command before the render/scoring recipe
- validate staged inputs against manifest IDs instead of counting directory contents
- require exactly one result per manifest ID in each lane
- reject every view-lane error before scoring while retaining explicit embedded error results

This addresses the remaining Codex review findings on #3994.

## Verification

- `node --test scripts/rc-lane-ab/validate-stage.test.mjs` (4 passing)
- `shellcheck scripts/rc-lane-ab/render-ab.sh`
- pinned artifact existence verified through GitHub
- `git diff --check`