### PR TITLE
fix(design-map): project an @OverrideVariant cell that sits on a @CatalogVariant

### DIFF
--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -98,21 +98,19 @@ export function sourceForRef(ref) {
  * its non-default seeds is missing the axes it happens to sit at, and a kit that spells its default
  * size explicitly in a combination cell then has nothing to match against.
  */
-export function variantSeeds(preview) {
-  const catalog = preview.catalog;
-  if (catalog?.role === "VARIANT") {
-    // `props` names the axis; `state` is the annotation's shorthand for the one axis common enough
-    // to have its own parameter. Either is a declaration, so neither is inferred —
-    // `@CatalogVariant(state = "disabled")` says the state axis as plainly as
-    // `props = ["state=disabled"]` would.
-    const props = [...(catalog.props ?? [])];
-    if (catalog.state && !props.some((p) => p.key === "state")) {
-      props.push({ key: "state", value: catalog.state });
-    }
-    return props.map((p) => ({ key: p.key, raw: p.value }));
+function foldSeeds(catalog) {
+  // `props` names the axis; `state` is the annotation's shorthand for the one axis common enough
+  // to have its own parameter. Either is a declaration, so neither is inferred —
+  // `@CatalogVariant(state = "disabled")` says the state axis as plainly as
+  // `props = ["state=disabled"]` would.
+  const props = [...(catalog.props ?? [])];
+  if (catalog.state && !props.some((p) => p.key === "state")) {
+    props.push({ key: "state", value: catalog.state });
   }
+  return props.map((p) => ({ key: p.key, raw: p.value }));
+}
 
-  const overrides = preview.overrides;
+function cellSeeds(overrides) {
   if (!overrides) return [];
 
   const seeds = overrides.props?.length
@@ -132,13 +130,36 @@ export function variantSeeds(preview) {
   return seeds;
 }
 
+export function variantSeeds(preview) {
+  const catalog = preview.catalog;
+  const fold = catalog?.role === "VARIANT" ? foldSeeds(catalog) : [];
+  const cell = cellSeeds(preview.overrides);
+  if (!fold.length) return cell;
+  if (!cell.length) return fold;
+
+  // BOTH: an `@OverrideVariant` cell on a `@CatalogVariant` render — the folded component's own
+  // matrix. The render sits at the product of the two axes (`type=wave` AND `progress=1.0`), so it
+  // declares both; taking either half alone would resolve to a sibling node and diff the wrong
+  // frame. Folding a component used to cost it its whole matrix for want of this.
+  //
+  // The CELL wins a key collision. Both describe the same render, but the cell's value is what the
+  // renderer actually seeded, and the fold's is the default it seeded over.
+  const seeded = new Set(cell.map((s) => s.key));
+  return [...fold.filter((s) => !seeded.has(s.key)), ...cell];
+}
+
 /** The name a variant render goes by, for a report and for the design-map `state` slot. */
 function variantName(preview, seeds) {
   const catalog = preview.catalog;
+  const cell = preview.overrides?.name;
   if (catalog?.role === "VARIANT") {
-    return catalog.state ?? seeds.map((s) => s.raw).join("-");
+    // Named for the FOLD's own axis, not for the merged vector — `wave`, not `wave-1.0` — so a
+    // folded component's cells read as `wave-full` / `wave-quarter` under it, the same shape a
+    // top-level component's cells have.
+    const fold = catalog.state ?? foldSeeds(catalog).map((s) => s.raw).join("-");
+    return cell ? `${fold}-${cell}` : fold;
   }
-  return preview.overrides?.name ?? seeds.map((s) => `${s.key}=${s.raw}`).join(", ");
+  return cell ?? seeds.map((s) => `${s.key}=${s.raw}`).join(", ");
 }
 
 /**
@@ -157,10 +178,18 @@ export function variantRendersByComponent(previews) {
     // An `@OverrideVariant` render is a reseed of the SAME composable, so it keeps the parent's
     // COMPONENT role and is distinguished only by the `_VARIANT_` tag discovery puts in its id.
     // A `@CatalogVariant` render is its own composable, so it carries the VARIANT role and an
-    // ordinary light-capture id. Either way only the light capture participates.
+    // ordinary light-capture id.
+    //
+    // A VARIANT role with a `_VARIANT_` id is the third case, and it used to fall through both
+    // tests into the `continue` below: a folded component carrying a matrix of its own. Discovery
+    // emitted those renders all along — they were simply never projected, so the kit nodes they
+    // sit on went uncompared, and a component could not be folded without deleting its cells.
+    // Either way only the light capture participates.
     const isOverrideVariant =
       catalog.role === "COMPONENT" && LIGHT_VARIANT_CAPTURE.test(preview.id);
-    const isCatalogVariant = catalog.role === "VARIANT" && LIGHT_CAPTURE.test(preview.id);
+    const isCatalogVariant =
+      catalog.role === "VARIANT" &&
+      (LIGHT_CAPTURE.test(preview.id) || LIGHT_VARIANT_CAPTURE.test(preview.id));
     if (!isOverrideVariant && !isCatalogVariant) continue;
 
     // A variant that names no axis says only "this is different", which is not enough to look

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -284,3 +284,63 @@ test("projects an empty manifest without complaint", () => {
   assert.deepEqual(variants.components, []);
   assert.deepEqual(diagnostics.unmapped, []);
 });
+
+/** A `@CatalogVariant` render carrying an `@OverrideVariant` cell of its own. */
+const foldedCell = (name, of, catalog, variant, overrides) => ({
+  id: `com.example.CatalogKt.${name}_Light_VARIANT_${variant}`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  catalog: { role: "VARIANT", componentId: of, ...catalog },
+  overrides: { name: variant, ...overrides },
+});
+
+test("variantSeeds crosses a fold's axis with its own override cell", () => {
+  assert.deepEqual(
+    variantSeeds(
+      foldedCell("CircularWavy", "Progress/Circular", { props: [{ key: "type", value: "wave" }] }, "full", {
+        seeds: [{ key: "progress", kind: "FLOAT", raw: "1.0" }],
+      }),
+    ),
+    [
+      { key: "type", raw: "wave" },
+      { key: "progress", raw: "1.0" },
+    ],
+  );
+});
+
+test("variantSeeds lets the override cell win a key collision with the fold", () => {
+  assert.deepEqual(
+    variantSeeds(
+      foldedCell("V", "Button", { state: "disabled" }, "error", {
+        seeds: [{ key: "state", kind: "STRING", raw: "error" }],
+      }),
+    ),
+    [{ key: "state", raw: "error" }],
+  );
+});
+
+test("a folded component's cells are collected under its parent, named for both axes", () => {
+  const byComponent = variantRendersByComponent([
+    component("CircularProgress", { reference: ref("1:2") }),
+    catalogVariant("CircularWavy", "CircularProgress", { props: [{ key: "type", value: "wave" }] }),
+    foldedCell("CircularWavy", "CircularProgress", { props: [{ key: "type", value: "wave" }] }, "full", {
+      seeds: [{ key: "progress", kind: "FLOAT", raw: "1.0" }],
+    }),
+  ]);
+  assert.deepEqual(
+    byComponent.get("CircularProgress").map((r) => r.name),
+    ["wave", "wave-full"],
+  );
+});
+
+test("a folded component's DARK cell is still ignored, like every other dark capture", () => {
+  const byComponent = variantRendersByComponent([
+    {
+      ...foldedCell("W", "Button", { props: [{ key: "type", value: "wave" }] }, "full", {
+        seeds: [{ key: "progress", kind: "FLOAT", raw: "1.0" }],
+      }),
+      id: "com.example.CatalogKt.W_Dark_VARIANT_full",
+    },
+  ]);
+  assert.equal(byComponent.size, 0);
+});


### PR DESCRIPTION
Fixes #4073.

## The bug

`variantRendersByComponent` collected the two variant forms with different role requirements, and a render that is **both** fell through the gap:

```js
const isOverrideVariant = catalog.role === "COMPONENT" && LIGHT_VARIANT_CAPTURE.test(preview.id);
const isCatalogVariant  = catalog.role === "VARIANT"   && LIGHT_CAPTURE.test(preview.id);
if (!isOverrideVariant && !isCatalogVariant) continue;
```

An `@OverrideVariant` cell on a `@CatalogVariant` function has role `VARIANT` (so the first test fails) and `_VARIANT_` in its id (so `/_Light$/` fails). Discovery emits the render — it is in `previews.json` — but the projection never declared it, so no resolver ever paired it with a kit node.

## Why it matters

**Folding a component costs it its whole matrix.** yschimke/m3-catalog#130 folded seven components onto the kit sets they belong to and had to *delete* four cells to do it, because leaving them would render captures attached to nothing:

| Node | Cell |
| --- | --- |
| `58005:8175` | linear wavy × `Progress=100` |
| `58005:8520` | circular wavy × `Progress=100` |
| `58008:10710` | vertical slider × `State=Disabled` |
| `58467:8350` | vertical toolbar × `Color=Vibrant` |

Each is a real cell of a real kit set, and the resolver already handles both of its axes individually — they just could not be carried on one render. That trade is what this removes.

## The fix

Collect the third case, and **cross** the axes rather than picking one. The render sits at `type=wave` AND `progress=1.0`; declaring either half alone resolves to a sibling node and diffs the wrong frame.

`variantSeeds` splits into `foldSeeds` (the `@CatalogVariant`'s own axis) and `cellSeeds` (the `@OverrideVariant`'s), and merges when both are present — so the two pre-existing paths return exactly what they returned before, and only the previously-dropped case is new. On a key collision the **cell wins**: both describe the same render, but the cell's value is what the renderer actually seeded and the fold's is the default it seeded over.

`variantName` names such a render for the fold's axis plus the cell — `wave-full`, not `wave-1.0` — so a folded component's cells read the same way a top-level component's do.

## Verification

`node --test design-map/` — 24 pass, 0 fail. Four new tests: the crossed vector, the collision rule, collection under the parent with the merged name, and that a folded component's `_Dark_VARIANT_` capture is still ignored like every other dark capture.

End to end against m3-catalog, which is where the four nodes were lost. Restoring two of the deleted cells and running this projection through the real `@design-parity/kit-index@0.1.51` resolver:

```
  RECOVERED  58005:8520 circular wavy x full        ('CircularProgress', 'wave-full')
  RECOVERED  58467:8350 vertical toolbar x vibrant  ('HorizontalFloatingToolbarSticker', 'vertical-vibrant')
```

Both land under the parent they fold onto, tagged with the crossed axis. On `main` neither appears in the map at all.

Not a visual change — this is design-map plumbing, so text-only evidence is the right kind here. No render moves; the change is which declarations reach a resolver.

## Note on rollout

m3-catalog pins its copy by commit (`TOOL_REF` in `scripts/design-map.sh`, currently a pre-move SHA that still serves `scripts/design-artifacts/design-map.mjs`), so it picks this up when that pin is bumped — deliberately, in a commit that regenerates its committed map in the same diff. The four cells can be restored there at that point.

Two smaller things from #4073 are **not** in this PR, and neither blocks it:

- `@CatalogVariant` has no `kitAxis` / `kitValue`, so a fold has to spell the kit's own value in catalog source — m3-catalog#130 carries `props = ["type=full-screen (range)"]` for that reason.
- A prop that resolves to nothing drops its node with no diagnostic; `type=range` against `Type=Full-screen (range)` fails silently. That warning belongs in the resolver, in design-parity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMqCAjq4C7mZHRcnfKY3tG)_