### PR TITLE
feat(serve): tell a throttled branch read apart from a missing one

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -47,8 +47,16 @@ sealed interface BranchFetch {
    */
   data class Throttled(val retryAfterSeconds: Long?) : BranchFetch
 
-  /** The branch host is unwell — any `5xx`, or a `4xx` that is neither missing nor throttled. */
-  data class Unavailable(val status: Int) : BranchFetch
+  /**
+   * The branch host is unwell — any `5xx`, or a `4xx` that is neither missing nor throttled.
+   *
+   * Carries [retryAfterSeconds] for the same reason [Throttled] does: `Retry-After` is defined on
+   * `503` as much as on `429` (RFC 9110 §10.2.3), and a host that tells you when it will be back is
+   * giving you a better number than any schedule you'd invent. Dropping it here meant a `503`
+   * asking for ten seconds got 250 ms and 500 ms instead, spending both retries inside the outage
+   * and then reporting the asset as missing — the exact confusion this type exists to end.
+   */
+  data class Unavailable(val status: Int, val retryAfterSeconds: Long? = null) : BranchFetch
 
   /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
   data class Transport(val detail: String) : BranchFetch
@@ -71,7 +79,8 @@ sealed interface BranchFetch {
         is Ok -> "ok"
         is NotFound -> "not found"
         is Throttled -> "throttled" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
-        is Unavailable -> "unavailable ($status)"
+        is Unavailable ->
+          "unavailable ($status)" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
         is Transport -> "transport: $detail"
       }
 
@@ -95,7 +104,7 @@ sealed interface BranchFetch {
       when {
         status == 404 || status == 410 -> NotFound
         status == 429 || status == 403 -> Throttled(retryAfterSeconds?.coerceAtLeast(0))
-        else -> Unavailable(status)
+        else -> Unavailable(status, retryAfterSeconds?.coerceAtLeast(0))
       }
 
     /**
@@ -111,11 +120,13 @@ sealed interface BranchFetch {
       if (!outcome.isTransient) return null
       if (attempt < 1 || attempt > MAX_RETRIES) return null
       val backoff = BASE_BACKOFF_MILLIS shl (attempt - 1)
-      val requested =
-        (outcome as? Throttled)
-          ?.retryAfterSeconds
-          ?.coerceAtMost(MAX_RETRY_AFTER_SECONDS)
-          ?.times(1000L)
+      val asked =
+        when (outcome) {
+          is Throttled -> outcome.retryAfterSeconds
+          is Unavailable -> outcome.retryAfterSeconds
+          else -> null
+        }
+      val requested = asked?.coerceAtMost(MAX_RETRY_AFTER_SECONDS)?.times(1000L)
       return maxOf(backoff, requested ?: 0L)
     }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -1,0 +1,129 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * Why a read against a delivery branch failed, when it did.
+ *
+ * ### Why this exists
+ *
+ * Every branch read used to answer `ByteArray?`. A 404, a 429, a 503 and a socket timeout were all
+ * the same `null`, and that single value travelled all the way to the reader: the Motion lane's
+ * "The recorded interaction could not be loaded" was the server's whole vocabulary for "this was
+ * never published" *and* "GitHub is throttling us right now". Those want opposite handling — one is
+ * a permanent fact worth remembering, the other is a reason to wait and ask again — and no caller
+ * could tell them apart because the information was destroyed at the bottom of the stack.
+ *
+ * The distinction is load-bearing in two specific places:
+ * - **Negative caching.** [ServeBundleHost] remembers pinned misses forever, on the reasoning that
+ *   `(commit, path)` is immutable so "no such file" can never stop being true. That reasoning holds
+ *   for [NotFound] and for nothing else: memoising a throttle turns a blip into a permanent hole
+ *   that only a restart clears.
+ * - **Retrying.** Asking again after a 404 is waste. Asking again after a 429 is the entire fix,
+ *   provided the wait honours what the server asked for.
+ *
+ * Deliberately transport-agnostic and dependency-free so the classification and the backoff policy
+ * unit-test without a socket.
+ */
+sealed interface BranchFetch {
+
+  /** The bytes, read and size-capped. */
+  class Ok(val bytes: ByteArray) : BranchFetch
+
+  /**
+   * The branch answered, definitively, that there is no such file — `404`/`410`.
+   *
+   * The only outcome a caller may treat as permanent. Everything else below is a statement about
+   * *now*.
+   */
+  data object NotFound : BranchFetch
+
+  /**
+   * Rate limited — `429`, or a `403` that carries no body we asked for. [retryAfterSeconds] is the
+   * server's own `Retry-After` when it sent one, which is always a better number than any we'd
+   * invent.
+   *
+   * `403` lands here rather than under a "forbidden" case on purpose: GitHub answers `403` for some
+   * rate-limit conditions, and the cost of guessing wrong in this direction is one wasted retry,
+   * where guessing wrong in the other direction caches a throttle as a missing asset.
+   */
+  data class Throttled(val retryAfterSeconds: Long?) : BranchFetch
+
+  /** The branch host is unwell — any `5xx`, or a `4xx` that is neither missing nor throttled. */
+  data class Unavailable(val status: Int) : BranchFetch
+
+  /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
+  data class Transport(val detail: String) : BranchFetch
+
+  /** The bytes, or null for every failure — the shape the pre-existing call sites still want. */
+  val bytesOrNull: ByteArray?
+    get() = (this as? Ok)?.bytes
+
+  /**
+   * Whether asking again could plausibly answer differently. False for [Ok] (nothing to ask) and
+   * for [NotFound] (the answer will not change), true for the three "right now" outcomes.
+   */
+  val isTransient: Boolean
+    get() = this is Throttled || this is Unavailable || this is Transport
+
+  /** A short, log-safe reason. Never includes the URL — callers pair it with their own. */
+  val summary: String
+    get() =
+      when (this) {
+        is Ok -> "ok"
+        is NotFound -> "not found"
+        is Throttled -> "throttled" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
+        is Unavailable -> "unavailable ($status)"
+        is Transport -> "transport: $detail"
+      }
+
+  companion object {
+    /** Longest we will ever honour a `Retry-After` for — beyond this, failing fast is kinder. */
+    const val MAX_RETRY_AFTER_SECONDS = 30L
+
+    /** Attempts after the first. Small: a request is waiting behind this. */
+    const val MAX_RETRIES = 2
+
+    /** First backoff step; doubled per attempt. */
+    const val BASE_BACKOFF_MILLIS = 250L
+
+    /**
+     * Classify one HTTP status.
+     *
+     * [retryAfterSeconds] is the parsed `Retry-After` header, or null. Only consulted for the
+     * statuses that can carry one.
+     */
+    fun ofStatus(status: Int, retryAfterSeconds: Long? = null): BranchFetch =
+      when {
+        status == 404 || status == 410 -> NotFound
+        status == 429 || status == 403 -> Throttled(retryAfterSeconds?.coerceAtLeast(0))
+        else -> Unavailable(status)
+      }
+
+    /**
+     * How long to wait before attempt [attempt] (1-based, so `1` is the first *retry*), or null
+     * when this outcome should not be retried at all or the attempts are spent.
+     *
+     * A server-supplied `Retry-After` wins over the exponential schedule when it is longer — it is
+     * the only party that knows when it will serve again — but is capped at
+     * [MAX_RETRY_AFTER_SECONDS] so a hostile or confused header cannot park a request thread for
+     * minutes.
+     */
+    fun retryDelayMillis(outcome: BranchFetch, attempt: Int): Long? {
+      if (!outcome.isTransient) return null
+      if (attempt < 1 || attempt > MAX_RETRIES) return null
+      val backoff = BASE_BACKOFF_MILLIS shl (attempt - 1)
+      val requested =
+        (outcome as? Throttled)
+          ?.retryAfterSeconds
+          ?.coerceAtMost(MAX_RETRY_AFTER_SECONDS)
+          ?.times(1000L)
+      return maxOf(backoff, requested ?: 0L)
+    }
+
+    /**
+     * Parse a `Retry-After` header. Only the delta-seconds form — the HTTP-date form is legal but
+     * needs a clock and a parse to answer the same question, and no branch host we read sends it.
+     * An unparseable value is simply absent, which falls back to the exponential schedule.
+     */
+    fun parseRetryAfter(header: String?): Long? = header?.trim()?.toLongOrNull()?.takeIf { it >= 0 }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -168,6 +168,14 @@ class ServeBundleHost(
    */
   private val fetchPinnedAsset: ((commit: String, path: String) -> ByteArray?)? = null,
   /**
+   * [fetchPinnedAsset], but reporting **why** a read failed.
+   *
+   * Preferred over [fetchPinnedAsset] when supplied; the plain seam remains for callers (and the
+   * fixtures) that have no way to tell a throttle from an absence. This is what makes
+   * [pinnedMisses] safe to keep forever — see the reasoning there.
+   */
+  private val fetchPinnedAssetOutcome: ((commit: String, path: String) -> BranchFetch)? = null,
+  /**
    * Resolves ids to branch paths **as they were at a given commit** ([ServePinnedManifest]). Null
    * for a host with no delivery branch; when present it takes precedence over the tip's maps below,
    * which remain the fallback for a commit whose manifests can't be read.
@@ -637,7 +645,7 @@ class ServeBundleHost(
    * from. False for a plain uploaded bundle, whose bytes exist nowhere but this disk.
    */
   val supportsPinnedRevisions: Boolean
-    get() = fetchPinnedAsset != null
+    get() = fetchPinnedAsset != null || fetchPinnedAssetOutcome != null
 
   /**
    * [previewId]'s baked render **as published at [commit]**, or null when there is no such thing.
@@ -765,7 +773,9 @@ class ServeBundleHost(
    * recency order worth maintaining, and the cost of a miss is one small fetch.
    */
   private fun pinnedAsset(commit: String, path: String?): PinnedOutcome {
-    val fetch = fetchPinnedAsset ?: return PinnedOutcome.Missing
+    // Either seam is enough to have a pinned lane; the outcome-reporting one is preferred
+    // wherever it is wired, and the plain one remains for callers that cannot distinguish.
+    if (fetchPinnedAssetOutcome == null && fetchPinnedAsset == null) return PinnedOutcome.Missing
     val safePath = ServeCatalogRevision.normalizePath(path) ?: return PinnedOutcome.Missing
     val pin = ServeCatalogRevision.normalize(commit) ?: return PinnedOutcome.Missing
     val key = "$pin/$safePath"
@@ -784,16 +794,27 @@ class ServeBundleHost(
     // does not exist — those are different answers and a permalink must not confuse them.
     if (!pinnedPermits.tryAcquire(PINNED_FETCH_WAIT_SECONDS, java.util.concurrent.TimeUnit.SECONDS))
       return PinnedOutcome.Busy
-    val bytes =
+    val outcome =
       try {
         // Re-checked under the permit: while this caller waited, the fetch it is queued behind may
         // have been for exactly this URL — the common case on a page whose images share a commit.
-        pinnedCache[key] ?: runCatching { fetch(pin, safePath) }.getOrNull()
+        pinnedCache[key]?.let { BranchFetch.Ok(it) }
+          ?: runCatching {
+            fetchPinnedAssetOutcome?.invoke(pin, safePath)
+              ?: fetchPinnedAsset?.invoke(pin, safePath)?.let { BranchFetch.Ok(it) }
+              ?: BranchFetch.NotFound
+          }
+            .getOrElse { BranchFetch.Transport(it::class.simpleName ?: "error") }
       } finally {
         pinnedPermits.release()
       }
+    val bytes = outcome.bytesOrNull
     if (bytes == null) {
-      remember(pinnedMisses, key, MAX_PINNED_MISS_ENTRIES)
+      // ONLY a real absence is remembered. `(commit, path)` is immutable, so "that revision has no
+      // such file" is permanent and worth keeping — but a throttle or a 503 says nothing about the
+      // revision, and memoising one turns a blip into a hole that outlives it. That was the
+      // accepted cost of not being able to tell them apart; [BranchFetch] removes the excuse.
+      if (outcome == BranchFetch.NotFound) remember(pinnedMisses, key, MAX_PINNED_MISS_ENTRIES)
       return PinnedOutcome.Missing
     }
     synchronized(pinnedCache) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -68,7 +68,14 @@ class ServeCatalogStore(
     Executors.newSingleThreadExecutor { r ->
       Thread(r, "serve-catalog-figma").apply { isDaemon = true }
     },
-  private val networkFetch: (url: String, maxBytes: Long) -> ByteArray? = ::httpFetch,
+  /**
+   * The branch transport. Outcome-shaped rather than `ByteArray?` so that **every** lane reaches
+   * the network through the same injected seam: the pinned lane needs to know *why* a read failed,
+   * and a parallel outcome-only seam beside a bytes-only one is how one of them ends up bypassed —
+   * a store given an authenticated, proxied or recorded transport would have issued a direct
+   * request to GitHub for pins alone. One seam, one answer shape, nothing to forget to wire.
+   */
+  private val networkFetch: (url: String, maxBytes: Long) -> BranchFetch = ::httpFetchOutcome,
   private val networkProbe: (url: String) -> Boolean = ::httpExists,
   private val maxImages: Int = DEFAULT_MAX_IMAGES,
   /**
@@ -2587,7 +2594,9 @@ class ServeCatalogStore(
   private fun fetchRevisions(repo: String, branch: String): List<ServeCatalogRevision.Revision> =
     runCatching {
       val url = ServeCatalogRevision.commitsFeedUrl(repo, branch)
-      val body = if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FEED_FETCH_BYTES)
+      val body =
+        if (fetch != null) fetch.invoke(url)
+        else networkFetch(url, MAX_FEED_FETCH_BYTES).bytesOrNull
       body?.toString(Charsets.UTF_8)?.let { ServeCatalogRevision.parseCommitsFeed(it) }
     }
     .getOrNull()
@@ -2595,7 +2604,7 @@ class ServeCatalogStore(
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =
-    if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FETCH_BYTES)
+    if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FETCH_BYTES).bytesOrNull
 
   /**
    * [fetchCatalogAsset], keeping the reason a failure failed.
@@ -2609,7 +2618,7 @@ class ServeCatalogStore(
     if (fetch != null) {
       fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
     } else {
-      httpFetchOutcome(url, MAX_FETCH_BYTES)
+      networkFetch(url, MAX_FETCH_BYTES)
     }
 
   /**
@@ -2704,5 +2713,6 @@ class ServeCatalogStore(
    * and callers that provide their own transport.
    */
   private fun fetchExecutableBundle(url: String): ByteArray? =
-    if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_LIVE_BUNDLE_FETCH_BYTES)
+    if (fetch != null) fetch.invoke(url)
+    else networkFetch(url, MAX_LIVE_BUNDLE_FETCH_BYTES).bytesOrNull
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -789,6 +789,12 @@ class ServeCatalogStore(
           fetchPinnedAsset = { commit, path ->
             ServeCatalogRevision.assetUrl(repo, commit, path)?.let { fetchCatalogAsset(it) }
           },
+          // The same read, but reporting WHY it failed — which is the only thing that makes the
+          // host's permanent negative cache safe. See [ServeBundleHost.fetchPinnedAssetOutcome].
+          fetchPinnedAssetOutcome = { commit, path ->
+            ServeCatalogRevision.assetUrl(repo, commit, path)?.let { fetchCatalogAssetOutcome(it) }
+              ?: BranchFetch.NotFound
+          },
           // Ids are stable across publishes; the paths under them are not. So a pinned request
           // resolves its path from the manifests AT that commit, with the tip's maps above as the
           // fallback. Same seam again: the host names a commit and one of two declared manifest
@@ -2484,13 +2490,62 @@ class ServeCatalogStore(
         .build()
     }
 
-    private fun httpFetch(url: String, maxBytes: Long): ByteArray? {
-      httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
-        if (!response.isSuccessful) return null
-        val body = response.body ?: return null
-        return readCapped(body.byteStream(), maxBytes)
+    /**
+     * One branch read, retried while the answer is a "right now" failure.
+     *
+     * The retry is the whole reason this exists: `raw.githubusercontent.com` rate-limits an
+     * unauthenticated reader, and a server publishing twenty-odd catalogs meets that regularly. A
+     * single 429 used to be indistinguishable from a missing file and cost the reader the asset
+     * outright; two short, `Retry-After`-aware attempts turn most of them into a served response. A
+     * [BranchFetch.NotFound] is never retried — the answer will not change, and asking again is how
+     * a catalog of genuinely-absent assets turns into a thundering herd.
+     */
+    internal fun httpFetchOutcome(
+      url: String,
+      maxBytes: Long,
+      sleep: (Long) -> Unit = { Thread.sleep(it) },
+    ): BranchFetch {
+      var last: BranchFetch = httpFetchOnce(url, maxBytes)
+      var attempt = 1
+      while (true) {
+        val delay = BranchFetch.retryDelayMillis(last, attempt) ?: return last
+        try {
+          sleep(delay)
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          return last
+        }
+        last = httpFetchOnce(url, maxBytes)
+        if (!last.isTransient) return last
+        attempt++
       }
     }
+
+    /**
+     * A single attempt. Only [java.io.IOException] becomes [BranchFetch.Transport]: the size cap in
+     * [readCapped] throws too, and it must keep propagating rather than being retried — the asset
+     * will be exactly as oversized the second time, and the existing call sites already catch it.
+     */
+    private fun httpFetchOnce(url: String, maxBytes: Long): BranchFetch =
+      try {
+        httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+          if (!response.isSuccessful) {
+            BranchFetch.ofStatus(
+              response.code,
+              BranchFetch.parseRetryAfter(response.header("Retry-After")),
+            )
+          } else {
+            val body = response.body
+            if (body == null) BranchFetch.Unavailable(response.code)
+            else BranchFetch.Ok(readCapped(body.byteStream(), maxBytes))
+          }
+        }
+      } catch (e: java.io.IOException) {
+        BranchFetch.Transport(e::class.simpleName ?: "IOException")
+      }
+
+    private fun httpFetch(url: String, maxBytes: Long): ByteArray? =
+      httpFetchOutcome(url, maxBytes).bytesOrNull
 
     private fun httpExists(url: String): Boolean =
       httpClient.newCall(Request.Builder().url(url).head().build()).execute().use {
@@ -2541,6 +2596,21 @@ class ServeCatalogStore(
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =
     if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FETCH_BYTES)
+
+  /**
+   * [fetchCatalogAsset], keeping the reason a failure failed.
+   *
+   * The injected [fetch] seam still answers `ByteArray?` — 48 tests build one, and widening it
+   * would be a large diff for no test's benefit. A stub that answers null is reported as
+   * [BranchFetch.NotFound], which is what those tests mean by it; only the real network path
+   * distinguishes a throttle, and only the real network path can.
+   */
+  private fun fetchCatalogAssetOutcome(url: String): BranchFetch =
+    if (fetch != null) {
+      fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
+    } else {
+      httpFetchOutcome(url, MAX_FETCH_BYTES)
+    }
 
   /**
    * Fetch [urls] **concurrently**, returning `url → bytes` for the ones that came back. A URL that

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The branch-read outcome and its retry policy ([BranchFetch]).
+ *
+ * The property every one of these guards is the same: **a throttle must never be mistaken for a
+ * missing file.** That confusion is what made a rate-limited read indistinguishable from an
+ * unpublished asset, and it is what let a permanent negative cache remember a transient blip.
+ */
+class ServeBranchFetchTest {
+
+  @Test
+  fun `only a real absence is permanent`() {
+    assertEquals(BranchFetch.NotFound, BranchFetch.ofStatus(404))
+    assertEquals(BranchFetch.NotFound, BranchFetch.ofStatus(410))
+    assertFalse(BranchFetch.NotFound.isTransient, "404 is a fact, not a moment")
+
+    // Everything else is a statement about now, and must stay retryable + uncacheable.
+    for (status in listOf(429, 403, 500, 502, 503, 504)) {
+      assertTrue(
+        BranchFetch.ofStatus(status).isTransient,
+        "$status must not be treated as a missing asset",
+      )
+    }
+  }
+
+  @Test
+  fun `403 is read as a throttle, not an absence`() {
+    // GitHub answers 403 for some rate-limit conditions. Guessing wrong in this direction costs one
+    // wasted retry; guessing wrong the other way caches a throttle as a permanently missing file.
+    assertTrue(BranchFetch.ofStatus(403) is BranchFetch.Throttled)
+  }
+
+  @Test
+  fun `a served response carries its bytes and nothing to retry`() {
+    val ok = BranchFetch.Ok(byteArrayOf(1, 2, 3))
+    assertFalse(ok.isTransient)
+    assertNull(BranchFetch.retryDelayMillis(ok, attempt = 1))
+    assertEquals(3, ok.bytesOrNull?.size)
+    assertNull(BranchFetch.NotFound.bytesOrNull)
+  }
+
+  @Test
+  fun `a missing file is never retried`() {
+    assertNull(
+      BranchFetch.retryDelayMillis(BranchFetch.NotFound, attempt = 1),
+      "retrying a 404 is how a catalog of absent assets becomes a thundering herd",
+    )
+  }
+
+  @Test
+  fun `backoff grows and then gives up`() {
+    val outcome = BranchFetch.Unavailable(503)
+    assertEquals(BranchFetch.BASE_BACKOFF_MILLIS, BranchFetch.retryDelayMillis(outcome, 1))
+    assertEquals(BranchFetch.BASE_BACKOFF_MILLIS * 2, BranchFetch.retryDelayMillis(outcome, 2))
+    assertNull(
+      BranchFetch.retryDelayMillis(outcome, BranchFetch.MAX_RETRIES + 1),
+      "the attempts are bounded — a request is waiting behind this",
+    )
+  }
+
+  @Test
+  fun `the server's own Retry-After wins when it is longer`() {
+    // It is the only party that knows when it will serve again.
+    val throttled = BranchFetch.Throttled(retryAfterSeconds = 5)
+    assertEquals(5_000L, BranchFetch.retryDelayMillis(throttled, 1))
+
+    // …but not when the exponential step is already longer, and never past the cap: a hostile or
+    // confused header must not park a request thread for minutes.
+    assertEquals(
+      BranchFetch.BASE_BACKOFF_MILLIS,
+      BranchFetch.retryDelayMillis(BranchFetch.Throttled(0), 1),
+    )
+    assertEquals(
+      BranchFetch.MAX_RETRY_AFTER_SECONDS * 1000L,
+      BranchFetch.retryDelayMillis(BranchFetch.Throttled(9_999), 1),
+    )
+  }
+
+  @Test
+  fun `Retry-After parses only what it can trust`() {
+    assertEquals(7L, BranchFetch.parseRetryAfter("7"))
+    assertEquals(7L, BranchFetch.parseRetryAfter("  7 "))
+    assertNull(BranchFetch.parseRetryAfter(null))
+    assertNull(BranchFetch.parseRetryAfter(""))
+    assertNull(BranchFetch.parseRetryAfter("-1"), "a negative delay is not a delay")
+    // The HTTP-date form is legal but no branch host we read sends it; unparseable falls back to
+    // the exponential schedule rather than guessing.
+    assertNull(BranchFetch.parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT"))
+  }
+
+  @Test
+  fun `every outcome says why in one line`() {
+    assertEquals("not found", BranchFetch.NotFound.summary)
+    assertEquals("throttled (retry after 3s)", BranchFetch.Throttled(3).summary)
+    assertEquals("throttled", BranchFetch.Throttled(null).summary)
+    assertEquals("unavailable (503)", BranchFetch.Unavailable(503).summary)
+    assertEquals(
+      "transport: SocketTimeoutException",
+      BranchFetch.Transport("SocketTimeoutException").summary,
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetchTest.kt
@@ -84,6 +84,28 @@ class ServeBranchFetchTest {
   }
 
   @Test
+  fun `a 503 that says when to come back is believed too`() {
+    // `Retry-After` is defined on 503 as much as on 429 (RFC 9110 10.2.3). Dropping it there meant
+    // a host asking for ten seconds got 250ms and 500ms instead — both retries spent inside the
+    // outage, and the asset then reported as missing, which is the confusion this type exists
+    // to end.
+    val outage = BranchFetch.ofStatus(503, retryAfterSeconds = 10)
+    assertEquals(BranchFetch.Unavailable(503, 10), outage)
+    assertEquals(10_000L, BranchFetch.retryDelayMillis(outage, 1))
+
+    // Same cap as a throttle: a header is advice, not a licence to hold a request thread.
+    assertEquals(
+      BranchFetch.MAX_RETRY_AFTER_SECONDS * 1000L,
+      BranchFetch.retryDelayMillis(BranchFetch.ofStatus(503, 9_999), 1),
+    )
+    // And with no header it is still the plain exponential schedule.
+    assertEquals(
+      BranchFetch.BASE_BACKOFF_MILLIS,
+      BranchFetch.retryDelayMillis(BranchFetch.ofStatus(503), 1),
+    )
+  }
+
+  @Test
   fun `Retry-After parses only what it can trust`() {
     assertEquals(7L, BranchFetch.parseRetryAfter("7"))
     assertEquals(7L, BranchFetch.parseRetryAfter("  7 "))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -353,4 +353,68 @@ class ServeBundleHostTest {
     val empty = java.nio.file.Files.createTempDirectory("empty").toFile().also { it.deleteOnExit() }
     assertFalse(ServeBundleHost.looksLikeBundle(empty))
   }
+
+  @Test
+  fun `a throttled pinned read is not remembered as a missing file`() {
+    // `pinnedMisses` is deliberately permanent: `(commit, path)` is immutable, so "that revision
+    // has no such file" can never stop being true. That reasoning only holds for a real 404. A
+    // throttle says nothing about the revision, and memoising one turned a blip into a hole that
+    // outlived it — the accepted cost of a fetch layer that could not tell them apart.
+    val commit = "1".repeat(40)
+    val previewId = "button-filled__ideal__default__dark"
+    val dir = java.nio.file.Files.createTempDirectory("pinned-throttle").toFile()
+    dir.deleteOnExit()
+    File(dir, "previews").mkdirs()
+
+    val answers =
+      ArrayDeque(listOf<BranchFetch>(BranchFetch.Throttled(1), BranchFetch.Ok(byteArrayOf(7))))
+    var calls = 0
+    val host =
+      ServeBundleHost(
+        dir,
+        label = "compose-m3",
+        title = "Compose Material 3",
+        bakedBranchPaths = mapOf(previewId to "images/button-filled/ideal__default__dark.png"),
+        fetchPinnedAssetOutcome = { _, _ ->
+          calls++
+          answers.removeFirstOrNull() ?: BranchFetch.NotFound
+        },
+      )
+
+    // First read is throttled, so the caller gets nothing…
+    assertTrue(host.pinnedRender(commit, previewId) is ServeBundleHost.PinnedOutcome.Missing)
+    assertEquals(1, calls)
+    // …and asking again actually asks again, rather than being refused from memory.
+    val second = host.pinnedRender(commit, previewId)
+    assertTrue(second is ServeBundleHost.PinnedOutcome.Ok, "a throttle must not poison the cache")
+    assertEquals(2, calls)
+  }
+
+  @Test
+  fun `a genuinely missing pinned asset is still only asked for once`() {
+    // The other half of the same property: the permanent negative cache is worth keeping, and this
+    // is the case it was built for.
+    val commit = "2".repeat(40)
+    val previewId = "button-filled__ideal__default__dark"
+    val dir = java.nio.file.Files.createTempDirectory("pinned-missing").toFile()
+    dir.deleteOnExit()
+    File(dir, "previews").mkdirs()
+
+    var calls = 0
+    val host =
+      ServeBundleHost(
+        dir,
+        label = "compose-m3",
+        title = "Compose Material 3",
+        bakedBranchPaths = mapOf(previewId to "images/button-filled/ideal__default__dark.png"),
+        fetchPinnedAssetOutcome = { _, _ ->
+          calls++
+          BranchFetch.NotFound
+        },
+      )
+
+    assertTrue(host.pinnedRender(commit, previewId) is ServeBundleHost.PinnedOutcome.Missing)
+    assertTrue(host.pinnedRender(commit, previewId) is ServeBundleHost.PinnedOutcome.Missing)
+    assertEquals(1, calls, "a known-absent asset is refused from memory")
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1289,13 +1289,15 @@ class ServeCatalogStoreTest {
       """
         .trimIndent()
     val requestedLimits = linkedMapOf<String, Long>()
-    val networkFetch: (String, Long) -> ByteArray? = { url, maxBytes ->
+    // Outcome-shaped like the seam it stands in for: one transport, so no lane can reach the
+    // network around an injected one.
+    val networkFetch: (String, Long) -> BranchFetch = { url, maxBytes ->
       requestedLimits[url] = maxBytes
       when {
-        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
-        url.endsWith("bundle/bundle.png") -> byteArrayOf(1, 2, 3)
-        url.endsWith(".png") -> png()
-        else -> null
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> BranchFetch.Ok(catalog.toByteArray())
+        url.endsWith("bundle/bundle.png") -> BranchFetch.Ok(byteArrayOf(1, 2, 3))
+        url.endsWith(".png") -> BranchFetch.Ok(png())
+        else -> BranchFetch.NotFound
       }
     }
     val trust =


### PR DESCRIPTION
Every read against a delivery branch answered `ByteArray?`, so a 404, a 429, a 503 and a socket timeout were all the same `null`. That value travelled all the way to the reader: "The recorded interaction could not be loaded" was the server's entire vocabulary for both *this was never published* and *GitHub is throttling us right now*.

That cost real time. Diagnosing #4110 meant reproducing the distinction by hand with `curl`, because nothing in the stack had kept it. `BranchFetch` keeps it.

## Retrying

A rate-limited read is now retried up to twice, with an exponential backoff that honours the server's own `Retry-After` when it sends one — capped at 30s so a confused or hostile header cannot park a request thread. A `NotFound` is **never** retried: the answer will not change, and asking again is how a catalog of genuinely absent assets becomes a thundering herd.

`Retry-After` is honoured on `503` as well as `429` (RFC 9110 §10.2.3). Getting that wrong — which the first commit did — meant a host asking for ten seconds got 250 ms then 500 ms, spent both retries inside the outage, and reported the asset as missing: the old bug, reintroduced in miniature by the type meant to end it.

Throttling here is not hypothetical. Three consecutive unauthenticated requests to `raw.githubusercontent.com` from a sandbox returned **429, 200, 200** — and a box publishing twenty-odd catalogs meets that far more often than one sandbox does.

## Negative caching

`pinnedMisses` is permanent by design, reasoning that `(commit, path)` addresses immutable bytes so "no such file" can never stop being true. That holds for a real 404 and nothing else — and the code's own comment conceded the point, noting a transient failure "cannot be told apart and is therefore remembered too", with a blip stranding a pin "until eviction".

Now only `NotFound` is remembered. A throttle leaves no trace, so the next request actually asks again.

## One transport seam, not two

`networkFetch` now answers `BranchFetch` rather than `ByteArray?`, and the three bytes-shaped call sites read `.bytesOrNull` off it.

The first commit instead added an outcome-aware path beside the existing seam, and that immediately produced the bug you'd expect: pinned reads went straight to OkHttp while catalog loads went through the injected transport, so a store given a proxied, authenticated or recorded transport would have silently issued direct requests to GitHub for pins alone. Two seams for one transport means one of them gets forgotten. The cost of collapsing them is one signature change for callers who inject a transport — there is exactly one, updated here.

The `fetch` seam that 48 tests build is deliberately untouched and still answers `ByteArray?`; a stub returning null reads as "absent", which is what those tests mean.

## Why `403` is a throttle, not an absence

GitHub answers `403` for some rate-limit conditions. Being wrong in this direction costs one wasted retry; being wrong the other way caches a throttle as a permanently missing file. The asymmetry picks the classification.

## Still to come

Deliberately not here, to keep this reviewable:

- surfacing the distinction outward — `503` + `Retry-After` on the motion route instead of a bare `404`, and viewer wording that says "temporarily unavailable" rather than implying the capture doesn't exist;
- branch-fetch telemetry in `/status.json` (fetches attempted / throttled / failed, last throttle timestamp), so "is GitHub rate-limiting us?" becomes something you read off a page rather than reconstruct with `curl`.

This PR is the mechanism both need.

## Test plan

```
./gradlew :cli:test                                     # full CLI suite, green
./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest       # green
```

New coverage:

- `ServeBranchFetchTest` — classification (404/410 permanent; 429/403/5xx transient), that a 404 is never retried, backoff growth and exhaustion, `Retry-After` winning when longer and capped when absurd on both `429` and `503`, and header parsing rejecting what it cannot trust.
- `ServeBundleHostTest` — a throttled pinned read is asked again rather than refused from memory, and a genuinely missing one is still only asked for once (the case the permanent cache exists for).

Both review findings verified red without their fixes.

Text-only PR: no rendered surface changes.