### PR TITLE
fix(render): degrade the composer opt-in only for a real version floor

### DIFF
--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/LinkBufferComposer.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/LinkBufferComposer.kt
@@ -157,7 +157,9 @@ object LinkBufferComposer {
    *   such flag — an older Compose, or a future one that has finished the migration and removed it.
    *   Failing loudly is the point: a silently-ignored opt-in would produce a full set of renders
    *   that "tested" the new composer without ever enabling it. `auto` returns [Outcome.Unavailable]
-   *   there instead, which the lanes announce rather than swallow.
+   *   there instead, which the lanes announce rather than swallow. Also thrown on **either**
+   *   setting when the flag exists but cannot be read — see [isFlagAbsence] for why `auto` does not
+   *   absorb that case.
    * @throws IllegalArgumentException when the property is set to something other than `true` /
    *   `false` / [AUTO] (see [request]).
    */
@@ -174,6 +176,17 @@ object LinkBufferComposer {
     }
       .mapCatching { it.getDeclaredField(FLAG_FIELD) }
       .getOrElse { failure ->
+        if (!isFlagAbsence(failure)) {
+          throw IllegalStateException(
+            "compose-preview: -D$PROPERTY=${request.name.lowercase()} was requested, and " +
+              "$FLAGS_CLASS.$FLAG_FIELD could not be read on this render's Compose runtime — " +
+              "${failure::class.java.name}. That is not the version floor $AUTO degrades for, so " +
+              "it fails the render on either setting: a half-resolved Compose classpath or a " +
+              "reflection policy blocking the assignment would otherwise be reported as 'this " +
+              "runtime is too old' and quietly rendered on the old composer.",
+            failure,
+          )
+        }
         if (request == Request.Preferred) return Outcome.Unavailable
         throw IllegalStateException(
           "compose-preview: -D$PROPERTY=true was requested, but this render's Compose runtime " +
@@ -189,6 +202,25 @@ object LinkBufferComposer {
     field.setBoolean(/* obj= */ null, true)
     return Outcome.Enabled
   }
+
+  /**
+   * Whether [failure] means "this runtime does not have the flag" — the one thing [AUTO] is allowed
+   * to degrade for.
+   *
+   * Exactly two signals qualify: the class is not on this render's classpath
+   * ([ClassNotFoundException], a Compose below 1.11.0) or it is there without the field
+   * ([NoSuchFieldException], the 1.9.5 / 1.10.x shape, and the shape a post-migration Compose that
+   * dropped the flag will have again). Both describe a version, which is what the degrade notice
+   * tells the reader.
+   *
+   * Everything else is a different problem wearing the same clothes: a [LinkageError] or a failing
+   * static initializer from a half-resolved Compose classpath, or a `SecurityException` from a
+   * reflection policy. Those runtimes may well *have* the flag, so degrading on them would render
+   * the old composer under a message blaming the Compose version, drop the real cause, and leave an
+   * A/B run quietly answering a question nobody asked. They fail the render on `auto` too.
+   */
+  private fun isFlagAbsence(failure: Throwable): Boolean =
+    failure is ClassNotFoundException || failure is NoSuchFieldException
 
   private val announced = java.util.concurrent.atomic.AtomicBoolean(false)
 

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/LinkBufferComposerTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/LinkBufferComposerTest.kt
@@ -30,6 +30,16 @@ private class FlagsClassLoader(private val fieldName: String = LinkBufferCompose
     defined.getDeclaredField(fieldName).also { it.isAccessible = true }.getBoolean(null)
 }
 
+/**
+ * A runtime that *has* the flag holder but cannot produce it — the half-resolved Compose classpath
+ * shape. Distinct from `ClassLoader(null)`, which reports honest absence.
+ */
+private class BrokenFlagsClassLoader : ClassLoader(null) {
+  override fun loadClass(name: String, resolve: Boolean): Class<*> =
+    if (name == LinkBufferComposer.FLAGS_CLASS) throw LinkageError("half-resolved runtime")
+    else super.loadClass(name, resolve)
+}
+
 class LinkBufferComposerTest {
 
   @Test
@@ -128,6 +138,26 @@ class LinkBufferComposerTest {
       LinkBufferComposer.applyIfRequested(loader, LinkBufferComposer.AUTO),
     )
     assertTrue(loader.flagValue())
+  }
+
+  /**
+   * `auto` degrades for a version floor, not for anything that happens to throw. A runtime that has
+   * the flag but cannot hand it over may well be able to *set* it, so absorbing that would render
+   * the old composer under a notice blaming the Compose version and throw the real cause away.
+   */
+  @Test
+  fun autoStillFailsWhenTheFlagCannotBeReadRatherThanIsAbsent() {
+    for (raw in listOf(LinkBufferComposer.AUTO, "true")) {
+      val failure = runCatching {
+        LinkBufferComposer.applyIfRequested(BrokenFlagsClassLoader(), raw)
+      }
+        .exceptionOrNull()
+
+      assertTrue("$raw should fail, not degrade", failure is IllegalStateException)
+      // Names the real cause instead of asserting a version floor that was never established.
+      assertTrue(failure!!.message!!.contains("LinkageError"))
+      assertTrue(failure.cause is LinkageError)
+    }
   }
 
   @Test

--- a/docs/LINK_BUFFER_COMPOSER.md
+++ b/docs/LINK_BUFFER_COMPOSER.md
@@ -69,6 +69,13 @@ What `auto` drops is the build failure, not the report. Reach for `true` when th
 the *point* of the run — an A/B, or a bisect — and a module quietly sitting it out would invalidate
 the answer.
 
+`auto` degrades for a **version floor and nothing else**: the flag's class missing from the render
+classpath, or present without the field. A runtime that *has* the flag but cannot hand it over — a
+half-resolved Compose classpath throwing `LinkageError`, a reflection policy throwing
+`SecurityException` — fails the render on `auto` too, naming the real cause. Absorbing those would
+render the old composer under a notice blaming the Compose version, which is a misdiagnosis rather
+than a fallback.
+
 | Where | Form | Note |
 | --- | --- | --- |
 | One run, command line | `-PcomposePreview.linkBufferComposer=true\|auto\|false` | **In this repo pass `false`** for the old composer — `auto` is already the default |


### PR DESCRIPTION
Follow-up to #4099 — this review point arrived just before that PR auto-merged, so it lands separately.

## The problem

`auto` decided "this runtime does not have the flag" from `runCatching`, which catches every `Throwable` off `Class.forName` + `getDeclaredField`. So all of these became `Outcome.Unavailable`:

- a half-resolved Compose classpath throwing `LinkageError`
- a failing static initializer (`ExceptionInInitializerError`)
- a reflection policy throwing `SecurityException`

In each case the render continued on the old composer, printed a notice blaming the *Compose version*, and discarded the real cause. The `SecurityException` case is the worst of them: the flag may well exist and be settable, so an A/B run would quietly answer a question nobody asked — the exact failure mode `LinkBufferComposer`'s strictness exists to prevent, reintroduced through the degrade path.

## The fix

The degrade is now restricted to the two signals that actually mean absence:

| Signal | Meaning |
| --- | --- |
| `ClassNotFoundException` | class not on the render classpath — Compose below 1.11.0 |
| `NoSuchFieldException` | class present without the field — the 1.9.5 / 1.10.x shape, and the shape a post-migration Compose that drops the flag will have again |

Both describe a *version*, which is what the degrade notice tells the reader. Anything else fails the render on `auto` as well as on `true`, naming the real exception type and carrying it as the cause.

## Test plan

The regression risk here is breaking what #4099 just fixed, so that was checked against the real runtime rather than a synthesized one:

- `./gradlew :samples:sdk-matrix:composePreviewRender --rerun` — Compose 1.9.x, i.e. the genuine `NoSuchFieldException` path. **BUILD SUCCESSFUL**, still degrades, notice still on the console.
- `./gradlew :data-render-core:test :gradle-plugin:test ktfmtCheckAll` — green. New test drives a classloader that throws `LinkageError` for the flag holder and asserts both `auto` and `true` fail, that the message names `LinkageError`, and that the cause is preserved.

Text-only: build-time behaviour, no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxLTzz2N5LQP5C7HkSUejg)_