### PR TITLE
fix(ci): retry harness repository throttling

### DIFF
--- a/.github/scripts/retry-gradle-repository.sh
+++ b/.github/scripts/retry-gradle-repository.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Retry a Gradle invocation only when dependency resolution was rejected by a
+# remote HTTP repository. GitHub-hosted runners occasionally receive Maven
+# Central 429/403 responses; rerunning the unchanged task succeeds once the
+# shared runner IP's short throttle clears. Test failures and ordinary Gradle
+# errors return immediately, so this must not become a blanket flaky-test retry.
+
+set -uo pipefail
+
+max_attempts="${GRADLE_REPOSITORY_MAX_ATTEMPTS:-3}"
+base_delay_seconds="${GRADLE_REPOSITORY_RETRY_DELAY_SECONDS:-15}"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <gradle command> [args ...]" >&2
+  exit 2
+fi
+
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "GRADLE_REPOSITORY_MAX_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "$base_delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "GRADLE_REPOSITORY_RETRY_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+attempt=1
+while (( attempt <= max_attempts )); do
+  log_file="$(mktemp "${RUNNER_TEMP:-/tmp}/gradle-repository-attempt.XXXXXX.log")"
+  GRADLE_REPOSITORY_ATTEMPT="$attempt" "$@" 2>&1 | tee "$log_file"
+  status=${PIPESTATUS[0]}
+
+  if (( status == 0 )); then
+    rm -f "$log_file"
+    exit 0
+  fi
+
+  if (( attempt == max_attempts )) ||
+    ! grep -Eiq "Could not (GET|HEAD) 'https?://[^']+'.*Received status code (403|429|5[0-9][0-9])" "$log_file"; then
+    rm -f "$log_file"
+    exit "$status"
+  fi
+
+  rm -f "$log_file"
+  delay=$((base_delay_seconds * attempt))
+  echo "Gradle dependency repository returned a transient HTTP error; retrying attempt $((attempt + 1))/$max_attempts in ${delay}s…" >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/.github/workflows/daemon-harness.yml
+++ b/.github/workflows/daemon-harness.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       - name: Run harness scenarios (desktop, fake)
-        run: ./gradlew :daemon:harness:test
+        run: .github/scripts/retry-gradle-repository.sh ./gradlew :daemon:harness:test
       - name: Upload harness test results (desktop, fake)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -127,7 +127,7 @@ jobs:
       #       sudo apt-get install -y libfreetype6 libfontconfig1
       #
       - name: Run harness scenarios (desktop, real)
-        run: ./gradlew :daemon:harness:test -Pharness.host=real
+        run: .github/scripts/retry-gradle-repository.sh ./gradlew :daemon:harness:test -Pharness.host=real
       - name: Upload harness test results (desktop, real)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -167,7 +167,7 @@ jobs:
       # missing native libs (libfontconfig, libfreetype), install them
       # here.
       - name: Run harness scenarios (android, real)
-        run: ./gradlew :daemon:harness:test -Pharness.host=real -Pharness.target=android
+        run: .github/scripts/retry-gradle-repository.sh ./gradlew :daemon:harness:test -Pharness.host=real -Pharness.target=android
       - name: Upload harness test results (android, real)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

Makes the Daemon Harness resilient to transient dependency-repository throttling without retrying real test failures.

Two otherwise unrelated harness runs failed during dependency resolution when Maven Central returned 429 and 403 responses across many artifacts; later runs passed on unchanged harness code. A small wrapper now retries a Gradle invocation up to three times only when its output contains a failed HTTP GET/HEAD with status 403, 429, or 5xx. All other non-zero exits—including harness assertions—return immediately with the original status.

All three Daemon Harness Gradle invocations use the same wrapper.

## Test plan

- `bash -n .github/scripts/retry-gradle-repository.sh`
- Simulated 429: first invocation fails, second succeeds, wrapper exits 0
- Simulated ordinary test failure: wrapper exits immediately with the original status 7
- `git diff --check`
- GitHub Actions: all three Daemon Harness jobs