### PR TITLE
fix(renderer): share the pressed-ripple settle with focus GIFs

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1595,25 +1595,12 @@ abstract class RobolectricRenderTestBase(
               // deterministic timing; the Android clock and Compose's `mainClock` are
               // independent, so this advances only platform animations.
               //
-              // [FocusController.SETTLE_MS] is NOT the right window for it, which is the
-              // bug this replaced. That constant sizes a Compose-side settle; the platform
-              // ripple needs far more looper time, and how much more depends on how long
-              // the sandbox has already been running — so a 250ms window silently
-              // under-settles the ripple in proportion to the number of previews rendered
-              // before this one. Measured on `:samples:design-catalog-wear-m3`'s
-              // `ButtonPressed` at `shards = 1`, the pressed container faded from #C2B5DB
-              // (3 preview rows ahead of it) through #D5C8EC (11 rows) to #D4C8EC (the
-              // full 59-row catalog) — the last of those pixel-identical to the
-              // focus-only capture, i.e. a "pressed" specimen showing no press. Because
-              // `shards` auto-sizes off a `previews.json` a cold CI checkout does not
-              // have, the same commit rendered pressed pixels in one job and focus-only
-              // in another. [PRESS_SETTLE_MS] is sized for the settled end state instead,
-              // and stepping keeps the `Choreographer` delivering a callback per frame
-              // across it rather than one for the whole jump.
+              // This used to idle for [FocusController.SETTLE_MS], which is a Compose-side
+              // window and silently under-settles the ripple in proportion to how long the
+              // sandbox has been running — see [PRESS_SETTLE_MS] for the measurements and
+              // for why that made a pressed specimen depend on its shard layout.
               if (focus.pressed) {
-                val looper = org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
-                val step = java.time.Duration.ofMillis(PRESS_SETTLE_FRAME_MS)
-                repeat((PRESS_SETTLE_MS / PRESS_SETTLE_FRAME_MS).toInt()) { looper.idleFor(step) }
+                settlePressedRipple()
               }
             }
 
