### PR TITLE
fix(design-artifacts): union the tag index when folding a catalog section

### DIFF
--- a/scripts/design-artifacts/merge-catalog-section.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.mjs
@@ -115,6 +115,23 @@ async function sameBytes(a, b) {
 const ANNOTATIONS_REL = join("annotations", "index.json");
 
 /**
+ * The other nested asset that is a *map*: the published tag index.
+ *
+ * `tags/index.json` is `served preview id → {testTag: {count, bounds, space}}` (see
+ * `tag-index.mjs`), so — exactly like `annotations/index.json` above — both catalogs
+ * legitimately carry their own and byte-comparing them aborts the fold. That is not
+ * hypothetical: it took every folding catalog in compose-samples down once the M3
+ * section started emitting a non-empty one, which is the same way the annotations
+ * case first surfaced.
+ *
+ * Union by preview id, host wins. A folded component becomes a tab in the host, so
+ * its element gates belong alongside the host's; and a borrowed catalog must never
+ * redefine the geometry of an id the host already published, since a scoped parity
+ * acceptance resolves against exactly this map.
+ */
+const TAG_INDEX_REL = join("tags", "index.json");
+
+/**
  * The one nested directory that is **catalog-level**, not per-component.
  *
  * `themes/<provider-fqn>.dtcg.json` is a declared theme's own token set — a sibling of the
@@ -133,7 +150,15 @@ const ANNOTATIONS_REL = join("annotations", "index.json");
  */
 const THEMES_DIR = "themes";
 
-async function mergeAnnotationManifests(src, dest) {
+/**
+ * Union two `{schema, <map>: {id → …}}` sidecars, writing the result to [dest].
+ *
+ * Shared by the two nested map assets above. [mapKeys] names the id-keyed maps that
+ * manifest carries, and is also what the output declares — annotations publish
+ * `previews` + `references`, the tag index only `previews`, and neither should grow
+ * an empty map belonging to the other.
+ */
+async function mergeIdKeyedManifests(src, dest, mapKeys) {
   const read = async (p) => {
     try {
       return JSON.parse(await readFile(p, "utf8"));
@@ -143,14 +168,12 @@ async function mergeAnnotationManifests(src, dest) {
   };
   const a = (await read(dest)) ?? {};
   const b = (await read(src)) ?? {};
-  const schema = a.schema ?? b.schema;
   // Host entries win a key collision: the fold is additive, and a borrowed
   // catalog must never silently redefine an id the host already published.
-  const merged = {
-    schema,
-    previews: { ...(b.previews ?? {}), ...(a.previews ?? {}) },
-    references: { ...(b.references ?? {}), ...(a.references ?? {}) },
-  };
+  const merged = { schema: a.schema ?? b.schema };
+  for (const key of mapKeys) {
+    merged[key] = { ...(b[key] ?? {}), ...(a[key] ?? {}) };
+  }
   await mkdir(dirname(dest), { recursive: true });
   await writeFile(dest, `${JSON.stringify(merged, null, 2)}\n`, "utf8");
 }
@@ -167,7 +190,12 @@ async function copyAssets(fromDir, intoDir) {
     if (rel.split(sep)[0] === THEMES_DIR) continue;
     const dest = join(intoDir, rel);
     if (rel === ANNOTATIONS_REL) {
-      await mergeAnnotationManifests(src, dest);
+      await mergeIdKeyedManifests(src, dest, ["previews", "references"]);
+      copied += 1;
+      continue;
+    }
+    if (rel === TAG_INDEX_REL) {
+      await mergeIdKeyedManifests(src, dest, ["previews"]);
       copied += 1;
       continue;
     }

--- a/scripts/design-artifacts/merge-catalog-section.test.mjs
+++ b/scripts/design-artifacts/merge-catalog-section.test.mjs
@@ -291,3 +291,80 @@ test("a folded catalog cannot redefine an id the host already published", async 
   const merged = JSON.parse(await readFile(join(into, "annotations/index.json"), "utf8"));
   assert.equal(merged.previews.shared__id[0].label, "HOST");
 });
+
+test("mergeCatalogSection unions tag indexes instead of colliding", async () => {
+  // Regression (compose-samples): once the folded M3 section emitted a non-empty
+  // tags/index.json, every folding catalog aborted the `Fold in extra section` step
+  // with "asset 'tags/index.json' differs between the two catalogs". Both sides
+  // legitimately carry one — it is keyed by served preview id, not a per-component file.
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-tags-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+  await mkdir(join(into, "tags"), { recursive: true });
+  await mkdir(join(from, "tags"), { recursive: true });
+  await writeFile(join(into, "catalog.json"), JSON.stringify(manifest([comp("Host/One")])));
+  await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("M3/Two")])));
+  await writeFile(
+    join(into, "tags/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-tags/v1",
+      previews: {
+        "host-one__ideal__default": {
+          submit: { count: 1, bounds: { x: 0, y: 0, width: 10, height: 4 }, space: "render-pixels" },
+        },
+      },
+    }),
+  );
+  await writeFile(
+    join(from, "tags/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-tags/v1",
+      previews: {
+        "m3-two__ideal__default": { fab: { count: 2, space: "render-pixels" } },
+      },
+    }),
+  );
+
+  await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  const merged = JSON.parse(await readFile(join(into, "tags/index.json"), "utf8"));
+  assert.equal(merged.schema, "compose-preview-tags/v1");
+  assert.deepEqual(Object.keys(merged.previews).sort(), [
+    "host-one__ideal__default",
+    "m3-two__ideal__default",
+  ]);
+  // The tag index publishes only `previews`; folding must not graft on an empty
+  // `references` map that belongs to the annotations manifest.
+  assert.deepEqual(Object.keys(merged).sort(), ["previews", "schema"]);
+});
+
+test("a folded catalog cannot redefine tag geometry the host already published", async () => {
+  // A scoped parity acceptance resolves an element against this map, so a borrowed
+  // catalog silently moving the host's bounds would retarget the host's own gate.
+  const root = await mkdtemp(join(tmpdir(), "merge-catalog-tags-win-"));
+  const into = join(root, "into");
+  const from = join(root, "from");
+  await mkdir(join(into, "tags"), { recursive: true });
+  await mkdir(join(from, "tags"), { recursive: true });
+  await writeFile(join(into, "catalog.json"), JSON.stringify(manifest([comp("Host/One")])));
+  await writeFile(join(from, "catalog.json"), JSON.stringify(manifest([comp("M3/Two")])));
+  await writeFile(
+    join(into, "tags/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-tags/v1",
+      previews: { shared__id: { submit: { count: 1, space: "render-pixels" } } },
+    }),
+  );
+  await writeFile(
+    join(from, "tags/index.json"),
+    JSON.stringify({
+      schema: "compose-preview-tags/v1",
+      previews: { shared__id: { submit: { count: 99, space: "render-pixels" } } },
+    }),
+  );
+
+  await mergeCatalogSection({ into, from, section: "Material 3" });
+
+  const merged = JSON.parse(await readFile(join(into, "tags/index.json"), "utf8"));
+  assert.equal(merged.previews.shared__id.submit.count, 1);
+});


