### PR TITLE
fix(serve): rotate optimizer lanes so a large catalog cannot be starved

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
 import kotlinx.serialization.Serializable
 
 /**
@@ -62,7 +63,21 @@ class ServeBackgroundWork(
   private val lastCatalogLoadFinishedAt = AtomicLong(Long.MIN_VALUE)
 
   private val optimizerLanes = maxConcurrentOptimizers.coerceAtLeast(1)
-  private val optimizerPermits = Semaphore(optimizerLanes, true)
+  // Admission is a priority handoff, not a semaphore — see [withOptimizerSlot]. All four fields
+  // below are guarded by [admissionLock].
+  private val admissionLock = ReentrantLock()
+  private val laneFreed = admissionLock.newCondition()
+  private var optimizerLanesInUse = 0
+  private val optimizerQueue = ArrayList<OptimizerWaiter>()
+  private var optimizerArrivals = 0L
+  /**
+   * When each system's last pass *ended*, and the whole of admission's memory.
+   *
+   * End, not start: a pass that held a lane for an hour finished recently, and keying on its start
+   * would let it outrank catalogs that have been waiting that entire hour. A system absent from
+   * this map has never run and sorts ahead of every system that has.
+   */
+  private val optimizerLastRanAt = ConcurrentHashMap<String, Long>()
   private val optimizerRunning = ConcurrentHashMap.newKeySet<String>()
   private val optimizerWaiting = AtomicInteger()
   private val optimizerAdmissions = AtomicLong()
