### PR TITLE
feat(serve): answer 503 for a capture the branch is refusing

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -135,7 +135,15 @@ class ServeBundleHost(
    * Same seam as [fetchBakedPng], for the same reason: the store owns URL assembly, the SSRF gate,
    * the size cap and the test seam, and this host only names an id it was told about.
    */
-  private val fetchMotion: ((String) -> ByteArray?)? = null,
+  /**
+   * Fetches one declared capture off the delivery branch, reporting **why** a failure failed.
+   *
+   * Outcome-shaped rather than `ByteArray?` for the reason the transport seam is: a second seam
+   * beside a bytes-shaped one is a lane waiting to be forgotten. The reason travels because the
+   * route needs it — a throttled capture is a `503` the reader can retry, and a `404` says the
+   * catalog never published it.
+   */
+  private val fetchMotion: ((String) -> BranchFetch)? = null,
   /** Each declared capture's branch path, so a pinned (`?at=<sha>`) request can resolve one. */
   private val motionBranchPaths: Map<String, String> = emptyMap(),
   /**
@@ -862,33 +870,46 @@ class ServeBundleHost(
    * the part that is merely mechanical. Folding them together would mean threading a suffix through
    * the fill path, which is how a capture ends up written under a still's name.
    */
-  private fun motionFile(motionId: String, extension: String): okio.Path? {
-    if (motionId !in declaredMotionIds) return null
-    if (extension !in MOTION_EXTENSIONS) return null
+  private fun motionFile(motionId: String, extension: String): BranchFetch {
+    if (motionId !in declaredMotionIds) return BranchFetch.NotFound
+    if (extension !in MOTION_EXTENSIONS) return BranchFetch.NotFound
     // The requested suffix must be the one THIS capture was published as, not merely a format the
     // lane supports. Checking only the allowlist would let `<id>.gif` serve an APNG's bytes typed
     // as
     // a GIF: the same bytes, a content type the requester chose, and a browser that renders one
     // frame and stops. The declared branch path is the authority on which it is.
-    if (motionBranchPaths[motionId]?.endsWith(extension) != true) return null
-    val path = previewFile(motionId, extension)?.toOkioPath() ?: return null
-    if (fileSystem.exists(path)) return path
-    val fetch = fetchMotion ?: return null
+    if (motionBranchPaths[motionId]?.endsWith(extension) != true) return BranchFetch.NotFound
+    val path = previewFile(motionId, extension)?.toOkioPath() ?: return BranchFetch.NotFound
+    if (fileSystem.exists(path)) return readStagedMotion(path)
+    val fetch = fetchMotion ?: return BranchFetch.NotFound
     // Keyed distinctly from the baked lane: a capture and its sibling still share an id, so one
     // lock namespace would have a cold capture fetch block a warm sticker read on the same card.
     synchronized(fillLocks.computeIfAbsent("$MOTION_LOCK_PREFIX$motionId") { Any() }) {
-      if (fileSystem.exists(path)) return path
-      val bytes = runCatching { fetch(motionId) }.getOrNull() ?: return null
-      return runCatching {
+      if (fileSystem.exists(path)) return readStagedMotion(path)
+      val outcome = runCatching {
+        fetch(motionId)
+      }
+        .getOrElse { BranchFetch.Transport(it::class.simpleName ?: "error") }
+      // A failure is returned AS ITSELF rather than flattened: a throttle here is what makes the
+      // route answer 503 instead of telling the reader the capture was never published.
+      val bytes = outcome.bytesOrNull ?: return outcome
+      // Staging failing is not the branch's fault and not a missing asset either — the bytes are in
+      // hand, so serve them and let the next request try the disk again.
+      runCatching {
         path.parent?.let(fileSystem::createDirectories)
         val partial = path.parent!!.resolve(path.name + PARTIAL_SUFFIX)
         fileSystem.write(partial) { write(bytes) }
         fileSystem.atomicMove(partial, path)
-        path
       }
-        .getOrNull()
+      return BranchFetch.Ok(bytes)
     }
   }
+
+  /** A staged capture read back off disk; an unreadable stage is transient, not a missing asset. */
+  private fun readStagedMotion(path: okio.Path): BranchFetch = runCatching {
+    BranchFetch.Ok(fileSystem.read(path) { readByteArray() })
+  }
+    .getOrElse { BranchFetch.Transport(it::class.simpleName ?: "error") }
 
   /**
    * The bytes of one published capture, or null when this host can't serve it.
@@ -897,10 +918,8 @@ class ServeBundleHost(
    * manifest, and gets bytes or nothing. Both are checked against what the catalog declared, so a
    * request can neither invent an id nor choose the suffix its response is typed with.
    */
-  override fun motionBytes(motionId: String, extension: String): ByteArray? =
-    motionFile(motionId, extension)?.takeIf(fileSystem::exists)?.let {
-      runCatching { fileSystem.read(it) { readByteArray() } }.getOrNull()
-    }
+  override fun motionRead(motionId: String, extension: String): BranchFetch =
+    motionFile(motionId, extension)
 
   /** The branch path of a declared capture, for a pinned request. */
   fun motionBranchPath(motionId: String): String? = motionBranchPaths[motionId]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -175,8 +175,8 @@ class ServeCatalogLiveHost(
   // fell to `ServeHost.motionBytes`'s null default because this composite never forwarded them.
   // A static catalog is pinned and served by the bundle host directly, which is why the fixtures —
   // all of them pinned — never met the shape that breaks.
-  override fun motionBytes(motionId: String, extension: String): ByteArray? =
-    baked.motionBytes(motionId, extension)
+  override fun motionRead(motionId: String, extension: String): BranchFetch =
+    baked.motionRead(motionId, extension)
 
   override fun designReferenceRaster(referenceId: String): ByteArray? =
     baked.designReferenceRaster(referenceId)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -782,7 +782,8 @@ class ServeCatalogStore(
           // a reader actually asks to watch something.
           declaredMotion = motionPathById.keys.toList(),
           fetchMotion = { id ->
-            motionPathById[id]?.let { path -> fetchCatalogAsset(base + path) }
+            motionPathById[id]?.let { path -> fetchCatalogAssetOutcome(base + path) }
+              ?: BranchFetch.NotFound
           },
           motionBranchPaths = motionPathById.toMap(),
           // The branch path of every baked render, so a pinned (`?at=<sha>`) request can be

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHost.kt
@@ -234,7 +234,15 @@ interface ServeHost : AutoCloseable {
    * because the two formats aren't interchangeable to a browser, and it is validated against what
    * the catalog declared rather than trusted, so a request can't choose its own content type.
    */
-  fun motionBytes(motionId: String, extension: String): ByteArray? = null
+  /**
+   * One published capture, with the reason a failure failed.
+   *
+   * The reason is the point: a host that cannot distinguish a capture the catalog never published
+   * from one the delivery branch is currently refusing to serve leaves the route with nothing to
+   * say but 404, and the reader with "could not be loaded" for both. Defaults to
+   * [BranchFetch.NotFound] — a host with no branch behind it publishes no captures.
+   */
+  fun motionRead(motionId: String, extension: String): BranchFetch = BranchFetch.NotFound
 
   /**
    * A visitor is present on this session's pages right now (see `POST /api/presence`) — get its
@@ -610,3 +618,16 @@ interface ServeHost : AutoCloseable {
   /** Count of live upstream streams (0 for hosts without a live lane). */
   fun activeStreamCount(): Int
 }
+
+/**
+ * [ServeHost.motionRead]'s bytes, for callers that only care whether there are any.
+ *
+ * An **extension**, deliberately, rather than a second interface member: with both on the interface
+ * an implementor could override this one, see its override silently ignored (every caller goes
+ * through [ServeHost.motionRead]), and ship a host that serves no captures — which is the shape of
+ * the bug that made the Motion lane 404 in the first place, where `ServeCatalogLiveHost`
+ * implemented a pair and missed a member of it. An extension cannot be overridden, so there is one
+ * place to implement and no way to implement the wrong one.
+ */
+fun ServeHost.motionBytes(motionId: String, extension: String): ByteArray? =
+  motionRead(motionId, extension).bytesOrNull

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -6137,12 +6137,26 @@ class ServeHttpServer(
       return
     }
     val motionId = name.removeSuffix(extension)
-    val bytes =
+    val outcome =
       withLeasedSessionOrNull(selectedSessionId(sessionInPath)) { host ->
-        host.motionBytes(motionId, extension)
-      }
+        host.motionRead(motionId, extension)
+      } ?: BranchFetch.NotFound
+    val bytes = outcome.bytesOrNull
     if (bytes == null) {
-      call.respondText("", status = HttpStatusCode.NotFound)
+      // A capture the catalog never published is a 404 and always was. A capture the delivery
+      // branch is currently refusing us is NOT — answering 404 there tells the reader the recording
+      // does not exist, which is what "The recorded interaction could not be loaded" meant for both
+      // cases and what made diagnosing this lane a manual exercise. 503 with `Retry-After` says the
+      // true thing to a browser, a monitor and a person reading a log alike.
+      if (outcome.isTransient) {
+        call.response.headers.append(
+          HttpHeaders.RetryAfter,
+          motionRetryAfterSeconds(outcome).toString(),
+        )
+        call.respondText(outcome.summary, status = HttpStatusCode.ServiceUnavailable)
+      } else {
+        call.respondText("", status = HttpStatusCode.NotFound)
+      }
       return
     }
     // Revalidated, NOT `immutable` — and the distinction is the whole point of this block.
@@ -6167,6 +6181,24 @@ class ServeHttpServer(
       return
     }
     call.respondBytes(bytes, ContentType.parse(MOTION_CONTENT_TYPES.getValue(extension)))
+  }
+
+  /**
+   * The `Retry-After` a refused capture advertises: what the branch host itself asked for when it
+   * said so, else a short default. Clamped to the same ceiling the fetch policy honours, so the
+   * header can never promise a wait longer than the server would itself wait.
+   */
+  private fun motionRetryAfterSeconds(outcome: BranchFetch): Long {
+    val asked =
+      when (outcome) {
+        is BranchFetch.Throttled -> outcome.retryAfterSeconds
+        is BranchFetch.Unavailable -> outcome.retryAfterSeconds
+        else -> null
+      }
+    return (asked ?: MOTION_DEFAULT_RETRY_AFTER_SECONDS).coerceIn(
+      1L,
+      BranchFetch.MAX_RETRY_AFTER_SECONDS,
+    )
   }
 
   private suspend fun RoutingContext.rejectHeadProbe(): Boolean {
@@ -6933,6 +6965,9 @@ class ServeHttpServer(
      * unlike the hashed lanes these live at well-known paths whose bytes change across a deploy.
      */
     private const val SITE_ICON_CACHE_CONTROL = "public, max-age=86400"
+
+    /** `Retry-After` for a refused capture whose branch host named no interval of its own. */
+    private const val MOTION_DEFAULT_RETRY_AFTER_SECONDS = 5L
 
     /**
      * Caching for the prebaked image lanes: `/hero/` and `?thumb=` on the render lane.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -53,8 +53,8 @@ class ServeCatalogLiveHostTest {
     /** Published captures this host can serve, keyed `<motionId><extension>`. */
     private val motion: Map<String, ByteArray> = emptyMap(),
   ) : ServeHost {
-    override fun motionBytes(motionId: String, extension: String): ByteArray? =
-      motion["$motionId$extension"]
+    override fun motionRead(motionId: String, extension: String): BranchFetch =
+      motion["$motionId$extension"]?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
 
     override val label: String = tag
     override val canApplyOverrides: Boolean = streaming

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -715,7 +715,9 @@ class ServeHttpRoutingTest {
         title = "Suspended Catalog",
         declaredBaked = listOf("switch-on"),
         declaredMotion = listOf(motionId),
-        fetchMotion = { id -> if (id == motionId) "capture".toByteArray() else null },
+        fetchMotion = { id ->
+          if (id == motionId) BranchFetch.Ok("capture".toByteArray()) else BranchFetch.NotFound
+        },
         motionBranchPaths = mapOf(motionId to "motion/switch-on/ideal__default__light.apng"),
       )
     // The production shape, and the reason a bare bundle host would not have exercised the bug: a
@@ -762,6 +764,76 @@ class ServeHttpRoutingTest {
     } finally {
       suspendedServer.stop()
       suspendedRegistry.close()
+    }
+  }
+
+  @Test
+  fun `a capture the branch is refusing is a 503, not a 404`() {
+    // The whole point of BranchFetch reaching this route. 404 says "the catalog never published
+    // this recording", which is what the reader was told for a throttle too — so a rate-limited
+    // capture looked exactly like one that does not exist, in the viewer and in any log.
+    val motionId = "switch-on__ideal__default__light"
+    val dir = Files.createTempDirectory("routing-motion-503").toFile().also { it.deleteOnExit() }
+    File(dir, "previews").apply { mkdirs() }
+    File(dir, "previews/switch-on.png").writeBytes(png())
+
+    var answer: BranchFetch = BranchFetch.Throttled(retryAfterSeconds = 7)
+    val motionRegistry = ServeSessionRegistry(open = { null })
+    motionRegistry.register("default-mod", host = bundle("default-mod"), pinned = true)
+    motionRegistry.register(
+      "throttled-cat",
+      host =
+        ServeBundleHost(
+          dir,
+          label = "throttled-cat",
+          title = "Throttled Catalog",
+          declaredBaked = listOf("switch-on"),
+          declaredMotion = listOf(motionId),
+          fetchMotion = { answer },
+          motionBranchPaths = mapOf(motionId to "motion/switch-on/ideal__default__light.apng"),
+        ),
+      pinned = true,
+    )
+    val motionServer =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused-in-public",
+          sessions = motionRegistry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+          catalogSessions = listOf("throttled-cat"),
+        )
+        .also { it.start() }
+    fun fetchMotion(): Pair<Int, String?> {
+      val req =
+        Request.Builder()
+          .url("http://127.0.0.1:${motionServer.port}/throttled-cat/motion/$motionId.apng")
+          .build()
+      client.newCall(req).execute().use { r ->
+        return r.code to r.header("Retry-After")
+      }
+    }
+    try {
+      // Throttled: 503, and the branch host's own interval is passed straight through.
+      assertEquals(503 to "7", fetchMotion())
+
+      // An outage that names no interval still gets a usable one rather than none.
+      answer = BranchFetch.Unavailable(503)
+      val (code, retryAfter) = fetchMotion()
+      assertEquals(503, code)
+      assertNotEquals(null, retryAfter, "a 503 without Retry-After tells the client nothing")
+
+      // A capture the catalog genuinely never published stays a 404 — this is not a blanket 503.
+      answer = BranchFetch.NotFound
+      assertEquals(404 to null, fetchMotion())
+
+      // …and once the branch serves it, it serves.
+      answer = BranchFetch.Ok("capture".toByteArray())
+      assertEquals(200 to null, fetchMotion())
+    } finally {
+      motionServer.stop()
+      motionRegistry.close()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -74,7 +74,9 @@ class ServeTopLevelSiteTest {
       title = label,
       declaredBaked = listOf(previewId),
       declaredMotion = listOf(motionId),
-      fetchMotion = { id -> if (id == motionId) captureMarker.toByteArray() else null },
+      fetchMotion = { id ->
+        if (id == motionId) BranchFetch.Ok(captureMarker.toByteArray()) else BranchFetch.NotFound
+      },
       motionBranchPaths = mapOf(motionId to "motion/switch-on/ideal__default__light.apng"),
     )
   }


### PR DESCRIPTION
A capture the catalog never published and a capture the delivery branch is currently refusing were both a bare `404`, so the viewer said "The recorded interaction could not be loaded" for both. #4113 gave the fetch layer the vocabulary to tell them apart; this carries it out to the route.

## What changes

A transient outcome — throttled, unavailable, transport — now answers **`503` with `Retry-After`**. The interval is what the branch host itself asked for when it said so, otherwise a short default, clamped to the same ceiling the fetch policy honours so the header can never promise a longer wait than the server would itself take.

A genuine `NotFound` is still a `404`. This is deliberately not a blanket `503`: the two cases stay distinguishable to a browser, a monitor, and anyone reading a log.

```
Throttled(retryAfterSeconds = 7)  ->  503, Retry-After: 7
Unavailable(503)                  ->  503, Retry-After: <default>
NotFound                          ->  404
Ok                                ->  200
```

## A trap closed on the way past

`ServeHost` gains `motionRead`, which reports the reason. `motionBytes` becomes an **extension function** rather than a second interface member.

That is not tidiness. With both on the interface, an implementor could override `motionBytes`, have the override silently ignored because every caller goes through `motionRead`, and ship a host that serves no captures — which is *exactly* the shape of the bug this whole line of work started from, where `ServeCatalogLiveHost` implemented a pair and missed a member of it (#4110). Adding `motionRead` beside `motionBytes` rebuilt that trap with fresh timber.

`ServeCatalogLiveHostTest` caught it while it was still open — its `RecordingHost` overrode `motionBytes` and the composite stopped seeing it. That's the argument for closing the hole structurally rather than by remembering: an extension cannot be overridden, so there is one place to implement and no way to implement the wrong one.

For the same reason the motion fetch seam now answers `BranchFetch` rather than sitting beside a bytes-shaped sibling. Two seams for one job is how one of them gets forgotten — the lesson from the transport seam in #4113.

## Not in this PR

- **Viewer wording.** An `<img>` error handler cannot see a status code, so distinguishing in the UI needs a follow-up request on the failure path to read it. Worth doing, but it is a separate change with its own test surface — and the `503` is already the honest answer to every non-browser client today.
- **`/status.json` branch-fetch telemetry** — next.

## Test plan

```
./gradlew :cli:test                                     # full CLI suite, green
./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest       # green
```

New coverage in `ServeHttpRoutingTest` — a throttle passes its interval straight through, an outage with no stated interval still gets a usable one, a genuinely unpublished capture stays `404`, and a served one is `200`. Verified red without the mapping:

```
ServeHttpRoutingTest - a capture the branch is refusing is a 503, not a 404()  FAILED
```

Text-only PR: no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_