### PR TITLE
fix(ci): restore Wear pressed-state fixture

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/FocusedPreview.kt
@@ -132,10 +132,10 @@ annotation class FocusedPreview(
    * the only consumer that routes those events into per-modifier `onClick` / `onSwipeForward` /
    * `onSwipeBackward` lambdas, and it always targets the currently-focused composable — so this
    * flag pairs naturally with `indices` (focus the n-th focusable, then press it). If the focused
-   * component has no indirect-pointer handler (including Wear Material 3 components built from
-   * `Modifier.combinedClickable`), the renderer falls back to a focused `DPAD_CENTER` key-down. Its
-   * key-up is held until the next capture, preserving the pressed interaction lifecycle without
-   * firing `onClick` in the captured frame.
+   * component has no indirect-pointer handler, the renderer attempts a focused `DPAD_CENTER`
+   * key-down. Its key-up is held until the next capture, preserving the pressed interaction
+   * lifecycle without firing `onClick` in the captured frame. Host implementations can differ in
+   * focused-key delivery; consumers should verify the resulting pressed pixels.
    *
    * Only meaningful for indexed-mode captures (`indices`) — traversal-mode (`traverse`) doesn't
    * carry a "settle and press" point. Off by default; opt in per-preview when you want the

--- a/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
+++ b/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
@@ -37,7 +37,7 @@ import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExten
  *   per capture, so the `LaunchedEffect` re-walks on each transition (issue #3672).
  *
  * The press half of `@FocusedPreview(pressed = true)` is **not** here, unlike the Android
- * connector's indirect-pointer-first `dispatchPress`. Desktop has no indirect-pointer channel; the
+ * connector's key-first `dispatchPress`. Desktop has no indirect-pointer channel; the
  * renderer dispatches an ordinary pointer down onto the focused element through the test host's
  * injection API, which is a capability only the render host has (nothing inside composition can
  * synthesise it). See `renderFocusPreview` for the rationale.

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -123,8 +123,9 @@ class FocusOverrideExtension(private val seed: FocusOverride? = null) :
         }
         // `@FocusedPreview(pressed = true)` — after the focus walk lands, dispatch a Press onto the
         // focused composable so its `PressInteraction.Press` fires before the renderer captures
-        // pixels. Prefer the normal focused-key path used by clickable components (including Wear
-        // M3 Button), then fall back to indirect-pointer input for Glimmer-specific gestures. See
+        // pixels. Prefer the normal focused-key path used by clickable components, then fall back
+        // to indirect-pointer input for Glimmer-specific gestures. Host implementations differ in
+        // focused-key delivery, so catalog consumers still verify the resulting pixels. See
         // [dispatchPress] for the platform rationale.
         // The matching Release is held off
         // until the NEXT capture's LaunchedEffect runs (above) — held-press across the capture
@@ -162,8 +163,8 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
 
 /**
  * Dispatches a held Press through the focused component's real input path. It first sends a focused
- * DPAD_CENTER key-down, which covers Compose components built from `clickable` or
- * `combinedClickable`, including Wear M3 Button. When that event is unhandled, it falls back to an
+ * DPAD_CENTER key-down, which can cover Compose components built from `clickable` or
+ * `combinedClickable`. When that event is unhandled, it falls back to an
  * indirect-pointer event through Compose UI's `AndroidComposeView.sendIndirectPointerEvent` — the
  * same channel real XR Glasses touchpads use.
  *
@@ -241,12 +242,9 @@ private fun View.sendIndirectPointer(action: Int): Boolean {
 }
 
 /**
- * Focus-targeted fallback for components with no indirect-pointer modifier. Wear Material 3's
- * `Button` is implemented with `combinedClickable`; unlike plain `clickable` and Glimmer's
- * `onIndirectPointerGesture`, that modifier does not consume an [IndirectPointerEvent]. A
- * DPAD_CENTER key event is Wear's ordinary focused activation channel, and `combinedClickable`
- * turns its down/up pair into the same held `PressInteraction.Press` / release lifecycle as a
- * physical button press.
+ * Focus-targeted fallback for components with no indirect-pointer modifier. A DPAD_CENTER key
+ * event is the ordinary focused activation channel for clickable components, though host
+ * implementations can differ in whether they deliver it to the focused modifier.
  */
 private fun View.dispatchKeyPress(): Boolean =
   dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_CENTER))

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -459,16 +459,18 @@ as a hairline; driven, it draws the full ring.
 - **Android** sends an *indirect* pointer event (`sendIndirectPointerEvent`) —
   the XR-Glasses channel, which routes to the focused composable. If no
   indirect-pointer modifier consumes the event, the renderer falls back to a
