### PR TITLE
fix(ci): refresh design artifact driver pin

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -405,7 +405,7 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -477,7 +477,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -490,7 +490,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Do not honor a caller-controlled ref here: refs/pull/* in this repo
           # can contain fork code, and this privileged workflow executes the driver.
-          ref: df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
+          ref: b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 
@@ -713,7 +713,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -728,7 +728,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Never execute a caller-selected refs/pull/* revision in this
           # privileged workflow. Update this alongside the other driver pin.
-          ref: df2b08c9f091c379c1cb4285fa7221395d097e01 # catalog integrity at 2026-08-16
+          ref: b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Moves the pinned export driver from `df2b08c9` onto **`b2660a2`** (#4074), across all five occurrences in `design-artifacts-reusable.yml` — the two `ref:` checkouts and the three `install@` action pins — the same five the last refresh (#4016) moved together.

The pin is a SHA rather than `main` on purpose: the reusable workflow is privileged and must never run a caller-selected ref. The cost of that is that a driver change lands **inert** until this moves, which is exactly the state #4074 is in right now — its `bundle pack` half is live for any catalog that builds the CLI from source, but the generator half that puts `motion` into `catalog.json` is still being read from a driver that predates it. Until this merges, every catalog keeps publishing with no Motion section.

## Test plan

- Mechanical pin bump; no code change. `git diff` is 5 insertions, 5 deletions, all the same SHA substitution.
- Verified on `b2660a2` itself (merged `main`) that the driver it now points at is good: `node --test` in `scripts/design-artifacts` → **752 pass, 0 fail**, with `@design-parity/catalog-export` resolving to 0.1.52 from the lockfile.
- The real check is the next `design-artifacts` run: its log should now carry a `motion: N component(s) carry M capture(s)` line, and the delivery branch should grow a `motion/` directory. Silence on that line is itself the signal that something upstream dropped the axis.

## Follow-up

`bundle pack`'s half ships in the published plugin/CLI. 1.10.0 was cut at `bb19254`, *before* #4074 landed, so consumers pinned to a release (m3-catalog is on `composePreviewPlugin = 1.9.0`) still need a 1.11.0 plus the routine renovate bump before their captures are named so the export can join them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG)_