@@ -2211,32 +2198,6 @@ abstract class RobolectricRenderTestBase(
     private const val CAPTURE_ADVANCE_MS = 32L
 
     /**
-     * Virtual looper time a `@FocusedPreview(pressed = true)` capture idles so the platform
-     * `RippleDrawable` behind Material's pressed state reaches its end state, in milliseconds.
-     *
-     * Deliberately an order of magnitude past the ~75ms the ripple's own enter animation nominally
-     * runs for, and not shared with [FocusController.SETTLE_MS]. The two settle different clocks
-     * and want different sizes: the ripple's effective progress per unit of idled time falls off
-     * the longer the Robolectric sandbox has been reused, so a window sized to the animation is
-     * only enough for the first previews of a shard. Sized to the *settled* pixels instead —
-     * `:samples:design-catalog-wear-m3`'s `ButtonPressed` renders the same #C2B5DB container at
-     * `shards = 1` behind the full 59-row catalog as it does rendered on its own, which is the
-     * property that makes a pressed specimen independent of shard layout.
-     *
-     * It is virtual time, so the cost is running the callbacks that come due, not wall clock.
-     */
-    private const val PRESS_SETTLE_MS = 5_000L
-
-    /**
-     * Slice size for the [PRESS_SETTLE_MS] settle, in milliseconds. ~1 Choreographer frame at 60Hz.
-     *
-     * `idleFor` runs the callbacks that came due, not one per frame — so idling the whole window in
-     * one jump yields a single `Choreographer` callback and a single animation step. Stepping keeps
-     * the frame cadence the animation expects across the window.
-     */
-    private const val PRESS_SETTLE_FRAME_MS = 16L
-
-    /**
      * Virtual time advanced after flipping [reduceMotionState] around a LONG capture — enough
      * paused-clock frames for the recomposition to re-read `LocalReduceMotion` and for
      * `TransformingLazyColumn` to drop (or restore) its item transforms before the next capture
@@ -2610,6 +2571,59 @@ private fun settlePostScrollAnimations(rule: AndroidComposeTestRule<*, *>) {
  * `EdgeButton` expand spec (~250ms at the time of writing) with comfortable headroom for overshoot
  * / chained animations.
  */
+/**
+ * Virtual looper time a pressed capture idles so the platform `RippleDrawable` behind Material's
+ * pressed state reaches its end state, in milliseconds.
+ *
+ * Deliberately not shared with [FocusController.SETTLE_MS], which is the window for the
+ * *Compose-side* settle. The two drive different clocks and want different sizes: the ripple's
+ * effective progress per unit of idled looper time falls off the longer the Robolectric sandbox has
+ * been reused, so a window sized to the animation's nominal ~75ms only settles the first previews
+ * of a shard. Measured on `:samples:design-catalog-wear-m3`'s `ButtonPressed` at `shards = 1`, the
+ * 250ms window faded the pressed container from #C2B5DB (3 preview rows ahead of it)
+ * through #D5C8EC (11 rows) to #D4C8EC behind the full 59-row catalog — the last of those
+ * pixel-identical to the focus-only capture. This is sized to the *settled* pixels instead:
+ * `ButtonPressed` renders the same #C2B5DB behind the whole catalog as it does rendered on its own,
+ * which is what makes a pressed specimen independent of shard layout.
+ *
+ * **Known cost, deliberately accepted.** [settlePressedRipple] idles the looper across the whole
+ * window, so any main-looper work a pressed preview scheduled inside it — a `postDelayed`, a
+ * platform widget's own timer — runs before the capture rather than at its own time. Two things
+ * bound it: the settle is gated to pressed captures, which in this repo is a handful of catalog
+ * specimens, and the window is no larger than it has to be. Both cheaper alternatives were tried
+ * against the full catalog at `shards = 1` and neither settles the ripple: 1s instead of 5s
+ * renders #D4C8EC, and so does stopping early once `ShadowLooper.getNextScheduledTaskTime()`
+ * reports nothing due within a frame. A cleaner fix is to end the settle on the ripple's own state
+ * — poll `Animatable.isRunning()` on the `RippleHostView`s under the composition — which needs a
+ * way to reach those drawables from here that does not exist yet.
+ */
+private const val PRESS_SETTLE_MS = 5_000L
+
+/**
+ * Slice size for the [PRESS_SETTLE_MS] settle, in milliseconds. ~1 Choreographer frame at 60Hz.
+ *
+ * `idleFor` runs the callbacks that came due, not one per frame — so idling the whole window in one
+ * jump yields a single `Choreographer` callback and therefore a single animation step. Stepping
+ * keeps the frame cadence the animation expects across the window.
+ */
+private const val PRESS_SETTLE_FRAME_MS = 16L
+
+/**
+ * Advance the platform (non-Compose) animation clock far enough for a pressed capture's ripple to
+ * reach its end state.
+ *
+ * Material's pressed state layer is a platform `RippleDrawable` animated on the Android looper /
+ * `Choreographer`, not on Compose's `mainClock` — so the paused-clock advances around the call
+ * sites never progress it, and it needs its own settle. Shared by the static per-PNG focus capture
+ * and the `@FocusedPreview(gif = true)` per-step capture so a pressed GIF frame cannot drift from a
+ * pressed PNG; both gate the call on the step actually being pressed.
+ */
+private fun settlePressedRipple() {
+  val looper = org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+  val step = java.time.Duration.ofMillis(PRESS_SETTLE_FRAME_MS)
+  repeat((PRESS_SETTLE_MS / PRESS_SETTLE_FRAME_MS).toInt()) { looper.idleFor(step) }
+}
+
 private const val POST_SCROLL_SETTLE_MS = 1000L
 
 /**
@@ -3249,15 +3263,16 @@ private fun handleFocusGifCapture(
       // crossfades to the new highlight before the frame is captured.
       rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
       rule.mainClock.advanceTimeBy(focusGif.frameDelayMs.toLong())
-      // Same platform-ripple settling as the static per-PNG focus block: a
-      // pressed step's Material state layer is a platform `RippleDrawable`
-      // animated on the Android looper, not Compose's `mainClock`, so the
-      // advances above never progress it. Idle the looper for pressed frames so
-      // the ripple settles before capture; gated per-step so non-pressed frames
-      // keep their deterministic timing.
+      // Same platform-ripple settling as the static per-PNG focus block, through the
+      // same helper: a pressed step's Material state layer is a platform
+      // `RippleDrawable` animated on the Android looper, not Compose's `mainClock`, so
+      // the advances above never progress it. Gated per-step so non-pressed frames keep
+      // their deterministic timing. Shared rather than spelled out twice so a pressed GIF
+      // frame cannot settle differently from a pressed PNG — it used to idle for
+      // [FocusController.SETTLE_MS] here, which meant pressed GIF steps stayed
+      // shard-dependent for as long as that window was the one in use.
       if (step.pressed) {
-        org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
-          .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+        settlePressedRipple()
       }
       val frameFile = File(framesDir, "frame_$i.png")
       captureDecodableFrame(frameFile, role = "focus GIF") { f ->

--- a/samples/design-catalog-wear-m3/src/test/kotlin/com/example/designcatalogwearm3/WearFocusedPressPixelTest.kt
+++ b/samples/design-catalog-wear-m3/src/test/kotlin/com/example/designcatalogwearm3/WearFocusedPressPixelTest.kt
@@ -1,8 +1,10 @@
 package com.example.designcatalogwearm3
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import java.io.File
 import javax.imageio.ImageIO
+import kotlin.math.abs
 import org.junit.Test
 
 /** End-to-end guard that the documented Wear pressed specimen is not a focus-only capture. */
@@ -15,27 +17,49 @@ class WearFocusedPressPixelTest {
     val pressed = uniqueRender("ButtonPressed")
     val focused = uniqueRender("ButtonFocused")
     val resting = uniqueRender("FilledButton")
-    val pressedImage = ImageIO.read(pressed)
-    val focusedImage = ImageIO.read(focused)
-    val restingImage = ImageIO.read(resting)
 
     // This point is inside the rounded container of all three captures and outside every label, so
-    // it reads the container fill rather than glyph pixels. The three states must land on three
+    // it reads the container fill rather than glyph pixels. The three states land on three
     // different fills: resting #E9DDFF, focused #D4C8EC (Compose draws the focus state layer
     // itself), pressed #C2B5DB (Wear M3's only press affordance is `material-ripple`, a platform
     // `RippleDrawable` the renderer settles only on a `@FocusedPreview(pressed = true)` capture —
     // a hand-seeded `PressInteraction` renders as #E9DDFF, i.e. as no press at all).
-    //
-    // Both assertions are load-bearing and neither subsumes the other. Against `focused` they
-    // catch a press that never happened; against `resting` they catch a press that happened but
-    // did not paint — which is what an under-sized `PRESS_SETTLE_MS` produces, and it degrades
-    // gradually (#C2B5DB → #D5C8EC → #D4C8EC as the sandbox is reused), so a capture that is
-    // merely *close* to the focused fill still has to fail here rather than pass by a hair.
     val x = 30
     val y = 68
-    assertThat(pressedImage.getRGB(x, y)).isNotEqualTo(focusedImage.getRGB(x, y))
-    assertThat(pressedImage.getRGB(x, y)).isNotEqualTo(restingImage.getRGB(x, y))
+    val pressedFill = ImageIO.read(pressed).getRGB(x, y)
+    val focusedFill = ImageIO.read(focused).getRGB(x, y)
+    val restingFill = ImageIO.read(resting).getRGB(x, y)
+
+    // Distance, not inequality. The failure this exists to catch does not arrive as "pressed equals
+    // focused" — it arrives as a ripple that only partly settled, because `PRESS_SETTLE_MS` in
+    // `RobolectricRenderTest` was too small for how long the Robolectric sandbox had been reused.
+    // That degrades *gradually*: measured at `shards = 1`, #C2B5DB with 3 preview rows ahead of
+    // this one, #D5C8EC with 11, #D4C8EC behind the full catalog. Only the last of those is equal
+    // to the focused fill, so an inequality assertion passes the middle one — a capture one channel
+    // step away from focus-only, published as `pressed`.
+    assertChannelsApart(pressedFill, focusedFill, "pressed", "focused")
+    assertChannelsApart(pressedFill, restingFill, "pressed", "resting")
   }
+
+  /**
+   * Asserts every RGB channel of [a] differs from [b] by at least [MIN_CHANNEL_DELTA].
+   *
+   * Reports the two fills as hex on failure — the value is the diagnosis here (a fill equal to the
+   * focused one means no press at all; one a few steps from it means the ripple did not settle),
+   * and Truth's own message for two packed `Int` colours is unreadable.
+   */
+  private fun assertChannelsApart(a: Int, b: Int, aName: String, bName: String) {
+    val deltas =
+      listOf(16, 8, 0).map { shift -> abs((a shr shift and 0xFF) - (b shr shift and 0xFF)) }
+    assertWithMessage(
+        "$aName ${a.hex()} vs $bName ${b.hex()}: per-channel deltas $deltas, " +
+          "need every channel >= $MIN_CHANNEL_DELTA"
+      )
+      .that(deltas.min())
+      .isAtLeast(MIN_CHANNEL_DELTA)
+  }
+
+  private fun Int.hex(): String = "#%06X".format(this and 0xFFFFFF)
 
   private fun uniqueRender(functionName: String): File {
     val matches = rendersDir.listFiles { file ->
@@ -44,5 +68,18 @@ class WearFocusedPressPixelTest {
     assertThat(matches).isNotNull()
     assertThat(matches!!.asList()).hasSize(1)
     return matches.single()
+  }
+
+  private companion object {
+    /**
+     * Minimum per-channel separation between the pressed fill and its two neighbours.
+     *
+     * Sized off the settled values rather than picked round: a settled press sits ~17–19 steps from
+     * the focused fill (#C2B5DB vs #D4C8EC) and ~40 from the resting one, while the under-settled
+     * capture this guards against sat 1 step away. 8 is comfortably between, so the threshold
+     * separates "settled" from "barely moved" without pinning an exact colour that a legitimate
+     * palette change would have to come here to update.
+     */
+    const val MIN_CHANNEL_DELTA = 8
   }
 }


### PR DESCRIPTION
## Summary

Review follow-ups to #4096, which merged before they could be folded in. Three points, all from the Codex review on that PR.

**1. Pressed focus GIFs kept the old window.** `handleFocusGifCapture` still idled for `FocusController.SETTLE_MS` on a pressed step, so a `@FocusedPreview(gif = true)` frame stayed shard-dependent in exactly the way #4096 fixed for static PNGs. Both paths now call one `settlePressedRipple`, so a pressed GIF frame cannot settle differently from a pressed PNG.

**2. `WearFocusedPressPixelTest` did not catch what the settle gets wrong.** It asserted inequality, but an under-sized window degrades the ripple *gradually* — measured `#C2B5DB` → `#D5C8EC` → `#D4C8EC` as the sandbox is reused — and only the last of those is *equal* to the focused fill. The middle one passed: a capture one channel step away from focus-only, published as `pressed`. The comment I left on it claimed a merely-close result would fail, which was wrong. It now asserts a minimum per-channel distance, sized off the settled values (a settled press sits 17–19 steps from focused and ~36 from resting; the under-settled one sat 1) and reports both fills as hex on failure.

**3. The settle drains unrelated main-looper work.** Correct, and I could not make it not do that. Idling the window runs whatever a pressed preview had scheduled inside it — a `postDelayed`, a widget's own timer — before the capture. Two narrower forms were measured against the full catalog at `shards = 1`:

| attempt | pressed fill | settles? |
| --- | --- | --- |
| 1 s ceiling instead of 5 s | `#D4C8EC` | no |
| stop early once `ShadowLooper.getNextScheduledTaskTime()` reports nothing due within a frame | `#D4C8EC` | no |
| the merged form (5 s, stepped) | `#C2B5DB` | yes |

So the window stays as it is. What changed is that the cost is now written down rather than implied, along with the alternative I did not get to: ending the settle on the ripple's own state (`Animatable.isRunning()` on the composition's `RippleHostView`s), which needs a way to reach those drawables from the renderer that does not exist yet. The blast radius stays bounded by the gate — pressed captures only, a handful of catalog specimens.

## Test plan

Local, with a real Android SDK + Robolectric:

- `./gradlew :samples:design-catalog-wear-m3:composePreviewRenderAll :samples:design-catalog-wear-m3:testDebugUnitTest --rerun-tasks` at **`shards = 1`** (the CI-failing configuration) — **BUILD SUCCESSFUL**, 16 tests, 0 failures, `ButtonPressed` `#C2B5DB`. Same at **auto sharding** — **BUILD SUCCESSFUL**.
- The strengthened assertion was confirmed to fail on a genuinely under-settled render, not just to pass on a good one: the 1 s and early-exit attempts above both failed it.
- `./gradlew :renderer-android:test` and `./gradlew ktfmtCheckAll` — both clean.

## Visual evidence

No pixel change: `ButtonPressed` renders the same `#C2B5DB` this PR and last, and the evidence renders committed in #4096 under [`docs/design/evidence/wear-pressed/`](https://github.com/yschimke/compose-ai-tools/tree/main/docs/design/evidence/wear-pressed) still describe the current output. This PR moves the settle into a shared helper, extends it to the GIF path, and tightens a test — the only surface whose pixels *could* move is a pressed `@FocusedPreview(gif = true)` capture, and no preview in this repo uses that combination today, which is why the GIF path's drift went unnoticed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K75KTvGkd2NRMZX6AXmaMB)_