### PR TITLE
style: format focus connector docs

### DIFF
--- a/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
+++ b/data/focus/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProductDesktop.kt
@@ -37,10 +37,10 @@ import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExten
  *   per capture, so the `LaunchedEffect` re-walks on each transition (issue #3672).
  *
  * The press half of `@FocusedPreview(pressed = true)` is **not** here, unlike the Android
- * connector's key-first `dispatchPress`. Desktop has no indirect-pointer channel; the
- * renderer dispatches an ordinary pointer down onto the focused element through the test host's
- * injection API, which is a capability only the render host has (nothing inside composition can
- * synthesise it). See `renderFocusPreview` for the rationale.
+ * connector's key-first `dispatchPress`. Desktop has no indirect-pointer channel; the renderer
+ * dispatches an ordinary pointer down onto the focused element through the test host's injection
+ * API, which is a capability only the render host has (nothing inside composition can synthesise
+ * it). See `renderFocusPreview` for the rationale.
  *
  * Runs in the [DataExtensionPhase.OuterEnvironment] phase so the input-mode flip happens before the
  * user-environment phase reaches preview content.

--- a/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
+++ b/data/focus/connector/src/main/kotlin/ee/schimke/composeai/daemon/FocusDataProduct.kt
@@ -164,9 +164,9 @@ fun FocusManager.applyFocusOverride(override: FocusOverride?) {
 /**
  * Dispatches a held Press through the focused component's real input path. It first sends a focused
  * DPAD_CENTER key-down, which can cover Compose components built from `clickable` or
- * `combinedClickable`. When that event is unhandled, it falls back to an
- * indirect-pointer event through Compose UI's `AndroidComposeView.sendIndirectPointerEvent` — the
- * same channel real XR Glasses touchpads use.
+ * `combinedClickable`. When that event is unhandled, it falls back to an indirect-pointer event
+ * through Compose UI's `AndroidComposeView.sendIndirectPointerEvent` — the same channel real XR
+ * Glasses touchpads use.
  *
  * Key input must be tried first. `AndroidComposeView.sendIndirectPointerEvent` can report that the
  * root handled an event even when the focused component has no indirect-pointer modifier; treating
@@ -242,9 +242,9 @@ private fun View.sendIndirectPointer(action: Int): Boolean {
 }
 
 /**
- * Focus-targeted fallback for components with no indirect-pointer modifier. A DPAD_CENTER key
- * event is the ordinary focused activation channel for clickable components, though host
- * implementations can differ in whether they deliver it to the focused modifier.
+ * Focus-targeted fallback for components with no indirect-pointer modifier. A DPAD_CENTER key event
+ * is the ordinary focused activation channel for clickable components, though host implementations
+ * can differ in whether they deliver it to the focused modifier.
  */
 private fun View.dispatchKeyPress(): Boolean =
   dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_CENTER))


### PR DESCRIPTION
## What changed

- apply the repository's Google-style ktfmt wrapping to the Android and desktop focus connector KDoc

## Root cause

The documentation corrections merged in #4046 wrapped paragraphs in both connector files differently from ktfmt's expected output, causing `ktfmtCheckMain` to fail on main.

## Validation

- `:data-focus-connector:ktfmtFormatMain` with the installed JDK 17
- `:data-focus-connector-desktop:ktfmtFormatMain` with the installed JDK 17
- `git diff --check`
- no compilation or local build was run