-  focused `DPAD_CENTER` key-down. Wear M3 takes that path: its `Button` is built
+  focused `DPAD_CENTER` key-down. Wear M3 attempts that path: its `Button` is built
   from `combinedClickable`, which owns focused key input but has no
-  indirect-pointer handler.
+  indirect-pointer handler. Robolectric does not reliably deliver that focused
+  key path to Wear M3, so the catalog specimen retains a held interaction-source
+  fallback instead of publishing a focus-only image as pressed.
 - **CMP/desktop** has no indirect-pointer channel, so the renderer dispatches an
   ordinary pointer down onto the focused element's bounds. Hit-tested like a
   real click, so the pressed state can only appear if the component itself
   consumed it.
-- **Wear M3** uses that focused-key fallback. Its `ButtonPressed` capture differs
-  from the focus-only capture across the button container, so the former
-  hand-seeded `MutableInteractionSource` stopgap has been removed.
+- **Wear M3** keeps a narrowly scoped held `MutableInteractionSource` for its
+  `ButtonPressed` catalog specimen. A pixel guard ensures the pressed capture
+  differs from focus-only across the button container.
 
 Note `pressed = true` necessarily focuses *and* presses, so a pressed capture may
 carry a focus indicator alongside the pressed state layer; Material's state layer

--- a/renders/preview-fidelity/README.md
+++ b/renders/preview-fidelity/README.md
@@ -30,11 +30,11 @@ indirect-pointer Press does not reach Wear M3's `Button` interaction source, so
 the capture documented *focus*, not press.
 
 Wear M3's `Button` uses `combinedClickable`, which does not consume the
-indirect-pointer event. The renderer now checks whether the indirect event was
-handled and, when it was not, holds a focus-targeted `DPAD_CENTER` key-down.
-`combinedClickable` consumes that ordinary Wear input channel and emits the
-component's real pressed interaction, so the catalog no longer needs its held
-`MutableInteractionSource` stopgap.
+indirect-pointer event. The renderer can fall back to a focus-targeted
+`DPAD_CENTER` key-down, but Robolectric does not reliably deliver that path to
+Wear M3: the capture remains focus-only. The catalog therefore retains a
+narrowly scoped held `MutableInteractionSource`, with a pixel test guarding that
+the published pressed specimen differs from focus-only.
 
 The Android M3 focus ring (`m3-focus-ring-after.png`) is the counter-example
 showing the mechanism does work where the component cooperates.

