### PR TITLE
fix(rc-player): track diagnostic task output

### DIFF
--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -111,11 +111,16 @@ tasks.withType<Test>().configureEach {
     listOf("rc.embedded.input", "rc.embedded.output", "rc.view.output", "rc.semantics.report")) {
     (project.findProperty(key) as String?)?.let { systemProperty(key, it) }
   }
-  systemProperty(
-    "rc.dynamic-color.report",
-    (project.findProperty("rc.dynamic-color.report") as String?)
-      ?: layout.buildDirectory.file("reports/dynamic-color-diag.txt").get().asFile.absolutePath,
-  )
+  val dynamicColorReport =
+    (project.findProperty("rc.dynamic-color.report") as String?)?.let(project::file)
+      ?: layout.buildDirectory.file("reports/dynamic-color-diag.txt").get().asFile
+  systemProperty("rc.dynamic-color.report", dynamicColorReport.absolutePath)
+  // The diagnostic skips without staged input, so normal test runs advertise no missing output.
+  // When the documented diagnostic command is active, however, the report is part of the task's
+  // contract: Gradle must rerun (or restore it from the build cache) after the file is deleted.
+  if (project.findProperty("rc.embedded.input") != null) {
+    outputs.file(dynamicColorReport).withPropertyName("dynamicColorReport")
+  }
   // Robolectric's NATIVE graphics mode needs a real heap to rasterize into.
   maxHeapSize = "2g"
 


### PR DESCRIPTION
## What changed

- resolve the dynamic-color diagnostic report path once per test task
- declare the report as a named Gradle output whenever staged RC input activates the diagnostic
- keep normal unstaged test runs free of a permanently missing output declaration

## Why

This follows up on the unresolved Codex review thread on #4037. The test could be restored from cache or considered up-to-date without recreating its advertised report.

## Validation

- `./gradlew :third-party-rc-embedded-player:ktfmtCheck`
- `./gradlew :third-party-rc-embedded-player:assemble`
- staged `DynamicColorDiagTest` run produced the custom report
- after moving the report aside, the next invocation restored `testDebugUnitTest FROM-CACHE`
- restored report matched the original byte-for-byte