### PR TITLE
fix(rc-player): make dynamic color diagnostics reproducible

### DIFF
--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -111,6 +111,11 @@ tasks.withType<Test>().configureEach {
     listOf("rc.embedded.input", "rc.embedded.output", "rc.view.output", "rc.semantics.report")) {
     (project.findProperty(key) as String?)?.let { systemProperty(key, it) }
   }
+  systemProperty(
+    "rc.dynamic-color.report",
+    (project.findProperty("rc.dynamic-color.report") as String?)
+      ?: layout.buildDirectory.file("reports/dynamic-color-diag.txt").get().asFile.absolutePath,
+  )
   // Robolectric's NATIVE graphics mode needs a real heap to rasterize into.
   maxHeapSize = "2g"
 

--- a/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/DynamicColorDiagTest.kt
+++ b/third_party/rc-embedded-player/src/test/kotlin/ee/schimke/composeai/rcembedded/DynamicColorDiagTest.kt
@@ -20,13 +20,16 @@ import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.Operation
 import androidx.compose.remote.core.RemoteClock
 import androidx.compose.remote.core.RemoteComposeBuffer
+import androidx.compose.remote.core.VariableProvider
 import androidx.compose.remote.core.operations.layout.Container
 import androidx.compose.remote.core.operations.layout.LayoutComponent
 import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
+import androidx.compose.remote.player.compose.embedded.enableEncodedImageReferences
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.ByteArrayInputStream
 import java.io.File
+import kotlinx.serialization.json.Json
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,8 +49,12 @@ import org.robolectric.annotation.Config
  * Skips unless a document is staged, so it costs nothing in a normal run:
  * ```
  * ./gradlew :third-party-rc-embedded-player:testDebugUnitTest \
- *   --tests '*DynamicColorDiagTest*' -Prc.embedded.input=<dir with the .rc files>
+ *   --tests '*DynamicColorDiagTest*' -Prc.embedded.input=<dir with the .rc files> \
+ *   [-Prc.dynamic-color.report=<output file>]
  * ```
+ *
+ * The report defaults to this module's `build/reports/dynamic-color-diag.txt`; the staged input is
+ * never mutated.
  */
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [35])
@@ -55,14 +62,24 @@ class DynamicColorDiagTest {
 
   @Test
   fun reportDynamicColourChain() {
-    val dir = System.getProperty("rc.embedded.input")?.let(::File)?.takeIf { it.isDirectory }
-    assumeTrue("no rc.embedded.input staged", dir != null)
+    val configuredDir =
+      System.getProperty("rc.embedded.input")?.let(::File)?.takeIf { it.isDirectory }
+    assumeTrue("no rc.embedded.input staged", configuredDir != null)
+    val dir = checkNotNull(configuredDir)
+    val manifest = File(dir, "manifest.json")
+    assumeTrue("no manifest.json staged", manifest.isFile)
+    val output = File(checkNotNull(System.getProperty("rc.dynamic-color.report")))
+    output.parentFile?.mkdirs()
+
+    val entries = Json.decodeFromString<List<RcEmbeddedRenderHarness.Entry>>(manifest.readText())
 
     val report = StringBuilder()
-    dir!!
-      .listFiles { f -> f.extension == "rc" }
-      ?.sortedBy { it.name }
-      ?.forEach { rc ->
+    entries
+      .sortedBy { it.id }
+      .forEach { entry ->
+        val rc = File(dir, "${entry.id}.rc")
+        require(rc.isFile) { "manifest document has no staged input: ${entry.id}" }
+        enableEncodedImageReferences()
         val document =
           CoreDocument(RemoteClock.SYSTEM).apply {
             ByteArrayInputStream(rc.readBytes()).use {
@@ -72,14 +89,14 @@ class DynamicColorDiagTest {
         val index = buildComputedOpIndex(document.getOperationsReflection())
 
         // Where every op of interest actually sits: top level, inside a container, or only
-        // reachable
-        // through a component's canvas operations.
-        val located = LinkedHashMap<String, MutableList<String>>()
+        // reachable through a component's canvas operations.
+        val located = LinkedHashMap<String, MutableList<Pair<Int?, String>>>()
         fun visit(ops: Collection<Operation>, path: String) {
           for (op in ops) {
             val name = op.javaClass.simpleName
             if (name.startsWith("Color")) {
-              located.getOrPut(name) { mutableListOf() }.add(path)
+              val id = (op as? VariableProvider)?.id
+              located.getOrPut(name) { mutableListOf() }.add(id to path)
             }
             if (op is Container) visit(op.getList(), "$path/container")
             if (op is LayoutComponent) {
@@ -89,11 +106,12 @@ class DynamicColorDiagTest {
         }
         visit(document.getOperationsReflection(), "root")
 
-        report.appendLine("=== ${rc.name}")
+        report.appendLine("=== ${entry.id}")
         report.appendLine("  computed-op index size = ${index.size}; ids = ${index.keys.sorted()}")
-        located.forEach { (name, paths) ->
-          val counts = paths.groupingBy { it }.eachCount()
-          report.appendLine("  $name -> $counts")
+        located.forEach { (name, operations) ->
+          report.appendLine(
+            "  $name -> " + operations.joinToString { (id, path) -> "id=${id ?: "none"}@$path" }
+          )
         }
         report.appendLine(
           "  indexed op types = ${index.values.map { it.javaClass.simpleName }.toSortedSet()}"
@@ -101,6 +119,6 @@ class DynamicColorDiagTest {
       }
     // Written to a file rather than stdout: Gradle does not surface test stdout here, and the
     // point of a diagnostic is that its output survives the harness.
-    File(dir, "diag.txt").writeText(report.toString())
+    output.writeText(report.toString())
   }
 }


### PR DESCRIPTION
Addresses the remaining Codex review feedback from #3973.

- scope diagnostic inputs to manifest entries instead of every `.rc` in a reused staging directory
- report produced operation IDs together with their tree paths
- write the report to a configurable build/output path without mutating staged inputs
- enable encoded image references before parsing documents

Verification:
- `:third-party-rc-embedded-player:ktfmtCheck`
- `:third-party-rc-embedded-player:testDebugUnitTest --tests '*DynamicColorDiagTest*'`