### PR TITLE
fix(catalog): isolate multi-module preview identities

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -405,7 +405,7 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@81727e959c63ff46ba6e598760771d9905386d9a # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -477,7 +477,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@81727e959c63ff46ba6e598760771d9905386d9a # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -490,7 +490,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Do not honor a caller-controlled ref here: refs/pull/* in this repo
           # can contain fork code, and this privileged workflow executes the driver.
-          ref: 81727e959c63ff46ba6e598760771d9905386d9a # main at 2026-08-16
+          ref: df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 
@@ -713,7 +713,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@81727e959c63ff46ba6e598760771d9905386d9a # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -728,7 +728,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Never execute a caller-selected refs/pull/* revision in this
           # privileged workflow. Update this alongside the other driver pin.
-          ref: 81727e959c63ff46ba6e598760771d9905386d9a # main at 2026-08-16
+          ref: df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 
@@ -798,6 +798,7 @@ jobs:
           node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/preview-modules.mjs" \
             --input "$GITHUB_WORKSPACE/discovered-previews.json" \
             --output "$GITHUB_WORKSPACE/preview-modules.txt" \
+            --sources-output "$GITHUB_WORKSPACE/preview-module-sources.txt" \
             "${preferred_args[@]}"
           echo "Publishing $(wc -l < "$GITHUB_WORKSPACE/preview-modules.txt" | tr -d ' ') preview-enabled module(s):"
           sed 's/^/  /' "$GITHUB_WORKSPACE/preview-modules.txt"
@@ -818,14 +819,15 @@ jobs:
           ALL_MODULES: ${{ inputs.module == '' || inputs.modules == 'all' }}
         run: |
           set -euo pipefail
-          # Gradle path (":app", "a:b") → directory ("app", "a/b"), under the
-          # build's directory when the caller is a multi-build monorepo.
+          # Single-module callers predate repository-wide discovery and still use the conventional
+          # Gradle-path mapping. All-module callers consume BasicGradleProject.projectDirectory
+          # captured by discovery; settings.gradle can map :ui to components/ui (or anywhere else).
           to_dir() { printf '%s' "${WORKDIR:+$WORKDIR/}${1#:}" | tr ':' '/'; }
           args=(--spec "$SPEC")
           if [ "$ALL_MODULES" = "true" ]; then
