### PR TITLE
fix(serve): keep the motion lease safe under cancellation and unknown ids

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1366,16 +1366,31 @@ class ServeHttpServer(
    * callers distinguish. [block] runs on [Dispatchers.IO]: reading a published asset can miss the
    * staged copy and go to the delivery branch, and that is a network round trip which must not run
    * on a request thread.
+   *
+   * **Resumes, but never creates.** [ServeSessionRegistry.lease] falls through to the session
+   * factory for an id it doesn't know, which in project mode with `--revisions` means checking out
+   * a ref and running a Gradle build. That is the right behaviour for a render — the whole point of
+   * a revision session — and exactly wrong here, where a revision host has no published captures
+   * and the request can only end in 404 anyway. Gating on [isKnownSession] keeps what the fix is
+   * for (an already-registered catalog that went idle) without turning a published-asset lane into
+   * a way to make a stranger's server build arbitrary refs.
    */
   private suspend fun <T> RoutingContext.withLeasedSessionOrNull(
     sessionId: String,
     block: (ServeHost) -> T?,
   ): T? {
+    if (!sessions.isKnownSession(sessionId)) return null
     val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) } ?: return null
     return try {
       withContext(Dispatchers.IO) { block(lease.host) }
     } finally {
-      withContext(Dispatchers.IO) { lease.close() }
+      // Called directly, NOT through `withContext`. `Lease.close` is a non-suspending
+      // compare-and-set, and a `withContext` in a `finally` is skipped outright once the job is
+      // cancelled — which is precisely when this matters, since a client that disconnects during
+      // the branch fetch cancels here. A skipped release leaves the lease count permanently
+      // elevated, and a session with an open lease is never suspended: one aborted request would
+      // pin that catalog's daemon resident for the life of the process.
+      lease.close()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -766,6 +766,46 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `the motion lane resumes a known session but never forks an unknown one`() {
+    // Leasing falls through to the session factory for an unknown id, which in project mode with
+    // `--revisions` checks out a ref and runs a Gradle build. A revision host publishes no
+    // captures, so such a request can only 404 — after paying for the build. The lane must resume
+    // what is already registered and refuse everything else.
+    val forked = mutableListOf<String>()
+    val factoryRegistry =
+      ServeSessionRegistry(
+        open = { null },
+        factory =
+          ServeSessionFactory { id ->
+            forked += id
+            null
+          },
+      )
+    factoryRegistry.register("default-mod", host = bundle("default-mod"), pinned = true)
+    val factoryServer =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = factoryRegistry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+        )
+        .also { it.start() }
+    try {
+      val req =
+        Request.Builder()
+          .url("http://127.0.0.1:${factoryServer.port}/some-unknown-ref/motion/anything.apng")
+          .build()
+      client.newCall(req).execute().use { r -> assertEquals(404, r.code) }
+      assertTrue(forked.isEmpty(), "the lane must not fork a session to answer 404: $forked")
+    } finally {
+      factoryServer.stop()
+      factoryRegistry.close()
+    }
+  }
+
+  @Test
   fun `a failed optional catalog does not block readiness`() {
     val partialRegistry = ServeSessionRegistry(open = { null })
     partialRegistry.register("default-mod", host = bundle("partial-default"), pinned = true)


### PR DESCRIPTION
Follow-up to #4110, which merged before these two landed. Both were raised in review there by @chatgpt-codex-connector, and both are in the `withLeasedSessionOrNull` helper that PR introduced — so this is cleaning up after my own change, not a pre-existing defect.

## The lease could leak on client disconnect

It was released through `withContext(Dispatchers.IO)` inside a `finally`. `Lease.close` is a non-suspending compare-and-set, so the context switch bought nothing — and a `withContext` in a `finally` is skipped outright once the job is cancelled. That is exactly the case that matters here: a client disconnecting during the delivery-branch fetch cancels the request coroutine.

The consequence is not a one-off leak. A session holding a lease is never suspended, so a single aborted request would pin that catalog's daemon resident for the life of the process. Closed directly instead.

## Leasing could fork a session, not just resume one

`ServeSessionRegistry.lease` falls through to the session factory for an id it doesn't know, which in project mode with `--revisions` means checking out a ref and running a Gradle build. A revision host publishes no captures, so `/some-ref/motion/x.apng` could only ever 404 — after paying for that build.

The `peekHost` this replaced never forked, so #4110 introduced this. Gated on `isKnownSession`, which preserves what the fix was actually for — resuming an already-registered catalog that the idle timer suspended — and nothing else.

## Test plan

```
./gradlew :cli:test                                     # full CLI suite, green
./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest       # green
```

New test verified red without the guard:

```
ServeHttpRoutingTest - the motion lane resumes a known session but never forks an unknown one() FAILED
```

The cancellation fix has no accompanying test: reproducing it needs a client that disconnects mid-fetch while the branch read blocks, which the current fixtures have no seam for. The change is a strict simplification — a direct call replacing a context switch that was never needed — so I judged the test scaffolding disproportionate. Say the word if you'd rather have it covered.

## Note on a sibling

The pre-existing `withLeasedSession` (the suspend-block variant used by roughly twenty routes) has the same `withContext(Dispatchers.IO) { lease.close() }` in its `finally`, so it carries the same cancellation hazard. I have deliberately **not** touched it here — it is on a much broader blast radius and deserves its own change with its own testing rather than riding along on a motion-lane follow-up. Worth a separate issue.

Text-only PR: no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_