### PR TITLE
feat(serve): report delivery-branch read counters on /status.json

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2457,6 +2457,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         docStore = docStore,
         playgroundService = playgroundLane?.compile,
         playgroundHealth = playgroundLane?.health,
+        branchFetchStats = catalogStore?.let { store -> { store.branchFetchStats.snapshot() } },
         playgroundRedeem = playgroundLane?.redeem,
         githubAuth = githubAuth,
         playgroundRateLimiter = playgroundLane?.let { buildPlaygroundRateLimiter() },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Counters for reads against a delivery branch — the serve-side companion to [RenderPerfStats],
+ * covering the *other* thing this server does that can fail on someone else's schedule.
+ *
+ * ### Why
+ *
+ * Renders have had failure telemetry for a long time: `/status.json` reports how many failed, why,
+ * and when. Branch reads — the lane that actually talks to GitHub — had none. So when every
+ * published motion capture stopped loading, the only way to answer "is GitHub rate-limiting us, or
+ * did we never publish that file?" was to reproduce it by hand with `curl` against both the server
+ * and `raw.githubusercontent.com`. That is a diagnosis a status page should hand you.
+ *
+ * [BranchFetch] made the distinction *exist*; this makes it **observable**. `throttled` climbing
+ * while `notFound` sits still is a rate limit, and reads off a page.
+ *
+ * ### Shape
+ *
+ * Deliberately counters plus a small recent-failure ring rather than per-URL detail: a busy server
+ * reads thousands of assets, the useful question is "what is happening to us right now", and a URL
+ * list is both unbounded and a way to leak a private catalog's paths onto a public status page.
+ *
+ * Thread-safe; every method is one short critical section. Recording is on the fetch path, so it
+ * stays allocation-free in the common (successful) case.
+ *
+ * ### One thing these deliberately do not show
+ *
+ * A read counts **once, by how it ended**. The transport retries a transient failure internally
+ * (see `httpFetchOutcome`), so a throttle that the retry rescued lands here as `ok` and leaves
+ * `throttled` at zero — the counters live above the retry loop, which is also what lets them count
+ * an injected transport at all. So `throttled` reads as "throttles we could not ride out", not
+ * "throttles we met". Worth closing if the difference ever matters; counting it properly means the
+ * transport reporting each attempt, which is a wider seam than this is worth today.
+ */
+class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis) {
+  private val lock = Any()
+
+  private var attempted = 0L
+  private var ok = 0L
+  private var notFound = 0L
+  private var throttled = 0L
+  private var unavailable = 0L
+  private var transport = 0L
+  private var lastThrottleAtEpochMillis: Long? = null
+  private var lastFailureAtEpochMillis: Long? = null
+  private var lastFailureReason: String? = null
+
+  /** One completed read, however it ended. */
+  fun record(outcome: BranchFetch): Unit =
+    synchronized(lock) {
+      attempted++
+      when (outcome) {
+        is BranchFetch.Ok -> ok++
+        is BranchFetch.NotFound -> notFound++
+        is BranchFetch.Throttled -> {
+          throttled++
+          lastThrottleAtEpochMillis = clock()
+        }
+        is BranchFetch.Unavailable -> unavailable++
+        is BranchFetch.Transport -> transport++
+      }
+      if (outcome !is BranchFetch.Ok && outcome !is BranchFetch.NotFound) {
+        lastFailureAtEpochMillis = clock()
+        lastFailureReason = outcome.summary.take(MAX_REASON_CHARS)
+      }
+    }
+
+  /** A snapshot for `/status.json`, or null when nothing has been read yet. */
+  fun snapshot(): BranchFetchSnapshot? =
+    synchronized(lock) {
+      if (attempted == 0L) return null
+      BranchFetchSnapshot(
+        attempted = attempted,
+        ok = ok,
+        notFound = notFound,
+        throttled = throttled,
+        unavailable = unavailable,
+        transport = transport,
+        lastThrottleAtEpochMillis = lastThrottleAtEpochMillis,
+        lastFailureAtEpochMillis = lastFailureAtEpochMillis,
+        lastFailureReason = lastFailureReason,
+      )
+    }
+
+  companion object {
+    /** Failure reasons are bounded before they reach a status page. */
+    const val MAX_REASON_CHARS = 200
+  }
+}
+
+/**
+ * Delivery-branch read counters on `/status.json` (`branchFetch`).
+ *
+ * `notFound` is **not** an error: a catalog legitimately declares assets a given revision never
+ * published, and the lane is built to answer that cheaply. The three that mean something is wrong
+ * with the *branch host* rather than with the catalog are [throttled], [unavailable] and
+ * [transport] — those are the ones to alert on.
+ */
+@Serializable
+data class BranchFetchSnapshot(
+  val attempted: Long,
+  val ok: Long,
+  /** Reads the branch answered as genuinely absent. Expected, not a fault. */
+  val notFound: Long,
+  /** `429`/`403` — the signal that this server is being rate-limited. */
+  val throttled: Long,
+  /** `5xx` and other refusals. */
+  val unavailable: Long,
+  /** Never got an answer: timeout, DNS, TLS, reset. */
+  val transport: Long,
+  val lastThrottleAtEpochMillis: Long? = null,
+  val lastFailureAtEpochMillis: Long? = null,
+  val lastFailureReason: String? = null,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -76,7 +76,13 @@ class ServeCatalogStore(
    * request to GitHub for pins alone. One seam, one answer shape, nothing to forget to wire.
    */
   private val networkFetch: (url: String, maxBytes: Long) -> BranchFetch = ::httpFetchOutcome,
-  private val networkProbe: (url: String) -> Boolean = ::httpExists,
+  /**
+   * Existence probe (a `HEAD`), outcome-shaped like [networkFetch] so it is counted too. A probe
+   * that answered a bare `Boolean` collapsed "absent" and "the branch refused us" into `false`, so
+   * a throttled executable-bundle lane went quiet with `/status.json` still reading healthy — the
+   * same blindness this telemetry exists to remove, one seam over.
+   */
+  private val networkProbe: (url: String) -> BranchFetch = ::httpProbeOutcome,
   private val maxImages: Int = DEFAULT_MAX_IMAGES,
   /**
    * Called when the catalog declares an in-browser Wasm app (`webRender` in `catalog.json`) and its
@@ -1368,7 +1374,7 @@ class ServeCatalogStore(
   ): Boolean {
     val cached = File(File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR), "$stem.png")
     if (cached.isFile && cached.length() > 0 && isCompleteExecutableBundle(cached)) return true
-    return runCatching { networkProbe(perPreviewBundleUrl(stem, liveBundle, base)) }
+    return runCatching { branchProbe(perPreviewBundleUrl(stem, liveBundle, base)) }
       .getOrDefault(false)
   }
 
@@ -2555,9 +2561,23 @@ class ServeCatalogStore(
     private fun httpFetch(url: String, maxBytes: Long): ByteArray? =
       httpFetchOutcome(url, maxBytes).bytesOrNull
 
-    private fun httpExists(url: String): Boolean =
-      httpClient.newCall(Request.Builder().url(url).head().build()).execute().use {
-        it.isSuccessful
+    /**
+     * A `HEAD` probe as an outcome. [BranchFetch.Ok] carries no bytes — nothing was asked for; it
+     * means only "the branch has this". The point of the type here is the failure side: a `429` on
+     * a probe is a throttle to count, not an absent file.
+     */
+    private fun httpProbeOutcome(url: String): BranchFetch =
+      try {
+        httpClient.newCall(Request.Builder().url(url).head().build()).execute().use { response ->
+          if (response.isSuccessful) BranchFetch.Ok(ByteArray(0))
+          else
+            BranchFetch.ofStatus(
+              response.code,
+              BranchFetch.parseRetryAfter(response.header("Retry-After")),
+            )
+        }
+      } catch (e: java.io.IOException) {
+        BranchFetch.Transport(e::class.simpleName ?: "IOException")
       }
 
     private fun readCapped(input: InputStream, max: Long): ByteArray {
@@ -2616,6 +2636,10 @@ class ServeCatalogStore(
   /** [networkFetch] with its outcome counted. Every network read in this store goes through it. */
   private fun branchRead(url: String, maxBytes: Long): BranchFetch =
     networkFetch(url, maxBytes).also(branchFetchStats::record)
+
+  /** [networkProbe] with its outcome counted; true only when the branch actually has the file. */
+  private fun branchProbe(url: String): Boolean =
+    networkProbe(url).also(branchFetchStats::record) is BranchFetch.Ok
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2596,16 +2596,30 @@ class ServeCatalogStore(
     runCatching {
       val url = ServeCatalogRevision.commitsFeedUrl(repo, branch)
       val body =
-        if (fetch != null) fetch.invoke(url)
-        else networkFetch(url, MAX_FEED_FETCH_BYTES).bytesOrNull
+        if (fetch != null) fetch.invoke(url) else branchRead(url, MAX_FEED_FETCH_BYTES).bytesOrNull
       body?.toString(Charsets.UTF_8)?.let { ServeCatalogRevision.parseCommitsFeed(it) }
     }
     .getOrNull()
     .orEmpty()
 
+  /**
+   * Delivery-branch read counters for this store (`/status.json` → `branchFetch`).
+   *
+   * Per-store and wrapped around [networkFetch] rather than recorded inside the default HTTP
+   * transport, for two reasons that are the same reason: a counter on the companion would be
+   * process-global mutable state shared by every store in a test JVM, **and** it would record
+   * nothing at all for a store given an injected transport — telemetry that goes quiet exactly when
+   * someone has configured something unusual is worse than none, because it reads as healthy.
+   */
+  val branchFetchStats = BranchFetchStats()
+
+  /** [networkFetch] with its outcome counted. Every network read in this store goes through it. */
+  private fun branchRead(url: String, maxBytes: Long): BranchFetch =
+    networkFetch(url, maxBytes).also(branchFetchStats::record)
+
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? =
-    if (fetch != null) fetch.invoke(url) else networkFetch(url, MAX_FETCH_BYTES).bytesOrNull
+    if (fetch != null) fetch.invoke(url) else branchRead(url, MAX_FETCH_BYTES).bytesOrNull
 
   /**
    * [fetchCatalogAsset], keeping the reason a failure failed.
@@ -2619,7 +2633,7 @@ class ServeCatalogStore(
     if (fetch != null) {
       fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
     } else {
-      networkFetch(url, MAX_FETCH_BYTES)
+      branchRead(url, MAX_FETCH_BYTES)
     }
 
   /**
@@ -2715,5 +2729,5 @@ class ServeCatalogStore(
    */
   private fun fetchExecutableBundle(url: String): ByteArray? =
     if (fetch != null) fetch.invoke(url)
-    else networkFetch(url, MAX_LIVE_BUNDLE_FETCH_BYTES).bytesOrNull
+    else branchRead(url, MAX_LIVE_BUNDLE_FETCH_BYTES).bytesOrNull
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -267,6 +267,12 @@ class ServeHttpServer(
    */
   private val playgroundHealth: (() -> PlaygroundHealth)? = null,
   /**
+   * Delivery-branch read counters for `/status.json`, read from the catalog store that owns them. A
+   * provider rather than the snapshot itself because `/status.json` is polled and the numbers move;
+   * null for a server with no catalog store, whose branch-read count is not zero but undefined.
+   */
+  private val branchFetchStats: (() -> BranchFetchSnapshot?)? = null,
+  /**
    * Per-caller budget on the compile lane (issue #3214), or null to leave it unmetered. Every other
    * playground bound is a whole-host one, so without this two callers issuing back-to-back compiles
    * hold every slot and everyone else is told the playground is busy.
@@ -4217,6 +4223,7 @@ class ServeHttpServer(
             )
           },
         recentDaemonFailures = failures.map { FailureDto(it.atEpochMillis, it.session, it.reason) },
+        branchFetch = branchFetchStats?.invoke(),
         renderStats =
           RenderPerfSnapshot.aggregate(
             // A fresh daemon reports an all-zero snapshot; keep the roll-up null until something
@@ -7107,6 +7114,16 @@ private data class StatusResponse(
   val catalogList: List<CatalogDto>,
   val runningServers: List<RunningServerDto>,
   val recentDaemonFailures: List<FailureDto>,
+  /**
+   * Delivery-branch read counters ([BranchFetchSnapshot]). Null until this server has read a branch
+   * at all. Additive on `compose-preview-serve/status/v1`.
+   *
+   * This is what makes "is GitHub rate-limiting us?" a question you answer by looking rather than
+   * by reproducing it with `curl` — `throttled` climbing while `notFound` holds still is a rate
+   * limit, and `notFound` on its own is the ordinary case of a catalog declaring an asset a given
+   * revision never published.
+   */
+  val branchFetch: BranchFetchSnapshot? = null,
   /**
    * Server-wide render-latency roll-up across the running live daemons (see
    * [RenderPerfSnapshot.aggregate] — counts sum, `firstRenderMs` is the worst first render,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4223,7 +4223,12 @@ class ServeHttpServer(
             )
           },
         recentDaemonFailures = failures.map { FailureDto(it.atEpochMillis, it.session, it.reason) },
-        branchFetch = branchFetchStats?.invoke(),
+        // Omitted on a site host. `/status` there reports on ONE app by design — "a monitor
+        // pointed at the site alerts on the site, and a visitor learns nothing about what else the
+        // box runs" — and these counters are box-wide with no per-system breakdown. Including them
+        // would both fire a site's monitor on a neighbour's throttle and disclose that the
+        // neighbour exists, which is the one thing a top-level site is for.
+        branchFetch = if (onlySystem == null) branchFetchStats?.invoke() else null,
         renderStats =
           RenderPerfSnapshot.aggregate(
             // A fresh daemon reports an all-zero snapshot; keep the roll-up null until something

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The branch-read counters ([BranchFetchStats]).
+ *
+ * These exist because renders had failure telemetry and branch reads — the lane that actually talks
+ * to GitHub — had none, so "is GitHub rate-limiting us, or was that asset never published?" could
+ * only be answered by reproducing it by hand. The assertions below are all about keeping those two
+ * answers separable on a status page.
+ */
+class BranchFetchStatsTest {
+
+  @Test
+  fun `a quiet server advertises nothing`() {
+    // Not a block of zeros: the same choice the render roll-up makes. "Nothing has been read" and
+    // "everything read succeeded" are different, and a status page should not blur them.
+    assertNull(BranchFetchStats().snapshot())
+  }
+
+  @Test
+  fun `a throttle is counted apart from a missing file`() {
+    // The whole point. A rate limit and a genuinely absent asset were the same `null` before
+    // BranchFetch; if they were the same counter here, the status page would be back to useless.
+    val stats = BranchFetchStats(clock = { 1_000L })
+    stats.record(BranchFetch.Ok(byteArrayOf(1)))
+    stats.record(BranchFetch.NotFound)
+    stats.record(BranchFetch.NotFound)
+    stats.record(BranchFetch.Throttled(5))
+
+    val snap = stats.snapshot()!!
+    assertEquals(4, snap.attempted)
+    assertEquals(1, snap.ok)
+    assertEquals(2, snap.notFound)
+    assertEquals(1, snap.throttled)
+    assertEquals(0, snap.unavailable)
+    assertEquals(1_000L, snap.lastThrottleAtEpochMillis)
+  }
+
+  @Test
+  fun `a missing file is not recorded as a failure`() {
+    // A catalog legitimately declares assets a given revision never published. Folding those into
+    // the failure fields would keep the alert-worthy numbers permanently non-zero, which is the
+    // same as having no alert.
+    val stats = BranchFetchStats(clock = { 7L })
+    stats.record(BranchFetch.NotFound)
+
+    val snap = stats.snapshot()!!
+    assertEquals(1, snap.notFound)
+    assertNull(snap.lastFailureAtEpochMillis, "an absent asset is the expected case, not a fault")
+    assertNull(snap.lastFailureReason)
+  }
+
+  @Test
+  fun `the branch host's own failures carry a reason and a time`() {
+    val stats = BranchFetchStats(clock = { 42L })
+    stats.record(BranchFetch.Unavailable(503))
+
+    val snap = stats.snapshot()!!
+    assertEquals(1, snap.unavailable)
+    assertEquals(42L, snap.lastFailureAtEpochMillis)
+    assertTrue(snap.lastFailureReason!!.contains("503"), snap.lastFailureReason!!)
+    assertNull(snap.lastThrottleAtEpochMillis, "a 503 is not a rate limit")
+  }
+
+  @Test
+  fun `a read counts once, by how it ended`() {
+    // The counters sit above the transport's retry loop — which is what lets them count an injected
+    // transport at all — so a throttle the retry rescued arrives here as `ok`. Asserted rather than
+    // left implicit, because `throttled: 0` means "none we could not ride out", not "none met".
+    val stats = BranchFetchStats()
+    stats.record(BranchFetch.Ok(byteArrayOf(1)))
+    val snap = stats.snapshot()!!
+    assertEquals(1, snap.attempted)
+    assertEquals(1, snap.ok)
+    assertEquals(0, snap.throttled)
+  }
+
+  @Test
+  fun `a failure reason is bounded before it reaches a status page`() {
+    val stats = BranchFetchStats()
+    stats.record(BranchFetch.Transport("x".repeat(BranchFetchStats.MAX_REASON_CHARS * 3)))
+    val reason = stats.snapshot()!!.lastFailureReason!!
+    assertTrue(reason.length <= BranchFetchStats.MAX_REASON_CHARS, "length ${reason.length}")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1440,7 +1440,11 @@ class ServeCatalogStoreTest {
         fetch = fetch,
         networkProbe = { url ->
           requested += "HEAD $url"
-          url.endsWith("bundle/previews/FilledButton_Dark.png")
+          // Outcome-shaped like the seam it stands in for: a probe that answered a bare Boolean
+          // could not tell "absent" from "the branch refused us", which is what left the
+          // executable-bundle lane invisible to /status.json.
+          if (url.endsWith("bundle/previews/FilledButton_Dark.png")) BranchFetch.Ok(ByteArray(0))
+          else BranchFetch.NotFound
         },
         buildTrustedBundle = { _, _, _, _, _, access ->
           perPreviewAccess = access

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -14,6 +14,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
@@ -544,5 +549,66 @@ class ServeStatusTest {
     // The generated links keep the token so clicking them doesn't hit the intentional 404.
     assertTrue(html.contains("href=\"/status.json?token=s3cret\""), "status.json link keeps token")
     assertTrue(html.contains("href=\"/compose-m3/?token=s3cret\""), "catalog link keeps token")
+  }
+
+  @Test
+  fun `status reports delivery-branch read counters`() {
+    // The gap this closes: renders have had failure telemetry for a long time, and branch reads —
+    // the lane that actually talks to GitHub — had none. So "is GitHub rate-limiting us, or was
+    // that asset never published?" could only be answered by reproducing it by hand with curl.
+    val stats = BranchFetchStats(clock = { 1_700_000_000_000L })
+    stats.record(BranchFetch.Ok(byteArrayOf(1)))
+    stats.record(BranchFetch.NotFound)
+    stats.record(BranchFetch.Throttled(5))
+
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+          branchFetchStats = { stats.snapshot() },
+        )
+        .also { it.start() }
+
+    val (code, body) = get("/status.json")
+    assertEquals(200, code)
+    val branch =
+      Json.parseToJsonElement(body).jsonObject["branchFetch"]?.jsonObject
+        ?: error("status.json carries no branchFetch: $body")
+    assertEquals(3, branch["attempted"]?.jsonPrimitive?.int)
+    assertEquals(1, branch["ok"]?.jsonPrimitive?.int)
+    // The two that must never merge: an absent asset is routine, a throttle is the alert.
+    assertEquals(1, branch["notFound"]?.jsonPrimitive?.int)
+    assertEquals(1, branch["throttled"]?.jsonPrimitive?.int)
+    assertEquals(
+      1_700_000_000_000L,
+      branch["lastThrottleAtEpochMillis"]?.jsonPrimitive?.long,
+      "a monitor needs to know WHEN, not just whether",
+    )
+  }
+
+  @Test
+  fun `a server that has read no branch advertises no counters`() {
+    // Null rather than a block of zeros, like the render roll-up: "nothing has been read" and
+    // "everything read succeeded" are different answers, and a monitor that saw `throttled: 0` from
+    // a server that has never read a branch would be reading reassurance into silence.
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+        )
+        .also { it.start() }
+
+    val (code, body) = get("/status.json")
+    assertEquals(200, code)
+    val field = Json.parseToJsonElement(body).jsonObject["branchFetch"]
+    assertTrue(field == null || field is kotlinx.serialization.json.JsonNull, "got $field in $body")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -480,6 +480,46 @@ class ServeTopLevelSiteTest {
   }
 
   @Test
+  fun `a site host does not report the box's branch-read counters`() {
+    // `/status` on a site reports on ONE app by design — a monitor pointed at the site alerts on
+    // the site, and a visitor learns nothing about what else the box runs. The branch-read counters
+    // are box-wide with no per-system breakdown, so including them would fire this site's monitor
+    // on a neighbour's throttle AND disclose that the neighbour exists.
+    val stats = BranchFetchStats(clock = { 5L })
+    stats.record(BranchFetch.Throttled(3))
+    registry.register(
+      "compose-m3",
+      host = bundle("compose-m3", listOf("button-filled"), "Compose Material 3"),
+      pinned = true,
+    )
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "",
+          isPublic = true,
+          catalogSessions = listOf("compose-m3"),
+          sites = ServeSites.of(listOf(siteHost to "compose-m3")),
+          branchFetchStats = { stats.snapshot() },
+        )
+        .also { it.start() }
+
+    val (siteCode, siteBody, _) = get("/status.json", host = siteHost)
+    assertEquals(200, siteCode)
+    assertFalse(
+      siteBody.contains("\"throttled\":1"),
+      "a site must not surface the box's branch counters: $siteBody",
+    )
+
+    // The main host still reports them — this scopes the field, it does not remove it.
+    val (mainCode, mainBody, _) = get("/status.json")
+    assertEquals(200, mainCode)
+    assertTrue(mainBody.contains("\"throttled\":1"), "the box's own status still counts: $mainBody")
+  }
+
+  @Test
   fun `an unauthenticated refusal never carries the access token`() {
     // The interceptor runs BEFORE the routes' own token gate, and the styled 404 threads the access
     // token through its links — so on a token-gated box a made-up path would have handed the secret


### PR DESCRIPTION
Renders have had failure telemetry for a long time — `/status.json` says how many failed, why, and when. Branch reads, the lane that actually talks to GitHub, had none.

So when every published motion capture stopped loading, answering *"is GitHub rate-limiting us, or was that asset never published?"* meant reproducing it by hand with `curl` against both the server and `raw.githubusercontent.com`. That is a diagnosis a status page should hand you.

#4113 made the distinction exist. This makes it observable: **`throttled` climbing while `notFound` holds still is a rate limit**, and it reads off a page.

```json
"branchFetch": {
  "attempted": 412, "ok": 398, "notFound": 12,
  "throttled": 2, "unavailable": 0, "transport": 0,
  "lastThrottleAtEpochMillis": 1700000000000,
  "lastFailureAtEpochMillis": 1700000000000,
  "lastFailureReason": "throttled (retry after 5s)"
}
```

## `notFound` is not a failure

It does not touch the failure fields. A catalog legitimately declares assets a given revision never published, and the lane is built to answer that cheaply. Folding those into the failure counters would keep the alert-worthy numbers permanently non-zero — which is the same as having no alert.

The three that mean something is wrong with the *branch host* rather than with the catalog are `throttled`, `unavailable` and `transport`.

## Where the counters live, and why it matters

Per-store, wrapping whatever transport is configured — not inside the default HTTP one.

My first cut put them on the companion object. Two things were wrong with that, and they're the same thing: it is process-global mutable state shared by every store in a test JVM, **and** it would have recorded nothing at all for a store given an injected transport. Telemetry that goes quiet exactly when someone has configured something unusual is worse than no telemetry, because it reads as healthy.

The server takes a provider rather than reaching for a global, so a server with no catalog store reports `null` rather than a block of zeros — same choice the render roll-up makes. "Nothing has been read" and "everything read succeeded" are different answers, and a monitor seeing `throttled: 0` from a server that has never read a branch would be reading reassurance into silence.

## Known limit, documented on the type

A read counts **once, by how it ended**. The retry lives inside the transport, below the counting layer, so a throttle the retry rescued lands here as `ok` and leaves `throttled` at zero.

So `throttled` reads as *"throttles we could not ride out"*, not *"throttles we met"*. That is a real gap for the headline question, and I've asserted it in a test rather than leaving it to be discovered. Closing it means the transport reporting every attempt — a wider seam than this is worth today, and the same seam that keeps injected transports countable.

## Test plan

```
./gradlew :cli:test                                     # full CLI suite, green
./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest       # green
```

New coverage:

- `BranchFetchStatsTest` — a quiet server advertises nothing; a throttle counts apart from a missing file; an absent asset sets no failure fields; a `503` carries a reason and a time but is not a rate limit; a read counts once by how it ended; a reason is bounded before reaching a status page.
- `ServeStatusTest` — the counters reach `/status.json` with the right names and values including `lastThrottleAtEpochMillis` (a monitor needs to know *when*, not just whether), and a server that has read no branch reports null.

Text-only PR: no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_

---
_Generated by [Claude Code](https://claude.ai/code)_