-            while IFS= read -r discovered_module; do
-              [ -n "$discovered_module" ] && args+=(--src "$(to_dir "$discovered_module")")
-            done < "$GITHUB_WORKSPACE/preview-modules.txt"
+            while IFS= read -r discovered_source; do
+              [ -n "$discovered_source" ] && args+=(--src "$discovered_source")
+            done < "$GITHUB_WORKSPACE/preview-module-sources.txt"
             # One source.module cannot describe a repository-wide catalog. Keep validation honest:
             # deferred coverage must not pass on a live path the generate step intentionally omits.
             LIVE_SOURCE=false

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/cli/PreviewResultBuilder.kt
@@ -122,6 +122,7 @@ object PreviewResultBuilder {
           PreviewResult(
             id = p.id,
             module = module.gradlePath,
+            projectDirectory = module.projectDir.canonicalPath,
             functionName = p.functionName,
             className = p.className,
             sourceFile = p.sourceFile,

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultBuilderTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultBuilderTest.kt
@@ -86,6 +86,7 @@ class PreviewResultBuilderTest {
     val home = results.single()
     assertEquals("HomeScreen", home.id)
     assertEquals(":app", home.module)
+    assertEquals(module.projectDir.canonicalPath, home.projectDirectory)
     assertNotNull(home.pngPath)
     assertTrue(File(home.pngPath!!).exists(), "PNG path should resolve: ${home.pngPath}")
     assertNotNull(home.sha256)

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -304,6 +304,8 @@ data class CaptureResult(
 data class PreviewResult(
   val id: String,
   val module: String,
+  /** Gradle's resolved project directory; never reconstruct this from [module]. */
+  val projectDirectory: String? = null,
   val functionName: String,
   val className: String,
   val sourceFile: String? = null,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -22,6 +22,7 @@ class PreviewListResponseTest {
             PreviewResult(
               id = "Preview_A",
               module = "sample-android",
+              projectDirectory = "/workspace/components/sample-android",
               functionName = "PreviewA",
               className = "com.example.PreviewsKt",
               sourceFile = "Previews.kt",
@@ -57,6 +58,10 @@ class PreviewListResponseTest {
     // Multi-capture fan-out is faithfully serialised.
     assertEquals(2, parsed.previews.single().captures.size)
     assertEquals(500L, parsed.previews.single().captures[1].advanceTimeMillis)
+    assertEquals(
+      "/workspace/components/sample-android",
+      parsed.previews.single().projectDirectory,
+    )
   }
 
   @Test

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -23,13 +23,144 @@ function previewFunction(preview) {
   return preview?.functionName ?? preview?.id;
 }
 
+function moduleIdentityPrefix(module) {
+  return `module_${Buffer.from(module, "utf8").toString("hex")}__`;
+}
+
+function rewriteArtifactPath(path, oldId, newId) {
+  if (typeof path !== "string") return path;
+  const slash = path.lastIndexOf("/");
+  const leaf = path.slice(slash + 1);
+  if (!leaf.startsWith(oldId)) return path;
+  const suffix = leaf.slice(oldId.length);
+  if (suffix !== "" && !suffix.startsWith(".") && !suffix.startsWith("_")) return path;
+  return `${path.slice(0, slash + 1)}${newId}${suffix}`;
+}
+
+function rewriteJsonEntry(entries, name, transform) {
+  const bytes = entries[name];
+  if (!bytes) return;
+  try {
+    const value = JSON.parse(new TextDecoder().decode(bytes));
+    entries[name] = new TextEncoder().encode(JSON.stringify(transform(value)));
+  } catch {
+    // The normal bundle reader has already validated these entries. Leave an opaque/legacy entry
+    // alone rather than turning identity isolation into a second parser failure surface.
+  }
+}
+
+/**
+ * Give an additional module's in-memory bundle identities a collision-free prefix.
+ *
+ * Repository-wide catalogs are baked-only, so these ids do not address a daemon. They exist solely
+ * to join entries and sidecars from several bundles without allowing equal preview ids to collapse
+ * onto one another. The primary bundle remains unchanged for backwards-compatible authored joins.
+ */
+function namespaceAdditionalRecord(record, module, keyByFunction) {
+  const prefix = moduleIdentityPrefix(module);
+  const manifest = record.bundle?.manifest ?? {};
+  const entryIds = manifest.previewIds ?? (record.bundle?.previews ?? []).map((p) => p.id);
+  const rawIds = manifest.rawPreviewIds ?? entryIds;
+  const entryIdMap = new Map(entryIds.map((id) => [id, `${prefix}${id}`]));
+  const rawIdMap = new Map(rawIds.map((id) => [id, `${prefix}${id}`]));
+  const anyIdMap = new Map([...entryIdMap, ...rawIdMap]);
+  const rewriteId = (id) => anyIdMap.get(id) ?? id;
+  const rewriteCapture = (capture, oldId, newId) => ({
+    ...capture,
+    ...(capture?.renderOutput
+      ? { renderOutput: rewriteArtifactPath(capture.renderOutput, oldId, newId) }
+      : {}),
+  });
+
+  const previews = (record.bundle?.previews ?? []).map((preview) => {
+    const oldId = preview.id;
+    const newId = rewriteId(oldId);
+    return {
+      ...preview,
+      id: newId,
+      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+      ...(Array.isArray(preview.captures)
+        ? { captures: preview.captures.map((capture) => rewriteCapture(capture, oldId, newId)) }
+        : {}),
+    };
+  });
+  const candidates = (record.candidates ?? []).map((candidate) => ({
+    ...candidate,
+    functionName:
+      keyByFunction.get(candidateFunction(candidate)) ?? candidateFunction(candidate),
+    module,
+    ...(candidate.previewId ? { previewId: rewriteId(candidate.previewId) } : {}),
+    ...(Array.isArray(candidate.images)
+      ? {
+          images: candidate.images.map((image) => ({
+            ...image,
+            ...(image.previewId ? { previewId: rewriteId(image.previewId) } : {}),
+          })),
+        }
+      : {}),
+  }));
+
+  const entries = {};
+  const orderedEntryIds = [...entryIdMap.keys()].sort((a, b) => b.length - a.length);
+  for (const [path, bytes] of Object.entries(record.bundle?.entries ?? {})) {
+    let rewritten = path;
+    if (path.startsWith("previews/")) {
+      const rest = path.slice("previews/".length);
+      const oldId = orderedEntryIds.find(
+        (id) => rest === id || rest.startsWith(`${id}.`) || rest.startsWith(`${id}_`),
+      );
+      if (oldId) rewritten = `previews/${entryIdMap.get(oldId)}${rest.slice(oldId.length)}`;
+    }
+    entries[rewritten] = bytes;
+  }
+  rewriteJsonEntry(entries, "previews.json", (value) => {
+    const list = Array.isArray(value) ? value : value.previews ?? [];
+    const rewritten = list.map((preview) => ({
+      ...preview,
+      id: rewriteId(preview.id),
+      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+    }));
+    return Array.isArray(value) ? rewritten : { ...value, previews: rewritten };
+  });
+  rewriteJsonEntry(entries, "bundle.json", (value) => ({
+    ...value,
+    ...(Array.isArray(value.previewIds)
+      ? { previewIds: value.previewIds.map((id) => entryIdMap.get(id) ?? id) }
+      : {}),
+    ...(Array.isArray(value.rawPreviewIds)
+      ? { rawPreviewIds: value.rawPreviewIds.map((id) => rawIdMap.get(id) ?? id) }
+      : {}),
+  }));
+
+  return {
+    ...record,
+    module,
+    candidates,
+    bundle: {
+      ...record.bundle,
+      previews,
+      entries,
+      manifest: {
+        ...manifest,
+        ...(Array.isArray(manifest.previewIds)
+          ? { previewIds: manifest.previewIds.map((id) => entryIdMap.get(id) ?? id) }
+          : {}),
+        ...(Array.isArray(manifest.rawPreviewIds)
+          ? { rawPreviewIds: manifest.rawPreviewIds.map((id) => rawIdMap.get(id) ?? id) }
+          : {}),
+      },
+    },
+  };
+}
+
 /**
  * Namespace duplicate function names across module bundles.
  *
  * The primary record wins the familiar unqualified name, preserving authored specs. Additional
  * records are sorted by Gradle path and use `<module>::<function>` only when an earlier module has
- * already claimed that function. Unique names stay untouched. Bundle entry ids are not rewritten:
- * they are normally class-qualified already, and keeping them intact preserves daemon addressing.
+ * already claimed that function. Unique names stay untouched. Additional records also receive a
+ * collision-free preview-id prefix because class-qualified ids can still be identical in separate
+ * Gradle modules. Repository-wide publication is baked-only, so no daemon address is changed.
  */
 export function namespaceModuleRecords(primary, additional = []) {
   const ordered = [
@@ -59,6 +190,7 @@ export function namespaceModuleRecords(primary, additional = []) {
         if (!owner) claimed.set(fn, module);
       }
     }
+    if (record !== ordered[0]) return namespaceAdditionalRecord(record, module, keyByFunction);
     const previews = (record.bundle?.previews ?? []).map((preview) => ({
       ...preview,
       functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),

--- a/scripts/design-artifacts/multi-module-catalog.test.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.test.mjs
@@ -37,6 +37,68 @@ test("additional modules are sorted and duplicate functions are deterministicall
   assert.deepEqual(z.candidates.map((it) => it.functionName), [":z::Shared"]);
 });
 
+test("additional modules namespace equal preview ids and every keyed sidecar", () => {
+  const bytes = (value) => new TextEncoder().encode(value);
+  const collisionRecord = (module) => ({
+    bundle: {
+      manifest: {
+        modulePath: module,
+        previewIds: ["pkg.ScreenPreview"],
+        rawPreviewIds: ["pkg.ScreenPreview"],
+      },
+      previews: [
+        {
+          id: "pkg.ScreenPreview",
+          functionName: "ScreenPreview",
+          captures: [{ renderOutput: "renders/pkg.ScreenPreview.gif" }],
+        },
+      ],
+      entries: {
+        "previews/pkg.ScreenPreview.png": bytes(module),
+        "previews/pkg.ScreenPreview.semantics.json": bytes(module),
+        "previews/pkg.ScreenPreview.figma-raster/node.png": bytes(module),
+        "previews.json": bytes(
+          JSON.stringify({
+            previews: [{ id: "pkg.ScreenPreview", functionName: "ScreenPreview", targets: [] }],
+          }),
+        ),
+      },
+    },
+    candidates: [
+      {
+        componentId: "ScreenPreview",
+        previewId: "pkg.ScreenPreview",
+        images: [{ path: "ScreenPreview.png", previewId: "pkg.ScreenPreview" }],
+      },
+    ],
+  });
+
+  const [primary, additional] = namespaceModuleRecords(collisionRecord(":app"), [
+    collisionRecord(":feature"),
+  ]);
+  const additionalId = additional.bundle.previews[0].id;
+  assert.equal(primary.bundle.previews[0].id, "pkg.ScreenPreview");
+  assert.notEqual(additionalId, "pkg.ScreenPreview");
+  assert.equal(additional.candidates[0].previewId, additionalId);
+  assert.equal(additional.candidates[0].images[0].previewId, additionalId);
+  assert.equal(additional.bundle.previews[0].captures[0].renderOutput, `renders/${additionalId}.gif`);
+  assert.ok(additional.bundle.entries[`previews/${additionalId}.png`]);
+  assert.ok(additional.bundle.entries[`previews/${additionalId}.semantics.json`]);
+  assert.ok(additional.bundle.entries[`previews/${additionalId}.figma-raster/node.png`]);
+  assert.deepEqual(
+    Object.keys(combinedBundleEntries([primary.bundle, additional.bundle])).filter((path) =>
+      path.endsWith(".semantics.json"),
+    ),
+    [
+      "previews/pkg.ScreenPreview.semantics.json",
+      `previews/${additionalId}.semantics.json`,
+    ],
+  );
+  const raw = JSON.parse(new TextDecoder().decode(additional.bundle.entries["previews.json"]));
+  assert.equal(raw.previews[0].id, additionalId);
+  assert.equal(raw.previews[0].functionName, ":feature::ScreenPreview");
+});
+
 test("fallback inventory groups by Gradle module and preview group and skips curated previews", () => {
   const records = namespaceModuleRecords(
     record(":catalog", ["Curated"]),

--- a/scripts/design-artifacts/preview-modules.mjs
+++ b/scripts/design-artifacts/preview-modules.mjs
@@ -4,17 +4,31 @@ import { readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
-export function previewModules(response, preferred) {
-  const modules = [...new Set((response?.previews ?? []).map((p) => p?.module).filter(Boolean))]
-    .sort((a, b) => a.localeCompare(b));
+export function previewModuleRecords(response, preferred) {
+  const byModule = new Map();
+  for (const preview of response?.previews ?? []) {
+    if (!preview?.module) continue;
+    const existing = byModule.get(preview.module);
+    if (!existing?.projectDirectory || preview.projectDirectory) {
+      byModule.set(preview.module, {
+        module: preview.module,
+        projectDirectory: preview.projectDirectory,
+      });
+    }
+  }
+  const records = [...byModule.values()].sort((a, b) => a.module.localeCompare(b.module));
   const normalizedPreferred = preferred?.replace(/^:/, "");
-  const preferredIndex = modules.findIndex(
-    (module) => module.replace(/^:/, "") === normalizedPreferred,
+  const preferredIndex = records.findIndex(
+    (record) => record.module.replace(/^:/, "") === normalizedPreferred,
   );
   if (normalizedPreferred && preferredIndex >= 0) {
-    modules.unshift(...modules.splice(preferredIndex, 1));
+    records.unshift(...records.splice(preferredIndex, 1));
   }
-  return modules;
+  return records;
+}
+
+export function previewModules(response, preferred) {
+  return previewModuleRecords(response, preferred).map((record) => record.module);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
@@ -22,17 +36,37 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     options: {
       input: { type: "string" },
       output: { type: "string" },
+      "sources-output": { type: "string" },
       preferred: { type: "string" },
     },
   });
   if (!values.input || !values.output) {
-    console.error("usage: preview-modules.mjs --input <list.json> --output <modules.txt> [--preferred <:module>]");
+    console.error(
+      "usage: preview-modules.mjs --input <list.json> --output <modules.txt> " +
+        "[--sources-output <project-directories.txt>] [--preferred <:module>]",
+    );
     process.exit(2);
   }
-  const modules = previewModules(JSON.parse(await readFile(values.input, "utf8")), values.preferred);
+  const response = JSON.parse(await readFile(values.input, "utf8"));
+  const records = previewModuleRecords(response, values.preferred);
+  const modules = records.map((record) => record.module);
   if (modules.length === 0) {
     console.error("preview-modules: discovery returned no preview-enabled modules");
     process.exit(1);
   }
   await writeFile(values.output, `${modules.join("\n")}\n`, "utf8");
+  if (values["sources-output"]) {
+    const missing = records.filter((record) => !record.projectDirectory);
+    if (missing.length > 0) {
+      console.error(
+        `preview-modules: discovery omitted projectDirectory for: ${missing.map((r) => r.module).join(", ")}`,
+      );
+      process.exit(1);
+    }
+    await writeFile(
+      values["sources-output"],
+      `${records.map((record) => record.projectDirectory).join("\n")}\n`,
+      "utf8",
+    );
+  }
 }

--- a/scripts/design-artifacts/preview-modules.mjs
+++ b/scripts/design-artifacts/preview-modules.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /** Extract the deterministic module list from `compose-preview list --json`. */
 import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 
@@ -31,6 +32,15 @@ export function previewModules(response, preferred) {
   return previewModuleRecords(response, preferred).map((record) => record.module);
 }
 
+export function previewModuleSources(records, baseDirectory = process.cwd()) {
+  return records.map((record) =>
+    resolve(
+      baseDirectory,
+      record.projectDirectory ?? record.module.replace(/^:/, "").replaceAll(":", "/"),
+    ),
+  );
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { values } = parseArgs({
     options: {
@@ -58,14 +68,14 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   if (values["sources-output"]) {
     const missing = records.filter((record) => !record.projectDirectory);
     if (missing.length > 0) {
-      console.error(
-        `preview-modules: discovery omitted projectDirectory for: ${missing.map((r) => r.module).join(", ")}`,
+      console.warn(
+        `preview-modules: discovery omitted projectDirectory for ${missing.map((r) => r.module).join(", ")}; ` +
+          "falling back to the conventional Gradle-path directory until the caller upgrades its CLI",
       );
-      process.exit(1);
     }
     await writeFile(
       values["sources-output"],
-      `${records.map((record) => record.projectDirectory).join("\n")}\n`,
+      `${previewModuleSources(records).join("\n")}\n`,
       "utf8",
     );
   }

--- a/scripts/design-artifacts/preview-modules.test.mjs
+++ b/scripts/design-artifacts/preview-modules.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { previewModuleRecords, previewModules } from "./preview-modules.mjs";
+import {
+  previewModuleRecords,
+  previewModules,
+  previewModuleSources,
+} from "./preview-modules.mjs";
 
 test("preview modules are unique and sorted", () => {
   assert.deepEqual(
@@ -24,8 +28,7 @@ test("preferred spec module matches discovery without a leading colon", () => {
 });
 
 test("module records retain Gradle-resolved nonconventional project directories", () => {
-  assert.deepEqual(
-    previewModuleRecords(
+  const records = previewModuleRecords(
       {
         previews: [
           { module: "ui", projectDirectory: "/workspace/components/ui" },
@@ -34,10 +37,29 @@ test("module records retain Gradle-resolved nonconventional project directories"
         ],
       },
       ":ui",
-    ),
+    );
+  assert.deepEqual(
+    records,
     [
       { module: "ui", projectDirectory: "/workspace/components/ui" },
       { module: "app", projectDirectory: "/workspace/application" },
     ],
+  );
+  assert.deepEqual(previewModuleSources(records, "/workspace"), [
+    "/workspace/components/ui",
+    "/workspace/application",
+  ]);
+});
+
+test("module sources retain a conventional fallback for pre-field CLI output", () => {
+  assert.deepEqual(
+    previewModuleSources(
+      [
+        { module: "feature:ui" },
+        { module: ":app" },
+      ],
+      "/workspace/build-root",
+    ),
+    ["/workspace/build-root/feature/ui", "/workspace/build-root/app"],
   );
 });

--- a/scripts/design-artifacts/preview-modules.test.mjs
+++ b/scripts/design-artifacts/preview-modules.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { previewModules } from "./preview-modules.mjs";
+import { previewModuleRecords, previewModules } from "./preview-modules.mjs";
 
 test("preview modules are unique and sorted", () => {
   assert.deepEqual(
@@ -20,5 +20,24 @@ test("preferred spec module matches discovery without a leading colon", () => {
   assert.deepEqual(
     previewModules({ previews: [{ module: "feature" }, { module: "catalog" }] }, ":catalog"),
     ["catalog", "feature"],
+  );
+});
+
+test("module records retain Gradle-resolved nonconventional project directories", () => {
+  assert.deepEqual(
+    previewModuleRecords(
+      {
+        previews: [
+          { module: "ui", projectDirectory: "/workspace/components/ui" },
+          { module: "app", projectDirectory: "/workspace/application" },
+          { module: "ui", projectDirectory: "/workspace/components/ui" },
+        ],
+      },
+      ":ui",
+    ),
+    [
+      { module: "ui", projectDirectory: "/workspace/components/ui" },
+      { module: "app", projectDirectory: "/workspace/application" },
+    ],
   );
 });


### PR DESCRIPTION
Addresses the two remaining Codex review findings from #3986; the other six findings are already fixed on current `main`.

- namespace additional modules' in-memory preview IDs, candidate/image IDs, entry paths, sidecars, manifests, and raw discovery metadata before cross-bundle aggregation
- expose Gradle's resolved `projectDirectory` in preview-list results
- validate repository-wide specs against those resolved directories instead of reconstructing paths from Gradle module names
- retain an explicit conventional-path fallback for callers using a pre-field released CLI
- advance every immutable install/driver pin together so the reusable workflow executes these fixes

Verification:
- complete design-artifact Node suite: 743 passing, 11 environment skips; one unrelated webfont test hung and the broad run was interrupted after all relevant tests passed
- focused `multi-module-catalog` and `preview-modules` Node tests: 13 passing
- `:preview-data-api:ktfmtCheck`, `:gradle-preview-driver:ktfmtCheck`, `:cli:ktfmtCheck`
- focused `PreviewResultBuilderTest` and `PreviewListResponseTest`
- workflow YAML parse and `git diff --check`