### PR TITLE
fix(ci): refresh the design-artifacts driver pin to v1.12.0

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -405,7 +405,7 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -477,7 +477,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -490,7 +490,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Do not honor a caller-controlled ref here: refs/pull/* in this repo
           # can contain fork code, and this privileged workflow executes the driver.
-          ref: 62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
+          ref: c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
           path: compose-ai-tools
           persist-credentials: false
 
@@ -713,7 +713,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -728,7 +728,7 @@ jobs:
           repository: yschimke/compose-ai-tools
           # Never execute a caller-selected refs/pull/* revision in this
           # privileged workflow. Update this alongside the other driver pin.
-          ref: 62008800ae1c15be95b9a8f891e7261f431d2fdf # live module bundles at 2026-08-16
+          ref: c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
           path: compose-ai-tools
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

`design-artifacts-reusable.yml` pins the privileged export driver — and the three `install` action refs beside it — to an immutable SHA, deliberately, so the workflow never executes a movable ref. That pin was `6200880` ("support live bundles across all modules", #4080), which calls `bundleModulePath` in `generate-design-catalog.mjs` without importing it, so every run of the workflow died in `generate`:

```
scripts/design-artifacts/generate-design-catalog.mjs:1351
    module: bundleModulePath(moduleRecords[0].bundle),
            ^
ReferenceError: bundleModulePath is not defined
```

#4103 added the missing import, but a pinned driver does not pick a `main` fix up on its own — the pin has to move. All five refs go to `c990303` = `v1.12.0`, the first release carrying the import. Same shape as #4079 / #4084 / #4085.

This is not only a downstream problem. Both sides are red on it right now:

- this repo's own delivery-branch renders — `wear-m3` and `remote-m3` in run [32018634738](https://github.com/yschimke/compose-ai-tools/actions/runs/32018634738), which is the push that *landed* #4103 and still failed, because the driver comes from the pin rather than from the pushed tree;
- m3-catalog's Design Artifacts, run [32022538804](https://github.com/yschimke/m3-catalog/actions/runs/32022538804) plus the two before it.

It also matters for the release in flight: `post-release-design-artifacts.yml` republishes every bundle against the newly released runtime, and with the old pin that chain fails in `generate` for all three systems. Once this lands, that regeneration wants a re-dispatch.

## Test plan

- `bundleModulePath` is exported by `multi-module-catalog.mjs:12` and imported by `generate-design-catalog.mjs:146` at the new pin; at the old pin the import is absent while all three call sites (338, 1351, 1401) are present — that is the whole failure.
- `v1.12.0` resolves to `c9903031d28b7a3d6e5f53f159ec1d3155f2ff59`, which is `main`'s tip and contains `9ca91f7` (#4103).
- Workflow YAML parses; the change is five ref/comment lines and nothing else.
- End-to-end proof is a real render, which only runs post-merge: re-dispatch **Design Artifacts** here and in m3-catalog (it calls this workflow at `@main`) and confirm `generate` gets past the line that has been failing all morning.

## Not in this PR

Nothing statically checks the driver scripts for undefined identifiers — there is no eslint (or equivalent `no-undef`) pass over `scripts/design-artifacts/**`, and no `node --test` case covers the multi-module `generate` path, which is why a one-line missing import stopped three delivery branches and a consumer repo instead of failing in CI here. Worth closing separately; it needs new lint infrastructure rather than a pin bump.