### PR TITLE
fix(rc-player): preserve JVM text correctness

### DIFF
--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/androidx/compose/remote/player/compose/embedded/RcPlayerTextLayoutJvm.kt
@@ -34,6 +34,9 @@ import androidx.compose.ui.layout.LastBaseline
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -51,8 +54,6 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import java.text.BreakIterator
-import java.util.Locale
 
 /*
  * The jvm counterpart of `RcPlayerTextLayout.kt`'s two `RcPlayerText` composables. The size, weight,
@@ -120,7 +121,7 @@ internal fun RcPlayerText(layout: CoreText, modifier: Modifier) {
             else -> TextDecoration.None
         }
 
-    val textStyle =
+    val ambientLineHeightStyle =
         baseStyle.copy(
             color = color,
             fontSize = fontSizeSp,
@@ -140,16 +141,6 @@ internal fun RcPlayerText(layout: CoreText, modifier: Modifier) {
                     else -> TextAlign.Start
                 },
             letterSpacing = data.letterSpacing.em,
-            lineHeight =
-                if (data.lineHeightMultiplier != 1f || data.lineHeightAdd != 0f) {
-                    if (data.autosize) {
-                        (data.lineHeightMultiplier + data.lineHeightAdd / fontSize.coerceAtLeast(0.0001f)).em
-                    } else {
-                        with(density) { (fontSize * data.lineHeightMultiplier + data.lineHeightAdd).toSp() }
-                    }
-                } else {
-                    TextUnit.Unspecified
-                },
             textDecoration = textDecoration,
             // Unset means `Unspecified`, not "inherit": a document that says nothing about line
             // breaking must not pick up Material3's line-break role from the host (#3667).
@@ -161,6 +152,19 @@ internal fun RcPlayerText(layout: CoreText, modifier: Modifier) {
                 },
             hyphens = if (data.hyphenationFrequency > 0) Hyphens.Auto else Hyphens.Unspecified,
         )
+    val textStyle =
+        if (data.lineHeightMultiplier != 1f || data.lineHeightAdd != 0f) {
+            ambientLineHeightStyle.copy(
+                lineHeight =
+                    if (data.autosize) {
+                        (data.lineHeightMultiplier + data.lineHeightAdd / fontSize.coerceAtLeast(0.0001f)).em
+                    } else {
+                        with(density) { (fontSize * data.lineHeightMultiplier + data.lineHeightAdd).toSp() }
+                    },
+            )
+        } else {
+            ambientLineHeightStyle
+        }
     SynchronousOneLineEllipsisText(
         text = text,
         modifier = modifier,
@@ -306,7 +310,7 @@ private fun SynchronousOneLineEllipsisText(
             subcompose(displayText) {
                     content(
                         displayText,
-                        Modifier,
+                        Modifier.clearAndSetSemantics { this.text = AnnotatedString(text) },
                         TextOverflow.Clip,
                         autoSize?.let { resolvedStyle.fontSize },
                     )
@@ -430,16 +434,13 @@ internal fun synchronousEllipsis(
     return candidate
 }
 
-private fun graphemeBoundaries(text: String): List<Int> {
-    val iterator = BreakIterator.getCharacterInstance(Locale.ROOT).apply { setText(text) }
-    return buildList {
-        var boundary = iterator.first()
-        while (boundary != BreakIterator.DONE) {
-            add(boundary)
-            boundary = iterator.next()
-        }
+private val extendedGrapheme = Regex("\\X")
+
+private fun graphemeBoundaries(text: String): List<Int> =
+    buildList {
+        add(0)
+        extendedGrapheme.findAll(text).forEach { match -> add(match.range.last + 1) }
     }
-}
 
 private fun composeOverflow(overflow: Int): TextOverflow =
     when (overflow) {

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmRenderer.kt
@@ -46,8 +46,8 @@ import androidx.compose.remote.player.compose.embedded.RcPlayerRawDocument
 import androidx.compose.remote.player.compose.embedded.RcPlayerRootLayoutComponent
 import androidx.compose.remote.player.compose.embedded.SnapshotRemoteComposeState
 import androidx.compose.remote.player.compose.embedded.applyDataOperationsWithoutBitmaps
-import androidx.compose.remote.player.compose.embedded.applyOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.applyOperationsReflection
+import androidx.compose.remote.player.compose.embedded.applyOperationsWithoutBitmaps
 import androidx.compose.remote.player.compose.embedded.buildComputedOpIndex
 import androidx.compose.remote.player.compose.embedded.getOperationsReflection
 import androidx.compose.remote.player.compose.embedded.recollectCollectionsReflection

--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/SynchronousEllipsisTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/SynchronousEllipsisTest.kt
@@ -55,4 +55,28 @@ class SynchronousEllipsisTest {
       synchronousEllipsis("ab😀cdef", TextOverflow.StartEllipsis, 5, monospaceWidth),
     )
   }
+
+  @Test
+  fun `ellipsis never splits a zwj family`() {
+    assertEquals(
+      "…b",
+      synchronousEllipsis("a👨‍👩‍👧‍👦b", TextOverflow.StartEllipsis, 5, monospaceWidth),
+    )
+  }
+
+  @Test
+  fun `ellipsis never splits a regional indicator flag`() {
+    assertEquals(
+      "…cd",
+      synchronousEllipsis("ab🇬🇧cd", TextOverflow.StartEllipsis, 3, monospaceWidth),
+    )
+  }
+
+  @Test
+  fun `ellipsis never splits an emoji modifier sequence`() {
+    assertEquals(
+      "…cd",
+      synchronousEllipsis("ab👍🏽cd", TextOverflow.StartEllipsis, 4, monospaceWidth),
+    )
+  }
 }


### PR DESCRIPTION
Addresses the remaining Codex review feedback from #4004.

- retain `LocalTextStyle` line height when the document does not declare an override
- expose the original source string in semantics while painting a manually truncated string
- truncate only at Java 17 extended-grapheme (`\\X`) boundaries
- cover ZWJ-family, regional-indicator flag, and emoji-modifier sequences

Verification:
- `:third-party-rc-embedded-player-jvm:ktfmtCheck`
- `:third-party-rc-embedded-player-jvm:test --tests '*SynchronousEllipsisTest*'`