### PR TITLE
fix(vscode): render a @Preview added to the file already on screen

### DIFF
--- a/vscode-extension/src/daemonWarmScopes.ts
+++ b/vscode-extension/src/daemonWarmScopes.ts
@@ -1,0 +1,83 @@
+/**
+ * Which (module, file) scopes have had their previews pre-rendered by the
+ * daemon, and **for which previews**.
+ *
+ * ### Why this is a ledger and not a `Set`
+ *
+ * The daemon view-open warm-up exists to stop a focus bounce re-rendering cards
+ * that are already on screen. It was suppressed by a bare set of scope keys, so
+ * "this file has been warmed" was the whole memory — and a scope, once warmed,
+ * stayed warmed for the life of the daemon. Only a daemon death (classpath
+ * dirty, channel closed) cleared it.
+ *
+ * That is wrong for the case where the file's previews *change* under a living
+ * daemon, which is the ordinary act of adding a `@Preview` to the file you are
+ * looking at. Discovery found the new id and the panel drew its card; the
+ * warm-up then declined to render, because the scope was already warm. The card
+ * sat there with no pixels behind it until the user navigated away and back, or
+ * something restarted the daemon. It also made the
+ * `B. edit a @Preview source, refresh, expect new id` end-to-end scenario fail
+ * intermittently — whenever the daemon happened to survive the edit, the PNG the
+ * test waits for was never written.
+ *
+ * Recording the id set turns the question from "has this file been warmed" into
+ * "has it been warmed for *these* previews", which suppresses the bounce (same
+ * ids, same answer) without swallowing a real change.
+ */
+export class DaemonWarmScopeLedger {
+    private readonly warmed = new Map<string, string>();
+
+    /**
+     * Whether [ids] still need a warm-up render in [scopeKey].
+     *
+     * True when the scope has never been warmed, or was warmed for a different
+     * set of previews. Order is not significant — discovery is free to reorder
+     * a manifest without that meaning anything changed.
+     */
+    shouldWarm(scopeKey: string, ids: readonly string[]): boolean {
+        return this.warmed.get(scopeKey) !== fingerprint(ids);
+    }
+
+    /** Record that [scopeKey] has been warmed for exactly [ids]. */
+    markWarmed(scopeKey: string, ids: readonly string[]): void {
+        this.warmed.set(scopeKey, fingerprint(ids));
+    }
+
+    /**
+     * Forget one scope — used when a warm-up throws, so the next attempt is not
+     * suppressed by a render that never happened.
+     */
+    forget(scopeKey: string): void {
+        this.warmed.delete(scopeKey);
+    }
+
+    /**
+     * Forget every scope belonging to [moduleId]. Called when its daemon dies:
+     * a new JVM has rendered nothing, whatever the previous one covered.
+     */
+    clearModule(moduleId: string): void {
+        const prefix = `${moduleId}::`;
+        for (const key of [...this.warmed.keys()]) {
+            if (key.startsWith(prefix)) {
+                this.warmed.delete(key);
+            }
+        }
+    }
+
+    /** Scope key for a module path and its module-relative source file. */
+    static scopeKey(modulePath: string, filterFile: string): string {
+        return `${modulePath}::${filterFile}`;
+    }
+}
+
+/**
+ * Order-independent fingerprint of an id set.
+ *
+ * The separator is a newline, which cannot occur in a preview id (they are
+ * Kotlin FQNs plus a variant suffix), so two different sets cannot fingerprint
+ * alike. A separator that *can* appear in an id would let `["a", "b"]` and
+ * `["a<sep>b"]` collide.
+ */
+function fingerprint(ids: readonly string[]): string {
+    return [...ids].sort().join("\n");
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -83,6 +83,7 @@ import { mergeRemoteComposeChange } from "./daemon/remoteComposeMerge";
 import { mergePermissionsChange } from "./daemon/permissionsMerge";
 import { PreviewOverrideStore } from "./daemon/previewOverrideStore";
 import { DaemonRefreshIndicator } from "./daemonRefreshIndicator";
+import { DaemonWarmScopeLedger } from "./daemonWarmScopes";
 import {
     buildHistorySource,
     HistoryPanel,
@@ -358,10 +359,10 @@ const daemonRefresh = new DaemonRefreshIndicator({
     clearTimeout: (handle) => clearTimeout(handle as NodeJS.Timeout),
 });
 
-/** Module/file scopes that already received a daemon view-open pre-render in
- *  this extension session. Keeps "show this file's previews" warm-up from
- *  re-rendering the same cards on every focus bounce. */
-const daemonShownPreviewWarmScopes = new Set<string>();
+/** Which (module, file) scopes the daemon has already pre-rendered, and for
+ *  which previews. See {@link DaemonWarmScopeLedger} for why the id set is part
+ *  of the key rather than the scope alone. */
+const daemonShownPreviewWarmScopes = new DaemonWarmScopeLedger();
 const daemonStartupProgressTimers = new Map<string, NodeJS.Timeout>();
 /** Workspace-state key for per-module phase-duration calibration. Shape:
  *  `Record<moduleId, PhaseDurations>`. Updated after every successful refresh
@@ -3908,10 +3909,10 @@ async function warmShownPreviewsForFile(
         gradleService.workspaceRoot,
         module,
     );
-    const scopeKey = `${module.modulePath}::${filterFile}`;
-    if (daemonShownPreviewWarmScopes.has(scopeKey)) {
-        return;
-    }
+    const scopeKey = DaemonWarmScopeLedger.scopeKey(
+        module.modulePath,
+        filterFile,
+    );
 
     const ids = (moduleManifestCache.get(module.modulePath) ?? [])
         .filter((p) =>
@@ -3927,7 +3928,16 @@ async function warmShownPreviewsForFile(
         return;
     }
 
-    daemonShownPreviewWarmScopes.add(scopeKey);
+    // Computed BEFORE the guard, unlike the old bare-scope check: the question
+    // is not "has this file been warmed" but "has it been warmed for THESE
+    // previews". A focus bounce answers the same ids and still skips; a file
+    // that just grew a `@Preview` does not, and gets the render its new card
+    // needs. Costs one filter over the module manifest per bounce.
+    if (!daemonShownPreviewWarmScopes.shouldWarm(scopeKey, ids)) {
+        return;
+    }
+
+    daemonShownPreviewWarmScopes.markWarmed(scopeKey, ids);
     try {
         await daemonScheduler.setFocus(module, ids);
         await daemonScheduler.setVisible(module, ids, []);
@@ -3943,7 +3953,7 @@ async function warmShownPreviewsForFile(
         await daemonScheduler.awaitPendingSubscribes(module.modulePath);
         await daemonScheduler.renderNow(module, ids, "fast", reason);
     } catch (err) {
-        daemonShownPreviewWarmScopes.delete(scopeKey);
+        daemonShownPreviewWarmScopes.forget(scopeKey);
         logLine(
             `daemon: view-open warmup failed for ${module.modulePath}: ${String((err as Error).message ?? err)}`,
         );
@@ -3951,12 +3961,7 @@ async function warmShownPreviewsForFile(
 }
 
 function clearDaemonShownPreviewWarmScopes(moduleId: string): void {
-    const prefix = `${moduleId}::`;
-    for (const key of [...daemonShownPreviewWarmScopes]) {
-        if (key.startsWith(prefix)) {
-            daemonShownPreviewWarmScopes.delete(key);
-        }
-    }
+    daemonShownPreviewWarmScopes.clearModule(moduleId);
 }
 
 /**

--- a/vscode-extension/src/test/daemonWarmScopes.test.ts
+++ b/vscode-extension/src/test/daemonWarmScopes.test.ts
@@ -1,0 +1,116 @@
+import * as assert from "assert";
+import { DaemonWarmScopeLedger } from "../daemonWarmScopes";
+
+/**
+ * The daemon view-open warm-up ledger.
+ *
+ * The behaviour under test is one property: warm-up is suppressed when nothing
+ * about the file's previews changed, and **not** suppressed when they did. The
+ * bug this replaces got that second half wrong — a scope warmed once stayed
+ * warmed for the life of the daemon, so a `@Preview` added to the file on
+ * screen was discovered, drawn as a card, and never rendered.
+ */
+describe("DaemonWarmScopeLedger", () => {
+    const scope = DaemonWarmScopeLedger.scopeKey(":samples:cmp", "Previews.kt");
+
+    it("warms a scope it has never seen", () => {
+        const ledger = new DaemonWarmScopeLedger();
+        assert.strictEqual(ledger.shouldWarm(scope, ["a", "b"]), true);
+    });
+
+    it("suppresses a focus bounce over the same previews", () => {
+        // The reason the guard exists: moving focus away and back must not
+        // re-render cards that are already on screen.
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a", "b"]);
+        assert.strictEqual(ledger.shouldWarm(scope, ["a", "b"]), false);
+    });
+
+    it("ignores ordering, which discovery does not promise", () => {
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a", "b", "c"]);
+        assert.strictEqual(ledger.shouldWarm(scope, ["c", "a", "b"]), false);
+    });
+
+    it("warms again when a preview is added to a warmed file", () => {
+        // THE REGRESSION. Adding a @Preview to the file you are looking at
+        // leaves the daemon alive, so nothing cleared the old guard and the new
+        // card never got pixels. Discovery had already announced the id.
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a", "b"]);
+        assert.strictEqual(
+            ledger.shouldWarm(scope, ["a", "b", "c"]),
+            true,
+            "a newly discovered preview must not be suppressed by an earlier warm-up",
+        );
+    });
+
+    it("warms again when a preview is removed", () => {
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a", "b"]);
+        assert.strictEqual(ledger.shouldWarm(scope, ["a"]), true);
+    });
+
+    it("cannot be fooled by an id that contains the separator", () => {
+        // A printable separator would make ["a", "b"] and ["a<sep>b"] the same
+        // fingerprint, silently suppressing a real change.
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a", "b"]);
+        assert.strictEqual(ledger.shouldWarm(scope, ["a b"]), true);
+        assert.strictEqual(ledger.shouldWarm(scope, ["a,b"]), true);
+    });
+
+    it("keeps scopes apart", () => {
+        const other = DaemonWarmScopeLedger.scopeKey(
+            ":samples:cmp",
+            "Other.kt",
+        );
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a"]);
+        assert.strictEqual(ledger.shouldWarm(other, ["a"]), true);
+    });
+
+    it("forgets a scope whose warm-up threw", () => {
+        // Marked before the render is dispatched, so a throw must undo it or
+        // the next attempt is suppressed by a render that never happened.
+        const ledger = new DaemonWarmScopeLedger();
+        ledger.markWarmed(scope, ["a"]);
+        ledger.forget(scope);
+        assert.strictEqual(ledger.shouldWarm(scope, ["a"]), true);
+    });
+
+    it("clears a dead daemon's module without touching its neighbours", () => {
+        const ledger = new DaemonWarmScopeLedger();
+        const mine = DaemonWarmScopeLedger.scopeKey(":samples:cmp", "A.kt");
+        const alsoMine = DaemonWarmScopeLedger.scopeKey(":samples:cmp", "B.kt");
+        const neighbour = DaemonWarmScopeLedger.scopeKey(
+            ":samples:android",
+            "A.kt",
+        );
+        ledger.markWarmed(mine, ["a"]);
+        ledger.markWarmed(alsoMine, ["b"]);
+        ledger.markWarmed(neighbour, ["c"]);
+
+        ledger.clearModule(":samples:cmp");
+
+        assert.strictEqual(ledger.shouldWarm(mine, ["a"]), true);
+        assert.strictEqual(ledger.shouldWarm(alsoMine, ["b"]), true);
+        assert.strictEqual(
+            ledger.shouldWarm(neighbour, ["c"]),
+            false,
+            "another module's daemon is still alive and its renders still stand",
+        );
+    });
+
+    it("does not clear a module whose id is a prefix of another", () => {
+        // `:samples:cmp` must not clear `:samples:cmp-wasm`.
+        const ledger = new DaemonWarmScopeLedger();
+        const sibling = DaemonWarmScopeLedger.scopeKey(
+            ":samples:cmp-wasm",
+            "A.kt",
+        );
+        ledger.markWarmed(sibling, ["a"]);
+        ledger.clearModule(":samples:cmp");
+        assert.strictEqual(ledger.shouldWarm(sibling, ["a"]), false);
+    });
+});


### PR DESCRIPTION
`VS Code Extension E2E (interactive-a-d)` scenario **B** has been failing intermittently on `main`. It is not a flaky test. It is a real user-facing bug, and the test was right.

## The bug

Add a `@Preview` to the file you are currently looking at. Discovery finds the new id and the panel draws its card — and the card never gets pixels. It stays empty until you navigate away and back, or something restarts the daemon.

The daemon view-open warm-up was suppressed by a bare `Set` of `(module, file)` scope keys, so *"this file has been warmed"* was its entire memory. A scope, once warmed, stayed warmed for the life of the daemon — the only things that cleared it were `onClasspathDirty` and `onChannelClosed`, i.e. daemon death.

Editing a source file leaves the daemon alive. So `warmShownPreviewsForFile` returned early and never asked the daemon to render the preview that had just appeared.

## Why it looked like flakiness

The scenario fails only when the daemon survives the edit. When the render instead goes through Gradle's `composePreviewRenderAll`, the PNG lands and the test passes — hence the intermittency.

The scenario's own comments had already got halfway there, noting that after `composePreviewDiscover` "the extension then issues no further Gradle command … it is wedged, not slow". That was correct and the conclusion was the near-miss: the missing command was never Gradle's. It was a daemon render nobody requested. The CI transcript matches exactly — `composePreviewDiscover` at 20:20:24, silence, timeout at 20:27:09.

Worth noting the failure predates this line of work: the same job failed on `0568bcc99` (a CI-pin refresh) and `c9903031d`, both before any of it.

## The fix

The guard now records **which previews** a warm-up covered, so the question becomes "has this file been warmed for *these* previews" rather than "has this file been warmed". A focus bounce answers the same id set and is still suppressed — that is what the guard exists for — while a file that just grew a preview gets its render.

Extracted as `DaemonWarmScopeLedger` rather than patched in place. The decision is pure logic and was untestable inside a 5,000-line module, and this is a bug about a decision, not about wiring. Fingerprints are order-independent (discovery does not promise ordering) and use a separator that cannot occur in a preview id, so `["a", "b"]` cannot collide with `["a b"]`.

## Test plan

```
npm test          # 1711 → 1721 passing
npx tsc -p ./     # clean
npm run format:check
```

Three of the ten new tests fail against the old set semantics — including the one that is the bug:

```
1) warms again when a preview is added to a warmed file
2) warms again when a preview is removed
3) cannot be fooled by an id that contains the separator
```

The rest pin the behaviour that must survive: focus-bounce suppression, order independence, scope isolation, forgetting a scope whose warm-up threw, clearing a dead daemon's module without touching neighbours, and not letting `:samples:cmp` clear `:samples:cmp-wasm`.

## What I could not verify here

**I could not run the E2E scenario itself.** `@vscode/test-electron` downloads the VS Code binary from `update.code.visualstudio.com`, and this environment's egress proxy refuses that host:

```
connect_rejected  update.code.visualstudio.com:443  gateway answered 403 to CONNECT
```

So the end-to-end proof is CI's to give, not mine. What stands behind the fix here is the unit-level regression test plus the traced code path; if scenario B fails again after this lands, the diagnosis above is wrong and I would want to know.

Text-only PR: no rendered surface changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_