### PR DESCRIPTION
## Summary

Every compose-samples catalog that folds in the re-themed compose-m3 tab is currently failing to publish at the `Fold in extra section` step:

```
Error: merge-catalog-section: asset 'tags/index.json' differs between the two catalogs
  — refusing to overwrite <out>/tags/index.json
    at copyAssets (scripts/design-artifacts/merge-catalog-section.mjs:177)
```

Five of the seven systems are down on this — jetnews, jetlagged, reply, jetsnack, jetchat. (jetcaster-wear folds nothing and publishes fine; jetcaster fails earlier on an unrelated completeness gate.)

`copyAssets` skips top-level files as catalog-level and byte-compares everything nested, on the reasoning that nested ⇒ per-component. `tags/index.json` breaks that: it is `served preview id → {testTag: {count, bounds, space}}` (see `tag-index.mjs`), so the host and the folded section each legitimately carry their own. This is the identical shape to `annotations/index.json`, whose comment already records the same failure — *"which is exactly what happened the first time the host catalog produced a non-empty one"*. The tag index has now hit it the same way.

Union by preview id with the host winning collisions, matching the annotations rule: a folded component becomes a tab in the host, so its element gates belong alongside the host's, and a borrowed catalog must not redefine geometry that a scoped parity acceptance (#3680) resolves against.

Rather than a second near-identical merge function, the two sidecars now share one helper parameterised on the id-keyed maps each publishes. That parameter is load-bearing, not cosmetic: annotations publish `previews` + `references`, the tag index only `previews`, and hardcoding both would graft an empty `references` map onto the published tag index.

## Test plan

- `node --test merge-catalog-section.test.mjs` → **13/13 pass**, including the two pre-existing annotations tests, which is what pins the shared helper to the old behaviour.
- Two new tests mirroring the annotations pair: the union case (both indexes survive, and the output declares only `schema` + `previews`), and the host-wins case (a borrowed catalog cannot move the host's tag geometry).
- Full `node --test *.test.mjs` in `scripts/design-artifacts`: 732 pass / 6 fail. I checked those 6 against a clean `origin/main` checkout and they fail identically there — they need `npm ci` dependencies that aren't installed in this sandbox (`catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, `rc-compare-pixels`, `rc-size-modifier`). No regression from this change.

Text-only is right here: this is export-driver plumbing with no rendered surface. The user-visible effect is that the five blocked catalogs publish again, which the next `design-artifacts` run on compose-samples' `previews` demonstrates.

---
_Generated by [Claude Code](https://claude.ai/code/session_015WA5cgxHyG8n5wgaLVKVV3)_