### PR TITLE
fix(cli): make URL state assertion resilient

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlStateTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeUrlStateTest.kt
@@ -158,8 +158,12 @@ class ServeUrlStateTest {
     assertTrue(script.contains("window.cpUrlState.onPop("), "the viewer must handle Back/Forward")
     // The interactive lanes render themselves and never reach refreshLinks, so without this the
     // chosen lane never reaches the URL and the pending push lands on some later edit instead.
+    val interactiveLaneTransition =
+      script
+        .substringAfter("// The interactive lanes drive their own render")
+        .substringBefore("// SVG format toggle")
     assertTrue(
-      script.contains("else syncUrl();"),
+      interactiveLaneTransition.contains("syncUrl();"),
       "entering Live / Wasm / RC must write ?mode= at the moment of the transition",
     )
     // …and the other half of the round trip: a bookmarked lane has to open in that lane. The


### PR DESCRIPTION
## What

Update `ServeUrlStateTest` to inspect the interactive-lane transition block for `syncUrl()` instead of requiring the old one-line `else syncUrl();` spelling.

## Why

The viewer still synchronizes `?mode=` immediately. A recent change added `syncSpecBaseline()` beside it, turning the one-line `else` into a block and making the source-shape assertion stale. This is the current `Build CLI` failure on `main`.

## Impact

Test-only change. It preserves the behavioral guard while allowing the transition block to contain additional required work.

## Root cause

The assertion matched an exact TypeScript formatting shape rather than the relevant transition region.

## Checks

- `:cli:test --tests ee.schimke.composeai.cli.serve.ServeUrlStateTest` — passed locally
- Full validation delegated to GitHub CI at user request