--- a/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
+++ b/samples/design-catalog-wear-m3/src/main/kotlin/com/example/designcatalogwearm3/CatalogPreviews.kt
@@ -1,6 +1,8 @@
 package com.example.designcatalogwearm3
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,8 +11,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -643,10 +648,11 @@ fun TextMaxLinesTruncated() = WearSticker {
 // traversal and flips `LocalInputModeManager` to Keyboard mode — which Robolectric
 // needs, since its host environment is permanently Touch and `Modifier.clickable`
 // registers its focusable as `Focusability.SystemDefined` (refused while in touch
-// mode). `pressed = true` additionally dispatches a real indirect-pointer Press
-// onto whatever the focus walk landed on, so the pressed state layer is raised by
-// the component's own interaction source. `indices = [0]` is the single Button in
-// the sticker; a single-capture `@FocusedPreview` keeps the plain
+// mode). Wear M3's `combinedClickable` does not expose a reliable synthetic input
+// path under Robolectric, so the pressed specimen seeds its interaction source
+// directly while the focused specimen continues to use real focus traversal.
+// `indices = [0]` is the single Button in the focused sticker; a single-capture
+// `@FocusedPreview` keeps the plain
 // `renders/<id>.png` filename (see `emitStaticCross` in PreviewDiscovery.kt), so
 // the design-artifacts fold by function name is untouched.
 //
@@ -657,15 +663,22 @@ fun TextMaxLinesTruncated() = WearSticker {
 @CatalogVariant(
   of = "Button/Filled",
   state = "pressed",
-  caption = "Real focused key press → pressed state layer.",
+  caption = "Held PressInteraction → pressed state layer.",
 )
 @CatalogWearModes
-@FocusedPreview(indices = [0], pressed = true)
 @Composable
 fun ButtonPressed() = WearSticker {
   val (label, onClick) =
     wearCounted(previewOverrideString("label", stringResource(R.string.label_pressed)))
-  Button(onClick = onClick) { Text(label) }
+  Button(onClick = onClick, interactionSource = pressedSource()) { Text(label) }
+}
+
+/** Seeds a held press because Robolectric cannot drive Wear M3's focused key path reliably. */
+@Composable
+private fun pressedSource(): MutableInteractionSource {
+  val source = remember { MutableInteractionSource() }
+  LaunchedEffect(source) { source.emit(PressInteraction.Press(Offset.Zero)) }
+  return source
 }
 
 @CatalogVariant(

--- a/samples/design-catalog-wear-m3/src/test/kotlin/com/example/designcatalogwearm3/WearFocusedPressPixelTest.kt
+++ b/samples/design-catalog-wear-m3/src/test/kotlin/com/example/designcatalogwearm3/WearFocusedPressPixelTest.kt
@@ -5,7 +5,7 @@ import java.io.File
 import javax.imageio.ImageIO
 import org.junit.Test
 
-/** End-to-end guard for the focused-key press fallback used by Wear M3 `combinedClickable`. */
+/** End-to-end guard that the documented Wear pressed specimen is not a focus-only capture. */
 class WearFocusedPressPixelTest {
 
   private val rendersDir = File("build/compose-previews/renders")
@@ -17,9 +17,9 @@ class WearFocusedPressPixelTest {
     val pressedImage = ImageIO.read(pressed)
     val focusedImage = ImageIO.read(focused)
 
-    // This point is inside the rounded container and outside both labels. Before the renderer's
-    // DPAD_CENTER fallback, both pixels were #D4C8EC: the requested Press never reached Wear M3's
-    // combinedClickable interaction source, so `pressed = true` only captured focus.
+    // This point is inside the rounded container and outside both labels. A synthetic focused key
+    // press does not reliably reach Wear M3's combinedClickable under Robolectric, producing the
+    // same #D4C8EC pixel in both captures. The catalog's seeded press must keep them distinct.
     val x = 30
     val y = 68
     assertThat(pressedImage.getRGB(x, y)).isNotEqualTo(focusedImage.getRGB(x, y))


### PR DESCRIPTION
## What changed

- restore the narrowly scoped held `PressInteraction` for the Wear M3 pressed catalog specimen
- retain the pixel guard that distinguishes pressed from focus-only output
- document that Robolectric does not reliably deliver the focused key fallback to Wear M3 `combinedClickable`

## Root cause

Both indirect-pointer-first and key-first renderer dispatch were tried on main. The focused `DPAD_CENTER` event is reported as handled by the host but does not reach Wear M3's `combinedClickable` interaction source under Robolectric, so the pressed capture remains pixel-identical to the focused capture.

## Validation

- `git diff --check`
- GitHub Actions only, per request; no local build was run
- intended gate: `samples:design-catalog-wear-m3:testDebugUnitTest`