@@ -142,30 +157,7 @@ class ServeBackgroundWork(
    * waiting for.
    */
   fun <T : Any> withOptimizerSlot(system: String, waitMillis: Long, block: () -> T): T? {
-    if (optimizersPaused()) {
-      optimizerRefusals.incrementAndGet()
-      return null
-    }
-    val waitedFrom = clock()
-    optimizerWaiting.incrementAndGet()
-    val acquired =
-      try {
-        optimizerPermits.tryAcquire(waitMillis.coerceAtLeast(0), TimeUnit.MILLISECONDS)
-      } catch (_: InterruptedException) {
-        Thread.currentThread().interrupt()
-        false
-      } finally {
-        optimizerWaiting.decrementAndGet()
-      }
-    optimizerAdmissionWaitMillis.addAndGet((clock() - waitedFrom).coerceAtLeast(0))
-    if (!acquired) {
-      optimizerRefusals.incrementAndGet()
-      return null
-    }
-    // Re-checked under the permit: a pause can land while this catalog was queueing, and admitting
-    // it then would let one pass slip past an operator who just asked for quiet.
-    if (optimizersPaused()) {
-      optimizerPermits.release()
+    if (!acquireOptimizerLane(system, waitMillis)) {
       optimizerRefusals.incrementAndGet()
       return null
     }
@@ -175,8 +167,93 @@ class ServeBackgroundWork(
       block()
     } finally {
       optimizerRunning.remove(system)
-      optimizerPermits.release()
+      releaseOptimizerLane(system)
     }
+  }
+
+  /**
+   * Take a lane for [system], preferring whoever has gone longest without one.
+   *
+   * **This was a fair `Semaphore` and fairness there did not reach far enough.** A semaphore orders
+   * the callers *currently blocked on it*, and an optimizer pass is only blocked for
+   * `OPTIMIZER_ADMISSION_WAIT_MILLIS` (20s) before it gives up and parks until the next presence
+   * heartbeat. So the ordering only ever covered whoever happened to be at the door inside the same
+   * 20s window, and a catalog refused on one attempt arrived at the next one with no advantage over
+   * a catalog that had just run. Nothing accumulated, so nothing prevented the same few systems
+   * winning every draw.
+   *
+   * Measured on the deployed box 45 minutes after v1.14.0: `admissions 5, refusals 20`, with three
+   * catalogs having taken both lanes and the other nineteen reporting `turnsGranted 0` — including
+   * `m3-catalog`, the largest queue on the box at 10,120 targets and therefore the one that most
+   * needed the time.
+   *
+   * [optimizerLastRanAt] is the memory the semaphore lacked. A never-run system outranks every
+   * system that has run, and among equals it is first-come — so **every catalog gets a lane before
+   * any catalog gets a second**, which is a stronger guarantee than a size heuristic and needs no
+   * knowledge of how much work each one has left.
+   */
+  private fun acquireOptimizerLane(system: String, waitMillis: Long): Boolean {
+    val waitedFrom = clock()
+    admissionLock.lock()
+    val waiter =
+      OptimizerWaiter(
+        system = system,
+        lastRanAt = optimizerLastRanAt[system] ?: Long.MIN_VALUE,
+        arrival = optimizerArrivals++,
+      )
+    optimizerQueue.add(waiter)
+    optimizerWaiting.incrementAndGet()
+    try {
+      var remainingNanos = TimeUnit.MILLISECONDS.toNanos(waitMillis.coerceAtLeast(0))
+      while (true) {
+        // Re-checked every wakeup rather than only on entry: a pause can land while this catalog is
+        // queueing, and admitting it then would let one pass slip past an operator who just asked
+        // for quiet.
+        if (optimizersPaused()) return false
+        if (optimizerLanesInUse < optimizerLanes && optimizerQueue.min() === waiter) {
+          optimizerLanesInUse++
+          return true
+        }
+        if (remainingNanos <= 0) return false
+        remainingNanos =
+          try {
+            laneFreed.awaitNanos(remainingNanos)
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return false
+          }
+      }
+    } finally {
+      optimizerQueue.remove(waiter)
+      optimizerWaiting.decrementAndGet()
+      // Whether this waiter was admitted or gave up, the queue's head may have moved — and the
+      // remaining waiters are parked in `awaitNanos` with no other reason to look again. Without
+      // this, a free lane can sit unclaimed until someone's timeout happens to fire.
+      laneFreed.signalAll()
+      admissionLock.unlock()
+      optimizerAdmissionWaitMillis.addAndGet((clock() - waitedFrom).coerceAtLeast(0))
+    }
+  }
+
+  private fun releaseOptimizerLane(system: String) {
+    admissionLock.lock()
+    try {
+      optimizerLanesInUse--
+      optimizerLastRanAt[system] = clock()
+      laneFreed.signalAll()
+    } finally {
+      admissionLock.unlock()
+    }
+  }
+
+  /** One catalog queued for a lane. Ordered by [acquireOptimizerLane]'s priority rule. */
+  private class OptimizerWaiter(
+    val system: String,
+    val lastRanAt: Long,
+    val arrival: Long,
+  ) : Comparable<OptimizerWaiter> {
+    override fun compareTo(other: OptimizerWaiter): Int =
+      compareValuesBy(this, other, { it.lastRanAt }, { it.arrival })
   }
 
   /**
@@ -195,6 +272,14 @@ class ServeBackgroundWork(
     val until = clock() + millis.coerceAtLeast(0)
     optimizerPausedUntil.set(until)
     optimizerPauseReason["reason"] = reason.take(MAX_PAUSE_REASON_CHARS)
+    // Wake the queue so a pause is felt at the door now, rather than when each waiter's admission
+    // timeout happens to expire.
+    admissionLock.lock()
+    try {
+      laneFreed.signalAll()
+    } finally {
+      admissionLock.unlock()
+    }
     return until
   }
 
@@ -211,11 +296,20 @@ class ServeBackgroundWork(
   fun optimizerAdmissionSnapshot(): ThemeOptimizerAdmissionSnapshot {
     val until = optimizerPausedUntil.get()
     val paused = clock() < until
+    val queued = admissionLock.run {
+      lock()
+      try {
+        optimizerQueue.sorted().map { it.system }
+      } finally {
+        unlock()
+      }
+    }
     return ThemeOptimizerAdmissionSnapshot(
       lanes = optimizerLanes,
       running = optimizerRunning.size,
       runningSystems = optimizerRunning.toSortedSet().toList(),
       waiting = optimizerWaiting.get(),
+      waitingSystems = queued,
       admissions = optimizerAdmissions.get(),
       refusals = optimizerRefusals.get(),
       admissionWaitMillis = optimizerAdmissionWaitMillis.get(),
@@ -310,6 +404,10 @@ class ServeBackgroundWork(
  * The number that matters when the box feels slow is [running] against [lanes], and [waiting]
  * beside it: passes parked at the door are cheap, passes inside the door are not. [refusals]
  * climbing while [admissions] holds steady is the cap doing its job.
+ *
+ * [waitingSystems] is who is at the door **in the order they will be let in**, which is the read
+ * that was missing when the cap starved the box's largest catalog: `refusals 20` said work was
+ * being turned away and nothing said the same system was being turned away every time.
  */
 @Serializable
 data class ThemeOptimizerAdmissionSnapshot(
@@ -317,6 +415,7 @@ data class ThemeOptimizerAdmissionSnapshot(
   val running: Int,
   val runningSystems: List<String>,
   val waiting: Int,
+  val waitingSystems: List<String> = emptyList(),
   val admissions: Long,
   val refusals: Long,
   val admissionWaitMillis: Long,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -122,6 +122,19 @@ class ServeCatalogLiveHost(
   private val themeOptimizationIdleMillis: Long =
     System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L,
   /**
+   * How long one admitted pass may hold its optimizer lane before giving it back and re-queueing.
+   *
+   * The knob trades **rotation latency against re-warming**. A slice shorter than a cold daemon
+   * start (34-68s on an Android/Robolectric lane) spends most of its lane warming and renders
+   * almost nothing; a slice long enough to finish a large catalog is no slice at all, and on a box
+   * with 22 catalogs and 2 lanes that is what starved `m3-catalog` to `turnsGranted 0`. Five
+   * minutes puts a full rotation of 22 catalogs at under an hour while keeping the worst-case warm
+   * overhead near a fifth of the lane — and the warm is paid once per slice, not per preview.
+   */
+  private val optimizerSliceMillis: Long =
+    System.getProperty("composeai.serve.themeOptimizerSliceMillis")?.toLongOrNull()
+      ?: DEFAULT_OPTIMIZER_SLICE_MILLIS,
+  /**
    * Route snapshot renders to the shared monolithic daemon rather than the per-preview pool — see
    * [renderHostFor]. `-Dcomposeai.serve.sharedDaemonRenders=false` restores per-preview routing for
    * a deployment that wants each preview isolated at the cost of a cold start per card.
@@ -453,20 +466,33 @@ class ServeCatalogLiveHost(
         // — but with the cap in place a simultaneous arrival is harmless: two are admitted and the
         // rest are refused in microseconds and park. Sleeping them first would delay the two that
         // are going to win anyway, which costs cache throughput on an idle box to solve a problem
-        // the cap already solved. The fair semaphore hands the lanes on in arrival order.
+        // the cap already solved. Admission orders the arrivals by who has gone longest without a
+        // lane, so losing a draw is not a permanent condition.
         //
-        // ONE pass slot for the whole pass, held across warms and batches alike. Taking it per
+        // ONE pass slot for the whole SLICE, held across warms and batches alike. Taking it per
         // batch would let a catalog pay a cold warm and then lose the slot before rendering
         // anything, which is the waste this cap exists to remove, not to reproduce.
-        val admitted =
-          backgroundWork.withOptimizerSlot(label, OPTIMIZER_ADMISSION_WAIT_MILLIS) {
-            runOptimizerPass(jobs)
-            true
+        //
+        // The loop is what makes rotation actually happen. Fair admission alone does not: a pass on
+        // an idle box runs until its catalog is fully optimized, which for the 10,120-target
+        // m3-catalog is ~28 hours, and a queue you reach the front of in 28 hours is still
+        // starvation. A slice returns the lane on a preview boundary and re-queues — where its
+        // freshly-stamped `lastRanAt` puts it behind everyone still waiting, so the next slice goes
+        // to them and this catalog resumes once they have had theirs.
+        while (true) {
+          val outcome =
+            backgroundWork.withOptimizerSlot(label, OPTIMIZER_ADMISSION_WAIT_MILLIS) {
+              runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
+            }
+          if (outcome == null) {
+            // Parked, not failed: `keepLiveWarm` re-enters on the next presence heartbeat, and
+            // `optimizationStarted` is reset below so it can.
+            catalogThemeCache.markPaused()
+            return@execute
           }
-        if (admitted == null) {
-          // Parked, not failed: `keepLiveWarm` re-enters on the next presence heartbeat, and
-          // `optimizationStarted` is reset below so it can.
-          catalogThemeCache.markPaused()
+          // Anything other than a spent slice is the pass deciding it is done for now — finished,
+          // gated, paused or breakered — and re-queueing on those would spin.
+          if (outcome != PassOutcome.SLICE_SPENT) return@execute
         }
       } finally {
         optimizationActive.set(false)
@@ -475,132 +501,158 @@ class ServeCatalogLiveHost(
     }
   }
 
-  private fun runOptimizerPass(jobs: List<ThemeOptimizationJob>) {
-    run {
-      try {
-        // Render in BATCHES through the replica pool rather than one at a time through the
-        // monolithic daemon. The pool is already five wide — it is what a visitor gets when they
-        // pick a theme — and the prefetcher was queueing behind a single daemon lock right next to
-        // it. One catalog at a time still (the background permit now wraps the batch, not each
-        // render), so the box sees one bursting catalog rather than 21 taking turns per render.
-        // Batched by PREVIEW, which is both the unit the daemon warms for and the unit the job
-        // list is already ordered by: every theme of one preview renders together, so one warm is
-        // amortised across all of them and the pass never interleaves two previews' daemon opens.
-        val byPreview =
-          jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
-        for ((previewId, previewJobs) in byPreview) {
-          // Re-checked per preview as well as at entry: a breaker can trip mid-pass (that is the
-          // rate trip's whole job), and the pass must stop feeding the renderer the moment it does
-          // rather than grinding through the remaining thousands of items.
-          if (renderBreakerStopsBackgroundWork()) return
-          // Gate BEFORE the warm, not just before the renders. `daemonWarmOrScheduling` starts a
-          // cold daemon, which is the single most expensive thing this pass can do to a box that is
-          // still loading catalogs or serving traffic — exactly what the idle gate exists to
-          // prevent. Warming ahead of it let every catalog host kick off a cold start at prewarm.
-          if (!awaitOptimizerTurn()) return
-          val previewDaemonId = alias[previewId]
-          // Await a cold warm ONCE per preview rather than letting each theme rediscover it. The
-          // old per-job loop spent retry budget on this; here it is a precondition of the batch.
-          if (previewDaemonId != null && !warmDaemonIds.contains(previewDaemonId)) {
-            daemonWarmOrScheduling(previewDaemonId)
-            // A cold warm is real render work and can run to minutes. Excluding it from both
-            // buckets shrank the rate's denominator, so a cold catalog reported a rate it was
-            // nowhere near.
-            val warmFrom = clock()
-            if (
-              warmingInFlight.contains(previewDaemonId) && !awaitWarmCompletion(previewDaemonId)
-            ) {
-              catalogThemeCache.recordWarm(clock() - warmFrom)
-              return
+  /** Why an optimizer pass returned; only [SLICE_SPENT] asks for another lane. */
+  private enum class PassOutcome {
+    /** Every target this pass could see is cached — nothing left to re-queue for. */
+    FINISHED,
+    /** The idle gate, a pause, or the render breaker stopped the pass. */
+    STOPPED,
+    /** The lane slice ran out with work remaining. */
+    SLICE_SPENT,
+  }
+
+  /**
+   * One lane slice of the pass. Ends at [sliceUntil], when the work runs out, or when the gate, a
+   * pause or the breaker stops it.
+   *
+   * Deliberately does NOT clear `optimizationActive` / `optimizationStarted` — those belong to the
+   * executor task that may call this several times across slices, and clearing them here would let
+   * a presence heartbeat start a second task on top of the loop still running.
+   */
+  private fun runOptimizerPass(jobs: List<ThemeOptimizationJob>, sliceUntil: Long): PassOutcome {
+    // Render in BATCHES through the replica pool rather than one at a time through the
+    // monolithic daemon. The pool is already five wide — it is what a visitor gets when they
+    // pick a theme — and the prefetcher was queueing behind a single daemon lock right next to
+    // it. One catalog at a time still (the background permit now wraps the batch, not each
+    // render), so the box sees one bursting catalog rather than 21 taking turns per render.
+    // Batched by PREVIEW, which is both the unit the daemon warms for and the unit the job
+    // list is already ordered by: every theme of one preview renders together, so one warm is
+    // amortised across all of them and the pass never interleaves two previews' daemon opens.
+    val byPreview =
+      jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
+    var previewsDone = 0
+    for ((previewId, previewJobs) in byPreview) {
+      // The slice is checked HERE and nowhere finer, on the preview boundary. A preview is the
+      // unit a daemon warms for, so giving the lane back between previews never abandons a warm
+      // that has just been paid for — whereas cutting mid-preview would throw away the most
+      // expensive thing the pass does (34-68s on an Android lane) to save a few seconds of the
+      // cheapest.
+      //
+      // A slice always yields at least one preview, whatever the clock says. Checking the deadline
+      // before any work would let a slice shorter than the admission round-trip re-queue forever
+      // without rendering anything — a livelock dressed as fairness, and the exact shape of the
+      // starvation this whole change is undoing.
+      if (previewsDone > 0 && clock() >= sliceUntil) {
+        catalogThemeCache.markPaused()
+        return PassOutcome.SLICE_SPENT
+      }
+      previewsDone++
+      // Re-checked per preview as well as at entry: a breaker can trip mid-pass (that is the
+      // rate trip's whole job), and the pass must stop feeding the renderer the moment it does
+      // rather than grinding through the remaining thousands of items.
+      if (renderBreakerStopsBackgroundWork()) return PassOutcome.STOPPED
+      // Gate BEFORE the warm, not just before the renders. `daemonWarmOrScheduling` starts a
+      // cold daemon, which is the single most expensive thing this pass can do to a box that is
+      // still loading catalogs or serving traffic — exactly what the idle gate exists to
+      // prevent. Warming ahead of it let every catalog host kick off a cold start at prewarm.
+      if (!awaitOptimizerTurn()) return PassOutcome.STOPPED
+      val previewDaemonId = alias[previewId]
+      // Await a cold warm ONCE per preview rather than letting each theme rediscover it. The
+      // old per-job loop spent retry budget on this; here it is a precondition of the batch.
+      if (previewDaemonId != null && !warmDaemonIds.contains(previewDaemonId)) {
+        daemonWarmOrScheduling(previewDaemonId)
+        // A cold warm is real render work and can run to minutes. Excluding it from both
+        // buckets shrank the rate's denominator, so a cold catalog reported a rate it was
+        // nowhere near.
+        val warmFrom = clock()
+        if (warmingInFlight.contains(previewDaemonId) && !awaitWarmCompletion(previewDaemonId)) {
+          catalogThemeCache.recordWarm(clock() - warmFrom)
+          return PassOutcome.STOPPED
+        }
+        catalogThemeCache.recordWarm(clock() - warmFrom)
+      }
+      var index = 0
+      while (index < previewJobs.size) {
+        // Checked per batch, and a batch is bounded by ONE render — so a visitor arriving mid
+        // batch still waits at most a render, which is the guarantee the old per-render permit
+        // was expressing.
+        if (!awaitOptimizerTurn()) return PassOutcome.STOPPED
+        val batch =
+          previewJobs.subList(index, minOf(index + optimizerBatchWidth(), previewJobs.size))
+        index += batch.size
+        catalogThemeCache.markRunning(clock())
+        // Time the RENDER inside the permit. Starting the clock before `withRenderPermit`
+        // charged the server-wide queue to renderMillis, which would make a permit-bound
+        // deployment read as render-bound — defeating the one diagnostic this exists for.
+        // The queue time is its own bucket: this pass HAS its turn and is merely outnumbered by
+        // other catalogs, which is a different problem from the gate withholding the turn.
+        val permitWaitFrom = clock()
+        val outcomes =
+          backgroundWork.withRenderPermit {
+            val renderFrom = clock()
+            catalogThemeCache.recordPermitWait(renderFrom - permitWaitFrom)
+            // Clear the pool's high-water marks so the reads below belong to THIS batch.
+            sharedDaemonPool?.takePeakInFlight()
+            sharedDaemonPool?.takeColdStartMillis()
+            renderOptimizerBatch(batch).also {
+              val elapsed = clock() - renderFrom
+              // A replica's daemon starts on its FIRST render, so that render carries a full
+              // cold start. Only the primary's warm is visible above (`awaitWarmCompletion`),
+              // and a five-wide batch can be opening four cold replicas underneath it — which
+              // would land 34-68s each in the per-entry bucket, exactly the conflation the
+              // warm/batch split exists to remove. Capped at the interval it is taken from:
+              // the pool reports the longest overlapping cold start, but a foreground borrow
+              // could have started one before this batch began.
+              val cold = (sharedDaemonPool?.takeColdStartMillis() ?: 0L).coerceIn(0L, elapsed)
+              catalogThemeCache.recordWarm(cold)
+              // Width is the peak number of daemons that ran CONCURRENTLY, not the job count.
+              // A batch submits N jobs, but when the seat budget affords no replica the pool
+              // queues them onto a host already in circulation instead of spawning one — so N
+              // jobs can be N threads taking turns on one daemon. Counting jobs reported that
+              // as N-wide, which is exactly the collapse this number exists to expose.
+              catalogThemeCache.recordBatch(
+                sharedDaemonPool?.takePeakInFlight() ?: 1,
+                elapsed - cold,
+              )
             }
-            catalogThemeCache.recordWarm(clock() - warmFrom)
+          } ?: return PassOutcome.STOPPED
+        // Only a FRESH daemon render is optimizer production. The batch is filtered for cache
+        // misses when it is built, but a foreground request can fill a target while this
+        // catalog queues for the render permit — `renderLeased` then short-circuits through
+        // `cachedRender` and hands back an Ok stamped CATALOG_CACHE. Counting that would
+        // re-open the same inflated rate this counter exists to close.
+        catalogThemeCache.recordProduced(
+          outcomes.count {
+            it is RenderOutcome.Ok && it.generation == RenderOutcome.Generation.DAEMON
           }
-          var index = 0
-          while (index < previewJobs.size) {
-            // Checked per batch, and a batch is bounded by ONE render — so a visitor arriving mid
-            // batch still waits at most a render, which is the guarantee the old per-render permit
-            // was expressing.
-            if (!awaitOptimizerTurn()) return
-            val batch =
-              previewJobs.subList(index, minOf(index + optimizerBatchWidth(), previewJobs.size))
-            index += batch.size
-            catalogThemeCache.markRunning(clock())
-            // Time the RENDER inside the permit. Starting the clock before `withRenderPermit`
-            // charged the server-wide queue to renderMillis, which would make a permit-bound
-            // deployment read as render-bound — defeating the one diagnostic this exists for.
-            // The queue time is its own bucket: this pass HAS its turn and is merely outnumbered by
-            // other catalogs, which is a different problem from the gate withholding the turn.
-            val permitWaitFrom = clock()
-            val outcomes =
-              backgroundWork.withRenderPermit {
-                val renderFrom = clock()
-                catalogThemeCache.recordPermitWait(renderFrom - permitWaitFrom)
-                // Clear the pool's high-water marks so the reads below belong to THIS batch.
-                sharedDaemonPool?.takePeakInFlight()
-                sharedDaemonPool?.takeColdStartMillis()
-                renderOptimizerBatch(batch).also {
-                  val elapsed = clock() - renderFrom
-                  // A replica's daemon starts on its FIRST render, so that render carries a full
-                  // cold start. Only the primary's warm is visible above (`awaitWarmCompletion`),
-                  // and a five-wide batch can be opening four cold replicas underneath it — which
-                  // would land 34-68s each in the per-entry bucket, exactly the conflation the
-                  // warm/batch split exists to remove. Capped at the interval it is taken from:
-                  // the pool reports the longest overlapping cold start, but a foreground borrow
-                  // could have started one before this batch began.
-                  val cold = (sharedDaemonPool?.takeColdStartMillis() ?: 0L).coerceIn(0L, elapsed)
-                  catalogThemeCache.recordWarm(cold)
-                  // Width is the peak number of daemons that ran CONCURRENTLY, not the job count.
-                  // A batch submits N jobs, but when the seat budget affords no replica the pool
-                  // queues them onto a host already in circulation instead of spawning one — so N
-                  // jobs can be N threads taking turns on one daemon. Counting jobs reported that
-                  // as N-wide, which is exactly the collapse this number exists to expose.
-                  catalogThemeCache.recordBatch(
-                    sharedDaemonPool?.takePeakInFlight() ?: 1,
-                    elapsed - cold,
-                  )
-                }
-              } ?: return
-            // Only a FRESH daemon render is optimizer production. The batch is filtered for cache
-            // misses when it is built, but a foreground request can fill a target while this
-            // catalog queues for the render permit — `renderLeased` then short-circuits through
-            // `cachedRender` and hands back an Ok stamped CATALOG_CACHE. Counting that would
-            // re-open the same inflated rate this counter exists to close.
-            catalogThemeCache.recordProduced(
-              outcomes.count {
-                it is RenderOutcome.Ok && it.generation == RenderOutcome.Generation.DAEMON
-              }
-            )
-            for ((job, outcome) in batch.zip(outcomes)) {
-              if (catalogThemeCache.get(job.cacheKey) != null) continue
-              // Busy is "ask again", not a failure: the warm above may still be settling. Leave it
-              // unmarked so a later pass retries instead of spending the `failed` count on it.
-              when (outcome) {
-                // "ask again" — the warm above may still be settling, so a later pass retries
-                // rather than spending the catalog's `failed` count on it. Counted, though: "ask
-                // again" with no ceiling is indistinguishable from "never", and this is the only
-                // lane that can tell them apart. After `BUSY_LATCH` consecutive passes the key
-                // latches with a reason, so /status names it instead of reporting `failed: 0`
-                // beside a `remaining` that never moves. A successful render clears the count.
-                RenderOutcome.Busy -> catalogThemeCache.recordBackgroundBusy(job.cacheKey)
-                // Count the failure but do NOT latch on the first one. `failureReason` treats a
-                // latched key as terminal and answers foreground requests with a 409, so a single
-                // flaky background render — a cold-start timeout, a daemon restart — would
-                // otherwise make that thumbnail permanently unavailable until the catalog
-                // generation refreshes. `recordRenderFailure` latches only after a run of them,
-                // which is the retry budget the old per-job loop provided.
-                is RenderOutcome.Failed ->
-                  catalogThemeCache.recordRenderFailure(job.cacheKey, outcome.reason)
-                else -> catalogThemeCache.markFailed(job.cacheKey)
-              }
-            }
+        )
+        for ((job, outcome) in batch.zip(outcomes)) {
+          if (catalogThemeCache.get(job.cacheKey) != null) continue
+          // Busy is "ask again", not a failure: the warm above may still be settling. Leave it
+          // unmarked so a later pass retries instead of spending the `failed` count on it.
+          when (outcome) {
+            // "ask again" — the warm above may still be settling, so a later pass retries
+            // rather than spending the catalog's `failed` count on it. Counted, though: "ask
+            // again" with no ceiling is indistinguishable from "never", and this is the only
+            // lane that can tell them apart. After `BUSY_LATCH` consecutive passes the key
+            // latches with a reason, so /status names it instead of reporting `failed: 0`
+            // beside a `remaining` that never moves. A successful render clears the count.
+            RenderOutcome.Busy -> catalogThemeCache.recordBackgroundBusy(job.cacheKey)
+            // Count the failure but do NOT latch on the first one. `failureReason` treats a
+            // latched key as terminal and answers foreground requests with a 409, so a single
+            // flaky background render — a cold-start timeout, a daemon restart — would
+            // otherwise make that thumbnail permanently unavailable until the catalog
+            // generation refreshes. `recordRenderFailure` latches only after a run of them,
+            // which is the retry budget the old per-job loop provided.
+            is RenderOutcome.Failed ->
+              catalogThemeCache.recordRenderFailure(job.cacheKey, outcome.reason)
+            else -> catalogThemeCache.markFailed(job.cacheKey)
           }
         }
-        catalogThemeCache.markPassFinished(clock())
-      } finally {
-        optimizationActive.set(false)
-        optimizationStarted.set(false)
       }
     }
+    catalogThemeCache.markPassFinished(clock())
+    return PassOutcome.FINISHED
   }
 
   /**
@@ -1388,6 +1440,9 @@ class ServeCatalogLiveHost(
      * next presence heartbeat.
      */
     internal const val OPTIMIZER_ADMISSION_WAIT_MILLIS = 20_000L
+
+    /** Default lane slice — see the `optimizerSliceMillis` constructor parameter for the trade. */
+    internal const val DEFAULT_OPTIMIZER_SLICE_MILLIS = 5 * 60_000L
 
     internal const val OPTIMIZER_YIELD_MILLIS = 1_500L
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkOptimizerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkOptimizerTest.kt
@@ -171,6 +171,175 @@ class ServeBackgroundWorkOptimizerTest {
     assertNull(snap.pauseReason)
   }
 
+  /**
+   * Park [system] at the admission door and return once it is genuinely queued.
+   *
+   * The polling matters: starting the thread proves nothing about whether it has reached the lock,
+   * and asserting on priority order before both waiters are registered would test the scheduler
+   * rather than the priority rule.
+   */
+  private fun queueWaiter(
+    bg: ServeBackgroundWork,
+    system: String,
+    expectWaiting: Int,
+    ran: MutableList<String>,
+    release: CountDownLatch,
+  ): Thread {
+    val t = Thread {
+      bg.withOptimizerSlot(system, waitMillis = 10_000) {
+        synchronized(ran) { ran += system }
+        release.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    // Polled on the queue itself, not the `waiting` counter: the two are updated together under the
+    // same lock, but only the queue is what the priority assertions below actually read.
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (bg.optimizerAdmissionSnapshot().waitingSystems.size < expectWaiting) {
+      check(System.nanoTime() < deadline) { "$system never reached the door" }
+      Thread.sleep(5)
+    }
+    return t
+  }
+
+  @Test
+  fun `the lane goes to whoever has gone longest without one, not whoever asked first`() {
+    // The starvation this exists to prevent: a fair semaphore only orders the callers blocked on it
+    // right now, so a catalog refused twenty times arrived at attempt twenty-one with no advantage
+    // over one that had just run. On the deployed box that read as `admissions 5, refusals 20` with
+    // m3-catalog — the largest queue on the box — never admitted once.
+    var now = 0L
+    val bg = work(lanes = 1, now = { now })
+    val ran = mutableListOf<String>()
+
+    // `recent` runs first and therefore most recently; `stale` ran long ago.
+    now = 100
+    bg.withOptimizerSlot("stale", waitMillis = 1_000) { true }
+    now = 200
+    bg.withOptimizerSlot("recent", waitMillis = 1_000) { true }
+
+    now = 300
+    val holderRelease = CountDownLatch(1)
+    val holding = CountDownLatch(1)
+    val holder = Thread {
+      bg.withOptimizerSlot("holder", waitMillis = 1_000) {
+        holding.countDown()
+        holderRelease.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(holding.await(5, TimeUnit.SECONDS))
+
+    // `recent` queues FIRST, `stale` second — so arrival order and priority order disagree.
+    val release = CountDownLatch(1)
+    val tRecent = queueWaiter(bg, "recent", expectWaiting = 1, ran = ran, release = release)
+    val tStale = queueWaiter(bg, "stale", expectWaiting = 2, ran = ran, release = release)
+
+    assertEquals(
+      listOf("stale", "recent"),
+      bg.optimizerAdmissionSnapshot().waitingSystems,
+      "the door should report who is next, in the order they will be let in",
+    )
+
+    holderRelease.countDown()
+    holder.join(10_000)
+    // One lane, so the first entrant is decided before the second can start.
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (synchronized(ran) { ran.isEmpty() }) {
+      check(System.nanoTime() < deadline) { "nobody was admitted" }
+      Thread.sleep(5)
+    }
+    assertEquals(
+      "stale",
+      synchronized(ran) { ran.first() },
+      "the longest-waiting system goes first",
+    )
+
+    release.countDown()
+    tRecent.join(10_000)
+    tStale.join(10_000)
+    // `waiting` is a gauge, not a tally. It read as a tally once — the decrement was dropped when
+    // admission moved off the semaphore — and a door that reports a permanent queue is worse than
+    // one that reports none, because it looks exactly like the starvation this change fixes.
+    assertEquals(0, bg.optimizerAdmissionSnapshot().waiting)
+    assertEquals(emptyList(), bg.optimizerAdmissionSnapshot().waitingSystems)
+  }
+
+  @Test
+  fun `a system that has never run outranks every system that has`() {
+    // The anti-starvation guarantee stated positively: every catalog gets a lane before any catalog
+    // gets a second one. That holds without knowing how much work each has left, which is why there
+    // is no size heuristic here.
+    var now = 0L
+    val bg = work(lanes = 1, now = { now })
+    val ran = mutableListOf<String>()
+
+    now = 100
+    bg.withOptimizerSlot("veteran", waitMillis = 1_000) { true }
+
+    now = 200
+    val holderRelease = CountDownLatch(1)
+    val holding = CountDownLatch(1)
+    val holder = Thread {
+      bg.withOptimizerSlot("holder", waitMillis = 1_000) {
+        holding.countDown()
+        holderRelease.await(5, TimeUnit.SECONDS)
+        true
+      }
+    }
+      .also(Thread::start)
+    assertTrue(holding.await(5, TimeUnit.SECONDS))
+
+    val release = CountDownLatch(1)
+    val tVeteran = queueWaiter(bg, "veteran", expectWaiting = 1, ran = ran, release = release)
+    val tNewcomer = queueWaiter(bg, "newcomer", expectWaiting = 2, ran = ran, release = release)
+
+    assertEquals(listOf("newcomer", "veteran"), bg.optimizerAdmissionSnapshot().waitingSystems)
+
+    holderRelease.countDown()
+    holder.join(10_000)
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+    while (synchronized(ran) { ran.isEmpty() }) {
+      check(System.nanoTime() < deadline) { "nobody was admitted" }
+      Thread.sleep(5)
+    }
+    assertEquals("newcomer", synchronized(ran) { ran.first() })
+
+    release.countDown()
+    tVeteran.join(10_000)
+    tNewcomer.join(10_000)
+  }
+
+  @Test
+  fun `priority admission still never exceeds the lane count`() {
+    // Rotation must not be bought by widening the door — the cap is the reason the box stopped
+    // thrashing, and a priority queue that admits an extra pass would undo it.
+    val bg = work(lanes = 2)
+    val inside = AtomicInteger()
+    val peak = AtomicInteger()
+    val done = CountDownLatch(6)
+    val threads =
+      (1..6).map { n ->
+        Thread {
+            bg.withOptimizerSlot("cat-$n", waitMillis = 5_000) {
+              val now = inside.incrementAndGet()
+              peak.getAndUpdate { max -> maxOf(max, now) }
+              Thread.sleep(20)
+              inside.decrementAndGet()
+              true
+            }
+            done.countDown()
+          }
+          .also(Thread::start)
+      }
+    assertTrue(done.await(20, TimeUnit.SECONDS))
+    threads.forEach { it.join(10_000) }
+    assertTrue(peak.get() <= 2, "never more than ${2} inside the door, saw ${peak.get()}")
+    assertEquals(0, bg.optimizerAdmissionSnapshot().running)
+  }
+
   @Test
   fun `admission counters distinguish work done from work refused`() {
     // The pair that tells an operator the cap is working rather than wedged: refusals climbing

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1195,6 +1195,102 @@ class ServeCatalogLiveHostTest {
   }
 
   /**
+   * A pass gives its lane back on a preview boundary and re-queues for another.
+   *
+   * Without this, fair admission is not enough to un-starve anything. A pass on an idle box runs
+   * until its catalog is fully optimized — measured on the deployed box, `reply` took a lane and
+   * held it through all 354 of its entries — so a 10,120-target catalog would hold a lane for ~28
+   * hours and the queue behind it would be fair and immovable at the same time.
+   */
+  @Test
+  fun `a long pass yields its lane between previews instead of holding it to the end`() {
+    val backgroundWork = ServeBackgroundWork(maxConcurrentRenders = 4, maxConcurrentOptimizers = 1)
+    val previews = (1..4).map { ServePreview("$daemonId-$it", "$daemonId-$it") }
+    fun host(sliceMillis: Long) =
+      ServeCatalogLiveHost(
+        alias = previews.associate { "cat-${it.id}" to it.id },
+        live =
+          RecordingHost(previews = previews, tag = "live", declaredThemes = listOf(brandTheme)),
+        baked =
+          RecordingHost(previews.map { ServePreview("cat-${it.id}", "cat-${it.id}") }, "baked"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+        optimizerSliceMillis = sliceMillis,
+        backgroundWork = backgroundWork,
+      )
+
+    // A slice that is already spent hands the lane back after every preview, so the four previews
+    // cost four admissions rather than one.
+    val sliced = host(sliceMillis = 0)
+    sliced.prewarm()
+    val slicedSnapshot = awaitOptimization(sliced)
+
+    assertTrue(slicedSnapshot.fullyOptimized, "yielding the lane must not lose the work")
+    assertEquals(4, slicedSnapshot.cached)
+    assertEquals(
+      4,
+      backgroundWork.optimizerAdmissionSnapshot().admissions,
+      "one admission per preview — the lane goes back to the queue between them",
+    )
+
+    // The control: a slice longer than the pass never fires, and the whole catalog is one
+    // admission. Without it, "4 admissions" would also be satisfied by a pass that re-queues for
+    // reasons having nothing to do with the slice.
+    val whole = ServeBackgroundWork(maxConcurrentRenders = 4, maxConcurrentOptimizers = 1)
+    val unsliced =
+      ServeCatalogLiveHost(
+        alias = previews.associate { "cat-${it.id}" to it.id },
+        live =
+          RecordingHost(previews = previews, tag = "live", declaredThemes = listOf(brandTheme)),
+        baked =
+          RecordingHost(previews.map { ServePreview("cat-${it.id}", "cat-${it.id}") }, "baked"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+        optimizerSliceMillis = 10 * 60_000,
+        backgroundWork = whole,
+      )
+    unsliced.prewarm()
+    assertTrue(awaitOptimization(unsliced).fullyOptimized)
+    assertEquals(1, whole.optimizerAdmissionSnapshot().admissions)
+  }
+
+  /**
+   * A slice yields at least one preview however short it is.
+   *
+   * The failure this closes is a livelock: check the deadline before doing any work and a slice
+   * shorter than the admission round-trip re-queues forever, rendering nothing while looking busy.
+   */
+  @Test
+  fun `an already-spent slice still renders one preview before giving the lane back`() {
+    val backgroundWork = ServeBackgroundWork(maxConcurrentRenders = 4, maxConcurrentOptimizers = 1)
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = { Long.MAX_VALUE },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+        optimizerSliceMillis = 0,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+
+    assertTrue(awaitOptimization(composite).fullyOptimized)
+    assertEquals(1, live.renderCalls)
+    assertEquals(1, backgroundWork.optimizerAdmissionSnapshot().admissions)
+  }
+
+  /**
    * The shared lane bounds the optimizers — it no longer serialises them.
    *
    * This asserted a peak of exactly 1 while the background cap was 1. That cap was measured on the


### PR DESCRIPTION
Closes #4129.

## What was broken

The concurrent-pass cap in #4124 was right about the problem and wrong about the hand-off. It bounds the theme optimizer to two lanes, but gives them to whoever knocks first and lets a pass keep its lane for the whole catalog. Measured on `preview.coo.ee` 45 minutes after v1.14.0 deployed:

```
themeOptimizer: lanes 2, running 2, admissions 5, refusals 20
  running:  meshcore-mobile (287/572), remote-m3 (251/255)
  complete: reply (354/354)
  the other 19: state "paused", turnsGranted 0
```

`m3-catalog` — 10,120 targets, the largest queue on the box — reported `cached 0, turnsGranted 0, gateWaitMillis 0, batchMillis 0`. Every counter that only a pass which actually ran can move was zero. It had not been admitted once. Before the cap it always ran, just slowly; after it, the catalog that most needed lane time was the least likely to get any.

## Why this takes two changes

**Admission had no memory.** A fair `Semaphore` orders the callers *currently blocked on it*, and an optimizer pass blocks for `OPTIMIZER_ADMISSION_WAIT_MILLIS` (20s) before giving up and parking until the next presence heartbeat. So the ordering only ever covered whoever happened to be at the door in the same 20s window, and a catalog refused twenty times arrived at attempt twenty-one with no advantage over one that had just run.

Lanes now go to whoever has gone longest without one, keyed on when each system's pass last *ended* (not started — a pass that held a lane for an hour finished recently, and keying on its start would let it outrank catalogs that waited that entire hour). A never-run system outranks every system that has run, so **every catalog gets a lane before any catalog gets a second**. That is a stronger guarantee than a size heuristic and needs no knowledge of how much work each catalog has left, which is why there is no size tie-break here.

**Fair admission alone would not have fixed it.** On an idle box a pass runs until its catalog is fully optimized — `reply` took a lane and held it through all 354 of its entries. For m3-catalog that is ~28 hours, and a queue you reach the front of in 28 hours is still starvation. A pass now returns its lane after five minutes and re-queues, where its freshly-stamped `lastRanAt` puts it behind everyone still waiting.

The slice yields on a **preview** boundary, because a preview is the unit a daemon warms for: giving the lane back between previews never abandons a warm that has just been paid for, whereas cutting mid-preview would throw away the most expensive thing the pass does (34–68s on an Android/Robolectric lane) to save a few seconds of the cheapest. Five minutes puts a full rotation of the box's 22 catalogs under an hour while keeping worst-case warm overhead near a fifth of the lane. `-Dcomposeai.serve.themeOptimizerSliceMillis` overrides it.

A slice always yields at least one preview whatever the clock says — checking the deadline before doing any work would let a slice shorter than the admission round-trip re-queue forever, rendering nothing while looking busy.

## Observability

`/status.json` gains `themeOptimizer.waitingSystems`: who is at the door, **in the order they will be let in**. This is the read that was missing. `refusals 20` said work was being turned away; nothing said it was the same system being turned away every time.

## What this does not fix

The cache still returns to zero on every server restart and every delivery-branch regeneration — 7–10 times a day for m3-catalog, against ~28 hours of lane time to finish. This change gets it warming again; #4130 is what lets the work survive to completion.

## Test plan

`./gradlew :cli:test` green (full module suite), `./gradlew ktfmtCheckAll` clean.

New in `ServeBackgroundWorkOptimizerTest`:
- the lane goes to the longest-waiting system, not the first to ask (both queue while a holder occupies the only lane, so arrival order and priority order disagree);
- a never-run system outranks one that has run;
- priority admission still never exceeds the lane count — rotation must not be bought by widening the door;
- `waiting` returns to zero. It read as a monotonic tally at one point during this change (the decrement was dropped when admission moved off the semaphore) and the first priority test caught it — a door reporting a permanent queue looks exactly like the starvation being fixed.

New in `ServeCatalogLiveHostTest`:
- a four-preview catalog with a spent slice costs four admissions where the same catalog with a long slice costs one, and reaches `fullyOptimized` either way — the control is what makes the four-admission assertion mean the slice rather than some other re-entry;
- an already-spent slice still renders one preview before giving the lane back.

Text-only evidence: this changes background scheduling and a status counter, no rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_