### PR TITLE
fix(catalog): pair a motion capture with its own theme

### DIFF
--- a/scripts/design-artifacts/catalog-motion.mjs
+++ b/scripts/design-artifacts/catalog-motion.mjs
@@ -117,28 +117,49 @@ function bundleEntryFor(bundle, previewId, renderOutput) {
  * The theme is read off the sibling **still** rather than off the motion artifact, deliberately: a
  * capture's own id carries the same `_Dark` / `_Light` suffix, but re-deriving it here would be a
  * second implementation of the mode-naming rule that `catalog-themes.mjs` already owns, and the two
- * would eventually disagree about a catalog with unusual mode names. Matching the discovery
- * parameters against the images the join already resolved keeps one rule. When `motionPreview`
- * names a separate function, its filenames necessarily have different stems. In that case
- * [motionPreviewCells] describe the two functions' fan-outs with their preview parameters; the join
- * maps equal axis cells even when declaration order differs, and declines ambiguous cells.
+ * would eventually disagree about a catalog with unusual mode names. Taking the theme the sibling
+ * still already resolved keeps one rule.
  *
- * @param {Array<{path: string, theme?: string}>} images the component's baked stills.
+ * **That sibling is found by preview id, not by filename.** A capture and its still share a preview
+ * id, and [themeByPreviewId] carries the theme each id's candidate resolved. The filename-stem match
+ * below looks like it would do the same job and does not: a candidate image is
+ * `{state, width, height, theme, uri}` with a `data:` URI — it has no `path` at all — so that
+ * comparison silently answered `undefined` for every real catalog. A capture with no theme is pinned
+ * to *every* card of its component, so the first catalog to publish captures showed the dark
+ * recording on the light card and the light one on the dark card, offered as an unlabelled
+ * "Motion (2)" picker. The stem match is kept only as a fallback for a caller whose images do carry
+ * `path`.
+ *
+ * When `motionPreview` names a separate function, its ids differ from the still's. In that case
+ * [motionPreviewCells] describe the two functions' fan-outs with their preview parameters; the join
+ * maps equal axis cells even when declaration order differs, declines ambiguous cells, and the
+ * mapped still's id is then looked up in the same [themeByPreviewId].
+ *
+ * @param {Array<{path?: string, theme?: string}>} images the component's baked stills.
  * @param {Array<{path: string, previewId?: string, kind: string, caption?: string}>} artifacts from [motionArtifactsFor].
  * @param {Array<{id: string, params?: object}>} previewCells static preview fan-out cells.
  * @param {Array<{id: string, params?: object}>} motionPreviewCells motion preview fan-out cells.
+ * @param {Map<string, string>} [themeByPreviewId] preview id → the theme its candidate resolved.
  * @returns {Array<object>} one motion entry per artifact, theme-tagged where it could be resolved.
  */
-export function foldMotion(images, artifacts, previewCells = [], motionPreviewCells = []) {
+export function foldMotion(
+  images,
+  artifacts,
+  previewCells = [],
+  motionPreviewCells = [],
+  themeByPreviewId = undefined,
+) {
   if (!artifacts?.length) return [];
   const correspondingStillIds = equivalentFanOut(previewCells, motionPreviewCells);
   return artifacts.map((artifact) => {
     const { previewId, ...published } = artifact;
-    const theme = themeForArtifact(
-      images,
-      artifact.path,
-      correspondingStillIds.get(previewId),
-    );
+    const correspondingStillId = correspondingStillIds.get(previewId);
+    const theme =
+      themeByPreviewId?.get(previewId) ??
+      (correspondingStillId !== undefined
+        ? themeByPreviewId?.get(correspondingStillId)
+        : undefined) ??
+      themeForArtifact(images, artifact.path, correspondingStillId);
     return {
       ...published,
       ...(theme !== undefined ? { theme } : {}),

--- a/scripts/design-artifacts/catalog-motion.test.mjs
+++ b/scripts/design-artifacts/catalog-motion.test.mjs
@@ -265,3 +265,76 @@ test("no artifacts folds to nothing, so a component without motion gains no fiel
   assert.deepEqual(foldMotion([{ path: "previews/Sw.png", theme: "light" }], []), []);
   assert.deepEqual(foldMotion([], undefined), []);
 });
+
+// --- theme pairing off the preview id -----------------------------------------------------------
+// These pin the shape a REAL candidate image has: `{state, width, height, theme}` plus a `data:`
+// URI, and no `path`. The original fixtures gave their images a `path`, which the production join
+// never produces — so `themeForArtifact` matched nothing, every published capture came out
+// untagged, and an untagged capture is pinned to every card of its component. The first catalog to
+// publish captures showed the dark recording on the light card and vice versa.
+
+const bakedStill = (theme) => ({
+  state: "default",
+  theme,
+  width: 221,
+  height: 210,
+  uri: "data:image/png;base64,iVBORw0KGgo=",
+});
+
+test("themes a capture from its own preview id, with images that carry no path", () => {
+  const images = [bakedStill("light"), bakedStill("dark")];
+  const artifacts = [
+    { path: "previews/pkg.Kt.SwitchOn_Light.apng", previewId: "pkg.Kt.SwitchOn_Light", kind: "interaction" },
+    { path: "previews/pkg.Kt.SwitchOn_Dark.apng", previewId: "pkg.Kt.SwitchOn_Dark", kind: "interaction" },
+  ];
+  const themeByPreviewId = new Map([
+    ["pkg.Kt.SwitchOn_Light", "light"],
+    ["pkg.Kt.SwitchOn_Dark", "dark"],
+  ]);
+
+  const folded = foldMotion(images, artifacts, [], [], themeByPreviewId);
+
+  assert.deepEqual(
+    folded.map((m) => m.theme),
+    ["light", "dark"],
+  );
+});
+
+test("a separately named motion function inherits the mapped still's theme", () => {
+  const images = [bakedStill("light")];
+  const artifacts = [
+    { path: "previews/pkg.Kt.SwitchMotion_Light.apng", previewId: "pkg.Kt.SwitchMotion_Light", kind: "interaction" },
+  ];
+  // The motion function's own id is absent from the map (it renders no still of its own); the
+  // fan-out join maps it onto the still function's cell, whose theme is then used.
+  const previewCells = [{ id: "pkg.Kt.SwitchOn_Light", params: { uiMode: 16 } }];
+  const motionPreviewCells = [{ id: "pkg.Kt.SwitchMotion_Light", params: { uiMode: 16 } }];
+  const themeByPreviewId = new Map([["pkg.Kt.SwitchOn_Light", "light"]]);
+
+  const folded = foldMotion(images, artifacts, previewCells, motionPreviewCells, themeByPreviewId);
+
+  assert.equal(folded[0].theme, "light");
+});
+
+test("an id the map does not know stays untagged rather than guessing", () => {
+  const folded = foldMotion(
+    [bakedStill("light")],
+    [{ path: "previews/pkg.Kt.Mystery.apng", previewId: "pkg.Kt.Mystery", kind: "interaction" }],
+    [],
+    [],
+    new Map([["pkg.Kt.SwitchOn_Light", "light"]]),
+  );
+  assert.equal("theme" in folded[0], false);
+});
+
+test("an unthemed catalog folds captures with no theme, as before", () => {
+  const folded = foldMotion(
+    [{ state: "default", width: 1, height: 1, uri: "data:," }],
+    [{ path: "previews/pkg.Kt.Thing.apng", previewId: "pkg.Kt.Thing", kind: "animation" }],
+    [],
+    [],
+    new Map(),
+  );
+  assert.equal("theme" in folded[0], false);
+  assert.equal(folded[0].kind, "animation");
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -466,6 +466,20 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
     );
   }
 
+  // Preview id → the theme that id's candidate resolved, read BEFORE the per-function merge
+  // flattens the candidates into one image list. This is what pairs a motion capture with the
+  // themed card it accompanies: a capture knows its preview id, and its sibling still's theme is
+  // the theme of the candidate carrying that id. Taken from the candidate rather than re-derived
+  // from the id's `_Dark` / `_Light` suffix, so there stays exactly one implementation of the
+  // mode-naming rule (`catalog-themes.mjs` owns it). See foldMotion.
+  const themeByPreviewId = new Map();
+  for (const candidate of candidates) {
+    const id = candidate?.componentId;
+    if (!id) continue;
+    const theme = (candidate.images ?? []).find((image) => image?.theme)?.theme;
+    if (theme !== undefined) themeByPreviewId.set(id, theme);
+  }
+
   const sources = [];
   const missing = [];
   const noSticker = [];
@@ -668,6 +682,7 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
         motionArtifactsFor(opts.motionBundle, motionPreviewFor(component)),
         opts.previewCellsByFunction?.get(component.preview),
         opts.previewCellsByFunction?.get(motionPreviewFor(component)),
+        themeByPreviewId,
       );
       if (motion.length > 0) {
         source.motion = motion;


### PR DESCRIPTION
## Summary

#4074 + #4079 got interaction captures published for the first time — `design-artifacts/compose-m3` now carries `motion/switch-on/ideal__default__{light,dark}.apng`. They land on the wrong cards.

Every published capture came out with **no `theme`**, and `ServeCatalogStore` treats an untagged capture as belonging to *every* card of its component ("a capture with no theme belongs to every card"). Live right now on the box, both pages serve both recordings:

```
GET /compose-m3/p/switch-on__ideal__default__light
  data-motion-src="/compose-m3/motion/switch-on__ideal__default__dark.apng"   … 1
  data-motion-src="/compose-m3/motion/switch-on__ideal__default__light.apng"  … 2

GET /compose-m3/p/switch-on__ideal__default__dark
  … identical
```

The light card plays the dark switch, in an unlabelled "Motion (2)" picker, on both.

**Cause.** `themeForArtifact` resolved the theme by comparing the capture's bundle stem against `image.path` of the sibling stills. A real candidate image has no `path` — read straight out of the bundle it is `{state, width, height, theme}` plus a `data:` URI:

```
baked still fields: ["state","uri","width","height","theme"]
```

So `image?.path?.replace(…)` was `undefined` on every iteration, for every catalog, and had been since the axis was introduced. It was invisible until captures reached a delivery branch at all. The existing fixtures gave their images a `path` the production join never produces, so the tests passed on a shape that does not exist.

**Fix.** Pair on the preview id, which a capture and its still already share. The join builds `previewId → theme` from the candidate that resolved it — read *before* the per-function merge flattens candidates into one image list — and `foldMotion` prefers that. Taken from the candidate rather than re-derived from the id's `_Dark` / `_Light` suffix, so `catalog-themes.mjs` remains the only implementation of the mode-naming rule, which is the constraint the original code was written to respect. A separately named `motionPreview` function still routes through the existing fan-out join and then looks the mapped still's id up in the same map. An id the map doesn't know stays untagged rather than guessing.

The stem match survives as a fallback for any caller whose images do carry `path`.

## Test plan

- `node --test` in `scripts/design-artifacts` — **756 pass, 0 fail** (781 total, 25 pre-existing skips).
- Four new cases in `catalog-motion.test.mjs` deliberately use the **real** candidate shape — path-less, `data:` URI — so a fixture can no longer pass where production fails: themes resolve from the preview id; a separately named motion function inherits the mapped still's theme; an unknown id stays untagged; an unthemed catalog still folds untagged.
- **Replayed against the real `design-artifacts/compose-m3` bundle** read through `loadPreviewBundle` (not hand-built objects — that shortcut is what let the bug through the first time). Before: both captures untagged. After:
  ```
  theme=dark   previews/…CatalogSelectionKt.SwitchOn_Dark.apng
  theme=light  previews/…CatalogSelectionKt.SwitchOn_Light.apng
  ```

## Visual evidence

The affected surface is the Motion lane's card pairing, which needs a published catalog plus a running serve host to show. It is currently observable on the box — the two `curl` outputs above are the defect, from `preview.coo.ee` as it stands. After this lands and compose-m3 republishes, the same two requests should each carry exactly one `data-motion-src`, matching their own theme, and the numeric " 1"/" 2" suffixes should disappear because the labels no longer collide. That is a one-command check and I'll confirm it on the box rather than asserting it here.

The recording itself is unchanged by this PR — it is the same APNG, attached to the right card:

![The five expressive components' interaction captures](https://raw.githubusercontent.com/yschimke/m3-catalog/c9a5974c3073337d8461d2121891fa8dfc6aa74b/docs/motion/interaction-captures.png)

## Note

`main` is red on `ServeWebFixtureTest > serve web fixtures are in sync with ServeWeb()` (ServeWebFixtureTest.kt:6162), pre-existing and unrelated — it hits Build CLI and Module Unit Tests on every PR right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG)_