### PR TITLE
fix(build): restore JVM checks

### DIFF
--- a/runtimes/appwidget/src/main/kotlin/ee/schimke/composeai/preview/appwidget/AppWidgetContent.kt
+++ b/runtimes/appwidget/src/main/kotlin/ee/schimke/composeai/preview/appwidget/AppWidgetContent.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.preview.appwidget
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -100,12 +101,27 @@ internal fun translate(context: Context, info: AppWidgetProviderInfo): LauncherW
   // bound the supported-cells rectangle on the top end; missing values fall back to the
   // platform default (no upper cap → use `minResize` as the only declared size).
   val minWidthCells =
-    if (info.targetCellWidth > 0) info.targetCellWidth else pxToCells(info.minResizeWidth, density)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && info.targetCellWidth > 0) {
+      info.targetCellWidth
+    } else {
+      pxToCells(info.minResizeWidth, density)
+    }
   val minHeightCells =
-    if (info.targetCellHeight > 0) info.targetCellHeight
-    else pxToCells(info.minResizeHeight, density)
-  val maxWidthCells = pxToCells(info.maxResizeWidth, density).coerceAtLeast(minWidthCells)
-  val maxHeightCells = pxToCells(info.maxResizeHeight, density).coerceAtLeast(minHeightCells)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && info.targetCellHeight > 0) {
+      info.targetCellHeight
+    } else {
+      pxToCells(info.minResizeHeight, density)
+    }
+  val maxWidthPx =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.maxResizeWidth else info.minResizeWidth
+  val maxHeightPx =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      info.maxResizeHeight
+    } else {
+      info.minResizeHeight
+    }
+  val maxWidthCells = pxToCells(maxWidthPx, density).coerceAtLeast(minWidthCells)
+  val maxHeightCells = pxToCells(maxHeightPx, density).coerceAtLeast(minHeightCells)
 
   val resizeAxes =
     when {

--- a/runtimes/notification/src/main/kotlin/ee/schimke/composeai/preview/notification/NotificationContent.kt
+++ b/runtimes/notification/src/main/kotlin/ee/schimke/composeai/preview/notification/NotificationContent.kt
@@ -273,7 +273,12 @@ private object NotificationSidecar {
 
   private fun appendSmallIcon(sb: StringBuilder, n: Notification, context: Context) {
     val icon = n.smallIcon ?: return
-    val resId = icon.resId
+    val resId =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        icon.resId
+      } else {
+        @Suppress("DEPRECATION") n.icon
+      }
     val name = runCatching { context.resources.getResourceName(resId) }.getOrNull()
     sb.append("\"smallIcon\":{")
     sb.append("\"resourceId\":").append(resId)

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -46,8 +46,8 @@ import androidx.compose.remote.player.compose.embedded.RcPlayerRawDocument
 import androidx.compose.remote.player.compose.embedded.RcPlayerRootLayoutComponent
 import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
 import androidx.compose.remote.player.compose.embedded.applyDataOperationsWithoutBitmaps
-import androidx.compose.remote.player.compose.embedded.applyOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.applyOperationsReflection
+import androidx.compose.remote.player.compose.embedded.applyOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
 import androidx.compose.remote.player.compose.embedded.recollectCollectionsReflection


### PR DESCRIPTION
## What changed

- restore ktfmt import ordering in the embedded JVM renderer
- guard Android 12 app-widget sizing fields and use pre-31 fallbacks
- guard the API 28 notification icon resource accessor and use the legacy resource ID on API 24–27

## Why

The aggregate build on current `main` failed first at the JVM renderer formatting check, then exposed Android lint failures from unguarded platform APIs in the app-widget and notification runtimes.

## Impact

Build checks pass without raising the Android minimum SDK. Runtime behavior is unchanged on newer Android versions, while API 24–30 now use compatible metadata access paths.

## Root cause

Recent code used platform fields introduced in API 31 and an icon accessor introduced in API 28 without SDK guards. The JVM renderer also had imports out of ktfmt order.

## Checks

- `:appwidget-preview-runtime:ktfmtCheck`
- `:appwidget-preview-runtime:testDebugUnitTest`
- `:appwidget-preview-runtime:lintDebug`
- `:notification-preview-runtime:ktfmtCheck`
- `:notification-preview-runtime:testDebugUnitTest`
- `:notification-preview-runtime:lintDebug`
- `:third-party-rc-embedded-player-jvm:ktfmtCheckMain`
- `:rc-player-protocol:compileCommonMainKotlinMetadata`

The repository-wide build advanced through these failures; remaining Kotlin/Native linking is being investigated separately because the local Xcode command-line tool invocation exits 72.