### PR TITLE
fix(ci): refresh design artifact driver pin

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -405,7 +405,7 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -477,7 +477,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -490,7 +490,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Do not honor a caller-controlled ref here: refs/pull/* in this repo
           # can contain fork code, and this privileged workflow executes the driver.
-          ref: b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
+          ref: 2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 
@@ -713,7 +713,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -728,7 +728,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Never execute a caller-selected refs/pull/* revision in this
           # privileged workflow. Update this alongside the other driver pin.
-          ref: b2660a25118b634ddb6a94ccb0e7979d65b157e8 # main at 2026-08-16
+          ref: 2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Moves the pinned export driver from `b2660a2` onto **`2f12fd6`** (#4082), across the same five occurrences in `design-artifacts-reusable.yml` the previous refreshes moved — two `ref:` checkouts and three `install@` action pins.

`b2660a2` is the state that publishes captures but tags none of them, and an untagged capture is pinned to every card of its component. So `preview.coo.ee/compose-m3` is right now serving the dark Switch recording on its light card and the light one on its dark card, both as an unlabelled "Motion (2)" picker. #4082 fixes the pairing; this is what carries it into a delivery run.

Second pin refresh in an hour, which is inherent rather than accidental: the driver is pinned to a SHA precisely so a privileged workflow never runs a caller-selected ref, and the cost of that is a follow-up whenever `scripts/design-artifacts/` moves.

## Test plan

- Mechanical pin bump, no code change: 5 insertions, 5 deletions, one SHA substitution. Verified the substituted value is the real merge commit (`git rev-parse origin/main` → `2f12fd64f9d3abf7d6d646445c911386cc56d14d`) and that the file's other 40-char hashes — the `actions/checkout`, `upload-artifact` and `setup-*` pins — are untouched.
- Verified `2f12fd6` is good before pointing at it: `node --test` in `scripts/design-artifacts` on that tree → **756 pass, 0 fail**.
- Acceptance after the next `design-artifacts` run, which I'll check on the box rather than assume: `/compose-m3/p/switch-on__ideal__default__light` should carry exactly **one** `data-motion-src`, ending `…__light.apng`, and the numeric " 1"/" 2" label suffixes should be gone — they only appear because two identical labels currently collide on one card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG

---
_Generated by [Claude Code](https://claude.ai/code/session_01TNe5b6rJ5Wm8actAqGLifG)_