### PR TITLE
fix(vscode): reconcile manifests before daemon startup

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -36,6 +36,7 @@ import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
 import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
 import { moduleRelativeSourcePath, previewSourceMatches } from "./sourcePath";
 import { visiblePreviewsForFile } from "./previewScope";
+import { sourceMayDifferFromCachedPreviews } from "./previewSourceState";
 import { anyPreviewSourceTabOpen } from "./previewTabs";
 import {
     AccessibilityFinding,
@@ -3108,6 +3109,36 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     }
     const moduleKey = module.modulePath;
 
+    // Reconcile before bootstrap. The daemon's PreviewManifestRouter snapshots
+    // previews.json when the JVM starts and does not reload it. A Gradle build
+    // cache can restore empty class outputs while discovery still finds asset
+    // previews, leaving a non-empty but stale asset-only manifest. Starting the
+    // daemon from that file permanently rejects every code preview discovered
+    // afterward with "no manifest entry".
+    let manifest = moduleManifestCache.get(moduleKey) ?? [];
+    const repaintFile =
+        editorScope.file &&
+        gradleService.resolveModule(editorScope.file)?.modulePath === moduleKey
+            ? editorScope.file
+            : undefined;
+    let filePreviews = previewsForFile(manifest, module, filePath);
+    const sourceDiffers = await previewSourceMayDifferFromCache(
+        filePath,
+        filePreviews,
+    );
+    if (manifest.length === 0 || sourceDiffers) {
+        if (sourceDiffers) {
+            logLine(
+                `daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before startup`,
+            );
+        }
+        const fresh = await reconcilePreviewManifest(module, repaintFile);
+        if (fresh) {
+            manifest = fresh;
+            filePreviews = previewsForFile(fresh, module, filePath);
+        }
+    }
+
     // Bootstrap (Gradle task + JVM spawn) happens once per module per
     // session. Normally it has already fired from the active-editor warm
     // path; on the rare case where the user saves before scope-in (e.g.
@@ -3145,46 +3176,9 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
     }
 
