### PR TITLE
fix(serve): expose accessibility inspection on catalog previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -794,6 +794,13 @@ class ServeCatalogLiveHost(
 
   override val hasScrollExport: Boolean by lazy { live.hasScrollExport }
 
+  /**
+   * Accessibility inspection is another explicit live render, just like scroll capture. The
+   * catalog's baked lane has no semantics tree, but its carried daemon does; forwarding the
+   * capability is what makes the Accessibility control appear on a catalog component page.
+   */
+  override val hasA11yOverlay: Boolean by lazy { live.hasA11yOverlay }
+
   override fun hasScrollExportFor(previewId: String): Boolean =
     previewId in alias && live.hasScrollExportFor(alias.getValue(previewId))
 
@@ -1171,6 +1178,16 @@ class ServeCatalogLiveHost(
   override fun renderScrollSvg(previewId: String, overrides: PreviewOverrides): SvgOutcome {
     val daemonId = alias[previewId] ?: return SvgOutcome.NotFound
     return liveHostFor(daemonId).renderScrollSvg(daemonId, overrides)
+  }
+
+  /**
+   * Produce accessibility data from the live daemon rather than the baked snapshot. The exact
+   * viewer overrides are deliberately retained: changing theme, font scale, device, locale or a
+   * named knob must inspect the newly rendered composition, not the catalog's original pixels.
+   */
+  override fun renderA11y(previewId: String, overrides: PreviewOverrides): A11yOutcome {
+    val daemonId = alias[previewId] ?: return A11yOutcome.NotFound
+    return liveHostFor(daemonId).renderA11y(daemonId, overrides)
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -43,6 +43,7 @@ class ServeCatalogLiveHostTest {
     private val forcedRenderOutcome: RenderOutcome? = null,
     override val declaredThemes: List<ServeTheme> = emptyList(),
     override val gesturesRenderable: Boolean = false,
+    override val hasA11yOverlay: Boolean = false,
     /**
      * Ids this host lists but has no pixels for (a catalog's deferred previews) — `render` reports
      * `NotFound` for them, exactly as the real baked host does.
@@ -55,6 +56,7 @@ class ServeCatalogLiveHostTest {
     var lastRenderOverrides: PreviewOverrides? = null
     var lastSvgId: String? = null
     var lastStreamId: String? = null
+    var lastA11yId: String? = null
     var renderCalls = 0
     var closed = false
 
@@ -80,6 +82,19 @@ class ServeCatalogLiveHostTest {
       lastRenderOverrides = overrides
       if (svgNotFound) return SvgOutcome.NotFound
       return SvgOutcome.Ok("$tag-svg:$previewId".encodeToByteArray())
+    }
+
+    override fun renderA11y(
+      previewId: String,
+      overrides: PreviewOverrides,
+    ): A11yOutcome {
+      lastA11yId = previewId
+      lastRenderOverrides = overrides
+      if (!hasA11yOverlay) return A11yOutcome.NotFound
+      return A11yOutcome.Ok(
+        """{"previewId":"$previewId","nodes":[],"findings":[],"touchTargets":[]}"""
+          .encodeToByteArray()
+      )
     }
 
     override fun subscribeStream(
@@ -339,6 +354,49 @@ class ServeCatalogLiveHostTest {
     val out = composite.renderSvg(catalogId, knobOverride()) as SvgOutcome.Ok
     assertEquals("live-svg:$daemonId", out.svg.decodeToString())
     assertEquals(daemonId, live.lastSvgId)
+  }
+
+  @Test
+  fun `accessibility inspection maps the catalog id and preserves live overrides`() {
+    val baked = RecordingHost(previews = listOf(ServePreview(catalogId, catalogId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+        hasA11yOverlay = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+    val overrides = knobOverride().copy(uiMode = UiMode.DARK, fontScale = 1.3f)
+
+    assertTrue(composite.hasA11yOverlay)
+    val out = composite.renderA11y(catalogId, overrides) as A11yOutcome.Ok
+    assertEquals(daemonId, live.lastA11yId)
+    assertEquals(overrides, live.lastRenderOverrides)
+    assertTrue(out.json.decodeToString().contains("\"previewId\":\"$daemonId\""))
+    // CMP represents unavailable Android-only ATF products as empty arrays. Do not add an
+    // unsupported-platform note to the component-page legend.
+    assertFalse(out.json.decodeToString().contains("unsupported", ignoreCase = true))
+  }
+
+  @Test
+  fun `accessibility inspection stays unavailable for a catalog preview without a daemon twin`() {
+    val baked =
+      RecordingHost(previews = listOf(ServePreview(androidOnlyId, androidOnlyId)), tag = "baked")
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        streaming = true,
+        hasA11yOverlay = true,
+      )
+    val composite = ServeCatalogLiveHost(mapOf(catalogId to daemonId), live, baked)
+
+    assertEquals(
+      A11yOutcome.NotFound,
+      composite.renderA11y(androidOnlyId, PreviewOverrides()),
+    )
+    assertNull(live.lastA11yId)
   }
 
   @Test


### PR DESCRIPTION
## What changed

- Forward the live daemon's accessibility capability through `ServeCatalogLiveHost`.
- Route catalog preview `.a11y` requests to the mapped daemon preview ID.
- Preserve the active theme, font scale, device, locale, and named overrides when accessibility data is rendered.
- Keep previews without a daemon twin unavailable instead of advertising a dead inspection control.

## Why

The underlying Android and CMP desktop render hosts could already produce accessibility hierarchy data, overlays, and legends. The catalog composite did not forward `hasA11yOverlay` or `renderA11y`, so catalog component pages omitted the Accessibility control and their `.a11y` endpoint returned 404.

## Impact

Catalog component pages can now show the accessibility visual overlay and legend from a fresh live render. Android also surfaces ATF findings and touch targets. CMP desktop remains hierarchy-only, with empty Android-only findings and no unsupported-platform note.

## Validation

- `ServeCatalogLiveHostTest` passes, including override forwarding and unmapped-preview coverage.
- `git diff --check` passes.
- Full `:cli:ktfmtCheck` is currently blocked by pre-existing formatting failures on `main` in `ServeHttpServer.kt` and `ServeWeb.kt`; neither is changed by this PR.