### PR TITLE
feat(design-artifacts): support live bundles across all modules

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -25,8 +25,8 @@ name: Design Artifacts (reusable)
 #
 # Bespoke lanes some catalogs add (e.g. compose-m3's re-theme fold-in, a Wasm
 # tier) are intentionally out of scope — a caller that needs them keeps its own
-# workflow. This covers single-module (± one extra module) catalogs and repository-wide baked
-# catalogs spanning every preview-enabled module.
+# workflow. This covers single-module (± one extra module) catalogs and repository-wide static or
+# multi-live-bundle catalogs spanning every preview-enabled module.
 
 on:
   workflow_call:
@@ -784,12 +784,8 @@ jobs:
             echo "::error title=all modules::render-shards currently shards one module; use 1 when publishing all modules."
             exit 1
           fi
-          if [ "$PUBLISH_LIVE_BUNDLE" = "true" ]; then
-            echo "::error title=all modules::publish-live-bundle requires one executable module bundle; repository-wide catalogs publish baked/static bundles."
-            exit 1
-          fi
-          if [ "$SPLIT_PER_PREVIEW" = "true" ] && [ "$SPLIT_MODE" != "view-only" ]; then
-            echo "::error title=all modules::repository-wide per-preview splits must use split-mode: view-only because there is no single live classpath."
+          if [ "$SPLIT_PER_PREVIEW" = "true" ] && [ "$SPLIT_MODE" != "view-only" ] && [ "$PUBLISH_LIVE_BUNDLE" != "true" ]; then
+            echo "::error title=all modules::repository-wide live per-preview splits require publish-live-bundle: true."
             exit 1
           fi
           compose-preview list --json > "$GITHUB_WORKSPACE/discovered-previews.json"
@@ -829,7 +825,8 @@ jobs:
               [ -n "$discovered_source" ] && args+=(--src "$discovered_source")
             done < "$GITHUB_WORKSPACE/preview-module-sources.txt"
             # One source.module cannot describe a repository-wide catalog. Keep validation honest:
-            # deferred coverage must not pass on a live path the generate step intentionally omits.
+            # deferred coverage needs the carried live bundles, while source modules are stamped
+            # per component after export.
             LIVE_SOURCE=false
           else
             args+=(--module-dir "$(to_dir "$MODULE")")
@@ -1009,7 +1006,12 @@ jobs:
             index=0
             while IFS= read -r discovered_module; do
               [ -z "$discovered_module" ] && continue
-              output="$GITHUB_WORKSPACE/module-bundles/$(printf '%04d' "$index").png"
+              if [ "$index" -eq 0 ]; then
+                output="$GITHUB_WORKSPACE/module-bundles/0000.png"
+              else
+                module_key="$(node "$GITHUB_WORKSPACE/compose-ai-tools/scripts/design-artifacts/module-artifact-key.mjs" --module "$discovered_module")"
+                output="$GITHUB_WORKSPACE/module-bundles/$module_key.png"
+              fi
               # The authored render filter belongs to the preferred/primary module. Every later
               # module is fallback inventory and must render in full; applying the primary's
               # function names there can fail on no match or silently thin unrelated previews.
@@ -1119,6 +1121,23 @@ jobs:
           path: ~/.cache/composeai/fonts
           key: composeai-fonts-${{ runner.os }}-${{ inputs.system }}-${{ github.run_id }}
 