-    // Focus scope = the saved file's previews, derived from the most recent
-    // manifest snapshot we got from Gradle's composePreviewDiscover. The daemon
-    // reads this for queue ordering — focused first. If we don't yet have a
-    // manifest for this module the focus call is skipped; the next refresh
-    // will populate moduleManifestCache. Returning true with no ids is
-    // intentional — the daemon already saw `fileChanged` so its internal
-    // discovery + render will catch any newly-discovered previews on its
-    // own; the caller just shouldn't escalate to a Gradle render in that
-    // case (the panel will repopulate via discover + the daemon's
-    // discoveryUpdated push).
-    let manifest = moduleManifestCache.get(moduleKey) ?? [];
-    const repaintFile =
-        editorScope.file &&
-        gradleService.resolveModule(editorScope.file)?.modulePath === moduleKey
-            ? editorScope.file
-            : undefined;
-    // The manifest snapshot persists across identity edits, but it can be empty
-    // on a cold save: the first save before any discover ran, or right after an
-    // explicit refresh cleared it. An empty snapshot would derive renderIds=0
-    // and render nothing — and an identity edit keeps the daemon quiet, so no
-    // `discoveryUpdated` would repopulate it. Recover by discovering once here.
-    // (`sourceMayHaveDroppedCachedPreviews` can't cover this — it returns false
-    // for an empty preview list.) Once populated, subsequent identity saves skip
-    // this and reuse the snapshot.
-    if (manifest.length === 0) {
-        const fresh = await reconcilePreviewManifest(module, repaintFile);
-        if (fresh) {
-            manifest = fresh;
-        }
-    }
-    let filePreviews = previewsForFile(manifest, module, filePath);
-    if (await sourceMayHaveDroppedCachedPreviews(filePath, filePreviews)) {
-        logLine(
-            `daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before render`,
-        );
-        const fresh = await reconcilePreviewManifest(module, repaintFile);
-        filePreviews = fresh
-            ? previewsForFile(fresh, module, filePath)
-            : filePreviews;
-    }
+    // Focus scope = the saved file's previews, derived from the manifest we
+    // reconciled before daemon startup. The daemon reads this for queue
+    // ordering — focused first.
     const ids = prioritizeEditedPreview(
         filePath,
         filePreviews.map((p) => p.id),
@@ -4568,57 +4562,17 @@ function heavyOptInsFor(moduleId: string, previewIds: string[]): string[] {
     return previewIds.filter((id) => opted.has(id));
 }
 
-async function sourceMayHaveDroppedCachedPreviews(
+async function previewSourceMayDifferFromCache(
     filePath: string,
     previews: PreviewInfo[],
 ): Promise<boolean> {
-    if (previews.length === 0) {
-        return false;
-    }
     let source: string;
     try {
         source = await fs.promises.readFile(filePath, "utf-8");
     } catch {
         return false;
     }
-    return previews.some(
-        (preview) =>
-            !sourceLooksLikePreviewDeclaration(source, preview.functionName),
-    );
-}
-
-function sourceLooksLikePreviewDeclaration(
-    source: string,
-    functionName: string,
-): boolean {
-    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const match = new RegExp(`\\bfun\\s+${escaped}\\s*\\(`).exec(source);
-    if (!match) {
-        return false;
-    }
-
-    const lines = source.slice(0, match.index).split(/\r?\n/);
-    const annotationLines: string[] = [];
-    for (let i = lines.length - 1; i >= 0; i--) {
-        const line = lines[i].trim();
-        if (line.length === 0) {
-            if (annotationLines.length === 0) {
-                continue;
-            }
-            break;
-        }
-        if (
-            line.startsWith("@") ||
-            line.startsWith("//") ||
-            line.startsWith("/*") ||
-            line.startsWith("*")
-        ) {
-            annotationLines.unshift(line);
-            continue;
-        }
-        break;
-    }
-    return annotationLines.some((line) => line.includes("Preview"));
+    return sourceMayDifferFromCachedPreviews(source, previews);
 }
 
 /**

--- a/vscode-extension/src/previewSourceState.ts
+++ b/vscode-extension/src/previewSourceState.ts
@@ -1,0 +1,80 @@
+export interface CachedPreviewIdentity {
+    functionName: string;
+}
+
+/**
+ * Returns true when Kotlin source and the previews cached for that file can no
+ * longer describe the same preview set.
+ *
+ * The empty-cache case matters during daemon startup: discovery can leave an
+ * asset-only manifest behind when Gradle restores empty class outputs. If the
+ * source still declares a preview, that manifest must be rebuilt before the
+ * daemon snapshots it.
+ */
+export function sourceMayDifferFromCachedPreviews(
+    source: string,
+    previews: readonly CachedPreviewIdentity[],
+): boolean {
+    if (previews.length === 0) {
+        for (const functionName of declaredFunctionNames(source)) {
+            if (sourceLooksLikePreviewDeclaration(source, functionName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return previews.some(
+        (preview) =>
+            !sourceLooksLikePreviewDeclaration(source, preview.functionName),
+    );
+}
+
+function declaredFunctionNames(source: string): string[] {
+    const names: string[] = [];
+    const functionPattern = /\bfun\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+    for (
+        let match = functionPattern.exec(source);
+        match;
+        match = functionPattern.exec(source)
+    ) {
+        names.push(match[1]);
+    }
+    return names;
+}
+
+function sourceLooksLikePreviewDeclaration(
+    source: string,
+    functionName: string,
+): boolean {
+    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = new RegExp(`\\bfun\\s+${escaped}\\s*\\(`).exec(source);
+    if (!match) {
+        return false;
+    }
+
+    const lines = source.slice(0, match.index).split(/\r?\n/);
+    const annotationLines: string[] = [];
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (line.length === 0) {
+            if (annotationLines.length === 0) {
+                continue;
+            }
+            break;
+        }
+        if (
+            line.startsWith("@") ||
+            line.startsWith("//") ||
+            line.startsWith("/*") ||
+            line.startsWith("*")
+        ) {
+            annotationLines.unshift(line);
+            continue;
+        }
+        break;
+    }
+    return annotationLines.some(
+        (line) => line.startsWith("@") && line.includes("Preview"),
+    );
+}

--- a/vscode-extension/src/test/previewSourceState.test.ts
+++ b/vscode-extension/src/test/previewSourceState.test.ts
@@ -1,0 +1,50 @@
+import * as assert from "assert";
+import { sourceMayDifferFromCachedPreviews } from "../previewSourceState";
+
+describe("previewSourceState", () => {
+    it("detects a preview declaration missing from an empty file cache", () => {
+        const source = `
+@androidx.compose.ui.tooling.preview.Preview
+@androidx.compose.runtime.Composable
+fun AddedPreview() = Unit
+`;
+
+        assert.strictEqual(sourceMayDifferFromCachedPreviews(source, []), true);
+    });
+
+    it("accepts an empty cache for source without preview declarations", () => {
+        const source = `
+@androidx.compose.runtime.Composable
+fun OrdinaryComposable() = Unit
+`;
+
+        assert.strictEqual(
+            sourceMayDifferFromCachedPreviews(source, []),
+            false,
+        );
+    });
+
+    it("accepts a cached preview that is still declared", () => {
+        const source = `
+@Preview
+@Composable
+fun ExistingPreview() = Unit
+`;
+
+        assert.strictEqual(
+            sourceMayDifferFromCachedPreviews(source, [
+                { functionName: "ExistingPreview" },
+            ]),
+            false,
+        );
+    });
+
+    it("detects a cached preview removed from source", () => {
+        assert.strictEqual(
+            sourceMayDifferFromCachedPreviews("fun Replacement() = Unit", [
+                { functionName: "RemovedPreview" },
+            ]),
+            true,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- reconcile stale or empty preview manifests before starting the VS Code preview daemon
- detect Kotlin preview declarations when an asset-only manifest has no cached previews for the active file
- add regression coverage for empty, current, and removed preview cache states

## Root cause

The failing `interactive-a-d` E2E shard restored empty compiled class outputs, leaving a valid but asset-only three-entry `previews.json`. The daemon's `PreviewManifestRouter` snapshots that file at startup. Discovery later recovered 70 code previews, including the test's newly added `Interactive…` preview, but the running router still knew only the three asset entries and rejected every render with `no manifest entry`. The expected PNG therefore never reached disk.

This change performs the source/cache reconciliation before daemon bootstrap, ensuring the daemon snapshots the recovered code-preview manifest.

## Validation

- `npm run compile:host`
- focused `previewSourceState` tests: 4 passing
- `npm test`: 1,696 passing
- Prettier check and `git diff --check`

ESLint was not run because the package declares a lint script but does not install an ESLint executable.