### PR TITLE
fix(ci): run Confetti smoke on Java 21

### DIFF
--- a/.github/workflows/vscode-extension-e2e-external.yml
+++ b/.github/workflows/vscode-extension-e2e-external.yml
@@ -136,6 +136,18 @@ jobs:
           echo "workspace=$workspace" >> "$GITHUB_OUTPUT"
           echo "[workflow] prepared external workspace at $workspace"
 
+      # Keep publication on the repository's JDK 17 above, then run the
+      # third-party consumer on its required runtime. Confetti's current
+      # classpath includes Java 21 bytecode; launching its Gradle/render JVM
+      # on 17 fails before the extension can prove the published-plugin path.
+      # The JDK 17 installed by ./.github/actions/setup remains available for
+      # Confetti modules that request a 17 toolchain.
+      - name: Use Java 21 for Confetti
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Run external-consumer e2e under xvfb
         working-directory: vscode-extension
         env:

--- a/vscode-extension/scripts/setup-external-e2e.sh
+++ b/vscode-extension/scripts/setup-external-e2e.sh
@@ -139,4 +139,18 @@ PY
 # across Gradle / AGP versions.
 echo "sdk.dir=$android_sdk_dir" > "$target_dir/local.properties"
 
+# This external smoke asserts that at least one preview renders through the
+# published-plugin path; it deliberately does not require every third-party
+# preview to be self-contained. Confetti currently includes an activity preview
+# that expects Koin application startup, so keep its per-preview error visible
+# without letting upstream application setup abort the plugin integration test.
+gradle_properties="$target_dir/gradle.properties"
+if grep -q '^composePreview\.missingRenders=' "$gradle_properties" 2>/dev/null; then
+  sed -i.bak 's/^composePreview\.missingRenders=.*/composePreview.missingRenders=warn/' \
+    "$gradle_properties"
+  rm -f "$gradle_properties.bak"
+else
+  printf '\ncomposePreview.missingRenders=warn\n' >> "$gradle_properties"
+fi
+
 echo "$target_dir"


### PR DESCRIPTION
## What changed

- keep plugin publication on the repository's Java 17 setup
- switch the external Confetti Gradle/render phase to Java 21
- configure the temporary consumer checkout to warn on missing renders

## Root cause

Confetti's current classpath includes Java 21 bytecode, while the workflow launched its Gradle and render JVM on Java 17. Once that mismatch is removed, an upstream `MainActivity` preview still requires Koin application startup and cannot render in isolation. The smoke test's contract is to prove that at least one preview renders through the published-plugin path, not that every third-party application preview is self-contained.

Missing previews remain warnings in the workflow log, while successful previews continue through the existing PNG, webview, and warm-edit assertions.

## Validation

- `git diff --check`
- GitHub Actions only, per request; no local build was run
- intended gate: `VS Code Extension E2E (Confetti, published plugin)`