+      # One executable bundle still owns exactly one Gradle module/classpath. Prefix every
+      # additional module's preview ids before publication so equal ids in two modules remain
+      # distinct daemon addresses. The primary stays unchanged for backwards compatibility.
+      - name: Namespace live module bundles
+        if: ${{ inputs.publish-live-bundle && (inputs.module == '' || inputs.modules == 'all') }}
+        run: |
+          set -euo pipefail
+          mapfile -t modules < "$GITHUB_WORKSPACE/preview-modules.txt"
+          for ((index = 1; index < ${#modules[@]}; index++)); do
+            module_key="$(node compose-ai-tools/scripts/design-artifacts/module-artifact-key.mjs --module "${modules[$index]}")"
+            bundle="$GITHUB_WORKSPACE/module-bundles/$module_key.png"
+            namespaced="$bundle.namespaced"
+            node compose-ai-tools/scripts/design-artifacts/namespace-live-bundle.mjs \
+              --input "$bundle" --output "$namespaced" --module "${modules[$index]}"
+            mv "$namespaced" "$bundle"
+          done
+
       - name: Generate importable catalog
         env:
           # The ref actually rendered (see "Check out the calling repo"). Empty ⇒ the
@@ -1145,7 +1164,9 @@ jobs:
             source_ref="${RENDERED_REF:-$GITHUB_REF_NAME}"
             source_args=(--source-repo "${GITHUB_REPOSITORY}" --source-ref "${source_ref}" --source-module "$INPUT_MODULE")
           elif [ "$INPUT_LIVE_RERENDER_SOURCE" = "true" ]; then
-            echo "::notice title=All-module catalog::live-rerender-source is omitted because one source.module cannot represent multiple Gradle modules; baked previews are still published."
+            source_ref="${RENDERED_REF:-$GITHUB_REF_NAME}"
+            source_args=(--source-repo "${GITHUB_REPOSITORY}" --source-ref "${source_ref}")
+            echo "::notice title=All-module catalog::source modules are recorded per preview; trusted live rendering uses the carried module bundles."
           fi
           incomplete=()
           if [ "$INPUT_ALLOW_INCOMPLETE" = "true" ]; then incomplete=(--allow-incomplete); fi
@@ -1215,10 +1236,18 @@ jobs:
           fi
           if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
             while IFS= read -r additional_bundle; do
-              module_index="$(basename "$additional_bundle" .png)"
-              compose-preview bundle split "$additional_bundle" --view-only \
-                -o "$GITHUB_WORKSPACE/out/bundle/previews/modules/$module_index"
-            done < <(find "$GITHUB_WORKSPACE/module-bundles" -type f -name '*.png' ! -name '0000.png' | sort -V)
+              module_key="$(basename "$additional_bundle" .png)"
+              module_previews="$GITHUB_WORKSPACE/out/bundle/modules/$module_key/previews"
+              if [ "$INPUT_SPLIT_MODE" = "view-only" ]; then
+                compose-preview bundle split "$additional_bundle" --view-only \
+                  -o "$module_previews"
+              else
+                # Each module owns its classpath/resource closure. Additional-module splits remain
+                # self-contained instead of borrowing the primary module's external resource pool.
+                compose-preview bundle split "$additional_bundle" \
+                  -o "$module_previews"
+              fi
+            done < <(find "$GITHUB_WORKSPACE/module-bundles" -type f -name 'module_*.png' | sort)
           fi
           if [ -n "$INPUT_EXTRA_MODULE" ] && [ -f "$GITHUB_WORKSPACE/extra-bundle.png" ]; then
             if [ "$INPUT_EXTRA_SPLIT_MODE" = "full" ]; then

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -13,6 +13,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundAndroidRenderService
 import ee.schimke.composeai.cli.serve.PlaygroundAndroidSessionOpener
 import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
 import ee.schimke.composeai.cli.serve.PlaygroundBundleSource
+import ee.schimke.composeai.cli.serve.PlaygroundCatalogAvailable
 import ee.schimke.composeai.cli.serve.PlaygroundCatalogClasspath
 import ee.schimke.composeai.cli.serve.PlaygroundCatalogTargets
 import ee.schimke.composeai.cli.serve.PlaygroundClasspathSupplier
@@ -326,7 +327,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * written by catalog load / refresh threads, read from request threads.
    */
   private val catalogLiveBundles =
-    java.util.concurrent.ConcurrentHashMap<String, CatalogLiveBundle>()
+    java.util.concurrent.ConcurrentHashMap<String, List<CatalogLiveBundle>>()
 
   /**
    * A served catalog's verified liveBundle, as the playground sees it: where the bytes landed and
@@ -335,7 +336,15 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * a catalog can offer *before* anyone pays for a full classpath resolve. Null when the bundle's
    * metadata could not be read at all — such a catalog is simply not offered.
    */
-  private class CatalogLiveBundle(val file: java.io.File, val backend: String?)
+  private data class CatalogLiveBundle(
+    val id: String,
+    val module: String,
+    val file: java.io.File,
+    val backend: String?,
+  )
+
+  private fun catalogTargetId(system: String, module: String, primary: Boolean): String =
+    if (primary) system else "$system@$module"
 
   /**
    * `--playground-bundle <path|system>`: enable the playground lane (`POST /api/{v}/compiler/run`),
@@ -1585,7 +1594,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       else
         PlaygroundCatalogTargets(
           available = {
-            catalogLiveBundles.mapNotNull { (system, live) -> live.backend?.let { system to it } }
+            catalogLiveBundles.flatMap { (system, bundles) ->
+              bundles.mapNotNull { live ->
+                live.backend?.let { PlaygroundCatalogAvailable(live.id, system, live.module, it) }
+              }
+            }
           },
           modesForBackend = { backend ->
             PlaygroundCatalogTargets.naturalModes(backend).filter { mode ->
@@ -1598,12 +1611,15 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
               }
             }
           },
-          newSupplier = { system ->
+          newSupplier = { id ->
+            val system = id.substringBefore('@')
             PlaygroundClasspathSupplier(
               source = PlaygroundBundleSource.ServedCatalog(system),
-              locateServedBundle = { catalogLiveBundles[it]?.file },
-              resolve = { bundleFile -> resolvePlaygroundClasspath(bundleFile, workRoot, system) },
-              onLog = { System.err.println("serve: playground catalog $system: $it") },
+              locateServedBundle = {
+                catalogLiveBundles[system]?.firstOrNull { live -> live.id == id }?.file
+              },
+              resolve = { bundleFile -> resolvePlaygroundClasspath(bundleFile, workRoot, id) },
+              onLog = { System.err.println("serve: playground catalog $id: $it") },
             )
           },
           limit = playgroundCatalogLimit,
@@ -1897,7 +1913,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     }
     return PlaygroundClasspathSupplier(
       source = source,
-      locateServedBundle = { catalogLiveBundles[it]?.file },
+      locateServedBundle = { catalogLiveBundles[it]?.firstOrNull()?.file },
       resolve = { bundleFile -> resolvePlaygroundClasspath(bundleFile, workRoot, mode) },
       onLog = { System.err.println("serve: playground $mode — $it") },
     )
@@ -2876,7 +2892,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     val store =
       ServeCatalogStore(
         root = dir,
-        register = { id, host -> registry.register(id, host = host, pinned = true) },
+        register = { id, host -> publishStaticCatalog(id, host, registry) },
         trust = { trustStore.get() },
         repo = catalogRepo,
         branchPrefix = catalogBranchPrefix,
@@ -2899,23 +2915,6 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           alias,
           bakedFallback,
           perPreviewBundle ->
-          // Record where this catalog's verified liveBundle landed, so `--playground-bundle
-          // <system>` can compile against the very bytes the live lane runs — no second copy on the
-          // config volume, and the playground inherits the catalog's Trusted(Branch) verdict rather
-          // than trusting whatever an operator scp'd there (issue #3212). Only reached for a
-          // catalog that verified Trusted AND declared a liveBundle, which is exactly the set a
-          // playground mode may name.
-          //
-          // The backend rides along because the runtime selector needs it to decide which modes a
-          // catalog offers, and that decision has to be answerable while rendering the selector —
-          // long before anyone pays for a classpath resolve. One metadata read per catalog load,
-          // never on a request thread.
-          catalogLiveBundles[system] =
-            CatalogLiveBundle(
-              file = bundleFile,
-              backend =
-                runCatching { BundleReader.readMetadata(bundleFile).manifest.backend }.getOrNull(),
-            )
           buildTrustedCatalogBundle(
             system,
             bundleFile,
@@ -2927,6 +2926,17 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             openHost,
           )
         },
+        buildTrustedBundles = { system, bundles, bakedFallback ->
+          buildTrustedCatalogBundles(
+            system,
+            bundles,
+            bakedFallback,
+            registry,
+            openHost,
+          )
+        },
+        recordTrustedBundles = { system, bundles -> recordCatalogCompileTargets(system, bundles) },
+        clearTrustedBundles = catalogLiveBundles::remove,
         buildTrustedSource = { system, source, alias, bakedFallback ->
           buildTrustedCatalogSource(
             system,
@@ -2981,6 +2991,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         synchronized(catalogRegistrationLock) {
           registry.unregister(system)
           catalogPerPreviewPools.remove(system)?.let { runCatching { it.close() } }
+          catalogLiveBundles.remove(system)
           registeredCatalogs.remove(system)
           registeredUnlistedCatalogs.remove(system)
           // Stop serving the retired catalog's in-browser app too — but never drop a local
@@ -3130,18 +3141,232 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           catalogThemeCache = CatalogThemeCache(),
           serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
           backgroundWork = backgroundWork,
-        ) ?: return false
+        )
+        ?: run {
+          perPreviewPool.close()
+          return false
+        }
     // Now that the backend is known, the pool's daemons charge this catalog's real weight — an
     // Android/Robolectric per-preview daemon is not the same cost to the box as a desktop one.
     perPreviewSeatWeight = state.liveSeatWeight
-    val host = openHost(state) ?: return false
-    registry.register(system, state, host = host)
-    // Track the new pool and close the one it replaces — but only AFTER the fresh host is
-    // registered (register already closed the old host), so a re-load never closes a pool the
-    // still-live old host is mid-render on. First load for a system has no predecessor.
-    catalogPerPreviewPools.put(system, perPreviewPool)?.let { runCatching { it.close() } }
+    val host =
+      openHost(state)
+        ?: run {
+          perPreviewPool.close()
+          return false
+        }
+    if (!publishCatalogRuntime(system, state, host, perPreviewPool, registry)) {
+      return false
+    }
     System.err.println("serve: catalog $system → LIVE from bundle (no build) (?session=$system)")
     return true
+  }
+
+  /**
+   * Publish a catalog host and the resources its state closures capture as one ownership transfer.
+   * The ownership maps move first, then the registry entry becomes request-visible; on failure both
+   * maps are restored and the unpublished host/resources are closed. The caller's catalog
+   * registration lock makes this atomic with admin unload and branch refresh.
+   */
+  private fun publishCatalogRuntime(
+    system: String,
+    state: ServeSessionState,
+    host: ServeHost,
+    resources: AutoCloseable,
+    registry: ServeSessionRegistry,
+  ): Boolean {
+    var previousResources: AutoCloseable? = null
+    try {
+      synchronized(catalogRegistrationLock) {
+        previousResources = catalogPerPreviewPools.put(system, resources)
+        try {
+          registry.register(system, state, host = host)
+        } catch (failure: Throwable) {
+          previousResources?.let { catalogPerPreviewPools[system] = it }
+            ?: catalogPerPreviewPools.remove(system, resources)
+          throw failure
+        }
+      }
+    } catch (failure: Throwable) {
+      runCatching { host.close() }
+      runCatching { resources.close() }
+      System.err.println("serve: catalog $system publication failed (${failure.message})")
+      return false
+    }
+    previousResources?.let { runCatching { it.close() } }
+    return true
+  }
+
+  /** Record every verified module bundle as an independent lazy playground compile target. */
+  private fun recordCatalogCompileTargets(
+    system: String,
+    bundles: List<ServeCatalogStore.VerifiedModuleBundle>,
+  ) {
+    catalogLiveBundles[system] = bundles.mapIndexed { index, bundle ->
+      val metadata = runCatching { BundleReader.readMetadata(bundle.file).manifest }.getOrNull()
+      CatalogLiveBundle(
+        id = catalogTargetId(system, bundle.module, primary = index == 0),
+        module = bundle.module.ifBlank { metadata?.modulePath.orEmpty() },
+        file = bundle.file,
+        backend = metadata?.backend,
+      )
+    }
+  }
+
+  /** Replace a formerly-live catalog without leaving stale pools or playground targets behind. */
+  private fun publishStaticCatalog(
+    system: String,
+    host: ServeHost,
+    registry: ServeSessionRegistry,
+  ) {
+    var previousResources: AutoCloseable? = null
+    synchronized(catalogRegistrationLock) {
+      previousResources = catalogPerPreviewPools.remove(system)
+      try {
+        registry.register(system, host = host, pinned = true)
+      } catch (failure: Throwable) {
+        previousResources?.let { catalogPerPreviewPools[system] = it }
+        throw failure
+      }
+    }
+    previousResources?.let { runCatching { it.close() } }
+  }
+
+  /** Stand up one independently materialised live runtime per module and route by namespaced id. */
+  private fun buildTrustedCatalogBundles(
+    system: String,
+    bundles: List<ServeCatalogStore.TrustedModuleBundle>,
+    bakedFallback: () -> ServeHost,
+    registry: ServeSessionRegistry,
+    openHost: (ServeSessionState) -> ServeHost?,
+  ): Boolean {
+    if (!allowRenderTrusted || bundles.isEmpty()) return false
+    data class Runtime(
+      val published: ServeCatalogStore.TrustedModuleBundle,
+      val state: ServeSessionState,
+      val pool: ServePerPreviewDaemonPool,
+      var monolithic: ServeHost? = null,
+    )
+
+    val opened = mutableListOf<Runtime>()
+    var publishedSuccessfully = false
+    try {
+      for ((index, published) in bundles.withIndex()) {
+        var seatWeight = 1
+        val pool =
+          ServePerPreviewDaemonPool(
+            liveSeats = liveSeatLimiter,
+            seatWeight = { seatWeight },
+          ) { daemonId ->
+            val file =
+              published.perPreviewBundle.fetch(daemonId) ?: return@ServePerPreviewDaemonPool null
+            val dest =
+              java.nio.file.Files.createTempDirectory("serve-catalog-preview-$system-$index")
+                .toFile()
+                .also { it.deleteOnExit() }
+            val state =
+              ServeBundleDaemon.materialize(
+                file,
+                dest,
+                "$system:${published.module}",
+                extraMavenRepos = extraMavenRepos,
+                extraClasspathDirs = listOfNotNull(published.externalResourcesDir),
+              ) ?: return@ServePerPreviewDaemonPool null
+            openHost(state)
+          }
+        val dest =
+          java.nio.file.Files.createTempDirectory("serve-catalog-module-$system-$index")
+            .toFile()
+            .also { it.deleteOnExit() }
+        val state =
+          ServeBundleDaemon.materialize(
+            published.file,
+            dest,
+            "$system:${published.module}",
+            extraMavenRepos = extraMavenRepos,
+            extraClasspathDirs = listOfNotNull(published.externalResourcesDir),
+          )
+            ?: run {
+              pool.close()
+              return false
+            }
+        seatWeight = state.liveSeatWeight
+        opened += Runtime(published, state, pool)
+      }
+
+      val primary = opened.first()
+      for (runtime in opened.drop(1)) {
+        runtime.monolithic = openHost(runtime.state) ?: return false
+      }
+      val ownerByDaemonId =
+        opened
+          .flatMap { runtime ->
+            runtime.published.alias.values.map { daemonId -> daemonId to runtime }
+          }
+          .toMap()
+      val alias = opened.flatMap { it.published.alias.entries }.associate { it.toPair() }
+      val resolver: (String) -> ServeHost? = { daemonId ->
+        val runtime = ownerByDaemonId[daemonId]
+        when {
+          runtime == null -> null
+          runtime === primary -> runtime.pool.get(daemonId)
+          else -> runtime.pool.get(daemonId) ?: runtime.monolithic
+        }
+      }
+      val state =
+        primary.state.copy(
+          previewAliases = alias,
+          bakedFallback = bakedFallback,
+          perPreviewResolve = resolver,
+          executableBundleAvailable = { daemonId ->
+            ownerByDaemonId[daemonId]?.published?.perPreviewBundle?.available?.invoke(daemonId)
+              ?: false
+          },
+          executableBundleProvider = { daemonId ->
+            ownerByDaemonId[daemonId]
+              ?.published
+              ?.perPreviewBundle
+              ?.fetch(daemonId)
+              ?.takeIf(File::isFile)
+              ?.readBytes()
+          },
+          perPreviewStreamCount = { opened.sumOf { it.pool.activeStreamCount() } },
+          perPreviewRenderStats = {
+            opened.flatMap { runtime ->
+              buildList {
+                addAll(runtime.pool.renderPerfStats())
+                runtime.monolithic?.renderPerfStats()?.let(::add)
+              }
+            }
+          },
+          perPreviewPoolStats = { opened.map { it.pool.snapshot() } },
+          perPreviewReapIdle = { idle -> opened.sumOf { it.pool.reapIdle(idle) } },
+          catalogThemeCache = CatalogThemeCache(),
+          serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
+          backgroundWork = backgroundWork,
+        )
+      val host = openHost(state) ?: return false
+      val resources = AutoCloseable {
+        opened.forEach { runtime ->
+          runCatching { runtime.pool.close() }
+          runCatching { runtime.monolithic?.close() }
+        }
+      }
+      if (!publishCatalogRuntime(system, state, host, resources, registry)) return false
+      System.err.println(
+        "serve: catalog $system → LIVE from ${opened.size} module bundles (no build) (?session=$system)"
+      )
+      publishedSuccessfully = true
+      return true
+    } finally {
+      // Once registered, ownership moves to catalogPerPreviewPools. Otherwise unwind partial opens.
+      if (!publishedSuccessfully) {
+        opened.forEach { runtime ->
+          runCatching { runtime.pool.close() }
+          runCatching { runtime.monolithic?.close() }
+        }
+      }
+    }
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundApi.kt
@@ -133,6 +133,10 @@ data class PlaygroundCatalogInfo(
    * True once this catalog's classpath is resolved — the first run against it pays for the unpack.
    */
   val resolved: Boolean = false,
+  /** Served catalog system, distinct from a module-qualified [id]. */
+  val system: String = id,
+  /** Owning Gradle module when this entry is one target in a repository-wide catalog. */
+  val module: String = "",
 )
 
 /** `GET /api/{version}/compiler/catalogs`: what the editor's catalog selector may offer. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargets.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargets.kt
@@ -20,6 +20,18 @@ data class PlaygroundCatalogTarget(
   val modes: List<PlaygroundMode>,
   /** True once this catalog's compile classpath has been resolved and memoized. */
   val resolved: Boolean,
+  /** Request id; equals [system] for a legacy/primary bundle and is module-qualified otherwise. */
+  val id: String = system,
+  /** Owning Gradle module for a repository-wide catalog target. */
+  val module: String = "",
+)
+
+/** One independently compilable bundle currently published by a served catalog. */
+data class PlaygroundCatalogAvailable(
+  val id: String,
+  val system: String,
+  val module: String,
+  val backend: String,
 )
 
 /**
@@ -56,7 +68,7 @@ class PlaygroundCatalogTargets(
    * are fetched in the background *after* the playground lane is wired, so a list captured once
    * would be empty forever on a freshly started host.
    */
-  private val available: () -> List<Pair<String, String>>,
+  private val available: () -> List<PlaygroundCatalogAvailable>,
   /**
    * Which modes this host can actually serve for a bundle backend — the backend's natural modes
    * intersected with the render backends that came up (no Robolectric sidecar ⇒ no Android modes,
@@ -75,18 +87,22 @@ class PlaygroundCatalogTargets(
   /** Everything the selector should offer, sorted by system id so the list is stable per render. */
   fun targets(): List<PlaygroundCatalogTarget> =
     available()
-      .mapNotNull { (system, backend) ->
-        val modes = modesForBackend(backend)
+      .mapNotNull { available ->
+        val modes = modesForBackend(available.backend)
         if (modes.isEmpty()) null
         else
           PlaygroundCatalogTarget(
-            system = system,
-            backend = backend,
+            system = available.system,
+            backend = available.backend,
             modes = modes,
-            resolved = suppliers[system]?.isResolved == true,
+            resolved = suppliers[available.id]?.isResolved == true,
+            id = available.id,
+            module = available.module,
           )
       }
-      .sortedBy { it.system }
+      .sortedWith(
+        compareBy<PlaygroundCatalogTarget>({ it.system }, { it.id != it.system }, { it.module })
+      )
 
   /** How many catalogs currently hold a resolved classpath — for `/status.json`. */
   fun resolvedCount(): Int = suppliers.values.count { it.isResolved }
@@ -98,22 +114,22 @@ class PlaygroundCatalogTargets(
    * the caller as "not available" rather than distinguished on the wire, and logged here with the
    * actual reason.
    */
-  fun classpath(system: String, mode: PlaygroundMode): PlaygroundCompileService.Classpath? {
-    val target = targets().firstOrNull { it.system == system }
+  fun classpath(id: String, mode: PlaygroundMode): PlaygroundCompileService.Classpath? {
+    val target = targets().firstOrNull { it.id == id }
     if (target == null) {
-      onLog("catalog '$system' is not a selectable playground catalog on this host")
+      onLog("catalog target '$id' is not selectable on this host")
       return null
     }
     if (mode !in target.modes) {
       onLog(
-        "catalog '$system' is a ${target.backend} catalog and cannot serve mode ${mode.name} here " +
+        "catalog target '$id' is a ${target.backend} bundle and cannot serve mode ${mode.name} here " +
           "(offers ${target.modes.joinToString { it.name }})"
       )
       return null
     }
     // Fast path: an already-resolved catalog is a map read plus a memo read, so concurrent compiles
     // against the common catalog never touch the lock below.
-    suppliers[system]
+    suppliers[id]
       ?.takeIf { it.isResolved }
       ?.let {
         return it.classpath()
@@ -121,7 +137,7 @@ class PlaygroundCatalogTargets(
     // First resolve of a catalog is serialized: it unpacks a bundle and resolves a full Maven
     // classpath, and serializing is what makes the cap exact rather than a racy over-shoot.
     synchronized(this) {
-      suppliers[system]
+      suppliers[id]
         ?.takeIf { it.isResolved }
         ?.let {
           return it.classpath()
@@ -135,12 +151,12 @@ class PlaygroundCatalogTargets(
       if (resolvedCount() >= limit) {
         onLog(
           "playground catalog budget spent: $limit catalog(s) already hold a resolved classpath " +
-            "and they cannot be evicted while snippet JVMs hold their jars open, so '$system' is " +
+            "and they cannot be evicted while snippet JVMs hold their jars open, so '$id' is " +
             "refused. Raise --playground-catalog-limit, or restart to pick a different set."
         )
         return null
       }
-      val supplier = suppliers[system] ?: newSupplier(system).also { suppliers[system] = it }
+      val supplier = suppliers[id] ?: newSupplier(id).also { suppliers[id] = it }
       return supplier.classpath()
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileService.kt
@@ -190,11 +190,15 @@ class PlaygroundCompileService(
     return listOfNotNull(default) +
       catalogTargets?.invoke().orEmpty().map {
         PlaygroundCatalogInfo(
-          id = it.system,
-          label = "${it.system} (${it.backend})",
+          id = it.id,
+          label =
+            if (it.module.isBlank()) "${it.system} (${it.backend})"
+            else "${it.system} · ${it.module} (${it.backend})",
           backend = it.backend,
           modes = it.modes,
           resolved = it.resolved,
+          system = it.system,
+          module = it.module,
         )
       }
   }
@@ -227,7 +231,7 @@ class PlaygroundCompileService(
    */
   fun compilesCatalog(system: String): Boolean {
     if (system.isBlank()) return false
-    if (catalogChoices().any { it.id == system && it.modes.isNotEmpty() }) return true
+    if (catalogChoices().any { it.system == system && it.modes.isNotEmpty() }) return true
     return system in pinnedCatalogSystems
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -29,6 +29,8 @@ import java.util.concurrent.ConcurrentHashMap
 data class PlaygroundSeed(
   /** The catalog to preselect — the system the preview belongs to. */
   val catalog: String,
+  /** Owning Gradle module, used to select the matching compile bundle in a multi-module catalog. */
+  val sourceModule: String? = null,
   /** The preview this came from, for the note the editor shows. */
   val previewId: String,
   /** Editor tab name, from the source path's basename (`FilledButton.kt`). */
@@ -273,6 +275,7 @@ class PlaygroundSeedResolver(
     val seed =
       PlaygroundSeed(
         catalog = system,
+        sourceModule = where.module,
         previewId = previewId,
         fileName = fileNameFor(where.sourceFile),
         text = cleaned?.text ?: sliced ?: text,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -409,6 +409,7 @@ class ServeBundleHost(
           group = meta?.group,
           catalogOrder = meta?.order,
           sourceFile = sourceFilesById[id],
+          sourceModule = meta?.sourceModule,
           bodyLine = bodyLinesById[id],
           uiMode = previewParamsById[id]?.uiMode ?: 0,
         )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -119,6 +119,24 @@ class ServeCatalogStore(
       false
     },
   /**
+   * Multi-module counterpart of [buildTrustedBundle]. Each entry owns one classpath and alias set.
+   */
+  private val buildTrustedBundles:
+    (
+      system: String,
+      bundles: List<TrustedModuleBundle>,
+      bakedFallback: () -> ServeHost,
+    ) -> Boolean =
+    { _, _, _ ->
+      false
+    },
+  /** Publish verified carried bundles to non-daemon consumers such as the playground compiler. */
+  private val recordTrustedBundles: (system: String, bundles: List<VerifiedModuleBundle>) -> Unit =
+    { _, _ ->
+    },
+  /** Clear compile targets when a successful refresh no longer carries a usable trusted bundle. */
+  private val clearTrustedBundles: (system: String) -> Unit = {},
+  /**
    * Trusted server-side re-render (opt-in, `--allow-render-trusted`). When a catalog is `Trusted`
    * AND declares a `source` (`{repo, ref, module}`), this is invoked to stand up a **daemon-backed,
    * re-renderable** session built from that source — so the viewer's controls re-render live at
@@ -143,6 +161,17 @@ class ServeCatalogStore(
 
   /** A catalog's buildable source — where to check out + build to re-render it live. */
   data class CatalogSource(val repo: String, val ref: String, val module: String)
+
+  data class TrustedModuleBundle(
+    val module: String,
+    val file: File,
+    val externalResourcesDir: File?,
+    val alias: Map<String, String>,
+    val perPreviewBundle: PerPreviewBundleAccess,
+  )
+
+  /** Minimal verified carried-bundle identity for compile consumers that do not run its daemon. */
+  data class VerifiedModuleBundle(val module: String, val file: File)
 
   /**
    * Build the **catalog-id → daemon-preview-id** alias from a catalog's images: each image's
@@ -231,6 +260,7 @@ class ServeCatalogStore(
     val section: String?,
     val group: String?,
     val componentSourceFile: String?,
+    val componentSourceModule: String?,
     val componentBodyLine: Int?,
     /**
      * The owning component's published captures, paired to this image by theme in the load loop.
@@ -365,6 +395,7 @@ class ServeCatalogStore(
         val group = component.group?.takeIf { it.isNotBlank() }
         val componentId = component.componentId?.takeIf { it.isNotBlank() }
         val componentSourceFile = component.sourceFile?.takeIf { it.isNotBlank() }
+        val componentSourceModule = component.sourceModule?.takeIf { it.isNotBlank() }
         val componentBodyLine = component.bodyLine?.takeIf { it > 0 }
         component.images.mapNotNull { image ->
           val path = image.path
@@ -387,6 +418,7 @@ class ServeCatalogStore(
             section,
             group,
             componentSourceFile,
+            componentSourceModule,
             componentBodyLine,
             component.motion,
           )
@@ -461,6 +493,7 @@ class ServeCatalogStore(
             planned.componentId != null ||
             hasSectionInfo ||
             planned.componentSourceFile != null ||
+            planned.componentSourceModule != null ||
             image.overrides.isNotEmpty() ||
             image.remoteComposeKnobs.isNotEmpty() ||
             image.supportsFocus ||
@@ -483,6 +516,7 @@ class ServeCatalogStore(
               group = planned.group,
               order = if (hasSectionInfo) count else null,
               sourceFile = planned.componentSourceFile,
+              sourceModule = planned.componentSourceModule,
               bodyLine = planned.componentBodyLine,
             )
         }
@@ -794,7 +828,106 @@ class ServeCatalogStore(
     // explain it (instead of the generic "no live bundle"). Null unless the catalog declared a
     // liveBundle we then couldn't use.
     var liveBundleFallback: ServeDegradation? = null
-    val liveBundle = catalog.liveBundle
+    var trustedBundlesRecorded = false
+    val declaredLiveBundles = catalog.liveBundles
+    val multiLiveBundle = declaredLiveBundles.size > 1
+    if (verdict is BundleVerifier.Verdict.Trusted && multiLiveBundle) {
+      val nonEmptyPrefixes =
+        declaredLiveBundles.map { it.previewIdPrefix }.filter { it.isNotEmpty() }
+      val descriptorsValid =
+        nonEmptyPrefixes.distinct().size == nonEmptyPrefixes.size &&
+          declaredLiveBundles.count { it.previewIdPrefix.isEmpty() } == 1
+      if (!descriptorsValid) {
+        liveBundleFallback =
+          ServeDegradation.liveBundleUnavailable("the module bundle identity map is invalid")
+      } else {
+        val prepared = mutableListOf<TrustedModuleBundle>()
+        for (descriptor in declaredLiveBundles) {
+          val moduleAlias = alias.filterValues { daemonId ->
+            if (descriptor.previewIdPrefix.isNotEmpty()) {
+              daemonId.startsWith(descriptor.previewIdPrefix)
+            } else {
+              nonEmptyPrefixes.none(daemonId::startsWith)
+            }
+          }
+          val bundleFile = fetchLiveBundle(descriptor, base, dir, safe)
+          if (bundleFile == null) {
+            prepared.clear()
+            liveBundleFallback =
+              ServeDegradation.liveBundleUnavailable(
+                "the ${descriptor.module.ifBlank { "primary" }} module bundle could not be fetched"
+              )
+            break
+          }
+          extractCatalogRcDocs(bundleFile, moduleAlias, dir)
+          val resources =
+            when (
+              val res = rehydrateExternalResources(bundleFile, base, descriptor.path, dir, safe)
+            ) {
+              is ResRehydrate.Ready -> res.dir
+              ResRehydrate.Unavailable -> {
+                prepared.clear()
+                liveBundleFallback =
+                  ServeDegradation.liveBundleUnavailable(
+                    "a resource for ${descriptor.module.ifBlank { "the primary module" }} could not be rehydrated"
+                  )
+                break
+              }
+            }
+          val safeStems = uniquePerPreviewStems(moduleAlias.values)
+          prepared +=
+            TrustedModuleBundle(
+              module = descriptor.module,
+              file = bundleFile,
+              externalResourcesDir = resources,
+              alias = moduleAlias,
+              perPreviewBundle =
+                PerPreviewBundleAccess(
+                  available = { daemonId ->
+                    safeStems[daemonId]?.let { stem ->
+                      perPreviewBundleAvailable(stem, descriptor, base, dir)
+                    } ?: false
+                  },
+                  fetch = { daemonId ->
+                    safeStems[daemonId]?.let { stem ->
+                      fetchPerPreviewBundle(stem, descriptor, base, dir, safe, resources)
+                    }
+                  },
+                ),
+            )
+        }
+        val preparedCompletely =
+          prepared.size == declaredLiveBundles.size && prepared.all { it.alias.isNotEmpty() }
+        if (preparedCompletely) {
+          recordTrustedBundles(
+            safe,
+            prepared.map { VerifiedModuleBundle(module = it.module, file = it.file) },
+          )
+          trustedBundlesRecorded = true
+        }
+        if (
+          preparedCompletely &&
+            buildTrustedBundles(
+              safe,
+              prepared,
+              { bakedFallback(emptyList(), deferredIds.toList()) },
+            )
+        ) {
+          return Result.Ok(
+            safe,
+            count + deferredIds.size + failedIds.size,
+            "${BundleVerifier.summary(verdict)} (${prepared.size} live module bundles)",
+            failedIds.size,
+          )
+        }
+        if (liveBundleFallback == null) {
+          liveBundleFallback =
+            ServeDegradation.liveBundleUnavailable("the module bundle daemons could not be started")
+        }
+      }
+    }
+    // A multi-module declaration is atomic: never silently start only its primary legacy bundle.
+    val liveBundle = if (multiLiveBundle) null else catalog.liveBundle
     if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
       val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
       if (bundleFile == null) {
@@ -803,6 +936,11 @@ class ServeCatalogStore(
             "the bundle could not be fetched from the delivery branch"
           )
       } else {
+        recordTrustedBundles(
+          safe,
+          listOf(VerifiedModuleBundle(module = liveBundle.module, file = bundleFile)),
+        )
+        trustedBundlesRecorded = true
         // Materialise the captured Remote Compose documents (`ir/<daemon-id>.rc`) from the fetched
         // bundle, re-keyed to the published catalog ids, so the baked host's in-browser canvas lane
         // can serve them. Done regardless of the rehydrate/daemon outcome below — the client-side
@@ -889,6 +1027,7 @@ class ServeCatalogStore(
     // source is even offered to the builder — an Unverified catalog NEVER reaches it, so a
     // compromised/spoofed catalog can't trigger a build. Like the bundle path, the builder fronts
     // the baked host with the daemon rather than replacing it.
+    if (!trustedBundlesRecorded) clearTrustedBundles(safe)
     val src = catalog.source
     if (
       verdict is BundleVerifier.Verdict.Trusted &&
@@ -934,7 +1073,8 @@ class ServeCatalogStore(
           liveBundleFallback
             ?: when {
               verdict is BundleVerifier.Verdict.Unverified &&
-                (liveBundle != null || (src != null && src.module.isNotBlank())) ->
+                ((liveBundle != null || declaredLiveBundles.isNotEmpty()) ||
+                  (src != null && src.module.isNotBlank())) ->
                 ServeDegradation.unverifiedNoRerender()
               else -> ServeDegradation.catalogBakedOnly()
             },
@@ -1902,6 +2042,10 @@ class ServeCatalogStore(
      */
     val liveBundle: LiveBundle? = null,
     /**
+     * One independently executable bundle per Gradle module; [liveBundle] remains the v1 primary.
+     */
+    val liveBundles: List<LiveBundle> = emptyList(),
+    /**
      * Live-only coverage: the entries and image axes the spec declared `priority: "deferred"` (or
      * thinned out of the palette with `modePriority`), which CI deliberately did NOT rasterise —
      * recorded here rather than in `components[].images` so no consumer of the baked sticker set is
@@ -1968,8 +2112,16 @@ class ServeCatalogStore(
    */
   @Serializable data class CatalogDisplay(val surface: String? = null, val hero: String? = null)
 
-  /** `catalog.json`'s `liveBundle`: the executable bundle at `<path><file>` on this branch. */
-  @Serializable private data class LiveBundle(val path: String = "", val file: String = "")
+  /**
+   * `catalog.json` live bundle descriptor. Prefix partitions collision-safe daemon ids by module.
+   */
+  @Serializable
+  private data class LiveBundle(
+    val path: String = "",
+    val file: String = "",
+    val module: String = "",
+    val previewIdPrefix: String = "",
+  )
 
   /** `catalog.json`'s `source`: the repo/ref/module to build to re-render this catalog live. */
   @Serializable
@@ -1994,6 +2146,12 @@ class ServeCatalogStore(
      * its source on GitHub. Null for an older catalog that predates the export change.
      */
     val sourceFile: String? = null,
+    /**
+     * Gradle project path that owns [sourceFile]. Set for repository-wide catalogs, where sibling
+     * modules cannot share the catalog-level [Source.module]. Null for legacy single-module
+     * catalogs, whose source module remains catalog-wide.
+     */
+    val sourceModule: String? = null,
     /**
      * A 1-based line inside the `@Preview` function's body within [sourceFile], stamped by the same
      * export pass from discovery's `previews.json`. Carried into `previews/variants.json` so the
@@ -2147,6 +2305,8 @@ class ServeCatalogStore(
      * source link. Null for a catalog with no recorded source (older export) or a deferred record.
      */
     val sourceFile: String? = null,
+    /** Per-preview Gradle project path; overrides the catalog-wide source module when present. */
+    val sourceModule: String? = null,
     /**
      * A 1-based line inside the preview function's body within [sourceFile] (from the catalog
      * component's [Component.bodyLine]). Shared by every image of a component, like [sourceFile].

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -356,7 +356,7 @@ class ServeHttpServer(
     return PlaygroundSeedResolver.Location(
       repo = source.repo,
       ref = source.ref,
-      module = source.module,
+      module = preview.sourceModule ?: source.module,
       sourceFile = sourceFile,
       // Absent on a catalog published before discovery recorded it, which is exactly the case the
       // resolver falls back to whole-file seeding for.
@@ -1194,7 +1194,7 @@ class ServeHttpServer(
   ): List<PlaygroundCatalogInfo> {
     val choices = service.catalogChoices()
     val site = siteSystem() ?: return choices
-    return choices.filter { it.id.isEmpty() && sitePinIsOwn(service) || it.id == site }
+    return choices.filter { it.id.isEmpty() && sitePinIsOwn(service) || it.system == site }
   }
 
   /**
@@ -2660,7 +2660,12 @@ class ServeHttpServer(
       val bundleHost = catalogBundleHost(renderHost)
       val sourceHref =
         bundleHost?.catalogSource?.let { source ->
-          ServeUrls.githubBlobUrl(source.repo, source.ref, source.module, preview.sourceFile)
+          ServeUrls.githubBlobUrl(
+            source.repo,
+            source.ref,
+            preview.sourceModule ?: source.module,
+            preview.sourceFile,
+          )
         }
       val reportContext =
         ServeIssueReport.Context(
@@ -3966,7 +3971,7 @@ class ServeHttpServer(
           PlaygroundSeedResolver.Location(
             repo = source.repo,
             ref = source.ref,
-            module = source.module,
+            module = preview.sourceModule ?: source.module,
             sourceFile = file,
             bodyLine = preview.bodyLine,
           )
@@ -5069,7 +5074,12 @@ class ServeHttpServer(
       // sourceFile. Null when the session has no catalog source or the preview recorded no path.
       val sourceHref =
         bundleHost?.catalogSource?.let { src ->
-          ServeUrls.githubBlobUrl(src.repo, src.ref, src.module, preview.sourceFile)
+          ServeUrls.githubBlobUrl(
+            src.repo,
+            src.ref,
+            preview.sourceModule ?: src.module,
+            preview.sourceFile,
+          )
         }
       val liveAuthPrompt =
         githubAuth

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -188,6 +188,11 @@ data class ServePreview(
    */
   val sourceFile: String? = null,
   /**
+   * Gradle project path that owns [sourceFile]. Repository-wide catalogs set this per preview;
+   * older single-module catalogs use their catalog-wide source module instead.
+   */
+  val sourceModule: String? = null,
+  /**
    * A 1-based line inside this preview's function body within [sourceFile], from the bundle's
    * `previews.json` ([ee.schimke.composeai.cli.PreviewInfo.bodyLine]).
    *

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4518,11 +4518,16 @@ $noteBlock        <div class="cp-site-footer-links">
     val handoffCatalog = seed?.catalog ?: preselectCatalog
     // Two ways this host can offer the named catalog: as the selector's own entry for it, or as the
     // pinned default (which the selector reports under the anonymous id `""`).
-    val wantedIndex = handoffCatalog?.let { id ->
-      catalogs.indexOfFirst { it.id == id }.takeIf { it >= 0 }
+    val wantedIndex = handoffCatalog?.let { system ->
+      catalogs
+        .indexOfFirst {
+          it.system == system &&
+            (seed?.sourceModule.isNullOrBlank() || it.module == seed.sourceModule)
+        }
+        .takeIf { it >= 0 }
         ?: catalogs
           .indexOfFirst { it.id.isEmpty() }
-          .takeIf { it >= 0 && id in pinnedCatalogSystems }
+          .takeIf { it >= 0 && system in pinnedCatalogSystems }
     }
     val selectedIndex = wantedIndex ?: 0
     // A host that pins its bundles and offers no runtime choice renders exactly the bar it always

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargetsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogTargetsTest.kt
@@ -48,7 +48,11 @@ class PlaygroundCatalogTargetsTest {
     log: MutableList<String> = mutableListOf(),
   ) =
     PlaygroundCatalogTargets(
-      available = { available },
+      available = {
+        available.map { (system, backend) ->
+          PlaygroundCatalogAvailable(system, system, "", backend)
+        }
+      },
       modesForBackend = { backend ->
         PlaygroundCatalogTargets.naturalModes(backend).filter {
           when (it) {
@@ -220,5 +224,27 @@ class PlaygroundCatalogTargetsTest {
         suppliers = { supplier(it) },
       )
     assertEquals(listOf("alpha", "mid", "zebra"), t.targets().map { it.system })
+  }
+
+  @Test
+  fun `modules in one catalog resolve independent classpaths`() {
+    val resolves = mutableListOf<String>()
+    val available =
+      listOf(
+        PlaygroundCatalogAvailable("all", "all", ":mobile", "android"),
+        PlaygroundCatalogAvailable("all@:tv", "all", ":tv", "android"),
+      )
+    val t =
+      PlaygroundCatalogTargets(
+        available = { available },
+        modesForBackend = PlaygroundCatalogTargets::naturalModes,
+        newSupplier = { id -> supplier(id, resolves = resolves) },
+      )
+
+    assertEquals(listOf(":mobile", ":tv"), t.targets().map { it.module })
+    assertNotNull(t.classpath("all@:tv", PlaygroundMode.ANDROID))
+    assertEquals(listOf("all@:tv"), resolves)
+    assertTrue(t.targets().single { it.module == ":tv" }.resolved)
+    assertTrue(!t.targets().single { it.module == ":mobile" }.resolved)
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -868,6 +868,39 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `repository-wide catalog retains each preview source module`() {
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"all-modules",
+       "source":{"repo":"yschimke/compose-ai-tools","ref":"main","module":""},
+       "components":[{"componentId":"TV","sourceFile":"src/main/kotlin/Main.kt",
+         "sourceModule":":tv","images":[{"path":"images/tv.png"}]}]}
+      """
+        .trimIndent()
+    val cleared = mutableListOf<String>()
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+            url.endsWith(".png") -> png()
+            else -> null
+          }
+        },
+        clearTrustedBundles = { cleared += it },
+      )
+
+    assertTrue(store.load("all-modules") is ServeCatalogStore.Result.Ok)
+    val preview = registered.getValue("all-modules").previews.single()
+    assertEquals("src/main/kotlin/Main.kt", preview.sourceFile)
+    assertEquals(":tv", preview.sourceModule)
+    assertEquals(listOf("all-modules"), cleared)
+  }
+
+  @Test
   fun `catalog image declarations reach the baked browse surface`() {
     // A supplement-only preview's daemon is opened lazily, so these catalog fields are the only
     // declaration source available when /api/previews and the initial viewer are built.
@@ -1105,6 +1138,66 @@ class ServeCatalogStoreTest {
     assertEquals(mapOf("button-filled__ideal__default__dark" to "FilledButton_Dark"), captured)
     // The live builder claimed the session, so nothing was registered as a plain static host.
     assertTrue(registered["compose-m3"] == null)
+  }
+
+  @Test
+  fun `liveBundles partition aliases and per-preview paths by module`() {
+    val prefix = "module_3a7476__"
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"all-modules",
+       "liveBundle":{"path":"bundle/","file":"0000.png"},
+       "liveBundles":[
+         {"module":":mobile","path":"bundle/","file":"0000.png","previewIdPrefix":""},
+         {"module":":tv","path":"bundle/modules/module_3a7476/","file":"module_3a7476.png","previewIdPrefix":"$prefix"}],
+       "components":[
+         {"componentId":"Mobile","images":[{"path":"images/mobile.png","previewId":"activity__MainActivity"}]},
+         {"componentId":"TV","images":[{"path":"images/tv.png","previewId":"${prefix}activity__MainActivity"}]}]}
+      """
+        .trimIndent()
+    val requested = java.util.concurrent.CopyOnWriteArrayList<String>()
+    val fetch: (String) -> ByteArray? = { url ->
+      requested += url
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> json.toByteArray()
+        url.endsWith("bundle/0000.png") ||
+          url.endsWith("bundle/modules/module_3a7476/module_3a7476.png") -> byteArrayOf(1, 2, 3)
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val trust =
+      TrustStore(
+        branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
+      )
+    var captured: List<ServeCatalogStore.TrustedModuleBundle>? = null
+    var recorded: List<ServeCatalogStore.VerifiedModuleBundle>? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trust },
+        fetch = fetch,
+        buildTrustedBundles = { _, bundles, _ ->
+          captured = bundles
+          true
+        },
+        recordTrustedBundles = { _, bundles -> recorded = bundles },
+      )
+
+    assertTrue(store.load("all-modules") is ServeCatalogStore.Result.Ok)
+    val modules = assertNotNull(captured)
+    assertEquals(listOf(":mobile", ":tv"), modules.map { it.module })
+    assertEquals(listOf(":mobile", ":tv"), assertNotNull(recorded).map { it.module })
+    assertEquals(mapOf("mobile" to "activity__MainActivity"), modules[0].alias)
+    assertEquals(mapOf("tv" to "${prefix}activity__MainActivity"), modules[1].alias)
+    modules[1].perPreviewBundle.fetch("${prefix}activity__MainActivity")
+    assertTrue(
+      requested.any {
+        it.endsWith("bundle/modules/module_3a7476/previews/${prefix}activity__MainActivity.png")
+      }
+    )
+    assertTrue(registered["all-modules"] == null)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebPlaygroundCatalogTest.kt
@@ -101,6 +101,27 @@ class ServeWebPlaygroundCatalogTest {
   }
 
   @Test
+  fun `a seeded repository-wide preview selects its owning module bundle`() {
+    val tvTarget =
+      PlaygroundCatalogInfo(
+        id = "all@:tv",
+        label = "all · :tv (android)",
+        backend = "android",
+        modes = listOf(PlaygroundMode.ANDROID),
+        system = "all",
+        module = ":tv",
+      )
+    val mobileTarget =
+      tvTarget.copy(id = "all", label = "all · :mobile (android)", module = ":mobile")
+    val seed = previewSeed.copy(catalog = "all", sourceModule = ":tv")
+
+    val html = page(listOf(mobileTarget, tvTarget), seed = seed)
+
+    assertTrue(html.contains("""<option value="all@:tv" selected>"""))
+    assertFalse(html.contains("""<option value="all" selected>"""))
+  }
+
+  @Test
   fun `a seeded page says where the code came from, and what that does not promise`() {
     val html = page(listOf(m3), seed = previewSeed)
     assertTrue(html.contains("""id="pg-seed""""))

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -302,6 +302,9 @@ To publish every Gradle module that applies `ee.schimke.composeai.preview`, omit
       system: your-system
       spec: catalog.spec.json
       modules: all
+      publish-live-bundle: true
+      split-per-preview: true
+      split-mode: full
 ```
 
 The workflow discovers the same repository-wide module set as `compose-preview list`, then packs
@@ -313,10 +316,25 @@ entry, including GIF/APNG artifacts. If two modules use the same preview functio
 spec-preferred/primary module keeps the unqualified name and later modules receive a stable
 `<module>::<function>` join key.
 
-Repository-wide mode publishes baked artifacts because executable bundles retain distinct module
-classpaths. Consequently it currently requires `render-shards: 1`, does not combine with
-`extra-module` or `publish-live-bundle`, and permits per-preview splitting only with
-`split-mode: view-only`. Supplying `module` keeps the existing single-module/live-bundle behavior.
+Executable bundles retain distinct module classpaths, so repository-wide publication never merges
+them. With `publish-live-bundle: true`, `catalog.json` carries a `liveBundles[]` descriptor for each
+module (and the primary legacy `liveBundle` for older servers). Additional modules receive a stable,
+collision-safe preview-id prefix before their executable bundle is split. A trusted serve host
+fetches and rehydrates every module atomically, then routes each catalog preview to its owning
+module daemon; equal ids such as `activity__MainActivity` therefore remain distinct and live.
+Module artifacts use a Gradle-path-derived key (for example `:tv` → `module_3a7476`) rather than a
+discovery-list index, so adding or reordering an unrelated module does not move existing bundle or
+per-preview URLs.
+
+`split-per-preview: true` may use `full` or `full-shared-classpath` for this mode. Each additional
+module's split remains self-contained—the primary module's external-resource pool is not a shared
+classpath. Static repository-wide publication still supports `split-mode: view-only` without live
+bundles. Repository-wide mode continues to require `render-shards: 1` and does not combine with
+`extra-module`, since both are separate fan-out mechanisms.
+
+The playground exposes each module bundle as an independent compile target. A handoff from a
+preview carries its `sourceModule` and preselects that module's classpath; the primary target keeps
+the historical plain system id, while additional targets are module-qualified.
 
 For the two bespoke needs a catalog like MeshCore has, the reusable workflow
 exposes generic hooks rather than forcing a copy: `stage-font-globs` stages

--- a/scripts/design-artifacts/apply-source-files.mjs
+++ b/scripts/design-artifacts/apply-source-files.mjs
@@ -19,9 +19,9 @@
  *  - only components whose spec function resolves to a `sourceFile` are touched;
  *  - a component that already carries a `sourceFile` is left as-is (never clobbered).
  *
- * The `sourceFile` is module-relative (`src/main/kotlin/…/Foo.kt`); the server prefixes it
- * with the catalog's source `module` when building the GitHub blob URL, so this stays the
- * bare path the discovery manifest recorded.
+ * The `sourceFile` is module-relative (`src/main/kotlin/…/Foo.kt`). `sourceModule` rides beside it
+ * for repository-wide catalogs, whose components can come from different Gradle projects; the
+ * server falls back to the catalog-wide source module for older single-module exports.
  *
  * `bodyLine` — a line inside the preview function's body — rides along on the same join,
  * for the same reason and to the same place. It is what lets the playground handoff open
@@ -29,12 +29,12 @@
  * its group. Stamped only alongside a `sourceFile` (a line number with no file is
  * meaningless), and the server treats its absence as "seed the whole file".
  *
- * @param {{components?: Array<{componentId: string, sourceFile?: string, bodyLine?: number}>}} manifest
+ * @param {{components?: Array<{componentId: string, sourceFile?: string, sourceModule?: string, bodyLine?: number}>}} manifest
  *   The parsed `catalog.json`, mutated in place.
  * @param {{groups?: Array<{components?: Array<{componentId: string, preview?: string}>}>}} spec
  *   The catalog spec the manifest was built from.
- * @param {Map<string, {sourceFile?: string, bodyLine?: number}>} sourceByFn
- *   Function-name → `{ sourceFile, bodyLine }` lookup (the generator's `sourceByFunction(bundle)`).
+ * @param {Map<string, {sourceFile?: string, bodyLine?: number, module?: string}>} sourceByFn
+ *   Function-name → source lookup (the generator's `sourceByFunction(bundle)`).
  * @returns {number} how many components had a `sourceFile` newly stamped.
  */
 export function applySourceFiles(manifest, spec, sourceByFn) {
@@ -51,11 +51,26 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
 
   let stamped = 0;
   for (const component of manifest?.components ?? []) {
-    if (component.sourceFile !== undefined) continue; // never clobber an existing path
     const fn = previewByComponentId.get(component.componentId);
     const source = fn ? sourceByFn.get(fn) : undefined;
+    if (component.sourceFile !== undefined) {
+      // A newer exporter may already preserve sourceFile. Add the matching module identity without
+      // replacing the path; never pair a module with a different pre-existing file.
+      if (
+        component.sourceModule === undefined &&
+        source?.sourceFile === component.sourceFile &&
+        typeof source.module === "string" &&
+        source.module.length > 0
+      ) {
+        component.sourceModule = source.module;
+      }
+      continue;
+    }
     if (source?.sourceFile) {
       component.sourceFile = source.sourceFile;
+      if (typeof source.module === "string" && source.module.length > 0) {
+        component.sourceModule = source.module;
+      }
       // Only with a path, and only when discovery actually recorded one — an older bundle
       // carries no `bodyLine`, and a component with a line but no file cannot be opened.
       if (typeof source.bodyLine === "number" && source.bodyLine > 0) {

--- a/scripts/design-artifacts/apply-source-files.test.mjs
+++ b/scripts/design-artifacts/apply-source-files.test.mjs
@@ -55,6 +55,19 @@ test("never clobbers a sourceFile already on the component", () => {
   assert.equal(m.components[0].sourceFile, "already/There.kt");
 });
 
+test("adds a matching module to a sourceFile already preserved by the exporter", () => {
+  const spec = {
+    groups: [{ name: "TV", components: [{ componentId: "tv/Main", preview: "MainPreview" }] }],
+  };
+  const m = manifest([comp("tv/Main", { sourceFile: "src/main/kotlin/Main.kt" })]);
+  const sources = new Map([
+    ["MainPreview", { sourceFile: "src/main/kotlin/Main.kt", module: ":tv" }],
+  ]);
+
+  assert.equal(applySourceFiles(m, spec, sources), 0);
+  assert.equal(m.components[0].sourceModule, ":tv");
+});
+
 test("leaves manifest components absent from the spec untouched", () => {
   const spec = {
     groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
@@ -102,6 +115,21 @@ test("stamps bodyLine alongside sourceFile so the playground can open one declar
 
   assert.equal(m.components[0].sourceFile, "src/main/kotlin/Buttons.kt");
   assert.equal(m.components[0].bodyLine, 81);
+});
+
+test("stamps the owning Gradle module alongside a repository-wide source path", () => {
+  const spec = {
+    groups: [{ name: "TV", components: [{ componentId: "tv/Main", preview: "MainPreview" }] }],
+  };
+  const m = manifest([comp("tv/Main")]);
+  const sources = new Map([
+    ["MainPreview", { sourceFile: "src/main/kotlin/Main.kt", bodyLine: 9, module: ":tv" }],
+  ]);
+
+  applySourceFiles(m, spec, sources);
+
+  assert.equal(m.components[0].sourceModule, ":tv");
+  assert.equal(m.components[0].sourceFile, "src/main/kotlin/Main.kt");
 });
 
 test("omits bodyLine when discovery recorded none, rather than writing a bogus zero", () => {

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -148,6 +148,8 @@ import {
   combinedBundleMap,
   combinedBundleEntries,
   generatedFallbackGroups,
+  moduleArtifactKey,
+  moduleIdentityPrefix,
   namespaceModuleRecords,
 } from "./multi-module-catalog.mjs";
 
@@ -333,12 +335,14 @@ function layoutByFunction(bundle) {
 function sourceByFunction(bundle) {
   const out = new Map();
   const prefer = (id) => /(_|\b)light$/i.test(id);
+  const module = bundleModulePath(bundle);
   for (const preview of bundle.previews ?? []) {
     const fn = preview.functionName ?? preview.id;
     if (out.has(fn) && !prefer(preview.id)) continue;
     if (preview.sourceFile)
-      out.set(fn, { sourceFile: preview.sourceFile, bodyLine: preview.bodyLine });
-    else if (!out.has(fn)) out.set(fn, { sourceFile: undefined, bodyLine: undefined });
+      out.set(fn, { sourceFile: preview.sourceFile, bodyLine: preview.bodyLine, module });
+    else if (!out.has(fn))
+      out.set(fn, { sourceFile: undefined, bodyLine: undefined, module });
   }
   return out;
 }
@@ -782,12 +786,9 @@ const { values } = parseArgs({
     // fetched from the same `bundle/` prefix the primary live bundle declares, so
     // without a declared liveBundle serve never opens the lane that would reach them.
     "extra-live-bundle": { type: "boolean", default: false },
-    // Optional buildable source for TRUSTED server-side re-render. When
-    // --source-module is given, a `source: {repo, ref, module}` is written into
-    // catalog.json so a `serve --allow-render-trusted` box (one with the toolchain
-    // to build it) can stand up a live, full-fidelity re-render of this catalog
-    // instead of replaying baked PNGs. Inert on the public desktop box (which never
-    // sets that flag).
+    // Optional source provenance. Repo + ref write `source` for GitHub links; adding
+    // --source-module also makes it buildable by a TRUSTED `serve --allow-render-trusted` box.
+    // Repository-wide catalogs omit the one catalog-level module and stamp it per component.
     "source-repo": { type: "string" },
     "source-ref": { type: "string" },
     "source-module": { type: "string" },
@@ -845,10 +846,17 @@ if (effectiveBreakpoints !== undefined) spec.breakpoints = effectiveBreakpoints;
 // the join folds a function's theme/size multipreview variants (whose ids differ
 // only by an appended `_<mode>`) onto one component. See `loadCandidates` (which
 // also works around the published null-widthDp crash) and the vendored join.
-const primaryRecord = await loadCandidates(rendersPath, spec.breakpoints);
+const primaryRecord = {
+  ...(await loadCandidates(rendersPath, spec.breakpoints)),
+  renderPath: rendersPath,
+};
 const additionalRecords = [];
 for (const path of values["additional-renders"] ?? []) {
-  additionalRecords.push(await loadCandidates(resolve(path), spec.breakpoints));
+  const renderPath = resolve(path);
+  additionalRecords.push({
+    ...(await loadCandidates(renderPath, spec.breakpoints)),
+    renderPath,
+  });
 }
 const moduleRecords = namespaceModuleRecords(primaryRecord, additionalRecords);
 let { candidates, bundle } = moduleRecords[0];
@@ -1316,12 +1324,18 @@ if (values["wasm-dist"]) {
 // systems whose bundle is a DESKTOP bundle serve can run (compose-m3); the
 // Android catalogs stay baked-PNG.
 let liveBundle = null;
+const liveBundles = [];
 if (values["publish-live-bundle"]) {
   const file = basename(rendersPath);
   const dest = join(outPath, "bundle", file);
   await mkdir(dirname(dest), { recursive: true });
   await cp(rendersPath, dest);
   liveBundle = { path: "bundle/", file };
+  liveBundles.push({
+    ...liveBundle,
+    module: bundleModulePath(moduleRecords[0].bundle),
+    previewIdPrefix: "",
+  });
   console.log(`[${spec.system}] carried live bundle → bundle/${file}`);
 
   // Lift the heavy font resources out of the carried bundle's classes/app.jar and publish them
@@ -1365,6 +1379,18 @@ if (values["publish-live-bundle"]) {
       `[${spec.system}] bundle externalize skipped (${err.message?.split("\n")[0] ?? err}) — ` +
         `publishing the self-contained bundle`,
     );
+  }
+
+  for (let index = 1; index < moduleRecords.length; index++) {
+    const record = moduleRecords[index];
+    const module = bundleModulePath(record.bundle);
+    const path = `bundle/modules/${moduleArtifactKey(module)}/`;
+    const file = basename(record.renderPath);
+    const dest = join(outPath, path, file);
+    await mkdir(dirname(dest), { recursive: true });
+    await cp(record.renderPath, dest);
+    liveBundles.push({ path, file, module, previewIdPrefix: moduleIdentityPrefix(module) });
+    console.log(`[${spec.system}] carried module live bundle ${module} → ${path}${file}`);
   }
 }
 
@@ -1412,6 +1438,7 @@ if (values["publish-live-bundle"]) {
   if (spec.display) manifest.display = spec.display;
   if (webRender) manifest.webRender = webRender;
   if (liveBundle) manifest.liveBundle = liveBundle;
+  if (liveBundles.length > 0) manifest.liveBundles = liveBundles;
   // Deferred (live-only) coverage, recorded alongside the baked components rather than inside
   // `components[].images` — an image with no `path` would reach every consumer that assumes
   // `images[]` is the baked sticker set (index.html, compare.html, matches.html, the per-variant
@@ -1468,15 +1495,16 @@ if (values["publish-live-bundle"]) {
         `route + daemon preview id (the live-only lane a trusted serve host registers them under)`,
     );
   }
-  // Buildable source for trusted server-side re-render (opt-in consumer side).
-  if (values["source-module"]) {
+  // Source provenance for links and, when module is non-empty, trusted server-side re-render.
+  // Repository-wide catalogs carry the repo/ref here and retain the owning module per component.
+  if (values["source-repo"] && values["source-ref"]) {
     manifest.source = {
-      repo: values["source-repo"] ?? "",
-      ref: values["source-ref"] ?? "",
-      module: values["source-module"],
+      repo: values["source-repo"],
+      ref: values["source-ref"],
+      module: values["source-module"] ?? "",
     };
     console.log(
-      `[${spec.system}] source → ${manifest.source.module}@${manifest.source.ref}`,
+      `[${spec.system}] source → ${manifest.source.module || "<per-preview module>"}@${manifest.source.ref}`,
     );
   }
   // Emit the catalog-id → daemon-id bridge whenever a live path can serve this catalog — a carried

--- a/scripts/design-artifacts/live-bundle-namespace.mjs
+++ b/scripts/design-artifacts/live-bundle-namespace.mjs
@@ -1,0 +1,114 @@
+import { unzipSync, zipSync } from "fflate";
+
+import { modulePreviewId } from "./multi-module-catalog.mjs";
+
+const ZIP_LOCAL_HEADER = [0x50, 0x4b, 0x03, 0x04];
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function matches(bytes, offset, expected) {
+  return expected.every((byte, index) => bytes[offset + index] === byte);
+}
+
+function pngEndOffset(bytes) {
+  if (bytes.length < PNG_SIGNATURE.length || !matches(bytes, 0, PNG_SIGNATURE)) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = PNG_SIGNATURE.length;
+  while (offset + 12 <= bytes.length) {
+    const length = view.getUint32(offset);
+    const chunkEnd = offset + 12 + length;
+    if (chunkEnd > bytes.length) return null;
+    const type = new TextDecoder().decode(bytes.subarray(offset + 4, offset + 8));
+    offset = chunkEnd;
+    if (type === "IEND") return offset;
+  }
+  return null;
+}
+
+function zipOffset(bytes) {
+  const pngEnd = pngEndOffset(bytes);
+  if (pngEnd != null && matches(bytes, pngEnd, ZIP_LOCAL_HEADER)) return pngEnd;
+  for (let i = 0; i <= bytes.length - ZIP_LOCAL_HEADER.length; i++) {
+    if (matches(bytes, i, ZIP_LOCAL_HEADER)) return i;
+  }
+  throw new Error("bundle has no ZIP payload");
+}
+
+function parseJson(bytes) {
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+function encodeJson(value) {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+function replacementPattern(replacements) {
+  const escaped = replacements.map(([id]) => id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return new RegExp(escaped.join("|"), "g");
+}
+
+function rewriteString(value, replacements, pattern) {
+  const byId = new Map(replacements);
+  return value.replace(pattern, (id) => byId.get(id));
+}
+
+function replaceIds(value, replacements, pattern) {
+  if (typeof value === "string") {
+    return rewriteString(value, replacements, pattern);
+  }
+  if (Array.isArray(value)) return value.map((item) => replaceIds(item, replacements, pattern));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        rewriteString(key, replacements, pattern),
+        replaceIds(item, replacements, pattern),
+      ]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Namespace every preview identity in one executable module bundle.
+ *
+ * The module prefix is applied to the manifest, preview records, JSON sidecars and keyed entry
+ * paths. App bytecode and classpath entries are left untouched. The operation is idempotent so the
+ * catalog loader may apply its in-memory isolation pass to an already-namespaced live bundle.
+ */
+export function namespaceLiveBundle(bytes, module) {
+  const offset = zipOffset(bytes);
+  const prefix = bytes.slice(0, offset);
+  const entries = unzipSync(bytes.slice(offset));
+  const bundle = parseJson(entries["bundle.json"]);
+  const previewsPayload = parseJson(entries["previews.json"]);
+  const previews = Array.isArray(previewsPayload) ? previewsPayload : previewsPayload.previews ?? [];
+  const ids = new Set([
+    ...(bundle.previewIds ?? []),
+    ...(bundle.rawPreviewIds ?? []),
+    ...previews.map((preview) => preview.id),
+  ].filter((id) => typeof id === "string" && id.length > 0));
+  const replacements = [...ids]
+    .map((id) => [id, modulePreviewId(module, id)])
+    .filter(([oldId, newId]) => oldId !== newId)
+    .sort(([a], [b]) => b.length - a.length);
+  if (replacements.length === 0) return bytes;
+  const pattern = replacementPattern(replacements);
+
+  const rewrittenEntries = {};
+  for (const [path, content] of Object.entries(entries)) {
+    const rewrittenPath = rewriteString(path, replacements, pattern);
+    let rewrittenContent = content;
+    if (path.endsWith(".json")) {
+      try {
+        rewrittenContent = encodeJson(replaceIds(parseJson(content), replacements, pattern));
+      } catch {
+        // An opaque JSON-named payload is not part of the identity contract; retain its bytes.
+      }
+    }
+    rewrittenEntries[rewrittenPath] = rewrittenContent;
+  }
+  const zip = zipSync(rewrittenEntries, { level: 6 });
+  const result = new Uint8Array(prefix.length + zip.length);
+  result.set(prefix);
+  result.set(zip, prefix.length);
+  return result;
+}

--- a/scripts/design-artifacts/live-bundle-namespace.test.mjs
+++ b/scripts/design-artifacts/live-bundle-namespace.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { unzipSync, zipSync } from "fflate";
+
+import { namespaceLiveBundle } from "./live-bundle-namespace.mjs";
+import { moduleIdentityPrefix } from "./multi-module-catalog.mjs";
+
+const json = (value) => new TextEncoder().encode(JSON.stringify(value));
+
+function pngChunk(type, payload = new Uint8Array()) {
+  const bytes = new Uint8Array(12 + payload.length);
+  new DataView(bytes.buffer).setUint32(0, payload.length);
+  bytes.set(new TextEncoder().encode(type), 4);
+  bytes.set(payload, 8);
+  return bytes;
+}
+
+function concat(...parts) {
+  const output = new Uint8Array(parts.reduce((size, part) => size + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    output.set(part, offset);
+    offset += part.length;
+  }
+  return output;
+}
+
+test("namespaces an executable bundle's ids, sidecars and keyed paths idempotently", () => {
+  // A valid PNG prefix whose compressed payload happens to contain a ZIP local-header signature.
+  // The namespace pass must start at IEND, not at those coincidental bytes.
+  const cover = concat(
+    new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk("IDAT", new Uint8Array([0x50, 0x4b, 0x03, 0x04])),
+    pngChunk("IEND"),
+  );
+  const zip = zipSync({
+    "bundle.json": json({ previewIds: ["activity__MainActivity"], rawPreviewIds: ["activity__MainActivity"] }),
+    "previews.json": json({ previews: [{ id: "activity__MainActivity", functionName: "MainActivity" }] }),
+    "previews/activity__MainActivity.png": new Uint8Array([1, 2, 3]),
+    "previews/activity__MainActivity.overrides.json": json({ previewId: "activity__MainActivity" }),
+    "classes/app.jar": new Uint8Array([4, 5, 6]),
+  });
+  const input = new Uint8Array(cover.length + zip.length);
+  input.set(cover);
+  input.set(zip, cover.length);
+
+  const output = namespaceLiveBundle(input, ":tv");
+  const prefix = moduleIdentityPrefix(":tv");
+  const entries = unzipSync(output.slice(cover.length));
+  const bundle = JSON.parse(new TextDecoder().decode(entries["bundle.json"]));
+  const previews = JSON.parse(new TextDecoder().decode(entries["previews.json"]));
+
+  assert.deepEqual(bundle.previewIds, [`${prefix}activity__MainActivity`]);
+  assert.equal(previews.previews[0].id, `${prefix}activity__MainActivity`);
+  assert.ok(entries[`previews/${prefix}activity__MainActivity.png`]);
+  assert.equal(
+    JSON.parse(new TextDecoder().decode(entries[`previews/${prefix}activity__MainActivity.overrides.json`])).previewId,
+    `${prefix}activity__MainActivity`,
+  );
+  assert.deepEqual(entries["classes/app.jar"], new Uint8Array([4, 5, 6]));
+  assert.deepEqual(namespaceLiveBundle(output, ":tv"), output);
+});
+
+test("namespaces overlapping ids in one pass", () => {
+  const zip = zipSync({
+    "bundle.json": json({ previewIds: ["A", "AB"] }),
+    "previews.json": json({ previews: [{ id: "A" }, { id: "AB" }] }),
+    "previews/AB.json": json({ previewId: "AB", byPreview: { AB: { selected: true } } }),
+  });
+  const prefix = moduleIdentityPrefix(":tv");
+  const entries = unzipSync(namespaceLiveBundle(zip, ":tv"));
+  const bundle = JSON.parse(new TextDecoder().decode(entries["bundle.json"]));
+
+  assert.deepEqual(bundle.previewIds, [`${prefix}A`, `${prefix}AB`]);
+  assert.ok(entries[`previews/${prefix}AB.json`]);
+  const sidecar = JSON.parse(new TextDecoder().decode(entries[`previews/${prefix}AB.json`]));
+  assert.equal(sidecar.byPreview[`${prefix}AB`].selected, true);
+});

--- a/scripts/design-artifacts/module-artifact-key.mjs
+++ b/scripts/design-artifacts/module-artifact-key.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+
+import { moduleArtifactKey } from "./multi-module-catalog.mjs";
+
+const { values } = parseArgs({ options: { module: { type: "string" } } });
+if (!values.module) {
+  console.error("usage: module-artifact-key --module <:path>");
+  process.exit(2);
+}
+process.stdout.write(`${moduleArtifactKey(values.module)}\n`);

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -23,8 +23,18 @@ function previewFunction(preview) {
   return preview?.functionName ?? preview?.id;
 }
 
-function moduleIdentityPrefix(module) {
+export function moduleIdentityPrefix(module) {
   return `module_${Buffer.from(module, "utf8").toString("hex")}__`;
+}
+
+/** Stable filesystem-safe key for a Gradle module, shared by the manifest and workflow. */
+export function moduleArtifactKey(module) {
+  return moduleIdentityPrefix(module).slice(0, -2);
+}
+
+export function modulePreviewId(module, id) {
+  const prefix = moduleIdentityPrefix(module);
+  return String(id).startsWith(prefix) ? String(id) : `${prefix}${id}`;
 }
 
 function rewriteArtifactPath(path, oldId, newId) {
@@ -50,19 +60,17 @@ function rewriteJsonEntry(entries, name, transform) {
 }
 
 /**
- * Give an additional module's in-memory bundle identities a collision-free prefix.
- *
- * Repository-wide catalogs are baked-only, so these ids do not address a daemon. They exist solely
- * to join entries and sidecars from several bundles without allowing equal preview ids to collapse
- * onto one another. The primary bundle remains unchanged for backwards-compatible authored joins.
+ * Give an additional module's bundle identities a collision-free prefix. The same transform is
+ * applied to published executable bundles, so these ids are both safe catalog join keys and real
+ * daemon addresses. The primary remains unchanged for backwards-compatible authored joins.
  */
 function namespaceAdditionalRecord(record, module, keyByFunction) {
   const prefix = moduleIdentityPrefix(module);
   const manifest = record.bundle?.manifest ?? {};
   const entryIds = manifest.previewIds ?? (record.bundle?.previews ?? []).map((p) => p.id);
   const rawIds = manifest.rawPreviewIds ?? entryIds;
-  const entryIdMap = new Map(entryIds.map((id) => [id, `${prefix}${id}`]));
-  const rawIdMap = new Map(rawIds.map((id) => [id, `${prefix}${id}`]));
+  const entryIdMap = new Map(entryIds.map((id) => [id, modulePreviewId(module, id)]));
+  const rawIdMap = new Map(rawIds.map((id) => [id, modulePreviewId(module, id)]));
   const anyIdMap = new Map([...entryIdMap, ...rawIdMap]);
   const rewriteId = (id) => anyIdMap.get(id) ?? id;
   const artifactPathMap = new Map();
@@ -169,7 +177,7 @@ function namespaceAdditionalRecord(record, module, keyByFunction) {
  * records are sorted by Gradle path and use `<module>::<function>` only when an earlier module has
  * already claimed that function. Unique names stay untouched. Additional records also receive a
  * collision-free preview-id prefix because class-qualified ids can still be identical in separate
- * Gradle modules. Repository-wide publication is baked-only, so no daemon address is changed.
+ * Gradle modules. Live publication applies this exact prefix to the executable bundle too.
  */
 export function namespaceModuleRecords(primary, additional = []) {
   const ordered = [
@@ -250,13 +258,10 @@ export function combinedBundleMap(bundles, mapBundle) {
   return combined;
 }
 
-/** Additional module bundles are baked-only until publication carries a real per-module live lane. */
+/** Additional bundles cannot share a single buildable source module. Live publication is supported. */
 export function additionalBundleLiveConflict(values) {
   if (!(values?.["additional-renders"]?.length > 0)) return null;
-  const conflicts = [
-    values["publish-live-bundle"] && "--publish-live-bundle",
-    values["source-module"] && "--source-module",
-  ].filter(Boolean);
+  const conflicts = [values["source-module"] && "--source-module"].filter(Boolean);
   return conflicts.length > 0 ? conflicts : null;
 }
 

--- a/scripts/design-artifacts/multi-module-catalog.test.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.test.mjs
@@ -8,8 +8,14 @@ import {
   combinedBundleMap,
   combinedBundleEntries,
   generatedFallbackGroups,
+  moduleArtifactKey,
   namespaceModuleRecords,
 } from "./multi-module-catalog.mjs";
+
+test("module artifact keys are stable and filesystem safe", () => {
+  assert.equal(moduleArtifactKey(":tv"), "module_3a7476");
+  assert.match(moduleArtifactKey(":feature:home"), /^module_[0-9a-f]+$/);
+});
 
 const record = (module, functions) => ({
   bundle: {
@@ -179,14 +185,21 @@ test("combined bundle metadata uses later-bundle precedence", () => {
   );
 });
 
-test("additional renders reject primary-only live publication modes", () => {
+test("additional renders allow live bundles but reject a single source module", () => {
   assert.deepEqual(
     additionalBundleLiveConflict({
       "additional-renders": ["feature.png"],
       "publish-live-bundle": true,
       "source-module": ":app",
     }),
-    ["--publish-live-bundle", "--source-module"],
+    ["--source-module"],
+  );
+  assert.equal(
+    additionalBundleLiveConflict({
+      "additional-renders": ["feature.png"],
+      "publish-live-bundle": true,
+    }),
+    null,
   );
   assert.equal(additionalBundleLiveConflict({ "additional-renders": ["feature.png"] }), null);
   assert.equal(additionalBundleLiveConflict({ "publish-live-bundle": true }), null);

--- a/scripts/design-artifacts/namespace-live-bundle.mjs
+++ b/scripts/design-artifacts/namespace-live-bundle.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import { namespaceLiveBundle } from "./live-bundle-namespace.mjs";
+
+const { values } = parseArgs({
+  options: {
+    input: { type: "string" },
+    output: { type: "string" },
+    module: { type: "string" },
+  },
+});
+if (!values.input || !values.output || !values.module) {
+  console.error("usage: namespace-live-bundle --input <bundle> --output <bundle> --module <:path>");
+  process.exit(2);
+}
+
+const input = new Uint8Array(await readFile(values.input));
+await writeFile(values.output, namespaceLiveBundle(input, values.module));

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -11,6 +11,7 @@
         "@design-parity/adapter-figma": "^0.1.52",
         "@design-parity/candidate": "^0.1.52",
         "@design-parity/catalog-export": "^0.1.52",
+        "fflate": "^0.8.2",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
         "pngjs": "^7.0.0"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -14,6 +14,7 @@
     "@design-parity/adapter-figma": "^0.1.52",
     "@design-parity/candidate": "^0.1.52",
     "@design-parity/catalog-export": "^0.1.52",
+    "fflate": "^0.8.2",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",
     "pngjs": "^7.0.0"

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground-uncompilable.html
@@ -231,7 +231,7 @@ fun MediaControlButtonsPlaying() {
   // The catalog selector. Each entry carries its own mode list because a catalog's bundle
   // backend picks the renderer — selecting `compose-m3` (desktop) and selecting an Android
   // catalog are not the same choice with a different classpath, they are different modes.
-  var catalogs = JSON.parse("{\"catalogs\":[{\"id\":\"compose-m3\",\"label\":\"compose-m3 (desktop)\",\"backend\":\"desktop\",\"modes\":[\"compose-cmp\"],\"resolved\":true}]}").catalogs || [];
+  var catalogs = JSON.parse("{\"catalogs\":[{\"id\":\"compose-m3\",\"label\":\"compose-m3 (desktop)\",\"backend\":\"desktop\",\"modes\":[\"compose-cmp\"],\"resolved\":true,\"system\":\"compose-m3\",\"module\":\"\"}]}").catalogs || [];
   var modeLabels = {"compose-cmp": "Compose (Desktop)", "compose-android": "Compose (Android)", "remote-compose": "Remote Compose"};
   function selectedCatalog() {
     var id = catalog ? catalog.value : "";

--- a/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-playground.html
@@ -226,7 +226,7 @@ fun Greeting() {
   // The catalog selector. Each entry carries its own mode list because a catalog's bundle
   // backend picks the renderer — selecting `compose-m3` (desktop) and selecting an Android
   // catalog are not the same choice with a different classpath, they are different modes.
-  var catalogs = JSON.parse("{\"catalogs\":[{\"id\":\"\",\"label\":\"Server default\",\"backend\":\"\",\"modes\":[\"compose-cmp\",\"compose-android\",\"remote-compose\"],\"resolved\":true},{\"id\":\"compose-m3\",\"label\":\"compose-m3 (desktop)\",\"backend\":\"desktop\",\"modes\":[\"compose-cmp\"],\"resolved\":true},{\"id\":\"compose-wear\",\"label\":\"compose-wear (android)\",\"backend\":\"android\",\"modes\":[\"compose-android\",\"remote-compose\"],\"resolved\":false}]}").catalogs || [];
+  var catalogs = JSON.parse("{\"catalogs\":[{\"id\":\"\",\"label\":\"Server default\",\"backend\":\"\",\"modes\":[\"compose-cmp\",\"compose-android\",\"remote-compose\"],\"resolved\":true,\"system\":\"\",\"module\":\"\"},{\"id\":\"compose-m3\",\"label\":\"compose-m3 (desktop)\",\"backend\":\"desktop\",\"modes\":[\"compose-cmp\"],\"resolved\":true,\"system\":\"compose-m3\",\"module\":\"\"},{\"id\":\"compose-wear\",\"label\":\"compose-wear (android)\",\"backend\":\"android\",\"modes\":[\"compose-android\",\"remote-compose\"],\"resolved\":false,\"system\":\"compose-wear\",\"module\":\"\"}]}").catalogs || [];
   var modeLabels = {"compose-cmp": "Compose (Desktop)", "compose-android": "Compose (Android)", "remote-compose": "Remote Compose"};
   function selectedCatalog() {
     var id = catalog ? catalog.value : "";


### PR DESCRIPTION
## Summary

- publish one verified executable live bundle for each preview-enabled Gradle module when `modules: all` is selected
- give module artifacts and preview IDs stable module-derived identities instead of positional identities
- route rendering and playground compilation through the owning module runtime, with atomic refresh and rollback behavior
- namespace appended bundle payloads safely and preserve the legacy primary bundle for compatibility

## Root cause

The multi-module catalog merged baked preview metadata, but a live executable bundle still represents one module classpath. The workflow therefore rejected `modules: all` for live publishing, while the server and playground modeled only one runtime owner. Positional bundle naming also made identity dependent on module discovery order.

## Impact

Repositories can publish and serve live catalogs across all selected modules. Existing single-module and primary-bundle consumers remain compatible. Runtime replacement is atomic, and failed materialization or host startup rolls back ownership without leaking daemon pools.

## Validation

- `node --test live-bundle-namespace.test.mjs multi-module-catalog.test.mjs apply-source-files.test.mjs` (22 passing)
- focused CLI routing, catalog-target, compile-service, catalog-store, playground, and fixture tests
- `:cli:ktfmtCheck`
- workflow YAML parse and `git diff --check`

## Rollout handling

After this lands, advance the reusable workflow's pinned export-driver SHA to a commit containing this implementation before regenerating or publishing production live artifacts. This avoids asking an older driver to process `modules: all`.

Closes #4054
