### PR TITLE
fix(vscode): await daemon warmup for viewport updates

### DIFF
--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -173,6 +173,7 @@ export interface DaemonScheduler {
         module: ModuleInfo,
         visible: string[],
         predicted?: string[],
+        gradleService?: GradleService,
     ): Promise<void>;
     /**
      * Update one or more `(previewId, kind)` subscriptions for `module`.
@@ -496,6 +497,7 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         module: ModuleInfo,
         visible: string[],
         predicted: string[] = [],
+        gradleService?: GradleService,
     ): Promise<void> {
         const moduleKey = module.modulePath;
         if (
@@ -504,14 +506,42 @@ export class LiveDaemonScheduler implements DaemonScheduler {
         ) {
             return;
         }
-        this.visibility.recordVisible(module, visible);
-        const client = await this.gate.getOrSpawn(
-            module,
-            this.daemonEvents(moduleKey),
-        );
+        let client;
+        try {
+            client = await this.gate.getOrSpawn(
+                module,
+                this.daemonEvents(moduleKey),
+            );
+        } catch (err) {
+            // Viewport messages can arrive while activation is still running
+            // composePreviewDaemonStart. Join that in-flight warm instead of
+            // surfacing an unhandled "no launch descriptor" rejection. The
+            // warm coalescer makes this cheap when another caller owns it.
+            if (!gradleService) {
+                this.logger.appendLine(
+                    `[daemon] viewport deferred for ${moduleKey}: ${(err as Error).message}`,
+                );
+                return;
+            }
+            this.logger.appendLine(
+                `[daemon] viewport waiting for ${moduleKey}: ${(err as Error).message}`,
+            );
+            const warmed = await this.warmModule(gradleService, module);
+            if (!warmed) {
+                return;
+            }
+            client = await this.gate.getOrSpawn(
+                module,
+                this.daemonEvents(moduleKey),
+            );
+        }
         if (!client) {
             return;
         }
+        // Only memoize after delivery is possible. Recording before
+        // getOrSpawn succeeds causes the retry of an identical viewport to be
+        // deduplicated forever after a bootstrap race.
+        this.visibility.recordVisible(module, visible);
         client.setVisible({ ids: visible });
 
         // D2 — drop bookkeeping for previews that fell out of view. The daemon already

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8125,6 +8125,7 @@ async function notifyDaemonViewport(
             mod,
             visibleByModule.get(modulePath) ?? [],
             predictedByModule.get(modulePath) ?? [],
+            gradleService ?? undefined,
         );
     }
     // Demand-driven `@ScrollingPreview` backfill. Cheap when `pendingScrollBackfill`

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -259,6 +259,47 @@ describe("DaemonScheduler", () => {
         assert.strictEqual(visibleCalls.length, 1);
     });
 
+    it("waits for daemon warm-up when a viewport arrives before the launch descriptor", async () => {
+        const { gate, scheduler, log } = build();
+        gate.getOrSpawnErrors.push(
+            new Error("[daemon] no launch descriptor for mod"),
+        );
+        const gradle = new FakeGradleService();
+
+        await scheduler.setVisible(
+            mod("mod"),
+            ["new-preview"],
+            [],
+            gradle as unknown as Parameters<typeof scheduler.setVisible>[3],
+        );
+
+        const visibleCalls = gate.client!.calls.filter(
+            (c) => c.method === "setVisible",
+        );
+        assert.strictEqual(visibleCalls.length, 1);
+        assert.deepStrictEqual(visibleCalls[0].args, {
+            ids: ["new-preview"],
+        });
+        assert.ok(
+            log.some((l) => l.includes("viewport waiting")),
+            `expected viewport warm-up log, got: ${log.join(" / ")}`,
+        );
+    });
+
+    it("does not memoize a viewport when no daemon client is available", async () => {
+        const { gate, scheduler } = build();
+        gate.client = null;
+        await scheduler.setVisible(mod("mod"), ["a"], []);
+
+        gate.client = new FakeClient();
+        await scheduler.setVisible(mod("mod"), ["a"], []);
+
+        const visibleCalls = gate.client.calls.filter(
+            (c) => c.method === "setVisible",
+        );
+        assert.strictEqual(visibleCalls.length, 1);
+    });
+
     it("caps speculative renderNow at the budget", async () => {
         const { gate, scheduler } = build();
         const predicted = ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"];


### PR DESCRIPTION
## Summary

- wait for an in-flight daemon warm-up when viewport updates arrive before the launch descriptor exists
- memoize viewport delivery only after a daemon client is available
- add regression coverage for bootstrap races and unavailable clients

## Root cause

A viewport update could race `composePreviewDaemonStart`. `setVisible()` recorded the viewport before `getOrSpawn()` succeeded, then rejected with `no launch descriptor`. A later identical viewport was deduplicated even though it had never reached the daemon, leaving newly discovered previews without their rendered PNG.

## Impact

Newly added previews now reach the daemon after bootstrap completes instead of remaining as permanent placeholder cards during this race.

## Validation

- `npm test` — 1698 passing
- focused `daemonScheduler.test.js` — 56 passing
- `npm run format:check`
- `git diff --check`

The repository's SSH signing helper was unavailable in the non-interactive environment, so the commit is unsigned.