### PR TITLE
fix(ci): stop the export-driver pin needing a hand-written PR

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -95,6 +95,7 @@
     "actions_tests": [
       ".github/actions/**",
       ".github/ci/**",
+      ".github/design-artifacts-driver-pin.txt",
       ".github/scripts/**",
       ".github/workflows/**",
       "scripts/design-artifacts/**",

--- a/.github/ci/test_path_scope.py
+++ b/.github/ci/test_path_scope.py
@@ -69,6 +69,18 @@ class RepositoryConfigsTest(unittest.TestCase):
         )
         self.assertFalse(any(result.values()))
 
+    def test_driver_pin_bump_runs_only_the_actions_validator(self):
+        # The export-driver pin bump is opened unattended after every release and
+        # is three lines of a data file. It matched no group and no ignore rule
+        # when it was introduced, which put it on the unknown-path fail-open route
+        # and ran the entire build suite on a routine release bump.
+        result = mod.decide(
+            [".github/design-artifacts-driver-pin.txt"], self.load("ci-paths.json")
+        )
+        self.assertEqual(
+            [group for group, on in result.items() if on], ["actions_tests"]
+        )
+
     def test_cli_change_selects_cli_and_affected_module_tests(self):
         result = mod.decide(
             ["cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt"],

--- a/.github/design-artifacts-driver-pin.txt
+++ b/.github/design-artifacts-driver-pin.txt
@@ -1,0 +1,39 @@
+# Which commit of compose-ai-tools' export driver (scripts/design-artifacts/)
+# external callers of design-artifacts-reusable.yml execute.
+#
+# WHY THIS IS A DATA FILE AND NOT A LINE IN THE WORKFLOW
+# -----------------------------------------------------
+# It has to be machine-writable after a release, and `GITHUB_TOKEN` cannot push
+# changes to anything under `.github/workflows/`: the App token needs a
+# `workflows` permission that is not one of the scopes a `permissions:` block can
+# request, so the push is rejected outright. Keeping the pin here is what lets
+# `refresh-driver-pin.yml` open the bump PR at all.
+#
+# What the pin still buys, unchanged: the privileged workflow executes an
+# immutable, release-blessed commit rather than a caller-selected `refs/pull/*`
+# revision that can carry fork code. That is the boundary it exists for.
+#
+# What moving it here costs: the workflow reads this file from `main`, so a
+# caller that pinned the WORKFLOW to a tag or SHA now tracks the newest pin
+# rather than the one frozen at their revision. While the pin was a literal in
+# the workflow, such a caller was fully reproducible. For the documented `@main`
+# usage (see the top of design-artifacts-reusable.yml and
+# docs/design/DESIGN_CATALOGS.md) nothing changes at all — the same people who
+# could already change the workflow under that caller are the ones who can
+# change this file.
+#
+# That gap is not currently closable: a reusable workflow cannot learn its own
+# revision from the `github` context, and the claim that does name it
+# (`job_workflow_sha`) exists only in an OIDC token, which every caller would
+# have to grant `id-token: write` to reach. The `driver` job carries the full
+# reasoning and the escape hatch if a pinned caller ever needs one.
+#
+# compose-ai-tools' own runs never read this: for that caller the workflow uses
+# the commit the run is on, so a driver fix merged to `main` applies immediately.
+#
+# Maintained by .github/scripts/refresh-driver-pin.sh, which is run for you by
+# .github/workflows/refresh-driver-pin.yml after each release. `--check` (run by
+# ci.yml) enforces the shape below, so keep the three keys and their spelling.
+sha=c9903031d28b7a3d6e5f53f159ec1d3155f2ff59
+tag=v1.12.0
+date=2026-08-17

--- a/.github/scripts/driver-pin-pr-body.md
+++ b/.github/scripts/driver-pin-pr-body.md
@@ -1,0 +1,27 @@
+## Summary
+
+Moves the export-driver pin in `.github/design-artifacts-driver-pin.txt` from
+`@BEFORE@` to `@SHA@` = **@TAG@**.
+
+External callers of that workflow execute the pinned revision of
+compose-ai-tools' `scripts/design-artifacts/`, so until this lands they keep
+running the driver from the previous release — including any fix this repo has
+already merged. Opened automatically on the tail of the @TAG@ release by
+`refresh-driver-pin.yml` (issue #4107), rather than waiting for a downstream
+failure to prompt a hand-written bump.
+
+compose-ai-tools' own catalogs are unaffected either way: the driver revision
+resolves to the caller commit for this repository, so this PR only changes what
+external consumers run.
+
+## Test plan
+
+- `.github/scripts/refresh-driver-pin.sh --check` passes on the result — run in
+  the workflow that opened this, and again by `ci`.
+- `@TAG@` resolves to `@SHA@`, verified against the GitHub API in that run.
+- The diff is the pin file only — nothing under `.github/workflows/`, which
+  `GITHUB_TOKEN` may not push to.
+
+> Opened by a workflow authenticated with `GITHUB_TOKEN`, whose pushes do not
+> start workflow runs — so PR checks will not report until someone pushes to the
+> branch or closes and reopens it.

--- a/.github/scripts/refresh-driver-pin.sh
+++ b/.github/scripts/refresh-driver-pin.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Refresh (or verify) the design-artifacts export-driver pin.
+#
+# WHY THIS EXISTS
+# ---------------
+# `design-artifacts-reusable.yml` is a privileged workflow that other repos call,
+# so the compose-ai-tools revision it executes is pinned to an immutable commit
+# rather than a movable ref. The consequence is that a fix merged to `main` does
+# not reach any external consumer until the pin moves, and moving the pin was a
+# hand-written PR every time: #4079, #4084, #4085, #4106 are four of them, each
+# one authored only AFTER a consumer's CI went red on a bug this repo had already
+# fixed. Issue #4107 is that loop.
+#
+# The pin can only ever be "the newest release", and resolving a tag to a commit
+# is mechanical, so this script owns the edit and `refresh-driver-pin.yml` runs
+# it on the tail of every release.
+#
+# The pin lives in a data file rather than in the workflow because `GITHUB_TOKEN`
+# cannot push changes under `.github/workflows/` — see the header of the pin file
+# itself for why that is trust-neutral.
+#
+# It also cannot be folded into release-please's `extra-files`: the pin has to
+# name the release COMMIT, which is the squash of the release PR and so does not
+# exist until after that PR merges. Post-release is the earliest any mechanism
+# can know it.
+#
+# USAGE
+#   refresh-driver-pin.sh --check                 verify the pin file's shape
+#   refresh-driver-pin.sh --print                 print the currently pinned SHA
+#   refresh-driver-pin.sh --tag vX.Y.Z --sha <40-hex> [--date YYYY-MM-DD]
+
+set -euo pipefail
+
+FILE="${DRIVER_PIN_FILE:-.github/design-artifacts-driver-pin.txt}"
+
+die() {
+  echo "refresh-driver-pin: $*" >&2
+  exit 1
+}
+
+mode=''
+tag=''
+sha=''
+date="$(date -u +%Y-%m-%d)"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check) mode=check ;;
+    --print) mode=print ;;
+    --tag) tag="${2:?--tag needs a value}"; mode="${mode:-write}"; shift ;;
+    --sha) sha="${2:?--sha needs a value}"; mode="${mode:-write}"; shift ;;
+    --date) date="${2:?--date needs a value}"; shift ;;
+    --file) FILE="${2:?--file needs a value}"; shift ;;
+    -h|--help) sed -n '28,32p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+[ -n "${mode}" ] || die "one of --check / --print / --tag+--sha is required"
+[ -f "${FILE}" ] || die "no such file: ${FILE}"
+
+# Read one `key=value` line, ignoring comments. A key that appears twice is an
+# error rather than a last-one-wins guess: the workflow reads this file with a
+# `sed` that takes the FIRST match, so a duplicate would make the two disagree.
+read_key() {
+  local key="$1" out
+  out="$(sed -nE "s/^${key}=(.*)$/\\1/p" "${FILE}")"
+  [ "$(printf '%s\n' "${out}" | grep -c .)" -eq 1 ] \
+    || die "expected exactly one '${key}=' line in ${FILE}"
+  printf '%s' "${out}"
+}
+
+current_sha="$(read_key sha)"
+current_tag="$(read_key tag)"
+current_date="$(read_key date)"
+
+validate() {
+  printf '%s' "$1" | grep -qE "$2" || die "$3"
+}
+
+case "${mode}" in
+  print)
+    validate "${current_sha}" '^[0-9a-f]{40}$' "pinned sha is not a 40-hex commit: '${current_sha}'"
+    echo "${current_sha}"
+    ;;
+
+  check)
+    # The workflow's `sed -nE 's/^sha=([0-9a-f]{40})$/\1/p'` matches nothing if the
+    # SHA is abbreviated or upper-case, and the run then fails closed at the
+    # 40-hex guard — after the caller has already paid for a checkout and a JDK.
+    # Catch the shape here instead, on every PR.
+    validate "${current_sha}" '^[0-9a-f]{40}$' "pinned sha is not a lower-case 40-hex commit: '${current_sha}'"
+    validate "${current_tag}" '^v[0-9]+\.[0-9]+\.[0-9]+$' "pinned tag is not vX.Y.Z: '${current_tag}'"
+    validate "${current_date}" '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' "pin date is not YYYY-MM-DD: '${current_date}'"
+    echo "driver pin OK: ${current_sha} (${current_tag}, pinned ${current_date})"
+    ;;
+
+  write)
+    [ -n "${tag}" ] || die "--tag is required to rewrite the pin"
+    [ -n "${sha}" ] || die "--sha is required to rewrite the pin"
+    validate "${tag}" '^v[0-9]+\.[0-9]+\.[0-9]+$' "tag must look like vX.Y.Z, got '${tag}'"
+    validate "${sha}" '^[0-9a-f]{40}$' "sha must be a lower-case 40-hex commit, got '${sha}'"
+    validate "${date}" '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' "date must be YYYY-MM-DD, got '${date}'"
+
+    if [ "${sha}" = "${current_sha}" ]; then
+      echo "driver pin already at ${sha} (${current_tag}) — nothing to do"
+      exit 0
+    fi
+
+    sed -E -i \
+      -e "s|^sha=.*$|sha=${sha}|" \
+      -e "s|^tag=.*$|tag=${tag}|" \
+      -e "s|^date=.*$|date=${date}|" \
+      "${FILE}"
+
+    # Re-read rather than trust the substitution: a rewrite that silently missed
+    # a key would otherwise ship a pin file whose sha and tag disagree.
+    [ "$(read_key sha)" = "${sha}" ] && [ "$(read_key tag)" = "${tag}" ] \
+      && [ "$(read_key date)" = "${date}" ] \
+      || die "rewrite did not converge"
+
+    echo "driver pin ${current_sha} (${current_tag}) -> ${sha} (${tag})"
+    ;;
+esac

