### PR TITLE
fix(design-artifacts): import bundleModulePath in the catalog generator

### DIFF
--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -143,6 +143,7 @@ import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.
 import { completenessFailure } from "./completeness-gate.mjs";
 import {
   additionalBundleLiveConflict,
+  bundleModulePath,
   claimedComponentIds,
   claimedPreviewFunctions,
   combinedBundleMap,


### PR DESCRIPTION
## Summary

`Design Artifacts` is failing on `main`. The `wear-m3 / wear-m3` job dies with:

```
ReferenceError: bundleModulePath is not defined
```

`generate-design-catalog.mjs` calls `bundleModulePath` at three sites — the `sourceByFunction` module stamp (line 338) and the two module-record paths (1351, 1401) — but its import list from `./multi-module-catalog.mjs` never picked it up. `multi-module-catalog.mjs` exports it correctly; the consumer just doesn't import it. ES modules have no implicit globals, so every one of those lines throws the moment it is evaluated.

One line: add it to the existing import.

## Why nothing caught it

The driver's own `node --test` suite cannot reach those call sites. `generate-design-catalog.mjs` exports nothing — it is a CLI entry point — so its internals are only exercised by running the driver end to end, which is what `design-artifacts.yml` does. That workflow runs on push to `main` scoped to catalog and driver paths, so it stayed quiet until a catalog change landed and then failed on the first system it reached.

I did not add a regression test, deliberately: there is no seam to test against without either exporting the internals or standing up a full bundle fixture, and neither is a change I'd want to smuggle into a one-line import fix. The end-to-end workflow is the guard that exists and it did fire — it just fires later than a PR check would.

## Test plan

- `node --check scripts/design-artifacts/generate-design-catalog.mjs` — clean.
- `node --test` in `scripts/design-artifacts` — **730 pass, 6 fail, 24 skipped**, identical with and without this change (verified by stashing it and re-running). The 6 failures are pre-existing and environmental in this container — `figma-rest-raster`, `rc-compare-pixels`, `rc-size-modifier`, `catalog-themes`, `live-bundle-namespace`, `package-version` — not something this touches.
- I have **not** run the driver end to end against a real bundle here; that needs the render pipeline the workflow builds. The fix is a static one and the failure mode is unambiguous — an undefined identifier in an ES module — so the claim is that the `ReferenceError` cannot recur, not that the whole export is otherwise healthy. `Design Artifacts` on merge is the real check.

Non-visual change — build/export plumbing, no rendered surface touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K75KTvGkd2NRMZX6AXmaMB)_