### PR TITLE
fix(ci): pin live module bundle driver

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -405,7 +405,7 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -477,7 +477,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -490,7 +490,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Do not honor a caller-controlled ref here: refs/pull/* in this repo
           # can contain fork code, and this privileged workflow executes the driver.
-          ref: 2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
+          ref: 62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 
@@ -713,7 +713,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -728,7 +728,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Never execute a caller-selected refs/pull/* revision in this
           # privileged workflow. Update this alongside the other driver pin.
-          ref: 2f12fd64f9d3abf7d6d646445c911386cc56d14d # main at 2026-08-16
+          ref: 62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
           path: compose-ai-tools
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- advance all five trusted compose-ai-tools self-references in the reusable Design Artifacts workflow
- pin both export-driver checkouts and all install-action references to the #4080 merge commit

## Why

#4084 refreshed these references after #4080 merged, but selected `2f12fd64f9d3abf7d6d646445c911386cc56d14d`, which predates the live multi-module bundle implementation. A `modules: all` workflow would therefore execute the older driver despite the feature being present on `main`.

The corrected immutable pin is `62008800ae1c15be95b9a8f891e7261f431d2fdf`, the merge commit for #4080.

## Impact and rollout

This makes the reusable workflow's build-from-source path use the live multi-module implementation. Do not publish external `modules: all` live catalogs on the strength of this pin alone: first release a compose-ai-tools version containing #4080 and upgrade or confirm the serve hosts that consume the new `liveBundles` manifest.

Safe order: merge this pin correction, publish the compose-ai-tools release, upgrade/confirm serve hosts, then regenerate live catalogs.

## Validation

- confirmed `62008800ae1c15be95b9a8f891e7261f431d2fdf` is on `main` and is the #4080 merge commit
- confirmed all five trusted self-references use the same immutable SHA
- parsed the workflow as YAML
- `git diff --check`