--- a/.github/scripts/test-refresh-driver-pin.sh
+++ b/.github/scripts/test-refresh-driver-pin.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Self-test for refresh-driver-pin.sh.
+#
+# The pin decides which revision of compose-ai-tools other people's CI executes,
+# and it is rewritten unattended on the tail of a release. Every failure mode is
+# quiet: a half-applied rewrite ships a file whose sha and tag disagree, and a
+# malformed SHA does not fail until a consumer's run has already paid for a
+# checkout and a JDK. Both are gated here, as is the exact regex the workflow
+# uses to read the file — if those two ever disagree the pin silently stops
+# resolving.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+SCRIPT=".github/scripts/refresh-driver-pin.sh"
+REAL=".github/design-artifacts-driver-pin.txt"
+WORKFLOW=".github/workflows/design-artifacts-reusable.yml"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+pass=0
+fail=0
+ok() { echo "  ok: $*"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $*" >&2; fail=$((fail + 1)); }
+
+OLD=1111111111111111111111111111111111111111
+NEW=2222222222222222222222222222222222222222
+
+fixture() {
+  cat > "$1" <<EOF
+# a comment, and a blank line follow
+
+sha=${OLD}
+tag=v1.0.0
+date=2026-01-01
+EOF
+}
+
+echo "== --check accepts a well-formed pin file"
+f="${tmp}/good.txt"
+fixture "${f}"
+"${SCRIPT}" --file "${f}" --check >/dev/null && ok "well-formed file passes" || bad "well-formed file rejected"
+
+echo "== --print reports the pinned SHA"
+got="$("${SCRIPT}" --file "${f}" --print)"
+[ "${got}" = "${OLD}" ] && ok "--print => ${got}" || bad "--print => ${got}, want ${OLD}"
+
+echo "== --check rejects malformed values"
+for mutate in "s/^sha=.*/sha=c990303/" "s/^sha=.*/sha=$(printf '%040d' 0 | tr 0 A)/" "s/^tag=.*/tag=1.12.0/" "s/^date=.*/date=17-08-2026/"; do
+  f2="${tmp}/bad.txt"; fixture "${f2}"; sed -i "${mutate}" "${f2}"
+  if "${SCRIPT}" --file "${f2}" --check >/dev/null 2>&1; then bad "accepted: ${mutate}"; else ok "rejected: ${mutate}"; fi
+done
+
+echo "== a duplicated key is an error, not last-one-wins"
+f2="${tmp}/dup.txt"; fixture "${f2}"; echo "sha=${NEW}" >> "${f2}"
+if "${SCRIPT}" --file "${f2}" --check >/dev/null 2>&1; then bad "duplicate sha accepted"; else ok "duplicate sha rejected"; fi
+
+echo "== a missing key is an error"
+f2="${tmp}/missing.txt"; fixture "${f2}"; sed -i "/^tag=/d" "${f2}"
+if "${SCRIPT}" --file "${f2}" --check >/dev/null 2>&1; then bad "missing tag accepted"; else ok "missing tag rejected"; fi
+
+echo "== a rewrite moves all three keys and keeps the comments"
+f="${tmp}/write.txt"
+fixture "${f}"
+"${SCRIPT}" --file "${f}" --tag v2.3.4 --sha "${NEW}" --date 2026-05-06 >/dev/null
+[ "$(sed -nE 's/^sha=(.*)/\1/p' "${f}")" = "${NEW}" ] && ok "sha moved" || bad "sha not moved"
+[ "$(sed -nE 's/^tag=(.*)/\1/p' "${f}")" = "v2.3.4" ] && ok "tag moved" || bad "tag not moved"
+[ "$(sed -nE 's/^date=(.*)/\1/p' "${f}")" = "2026-05-06" ] && ok "date moved" || bad "date not moved"
+grep -q "^# a comment" "${f}" && ok "comments preserved" || bad "comments lost"
+"${SCRIPT}" --file "${f}" --check >/dev/null && ok "rewritten file passes --check" || bad "rewritten file fails --check"
+
+echo "== rewriting to the SHA already pinned is a no-op"
+before="$(cat "${f}")"
+"${SCRIPT}" --file "${f}" --tag v2.3.4 --sha "${NEW}" --date 2026-09-09 >/dev/null
+[ "${before}" = "$(cat "${f}")" ] && ok "no-op left the file byte-identical" || bad "no-op modified the file"
+
+echo "== malformed arguments are refused"
+for args in "--tag v1 --sha ${NEW}" "--tag v1.2.3 --sha deadbeef" "--tag v1.2.3 --sha ${NEW} --date 6/5/2026"; do
+  # shellcheck disable=SC2086
+  if "${SCRIPT}" --file "${f}" ${args} >/dev/null 2>&1; then bad "accepted: ${args}"; else ok "refused: ${args}"; fi
+done
+
+echo "== the workflow's own reader agrees with this script"
+# The exact pipeline from the "Resolve the export-driver revision" step. If the
+# workflow's regex and --check ever drift, the pin resolves to empty at runtime
+# and every external caller fails after paying for a checkout.
+workflow_read() { sed -nE 's/^sha=([0-9a-f]{40})$/\1/p' "$1" | head -n1; }
+[ "$(workflow_read "${REAL}")" = "$("${SCRIPT}" --print)" ] \
+  && ok "workflow regex and --print agree on the real pin" \
+  || bad "workflow regex and --print disagree"
+grep -qF "s/^sha=([0-9a-f]{40})\$/\\1/p" "${WORKFLOW}" \
+  && ok "workflow still uses the regex this test pins" \
+  || bad "workflow's pin regex changed — update this test and re-verify"
+
+echo "== the real pin file is well-formed"
+"${SCRIPT}" --check >/dev/null && ok "${REAL} passes --check" || bad "${REAL} fails --check"
+
+echo
+echo "${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1230,6 +1230,15 @@ jobs:
         run: ./.github/scripts/test-comment-release-milestone.sh
       - name: Run PR run reaper tests
         run: node --test .github/scripts/reap-pr-runs.test.mjs
+      # The export-driver pin decides which revision of this repo other people's CI
+      # executes, and it is rewritten unattended after each release. Both failure
+      # modes are quiet: sites drifting apart means two jobs in one run render with
+      # different drivers, and a pin the rewrite regex no longer matches freezes
+      # silently while the release workflow still reports success.
+      - name: Check the design-artifacts driver pin
+        run: .github/scripts/refresh-driver-pin.sh --check
+      - name: Run driver-pin refresh tests
+        run: ./.github/scripts/test-refresh-driver-pin.sh
 
   # The design-artifacts driver's own `node --test` suite, including the browser tests that drive the
   # built Remote Compose player bundle (`cli/src/main/resources/rc-player/bundle.js`) in headless

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -98,7 +98,7 @@ on:
       # Same CodeQL "privileged checkout" note as `ref` above — the default is a
       # literal and no caller in this repo overrides it.
       driver-ref:
-        description: 'Deprecated compatibility input. The privileged export driver is commit-pinned by this workflow and caller-supplied refs are ignored.'
+        description: 'Deprecated compatibility input. The privileged export driver revision is decided by this workflow — the immutable release commit in .github/design-artifacts-driver-pin.txt for external callers, the caller commit for compose-ai-tools itself — and caller-supplied refs are ignored.'
         required: false
         type: string
         default: 'main'
@@ -345,7 +345,126 @@ env:
   SOURCE_REPOSITORY: ${{ github.repository }}
   SOURCE_REF_NAME: ${{ github.ref_name }}
 
+  # Which revision of compose-ai-tools' `scripts/design-artifacts/` this privileged
+  # workflow executes is resolved per-run by the "Resolve the export-driver
+  # revision" step before each driver checkout. Two answers, because the callers
+  # are in two different trust positions and were being served the wrong one:
+  #
+  #  * EXTERNAL callers get the immutable release commit recorded in
+  #    `.github/design-artifacts-driver-pin.txt`. A caller repo must not be able to
+  #    steer this workflow at a `refs/pull/*` revision of ours, which can carry
+  #    fork code. That constraint is what the pin is for and it is unchanged.
+  #
+  #  * compose-ai-tools ITSELF gets the commit the caller run is on. Its own
+  #    catalogs are supposed to publish HEAD's output — `cli-source: build` exists
+  #    precisely to render against HEAD's renderer — but the driver beside that CLI
+  #    came from the pin, so HEAD's renderer was being driven by a release-old
+  #    driver. A fix merged to `main` therefore did NOT reach our own delivery
+  #    branches until a release cut AND someone hand-bumped the pin: #4103 fixed a
+  #    missing import, and the very push that landed it still failed in `generate`
+  #    (run 32018634738) until #4106 moved the pin. That round trip is the friction
+  #    issue #4107 is about, and this is the half of it that should never have
+  #    existed. `github.repository` is the CALLER's repo and is not caller-settable,
+  #    so an external repo cannot opt into this branch; design-artifacts.yml (the
+  #    only in-repo caller) runs on schedule / dispatch / push-to-main /
+  #    workflow_call-from-release — no `pull_request` anywhere in the chain, so
+  #    `github.sha` is always a revision a repo writer put there.
+  DRIVER_PIN_REPO: yschimke/compose-ai-tools
+  DRIVER_PIN_PATH: .github/design-artifacts-driver-pin.txt
+
 jobs:
+  # Resolve, ONCE PER RUN, which compose-ai-tools commit this run's export driver
+  # comes from. Every job that checks the driver out reads this job's output, so a
+  # sharded run cannot straddle two drivers.
+  #
+  # That is the whole reason this is a job and not a step. While the revision was a
+  # literal in this file it was automatically consistent — GitHub resolves a
+  # reusable workflow once per run. Reading the pin at runtime reintroduced a
+  # window: `render-shard` reads it before rendering and `generate` would read it
+  # again after every shard finished, ~20 minutes later, so a pin bump landing in
+  # between would merge shard bundles written by the OLD driver with a NEW driver's
+  # merge/verify/export scripts. Automating the bump makes that window likelier to
+  # be hit, not less. Resolving once closes it.
+  #
+  # See the DRIVER_PIN_* env above for the trust argument. In short: an external
+  # caller gets the immutable release commit recorded in the pin file, this repo's
+  # own runs get the commit the run is on, and `github.repository` is the CALLER's
+  # repo and is not settable by a caller, so nobody can opt into the second branch.
+  #
+  # The pin is READ from the pin file rather than written into this workflow
+  # because `GITHUB_TOKEN` cannot push changes under `.github/workflows/` — there
+  # is no `workflows` scope a `permissions:` block can request — so a pin living
+  # here could not be refreshed by the release automation at all. It is read from
+  # `main`, which is exactly what the documented `@main` usage wants and is a
+  # known limitation for a caller that pinned this workflow to a tag — see the
+  # `driver` job for why that cannot currently be closed. Nothing from the pin
+  # file is executed; it names a commit, and the commit is what gets checked out.
+  driver:
+    name: ${{ inputs.system }} · driver
+    # The caller's runner, like every other job here. Hardcoding ubuntu-latest
+    # would queue forever (or be rejected) for a caller on self-hosted labels —
+    # and because every checkout job now needs this one, it would take the whole
+    # pipeline down with it rather than just itself.
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      ref: ${{ steps.driver.outputs.ref }}
+    steps:
+      - id: driver
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CALLER: ${{ github.repository }}
+          CALLER_SHA: ${{ github.sha }}
+          PIN_REF: main
+        run: |
+          set -euo pipefail
+          if [ "${CALLER}" = "${DRIVER_PIN_REPO}" ]; then
+            ref="${CALLER_SHA}"
+            echo "caller is ${DRIVER_PIN_REPO}; driving with the run's own commit ${ref}"
+          else
+            # KNOWN LIMITATION, and it is deliberate rather than overlooked: the
+            # pin is read from `main`, so a caller that pinned THIS WORKFLOW to a
+            # tag or SHA still tracks the newest pin instead of the one frozen at
+            # their revision. Before the pin became a data file it was a literal
+            # in this file and such a caller was fully reproducible, so this is a
+            # real (if narrow) regression for them.
+            #
+            # There is no supported way to close it. A reusable workflow cannot
+            # learn its OWN revision from the `github` context: `workflow_sha` and
+            # `workflow_ref` describe the ENTRY-POINT workflow — the caller's file
+            # in the caller's repo — and `job_workflow_sha`, which does name this
+            # file, exists only as an OIDC token claim. Reaching it would mean
+            # requesting an id-token, which every caller would have to grant
+            # `id-token: write` for; widening the permissions contract of a
+            # workflow other repos call, to serve callers who are not using it
+            # that way, is the worse trade. (An earlier revision of this PR read
+            # `github.job_workflow_sha` from the context directly — it silently
+            # evaluates to the empty string, so it always fell back here anyway.)
+            #
+            # The documented usage is `@main` (see the block at the top of this
+            # file and docs/design/DESIGN_CATALOGS.md), which this serves exactly.
+            # If a pinned caller ever needs frozen driver semantics, the way to
+            # give it to them is a `v*`-tag-constrained input naming the ref to
+            # read the pin from — constrained so a caller still cannot point it at
+            # a refs/pull/* revision.
+            ref=$(curl -fsSL \
+                    -H "Authorization: Bearer ${GH_TOKEN}" \
+                    -H "Accept: application/vnd.github.raw" \
+                    "${GITHUB_API_URL}/repos/${DRIVER_PIN_REPO}/contents/${DRIVER_PIN_PATH}?ref=${PIN_REF}" \
+                  | sed -nE 's/^sha=([0-9a-f]{40})$/\1/p' | head -n1)
+            echo "external caller; pin read at ${PIN_REF}; driving with ${ref:-<none>}"
+          fi
+          # Fail closed: an empty or malformed value must never reach `checkout`,
+          # where it would silently resolve to the default branch.
+          printf '%s' "${ref}" | grep -qE '^[0-9a-f]{40}$' || {
+            echo "::error::could not resolve a 40-hex export-driver commit (got '${ref}')"
+            exit 1
+          }
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "Export driver: \`${ref}\`" >> "$GITHUB_STEP_SUMMARY"
+
   # ── Sharded render (render-shards > 1) ──────────────────────────────────────────────────────
   # Two jobs that do not exist at all in the default single-shard pipeline. `shard-matrix` only
   # turns the count into a matrix (Actions has no range expression); `render-shard` is the render,
@@ -405,7 +524,13 @@ jobs:
         if: ${{ inputs.cli-source == 'released' }}
         # Security boundary: this privileged reusable workflow must not execute
         # a movable action ref. Dependabot/manual upgrades should update this SHA.
-        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
+        # This is an ORDINARY action pin, in the same category as the
+        # `actions/checkout` SHAs — it deliberately does NOT track releases. It
+        # used to be bumped in lockstep with the export-driver pin, which is what
+        # made a driver fix look like a five-line change; the driver revision is
+        # now resolved separately (see DRIVER_PIN_* at the top of this file) and
+        # this ref only needs to move when the install action itself changes.
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -442,7 +567,7 @@ jobs:
   render-shard:
     name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
     if: ${{ inputs.render-shards > 1 && inputs.module != '' && inputs.modules != 'all' }}
-    needs: [shard-matrix]
+    needs: [driver, shard-matrix]
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -477,7 +602,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same trust boundary as the non-sharded install above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -487,10 +612,10 @@ jobs:
       - name: Check out compose-ai-tools (export driver)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: yschimke/compose-ai-tools
-          # Do not honor a caller-controlled ref here: refs/pull/* in this repo
-          # can contain fork code, and this privileged workflow executes the driver.
-          ref: c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
+          repository: ${{ env.DRIVER_PIN_REPO }}
+          # Never a caller-supplied ref: resolved by the step above, which admits
+          # only a 40-hex commit.
+          ref: ${{ needs.driver.outputs.ref }}
           path: compose-ai-tools
           persist-credentials: false
 
@@ -678,7 +803,7 @@ jobs:
     # Skipped needs are the single-shard path, not a failure: with render-shards at its default the
     # two jobs above never run, and this job must still start. `!cancelled()` plus an explicit
     # failure check is the pattern that distinguishes "skipped" from "broke".
-    needs: [shard-matrix, render-shard]
+    needs: [driver, shard-matrix, render-shard]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -713,7 +838,7 @@ jobs:
       - name: Install compose-preview CLI
         if: ${{ inputs.cli-source == 'released' }}
         # Same immutable trust boundary as the other install steps above.
-        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
+        uses: yschimke/compose-ai-tools/.github/actions/install@c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0
         with:
           version: ${{ inputs.cli-version }}
           catalog-key: ${{ inputs.catalog-key }}
@@ -725,10 +850,10 @@ jobs:
       - name: Check out compose-ai-tools (export driver)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: yschimke/compose-ai-tools
-          # Never execute a caller-selected refs/pull/* revision in this
-          # privileged workflow. Update this alongside the other driver pin.
-          ref: c9903031d28b7a3d6e5f53f159ec1d3155f2ff59 # v1.12.0 at 2026-08-17
+          repository: ${{ env.DRIVER_PIN_REPO }}
+          # Never a caller-supplied ref: resolved by the step above, which admits
+          # only a 40-hex commit.
+          ref: ${{ needs.driver.outputs.ref }}
           path: compose-ai-tools
           persist-credentials: false
 

--- a/.github/workflows/refresh-driver-pin.yml
+++ b/.github/workflows/refresh-driver-pin.yml
@@ -1,0 +1,311 @@
+name: Refresh driver pin
+
+# Open the "move the export-driver pin to the release we just cut" PR, instead of
+# waiting for a consumer's CI to go red and someone to write it by hand.
+#
+# WHY THIS EXISTS
+# ---------------
+# `design-artifacts-reusable.yml` is called by other repos and executes
+# compose-ai-tools' export driver, so for external callers that driver is pinned
+# to an immutable commit (see the DRIVER_PIN_* env block there for the trust
+# argument).
+# The cost of that pin is a standing manual step: until it moves, every external
+# consumer keeps running the driver from an older release, including any bug this
+# repo has already fixed. #4079, #4084, #4085 and #4106 are four hand-written pin
+# bumps, each authored only after the breakage surfaced downstream — #4106 landed
+# a driver fix that had been on `main` since #4103 and was failing three delivery
+# branches plus m3-catalog in the meantime. Issue #4107 is that loop.
+#
+# release-please cannot do this from `extra-files`: the pin has to name the
+# release COMMIT, which is the squash of the release PR itself and does not exist
+# until after that PR merges. Post-release is the earliest anything can know it.
+#
+# The pin lives in `.github/design-artifacts-driver-pin.txt` rather than in the
+# workflow that reads it because `GITHUB_TOKEN` cannot push changes under
+# `.github/workflows/` — the App token needs a `workflows` permission that is not
+# one of the scopes a `permissions:` block can request, so this job's push would
+# be rejected outright. See the pin file's header for why that costs nothing in
+# trust.
+#
+# WHAT THIS DOES NOT FIX
+# ----------------------
+# compose-ai-tools' OWN renders no longer depend on the pin at all — the driver
+# revision resolves to the caller commit for this repository — so a stale pin now
+# only ever delays external consumers, and only for as long as this PR sits
+# unmerged.
+#
+# NOTE: chained on `workflow_run` for the same reason post-release-design-artifacts.yml
+# is — the release chain runs on the default GITHUB_TOKEN, whose events do not
+# start new workflow runs, and `workflow_run` is the one trigger that fires from
+# such a run's completion. Like every `workflow_run` workflow it only fires for
+# the copy on the DEFAULT branch, so changes here take effect once merged and
+# cannot be exercised from a PR branch.
+
+on:
+  workflow_run:
+    workflows: ["Release PR"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to pin to (e.g. v1.12.0). Empty ⇒ the newest published release.'
+        required: false
+        type: string
+        default: ''
+
+permissions: {}
+
+# NOTE: no workflow-level `concurrency`. GitHub keeps only ONE pending run per
+# group and cancels the older pending one — `cancel-in-progress: false` protects
+# the RUNNING run, not the queue. Since "Release PR" completes on every push to
+# `main`, a genuine release refresh sitting pending could be evicted by a
+# no-op run behind it, and the release would silently never get its pin bump
+# (a `workflow_run` fires once; there is no retry). The gate is therefore
+# unserialised — it is a few API calls — and only `refresh`, which pushes the
+# branch, carries a concurrency group.
+
+jobs:
+  # Cheap, unserialised, no checkout: decide whether this run corresponds to a
+  # published release, and to which tag.
+  gate:
+    # "Release PR" completes on every push to main, so most of these runs have
+    # nothing to do; the API gate in `resolve` is what decides, and it costs a few
+    # seconds.
+    #
+    # Deliberately NOT gated on `workflow_run.conclusion == 'success'`, which is
+    # what post-release-design-artifacts.yml uses. In release-please.yml
+    # `finalize-release` publishes the release BEFORE `verify-maven-readiness` and
+    # `reconcile-release-pr` run, so either of those failing marks the whole run a
+    # failure while a perfectly valid release exists. Skipping here on that basis
+    # would strand external callers on the old driver with no second trigger
+    # coming — a `workflow_run` fires once. The API gate is strictly stronger
+    # anyway: it requires the newest PUBLISHED release to point at exactly the
+    # commit this run built, which a draft or a half-finished release cannot
+    # satisfy. Cancelled runs are NOT excluded either: an operator can cancel the
+    # release run after `finalize-release` already published — while the Maven
+    # readiness job is still polling, say — and `workflow_run.head_sha` is still
+    # populated for a cancelled run, so the gate can prove the published release
+    # points at it. Excluding them would strand that release's pin with no second
+    # event coming. Let everything reach the gate and let the gate decide.
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      proceed: ${{ steps.resolve.outputs.proceed }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      # Resolve the tag to pin to, and the commit it points at.
+      #
+      # On workflow_run this doubles as the release gate, in the same shape
+      # post-release-design-artifacts.yml uses: the newest PUBLISHED release must
+      # point at exactly the commit that run built. A draft release — what a
+      # missing-asset failure leaves behind — is invisible to `releases/latest`,
+      # so this fails closed rather than pinning to a half-published release.
+      - id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          proceed=false
+          sha=""
+          tag="${INPUT_TAG}"
+
+          # Every lookup here distinguishes "the API answered, and the answer is
+          # no" from "the API did not answer". Swallowing both with `|| true` made
+          # a transient 5xx / rate-limit / auth blip look exactly like "no release
+          # exists", and the job then SUCCEEDED having done nothing — with no
+          # second chance, because a `workflow_run` fires once per run. Failing on
+          # an API error instead leaves a red job that can simply be re-run.
+          api() {
+            local path="$1" jq="$2" out status
+            set +e
+            out="$(gh api "${path}" --jq "${jq}" 2>/tmp/gh-err)"
+            status=$?
+            set -e
+            if [ "${status}" -ne 0 ]; then
+              if grep -qi 'HTTP 404' /tmp/gh-err; then
+                printf ''
+                return 0
+              fi
+              echo "::error::GitHub API call failed for ${path} — re-run this job." >&2
+              cat /tmp/gh-err >&2
+              exit 1
+            fi
+            printf '%s' "${out}"
+          }
+
+          if [ -z "${tag}" ]; then
+            tag="$(api "repos/${GH_REPO}/releases/latest" '.tag_name')"
+          fi
+
+          if [ -z "${tag}" ]; then
+            echo "no published release — nothing to pin to."
+          else
+            # `git/ref/tags/<tag>` answers with the ref object on an exact match and
+            # an ARRAY of near-misses otherwise; --jq over the array yields nothing,
+            # which lands in the "does not resolve" branch below. Fails closed.
+            ref_pair="$(api "repos/${GH_REPO}/git/ref/tags/${tag}" '.object.sha + " " + .object.type')"
+            sha="${ref_pair%% *}"
+            type="${ref_pair##* }"
+            # release-please's fallback step writes a lightweight ref; an annotated
+            # tag points at a tag object and needs dereferencing to the commit.
+            if [ "${type}" = "tag" ] && [ -n "${sha}" ]; then
+              sha="$(api "repos/${GH_REPO}/git/tags/${sha}" '.object.sha')"
+            fi
+
+            if [ -z "${sha}" ]; then
+              echo "::warning::${tag} does not resolve to a commit — not touching the pin."
+            elif [ "${EVENT}" = "workflow_dispatch" ]; then
+              proceed=true
+            elif [ "${sha}" = "${HEAD_SHA}" ]; then
+              proceed=true
+            else
+              echo "latest release ${tag} points at ${sha}, not ${HEAD_SHA} — not a release run."
+            fi
+          fi
+
+          {
+            echo "proceed=${proceed}"
+            echo "tag=${tag}"
+            echo "sha=${sha:-}"
+          } >> "$GITHUB_OUTPUT"
+
+  # Everything that touches the branch. Serialised, so two releases in quick
+  # succession cannot race for the same branch — and separate from the gate, so a
+  # queued no-op run can never evict a pending release refresh.
+  refresh:
+    needs: gate
+    if: ${{ needs.gate.outputs.proceed == 'true' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: refresh-driver-pin
+      cancel-in-progress: false
+    permissions:
+      contents: write # push the pin-bump branch
+      pull-requests: write # open the PR for it
+    env:
+      TAG: ${{ needs.gate.outputs.tag }}
+      SHA: ${{ needs.gate.outputs.sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A workflow_run run already checks out the default branch; be explicit
+          # so a dispatch from a side branch still bumps the pin on main.
+          ref: main
+          persist-credentials: false
+
+      - name: Rewrite the pin
+        id: rewrite
+        run: |
+          set -euo pipefail
+          before=$(.github/scripts/refresh-driver-pin.sh --print)
+          .github/scripts/refresh-driver-pin.sh --tag "${TAG}" --sha "${SHA}"
+          # --check re-reads the file: a rewrite that produced a malformed pin, or
+          # left sha and tag disagreeing, must not become a PR.
+          .github/scripts/refresh-driver-pin.sh --check
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Pin already at ${SHA} (${TAG}) — nothing to open." >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "changed=true"
+              echo "before=${before}"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open the pin-bump PR
+        if: ${{ steps.rewrite.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          BEFORE: ${{ steps.rewrite.outputs.before }}
+        run: |
+          set -euo pipefail
+
+          # github-actions[bot] only ever authors branch commits, never the
+          # squash-authored main — the house rule in CLAUDE.md.
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # checkout deliberately does not persist its token; wire gh's credential
+          # helper up so the push below uses this job's contents-write token.
+          gh auth setup-git
+
+          # ONE branch for all time, not one per tag. A tag-specific branch let a
+          # second release cut before the first bump merged open a SECOND PR from
+          # the same old pin — both editing the same three lines to different
+          # values, so merging either wedged the other in conflict and left the
+          # newest release needing exactly the manual repair this workflow exists
+          # to delete. A single branch means the newest release always supersedes
+          # the pending one, in place.
+          branch="agent/refresh-driver-pin"
+
+          # Rebuilt from the CURRENT main every run, so a superseded bump never
+          # stacks its predecessor's commit underneath.
+          git checkout -b "${branch}"
+          # Only the pin file. `GITHUB_TOKEN` may not push anything under
+          # `.github/workflows/`, so a stray staged workflow edit would fail the
+          # push rather than being quietly dropped.
+          git add .github/design-artifacts-driver-pin.txt
+          git commit -m "chore(ci): refresh the design-artifacts driver pin to ${TAG}"
+
+          # The branch usually already exists — from a superseded bump, or from a
+          # run that pushed and then failed in `gh pr create`. checkout fetched
+          # only `main`, so there is no remote-tracking ref for it and a bare
+          # --force-with-lease would be refused as "stale info", turning a
+          # recoverable retry into a permanent failure. Fetch it and lease against
+          # what is actually there, so a concurrent writer still wins the race
+          # rather than being clobbered.
+          if git fetch --no-tags origin "${branch}" 2>/dev/null; then
+            lease="$(git rev-parse FETCH_HEAD)"
+            echo "Branch ${branch} exists at ${lease} — superseding it with ${TAG}."
+            git push --force-with-lease="${branch}:${lease}" origin "HEAD:${branch}"
+          else
+            git push origin "HEAD:${branch}"
+          fi
+
+          # The PR body lives in a template file rather than a heredoc: a
+          # heredoc terminator must start at column 0, which cannot happen inside
+          # a YAML block scalar. Placeholders are replaced with `sed`, and the
+          # values are hex SHAs / a vX.Y.Z tag, so no delimiter escaping is needed.
+          sed -e "s|@BEFORE@|${BEFORE}|g" \
+              -e "s|@SHA@|${SHA}|g" \
+              -e "s|@TAG@|${TAG}|g" \
+              .github/scripts/driver-pin-pr-body.md > /tmp/pr-body.md
+
+          # `chore(ci):`, NOT `fix(ci):`. A squash merge uses the PR title as the
+          # commit headline, and release-please cuts a patch release for `fix:`
+          # (docs/RELEASING.md), so a `fix:`-titled bump would make every release
+          # propose another release, whose publish opens another bump. The
+          # hand-written bumps this replaces were all titled `fix(ci):` — #4106 and
+          # friends each cut a release of their own. `chore:` is in the
+          # non-releasing set and still passes the pr-title gate.
+          title="chore(ci): refresh the design-artifacts driver pin to ${TAG}"
+
+          # Force-pushing the branch already updated any open PR's diff; retitle
+          # and rewrite its body so it describes the release it now carries rather
+          # than the superseded one.
+          # `--head` filters by branch NAME and does not accept `owner:branch`, so a
+          # fork PR from an identically-named branch can match. Editing that PR
+          # would also mean skipping `gh pr create`, leaving the branch we just
+          # pushed with no PR at all and consumers on the stale driver. Require a
+          # same-repo head, the way release-pr-heal.yml does.
+          existing="$(gh pr list --head "${branch}" --state open \
+            --json number,isCrossRepository \
+            --jq 'map(select(.isCrossRepository == false)) | .[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            echo "Updating open PR #${existing} to ${TAG}."
+            gh pr edit "${existing}" --title "${title}" --body-file /tmp/pr-body.md
+          else
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "${title}" \
+              --body-file /tmp/pr-body.md
+          fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -41,6 +41,50 @@ Each milestone carries a hidden marker, so re-running a failed **Maven readiness
 
 If a milestone comment never appears, the release itself is unaffected — check the corresponding job. A missing deploy comment usually means the rollout never converged (or the deployer has no `DEPLOY_HOOK_TOKEN`, as on a fork); a missing Maven comment means the readiness job is still polling or failed, which is the thing that actually matters, and is covered under [Fallback paths](#fallback-paths).
 
+## The export-driver pin refreshes itself
+
+[`design-artifacts-reusable.yml`](../.github/workflows/design-artifacts-reusable.yml) is a **privileged workflow other repos call**, and it executes this repo's export driver (`scripts/design-artifacts/`). A caller must not be able to steer it at one of our `refs/pull/*` revisions, which can carry fork code, so for external callers the driver revision is an immutable commit — recorded in [`.github/design-artifacts-driver-pin.txt`](../.github/design-artifacts-driver-pin.txt).
+
+That pin used to be a standing manual step, and it is the friction [#4107](https://github.com/yschimke/compose-ai-tools/issues/4107) was about. Two separate things were wrong with it:
+
+**1. This repo was pinning itself.** `cli-source: build` exists so compose-ai-tools' own catalogs render against HEAD's renderer — but the *driver* beside that CLI still came from the pin, so HEAD's renderer was being driven by a release-old driver. A fix merged to `main` did not reach our own delivery branches until a release cut **and** someone hand-bumped the pin. [#4103](https://github.com/yschimke/compose-ai-tools/pull/4103) fixed a missing import and the very push that landed it still died in `generate`; it took [#4106](https://github.com/yschimke/compose-ai-tools/pull/4106) to move the pin. The driver revision now resolves to **the caller commit when the caller is this repository**, and to the pin for everyone else. `github.repository` is the caller's repo and is not caller-settable, and no `pull_request` trigger exists anywhere in the in-repo call chain, so this does not widen what the workflow will execute.
+
+**2. Moving the pin was a hand-written PR.** [#4079](https://github.com/yschimke/compose-ai-tools/pull/4079), [#4084](https://github.com/yschimke/compose-ai-tools/pull/4084), [#4085](https://github.com/yschimke/compose-ai-tools/pull/4085) and #4106 are four of them, each authored *after* a downstream repo's CI went red on a bug this repo had already fixed. [`refresh-driver-pin.yml`](../.github/workflows/refresh-driver-pin.yml) now opens that PR on the tail of every release: it hangs off the completed `Release PR` run via `workflow_run`, gated on the newest *published* release pointing at the commit that run built (so a draft can't trigger it), resolves the tag to a commit, and runs [`.github/scripts/refresh-driver-pin.sh`](../.github/scripts/refresh-driver-pin.sh). Nothing is left to discover; a diff that was already written is waiting to be reviewed.
+
+Three details there are load-bearing and easy to get wrong:
+
+- **The generated PR is titled `chore(ci):`, not `fix(ci):`.** A squash merge uses the PR title as the commit headline, and release-please cuts a patch release for `fix:` — so a `fix:`-titled bump would make every release propose another release, whose publish opens another bump. Worth noting that the hand-written bumps this replaces were all titled `fix(ci):` (#4106 and friends), so each of them cut a release of its own.
+- **The gate runs outside the concurrency group.** GitHub keeps only one *pending* run per group and cancels the older one — `cancel-in-progress: false` protects the running run, not the queue. Since `Release PR` completes on every push to `main`, a pending release refresh could otherwise be evicted by a no-op run behind it, and a `workflow_run` fires once, so there is no retry. Only the job that pushes the branch is serialised.
+- **One branch, `agent/refresh-driver-pin`, not one per tag.** Two releases in quick succession would otherwise open two PRs editing the same lines from the same base, each wedging the other in conflict. The newest release supersedes the pending one in place, retitling the open PR rather than opening a second.
+
+### Why the pin is a data file
+
+`GITHUB_TOKEN` **cannot push changes to anything under `.github/workflows/`** — the App token needs a `workflows` permission that is not one of the scopes a `permissions:` block can request. A pin living in the workflow therefore could not be refreshed by any GITHUB_TOKEN-authenticated automation at all, including release-please. Keeping it in a sibling data file is what makes the automation possible.
+
+What the pin still buys is unchanged: the privileged workflow executes an immutable, release-blessed commit rather than a caller-selected ref that can carry fork code. The workflow reads the file over the API, validates a 40-hex commit, and fails closed otherwise; nothing in the file is executed.
+
+**The known cost, stated plainly.** The pin is read from `main`, so a caller that pinned the *workflow* to a tag or SHA now tracks the newest pin rather than the one frozen at their revision — while the pin was a literal in the workflow, such a caller was fully reproducible. For the documented `@main` usage nothing changes: the same people who could already change the workflow under that caller are the ones who can change the pin file. The gap is not currently closable — a reusable workflow cannot learn its own revision from the `github` context (`workflow_sha` / `workflow_ref` describe the *entry-point* workflow, i.e. the caller's file in the caller's repo), and the claim that does name it, `job_workflow_sha`, exists only as an OIDC token claim, which every caller would have to grant `id-token: write` to reach. Widening the permissions contract of a workflow other repos call, to serve callers who aren't using it that way, is the worse trade. If a pinned caller ever needs frozen driver semantics, the shape to add is a `v*`-tag-constrained input naming the ref to read the pin from — constrained so a caller still can't point it at a `refs/pull/*` revision.
+
+The revision is resolved **once per run**, in a `driver` job every checkout job depends on. While it was a literal in the workflow it was consistent for free (a reusable workflow is resolved once per run); reading it at runtime would otherwise let a sharded run straddle two drivers — `render-shard` reading before rendering and `generate` reading again ~20 minutes later, merging old-driver bundles with new-driver scripts.
+
+Note that the `install@<sha>` action refs in the same workflow are **ordinary action pins**, in the same category as the `actions/checkout` SHAs. They used to be bumped in lockstep with the driver, which is what made a driver fix look like a five-line change; they deliberately do not track releases now and only move when the install action itself changes.
+
+Why release-please can't do this either, even setting the token aside: the pin has to name the release **commit**, which is the squash of the release PR itself and does not exist until after that PR merges. Post-release is the earliest any mechanism can know it.
+
+Two caveats worth knowing:
+
+- The PR is opened with `GITHUB_TOKEN`, whose pushes **do not start workflow runs**, so its checks won't report until someone pushes to the branch or closes and reopens it. The change is three lines of a data file and `ci` re-runs `refresh-driver-pin.sh --check` on merge to `main`, so this is a merge click, not a review burden.
+- If the PR sits unmerged, only **external** consumers stay on the older driver. Our own renders no longer read the pin.
+
+To move the pin by hand (or to repair a missed release), run **Refresh driver pin** via `workflow_dispatch` with the tag, or locally:
+
+```bash
+.github/scripts/refresh-driver-pin.sh --tag v1.12.0 --sha <40-hex commit>
+.github/scripts/refresh-driver-pin.sh --check
+```
+
+`--check` runs in `ci` on every PR. It fails on an abbreviated, upper-case or missing SHA, a malformed tag or date, and a duplicated key — all of which otherwise fail *at runtime in a consumer's repo*, after that run has already paid for a checkout and a JDK. It is covered by `.github/scripts/test-refresh-driver-pin.sh`, also run by `ci`, which additionally pins the exact `sed` expression the workflow uses to read the file, so the reader and the validator cannot drift apart. Change either only with those passing.
+
 ## Versioning after 1.0.0
 
 `v1.0.0` was cut by pinning `"release-as": "1.0.0"` in [`release-please-config.json`](../release-please-config.json). **That override has been removed, and it had to be** — `release-as` is sticky, not consumed by the release it forces, so left in place every subsequent release PR proposes 1.0.0 again, the tag already exists, and the release wedges. This repo had been bitten by it once before, by an override pinning 0.7.0 that outlived its release. If you ever force a version this way again, delete the key in the first PR after the release publishes.


### PR DESCRIPTION
Closes #4107.

## Summary

#4107 asks why #4106 was a thing. #4106 was the fourth hand-written "move the driver pin" PR (#4079, #4084, #4085 before it), and each was authored *after* something downstream had already gone red on a bug this repo had already fixed. The pin itself is legitimate — `design-artifacts-reusable.yml` is a privileged workflow other repos call, and it executes our `scripts/design-artifacts/`, so a caller must not be able to steer it at one of our `refs/pull/*` revisions, which can carry fork code. But two costs of that pin had nothing to do with the trust boundary it exists for.

**1. This repo was pinning itself, and that is the bug #4106 was working around.** `cli-source: build` exists so compose-ai-tools' own catalogs render against HEAD's renderer — the comment on that step says exactly that — but the *driver* beside that CLI came from the pin. So HEAD's renderer was being driven by a release-old driver, and a fix merged to `main` did not reach our own delivery branches until a release cut **and** somebody hand-bumped the pin. #4103 added the missing `bundleModulePath` import; the very push that landed it still died in `generate` ([run 32018634738](https://github.com/yschimke/compose-ai-tools/actions/runs/32018634738)), because the driver came from the pin rather than from the pushed tree. That round trip should never have applied to us.

The driver revision now resolves to **the caller commit when the caller is this repository**, and to the immutable pin for everyone else. This does not widen what the workflow executes: `github.repository` is the *caller's* repo and is not settable by a caller, and `design-artifacts.yml` — the only in-repo caller — runs on schedule / dispatch / push-to-`main` / `workflow_call`-from-release, with no `pull_request` anywhere in the chain.

**2. Moving the pin for external callers is mechanical, so it shouldn't be a discovery task.** [`refresh-driver-pin.yml`](https://github.com/yschimke/compose-ai-tools/blob/agent/release-process-automation-wpoqir/.github/workflows/refresh-driver-pin.yml) now opens that PR on the tail of every release, hanging off the completed `Release PR` run via `workflow_run`, resolving the tag to a commit and running the rewrite. What's left for a human is reviewing a diff that was already written.

## Where the pin lives, and what that costs

The first cut kept the pin in the workflow. That cannot work: **`GITHUB_TOKEN` cannot push changes under `.github/workflows/`** — the App token needs a `workflows` permission that is not one of the scopes a `permissions:` block can request. That rules out this automation *and* the release-please `extra-files` route — any GITHUB_TOKEN-authenticated mechanism.

So the pin lives in [`.github/design-artifacts-driver-pin.txt`](https://github.com/yschimke/compose-ai-tools/blob/agent/release-process-automation-wpoqir/.github/design-artifacts-driver-pin.txt), read over the API and validated as a 40-hex commit, failing closed. What the pin buys is unchanged: an immutable, release-blessed commit rather than a caller-selected ref. Nothing in the file is executed.

**The known cost, stated plainly** — I twice claimed to have closed this and was wrong both times, so it is documented in the code rather than argued away. The pin is read from `main`, so a caller that pinned the *workflow* to a tag or SHA tracks the newest pin rather than the one frozen at their revision; while the pin was a literal in the workflow, such a caller was fully reproducible. For the documented `@main` usage nothing changes — the same people who could already change the workflow under that caller are the ones who can change the pin file.

It isn't closable as far as I can find. A reusable workflow cannot learn its own revision from the `github` context: `workflow_sha` / `workflow_ref` describe the **entry-point** workflow (the caller's file in the caller's repo), and `job_workflow_sha`, which does name this file, exists only as an **OIDC token claim** — reaching it means every caller granting `id-token: write`. Widening the permissions contract of a workflow other repos call, to serve callers who aren't using it that way, is the worse trade. If a pinned caller ever needs frozen driver semantics, the shape is a `v*`-tag-constrained input naming the ref to read the pin from, constrained so a caller still can't point it at a `refs/pull/*` revision.

**The revision is resolved once per run**, in a `driver` job every checkout job depends on. As a literal it was consistent for free (a reusable workflow resolves once per run); reading at runtime would otherwise let a sharded run straddle two drivers — `render-shard` reading before rendering, `generate` reading again ~20 min later and merging old-driver bundles with new-driver scripts. It has to be a job because `shard-matrix` is skipped on the single-shard path.

**The `install@<sha>` refs don't belong to this pin at all.** They're ordinary action pins, same category as `actions/checkout`, and Dependabot can update them (its token *does* carry workflow scope). They were only bumped in lockstep with the driver out of habit, which is what made a one-line driver fix look like a five-line change.

## Review fixes

Codex found twelve issues across four rounds; all are fixed, each with a reply on its thread.

| | Fix |
|---|---|
| P1 `GITHUB_TOKEN` can't push workflows | pin moved to a data file |
| pinned callers read a mutable pin | **not fixable** — documented as a known limitation (above) |
| `github.job_workflow_sha` isn't a context property | removed; it silently evaluated empty, so the attempted fix never worked |
| sharded run could straddle two drivers | single `driver` job |
| two releases → two conflicting PRs | one `agent/refresh-driver-pin` branch, superseded in place; open PR retitled |
| retry wedged on `stale info` | branch fetched, explicit lease |
| API blip read as "no release", job green | one `api()` helper: HTTP 404 is a real empty answer, anything else fails |
| gate skipped after a post-publish job failure | dropped `conclusion == 'success'` |
| cancelled release run skipped the gate | `if: always()`; `head_sha` is populated, so the API gate decides |
| driver job hardcoded `ubuntu-latest` | `inputs.runs-on` |
| `gh` not guaranteed on self-hosted runners | `curl` + `Accept: application/vnd.github.raw`, via `${GITHUB_API_URL}` |
| pin-only PR fail-opened all 10 CI groups | added to `actions_tests` + regression test |

### Honest caveats

- The generated PR is opened with `GITHUB_TOKEN`, whose pushes don't start workflow runs, so its checks won't report until someone pushes or closes/reopens. A merge click, not a hands-off merge.
- A stale pin still delays external consumers while the PR sits. It no longer affects our own renders.

### Not in this PR

The bigger structural questions in #4107 (splitting the VS Code extension and the preview server out) are answered in a comment on the issue rather than acted on here.

## Test plan

- `.github/scripts/test-refresh-driver-pin.sh` — 20 assertions, wired into `ci`. `--check` rejects an abbreviated SHA (`c990303`), an upper-case SHA, a bare `1.12.0` tag, a `DD-MM-YYYY` date, a duplicated key and a missing key; a rewrite moves all three keys and preserves comments; re-pinning to the current SHA is byte-identical; malformed `--tag`/`--sha`/`--date` refused.
- Two of those guard the script↔workflow seam: the test runs the workflow's own `sed -nE 's/^sha=([0-9a-f]{40})$/\1/p'` against the real pin file and requires agreement with `--print`, and asserts that expression is still what the workflow uses. Drift resolves the pin to empty at runtime and fails every external caller after they've paid for a checkout.
- `test_path_scope.py` gains `test_driver_pin_bump_runs_only_the_actions_validator` (14 pass). Verified against the real config before fixing: pin-only previously took the fail-open route lighting all 10 groups, now `['actions_tests']`.
- `refresh-driver-pin.sh --check` runs as its own `ci` step; `test_change_scope.py` (22) still passes.
- Job graph verified as `driver → {render-shard, generate}`, all four jobs on `inputs.runs-on`. Workflows parse as YAML; scripts pass `bash -n`.
- End-to-end proof is a real release, which only runs post-merge; `workflow_dispatch` with a tag is the same path and the manual repair route.

CodeQL red on this PR is a GitHub-side code-scanning outage, evidenced [here](https://github.com/yschimke/compose-ai-tools/pull/4112#issuecomment-5318647265) — `Analyze (actions)`, the language covering `.github/workflows/**`, passed end-to-end.

Non-visual change (CI wiring and a shell script), so no render evidence.