### PR TITLE
fix(playground): ignore comments in empty wrappers

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -545,7 +545,7 @@ object PlaygroundSourceCleaner {
         var replaceEnd = at + name.length
         if (out.getOrNull(next) == '(') {
           val close = matchParen(out, next) ?: continue
-          if (out.substring(next + 1, close).isNotBlank()) continue
+          if (containsCode(out.substring(next + 1, close))) continue
           replaceEnd = close + 1
           next = close + 1
           while (next < out.length && out[next].isWhitespace()) next++
@@ -883,6 +883,21 @@ object PlaygroundSourceCleaner {
       }
     }
     return mask
+  }
+
+  /** Whether [text] contains a non-whitespace code character rather than only comments. */
+  private fun containsCode(text: String): Boolean {
+    var i = 0
+    while (i < text.length) {
+      when {
+        text[i].isWhitespace() -> i++
+        text.startsWith("//", i) -> i = text.indexOf('\n', i).takeIf { it >= 0 } ?: text.length
+        text.startsWith("/*", i) ->
+          i = (text.indexOf("*/", i + 2).takeIf { it >= 0 }?.plus(2)) ?: text.length
+        else -> return true
+      }
+    }
+    return false
   }
 
   private fun isIdentifierChar(c: Char) = c.isLetterOrDigit() || c == '_'

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -297,6 +297,50 @@ class PlaygroundSourceCleanerTest {
   }
 
   @Test
+  fun `a system Material 3 theme wrapper treats comment-only arguments as empty`() {
+    val rules =
+      UsageRules(
+        scaffolds =
+          mapOf(
+            "Sticker" to
+              UsageRules.Scaffold(
+                kind = UsageRules.Kind.RENAME,
+                renameTo = "MaterialTheme",
+                special = UsageRules.MATERIAL3_SYSTEM_THEME,
+              )
+          )
+      )
+
+    for (arguments in listOf("/* default theme */", "\n        // default theme\n        ")) {
+      val source =
+        """
+        package com.example.catalog
+
+        import androidx.compose.runtime.Composable
+        import com.example.catalog.Sticker
+
+        @Composable
+        fun CardPreview() = Sticker($arguments) { Unit }
+        """
+          .trimIndent()
+
+      val result =
+        assertNotNull(
+          PlaygroundSourceCleaner.clean(
+            source,
+            source.lines().indexOfFirst { it.contains("fun CardPreview") } + 1,
+            rules,
+          ),
+          "comment-only arguments were not cleaned: ${arguments.replace("\n", "\\n")}",
+        )
+
+      assertFalse(result.text.contains("Sticker"), result.text)
+      assertTrue(result.text.contains("androidx.compose.material3.MaterialTheme("), result.text)
+      assertEquals(emptyList(), result.residue)
+    }
+  }
+
+  @Test
   fun `a system Material 3 expansion cannot collide with retained simple imports`() {
     val source =
       """


### PR DESCRIPTION
## What changed

- treat block-comment-only and line-comment-only wrapper parentheses as an empty argument list
- keep literals and real expressions classified as arguments
- add regression coverage for both comment forms

## Why

This follows up on the unresolved Codex review thread on #4035. `Sticker(/* default theme */) { ... }` was incorrectly retained as scaffold residue even though it has no arguments.

## Validation

- `./gradlew :cli:ktfmtCheck`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.PlaygroundSourceCleanerTest` (44 tests)
- `./gradlew :cli:classes`