### PR TITLE
feat(serve): persist warmed theme renders across restarts and regenerations

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -136,6 +136,8 @@ internal object CliFlagValidation {
             "--bundles",
             "--catalog-branch-prefix",
             "--catalog-feed-cache",
+            "--theme-cache-dir",
+            "--theme-cache-max-bytes",
             "--catalog-feed-idle-timeout",
             "--catalog-max-images",
             "--catalog-refresh-interval",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -107,6 +107,8 @@ internal object CliFlags {
       "--catalog-max-images",
       "--catalog-feed-idle-timeout",
       "--catalog-feed-cache",
+      "--theme-cache-dir",
+      "--theme-cache-max-bytes",
       "--catalog-source-root",
       "--wasm-dir",
       "--rc-player-wasm-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -868,6 +868,9 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
               ThemeCacheFingerprint.renderedClasspath(
                 launch.classpath,
                 launch.systemProperties,
+                // Same preview manifest, reachable by a second route on descriptors that name it
+                // here rather than in a system property.
+                extraPayloads = listOfNotNull(launch.manifestPath),
               ),
             variant = launch.variant,
             toolVersion = BUNDLE_VERSION,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.CatalogRefreshResult
 import ee.schimke.composeai.cli.serve.CatalogThemeCache
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
+import ee.schimke.composeai.cli.serve.GenerationInputs
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
 import ee.schimke.composeai.cli.serve.LiveSeatLimiter
@@ -68,6 +69,8 @@ import ee.schimke.composeai.cli.serve.ServeTrustAdmin
 import ee.schimke.composeai.cli.serve.ServeTrustStoreFile
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.ServeWeb
+import ee.schimke.composeai.cli.serve.ThemeCacheFingerprint
+import ee.schimke.composeai.cli.serve.ThemeCacheStore
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
 import ee.schimke.composeai.cli.serve.detectedFeaturesOf
@@ -744,6 +747,115 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    */
   private val backgroundWork =
     ServeBackgroundWork(maxConcurrentRenders = ServeBackgroundWork.renderLaneFor(liveSeatLimiter))
+
+  /**
+   * Durable home for warmed theme renders (`--theme-cache-dir`), or null to keep the cache in
+   * memory only.
+   *
+   * Defaults beside `catalogs.json` exactly as the feed cache does, because that is the directory a
+   * deployment already mounts as a persistent volume — and persistence across container recreation
+   * is the entire point.
+   *
+   * **Unlike the feed cache, there is deliberately no temp-directory fallback.** A theme cache in
+   * `/tmp` would be written once, read never, and thrown away with the container: it would consume
+   * disk and render time to buy exactly nothing, while reporting itself as working. Where there is
+   * no durable location, the honest configuration is no disk tier at all.
+   */
+  private val themeCacheStore: ThemeCacheStore? by lazy {
+    val explicit = args.flagValue("--theme-cache-dir")?.takeIf { it.isNotBlank() }?.let(::File)
+    val preferred =
+      explicit
+        ?: catalogsFile?.displayPath?.let(::File)?.absoluteFile?.parentFile?.resolve("theme-cache")
+        ?: return@lazy null
+    if (!(preferred.isDirectory || preferred.mkdirs()) || !preferred.canWrite()) {
+      System.err.println("serve: theme cache disabled — $preferred is not writable")
+      return@lazy null
+    }
+    val maxBytes =
+      args.flagValue("--theme-cache-max-bytes")?.toLongOrNull()?.takeIf { it > 0 }
+        ?: ThemeCacheStore.DEFAULT_MAX_BYTES
+    System.err.println("serve: theme cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB)")
+    ThemeCacheStore(preferred, maxBytes = maxBytes)
+  }
+
+  /**
+   * Reclaim theme-cache generations nothing can read any more.
+   *
+   * Run once the catalog pass has finished, which is the only moment the live set is actually
+   * known: sweeping earlier would delete a generation a catalog three places down the list was
+   * about to adopt. On a box regenerating several times a day this is where the disk is won back —
+   * every superseded catalog revision and every previous server version leaves a generation behind.
+   */
+  private fun sweepThemeCache() {
+    val store = themeCacheStore ?: return
+    val result = runCatching { store.sweep(liveThemeGenerations.toSet()) }.getOrNull() ?: return
+    if (result.deletedGenerations > 0) {
+      System.err.println(
+        "serve: theme cache swept ${result.deletedGenerations} stale generation(s), " +
+          "${result.reclaimedBytes / (1024 * 1024)} MB reclaimed"
+      )
+    }
+    if (result.overCap) {
+      System.err.println(
+        "serve: theme cache is ${result.bytes / (1024 * 1024)} MB, over its cap — every generation " +
+          "still in use, so nothing was evicted. Raise --theme-cache-max-bytes or serve fewer catalogs."
+      )
+    }
+  }
+
+  /** Generations opened this run, so [ThemeCacheStore.sweep] knows what it must not reclaim. */
+  private val liveThemeGenerations =
+    java.util.concurrent.ConcurrentHashMap.newKeySet<ThemeCacheStore.GenerationId>()
+
+  /**
+   * Build the disk tier for one catalog generation, or null when it has no durable identity.
+   *
+   * The fingerprint is computed from the daemon's own launch descriptor — the classpath it will
+   * render with, and the variant it will render as — so nothing here has to be kept in step by hand
+   * with what the renderer actually loads.
+   */
+  private fun themeCacheFor(system: String, vararg descriptors: File): CatalogThemeCache {
+    val store = themeCacheStore ?: return CatalogThemeCache()
+    val launches = descriptors.map {
+      ServeBundleDaemon.readLaunchDescriptor(it) ?: return CatalogThemeCache()
+    }
+    if (launches.isEmpty()) return CatalogThemeCache()
+    // The JVM the render runs in is part of what produced the pixels; the descriptor's system
+    // properties are deliberately NOT, because they are dominated by absolute paths that a fresh
+    // staging directory changes on every load — hashing those would make every load a new
+    // generation and buy nothing.
+    val renderConfig = launches.flatMap { it.jvmArgs }.sorted().joinToString(" ")
+    val variant = launches.map { it.variant }.distinct().sorted().joinToString("+")
+    // A multi-module catalog renders from several bundles at once and its generation is all of them
+    // together — any one changing changes what a visitor sees.
+    val fingerprint =
+      ThemeCacheFingerprint.combine(
+        launches.map { launch ->
+          ThemeCacheFingerprint.of(
+            classpath = launch.classpath.map(::File),
+            variant = launch.variant,
+            toolVersion = BUNDLE_VERSION,
+            renderConfig = launch.jvmArgs.sorted().joinToString(" "),
+          ) ?: return CatalogThemeCache()
+        }
+      ) ?: return CatalogThemeCache()
+    val inputs =
+      GenerationInputs(
+        system = system,
+        fingerprint = fingerprint,
+        toolVersion = BUNDLE_VERSION,
+        variant = variant,
+        renderConfig = renderConfig,
+      )
+    val generation = store.open(system, fingerprint, inputs) ?: return CatalogThemeCache()
+    liveThemeGenerations += ThemeCacheStore.GenerationId(system, fingerprint)
+    if (generation.loadedEntries > 0) {
+      System.err.println(
+        "serve: catalog $system → ${generation.loadedEntries} theme renders adopted from disk"
+      )
+    }
+    return CatalogThemeCache(persistence = generation)
+  }
 
   /**
    * In-browser CMP tier (`--wasm-dir <system>=<dir>[,<system>=<dir>…]`): map a design system to the
@@ -2459,6 +2571,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         playgroundHealth = playgroundLane?.health,
         branchFetchStats = catalogStore?.let { store -> { store.branchFetchStats.snapshot() } },
         themeOptimizerStats = { backgroundWork.optimizerAdmissionSnapshot() },
+        themeCacheStats = { themeCacheStore?.snapshot() },
         themeOptimizerAdmin = backgroundWork,
         playgroundRedeem = playgroundLane?.redeem,
         githubAuth = githubAuth,
@@ -2858,6 +2971,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           // However the pass ended — loaded, failed, or shut down mid-pass — background catalog
           // work is free to start; leaving it claimed would park the optimizer forever.
           backgroundWork.initialCatalogLoadFinished()
+          sweepThemeCache()
           if (!closed.get()) onComplete(loaded)
         }
       }
@@ -3121,34 +3235,35 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // the mapped ids get a live lane. See ServeCatalogLiveHost. The rehydrated external-resource
     // pool (fonts lifted out of classes/app.jar) joins the daemon classpath so text rasterises with
     // the same faces.
-    val state =
+    val materialized =
       ServeBundleDaemon.materialize(
-          bundleFile,
-          destDir,
-          system,
-          extraMavenRepos = extraMavenRepos,
-          extraClasspathDirs = listOfNotNull(externalResourcesDir),
-        )
-        ?.copy(
-          previewAliases = alias,
-          bakedFallback = bakedFallback,
-          perPreviewResolve = perPreviewPool::get,
-          executableBundleAvailable = perPreviewBundle.available,
-          executableBundleProvider = { daemonId ->
-            perPreviewBundle.fetch(daemonId)?.takeIf(File::isFile)?.readBytes()
-          },
-          perPreviewStreamCount = perPreviewPool::activeStreamCount,
-          perPreviewRenderStats = perPreviewPool::renderPerfStats,
-          perPreviewPoolStats = { listOf(perPreviewPool.snapshot()) },
-          perPreviewReapIdle = perPreviewPool::reapIdle,
-          catalogThemeCache = CatalogThemeCache(),
-          serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
-          backgroundWork = backgroundWork,
-        )
+        bundleFile,
+        destDir,
+        system,
+        extraMavenRepos = extraMavenRepos,
+        extraClasspathDirs = listOfNotNull(externalResourcesDir),
+      )
         ?: run {
           perPreviewPool.close()
           return false
         }
+    val state =
+      materialized.copy(
+        previewAliases = alias,
+        bakedFallback = bakedFallback,
+        perPreviewResolve = perPreviewPool::get,
+        executableBundleAvailable = perPreviewBundle.available,
+        executableBundleProvider = { daemonId ->
+          perPreviewBundle.fetch(daemonId)?.takeIf(File::isFile)?.readBytes()
+        },
+        perPreviewStreamCount = perPreviewPool::activeStreamCount,
+        perPreviewRenderStats = perPreviewPool::renderPerfStats,
+        perPreviewPoolStats = { listOf(perPreviewPool.snapshot()) },
+        perPreviewReapIdle = perPreviewPool::reapIdle,
+        catalogThemeCache = themeCacheFor(system, materialized.descriptor),
+        serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
+        backgroundWork = backgroundWork,
+      )
     // Now that the backend is known, the pool's daemons charge this catalog's real weight — an
     // Android/Robolectric per-preview daemon is not the same cost to the box as a desktop one.
     perPreviewSeatWeight = state.liveSeatWeight
@@ -3344,7 +3459,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           },
           perPreviewPoolStats = { opened.map { it.pool.snapshot() } },
           perPreviewReapIdle = { idle -> opened.sumOf { it.pool.reapIdle(idle) } },
-          catalogThemeCache = CatalogThemeCache(),
+          catalogThemeCache =
+            themeCacheFor(system, *opened.map { it.state.descriptor }.toTypedArray()),
           serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
           backgroundWork = backgroundWork,
         )
@@ -3443,7 +3559,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         // URLs and falls back to baked PNGs for ids it can't render.
         previewAliases = alias,
         bakedFallback = bakedFallback,
-        catalogThemeCache = CatalogThemeCache(),
+        catalogThemeCache = themeCacheFor(system, built.descriptor),
         serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
         backgroundWork = backgroundWork,
         // A source-built Android/Robolectric catalog costs the same heavier live-seat weight as the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -855,7 +855,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // properties are deliberately NOT, because they are dominated by absolute paths that a fresh
     // staging directory changes on every load — hashing those would make every load a new
     // generation and buy nothing.
-    val renderConfig = launches.flatMap { it.jvmArgs }.sorted().joinToString(" ")
+    val renderConfig =
+      launches.joinToString(" | ") {
+        ThemeCacheFingerprint.renderConfig(it.systemProperties, it.jvmArgs)
+      }
     val routing = ThemeCacheFingerprint.routingDigest(alias)
     val variant = launches.map { it.variant }.distinct().sorted().joinToString("+")
     // A multi-module catalog renders from several bundles at once and its generation is all of them
@@ -874,7 +877,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
               ),
             variant = launch.variant,
             toolVersion = BUNDLE_VERSION,
-            renderConfig = launch.jvmArgs.sorted().joinToString(" "),
+            renderConfig =
+              ThemeCacheFingerprint.renderConfig(launch.systemProperties, launch.jvmArgs),
             routing = routing,
           ) ?: return CatalogThemeCache()
         }
@@ -3625,6 +3629,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       )
     val host = openHost(state) ?: return false
     registry.register(system, state, host = host)
+    // The source-backed path registers directly rather than through `publishCatalogRuntime`, so it
+    // needs its own post-publication sweep — without it a deployment of only source-backed catalogs
+    // never reclaims a superseded generation, whatever the cap says.
+    sweepThemeCache()
     System.err.println(
       "serve: catalog $system → LIVE server-render from ${source.module}@${source.ref} " +
         "(?session=$system)"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -788,17 +788,21 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    */
   private fun sweepThemeCache() {
     val store = themeCacheStore ?: return
-    // Scoped to the systems we actually hold a current generation for. A catalog whose load failed
-    // this pass — a transient fetch error, or a shutdown before the loader reached it — has no
-    // entry here, and its previously warmed generation must survive: deleting it would make the
-    // refresher's later success restart ~28 hours of warming from zero, punishing a catalog for a
-    // network blip.
     val live =
-      liveThemeGenerations.entries.map { (system, fingerprint) ->
-        ThemeCacheStore.GenerationId(system, fingerprint)
-      }
+      liveThemeGenerations.entries
+        .map { (system, fingerprint) -> ThemeCacheStore.GenerationId(system, fingerprint) }
+        .toSet()
+    // Three populations, and only the middle one is left alone:
+    //  - loaded now: sweep it, so a refresh reclaims the fingerprint it just superseded;
+    //  - configured but NOT loaded this pass: skip it. A transient fetch error or a shutdown before
+    //    the loader reached it must not cost ~28 hours of re-warming;
+    //  - no longer configured at all: sweep it, with no live generation to protect anything, so an
+    //    operator removing a catalog actually gets the disk back. Passing null here — "sweep
+    //    everything" — would collapse the first two together.
+    val configuredButUnloaded = themeCacheConfiguredSystems().orEmpty() - liveThemeGenerations.keys
+    val sweepable = runCatching { store.systems() }.getOrNull().orEmpty() - configuredButUnloaded
     val result =
-      runCatching { store.sweep(live.toSet(), onlySystems = liveThemeGenerations.keys.toSet()) }
+      runCatching { store.sweep(live, onlySystems = sweepable + liveThemeGenerations.keys) }
         .getOrNull() ?: return
     if (result.deletedGenerations > 0) {
       System.err.println(
@@ -813,6 +817,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       )
     }
   }
+
+  /**
+   * Systems this server is configured to serve, once the catalog tracker exists. Null before then,
+   * which makes the sweep conservative rather than destructive.
+   */
+  @Volatile private var themeCacheConfiguredSystems: () -> Set<String>? = { null }
 
   /**
    * The generation currently in use **per system**, so a sweep knows what it must not reclaim.
@@ -831,7 +841,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * render with, and the variant it will render as — so nothing here has to be kept in step by hand
    * with what the renderer actually loads.
    */
-  private fun themeCacheFor(system: String, vararg descriptors: File): CatalogThemeCache {
+  private fun themeCacheFor(
+    system: String,
+    alias: Map<String, String>,
+    vararg descriptors: File,
+  ): CatalogThemeCache {
     val store = themeCacheStore ?: return CatalogThemeCache()
     val launches = descriptors.map {
       ServeBundleDaemon.readLaunchDescriptor(it) ?: return CatalogThemeCache()
@@ -842,6 +856,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // staging directory changes on every load — hashing those would make every load a new
     // generation and buy nothing.
     val renderConfig = launches.flatMap { it.jvmArgs }.sorted().joinToString(" ")
+    val routing = ThemeCacheFingerprint.routingDigest(alias)
     val variant = launches.map { it.variant }.distinct().sorted().joinToString("+")
     // A multi-module catalog renders from several bundles at once and its generation is all of them
     // together — any one changing changes what a visitor sees.
@@ -857,6 +872,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             variant = launch.variant,
             toolVersion = BUNDLE_VERSION,
             renderConfig = launch.jvmArgs.sorted().joinToString(" "),
+            routing = routing,
           ) ?: return CatalogThemeCache()
         }
       ) ?: return CatalogThemeCache()
@@ -866,7 +882,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         fingerprint = fingerprint,
         toolVersion = BUNDLE_VERSION,
         variant = variant,
-        renderConfig = renderConfig,
+        renderConfig = "$renderConfig routing=$routing",
       )
     val generation = store.open(system, fingerprint, inputs) ?: return CatalogThemeCache()
     val superseded = liveThemeGenerations.put(system, fingerprint) != null
@@ -3031,6 +3047,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           )
         }
       )
+    // The sweeper needs configured-but-unloaded systems, which only the tracker knows.
+    themeCacheConfiguredSystems = loads::configuredSystems
     val store =
       ServeCatalogStore(
         root = dir,
@@ -3285,7 +3303,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         perPreviewRenderStats = perPreviewPool::renderPerfStats,
         perPreviewPoolStats = { listOf(perPreviewPool.snapshot()) },
         perPreviewReapIdle = perPreviewPool::reapIdle,
-        catalogThemeCache = themeCacheFor(system, materialized.descriptor),
+        catalogThemeCache = themeCacheFor(system, alias, materialized.descriptor),
         serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
         backgroundWork = backgroundWork,
       )
@@ -3485,7 +3503,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           perPreviewPoolStats = { opened.map { it.pool.snapshot() } },
           perPreviewReapIdle = { idle -> opened.sumOf { it.pool.reapIdle(idle) } },
           catalogThemeCache =
-            themeCacheFor(system, *opened.map { it.state.descriptor }.toTypedArray()),
+            themeCacheFor(system, alias, *opened.map { it.state.descriptor }.toTypedArray()),
           serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
           backgroundWork = backgroundWork,
         )
@@ -3584,7 +3602,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         // URLs and falls back to baked PNGs for ids it can't render.
         previewAliases = alias,
         bakedFallback = bakedFallback,
-        catalogThemeCache = themeCacheFor(system, built.descriptor),
+        catalogThemeCache = themeCacheFor(system, alias, built.descriptor),
         serverIdleMillis = backgroundWork.idleClock(registry::idleMillis),
         backgroundWork = backgroundWork,
         // A source-built Android/Robolectric catalog costs the same heavier live-seat weight as the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -788,7 +788,18 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    */
   private fun sweepThemeCache() {
     val store = themeCacheStore ?: return
-    val result = runCatching { store.sweep(liveThemeGenerations.toSet()) }.getOrNull() ?: return
+    // Scoped to the systems we actually hold a current generation for. A catalog whose load failed
+    // this pass — a transient fetch error, or a shutdown before the loader reached it — has no
+    // entry here, and its previously warmed generation must survive: deleting it would make the
+    // refresher's later success restart ~28 hours of warming from zero, punishing a catalog for a
+    // network blip.
+    val live =
+      liveThemeGenerations.entries.map { (system, fingerprint) ->
+        ThemeCacheStore.GenerationId(system, fingerprint)
+      }
+    val result =
+      runCatching { store.sweep(live.toSet(), onlySystems = liveThemeGenerations.keys.toSet()) }
+        .getOrNull() ?: return
     if (result.deletedGenerations > 0) {
       System.err.println(
         "serve: theme cache swept ${result.deletedGenerations} stale generation(s), " +
@@ -803,9 +814,15 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     }
   }
 
-  /** Generations opened this run, so [ThemeCacheStore.sweep] knows what it must not reclaim. */
-  private val liveThemeGenerations =
-    java.util.concurrent.ConcurrentHashMap.newKeySet<ThemeCacheStore.GenerationId>()
+  /**
+   * The generation currently in use **per system**, so a sweep knows what it must not reclaim.
+   *
+   * A map rather than a growing set, because a catalog refresh supersedes its own previous
+   * fingerprint: an append-only set would keep protecting every generation the box had ever opened,
+   * so a delivery branch regenerating a few times a day would accumulate multi-gigabyte generations
+   * that the cap could never reclaim.
+   */
+  private val liveThemeGenerations = java.util.concurrent.ConcurrentHashMap<String, String>()
 
   /**
    * Build the disk tier for one catalog generation, or null when it has no durable identity.
@@ -832,7 +849,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       ThemeCacheFingerprint.combine(
         launches.map { launch ->
           ThemeCacheFingerprint.of(
-            classpath = launch.classpath.map(::File),
+            classpath =
+              ThemeCacheFingerprint.renderedClasspath(
+                launch.classpath,
+                launch.systemProperties,
+              ),
             variant = launch.variant,
             toolVersion = BUNDLE_VERSION,
             renderConfig = launch.jvmArgs.sorted().joinToString(" "),
@@ -848,7 +869,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         renderConfig = renderConfig,
       )
     val generation = store.open(system, fingerprint, inputs) ?: return CatalogThemeCache()
-    liveThemeGenerations += ThemeCacheStore.GenerationId(system, fingerprint)
+    val superseded = liveThemeGenerations.put(system, fingerprint) != null
+    // A refresh that produced a NEW fingerprint has just retired the old one; reclaim it now rather
+    // than at the next restart, or a box that regenerates several times a day never gets the disk
+    // back. Swept only on the replacement path — a first load has nothing to supersede.
+    if (superseded) sweepThemeCache()
     if (generation.loadedEntries > 0) {
       System.err.println(
         "serve: catalog $system → ${generation.loadedEntries} theme renders adopted from disk"
@@ -4095,6 +4120,19 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         --catalog-feed-cache <dir>
                           Durable shallow-Git + generated-XML cache for catalog feeds. Defaults to a
                           catalog-feeds directory beside --catalogs-file, or a temp dir in local mode.
+        --theme-cache-dir <dir>
+                          Durable store for warmed theme renders, so background warming survives a
+                          restart and a catalog refresh. Defaults to a theme-cache directory beside
+                          --catalogs-file; with no durable location the cache stays in memory only
+                          (there is deliberately no temp-dir fallback — it would be thrown away with
+                          the process). Entries are keyed by a fingerprint of the render classpath,
+                          daemon variant, tool version and render config, so a new catalog revision
+                          or server build never reads the previous one's pixels.
+        --theme-cache-max-bytes <n>
+                          Ceiling for that store across every catalog (default
+                          ${ThemeCacheStore.DEFAULT_MAX_BYTES / (1024L * 1024 * 1024)} GB). Superseded
+                          generations are reclaimed; generations still in use are never evicted, so
+                          exceeding this is reported rather than acted on.
         --wasm-dir <system>=<dir>[,<system>=<dir>…]
                           In-browser CMP tier: map a design system to its assembled Kotlin/Wasm
                           catalog app (./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist →

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -852,11 +852,17 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     alias: Map<String, String>,
     vararg descriptors: File,
   ): CatalogThemeCache {
+    // Every bailout below names itself. A catalog that silently falls back to memory-only looks
+    // exactly like one on a server with no cache directory, and the difference — the cache is
+    // configured and this catalog alone is not using it — is the one an operator needs, because it
+    // is permanent for the life of the host and nothing else reports it.
     val store = themeCacheStore ?: return CatalogThemeCache()
     val launches = descriptors.map {
-      ServeBundleDaemon.readLaunchDescriptor(it) ?: return CatalogThemeCache()
+      ServeBundleDaemon.readLaunchDescriptor(it)
+        ?: return CatalogThemeCache(persistenceOffReason = "launch descriptor unreadable")
     }
-    if (launches.isEmpty()) return CatalogThemeCache()
+    if (launches.isEmpty())
+      return CatalogThemeCache(persistenceOffReason = "catalog has no launch descriptor")
     // The JVM the render runs in is part of what produced the pixels; the descriptor's system
     // properties are deliberately NOT, because they are dominated by absolute paths that a fresh
     // staging directory changes on every load — hashing those would make every load a new
@@ -886,9 +892,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             renderConfig =
               ThemeCacheFingerprint.renderConfig(launch.systemProperties, launch.jvmArgs),
             routing = routing,
-          ) ?: return CatalogThemeCache()
+          )
+            ?: return CatalogThemeCache(
+              persistenceOffReason = "fingerprint unavailable (a classpath entry could not be read)"
+            )
         }
-      ) ?: return CatalogThemeCache()
+      ) ?: return CatalogThemeCache(persistenceOffReason = "fingerprint unavailable")
     val inputs =
       GenerationInputs(
         system = system,
@@ -897,7 +906,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         variant = variant,
         renderConfig = "$renderConfig routing=$routing",
       )
-    val generation = store.open(system, fingerprint, inputs) ?: return CatalogThemeCache()
+    val generation =
+      store.open(system, fingerprint, inputs)
+        ?: return CatalogThemeCache(
+          persistenceOffReason = "generation directory could not be opened"
+        )
     // The map is updated here, but the SWEEP is not run here. This is called while a replacement
     // host is still being staged: `openHost` or publication can still fail and leave the previous
     // host serving from the registry — and reclaiming its generation at this point would delete a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -762,7 +762,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * no durable location, the honest configuration is no disk tier at all.
    */
   private val themeCacheStore: ThemeCacheStore? by lazy {
-    val explicit = args.flagValue("--theme-cache-dir")?.takeIf { it.isNotBlank() }?.let(::File)
+    val requested = args.flagValue("--theme-cache-dir")?.takeIf { it.isNotBlank() }
+    // `none` disables persistence outright, matching --trust-store's convention in this command.
+    // A sentinel is needed because *unset* cannot mean "off": the derived default lands beside
+    // --catalogs-file, which on the prebuilt image is the durable `preview_config` volume — so an
+    // untouched deployment would quietly fill its configuration volume with an 8 GB render cache.
+    if (requested == "none") return@lazy null
+    val explicit = requested?.let(::File)
     val preferred =
       explicit
         ?: catalogsFile?.displayPath?.let(::File)?.absoluteFile?.parentFile?.resolve("theme-cache")
@@ -4156,10 +4162,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         --catalog-feed-cache <dir>
                           Durable shallow-Git + generated-XML cache for catalog feeds. Defaults to a
                           catalog-feeds directory beside --catalogs-file, or a temp dir in local mode.
-        --theme-cache-dir <dir>
+        --theme-cache-dir <dir>|none
                           Durable store for warmed theme renders, so background warming survives a
-                          restart and a catalog refresh. Defaults to a theme-cache directory beside
-                          --catalogs-file; with no durable location the cache stays in memory only
+                          restart and a catalog refresh. `none` disables it. Defaults to a
+                          theme-cache directory beside --catalogs-file — note that on the prebuilt
+                          image that is the persistent config volume, so pass `none` to keep it off;
+                          with no durable location the cache stays in memory only
                           (there is deliberately no temp-dir fallback — it would be thrown away with
                           the process). Entries are keyed by a fingerprint of the render classpath,
                           daemon variant, tool version and render config, so a new catalog revision

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -885,11 +885,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         renderConfig = "$renderConfig routing=$routing",
       )
     val generation = store.open(system, fingerprint, inputs) ?: return CatalogThemeCache()
-    val superseded = liveThemeGenerations.put(system, fingerprint) != null
-    // A refresh that produced a NEW fingerprint has just retired the old one; reclaim it now rather
-    // than at the next restart, or a box that regenerates several times a day never gets the disk
-    // back. Swept only on the replacement path — a first load has nothing to supersede.
-    if (superseded) sweepThemeCache()
+    // The map is updated here, but the SWEEP is not run here. This is called while a replacement
+    // host is still being staged: `openHost` or publication can still fail and leave the previous
+    // host serving from the registry — and reclaiming its generation at this point would delete a
+    // warmed cache still in use, and leave its attached generation unable to write. Retirement
+    // waits
+    // for a successful publication (see [sweepThemeCache]'s callers).
+    liveThemeGenerations[system] = fingerprint
     if (generation.loadedEntries > 0) {
       System.err.println(
         "serve: catalog $system → ${generation.loadedEntries} theme renders adopted from disk"
@@ -3355,6 +3357,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       return false
     }
     previousResources?.let { runCatching { it.close() } }
+    // Publication succeeded, so any generation this catalog superseded is now genuinely retired and
+    // safe to reclaim. Doing it here rather than when the replacement cache was opened is what
+    // keeps
+    // a failed `openHost` from deleting the cache of the host still serving.
+    sweepThemeCache()
     return true
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -160,6 +160,16 @@ class CatalogLoadTracker(
     synchronized(lock) { ordered.toList() }.mapNotNull { states[it.system] }
 
   /** Catalogs with a usable registered copy; used to seed only successful branch heads. */
+  /**
+   * Every catalog this server is **configured** to serve, whether or not it loaded.
+   *
+   * The distinction that matters to the theme cache's sweeper: a configured system that failed to
+   * load must keep its warmed renders (a fetch can fail transiently, and re-warming m3-catalog
+   * costs ~28 hours), while a system no longer configured at all has renders nothing can ever read
+   * again and must be reclaimed. Absence from [availableSystems] alone cannot tell those apart.
+   */
+  fun configuredSystems(): Set<String> = states.keys.toSet()
+
   fun availableSystems(): Set<String> =
     states.values.asSequence().filter { it.available }.map { it.config.system }.toSet()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -84,13 +84,58 @@ data class ThemeOptimizationSnapshot(
   val maxBatchWidth: Int = 0,
 )
 
-/** Memory occupancy of one catalog generation's rendered-preview cache. */
+/**
+ * One catalog generation's rendered-preview cache: memory occupancy, what the reads did, and the
+ * disk tier behind it.
+ *
+ * [entries]/[bytes]/[maxBytes]/[evictions] describe the memory window. Everything after them exists
+ * to answer a question occupancy cannot: whether the cache is *being used*. A cache that is filling
+ * and a cache that is filling and never read look the same from the outside, and with a disk tier
+ * the second one costs I/O on every render for nothing.
+ */
 @Serializable
 data class CatalogRenderCacheSnapshot(
   val entries: Int,
   val bytes: Long,
   val maxBytes: Long,
   val evictions: Long,
+  /** Reads served from the memory window. */
+  val memoryHits: Long = 0,
+  /** Reads the memory window missed and the disk tier answered. */
+  val diskHits: Long = 0,
+  /** Reads neither tier could answer, so a render had to happen. */
+  val misses: Long = 0,
+  /**
+   * Reads deliberately refused because the generation was adopted from a previous process and had
+   * not yet been verified.
+   *
+   * Kept out of [misses] so it cannot be read as the cache failing: these are entries the cache
+   * holds and is choosing not to serve, and during a cold start they can outnumber real misses.
+   * Counted so a hit rate that looks terrible for the first few minutes of a process is explainable
+   * rather than alarming.
+   */
+  val withheld: Long = 0,
+  /**
+   * Hits over reads — `(memoryHits + diskHits) / (memoryHits + diskHits + misses)` — or null before
+   * anything has been read.
+   *
+   * Published rather than left to the reader because the counters are cumulative over the process
+   * and a cumulative pair read once tells you nothing about whether the cache is currently earning
+   * its keep. [withheld] is excluded from the denominator for the reason given above.
+   */
+  val hitRate: Double? = null,
+  /** The disk tier's own counters, or null when this catalog has none — see [persistenceOff]. */
+  val persisted: ThemeCacheGenerationSnapshot? = null,
+  /**
+   * Why this catalog has no disk tier, when it has none.
+   *
+   * Every reason a catalog falls back to memory-only used to be indistinguishable from "the server
+   * was started without a cache directory" — an unreadable launch descriptor, a classpath entry the
+   * fingerprint could not digest, a generation directory that could not be created. Those are
+   * exactly the failures worth knowing about, because they are silent and permanent for the life of
+   * the host, so they are named here.
+   */
+  val persistenceOff: String? = null,
 )
 
 /**
@@ -119,6 +164,11 @@ class CatalogThemeCache(
    * alone would have started evicting.
    */
   private val persistence: ThemeCacheStore.Generation? = null,
+  /**
+   * Why there is no disk tier, when [persistence] is null — surfaced as
+   * [CatalogRenderCacheSnapshot.persistenceOff].
+   */
+  private val persistenceOffReason: String? = null,
 ) {
   val maxBytes: Long = maxBytes.coerceAtLeast(0)
   private val renderLock = Any()
@@ -143,6 +193,13 @@ class CatalogThemeCache(
   private val busyCounts = ConcurrentHashMap<String, Int>()
   private val byteCount = AtomicLong(0)
   private val evictionCount = AtomicLong(0)
+  // Read outcomes, so `/status` can say whether this cache is answering anything at all. Split by
+  // tier because the two have different costs and different fixes: a memory hit is free, a disk hit
+  // is the persistence tier earning its I/O, and a miss is a render.
+  private val memoryHits = AtomicLong(0)
+  private val diskHits = AtomicLong(0)
+  private val readMisses = AtomicLong(0)
+  private val withheldReads = AtomicLong(0)
   private val state = AtomicReference("waiting")
   private val startedAt = AtomicLong(0)
   private val completedAt = AtomicLong(0)
@@ -237,6 +294,7 @@ class CatalogThemeCache(
   fun get(key: String): ByteArray? {
     synchronized(renderLock) { renders[key] }
       ?.let {
+        memoryHits.incrementAndGet()
         return it
       }
     // Adopted-but-unverified bytes are NOT served. Verification is asynchronous — it needs a lane
@@ -247,9 +305,23 @@ class CatalogThemeCache(
     //
     // Only the READ path is withheld. [contains] still reports them, so the optimizer does not
     // re-render what is already on disk while the question is open.
-    val store = persistence ?: return null
-    if (!persistenceTrusted.get() && store.wasAdopted(key)) return null
-    val fromDisk = store.get(key) ?: return null
+    val store =
+      persistence
+        ?: run {
+          readMisses.incrementAndGet()
+          return null
+        }
+    if (!persistenceTrusted.get() && store.wasAdopted(key)) {
+      withheldReads.incrementAndGet()
+      return null
+    }
+    val fromDisk =
+      store.get(key)
+        ?: run {
+          readMisses.incrementAndGet()
+          return null
+        }
+    diskHits.incrementAndGet()
     // Promoted through the ordinary write path so it takes part in the LRU and the byte accounting
     // like any other entry — but NOT written back to disk, which is where it just came from.
     remember(key, fromDisk)
@@ -520,15 +592,29 @@ class CatalogThemeCache(
     )
   }
 
-  fun renderCacheSnapshot(): CatalogRenderCacheSnapshot =
-    synchronized(renderLock) {
+  fun renderCacheSnapshot(): CatalogRenderCacheSnapshot {
+    // Read once and derive, for the reason [snapshot] gives: a rate computed from counters read
+    // separately can publish a hit rate that does not match the counts printed beside it.
+    val memory = memoryHits.get()
+    val disk = diskHits.get()
+    val missed = readMisses.get()
+    val reads = memory + disk + missed
+    return synchronized(renderLock) {
       CatalogRenderCacheSnapshot(
         entries = renders.size,
         bytes = byteCount.get(),
         maxBytes = maxBytes,
         evictions = evictionCount.get(),
+        memoryHits = memory,
+        diskHits = disk,
+        misses = missed,
+        withheld = withheldReads.get(),
+        hitRate = if (reads > 0) (memory + disk).toDouble() / reads else null,
+        persisted = persistence?.stats(),
+        persistenceOff = if (persistence == null) persistenceOffReason else null,
       )
     }
+  }
 
   /** [activeMillis] is passed in so the rate divides by the same numbers the snapshot publishes. */
   private fun ratePerMinute(activeMillis: Long): Double? {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -224,10 +224,17 @@ class CatalogThemeCache(
     synchronized(renderLock) { renders.containsKey(key) } || persistence?.contains(key) == true
 
   fun put(key: String, png: ByteArray) {
-    if (png.size.toLong() > maxBytes) return
-    // Disk first. A render that survives the process is worth more than one that does not, and if
-    // the two were to disagree the durable copy should be the one that exists.
-    persistence?.put(key, png)
+    // Disk first, and NOT gated on the memory cap: the disk tier has its own budget and is the
+    // authoritative store behind a deliberately smaller memory window, so a render too large for
+    // that window must still be persisted rather than silently re-rendered after every restart.
+    //
+    // **Only configured targets are persisted.** This method also takes successful foreground
+    // renders with arbitrary overrides — widths, locales, devices, knob values — and those are
+    // unbounded in a way `previews × declaredThemes` is not: on a public box a visitor could mint
+    // distinct keys indefinitely, and since a live generation is never evicted to honour
+    // `--theme-cache-max-bytes`, that fills the volume. Ad-hoc override renders stay in the bounded
+    // memory tier, exactly as they did before persistence existed.
+    if (key in targetKeys) persistence?.put(key, png)
     remember(key, png)
     failedKeys.remove(key)
     failureCounts.remove(key)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -125,6 +125,9 @@ class CatalogThemeCache(
   // Access-order map: the byte cap evicts the least-recently-read render first.
   private val renders = LinkedHashMap<String, ByteArray>(16, 0.75f, true)
   private val targetKeys = ConcurrentHashMap.newKeySet<String>()
+  // The bounded set the DISK tier accepts — see [configurePersistable] for why it is not
+  // targetKeys.
+  private val persistableKeys = ConcurrentHashMap.newKeySet<String>()
   private val failedKeys = ConcurrentHashMap.newKeySet<String>()
   // Consecutive live-render failures per key, and the last reason seen. Both are cleared by a
   // successful [put], so a key only stays latched while it keeps failing.
@@ -198,7 +201,26 @@ class CatalogThemeCache(
 
   fun configureTargets(keys: Collection<String>) {
     targetKeys += keys
+    configurePersistable(keys)
     refreshCompletion()
+  }
+
+  /**
+   * Declare the finite set of keys the disk tier will accept, without claiming them as optimization
+   * targets.
+   *
+   * The two are separate because the eager prefetch pass can be switched off
+   * (`-Dcomposeai.serve.themeOptimization=false`) while foreground renders of those same declared
+   * themes carry on. Gating persistence on [targetKeys] alone meant a disabled optimizer left the
+   * set empty for the host's lifetime, so every render a visitor actually asked for was refused by
+   * the disk tier and every restart began again — persistence silently doing nothing on exactly the
+   * configuration that most needs the renders it does get to be durable.
+   *
+   * Kept out of [targetKeys] so `/status` still reports no optimization row for a disabled pass,
+   * rather than one parked at "waiting" forever.
+   */
+  fun configurePersistable(keys: Collection<String>) {
+    persistableKeys += keys
   }
 
   /**
@@ -234,7 +256,7 @@ class CatalogThemeCache(
     // distinct keys indefinitely, and since a live generation is never evicted to honour
     // `--theme-cache-max-bytes`, that fills the volume. Ad-hoc override renders stay in the bounded
     // memory tier, exactly as they did before persistence existed.
-    if (key in targetKeys) persistence?.put(key, png)
+    if (key in persistableKeys) persistence?.put(key, png)
     remember(key, png)
     failedKeys.remove(key)
     failureCounts.remove(key)
@@ -283,13 +305,18 @@ class CatalogThemeCache(
    *
    * Returns true if the generation is trustworthy (verified, or nothing to verify).
    */
-  fun verifySample(sampleSize: Int = VERIFY_SAMPLE, render: (String) -> ByteArray?): Boolean {
-    val store = persistence ?: return true
-    val candidates = targetKeys.filter(store::contains).sorted().take(sampleSize)
-    if (candidates.isEmpty()) return true
+  fun verifySample(
+    sampleSize: Int = VERIFY_SAMPLE,
+    render: (String) -> ByteArray?,
+  ): VerifyOutcome {
+    val store = persistence ?: return VerifyOutcome.NOTHING_TO_VERIFY
+    val candidates = persistableKeys.filter(store::contains).sorted().take(sampleSize)
+    if (candidates.isEmpty()) return VerifyOutcome.NOTHING_TO_VERIFY
+    var compared = 0
     for (key in candidates) {
       val cached = store.get(key) ?: continue
       val fresh = render(key) ?: continue
+      compared++
       if (!fresh.contentEquals(cached)) {
         store.discard()
         synchronized(renderLock) {
@@ -298,10 +325,30 @@ class CatalogThemeCache(
         }
         state.set("paused")
         completedAt.set(0)
-        return false
+        return VerifyOutcome.MISMATCH
       }
     }
-    return true
+    // Zero successful comparisons is NOT a pass. Every sampled render can come back Busy, Failed or
+    // served from a cache during a cold start, and treating that as "verified" would latch the
+    // check permanently on the one occasion it was never actually performed — leaving a stale
+    // generation to serve wrong pixels for the life of the process. The caller retries instead.
+    return if (compared > 0) VerifyOutcome.VERIFIED else VerifyOutcome.NO_EVIDENCE
+  }
+
+  /** What [verifySample] managed to establish. */
+  enum class VerifyOutcome {
+    /** At least one persisted render was re-rendered and matched. */
+    VERIFIED,
+    /** No disk tier, or nothing adopted from it — there is nothing that could be stale. */
+    NOTHING_TO_VERIFY,
+    /** The renderer answered nothing usable, so the question is still open. Ask again. */
+    NO_EVIDENCE,
+    /** A persisted render no longer matches; the generation has been discarded. */
+    MISMATCH;
+
+    /** Whether the persisted renders may be trusted from here on. */
+    val settled: Boolean
+      get() = this == VERIFIED || this == NOTHING_TO_VERIFY
   }
 
   fun markRunning(nowMillis: Long) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -128,6 +128,11 @@ class CatalogThemeCache(
   // The bounded set the DISK tier accepts — see [configurePersistable] for why it is not
   // targetKeys.
   private val persistableKeys = ConcurrentHashMap.newKeySet<String>()
+  // False while renders ADOPTED FROM A PREVIOUS PROCESS are still unverified — see [get]. Only
+  // those
+  // are in question: anything this process rendered came from this renderer and needs no checking,
+  // which is why the quarantine is keyed on `wasAdopted` rather than on having a disk tier at all.
+  private val persistenceTrusted = java.util.concurrent.atomic.AtomicBoolean(false)
   private val failedKeys = ConcurrentHashMap.newKeySet<String>()
   // Consecutive live-render failures per key, and the last reason seen. Both are cleared by a
   // successful [put], so a key only stays latched while it keeps failing.
@@ -234,7 +239,17 @@ class CatalogThemeCache(
       ?.let {
         return it
       }
-    val fromDisk = persistence?.get(key) ?: return null
+    // Adopted-but-unverified bytes are NOT served. Verification is asynchronous — it needs a lane
+    // and a warm daemon — and until it settles these renders are exactly the thing the fingerprint
+    // might have got wrong. Serving them meanwhile hands out stale pixels precisely in the window
+    // the safety check exists to cover, and traffic can hold that window open for a long time by
+    // keeping the box non-idle. A miss here costs a fresh render; a hit here could cost the truth.
+    //
+    // Only the READ path is withheld. [contains] still reports them, so the optimizer does not
+    // re-render what is already on disk while the question is open.
+    val store = persistence ?: return null
+    if (!persistenceTrusted.get() && store.wasAdopted(key)) return null
+    val fromDisk = store.get(key) ?: return null
     // Promoted through the ordinary write path so it takes part in the LRU and the byte accounting
     // like any other entry — but NOT written back to disk, which is where it just came from.
     remember(key, fromDisk)
@@ -311,7 +326,11 @@ class CatalogThemeCache(
   ): VerifyOutcome {
     val store = persistence ?: return VerifyOutcome.NOTHING_TO_VERIFY
     val candidates = persistableKeys.filter(store::contains).sorted().take(sampleSize)
-    if (candidates.isEmpty()) return VerifyOutcome.NOTHING_TO_VERIFY
+    if (candidates.isEmpty()) {
+      // Nothing was adopted, so nothing can be stale: everything from here is this renderer's own.
+      persistenceTrusted.set(true)
+      return VerifyOutcome.NOTHING_TO_VERIFY
+    }
     var compared = 0
     for (key in candidates) {
       val cached = store.get(key) ?: continue
@@ -325,6 +344,8 @@ class CatalogThemeCache(
         }
         state.set("paused")
         completedAt.set(0)
+        // The suspect bytes are gone, so what the cache holds from here is this renderer's own.
+        persistenceTrusted.set(true)
         return VerifyOutcome.MISMATCH
       }
     }
@@ -332,6 +353,7 @@ class CatalogThemeCache(
     // served from a cache during a cold start, and treating that as "verified" would latch the
     // check permanently on the one occasion it was never actually performed — leaving a stale
     // generation to serve wrong pixels for the life of the process. The caller retries instead.
+    if (compared > 0) persistenceTrusted.set(true)
     return if (compared > 0) VerifyOutcome.VERIFIED else VerifyOutcome.NO_EVIDENCE
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -107,7 +107,18 @@ data class CatalogRenderCacheSnapshot(
 class CatalogThemeCache(
   maxBytes: Long =
     System.getProperty("composeai.serve.catalogRenderCacheMaxBytes")?.toLongOrNull()
-      ?: DEFAULT_MAX_BYTES
+      ?: DEFAULT_MAX_BYTES,
+  /**
+   * Disk tier for this catalog generation, or null to keep the historical memory-only behaviour.
+   *
+   * **Memory is a window onto this, not a copy of it.** The in-memory cap is 128 MB and a fully
+   * warmed m3-catalog is 10,120 PNGs — several times that — so preloading the generation would just
+   * thrash the LRU and, worse, would report `cached` as whatever happened to fit rather than what
+   * is actually warm. Instead [get] falls through to disk and promotes, and every count of what is
+   * cached asks both tiers. That is what lets `cached` keep climbing past the point where memory
+   * alone would have started evicting.
+   */
+  private val persistence: ThemeCacheStore.Generation? = null,
 ) {
   val maxBytes: Long = maxBytes.coerceAtLeast(0)
   private val renderLock = Any()
@@ -190,9 +201,43 @@ class CatalogThemeCache(
     refreshCompletion()
   }
 
-  fun get(key: String): ByteArray? = synchronized(renderLock) { renders[key] }
+  /**
+   * The render for [key] from memory, or from disk (promoted into memory), or null.
+   *
+   * The disk read is on the miss path only, so a warm working set costs exactly what it did before
+   * persistence existed.
+   */
+  fun get(key: String): ByteArray? {
+    synchronized(renderLock) { renders[key] }
+      ?.let {
+        return it
+      }
+    val fromDisk = persistence?.get(key) ?: return null
+    // Promoted through the ordinary write path so it takes part in the LRU and the byte accounting
+    // like any other entry — but NOT written back to disk, which is where it just came from.
+    remember(key, fromDisk)
+    return fromDisk
+  }
+
+  /** Whether [key] is warm in either tier, without paying to read the bytes. */
+  fun contains(key: String): Boolean =
+    synchronized(renderLock) { renders.containsKey(key) } || persistence?.contains(key) == true
 
   fun put(key: String, png: ByteArray) {
+    if (png.size.toLong() > maxBytes) return
+    // Disk first. A render that survives the process is worth more than one that does not, and if
+    // the two were to disagree the durable copy should be the one that exists.
+    persistence?.put(key, png)
+    remember(key, png)
+    failedKeys.remove(key)
+    failureCounts.remove(key)
+    failureReasons.remove(key)
+    busyCounts.remove(key)
+    refreshCompletion()
+  }
+
+  /** Hold [png] in the memory tier under the byte cap, evicting least-recently-read first. */
+  private fun remember(key: String, png: ByteArray) {
     synchronized(renderLock) {
       if (renders.containsKey(key)) return@synchronized
       if (png.size.toLong() > maxBytes) return@synchronized
@@ -203,17 +248,53 @@ class CatalogThemeCache(
         renders.remove(eldest.key)
         byteCount.addAndGet(-eldest.value.size.toLong())
         evictionCount.incrementAndGet()
-        if (eldest.key in targetKeys) {
+        // An eviction only un-completes the catalog when the entry is gone for good. With a disk
+        // tier it is not: the memory cap is smaller than a warmed catalog by design, so treating
+        // every eviction as lost progress would park a fully-warmed catalog at `paused` forever and
+        // send the optimizer back to re-render what is already on disk.
+        if (eldest.key in targetKeys && persistence?.contains(eldest.key) != true) {
           state.set("paused")
           completedAt.set(0)
         }
       }
     }
-    failedKeys.remove(key)
-    failureCounts.remove(key)
-    failureReasons.remove(key)
-    busyCounts.remove(key)
-    refreshCompletion()
+  }
+
+  /**
+   * Check a sample of the persisted generation against what the renderer produces **now**, and drop
+   * the whole generation if they disagree.
+   *
+   * This is the safety net for the one thing [ThemeCacheFingerprint] cannot promise. The
+   * fingerprint covers the inputs it was told about; an input nobody thought of — a base image
+   * bumped without a release, a render default that never reached the config string — changes the
+   * pixels without changing the name, and every entry under that name is then quietly wrong. Wrong
+   * pixels matter more here than in an ordinary build cache: a stale build artifact gets caught by
+   * a test, a stale preview is shown to an agent as ground truth.
+   *
+   * [render] returns the freshly rendered bytes for a cache key, or null if it could not render —
+   * which is **not** a mismatch and must not drop anything, or a busy daemon would wipe the cache.
+   *
+   * Returns true if the generation is trustworthy (verified, or nothing to verify).
+   */
+  fun verifySample(sampleSize: Int = VERIFY_SAMPLE, render: (String) -> ByteArray?): Boolean {
+    val store = persistence ?: return true
+    val candidates = targetKeys.filter(store::contains).sorted().take(sampleSize)
+    if (candidates.isEmpty()) return true
+    for (key in candidates) {
+      val cached = store.get(key) ?: continue
+      val fresh = render(key) ?: continue
+      if (!fresh.contentEquals(cached)) {
+        store.discard()
+        synchronized(renderLock) {
+          renders.clear()
+          byteCount.set(0)
+        }
+        state.set("paused")
+        completedAt.set(0)
+        return false
+      }
+    }
+    return true
   }
 
   fun markRunning(nowMillis: Long) {
@@ -298,7 +379,7 @@ class CatalogThemeCache(
   fun failureReason(key: String): String? = if (key in failedKeys) failureReasons[key] else null
 
   fun markPassFinished(nowMillis: Long) {
-    if (synchronized(renderLock) { targetKeys.all(renders::containsKey) }) {
+    if (targetKeys.all(::contains)) {
       completedAt.compareAndSet(0, nowMillis)
       state.set("complete")
     } else {
@@ -307,7 +388,10 @@ class CatalogThemeCache(
   }
 
   fun snapshot(): ThemeOptimizationSnapshot {
-    val cachedTargets = synchronized(renderLock) { targetKeys.count(renders::containsKey) }
+    // Counted across BOTH tiers. Counting memory alone would report a fully warmed catalog as
+    // partially cached the moment the 128 MB window started evicting, which is precisely the
+    // condition persistence exists to create.
+    val cachedTargets = targetKeys.count(::contains)
     val total = targetKeys.size
     val complete = total > 0 && cachedTargets == total
     // Read each counter ONCE and derive everything from those values. Reading them per-field lets a
@@ -327,10 +411,7 @@ class CatalogThemeCache(
       total = total,
       cached = cachedTargets,
       remaining = (total - cachedTargets).coerceAtLeast(0),
-      failed =
-        synchronized(renderLock) {
-          failedKeys.count { it in targetKeys && !renders.containsKey(it) }
-        },
+      failed = failedKeys.count { it in targetKeys && !contains(it) },
       cachedBytes = byteCount.get(),
       fullyOptimized = complete,
       startedAtEpochMillis = startedAt.get().takeIf { it > 0 },
@@ -374,15 +455,23 @@ class CatalogThemeCache(
   }
 
   private fun refreshCompletion() {
-    if (
-      targetKeys.isNotEmpty() && synchronized(renderLock) { targetKeys.all(renders::containsKey) }
-    ) {
+    if (targetKeys.isNotEmpty() && targetKeys.all(::contains)) {
       state.set("complete")
     }
   }
 
   companion object {
     const val DEFAULT_MAX_BYTES: Long = 128L * 1024 * 1024
+
+    /**
+     * Persisted renders re-rendered and compared when a generation is adopted.
+     *
+     * Small on purpose. This is a smoke test for "did the fingerprint miss an input", and an input
+     * that changes the renderer changes it for every preview — so a handful of entries answers the
+     * question as well as a thousand would, at a cost (a few seconds) that a startup can absorb
+     * against the 28 hours of rendering it is protecting.
+     */
+    const val VERIFY_SAMPLE: Int = 5
 
     /**
      * Consecutive on-demand render failures before a key is treated as permanently unrenderable.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -271,7 +271,10 @@ class CatalogThemeCache(
     // distinct keys indefinitely, and since a live generation is never evicted to honour
     // `--theme-cache-max-bytes`, that fills the volume. Ad-hoc override renders stay in the bounded
     // memory tier, exactly as they did before persistence existed.
-    if (key in persistableKeys) persistence?.put(key, png)
+    // While quarantined, a fresh render REPLACES the adopted copy rather than being dropped because
+    // a file already sits at that key — see [ThemeCacheStore.Generation.put].
+    if (key in persistableKeys)
+      persistence?.put(key, png, replaceExisting = !persistenceTrusted.get())
     remember(key, png)
     failedKeys.remove(key)
     failureCounts.remove(key)
@@ -325,7 +328,11 @@ class CatalogThemeCache(
     render: (String) -> ByteArray?,
   ): VerifyOutcome {
     val store = persistence ?: return VerifyOutcome.NOTHING_TO_VERIFY
-    val candidates = persistableKeys.filter(store::contains).sorted().take(sampleSize)
+    // Only entries ADOPTED FROM THE PREVIOUS PROCESS can answer the question. On a partly warmed
+    // restart, foreground traffic persists missing keys before the idle verification task runs, and
+    // sampling those would let five renders this process just made "verify" a generation whose old
+    // bytes were never looked at — trusting the cache on the strength of checking itself.
+    val candidates = persistableKeys.filter(store::wasAdopted).sorted().take(sampleSize)
     if (candidates.isEmpty()) {
       // Nothing was adopted, so nothing can be stale: everything from here is this renderer's own.
       persistenceTrusted.set(true)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -607,6 +607,26 @@ internal object ServeBundleDaemon {
   private const val BUNDLE_MANIFEST_PATH_PROPERTY = "composeai.daemon.bundleManifestPath"
 
   private val json = Json { encodeDefaults = true }
+
+  /**
+   * Read back a `daemon-launch.json` written by [materialize].
+   *
+   * Exists so the theme cache can fingerprint a generation from the launch the daemon will actually
+   * perform — the classpath it loads and the variant it renders as — rather than from a parallel
+   * description of it that someone would have to keep in step by hand.
+   *
+   * Null on anything unreadable, which the caller treats as "this generation has no durable
+   * identity" and therefore as "do not persist".
+   */
+  fun readLaunchDescriptor(descriptorFile: File): DaemonLaunchDescriptor? = runCatching {
+    launchDescriptorJson.decodeFromString(
+      DaemonLaunchDescriptor.serializer(),
+      descriptorFile.readText(),
+    )
+  }
+    .getOrNull()
+
+  private val launchDescriptorJson = Json { ignoreUnknownKeys = true }
   private val overridesJson = Json { ignoreUnknownKeys = true }
   private val previewsManifestJson = Json {
     ignoreUnknownKeys = true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -253,6 +253,11 @@ class ServeCatalogLiveHost(
    */
   private val themeRendersInFlight = ConcurrentHashMap.newKeySet<String>()
   private val optimizationStarted = AtomicBoolean()
+  /**
+   * Persisted renders are checked against this renderer once per host — see
+   * [verifyPersistedRenders].
+   */
+  private val persistenceVerified = AtomicBoolean()
   private val optimizationActive = AtomicBoolean()
   private val warmExecutor by lazy {
     Executors.newSingleThreadExecutor { r ->
@@ -501,6 +506,40 @@ class ServeCatalogLiveHost(
     }
   }
 
+  /**
+   * Check a few renders adopted from disk against what this daemon produces now, once per host.
+   *
+   * The fingerprint that named the persisted generation covers the inputs it was told about. An
+   * input nobody thought of — a base image bumped without a release, a render default that never
+   * reached the config string — changes the pixels without changing the name, and every entry under
+   * that name is then quietly wrong. That matters more here than in an ordinary build cache: a
+   * stale build artifact gets caught by a test, a stale preview is handed to an agent as ground
+   * truth.
+   *
+   * Rendered through [live] rather than [renderPrefetch], deliberately: the prefetch path consults
+   * this very cache and would hand back the bytes being verified, so the comparison would pass by
+   * construction. Only a `DAEMON` generation counts as fresh evidence — anything served from a
+   * cache proves nothing, and a daemon that cannot answer yet is "no evidence", not "mismatch".
+   */
+  private fun verifyPersistedRenders(jobs: List<ThemeOptimizationJob>) {
+    if (!persistenceVerified.compareAndSet(false, true)) return
+    val byKey = jobs.associateBy { it.cacheKey }
+    val trustworthy = catalogThemeCache.verifySample { key ->
+      val job = byKey[key] ?: return@verifySample null
+      val daemonId = alias[job.previewId] ?: return@verifySample null
+      val outcome = runCatching { live.render(daemonId, job.overrides) }.getOrNull()
+      (outcome as? RenderOutcome.Ok)
+        ?.takeIf { it.generation == RenderOutcome.Generation.DAEMON }
+        ?.png
+    }
+    if (!trustworthy) {
+      System.err.println(
+        "serve: catalog $label — persisted theme renders no longer match this renderer; " +
+          "dropped the generation and re-warming from scratch"
+      )
+    }
+  }
+
   /** Why an optimizer pass returned; only [SLICE_SPENT] asks for another lane. */
   private enum class PassOutcome {
     /** Every target this pass could see is cached — nothing left to re-queue for. */
@@ -530,6 +569,7 @@ class ServeCatalogLiveHost(
     // amortised across all of them and the pass never interleaves two previews' daemon opens.
     val byPreview =
       jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
+    verifyPersistedRenders(jobs)
     var previewsDone = 0
     for ((previewId, previewJobs) in byPreview) {
       // The slice is checked HERE and nowhere finer, on the preview boundary. A preview is the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -621,7 +621,11 @@ class ServeCatalogLiveHost(
     // list is already ordered by: every theme of one preview renders together, so one warm is
     // amortised across all of them and the pass never interleaves two previews' daemon opens.
     val byPreview =
-      jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
+      // `contains`, not `get`: planning only needs to know WHETHER a target is warm. Reading it
+      // pulls every already-persisted PNG off disk on every slice — hundreds of megabytes for a
+      // partly warmed catalog — only for the 128 MB memory window to evict most of them again
+      // before the next slice repeats the whole thing.
+      jobs.filterNot { catalogThemeCache.contains(it.cacheKey) }.groupBy { it.previewId }
     var previewsDone = 0
     for ((previewId, previewJobs) in byPreview) {
       // The slice is checked HERE and nowhere finer, on the preview boundary. A preview is the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -455,7 +455,13 @@ class ServeCatalogLiveHost(
       }
     }
     catalogThemeCache.configureTargets(jobs.map { it.cacheKey })
-    if (jobs.isEmpty() || catalogThemeCache.snapshot().fullyOptimized) return
+    if (jobs.isEmpty()) return
+    // `fullyOptimized` is deliberately NOT an early return until the persisted renders have been
+    // checked. A generation adopted whole from disk reports fully optimized on the first heartbeat,
+    // so returning here would skip verification in exactly the fully-warmed restart case it exists
+    // for — and a fingerprint that missed an input would then serve stale pixels indefinitely. The
+    // check moves inside the task, below.
+    if (catalogThemeCache.snapshot().fullyOptimized && persistenceVerified.get()) return
     // Never start a pass into a broken renderer. The optimizer is the largest consumer of the
     // render gate, and every item it queues against an open breaker is pure waste — 4740 remaining
     // at a ~7h ETA on work where every single render fails (issue #3448). Targets stay configured
@@ -466,6 +472,11 @@ class ServeCatalogLiveHost(
     optimizationActive.set(true)
     optimizationExecutor.execute {
       try {
+        // Before anything else, and before the fully-optimized shortcut: renders adopted from disk
+        // are worthless if they no longer match this renderer. A no-op when nothing was adopted, so
+        // a cold cache pays nothing.
+        verifyPersistedRenders(jobs)
+        if (catalogThemeCache.snapshot().fullyOptimized) return@execute
         // No stagger before the door, deliberately. Every catalog does become runnable the instant
         // the idle gate opens — measured on the deployed box as 11 catalogs entering inside 464 ms
         // — but with the cap in place a simultaneous arrival is harmless: two are admitted and the
@@ -569,7 +580,6 @@ class ServeCatalogLiveHost(
     // amortised across all of them and the pass never interleaves two previews' daemon opens.
     val byPreview =
       jobs.filter { catalogThemeCache.get(it.cacheKey) == null }.groupBy { it.previewId }
-    verifyPersistedRenders(jobs)
     var previewsDone = 0
     for ((previewId, previewJobs) in byPreview) {
       // The slice is checked HERE and nowhere finer, on the preview boundary. A preview is the

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -438,10 +438,6 @@ class ServeCatalogLiveHost(
 
   /** Fill every catalog-preview × declared-theme cache entry while the whole server is idle. */
   private fun startThemeOptimization() {
-    // Off by default — see [themeOptimizationEnabled]. Returning before `configureTargets` leaves
-    // the cache with no targets, so `themeOptimizationSnapshot()` reports null and `/status` shows
-    // no optimization row at all rather than one stuck at "waiting" forever.
-    if (!themeOptimizationEnabled) return
     val catalogIds =
       previews.asSequence().map { it.id }.filter(alias::containsKey).sorted().toList()
     val jobs = catalogIds.flatMap { previewId ->
@@ -454,6 +450,13 @@ class ServeCatalogLiveHost(
         )
       }
     }
+    // The finite declared-theme set is declared to the disk tier FIRST and unconditionally, so that
+    // a deployment with the eager pass switched off still persists the renders visitors ask for.
+    catalogThemeCache.configurePersistable(jobs.map { it.cacheKey })
+    // Off by default — see [themeOptimizationEnabled]. Returning before `configureTargets` leaves
+    // the cache with no targets, so `themeOptimizationSnapshot()` reports null and `/status` shows
+    // no optimization row at all rather than one stuck at "waiting" forever.
+    if (!themeOptimizationEnabled) return
     catalogThemeCache.configureTargets(jobs.map { it.cacheKey })
     if (jobs.isEmpty()) return
     // `fullyOptimized` is deliberately NOT an early return until the persisted renders have been
@@ -472,11 +475,10 @@ class ServeCatalogLiveHost(
     optimizationActive.set(true)
     optimizationExecutor.execute {
       try {
-        // Before anything else, and before the fully-optimized shortcut: renders adopted from disk
-        // are worthless if they no longer match this renderer. A no-op when nothing was adopted, so
-        // a cold cache pays nothing.
-        verifyPersistedRenders(jobs)
-        if (catalogThemeCache.snapshot().fullyOptimized) return@execute
+        // Verification does NOT run here, ahead of admission — see the slot below. It renders, and
+        // renders at startup are exactly what the catalog-load gate and the lane cap exist to
+        // hold back: `prewarm` starts one of these tasks per catalog, so a warmed restart would
+        // cold-start a daemon for every catalog at once while the others were still loading.
         // No stagger before the door, deliberately. Every catalog does become runnable the instant
         // the idle gate opens — measured on the deployed box as 11 catalogs entering inside 464 ms
         // — but with the cap in place a simultaneous arrival is harmless: two are admitted and the
@@ -498,7 +500,12 @@ class ServeCatalogLiveHost(
         while (true) {
           val outcome =
             backgroundWork.withOptimizerSlot(label, OPTIMIZER_ADMISSION_WAIT_MILLIS) {
-              runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
+              // Inside the lane and behind the idle gate, so the sample's renders are admitted on
+              // exactly the terms every other background render is. Cheap and once per host: a
+              // no-op when nothing was adopted from disk.
+              if (!persistenceVerified.get() && awaitOptimizerTurn()) verifyPersistedRenders(jobs)
+              if (catalogThemeCache.snapshot().fullyOptimized) PassOutcome.FINISHED
+              else runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
             }
           if (outcome == null) {
             // Parked, not failed: `keepLiveWarm` re-enters on the next presence heartbeat, and
@@ -533,9 +540,9 @@ class ServeCatalogLiveHost(
    * cache proves nothing, and a daemon that cannot answer yet is "no evidence", not "mismatch".
    */
   private fun verifyPersistedRenders(jobs: List<ThemeOptimizationJob>) {
-    if (!persistenceVerified.compareAndSet(false, true)) return
+    if (persistenceVerified.get()) return
     val byKey = jobs.associateBy { it.cacheKey }
-    val trustworthy = catalogThemeCache.verifySample { key ->
+    val outcome = catalogThemeCache.verifySample { key ->
       val job = byKey[key] ?: return@verifySample null
       val daemonId = alias[job.previewId] ?: return@verifySample null
       val outcome = runCatching { live.render(daemonId, job.overrides) }.getOrNull()
@@ -543,7 +550,12 @@ class ServeCatalogLiveHost(
         ?.takeIf { it.generation == RenderOutcome.Generation.DAEMON }
         ?.png
     }
-    if (!trustworthy) {
+    // Latched only once the question is actually answered. `NO_EVIDENCE` — every sampled render
+    // came back Busy, Failed, or out of some cache — leaves it unlatched so the next pass asks
+    // again; latching there would permanently skip the check on the one occasion it never ran.
+    if (outcome.settled) persistenceVerified.set(true)
+    if (outcome == CatalogThemeCache.VerifyOutcome.MISMATCH) {
+      persistenceVerified.set(true)
       System.err.println(
         "serve: catalog $label — persisted theme renders no longer match this renderer; " +
           "dropped the generation and re-warming from scratch"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -456,7 +456,15 @@ class ServeCatalogLiveHost(
     // Off by default — see [themeOptimizationEnabled]. Returning before `configureTargets` leaves
     // the cache with no targets, so `themeOptimizationSnapshot()` reports null and `/status` shows
     // no optimization row at all rather than one stuck at "waiting" forever.
-    if (!themeOptimizationEnabled) return
+    //
+    // But renders adopted from disk still have to be CHECKED. Disabling the eager pass turns off
+    // filling the cache, not trusting it: a restarted server with the pass off would otherwise
+    // serve
+    // every persisted entry without the fingerprint safety check ever running.
+    if (!themeOptimizationEnabled) {
+      verifyAdoptedRendersOnly(jobs)
+      return
+    }
     catalogThemeCache.configureTargets(jobs.map { it.cacheKey })
     if (jobs.isEmpty()) return
     // `fullyOptimized` is deliberately NOT an early return until the persisted renders have been
@@ -560,6 +568,28 @@ class ServeCatalogLiveHost(
         "serve: catalog $label — persisted theme renders no longer match this renderer; " +
           "dropped the generation and re-warming from scratch"
       )
+    }
+  }
+
+  /**
+   * Check adopted renders for a catalog whose eager pass is switched off.
+   *
+   * Same admission as the pass itself — a lane, then the idle gate — because it renders, and a
+   * disabled optimizer is not a licence to spend the box's daemons at startup. Runs on the
+   * optimizer executor so the caller (a prewarm or a presence heartbeat) is never blocked on it.
+   */
+  private fun verifyAdoptedRendersOnly(jobs: List<ThemeOptimizationJob>) {
+    if (persistenceVerified.get() || jobs.isEmpty()) return
+    if (!optimizationStarted.compareAndSet(false, true)) return
+    optimizationExecutor.execute {
+      try {
+        backgroundWork.withOptimizerSlot(label, OPTIMIZER_ADMISSION_WAIT_MILLIS) {
+          if (awaitOptimizerTurn()) verifyPersistedRenders(jobs)
+          true
+        }
+      } finally {
+        optimizationStarted.set(false)
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -274,6 +274,8 @@ class ServeHttpServer(
   private val branchFetchStats: (() -> BranchFetchSnapshot?)? = null,
   /** Cross-catalog optimizer admission for `/status.json`, read from the shared background-work. */
   private val themeOptimizerStats: (() -> ThemeOptimizerAdmissionSnapshot?)? = null,
+  /** Disk tier for warmed theme renders, for `/status.json`. Null when persistence is off. */
+  private val themeCacheStats: (() -> ThemeCacheStoreSnapshot?)? = null,
   /**
    * The shared background-work handle, for the admin pause/resume routes. Separate from
    * [themeOptimizerStats] because reading counters is safe on any server while standing the
@@ -4296,6 +4298,7 @@ class ServeHttpServer(
         // Box-wide and unattributed per system, so scoped out on a site host for the same reason
         // the branch counters are.
         themeOptimizer = if (onlySystem == null) themeOptimizerStats?.invoke() else null,
+        themeCache = if (onlySystem == null) themeCacheStats?.invoke() else null,
         renderStats =
           RenderPerfSnapshot.aggregate(
             // A fresh daemon reports an all-zero snapshot; keep the roll-up null until something
@@ -7251,6 +7254,14 @@ private data class StatusResponse(
    * reports "running" and nothing progresses looks identical, per catalog, to a box doing fine.
    */
   val themeOptimizer: ThemeOptimizerAdmissionSnapshot? = null,
+  /**
+   * The theme cache's disk tier ([ThemeCacheStoreSnapshot]), or null when it is memory-only.
+   *
+   * Answers the question the per-catalog rows could not: whether warming is *accumulating*. A box
+   * whose `cached` counts keep returning to zero and whose `themeCache` is absent is not slow — it
+   * is starting over, which is what m3-catalog did 7-10 times a day before this existed.
+   */
+  val themeCache: ThemeCacheStoreSnapshot? = null,
   /**
    * Server-wide render-latency roll-up across the running live daemons (see
    * [RenderPerfSnapshot.aggregate] — counts sum, `firstRenderMs` is the worst first render,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -125,7 +125,13 @@ object ThemeCacheFingerprint {
         ?.split(File.pathSeparator)
         ?.filter { it.isNotBlank() }
         ?.map(::File)
-        .orEmpty())
+        .orEmpty()) +
+      // Captured payloads the daemon renders FROM rather than executes: the extracted IR/Remote
+      // Compose documents and the bundle manifest. `BundleIrReplayStore` reads these bytes to
+      // produce the scene, so a bundle that regenerates a capture without touching a single class
+      // renders differently — and would otherwise carry the previous generation's name.
+      PAYLOAD_PROPERTIES.mapNotNull { key -> systemProperties[key]?.takeIf { it.isNotBlank() } }
+        .map(::File)
 
   /** Stable digest of a catalog-id to daemon-id map, for [of]'s `routing`. */
   fun routingDigest(alias: Map<String, String>): String {
@@ -139,6 +145,16 @@ object ThemeCacheFingerprint {
 
   /** Where the daemon launch carries the catalog's own classes — see [renderedClasspath]. */
   const val USER_CLASS_DIRS_PROPERTY: String = "composeai.daemon.userClassDirs"
+
+  /**
+   * Launch properties naming rendered-from *content* rather than executed code.
+   *
+   * Kept as a list because the failure they share is silent: each one is a path in a system
+   * property rather than a classpath entry, so anything that only reads `classpath` misses it and
+   * two genuinely different generations agree on a name.
+   */
+  val PAYLOAD_PROPERTIES: List<String> =
+    listOf("composeai.daemon.irDir", "composeai.daemon.bundleManifestPath")
 
   /**
    * Fold several module fingerprints into one.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -136,6 +136,49 @@ object ThemeCacheFingerprint {
         .distinct()
         .map(::File)
 
+  /**
+   * The render-affecting launch settings that are *values* rather than file contents, as a stable
+   * string for [of]'s `renderConfig`.
+   *
+   * Excluding the descriptor's whole system-property map was wrong, and wrong in the same way as
+   * excluding the user classpath was: most of it is absolute paths that a fresh staging directory
+   * churns every load, but not all of it. `composeai.fonts.offline`, `composeai.svg.embedFonts` and
+   * the Android launch's `robolectric.*` settings all change what the renderer produces while the
+   * classpath stays byte-identical — offline font resolution, for instance, substitutes fallback
+   * glyphs for downloaded faces.
+   *
+   * So the filter is on the *shape of the value*, not on the map: a value that names a filesystem
+   * path is dropped (its churn is meaningless, and where its contents matter they are hashed by
+   * [renderedClasspath] instead), and everything else is kept. A setting that legitimately varies
+   * per load and is not a path will cost an unnecessary re-warm, which is the right direction to
+   * err.
+   */
+  fun renderConfig(systemProperties: Map<String, String>, jvmArgs: List<String>): String {
+    val covered = PAYLOAD_PROPERTIES.toSet() + USER_CLASS_DIRS_PROPERTY
+    val settings =
+      systemProperties
+        .filterKeys { it !in covered }
+        .filterValues { !looksLikePath(it) }
+        .entries
+        .sortedBy { it.key }
+        .joinToString(" ") { (key, value) -> "$key=$value" }
+    val args = jvmArgs.filterNot(::looksLikePath).sorted().joinToString(" ")
+    return listOf(settings, args).filter { it.isNotBlank() }.joinToString(" ")
+  }
+
+  /**
+   * Whether [value] names a filesystem location, and is therefore churn rather than configuration.
+   *
+   * Deliberately crude: an absolute path, or a JVM argument carrying one. Both a false positive
+   * (dropping a real setting) and a false negative (keeping a path) fail toward a re-warm rather
+   * than a wrong pixel, because anything genuinely load-bearing about a path's *contents* is hashed
+   * by [renderedClasspath].
+   */
+  private fun looksLikePath(value: String): Boolean =
+    value.startsWith(File.separator) ||
+      value.contains("=${File.separator}") ||
+      Regex("^[A-Za-z]:[\\\\/]").containsMatchIn(value)
+
   /** Stable digest of a catalog-id to daemon-id map, for [of]'s `routing`. */
   fun routingDigest(alias: Map<String, String>): String {
     if (alias.isEmpty()) return ""

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Content identity of one *renderable catalog generation* — everything that decides what a theme
+ * render's pixels look like, reduced to a string.
+ *
+ * ### Why a cache key is not enough
+ *
+ * [ServeOverrides.cacheKey] identifies **what was asked for** — a preview id plus its overrides.
+ * That is sufficient while the cache lives inside one process holding exactly one generation of one
+ * catalog, and insufficient the moment an entry outlives the thing that rendered it. A persisted
+ * entry does exactly that, so it needs a second half: **what produced it**.
+ *
+ * ### The rule this is built on
+ *
+ * You cannot enumerate every input with confidence, so the design is not "list the inputs and
+ * hope". It is: key on the coarsest cheap thing that *provably* covers content and renderer, and
+ * let anything unenumerated be caught by [CatalogThemeCache]'s load-time sample verification rather
+ * than served as a wrong pixel.
+ *
+ * What goes in, and why each one:
+ * - **The classpath's bytes.** Not its paths — a load stages the same bundle into a fresh directory
+ *   every time, so paths churn while content does not. Hashing the actual jars covers the catalog's
+ *   code, its theme definitions, its resources *and* its dependencies in one move, without needing
+ *   to know which of them a given preview touches. This is the expensive part and it is the part
+ *   worth paying for: it is the only input that is derived from the thing itself rather than
+ *   asserted about it.
+ * - **The daemon variant.** Desktop and Android/Robolectric are different renderers reading the
+ *   same classpath, and they do not agree pixel-for-pixel.
+ * - **The tool version.** Covers the renderer, and stands proxy for the container image — hence the
+ *   JVM, Skia and the installed fonts, none of which are visible from here. **That proxying is an
+ *   assumption, not a proof:** a base-image bump that ships without a release would slip through
+ *   it. It is recorded in the generation manifest so a mismatch is at least explainable after the
+ *   fact, and the sample verification is what actually catches it.
+ * - **The render config.** The server-side defaults that never appear in a cache key — density,
+ *   default device, font scale, image encoding. The easiest inputs to forget precisely *because*
+ *   they are absent from the key, so they are named explicitly by the caller.
+ *
+ * Nothing here is asserted by hand: change the renderer and the version moves, change the catalog
+ * and the classpath moves. There is no cache-version constant to remember to bump, because a
+ * constant someone must remember is a constant that will eventually be wrong.
+ */
+object ThemeCacheFingerprint {
+
+  /**
+   * How many classpath entries will be hashed before this gives up and returns null.
+   *
+   * A bound rather than a best effort: a descriptor with an implausible classpath is a descriptor
+   * this does not understand, and the safe answer to "I do not understand this" is to decline to
+   * persist rather than to persist under an identity that might not be one.
+   */
+  const val MAX_CLASSPATH_ENTRIES: Int = 8192
+
+  /** Read size for hashing a classpath entry. */
+  private const val BUFFER_BYTES = 1 shl 16
+
+  /**
+   * Fingerprint the generation a daemon launched with [classpath] and [variant] will render, or
+   * null when it cannot be established.
+   *
+   * **Null is a first-class answer, and it means "do not persist".** A missing or unreadable
+   * classpath entry, or an implausible number of them, leaves the generation's identity unknown —
+   * and an unknown identity must never be invented, because every wrong pixel this cache could
+   * possibly serve begins with two different generations agreeing on a name.
+   */
+  fun of(
+    classpath: List<File>,
+    variant: String,
+    toolVersion: String,
+    renderConfig: String,
+  ): String? {
+    if (classpath.isEmpty() || classpath.size > MAX_CLASSPATH_ENTRIES) return null
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.line("schema", SCHEMA)
+    digest.line("variant", variant)
+    digest.line("version", toolVersion)
+    digest.line("renderConfig", renderConfig)
+    // Sorted by NAME, not by the order the descriptor happens to list them: a classpath reordered
+    // between loads is the same classpath, and a fingerprint that disagreed would throw away a
+    // whole generation's warming for nothing.
+    val entries = classpath.sortedBy { it.name }
+    for (entry in entries) {
+      val hash = hashFile(entry) ?: return null
+      digest.line("entry", "${entry.name}:$hash")
+    }
+    return digest.digest().hex()
+  }
+
+  /**
+   * Fold several module fingerprints into one.
+   *
+   * A multi-module catalog renders from several bundles at once, and its generation is all of them
+   * together — any one changing changes what a visitor sees. Sorted so the module order a caller
+   * happens to assemble does not invent a new generation.
+   */
+  fun combine(parts: List<String>): String? {
+    if (parts.isEmpty() || parts.any { it.isBlank() }) return null
+    if (parts.size == 1) return parts.single()
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.line("schema", SCHEMA)
+    parts.sorted().forEach { digest.line("part", it) }
+    return digest.digest().hex()
+  }
+
+  /** Content hash of one classpath entry, or null when it is missing or unreadable. */
+  private fun hashFile(file: File): String? {
+    if (!file.isFile) {
+      // A DIRECTORY on the classpath — exploded classes — is hashed by walking it, because that is
+      // exactly what a from-source catalog puts there and skipping it would fingerprint a
+      // generation by its dependencies alone.
+      if (file.isDirectory) return hashDirectory(file)
+      return null
+    }
+    return runCatching {
+      val digest = MessageDigest.getInstance("SHA-256")
+      file.inputStream().use { stream ->
+        val buffer = ByteArray(BUFFER_BYTES)
+        while (true) {
+          val read = stream.read(buffer)
+          if (read <= 0) break
+          digest.update(buffer, 0, read)
+        }
+      }
+      digest.digest().hex()
+    }
+      .getOrNull()
+  }
+
+  private fun hashDirectory(dir: File): String? = runCatching {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val files =
+      dir.walkTopDown().filter { it.isFile }.sortedBy { it.relativeTo(dir).invariantPath() }
+    var count = 0
+    for (file in files) {
+      if (++count > MAX_CLASSPATH_ENTRIES) return null
+      val hash = hashFile(file) ?: return null
+      digest.line("file", "${file.relativeTo(dir).invariantPath()}:$hash")
+    }
+    // An empty directory is legitimate but carries no identity of its own; folding the count in
+    // keeps two differently-empty classpaths from colliding.
+    digest.line("files", count.toString())
+    digest.digest().hex()
+  }
+    .getOrNull()
+
+  /**
+   * Feed one labelled field, length-prefixed.
+   *
+   * Length prefixes rather than a separator character: any separator can appear inside a file name,
+   * and `a|b` + `c` must not hash the same as `a` + `b|c`.
+   */
+  private fun MessageDigest.line(label: String, value: String) {
+    val bytes = value.toByteArray()
+    update(label.toByteArray())
+    update(bytes.size.toString().toByteArray())
+    update(0)
+    update(bytes)
+    update(0)
+  }
+
+  private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
+
+  private fun File.invariantPath(): String = path.replace(File.separatorChar, '/')
+
+  /**
+   * Bumped only when the fingerprint's own *composition* changes in a way that should invalidate
+   * everything already on disk. Not a cache version anyone has to remember for ordinary changes —
+   * the inputs cover those on their own.
+   */
+  private const val SCHEMA = "theme-cache/1"
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -71,6 +71,16 @@ object ThemeCacheFingerprint {
     variant: String,
     toolVersion: String,
     renderConfig: String,
+    /**
+     * Digest of the catalog-id to daemon-preview routing this generation renders through.
+     *
+     * Persisted keys name the **published catalog** preview id, but a render resolves that id
+     * through the alias map before it reaches a daemon. That map comes from the catalog manifest,
+     * not the bundle — so a delivery-branch update can repoint an id at a different daemon preview
+     * while shipping a byte-identical executable bundle. Same classpath, same key, different
+     * pixels, and a five-entry verification sample would very likely miss the one row that moved.
+     */
+    routing: String = "",
   ): String? {
     if (classpath.isEmpty() || classpath.size > MAX_CLASSPATH_ENTRIES) return null
     val digest = MessageDigest.getInstance("SHA-256")
@@ -78,6 +88,7 @@ object ThemeCacheFingerprint {
     digest.line("variant", variant)
     digest.line("version", toolVersion)
     digest.line("renderConfig", renderConfig)
+    digest.line("routing", routing)
     // Hashed in the order the descriptor lists them, NOT sorted. Classpath order is semantically
     // significant: when two entries carry the same class or resource the JVM resolves the earlier
     // one, so a reordering with identical bytes can genuinely change the pixels. Sorting made both
@@ -115,6 +126,16 @@ object ThemeCacheFingerprint {
         ?.filter { it.isNotBlank() }
         ?.map(::File)
         .orEmpty())
+
+  /** Stable digest of a catalog-id to daemon-id map, for [of]'s `routing`. */
+  fun routingDigest(alias: Map<String, String>): String {
+    if (alias.isEmpty()) return ""
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.line("schema", SCHEMA)
+    // Sorted by catalog id: the map's iteration order is not part of what it means.
+    alias.entries.sortedBy { it.key }.forEach { (id, daemonId) -> digest.line(id, daemonId) }
+    return digest.digest().hex()
+  }
 
   /** Where the daemon launch carries the catalog's own classes — see [renderedClasspath]. */
   const val USER_CLASS_DIRS_PROPERTY: String = "composeai.daemon.userClassDirs"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -119,6 +119,7 @@ object ThemeCacheFingerprint {
   fun renderedClasspath(
     classpath: List<String>,
     systemProperties: Map<String, String>,
+    extraPayloads: List<String> = emptyList(),
   ): List<File> =
     classpath.map(::File) +
       (systemProperties[USER_CLASS_DIRS_PROPERTY]
@@ -130,7 +131,9 @@ object ThemeCacheFingerprint {
       // Compose documents and the bundle manifest. `BundleIrReplayStore` reads these bytes to
       // produce the scene, so a bundle that regenerates a capture without touching a single class
       // renders differently — and would otherwise carry the previous generation's name.
-      PAYLOAD_PROPERTIES.mapNotNull { key -> systemProperties[key]?.takeIf { it.isNotBlank() } }
+      (PAYLOAD_PROPERTIES.mapNotNull { key -> systemProperties[key]?.takeIf { it.isNotBlank() } } +
+          extraPayloads.filter { it.isNotBlank() })
+        .distinct()
         .map(::File)
 
   /** Stable digest of a catalog-id to daemon-id map, for [of]'s `routing`. */
@@ -154,7 +157,16 @@ object ThemeCacheFingerprint {
    * two genuinely different generations agree on a name.
    */
   val PAYLOAD_PROPERTIES: List<String> =
-    listOf("composeai.daemon.irDir", "composeai.daemon.bundleManifestPath")
+    listOf(
+      "composeai.daemon.irDir",
+      "composeai.daemon.bundleManifestPath",
+      // The preview manifest carries each preview's discovery-time render spec — dimensions,
+      // density, device, declared themes. A repacked catalog can change any of those while keeping
+      // an identical classpath and identical alias routing, and the cache key is theme-only, so the
+      // new host would adopt the old pixels. The five-entry sample only catches it if the changed
+      // preview happens to be one of the five.
+      "composeai.daemon.previewsJsonPath",
+    )
 
   /**
    * Fold several module fingerprints into one.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -78,16 +78,46 @@ object ThemeCacheFingerprint {
     digest.line("variant", variant)
     digest.line("version", toolVersion)
     digest.line("renderConfig", renderConfig)
-    // Sorted by NAME, not by the order the descriptor happens to list them: a classpath reordered
-    // between loads is the same classpath, and a fingerprint that disagreed would throw away a
-    // whole generation's warming for nothing.
-    val entries = classpath.sortedBy { it.name }
-    for (entry in entries) {
+    // Hashed in the order the descriptor lists them, NOT sorted. Classpath order is semantically
+    // significant: when two entries carry the same class or resource the JVM resolves the earlier
+    // one, so a reordering with identical bytes can genuinely change the pixels. Sorting made both
+    // orders one generation, which would let a render be reused from the wrong resolution order.
+    // The cost of being order-sensitive is a re-warm if the order ever churns for no reason; the
+    // cost of being order-blind is wrong pixels, and only one of those is a correctness bug.
+    for (entry in classpath) {
       val hash = hashFile(entry) ?: return null
       digest.line("entry", "${entry.name}:$hash")
     }
     return digest.digest().hex()
   }
+
+  /**
+   * Everything a daemon launched with this descriptor will actually load, in load order — the
+   * parent [classpath] **and** the user classpath carried in [systemProperties].
+   *
+   * The user half is not a detail, it is the catalog itself. `ServeBundleDaemon.splitBundleRuntime`
+   * puts the bundle's own `classes/` directory, its rehydrated external resources and its child
+   * dependency jars into `composeai.daemon.userClassDirs`, leaving `classpath` holding only parent
+   * overlays and daemon sidecars. Fingerprinting the parent alone therefore gives two catalog
+   * revisions with unchanged framework dependencies the *same* name, and the new revision adopts
+   * the old one's pixels — the exact collision this whole mechanism exists to prevent.
+   *
+   * Only the contents of these paths are ever hashed, never the paths themselves, so the fresh
+   * staging directory each load creates does not invent a new generation.
+   */
+  fun renderedClasspath(
+    classpath: List<String>,
+    systemProperties: Map<String, String>,
+  ): List<File> =
+    classpath.map(::File) +
+      (systemProperties[USER_CLASS_DIRS_PROPERTY]
+        ?.split(File.pathSeparator)
+        ?.filter { it.isNotBlank() }
+        ?.map(::File)
+        .orEmpty())
+
+  /** Where the daemon launch carries the catalog's own classes — see [renderedClasspath]. */
+  const val USER_CLASS_DIRS_PROPERTY: String = "composeai.daemon.userClassDirs"
 
   /**
    * Fold several module fingerprints into one.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -1,0 +1,318 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * On-disk home for rendered theme PNGs, so warming survives the thing that produced it.
+ *
+ * ### What this exists to stop
+ *
+ * [CatalogThemeCache] is process memory. It is dropped by a server restart and, separately, by a
+ * catalog reload — every load builds a fresh `ServeSessionState` and therefore a fresh cache. For
+ * `m3-catalog` on the public box those two together fired 7-10 times a day (3 delivery-branch
+ * regenerations and 4 releases on 2026-08-17 alone) against a catalog needing roughly 28 hours of
+ * lane time to warm its 10,120 targets. It had never once had a window long enough to finish, on
+ * any day. Rotation ([ServeBackgroundWork]) got it warming; only persistence lets the work
+ * accumulate.
+ *
+ * ### Layout
+ *
+ * ```
+ * <root>/<system>/<fingerprint>/manifest.json
+ * <root>/<system>/<fingerprint>/<sha256(cacheKey)>.png
+ * ```
+ *
+ * A **generation** is one `(system, fingerprint)` pair — see [ThemeCacheFingerprint] for what the
+ * fingerprint covers. Generations are never mutated in place: a new catalog revision or a new
+ * server version simply writes under a new directory and the old one is swept. That is what makes
+ * invalidation structural rather than something a reader has to remember to check.
+ *
+ * The manifest is not consulted to decide validity — the directory name already is the decision. It
+ * records the inputs so a drop is *explainable* ("renderer 1.13.0 to 1.14.0 invalidated 8,412
+ * entries") instead of being another unexplained return to zero.
+ */
+class ThemeCacheStore(
+  private val root: File,
+  /**
+   * Ceiling for the whole store across every catalog and generation.
+   *
+   * Enforced by [sweep] rather than at write time. Writes must not block on a byte census — the
+   * optimizer is calling [Generation.put] once per render — and a cache that refused to grow
+   * between sweeps would silently stop persisting exactly when it was working hardest.
+   */
+  private val maxBytes: Long = DEFAULT_MAX_BYTES,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val json = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = true
+  }
+  private val writes = AtomicLong()
+  private val writeFailures = AtomicLong()
+  private val hits = AtomicLong()
+  private val misses = AtomicLong()
+  private val lastFailure = ConcurrentHashMap<String, String>()
+
+  /**
+   * Open (creating if needed) the generation for [system] at [fingerprint], or null when the store
+   * is unusable.
+   *
+   * Null rather than an exception: persistence is an optimisation, and a box with a read-only or
+   * full disk must serve catalogs exactly as it did before this existed.
+   */
+  fun open(system: String, fingerprint: String, inputs: GenerationInputs): Generation? {
+    val safeSystem = system.safeName() ?: return null
+    val safeFingerprint = fingerprint.safeName() ?: return null
+    val dir = File(File(root, safeSystem), safeFingerprint)
+    if (!runCatching { dir.mkdirs() }.getOrDefault(false) && !dir.isDirectory) {
+      recordFailure(system, "could not create $dir")
+      return null
+    }
+    writeManifest(dir, inputs)
+    return Generation(dir, system)
+  }
+
+  private fun writeManifest(dir: File, inputs: GenerationInputs) {
+    val file = File(dir, MANIFEST_NAME)
+    if (file.isFile) return
+    runCatching { file.writeText(json.encodeToString(inputs.copy(createdAtEpochMillis = clock()))) }
+      .onFailure { recordFailure(dir.name, "manifest: ${it.message}") }
+  }
+
+  /**
+   * Delete every generation not in [live], and report whether what remains fits [maxBytes].
+   *
+   * Reclaiming the dead set is the whole of the sweep, and on a box regenerating several times a
+   * day it is also nearly the whole of the garbage: every superseded catalog revision and every
+   * previous server version leaves one behind.
+   *
+   * **A live generation is never deleted, not even to fit the cap.** Evicting what is currently
+   * being warmed to make room for what is not would turn the cap into a treadmill — the optimizer
+   * would re-render exactly what the sweep just discarded, forever, and the box would look busy
+   * while making no progress. So an over-cap *live* set is reported ([SweepResult.overCap]) rather
+   * than acted on: it means the cap is too small for the catalog set, which is a configuration
+   * answer and not something this can quietly fix.
+   */
+  fun sweep(live: Set<GenerationId>): SweepResult {
+    val liveDirs = live.mapNotNull { it.dir() }.toSet()
+    var deleted = 0
+    var reclaimed = 0L
+    val survivors = mutableListOf<Pair<File, Long>>()
+
+    for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+      for (generationDir in systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+        val size = generationDir.sizeOnDisk()
+        if (generationDir in liveDirs) {
+          survivors += generationDir to size
+          continue
+        }
+        if (generationDir.deleteRecursively()) {
+          deleted++
+          reclaimed += size
+        }
+      }
+      // A system directory left empty by the sweep is itself garbage.
+      if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
+    }
+
+    val total = survivors.sumOf { it.second }
+    return SweepResult(
+      deletedGenerations = deleted,
+      reclaimedBytes = reclaimed,
+      bytes = total,
+      overCap = total > maxBytes,
+    )
+  }
+
+  fun snapshot(): ThemeCacheStoreSnapshot {
+    val generations =
+      root
+        .listFiles()
+        ?.filter { it.isDirectory }
+        ?.sumOf { it.listFiles()?.count { child -> child.isDirectory } ?: 0 } ?: 0
+    return ThemeCacheStoreSnapshot(
+      root = root.path,
+      generations = generations,
+      bytes = root.sizeOnDisk(),
+      maxBytes = maxBytes,
+      writes = writes.get(),
+      writeFailures = writeFailures.get(),
+      hits = hits.get(),
+      misses = misses.get(),
+      lastFailureReason = lastFailure["reason"],
+    )
+  }
+
+  private fun recordFailure(system: String, reason: String) {
+    writeFailures.incrementAndGet()
+    lastFailure["reason"] = "$system: ${reason.take(MAX_REASON_CHARS)}"
+  }
+
+  /** One `(system, fingerprint)` generation's directory of PNGs. */
+  inner class Generation internal constructor(private val dir: File, private val system: String) {
+
+    /**
+     * Cache keys already on disk, read once at open.
+     *
+     * Held as a set rather than re-listed per lookup because the question "is this target already
+     * warm" is asked for every target on every optimizer pass — 10,120 times for one catalog — and
+     * a directory listing per question would make the cache slower than the renders it replaces.
+     */
+    private val present: MutableSet<String> =
+      java.util.Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>()).apply {
+        dir
+          .listFiles()
+          ?.filter { it.isFile && it.name.endsWith(PNG_SUFFIX) }
+          ?.forEach { add(it.name.removeSuffix(PNG_SUFFIX)) }
+      }
+
+    /** How many renders were already on disk when this generation was opened. */
+    val loadedEntries: Int = present.size
+
+    fun contains(cacheKey: String): Boolean = fileName(cacheKey) in present
+
+    fun get(cacheKey: String): ByteArray? {
+      val name = fileName(cacheKey)
+      if (name !in present) {
+        misses.incrementAndGet()
+        return null
+      }
+      val bytes = runCatching { File(dir, "$name$PNG_SUFFIX").readBytes() }.getOrNull()
+      if (bytes == null) {
+        // On disk a moment ago and unreadable now — a sweep, an external delete, a truncated write.
+        // Forget it so the optimizer treats it as work still to do rather than as permanently
+        // cached-but-broken.
+        present.remove(name)
+        misses.incrementAndGet()
+        return null
+      }
+      hits.incrementAndGet()
+      return bytes
+    }
+
+    /**
+     * Persist one render. Best-effort and never throws: a failed write costs a re-render later,
+     * which is strictly better than failing the render that just succeeded.
+     *
+     * Written to a temp file and renamed, so a crash or a full disk leaves no half-PNG that a later
+     * process would read as a valid cached render.
+     */
+    fun put(cacheKey: String, png: ByteArray) {
+      val name = fileName(cacheKey)
+      if (name in present) return
+      val target = File(dir, "$name$PNG_SUFFIX")
+      val temp = File(dir, "$name$TEMP_SUFFIX")
+      try {
+        temp.writeBytes(png)
+        if (!temp.renameTo(target)) {
+          temp.delete()
+          recordFailure(system, "rename failed for $name")
+          return
+        }
+        present += name
+        writes.incrementAndGet()
+      } catch (e: IOException) {
+        runCatching { temp.delete() }
+        recordFailure(system, e.message ?: e::class.simpleName ?: "write failed")
+      }
+    }
+
+    /**
+     * Drop this whole generation — used when load-time verification finds a cached render that no
+     * longer matches what the renderer produces.
+     *
+     * The whole generation, not the offending entry: a mismatch means the fingerprint failed to
+     * capture some input, so every entry sharing it is suspect. Keeping the rest would be trusting
+     * the same broken identity that just proved untrustworthy.
+     */
+    fun discard(): Boolean {
+      present.clear()
+      return runCatching { dir.deleteRecursively() }.getOrDefault(false)
+    }
+
+    private fun fileName(cacheKey: String): String =
+      MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray()).joinToString("") {
+        "%02x".format(it)
+      }
+  }
+
+  /** A generation's coordinates, for [sweep]'s live set. */
+  data class GenerationId(val system: String, val fingerprint: String)
+
+  private fun GenerationId.dir(): File? {
+    val safeSystem = system.safeName() ?: return null
+    val safeFingerprint = fingerprint.safeName() ?: return null
+    return File(File(root, safeSystem), safeFingerprint)
+  }
+
+  companion object {
+    const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
+    const val MANIFEST_NAME: String = "manifest.json"
+    const val MAX_REASON_CHARS: Int = 200
+    private const val PNG_SUFFIX = ".png"
+    private const val TEMP_SUFFIX = ".png.tmp"
+
+    /**
+     * Names that may become a directory under the store root.
+     *
+     * A system id reaches here from deployment config and a fingerprint from a digest, so neither
+     * is attacker-controlled today — but both name a path, and a component that can contain `..` or
+     * a separator is a directory traversal waiting for the day one of them is. Rejected rather than
+     * sanitised: a silently rewritten name would let two catalogs share a generation.
+     */
+    private val SAFE_NAME = Regex("[A-Za-z0-9._-]{1,128}")
+
+    private fun String.safeName(): String? = takeIf {
+      it.isNotEmpty() && it != "." && it != ".." && SAFE_NAME.matches(it)
+    }
+
+    private fun File.sizeOnDisk(): Long = runCatching {
+      walkTopDown().filter { it.isFile }.sumOf { it.length() }
+    }
+      .getOrDefault(0L)
+  }
+}
+
+/**
+ * What a generation was fingerprinted from, recorded beside its PNGs.
+ *
+ * Never read to decide validity — the directory name is that decision. This exists so an operator
+ * can answer "why did the cache reset" from the box itself.
+ */
+@Serializable
+data class GenerationInputs(
+  val system: String,
+  val fingerprint: String,
+  val toolVersion: String,
+  val variant: String,
+  val renderConfig: String,
+  val createdAtEpochMillis: Long = 0,
+)
+
+/** What one [ThemeCacheStore.sweep] reclaimed. */
+data class SweepResult(
+  val deletedGenerations: Int,
+  val reclaimedBytes: Long,
+  val bytes: Long,
+  val overCap: Boolean,
+)
+
+/** Disk-tier counters for `/status.json` (`themeCache`). */
+@Serializable
+data class ThemeCacheStoreSnapshot(
+  val root: String,
+  val generations: Int,
+  val bytes: Long,
+  val maxBytes: Long,
+  val writes: Long,
+  val writeFailures: Long,
+  val hits: Long,
+  val misses: Long,
+  val lastFailureReason: String? = null,
+)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -57,6 +57,10 @@ class ThemeCacheStore(
   private val writeFailures = AtomicLong()
   private val hits = AtomicLong()
   private val misses = AtomicLong()
+  // Census published by [sweep] and advanced by each write — see [snapshot] for why it is not read
+  // from the filesystem on the request path.
+  private val knownBytes = AtomicLong()
+  private val knownGenerations = java.util.concurrent.atomic.AtomicInteger()
   private val lastFailure = ConcurrentHashMap<String, String>()
 
   /**
@@ -75,6 +79,8 @@ class ThemeCacheStore(
       return null
     }
     writeManifest(dir, inputs)
+    knownGenerations.incrementAndGet()
+    knownBytes.addAndGet(dir.sizeOnDisk())
     return Generation(dir, system)
   }
 
@@ -99,17 +105,28 @@ class ThemeCacheStore(
    * than acted on: it means the cap is too small for the catalog set, which is a configuration
    * answer and not something this can quietly fix.
    */
-  fun sweep(live: Set<GenerationId>): SweepResult {
+  fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
     val liveDirs = live.mapNotNull { it.dir() }.toSet()
     var deleted = 0
     var reclaimed = 0L
-    val survivors = mutableListOf<Pair<File, Long>>()
+    var survivingBytes = 0L
+    var survivingGenerations = 0
 
     for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
-      for (generationDir in systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+      val generationDirs = systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()
+      // A system the caller has no current generation for is left entirely alone. Absence from the
+      // live set means "we did not load this catalog", which is not the same as "this catalog's
+      // warmed renders are garbage" — a load can fail transiently, and its cache must outlive that.
+      if (onlySystems != null && systemDir.name !in onlySystems) {
+        survivingBytes += systemDir.sizeOnDisk()
+        survivingGenerations += generationDirs.size
+        continue
+      }
+      for (generationDir in generationDirs) {
         val size = generationDir.sizeOnDisk()
         if (generationDir in liveDirs) {
-          survivors += generationDir to size
+          survivingBytes += size
+          survivingGenerations++
           continue
         }
         if (generationDir.deleteRecursively()) {
@@ -121,7 +138,9 @@ class ThemeCacheStore(
       if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
     }
 
-    val total = survivors.sumOf { it.second }
+    val total = survivingBytes
+    knownBytes.set(total)
+    knownGenerations.set(survivingGenerations)
     return SweepResult(
       deletedGenerations = deleted,
       reclaimedBytes = reclaimed,
@@ -130,16 +149,21 @@ class ThemeCacheStore(
     )
   }
 
-  fun snapshot(): ThemeCacheStoreSnapshot {
-    val generations =
-      root
-        .listFiles()
-        ?.filter { it.isDirectory }
-        ?.sumOf { it.listFiles()?.count { child -> child.isDirectory } ?: 0 } ?: 0
-    return ThemeCacheStoreSnapshot(
+  /**
+   * Disk occupancy as of the last sweep, plus everything written since.
+   *
+   * **Deliberately not a live census.** `/status.json` is a monitoring endpoint that gets polled,
+   * and one warmed catalog is 10,120 files — recursively walking the tree per request would put
+   * tens of thousands of filesystem metadata operations on the request path, growing with every
+   * catalog served. The sweep already walks the tree for its own reasons, so it publishes the total
+   * on the way past and writes add to it from there. Slightly stale between sweeps, which is the
+   * right trade for a number nobody acts on within a second.
+   */
+  fun snapshot(): ThemeCacheStoreSnapshot =
+    ThemeCacheStoreSnapshot(
       root = root.path,
-      generations = generations,
-      bytes = root.sizeOnDisk(),
+      generations = knownGenerations.get(),
+      bytes = knownBytes.get(),
       maxBytes = maxBytes,
       writes = writes.get(),
       writeFailures = writeFailures.get(),
@@ -147,7 +171,6 @@ class ThemeCacheStore(
       misses = misses.get(),
       lastFailureReason = lastFailure["reason"],
     )
-  }
 
   private fun recordFailure(system: String, reason: String) {
     writeFailures.incrementAndGet()
@@ -217,6 +240,7 @@ class ThemeCacheStore(
         }
         present += name
         writes.incrementAndGet()
+        knownBytes.addAndGet(png.size.toLong())
       } catch (e: IOException) {
         runCatching { temp.delete() }
         recordFailure(system, e.message ?: e::class.simpleName ?: "write failed")
@@ -233,7 +257,16 @@ class ThemeCacheStore(
      */
     fun discard(): Boolean {
       present.clear()
-      return runCatching { dir.deleteRecursively() }.getOrDefault(false)
+      return runCatching {
+          // The PNGs go; the DIRECTORY stays. This generation object remains attached to a live
+          // CatalogThemeCache, and deleting the directory under it would make every later `put`
+          // fail its temp write, catch the IOException and persist nothing — so the optimizer would
+          // re-render the whole catalog into memory alone and lose it all again at restart. The
+          // point of discarding is to stop trusting these bytes, not to stop writing new ones.
+          dir.listFiles()?.forEach { it.deleteRecursively() }
+          dir.isDirectory || dir.mkdirs()
+        }
+        .getOrDefault(false)
     }
 
     private fun fileName(cacheKey: String): String =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -122,6 +122,7 @@ class ThemeCacheStore(
    */
   fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
     val youngerThan = clock() - graceMillis
+    val beforeScan = knownBytes.get()
     val liveDirs = live.mapNotNull { it.dir() }.toSet()
     var deleted = 0
     var reclaimed = 0L
@@ -167,7 +168,13 @@ class ThemeCacheStore(
     }
 
     val total = survivingBytes
-    knownBytes.set(total)
+    // Merged, not assigned. A sweep runs concurrently with other catalogs' optimizers writing into
+    // this store — startup releases the background-work gate immediately before sweeping — so a
+    // bare
+    // `set` can discard a write that landed during the scan, or publish a total that never saw a
+    // file created after its directory was walked. Either way `/status` under-reports occupancy
+    // until the next sweep, which is exactly when an over-cap volume most needs to be visible.
+    knownBytes.getAndUpdate { current -> total + (current - beforeScan).coerceAtLeast(0) }
     knownGenerations.set(survivingGenerations)
     return SweepResult(
       deletedGenerations = deleted,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -47,6 +47,17 @@ class ThemeCacheStore(
    * between sweeps would silently stop persisting exactly when it was working hardest.
    */
   private val maxBytes: Long = DEFAULT_MAX_BYTES,
+  /**
+   * How recently a generation must have been created to be spared by [sweep] even when this process
+   * has no use for it.
+   *
+   * This exists for the zero-downtime rollout the image deployment performs: a new replica boots
+   * alongside the running one, sharing the `/config` volume this store defaults into, and knows
+   * nothing of the old replica's fingerprints. Without a grace window it would reclaim the cache of
+   * the replica still serving production — and if the new replica then failed readiness, the old
+   * one would carry on with its warming deleted out from under it.
+   */
+  private val graceMillis: Long = DEFAULT_SWEEP_GRACE_MILLIS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) {
   private val json = Json {
@@ -106,6 +117,7 @@ class ThemeCacheStore(
    * answer and not something this can quietly fix.
    */
   fun sweep(live: Set<GenerationId>, onlySystems: Set<String>? = null): SweepResult {
+    val youngerThan = clock() - graceMillis
     val liveDirs = live.mapNotNull { it.dir() }.toSet()
     var deleted = 0
     var reclaimed = 0L
@@ -124,7 +136,19 @@ class ThemeCacheStore(
       }
       for (generationDir in generationDirs) {
         val size = generationDir.sizeOnDisk()
-        if (generationDir in liveDirs) {
+        // Live here, young enough to be live in ANOTHER PROCESS, or undeletable — all three are
+        // survivors, and each for its own reason:
+        //  - ours: obviously;
+        //  - young: the image deployment rolls out zero-downtime, so a new replica boots beside the
+        //    old one on the same volume and sees the old one's generations as unreferenced.
+        // Sweeping
+        //    them would delete a possibly 28-hour cache belonging to a replica that is still
+        // serving
+        //    production — and still the one serving it if the new replica fails its readiness
+        // check;
+        //  - undeletable: the bytes are still on the volume whatever the filesystem said, and a
+        //    census that omits them can report the store under a cap it is actually over.
+        if (generationDir in liveDirs || createdAt(generationDir) > youngerThan) {
           survivingBytes += size
           survivingGenerations++
           continue
@@ -132,6 +156,10 @@ class ThemeCacheStore(
         if (generationDir.deleteRecursively()) {
           deleted++
           reclaimed += size
+        } else {
+          survivingBytes += size
+          survivingGenerations++
+          recordFailure(systemDir.name, "could not reclaim ${generationDir.name}")
         }
       }
       // A system directory left empty by the sweep is itself garbage.
@@ -175,6 +203,20 @@ class ThemeCacheStore(
       misses = misses.get(),
       lastFailureReason = lastFailure["reason"],
     )
+
+  /**
+   * When this generation was first created, from its manifest, falling back to the directory's own
+   * timestamp and finally to "now" — an unreadable age must read as *young*, so an unparseable
+   * manifest errs toward keeping bytes rather than deleting another replica's cache.
+   */
+  private fun createdAt(dir: File): Long =
+    runCatching {
+      json
+        .decodeFromString(GenerationInputs.serializer(), File(dir, MANIFEST_NAME).readText())
+        .createdAtEpochMillis
+        .takeIf { it > 0 }
+    }
+      .getOrNull() ?: dir.lastModified().takeIf { it > 0 } ?: clock()
 
   private fun recordFailure(system: String, reason: String) {
     writeFailures.incrementAndGet()
@@ -294,6 +336,9 @@ class ThemeCacheStore(
 
   companion object {
     const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
+
+    /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
+    const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
     const val MANIFEST_NAME: String = "manifest.json"
     const val MAX_REASON_CHARS: Int = 200
     private const val PNG_SUFFIX = ".png"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -258,7 +258,10 @@ class ThemeCacheStore(
      * Snapshotted because [present] grows as this process writes, and a render this process just
      * produced needs no verification: it came from this renderer.
      */
-    private val adopted: Set<String> = present.toSet()
+    private val adopted: MutableSet<String> =
+      java.util.Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>()).apply {
+        addAll(present)
+      }
 
     /** Whether [cacheKey] came from a previous process rather than from this one. */
     fun wasAdopted(cacheKey: String): Boolean = fileName(cacheKey) in adopted
@@ -291,15 +294,21 @@ class ThemeCacheStore(
      * Written to a temp file and renamed, so a crash or a full disk leaves no half-PNG that a later
      * process would read as a valid cached render.
      */
-    fun put(cacheKey: String, png: ByteArray) {
+    fun put(cacheKey: String, png: ByteArray, replaceExisting: Boolean = false) {
       val name = fileName(cacheKey)
-      if (name in present) return
+      // Presence alone is not proof that no write is needed. While a generation is quarantined a
+      // foreground request deliberately misses the adopted copy and renders fresh bytes; returning
+      // here would leave the suspect PNG on disk, and once verification passed on OTHER sampled
+      // keys
+      // the read path would serve it again the moment the fresh copy fell out of memory.
+      if (name in present && !(replaceExisting && name in adopted)) return
       val target = File(dir, "$name$PNG_SUFFIX")
       // Writer-unique, because the zero-downtime rollout puts two processes on this volume at once.
       // A temp path shared by cache key lets one replica rename the inode while the other is still
       // writing it, publishing a half-PNG under a name that claims to be complete — and a reader
       // then promotes those bytes as a valid render.
       val temp = File(dir, "$name.${writerId}-${tempSequence.incrementAndGet()}$TEMP_SUFFIX")
+      val existingSize = target.length()
       try {
         temp.writeBytes(png)
         if (!temp.renameTo(target)) {
@@ -307,9 +316,15 @@ class ThemeCacheStore(
           recordFailure(system, "rename failed for $name")
           return
         }
+        // The size DELTA, not the payload size: two hosts for the same fingerprint can race to
+        // publish the same key during a catalog replacement and both rename over the target, but
+        // only one file ends up occupying the volume.
+        val previousSize = if (name in present) existingSize else 0L
         present += name
+        // Replaced by this process, so it is no longer a candidate for verifying the previous one.
+        adopted -= name
         writes.incrementAndGet()
-        knownBytes.addAndGet(png.size.toLong())
+        knownBytes.addAndGet(png.size.toLong() - previousSize)
       } catch (e: IOException) {
         runCatching { temp.delete() }
         recordFailure(system, e.message ?: e::class.simpleName ?: "write failed")
@@ -326,6 +341,7 @@ class ThemeCacheStore(
      */
     fun discard(): Boolean {
       present.clear()
+      adopted.clear()
       // Measured before the delete and subtracted, or the census would carry the discarded
       // generation's bytes plus its rebuilt replacement until the next sweep — making the one
       // number an operator uses to judge occupancy roughly twice the truth.
@@ -336,8 +352,12 @@ class ThemeCacheStore(
           // fail its temp write, catch the IOException and persist nothing — so the optimizer would
           // re-render the whole catalog into memory alone and lose it all again at restart. The
           // point of discarding is to stop trusting these bytes, not to stop writing new ones.
-          dir.listFiles()?.forEach { it.deleteRecursively() }
-          dir.isDirectory || dir.mkdirs()
+          // EVERY child must go. A partial discard leaves stale PNGs under a fingerprint this
+          // process has already decided it cannot trust, and the next restart adopts them again —
+          // reproducing the exact mismatch that triggered the discard, indefinitely.
+          val cleared = dir.listFiles()?.all { it.deleteRecursively() } ?: true
+          if (!cleared) recordFailure(system, "could not fully discard ${dir.name}")
+          cleared && (dir.isDirectory || dir.mkdirs())
         }
         .getOrDefault(false)
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -72,6 +73,18 @@ class ThemeCacheStore(
   // from the filesystem on the request path.
   private val knownBytes = AtomicLong()
   private val knownGenerations = java.util.concurrent.atomic.AtomicInteger()
+  /**
+   * Generation directories per system, as of the last [sweep].
+   *
+   * The single number that says whether the *key* is working. A system whose fingerprint is stable
+   * has one generation on disk; one whose fingerprint churns — because some input the digest reads
+   * changes on every load, a staging path that slipped into the render config, a jar rebuilt each
+   * boot — accumulates a directory per restart, each adopted by nobody. Both look identical in
+   * [writes] and in [hits], which is exactly the confusion this exists to remove: writes climbing
+   * while a system's generation count climbs beside them means the cache is buying disk I/O and
+   * nothing else.
+   */
+  private val knownGenerationsBySystem = AtomicReference<Map<String, Int>>(emptyMap())
   private val lastFailure = ConcurrentHashMap<String, String>()
   private val tempSequence = AtomicLong()
   /** Distinguishes this process's in-flight writes from a concurrently deployed replica's. */
@@ -95,6 +108,7 @@ class ThemeCacheStore(
     }
     writeManifest(dir, inputs)
     knownGenerations.incrementAndGet()
+    knownGenerationsBySystem.getAndUpdate { it + (system to (it[system] ?: 0) + 1) }
     knownBytes.addAndGet(dir.sizeOnDisk())
     return Generation(dir, system)
   }
@@ -128,6 +142,7 @@ class ThemeCacheStore(
     var reclaimed = 0L
     var survivingBytes = 0L
     var survivingGenerations = 0
+    val survivingBySystem = mutableMapOf<String, Int>()
 
     for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
       val generationDirs = systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()
@@ -137,6 +152,7 @@ class ThemeCacheStore(
       if (onlySystems != null && systemDir.name !in onlySystems) {
         survivingBytes += systemDir.sizeOnDisk()
         survivingGenerations += generationDirs.size
+        if (generationDirs.isNotEmpty()) survivingBySystem[systemDir.name] = generationDirs.size
         continue
       }
       for (generationDir in generationDirs) {
@@ -152,6 +168,7 @@ class ThemeCacheStore(
         if (generationDir in liveDirs || createdAt(generationDir) > youngerThan) {
           survivingBytes += size
           survivingGenerations++
+          survivingBySystem.merge(systemDir.name, 1, Int::plus)
           continue
         }
         if (generationDir.deleteRecursively()) {
@@ -160,6 +177,7 @@ class ThemeCacheStore(
         } else {
           survivingBytes += size
           survivingGenerations++
+          survivingBySystem.merge(systemDir.name, 1, Int::plus)
           recordFailure(systemDir.name, "could not reclaim ${generationDir.name}")
         }
       }
@@ -176,6 +194,7 @@ class ThemeCacheStore(
     // until the next sweep, which is exactly when an over-cap volume most needs to be visible.
     knownBytes.getAndUpdate { current -> total + (current - beforeScan).coerceAtLeast(0) }
     knownGenerations.set(survivingGenerations)
+    knownGenerationsBySystem.set(survivingBySystem.toMap())
     return SweepResult(
       deletedGenerations = deleted,
       reclaimedBytes = reclaimed,
@@ -202,6 +221,7 @@ class ThemeCacheStore(
     ThemeCacheStoreSnapshot(
       root = root.path,
       generations = knownGenerations.get(),
+      generationsBySystem = knownGenerationsBySystem.get(),
       bytes = knownBytes.get(),
       maxBytes = maxBytes,
       writes = writes.get(),
@@ -251,6 +271,17 @@ class ThemeCacheStore(
     /** How many renders were already on disk when this generation was opened. */
     val loadedEntries: Int = present.size
 
+    /** This generation's directory name — the fingerprint it was opened under. */
+    val fingerprint: String = dir.name
+
+    // Per-generation counters. The store-wide ones next to them answer "is the volume being used";
+    // these answer "is THIS catalog's cache working", which is the question an operator actually
+    // has — a box serving fifteen catalogs where one has an unstable fingerprint reports healthy
+    // store-wide totals while that one catalog re-renders from scratch every restart.
+    private val generationHits = AtomicLong()
+    private val generationMisses = AtomicLong()
+    private val generationWrites = AtomicLong()
+
     /**
      * Exactly the renders that were on disk when this generation was opened — the ones written by
      * some *other* process, and therefore the only ones whose trustworthiness is in question.
@@ -272,6 +303,7 @@ class ThemeCacheStore(
       val name = fileName(cacheKey)
       if (name !in present) {
         misses.incrementAndGet()
+        generationMisses.incrementAndGet()
         return null
       }
       val bytes = runCatching { File(dir, "$name$PNG_SUFFIX").readBytes() }.getOrNull()
@@ -281,9 +313,11 @@ class ThemeCacheStore(
         // cached-but-broken.
         present.remove(name)
         misses.incrementAndGet()
+        generationMisses.incrementAndGet()
         return null
       }
       hits.incrementAndGet()
+      generationHits.incrementAndGet()
       return bytes
     }
 
@@ -324,6 +358,7 @@ class ThemeCacheStore(
         // Replaced by this process, so it is no longer a candidate for verifying the previous one.
         adopted -= name
         writes.incrementAndGet()
+        generationWrites.incrementAndGet()
         knownBytes.addAndGet(png.size.toLong() - previousSize)
       } catch (e: IOException) {
         runCatching { temp.delete() }
@@ -361,6 +396,22 @@ class ThemeCacheStore(
         }
         .getOrDefault(false)
     }
+
+    /**
+     * What this generation has actually done, for `/status`.
+     *
+     * [ThemeCacheGenerationSnapshot.adopted] is the load-bearing number: it is the only evidence
+     * that persistence carried anything across a process boundary at all.
+     */
+    fun stats(): ThemeCacheGenerationSnapshot =
+      ThemeCacheGenerationSnapshot(
+        fingerprint = fingerprint,
+        adopted = loadedEntries,
+        entries = present.size,
+        hits = generationHits.get(),
+        misses = generationMisses.get(),
+        writes = generationWrites.get(),
+      )
 
     private fun fileName(cacheKey: String): String =
       MessageDigest.getInstance("SHA-256").digest(cacheKey.toByteArray()).joinToString("") {
@@ -432,11 +483,49 @@ data class SweepResult(
   val overCap: Boolean,
 )
 
+/**
+ * What one catalog generation's disk tier has done this process, for `/status.json`.
+ *
+ * The point of publishing this per catalog rather than only store-wide: a disk cache that is
+ * working and one that is pure write amplification produce the same store-wide `writes`, and the
+ * difference between them is visible only here. Read it in this order:
+ * - [adopted] `0` after a restart that should have found a warm generation ⇒ the **key** moved.
+ *   Compare [fingerprint] with the previous process's; if it changed while nothing about the
+ *   catalog or the server did, some input the digest reads is unstable, and every write this
+ *   process makes is being left for a sweep to reclaim.
+ * - [adopted] high but [hits] `0` ⇒ the entries are there and nothing is reading them: either
+ *   nothing asked for those keys, or the generation is still quarantined pending verification.
+ * - [writes] climbing with [adopted] `0` on every restart is the "disk I/O for nothing" case,
+ *   stated in two numbers.
+ */
+@Serializable
+data class ThemeCacheGenerationSnapshot(
+  /** The generation directory this catalog is reading and writing — its cache key. */
+  val fingerprint: String,
+  /** Renders already on disk when this process opened the generation. */
+  val adopted: Int,
+  /** Renders on disk now, adopted plus written since. */
+  val entries: Int,
+  /** Reads this process served from disk. */
+  val hits: Long,
+  /** Reads that went to disk and found nothing. */
+  val misses: Long,
+  /** Renders this process wrote to disk. */
+  val writes: Long,
+)
+
 /** Disk-tier counters for `/status.json` (`themeCache`). */
 @Serializable
 data class ThemeCacheStoreSnapshot(
   val root: String,
   val generations: Int,
+  /**
+   * Generation directories per system, as of the last sweep.
+   *
+   * More than one for a system that has only ever been served one way is fingerprint churn, and
+   * churn is the failure mode that reports itself as success everywhere else.
+   */
+  val generationsBySystem: Map<String, Int> = emptyMap(),
   val bytes: Long,
   val maxBytes: Long,
   val writes: Long,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -149,6 +149,10 @@ class ThemeCacheStore(
     )
   }
 
+  /** Every system with a directory in the store, whether or not this server still serves it. */
+  fun systems(): Set<String> =
+    root.listFiles()?.filter { it.isDirectory }?.map { it.name }?.toSet().orEmpty()
+
   /**
    * Disk occupancy as of the last sweep, plus everything written since.
    *
@@ -257,6 +261,10 @@ class ThemeCacheStore(
      */
     fun discard(): Boolean {
       present.clear()
+      // Measured before the delete and subtracted, or the census would carry the discarded
+      // generation's bytes plus its rebuilt replacement until the next sweep — making the one
+      // number an operator uses to judge occupancy roughly twice the truth.
+      knownBytes.addAndGet(-dir.sizeOnDisk())
       return runCatching {
           // The PNGs go; the DIRECTORY stays. This generation object remains attached to a live
           // CatalogThemeCache, and deleting the directory under it would make every later `put`

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -73,6 +73,10 @@ class ThemeCacheStore(
   private val knownBytes = AtomicLong()
   private val knownGenerations = java.util.concurrent.atomic.AtomicInteger()
   private val lastFailure = ConcurrentHashMap<String, String>()
+  private val tempSequence = AtomicLong()
+  /** Distinguishes this process's in-flight writes from a concurrently deployed replica's. */
+  private val writerId: String =
+    ProcessHandle.current().pid().toString(36) + "-" + System.identityHashCode(this).toString(36)
 
   /**
    * Open (creating if needed) the generation for [system] at [fingerprint], or null when the store
@@ -136,17 +140,13 @@ class ThemeCacheStore(
       }
       for (generationDir in generationDirs) {
         val size = generationDir.sizeOnDisk()
-        // Live here, young enough to be live in ANOTHER PROCESS, or undeletable — all three are
-        // survivors, and each for its own reason:
+        // Three kinds of survivor, each for its own reason:
         //  - ours: obviously;
         //  - young: the image deployment rolls out zero-downtime, so a new replica boots beside the
-        //    old one on the same volume and sees the old one's generations as unreferenced.
-        // Sweeping
-        //    them would delete a possibly 28-hour cache belonging to a replica that is still
-        // serving
-        //    production — and still the one serving it if the new replica fails its readiness
-        // check;
-        //  - undeletable: the bytes are still on the volume whatever the filesystem said, and a
+        //    running one on the same volume and sees its generations as unreferenced. Reclaiming
+        //    them deletes a possibly 28-hour cache from the replica still serving production — and
+        //    still serving it if the new replica fails readiness;
+        //  - undeletable: the bytes remain on the volume whatever the filesystem reported, and a
         //    census that omits them can report the store under a cap it is actually over.
         if (generationDir in liveDirs || createdAt(generationDir) > youngerThan) {
           survivingBytes += size
@@ -244,6 +244,18 @@ class ThemeCacheStore(
     /** How many renders were already on disk when this generation was opened. */
     val loadedEntries: Int = present.size
 
+    /**
+     * Exactly the renders that were on disk when this generation was opened — the ones written by
+     * some *other* process, and therefore the only ones whose trustworthiness is in question.
+     *
+     * Snapshotted because [present] grows as this process writes, and a render this process just
+     * produced needs no verification: it came from this renderer.
+     */
+    private val adopted: Set<String> = present.toSet()
+
+    /** Whether [cacheKey] came from a previous process rather than from this one. */
+    fun wasAdopted(cacheKey: String): Boolean = fileName(cacheKey) in adopted
+
     fun contains(cacheKey: String): Boolean = fileName(cacheKey) in present
 
     fun get(cacheKey: String): ByteArray? {
@@ -276,7 +288,11 @@ class ThemeCacheStore(
       val name = fileName(cacheKey)
       if (name in present) return
       val target = File(dir, "$name$PNG_SUFFIX")
-      val temp = File(dir, "$name$TEMP_SUFFIX")
+      // Writer-unique, because the zero-downtime rollout puts two processes on this volume at once.
+      // A temp path shared by cache key lets one replica rename the inode while the other is still
+      // writing it, publishing a half-PNG under a name that claims to be complete — and a reader
+      // then promotes those bytes as a valid render.
+      val temp = File(dir, "$name.${writerId}-${tempSequence.incrementAndGet()}$TEMP_SUFFIX")
       try {
         temp.writeBytes(png)
         if (!temp.renameTo(target)) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCacheTest.kt
@@ -20,10 +20,13 @@ class CatalogThemeCacheTest {
     assertNull(cache.get("b"))
     assertContentEquals(byteArrayOf(1, 1, 1), cache.get("a"))
     assertContentEquals(byteArrayOf(3, 3, 3), cache.get("c"))
-    assertEquals(
-      CatalogRenderCacheSnapshot(entries = 2, bytes = 6, maxBytes = 6, evictions = 1),
-      cache.renderCacheSnapshot(),
-    )
+    // Occupancy only. The same snapshot also carries read counters, and asserting the whole object
+    // would make this eviction test fail whenever a read is added to it.
+    val snapshot = cache.renderCacheSnapshot()
+    assertEquals(2, snapshot.entries)
+    assertEquals(6, snapshot.bytes)
+    assertEquals(6, snapshot.maxBytes)
+    assertEquals(1, snapshot.evictions)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -69,12 +69,16 @@ class ThemeCachePersistenceTest {
   }
 
   @Test
-  fun `classpath order does not invent a new generation`() {
+  fun `classpath order is part of the generation, because precedence decides the pixels`() {
+    // When two entries carry the same class or resource the JVM resolves the earlier one, so the
+    // same jars in a different order can genuinely render differently. Hashing order-insensitively
+    // would let a render be reused from the wrong resolution order — a wrong pixel, where being
+    // order-sensitive costs at worst an unnecessary re-warm.
     val dir = tempDir()
     val one = jar(dir, "a.jar", "A")
     val two = jar(dir, "b.jar", "B")
 
-    assertEquals(fingerprint(listOf(one, two)), fingerprint(listOf(two, one)))
+    assertNotEquals(fingerprint(listOf(one, two)), fingerprint(listOf(two, one)))
   }
 
   @Test
@@ -129,6 +133,48 @@ class ThemeCachePersistenceTest {
     // One unknown module makes the whole multi-module generation unknown.
     assertNull(ThemeCacheFingerprint.combine(listOf("aaa", "")))
     assertNull(ThemeCacheFingerprint.combine(emptyList()))
+  }
+
+  @Test
+  fun `the catalog's own classes are fingerprinted, not just its framework dependencies`() {
+    // The collision this closes. `splitBundleRuntime` puts the bundle's own classes/ directory into
+    // `composeai.daemon.userClassDirs` and leaves `classpath` holding parent overlays and daemon
+    // sidecars only — so hashing `classpath` alone gave two catalog revisions with unchanged
+    // dependencies the SAME name, and the new revision would adopt the old one's pixels. That is
+    // exactly the failure this whole mechanism exists to prevent, and it is invisible from the
+    // parent classpath.
+    val dir = tempDir()
+    val framework = jar(dir, "compose-runtime.jar", "UNCHANGED")
+    val classes = File(dir, "classes").apply { mkdirs() }
+    jar(classes, "Buttons.class", "revision-1")
+
+    fun fingerprintNow() =
+      fingerprint(
+        ThemeCacheFingerprint.renderedClasspath(
+          classpath = listOf(framework.absolutePath),
+          systemProperties =
+            mapOf(ThemeCacheFingerprint.USER_CLASS_DIRS_PROPERTY to classes.absolutePath),
+        )
+      )
+
+    val before = fingerprintNow()
+    jar(classes, "Buttons.class", "revision-2")
+
+    assertNotEquals(before, fingerprintNow(), "a catalog code change must be a new generation")
+  }
+
+  @Test
+  fun `a descriptor with no user classpath still fingerprints its parent classpath`() {
+    val dir = tempDir()
+    val framework = jar(dir, "compose-runtime.jar", "DEPS")
+
+    val resolved =
+      ThemeCacheFingerprint.renderedClasspath(
+        classpath = listOf(framework.absolutePath),
+        systemProperties = emptyMap(),
+      )
+
+    assertEquals(listOf(framework), resolved)
   }
 
   // ---- store ----------------------------------------------------------------------------------
@@ -298,6 +344,114 @@ class ThemeCachePersistenceTest {
 
     assertTrue(cache.verifySample { null })
     assertEquals(1, cache.snapshot().cached)
+  }
+
+  @Test
+  fun `only configured targets are written to disk`() {
+    // `put` also takes foreground renders with arbitrary overrides — widths, locales, devices, knob
+    // values — and those are unbounded where `previews × declaredThemes` is not. Since a live
+    // generation is never evicted to honour the cap, persisting them would let a visitor on a
+    // public
+    // box grow the store until the volume filled.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("declared-theme"))
+
+    cache.put("declared-theme", byteArrayOf(1))
+    cache.put("ad-hoc?width=999&locale=fr", byteArrayOf(2))
+
+    assertTrue(generation.contains("declared-theme"))
+    assertFalse(
+      generation.contains("ad-hoc?width=999&locale=fr"),
+      "an arbitrary override render must not reach the durable tier",
+    )
+    // It is still served from memory, exactly as before persistence existed.
+    assertContentEquals(byteArrayOf(2), cache.get("ad-hoc?width=999&locale=fr"))
+  }
+
+  @Test
+  fun `a render too large for the memory window is still persisted`() {
+    // The disk tier has its own budget and is the authoritative store behind a deliberately smaller
+    // memory window. Gating the durable write on the memory cap made a small-memory deployment
+    // silently re-render everything after each restart.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(maxBytes = 8, persistence = generation)
+    cache.configureTargets(listOf("big"))
+
+    cache.put("big", ByteArray(64) { 3 })
+
+    assertTrue(generation.contains("big"))
+    assertEquals(1, cache.snapshot().cached)
+    assertContentEquals(ByteArray(64) { 3 }, cache.get("big"))
+  }
+
+  @Test
+  fun `a discarded generation can still be rebuilt`() {
+    // Discarding deletes the stale PNGs but must leave a writable directory: the same Generation
+    // stays attached to the live cache, and if its directory vanished every later write would fail
+    // silently and the catalog would re-render into memory alone, losing it all again at restart.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("one"))
+    cache.put("one", byteArrayOf(1))
+
+    assertFalse(cache.verifySample { byteArrayOf(99) })
+
+    cache.put("one", byteArrayOf(42))
+    assertTrue(generation.contains("one"), "the generation must accept writes again")
+    assertContentEquals(
+      byteArrayOf(42),
+      ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!.get("one"),
+    )
+  }
+
+  @Test
+  fun `a system absent from the live set keeps its generations`() {
+    // A catalog whose load failed this pass — a transient fetch error, a shutdown before the loader
+    // reached it — has no live generation. Sweeping it would make the refresher's later success
+    // restart ~28 hours of warming, punishing a catalog for a network blip.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val store = ThemeCacheStore(root)
+    store.open("m3-catalog", fp, inputs(fp))!!.put("k", ByteArray(32))
+    store.open("did-not-load", fp, inputs(fp))!!.put("k", ByteArray(32))
+
+    val result =
+      store.sweep(
+        setOf(ThemeCacheStore.GenerationId("m3-catalog", fp)),
+        onlySystems = setOf("m3-catalog"),
+      )
+
+    assertEquals(0, result.deletedGenerations)
+    assertTrue(store.open("did-not-load", fp, inputs(fp))!!.contains("k"))
+  }
+
+  @Test
+  fun `a superseded generation of a loaded system is still reclaimed`() {
+    // The other half of the same rule: scoping the sweep to loaded systems must not stop it
+    // reclaiming that system's own previous fingerprint, or a branch regenerating several times a
+    // day accumulates generations until the volume fills.
+    val root = tempDir()
+    val old = "a".repeat(64)
+    val new = "b".repeat(64)
+    val store = ThemeCacheStore(root)
+    store.open("m3-catalog", old, inputs(old))!!.put("k", ByteArray(32))
+    store.open("m3-catalog", new, inputs(new))!!.put("k", ByteArray(32))
+
+    val result =
+      store.sweep(
+        setOf(ThemeCacheStore.GenerationId("m3-catalog", new)),
+        onlySystems = setOf("m3-catalog"),
+      )
+
+    assertEquals(1, result.deletedGenerations)
+    assertEquals(0, ThemeCacheStore(root).open("m3-catalog", old, inputs(old))!!.loadedEntries)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -221,6 +221,40 @@ class ThemeCachePersistenceTest {
     )
   }
 
+  @Test
+  fun `render-affecting system properties are part of the generation, but their paths are not`() {
+    // Excluding the whole system-property map was the same mistake as excluding the user classpath:
+    // most of it is staging paths that churn every load, but `composeai.fonts.offline` and the
+    // Android launch's `robolectric.*` settings genuinely change what the renderer produces —
+    // offline font resolution substitutes fallback glyphs for downloaded faces.
+    val online = mapOf("composeai.fonts.offline" to "false")
+    val offline = mapOf("composeai.fonts.offline" to "true")
+
+    assertNotEquals(
+      ThemeCacheFingerprint.renderConfig(online, emptyList()),
+      ThemeCacheFingerprint.renderConfig(offline, emptyList()),
+    )
+
+    // A path-valued property is churn, not configuration: its directory moves every load, and where
+    // its contents matter they are hashed as classpath entries instead.
+    val stagedHere = mapOf("composeai.fonts.cacheDir" to "${File.separator}tmp${File.separator}a")
+    val stagedThere = mapOf("composeai.fonts.cacheDir" to "${File.separator}tmp${File.separator}b")
+    assertEquals(
+      ThemeCacheFingerprint.renderConfig(stagedHere, emptyList()),
+      ThemeCacheFingerprint.renderConfig(stagedThere, emptyList()),
+    )
+  }
+
+  @Test
+  fun `render config ignores the order settings arrive in`() {
+    val one =
+      ThemeCacheFingerprint.renderConfig(mapOf("a" to "1", "b" to "2"), listOf("-Xmx1g", "-Xss2m"))
+    val two =
+      ThemeCacheFingerprint.renderConfig(mapOf("b" to "2", "a" to "1"), listOf("-Xss2m", "-Xmx1g"))
+
+    assertEquals(one, two)
+  }
+
   // ---- store ----------------------------------------------------------------------------------
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -316,6 +316,67 @@ class ThemeCachePersistenceTest {
   }
 
   @Test
+  fun `adopted renders are withheld from reads until verification settles`() {
+    // Verification is asynchronous — it needs a lane and a warm daemon — so between adopting a
+    // generation and checking it there is a window where the fingerprint might be wrong. Serving
+    // those bytes in that window is the one thing the safety check exists to prevent, and traffic
+    // can hold the window open by keeping the box non-idle.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.also { it.put("one", byteArrayOf(1)) }
+
+    // A NEW process adopts that generation.
+    val adopted = store(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = adopted)
+    cache.configurePersistable(listOf("one"))
+
+    assertNull(cache.get("one"), "an unverified adopted render must not be served")
+    // But it still counts as warm, so the optimizer does not re-render what is already on disk.
+    assertTrue(cache.contains("one"))
+
+    assertEquals(CatalogThemeCache.VerifyOutcome.VERIFIED, cache.verifySample { byteArrayOf(1) })
+    assertContentEquals(byteArrayOf(1), cache.get("one"))
+  }
+
+  @Test
+  fun `a cache that adopted nothing serves its own renders immediately`() {
+    // The quarantine must not cost anything on a cold generation: there is nothing to distrust when
+    // every entry was rendered by this process.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val cache = CatalogThemeCache(persistence = store(root).open("m3-catalog", fp, inputs(fp))!!)
+    cache.configurePersistable(listOf("one"))
+
+    cache.put("one", byteArrayOf(7))
+
+    assertContentEquals(byteArrayOf(7), cache.get("one"))
+  }
+
+  @Test
+  fun `concurrent writers do not share a temporary file`() {
+    // The zero-downtime rollout puts two processes on this volume at once. A temp path shared by
+    // cache key lets one replica rename the inode while the other is still writing it, publishing a
+    // half-PNG under a name that claims to be complete.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val one = store(root).open("m3-catalog", fp, inputs(fp))!!
+    val two = store(root).open("m3-catalog", fp, inputs(fp))!!
+    val payload = ByteArray(64) { 5 }
+
+    val threads =
+      listOf(one, two).map { generation ->
+        Thread { repeat(20) { generation.put("shared-key", payload) } }.also(Thread::start)
+      }
+    threads.forEach { it.join(10_000) }
+
+    assertContentEquals(payload, store(root).open("m3-catalog", fp, inputs(fp))!!.get("shared-key"))
+    // No temp files left behind under either writer's name.
+    val leftovers =
+      File(File(root, "m3-catalog"), fp).listFiles()?.filter { it.name.endsWith(".tmp") }.orEmpty()
+    assertEquals(emptyList(), leftovers)
+  }
+
+  @Test
   fun `a different generation cannot read the previous one's renders`() {
     val root = tempDir()
     val old = "a".repeat(64)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -185,7 +185,7 @@ class ThemeCachePersistenceTest {
     // renders it does get are most worth keeping.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configurePersistable(listOf("declared-theme"))
 
@@ -223,6 +223,16 @@ class ThemeCachePersistenceTest {
 
   // ---- store ----------------------------------------------------------------------------------
 
+  /**
+   * A store whose sweep grace window is disabled, so a test can assert reclamation directly.
+   *
+   * Production keeps a grace window for the zero-downtime rollout case — see the dedicated test
+   * below — but every other assertion here is about what the sweep decides, not about how long it
+   * waits to decide it.
+   */
+  private fun store(root: File, maxBytes: Long = ThemeCacheStore.DEFAULT_MAX_BYTES) =
+    ThemeCacheStore(root, maxBytes = maxBytes, graceMillis = 0)
+
   private fun inputs(fingerprint: String) =
     GenerationInputs(
       system = "m3-catalog",
@@ -233,15 +243,73 @@ class ThemeCachePersistenceTest {
     )
 
   @Test
+  fun `a generation young enough to belong to another replica is not reclaimed`() {
+    // The image deployment rolls out zero-downtime: a new replica boots beside the running one on
+    // the same volume and sees the old one's generations as unreferenced. Sweeping them would
+    // delete
+    // a possibly 28-hour cache belonging to the replica still serving production — and still
+    // serving
+    // it if the new replica fails readiness.
+    val root = tempDir()
+    val theirs = "a".repeat(64)
+    val ours = "b".repeat(64)
+    var now = 1_000_000L
+    val rolling = ThemeCacheStore(root, graceMillis = 60 * 60_000, clock = { now })
+    rolling.open("m3-catalog", theirs, inputs(theirs))!!.put("k", ByteArray(32))
+    rolling.open("m3-catalog", ours, inputs(ours))!!.put("k", ByteArray(32))
+
+    val during =
+      rolling.sweep(
+        setOf(ThemeCacheStore.GenerationId("m3-catalog", ours)),
+        onlySystems = setOf("m3-catalog"),
+      )
+    assertEquals(0, during.deletedGenerations, "the other replica's cache must survive the rollout")
+
+    // Once the window has passed there is no replica left that could be using it.
+    now += 2 * 60 * 60_000
+    val after =
+      rolling.sweep(
+        setOf(ThemeCacheStore.GenerationId("m3-catalog", ours)),
+        onlySystems = setOf("m3-catalog"),
+      )
+    assertEquals(1, after.deletedGenerations)
+  }
+
+  @Test
+  fun `captured IR payloads are part of the generation`() {
+    // A bundle can regenerate a Remote Compose / protolayout capture without touching a class. The
+    // daemon renders FROM those bytes, and they arrive as system-property paths rather than
+    // classpath entries — so anything reading only the classpath calls two different scenes one
+    // generation.
+    val dir = tempDir()
+    val jarFile = jar(dir, "catalog.jar", "UNCHANGED")
+    val ir = File(dir, "ir").apply { mkdirs() }
+    jar(ir, "scene.rc", "capture-1")
+
+    fun fingerprintNow() =
+      fingerprint(
+        ThemeCacheFingerprint.renderedClasspath(
+          classpath = listOf(jarFile.absolutePath),
+          systemProperties = mapOf(ThemeCacheFingerprint.PAYLOAD_PROPERTIES[0] to ir.absolutePath),
+        )
+      )
+
+    val before = fingerprintNow()
+    jar(ir, "scene.rc", "capture-2")
+
+    assertNotEquals(before, fingerprintNow(), "a regenerated capture must be a new generation")
+  }
+
+  @Test
   fun `a render written by one process is read by the next`() {
     // The whole point: a server restart is a new process over the same disk.
     val root = tempDir()
     val fp = "a".repeat(64)
 
-    val first = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val first = store(root).open("m3-catalog", fp, inputs(fp))!!
     first.put("button-filled__brand", byteArrayOf(1, 2, 3))
 
-    val second = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val second = store(root).open("m3-catalog", fp, inputs(fp))!!
     assertEquals(1, second.loadedEntries)
     assertTrue(second.contains("button-filled__brand"))
     assertContentEquals(byteArrayOf(1, 2, 3), second.get("button-filled__brand"))
@@ -252,9 +320,9 @@ class ThemeCachePersistenceTest {
     val root = tempDir()
     val old = "a".repeat(64)
     val new = "b".repeat(64)
-    ThemeCacheStore(root).open("m3-catalog", old, inputs(old))!!.put("k", byteArrayOf(9))
+    store(root).open("m3-catalog", old, inputs(old))!!.put("k", byteArrayOf(9))
 
-    val fresh = ThemeCacheStore(root).open("m3-catalog", new, inputs(new))!!
+    val fresh = store(root).open("m3-catalog", new, inputs(new))!!
 
     assertEquals(0, fresh.loadedEntries)
     assertNull(fresh.get("k"), "a new fingerprint must start clean, not inherit")
@@ -264,7 +332,7 @@ class ThemeCachePersistenceTest {
   fun `two catalogs with identical keys do not share renders`() {
     val root = tempDir()
     val fp = "c".repeat(64)
-    val store = ThemeCacheStore(root)
+    val store = store(root)
     store.open("m3-catalog", fp, inputs(fp))!!.put("shared-key", byteArrayOf(1))
 
     assertNull(store.open("wear-m3", fp, inputs(fp))!!.get("shared-key"))
@@ -275,7 +343,7 @@ class ThemeCachePersistenceTest {
     val root = tempDir()
     val live = "a".repeat(64)
     val dead = "b".repeat(64)
-    val store = ThemeCacheStore(root)
+    val store = store(root)
     store.open("m3-catalog", live, inputs(live))!!.put("k", ByteArray(64))
     store.open("m3-catalog", dead, inputs(dead))!!.put("k", ByteArray(64))
 
@@ -294,7 +362,7 @@ class ThemeCachePersistenceTest {
     // making no progress.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val store = ThemeCacheStore(root, maxBytes = 1)
+    val store = store(root, maxBytes = 1)
     store.open("m3-catalog", fp, inputs(fp))!!.put("k", ByteArray(4096))
 
     val result = store.sweep(setOf(ThemeCacheStore.GenerationId("m3-catalog", fp)))
@@ -325,7 +393,7 @@ class ThemeCachePersistenceTest {
     // was already on disk.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     // A memory tier far too small to hold both entries.
     val cache = CatalogThemeCache(maxBytes = 128, persistence = generation)
     cache.configureTargets(listOf("one", "two"))
@@ -348,7 +416,7 @@ class ThemeCachePersistenceTest {
     // the same identity that just proved untrustworthy.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one", "two"))
     cache.put("one", byteArrayOf(1))
@@ -365,7 +433,7 @@ class ThemeCachePersistenceTest {
   fun `verification keeps a generation whose renders still match`() {
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(7))
@@ -381,7 +449,7 @@ class ThemeCachePersistenceTest {
     // whole change exists to prevent.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(7))
@@ -403,7 +471,7 @@ class ThemeCachePersistenceTest {
     // box grow the store until the volume filled.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("declared-theme"))
 
@@ -426,7 +494,7 @@ class ThemeCachePersistenceTest {
     // silently re-render everything after each restart.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(maxBytes = 8, persistence = generation)
     cache.configureTargets(listOf("big"))
 
@@ -444,7 +512,7 @@ class ThemeCachePersistenceTest {
     // silently and the catalog would re-render into memory alone, losing it all again at restart.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(1))
@@ -455,7 +523,7 @@ class ThemeCachePersistenceTest {
     assertTrue(generation.contains("one"), "the generation must accept writes again")
     assertContentEquals(
       byteArrayOf(42),
-      ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!.get("one"),
+      store(root).open("m3-catalog", fp, inputs(fp))!!.get("one"),
     )
   }
 
@@ -466,7 +534,7 @@ class ThemeCachePersistenceTest {
     // restart ~28 hours of warming, punishing a catalog for a network blip.
     val root = tempDir()
     val fp = "a".repeat(64)
-    val store = ThemeCacheStore(root)
+    val store = store(root)
     store.open("m3-catalog", fp, inputs(fp))!!.put("k", ByteArray(32))
     store.open("did-not-load", fp, inputs(fp))!!.put("k", ByteArray(32))
 
@@ -488,7 +556,7 @@ class ThemeCachePersistenceTest {
     val root = tempDir()
     val old = "a".repeat(64)
     val new = "b".repeat(64)
-    val store = ThemeCacheStore(root)
+    val store = store(root)
     store.open("m3-catalog", old, inputs(old))!!.put("k", ByteArray(32))
     store.open("m3-catalog", new, inputs(new))!!.put("k", ByteArray(32))
 
@@ -499,7 +567,7 @@ class ThemeCachePersistenceTest {
       )
 
     assertEquals(1, result.deletedGenerations)
-    assertEquals(0, ThemeCacheStore(root).open("m3-catalog", old, inputs(old))!!.loadedEntries)
+    assertEquals(0, store(root).open("m3-catalog", old, inputs(old))!!.loadedEntries)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -478,6 +478,72 @@ class ThemeCachePersistenceTest {
     assertNull(store.open("m3/catalog", fp, inputs(fp)))
   }
 
+  @Test
+  fun `verification cannot be satisfied by renders this process just made`() {
+    // On a partly warmed restart, foreground traffic persists missing keys before the idle
+    // verification task runs. Sampling those would let five fresh renders "verify" a generation
+    // whose adopted bytes were never looked at — the cache vouching for itself.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("adopted", byteArrayOf(1))
+
+    val cache = CatalogThemeCache(persistence = store(root).open("m3-catalog", fp, inputs(fp))!!)
+    cache.configurePersistable(listOf("adopted", "fresh-a", "fresh-b"))
+    cache.put("fresh-a", byteArrayOf(2))
+    cache.put("fresh-b", byteArrayOf(3))
+
+    // A renderer that answers only for this process's own keys establishes nothing.
+    val outcome = cache.verifySample { key -> if (key == "adopted") null else byteArrayOf(9) }
+    assertEquals(CatalogThemeCache.VerifyOutcome.NO_EVIDENCE, outcome)
+    assertNull(cache.get("adopted"), "the adopted entry stays quarantined")
+  }
+
+  @Test
+  fun `a fresh render replaces the quarantined copy on disk`() {
+    // While quarantined a foreground request misses the adopted copy and renders fresh bytes. If
+    // the
+    // stale PNG stayed on disk, verification passing on OTHER keys would expose it again the moment
+    // the fresh copy fell out of the memory tier.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(1))
+
+    val cache = CatalogThemeCache(persistence = store(root).open("m3-catalog", fp, inputs(fp))!!)
+    cache.configurePersistable(listOf("one"))
+    cache.put("one", byteArrayOf(42))
+
+    // The durable copy is the fresh one, as seen by a later process.
+    assertContentEquals(
+      byteArrayOf(42),
+      store(root).open("m3-catalog", fp, inputs(fp))!!.get("one"),
+    )
+  }
+
+  @Test
+  fun `a discard that cannot delete everything reports failure`() {
+    // A partial discard leaves stale PNGs under a fingerprint this process has already decided it
+    // cannot trust, and the next restart adopts them again — reproducing the mismatch indefinitely.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
+    generation.put("one", byteArrayOf(1))
+    val dir = File(File(root, "m3-catalog"), fp)
+
+    assertTrue(generation.discard(), "an ordinary discard succeeds")
+
+    // Now make the directory unwritable so the next discard cannot remove its contents. Skipped
+    // where the filesystem does not enforce it — running as root, as CI containers do, deletes
+    // happily from a read-only directory and the assertion would test nothing.
+    generation.put("two", byteArrayOf(2))
+    val enforced =
+      dir.setWritable(false) &&
+        !File(dir, "probe").let { it.createNewFile().also { _ -> it.delete() } }
+    if (enforced) {
+      assertFalse(generation.discard(), "an incomplete discard must not report success")
+    }
+    dir.setWritable(true)
+  }
+
   // ---- two-tier cache -------------------------------------------------------------------------
 
   @Test
@@ -511,11 +577,15 @@ class ThemeCachePersistenceTest {
     // the same identity that just proved untrustworthy.
     val root = tempDir()
     val fp = "a".repeat(64)
+    // Written by one process...
+    store(root).open("m3-catalog", fp, inputs(fp))!!.also {
+      it.put("one", byteArrayOf(1))
+      it.put("two", byteArrayOf(2))
+    }
+    // ...and adopted by the next, which is the only case verification speaks to.
     val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one", "two"))
-    cache.put("one", byteArrayOf(1))
-    cache.put("two", byteArrayOf(2))
 
     val outcome = cache.verifySample { byteArrayOf(99) }
 
@@ -528,10 +598,10 @@ class ThemeCachePersistenceTest {
   fun `verification keeps a generation whose renders still match`() {
     val root = tempDir()
     val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(7))
     val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
-    cache.put("one", byteArrayOf(7))
 
     assertEquals(CatalogThemeCache.VerifyOutcome.VERIFIED, cache.verifySample { byteArrayOf(7) })
     assertEquals(1, cache.snapshot().cached)
@@ -544,10 +614,10 @@ class ThemeCachePersistenceTest {
     // whole change exists to prevent.
     val root = tempDir()
     val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(7))
     val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
-    cache.put("one", byteArrayOf(7))
 
     assertEquals(
       CatalogThemeCache.VerifyOutcome.NO_EVIDENCE,
@@ -607,10 +677,10 @@ class ThemeCachePersistenceTest {
     // silently and the catalog would re-render into memory alone, losing it all again at restart.
     val root = tempDir()
     val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(1))
     val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
     val cache = CatalogThemeCache(persistence = generation)
     cache.configureTargets(listOf("one"))
-    cache.put("one", byteArrayOf(1))
 
     assertEquals(CatalogThemeCache.VerifyOutcome.MISMATCH, cache.verifySample { byteArrayOf(99) })
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -1,0 +1,320 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The disk tier for warmed theme renders, and the identity that decides when it may be read.
+ *
+ * The measurement this exists to make impossible again: `m3-catalog` needs ~28 hours of lane time
+ * to warm its 10,120 targets, and on 2026-08-17 its cache was dropped seven times — three
+ * delivery-branch regenerations and four server releases. It had never once had a window long
+ * enough to finish. Persistence only helps if the identity is right, so most of what is asserted
+ * here is about *when a generation must not be reused*.
+ */
+class ThemeCachePersistenceTest {
+
+  private val temps = mutableListOf<File>()
+
+  private fun tempDir(): File =
+    createTempDirectory("theme-cache-test").toFile().also { temps += it }
+
+  @AfterTest
+  fun cleanUp() {
+    temps.forEach { it.deleteRecursively() }
+  }
+
+  private fun jar(dir: File, name: String, content: String): File =
+    File(dir, name).apply {
+      parentFile.mkdirs()
+      writeText(content)
+    }
+
+  private fun fingerprint(
+    classpath: List<File>,
+    variant: String = "desktop",
+    version: String = "1.14.0",
+    renderConfig: String = "density=2",
+  ) = ThemeCacheFingerprint.of(classpath, variant, version, renderConfig)
+
+  // ---- fingerprint ----------------------------------------------------------------------------
+
+  @Test
+  fun `the same bytes staged in a different directory are the same generation`() {
+    // The property the whole design rests on. A catalog load stages its bundle into a fresh
+    // directory every time, so a fingerprint that looked at paths would call every load a new
+    // generation and persistence would buy exactly nothing.
+    val first = tempDir()
+    val second = tempDir()
+    val a = listOf(jar(first, "catalog.jar", "CLASSES"), jar(first, "compose.jar", "DEPS"))
+    val b = listOf(jar(second, "catalog.jar", "CLASSES"), jar(second, "compose.jar", "DEPS"))
+
+    assertEquals(fingerprint(a), fingerprint(b))
+  }
+
+  @Test
+  fun `a changed jar is a different generation`() {
+    val dir = tempDir()
+    val before = fingerprint(listOf(jar(dir, "catalog.jar", "v1")))
+    val after = fingerprint(listOf(jar(dir, "catalog.jar", "v2")))
+
+    assertNotEquals(before, after, "changed catalog code must not read a stale cache")
+  }
+
+  @Test
+  fun `classpath order does not invent a new generation`() {
+    val dir = tempDir()
+    val one = jar(dir, "a.jar", "A")
+    val two = jar(dir, "b.jar", "B")
+
+    assertEquals(fingerprint(listOf(one, two)), fingerprint(listOf(two, one)))
+  }
+
+  @Test
+  fun `renderer version, daemon variant and render config each change the generation`() {
+    val dir = tempDir()
+    val cp = listOf(jar(dir, "catalog.jar", "CLASSES"))
+    val base = fingerprint(cp)
+
+    // The version stands proxy for the whole container image — JVM, Skia, fonts — so a release must
+    // never read the previous release's pixels.
+    assertNotEquals(base, fingerprint(cp, version = "1.15.0"))
+    // Desktop and Android/Robolectric read the same classpath and do not agree pixel-for-pixel.
+    assertNotEquals(base, fingerprint(cp, variant = "android"))
+    // The inputs that never appear in a cache key, and are therefore the easiest to forget.
+    assertNotEquals(base, fingerprint(cp, renderConfig = "density=3"))
+  }
+
+  @Test
+  fun `an unreadable classpath declines to name the generation at all`() {
+    // Null means "do not persist". Inventing an identity for a classpath we could not read is how
+    // two different generations end up agreeing on a name, which is the origin of every wrong pixel
+    // this cache could serve.
+    val dir = tempDir()
+    assertNull(fingerprint(listOf(File(dir, "missing.jar"))))
+    assertNull(fingerprint(emptyList()))
+  }
+
+  @Test
+  fun `exploded class directories are hashed by content, not skipped`() {
+    // A from-source catalog puts a directory on the classpath. Skipping it would fingerprint the
+    // generation by its dependencies alone — so editing the catalog's own code would reuse the old
+    // renders.
+    val dir = tempDir()
+    val classes = File(dir, "classes").apply { mkdirs() }
+    jar(classes, "Button.class", "v1")
+    val before = fingerprint(listOf(classes))
+    jar(classes, "Button.class", "v2")
+
+    assertNotEquals(before, fingerprint(listOf(classes)))
+  }
+
+  @Test
+  fun `combining module fingerprints is order-independent and needs every part`() {
+    assertEquals(
+      ThemeCacheFingerprint.combine(listOf("aaa", "bbb")),
+      ThemeCacheFingerprint.combine(listOf("bbb", "aaa")),
+    )
+    assertNotEquals(
+      ThemeCacheFingerprint.combine(listOf("aaa", "bbb")),
+      ThemeCacheFingerprint.combine(listOf("aaa", "ccc")),
+    )
+    // One unknown module makes the whole multi-module generation unknown.
+    assertNull(ThemeCacheFingerprint.combine(listOf("aaa", "")))
+    assertNull(ThemeCacheFingerprint.combine(emptyList()))
+  }
+
+  // ---- store ----------------------------------------------------------------------------------
+
+  private fun inputs(fingerprint: String) =
+    GenerationInputs(
+      system = "m3-catalog",
+      fingerprint = fingerprint,
+      toolVersion = "1.14.0",
+      variant = "desktop",
+      renderConfig = "density=2",
+    )
+
+  @Test
+  fun `a render written by one process is read by the next`() {
+    // The whole point: a server restart is a new process over the same disk.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+
+    val first = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    first.put("button-filled__brand", byteArrayOf(1, 2, 3))
+
+    val second = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    assertEquals(1, second.loadedEntries)
+    assertTrue(second.contains("button-filled__brand"))
+    assertContentEquals(byteArrayOf(1, 2, 3), second.get("button-filled__brand"))
+  }
+
+  @Test
+  fun `a different generation cannot read the previous one's renders`() {
+    val root = tempDir()
+    val old = "a".repeat(64)
+    val new = "b".repeat(64)
+    ThemeCacheStore(root).open("m3-catalog", old, inputs(old))!!.put("k", byteArrayOf(9))
+
+    val fresh = ThemeCacheStore(root).open("m3-catalog", new, inputs(new))!!
+
+    assertEquals(0, fresh.loadedEntries)
+    assertNull(fresh.get("k"), "a new fingerprint must start clean, not inherit")
+  }
+
+  @Test
+  fun `two catalogs with identical keys do not share renders`() {
+    val root = tempDir()
+    val fp = "c".repeat(64)
+    val store = ThemeCacheStore(root)
+    store.open("m3-catalog", fp, inputs(fp))!!.put("shared-key", byteArrayOf(1))
+
+    assertNull(store.open("wear-m3", fp, inputs(fp))!!.get("shared-key"))
+  }
+
+  @Test
+  fun `sweeping reclaims dead generations and keeps the live one`() {
+    val root = tempDir()
+    val live = "a".repeat(64)
+    val dead = "b".repeat(64)
+    val store = ThemeCacheStore(root)
+    store.open("m3-catalog", live, inputs(live))!!.put("k", ByteArray(64))
+    store.open("m3-catalog", dead, inputs(dead))!!.put("k", ByteArray(64))
+
+    val result = store.sweep(setOf(ThemeCacheStore.GenerationId("m3-catalog", live)))
+
+    assertEquals(1, result.deletedGenerations)
+    assertTrue(result.reclaimedBytes > 0)
+    assertFalse(result.overCap)
+    assertTrue(store.open("m3-catalog", live, inputs(live))!!.contains("k"), "live must survive")
+  }
+
+  @Test
+  fun `a live set over the cap is reported, never evicted`() {
+    // Deleting what is currently being warmed to fit a cap turns the cap into a treadmill: the
+    // optimizer re-renders exactly what the sweep discarded, forever, and the box looks busy while
+    // making no progress.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val store = ThemeCacheStore(root, maxBytes = 1)
+    store.open("m3-catalog", fp, inputs(fp))!!.put("k", ByteArray(4096))
+
+    val result = store.sweep(setOf(ThemeCacheStore.GenerationId("m3-catalog", fp)))
+
+    assertTrue(result.overCap, "an operator must be told the cap is too small")
+    assertEquals(0, result.deletedGenerations)
+    assertTrue(store.open("m3-catalog", fp, inputs(fp))!!.contains("k"))
+  }
+
+  @Test
+  fun `a name that could escape the store root is refused, not sanitised`() {
+    // Rejected rather than rewritten: a silently sanitised name would let two catalogs collide on
+    // one generation, which is worse than not caching at all.
+    val store = ThemeCacheStore(tempDir())
+    val fp = "a".repeat(64)
+    assertNull(store.open("../escape", fp, inputs(fp)))
+    assertNull(store.open("m3-catalog", "../escape", inputs(fp)))
+    assertNull(store.open("m3/catalog", fp, inputs(fp)))
+  }
+
+  // ---- two-tier cache -------------------------------------------------------------------------
+
+  @Test
+  fun `a target evicted from memory still counts as cached while it is on disk`() {
+    // The reason `cached` asks both tiers. Memory is capped at 128 MB and a warmed m3-catalog is
+    // several times that, so counting memory alone would report a fully warmed catalog as partially
+    // cached the moment the window started evicting — and send the optimizer back to re-render what
+    // was already on disk.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    // A memory tier far too small to hold both entries.
+    val cache = CatalogThemeCache(maxBytes = 128, persistence = generation)
+    cache.configureTargets(listOf("one", "two"))
+
+    cache.put("one", ByteArray(100) { 1 })
+    cache.put("two", ByteArray(100) { 2 })
+
+    val snapshot = cache.snapshot()
+    assertEquals(2, snapshot.cached, "both targets are warm even though only one fits in memory")
+    assertTrue(snapshot.fullyOptimized)
+    assertEquals("complete", snapshot.state)
+    // And the evicted one still reads back, promoted from disk.
+    assertContentEquals(ByteArray(100) { 1 }, cache.get("one"))
+  }
+
+  @Test
+  fun `verification drops the whole generation when a cached render no longer matches`() {
+    // The safety net for the input nobody thought of. A mismatch means the fingerprint failed to
+    // capture something, so every entry under it is suspect — keeping the rest would be trusting
+    // the same identity that just proved untrustworthy.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("one", "two"))
+    cache.put("one", byteArrayOf(1))
+    cache.put("two", byteArrayOf(2))
+
+    val trustworthy = cache.verifySample { byteArrayOf(99) }
+
+    assertFalse(trustworthy)
+    assertEquals(0, cache.snapshot().cached, "a failed verification leaves nothing behind")
+    assertNull(cache.get("one"))
+  }
+
+  @Test
+  fun `verification keeps a generation whose renders still match`() {
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("one"))
+    cache.put("one", byteArrayOf(7))
+
+    assertTrue(cache.verifySample { byteArrayOf(7) })
+    assertEquals(1, cache.snapshot().cached)
+  }
+
+  @Test
+  fun `a daemon that cannot render verifies nothing rather than wiping the cache`() {
+    // A null render is "could not answer", not "answered differently". Treating the two alike would
+    // let a busy or cold daemon at startup throw away a fully warmed catalog — the exact loss this
+    // whole change exists to prevent.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("one"))
+    cache.put("one", byteArrayOf(7))
+
+    assertTrue(cache.verifySample { null })
+    assertEquals(1, cache.snapshot().cached)
+  }
+
+  @Test
+  fun `a cache with no disk tier behaves exactly as it did before`() {
+    val cache = CatalogThemeCache()
+    cache.configureTargets(listOf("one"))
+    cache.put("one", byteArrayOf(1))
+
+    assertTrue(
+      cache.verifySample { byteArrayOf(99) },
+      "nothing persisted means nothing to distrust",
+    )
+    assertEquals(1, cache.snapshot().cached)
+  }
+}
+
+private fun assertContentEquals(expected: ByteArray, actual: ByteArray?) {
+  kotlin.test.assertNotNull(actual)
+  kotlin.test.assertTrue(expected.contentEquals(actual), "byte contents differ")
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -177,6 +177,50 @@ class ThemeCachePersistenceTest {
     assertEquals(listOf(framework), resolved)
   }
 
+  @Test
+  fun `declared themes persist even when the eager optimizer pass is switched off`() {
+    // With `-Dcomposeai.serve.themeOptimization=false` the pass never declares its targets, so
+    // gating persistence on the target set refused every render a visitor actually asked for and
+    // each restart began again — persistence doing nothing on precisely the configuration where the
+    // renders it does get are most worth keeping.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    val generation = ThemeCacheStore(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configurePersistable(listOf("declared-theme"))
+
+    cache.put("declared-theme", byteArrayOf(5))
+
+    assertTrue(generation.contains("declared-theme"))
+    // And no optimization row is claimed, which is what a disabled pass should report.
+    assertNull(cache.snapshot().takeIf { it.total > 0 })
+  }
+
+  @Test
+  fun `the alias routing is part of the generation`() {
+    // Persisted keys name the published catalog id, but a render resolves it through the alias map
+    // first. A delivery-branch update can repoint an id at a different daemon preview while
+    // shipping
+    // a byte-identical bundle — same classpath, same key, different pixels.
+    val dir = tempDir()
+    val cp = listOf(jar(dir, "catalog.jar", "CLASSES"))
+    fun fp(alias: Map<String, String>) =
+      ThemeCacheFingerprint.of(
+        cp,
+        variant = "desktop",
+        toolVersion = "1.14.0",
+        renderConfig = "density=2",
+        routing = ThemeCacheFingerprint.routingDigest(alias),
+      )
+
+    assertNotEquals(fp(mapOf("button" to "daemon-a")), fp(mapOf("button" to "daemon-b")))
+    assertEquals(
+      fp(mapOf("a" to "x", "b" to "y")),
+      fp(mapOf("b" to "y", "a" to "x")),
+      "map iteration order is not part of what the routing means",
+    )
+  }
+
   // ---- store ----------------------------------------------------------------------------------
 
   private fun inputs(fingerprint: String) =
@@ -310,9 +354,9 @@ class ThemeCachePersistenceTest {
     cache.put("one", byteArrayOf(1))
     cache.put("two", byteArrayOf(2))
 
-    val trustworthy = cache.verifySample { byteArrayOf(99) }
+    val outcome = cache.verifySample { byteArrayOf(99) }
 
-    assertFalse(trustworthy)
+    assertEquals(CatalogThemeCache.VerifyOutcome.MISMATCH, outcome)
     assertEquals(0, cache.snapshot().cached, "a failed verification leaves nothing behind")
     assertNull(cache.get("one"))
   }
@@ -326,7 +370,7 @@ class ThemeCachePersistenceTest {
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(7))
 
-    assertTrue(cache.verifySample { byteArrayOf(7) })
+    assertEquals(CatalogThemeCache.VerifyOutcome.VERIFIED, cache.verifySample { byteArrayOf(7) })
     assertEquals(1, cache.snapshot().cached)
   }
 
@@ -342,7 +386,11 @@ class ThemeCachePersistenceTest {
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(7))
 
-    assertTrue(cache.verifySample { null })
+    assertEquals(
+      CatalogThemeCache.VerifyOutcome.NO_EVIDENCE,
+      cache.verifySample { null },
+      "a daemon that cannot answer leaves the question open, it does not settle it",
+    )
     assertEquals(1, cache.snapshot().cached)
   }
 
@@ -401,7 +449,7 @@ class ThemeCachePersistenceTest {
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(1))
 
-    assertFalse(cache.verifySample { byteArrayOf(99) })
+    assertEquals(CatalogThemeCache.VerifyOutcome.MISMATCH, cache.verifySample { byteArrayOf(99) })
 
     cache.put("one", byteArrayOf(42))
     assertTrue(generation.contains("one"), "the generation must accept writes again")
@@ -460,7 +508,8 @@ class ThemeCachePersistenceTest {
     cache.configureTargets(listOf("one"))
     cache.put("one", byteArrayOf(1))
 
-    assertTrue(
+    assertEquals(
+      CatalogThemeCache.VerifyOutcome.NOTHING_TO_VERIFY,
       cache.verifySample { byteArrayOf(99) },
       "nothing persisted means nothing to distrust",
     )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -763,6 +763,119 @@ class ThemeCachePersistenceTest {
     )
     assertEquals(1, cache.snapshot().cached)
   }
+
+  @Test
+  fun `read counters separate a cache that is used from one that is only filled`() {
+    // A cache that fills and a cache that fills and is never read report identical occupancy, and
+    // with a disk tier the second costs I/O on every render to buy nothing. These are the counters
+    // that tell them apart.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("warm", byteArrayOf(1))
+
+    val cache = CatalogThemeCache(persistence = store(root).open("m3-catalog", fp, inputs(fp))!!)
+    cache.configurePersistable(listOf("warm", "fresh"))
+    // Settle the quarantine so the adopted entry is readable — see the withheld test below for the
+    // window before this happens.
+    cache.verifySample { byteArrayOf(1) }
+
+    assertNull(cache.get("cold"), "never rendered, in neither tier")
+    assertContentEquals(byteArrayOf(1), cache.get("warm")) // disk, then promoted to memory
+    assertContentEquals(byteArrayOf(1), cache.get("warm")) // memory
+
+    val snapshot = cache.renderCacheSnapshot()
+    assertEquals(1, snapshot.diskHits)
+    assertEquals(1, snapshot.memoryHits)
+    assertEquals(1, snapshot.misses)
+    assertEquals(2.0 / 3, snapshot.hitRate)
+  }
+
+  @Test
+  fun `a read withheld by the quarantine is not counted as a miss`() {
+    // Withheld reads can outnumber real misses during a cold start, and folding them into `misses`
+    // would report the cache as failing at exactly the moment it is being deliberately careful.
+    val root = tempDir()
+    val fp = "a".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(1))
+
+    val cache = CatalogThemeCache(persistence = store(root).open("m3-catalog", fp, inputs(fp))!!)
+    cache.configurePersistable(listOf("one"))
+
+    assertNull(cache.get("one"))
+
+    val snapshot = cache.renderCacheSnapshot()
+    assertEquals(1, snapshot.withheld)
+    assertEquals(0, snapshot.misses)
+    assertNull(snapshot.hitRate, "no read has been answered either way yet")
+  }
+
+  @Test
+  fun `the disk tier reports what it adopted, so a key that moved is visible`() {
+    // `adopted` is the only evidence that persistence carried anything across a process boundary.
+    // A restart onto a fingerprint that moved adopts nothing and writes everything again, which is
+    // indistinguishable from a working cache in every other counter.
+    val root = tempDir()
+    val stable = "a".repeat(64)
+    val moved = "b".repeat(64)
+
+    val first =
+      CatalogThemeCache(persistence = store(root).open("m3-catalog", stable, inputs(stable))!!)
+    first.configurePersistable(listOf("one"))
+    first.put("one", byteArrayOf(1))
+    assertEquals(0, first.renderCacheSnapshot().persisted?.adopted)
+    assertEquals(1, first.renderCacheSnapshot().persisted?.writes)
+
+    val restarted =
+      CatalogThemeCache(persistence = store(root).open("m3-catalog", stable, inputs(stable))!!)
+    assertEquals(1, restarted.renderCacheSnapshot().persisted?.adopted)
+    assertEquals(stable, restarted.renderCacheSnapshot().persisted?.fingerprint)
+
+    val churned =
+      CatalogThemeCache(persistence = store(root).open("m3-catalog", moved, inputs(moved))!!)
+    assertEquals(
+      0,
+      churned.renderCacheSnapshot().persisted?.adopted,
+      "a fingerprint that moved adopts nothing — the case worth being able to see",
+    )
+  }
+
+  @Test
+  fun `a catalog that fell back to memory-only says why`() {
+    // Every reason a catalog loses its disk tier used to look identical to running the server
+    // without one, and all of them are permanent for the life of the host.
+    val silent = CatalogThemeCache()
+    assertNull(silent.renderCacheSnapshot().persistenceOff)
+
+    val explained = CatalogThemeCache(persistenceOffReason = "launch descriptor unreadable")
+    assertEquals("launch descriptor unreadable", explained.renderCacheSnapshot().persistenceOff)
+  }
+
+  @Test
+  fun `the census counts generations per system, so fingerprint churn is visible`() {
+    // Three generations for one catalog on a box that has only ever served it one way is churn, and
+    // churn reports itself as success in every other counter: writes climb, the volume fills, and
+    // nothing is ever adopted.
+    val root = tempDir()
+    var now = 1_000_000L
+    val churning = ThemeCacheStore(root, graceMillis = 60 * 60_000, clock = { now })
+    for (fp in listOf("a", "b", "c")) {
+      churning.open("m3-catalog", fp.repeat(64), inputs(fp.repeat(64)))!!.put("k", ByteArray(8))
+    }
+    churning.open("meshcore", "d".repeat(64), inputs("d".repeat(64)))!!.put("k", ByteArray(8))
+
+    churning.sweep(
+      setOf(ThemeCacheStore.GenerationId("m3-catalog", "c".repeat(64))),
+      onlySystems = setOf("m3-catalog", "meshcore"),
+    )
+
+    val census = churning.snapshot().generationsBySystem
+    assertEquals(
+      3,
+      census["m3-catalog"],
+      "all three spared by the grace window, and all three real",
+    )
+    assertEquals(1, census["meshcore"])
+  }
 }
 
 private fun assertContentEquals(expected: ByteArray, actual: ByteArray?) {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -531,18 +531,32 @@ class ThemeCachePersistenceTest {
 
     assertTrue(generation.discard(), "an ordinary discard succeeds")
 
-    // Now make the directory unwritable so the next discard cannot remove its contents. Skipped
-    // where the filesystem does not enforce it — running as root, as CI containers do, deletes
-    // happily from a read-only directory and the assertion would test nothing.
+    // Now make the directory unwritable so the next discard cannot remove its contents.
     generation.put("two", byteArrayOf(2))
-    val enforced =
-      dir.setWritable(false) &&
-        !File(dir, "probe").let { it.createNewFile().also { _ -> it.delete() } }
-    if (enforced) {
+    if (!dir.setWritable(false)) return
+    try {
+      // Skipped where the filesystem does not actually enforce it: as root — which is how this
+      // container runs, though CI does not — a read-only directory still accepts deletes, and the
+      // assertion would pass without testing anything.
+      if (writable(dir)) return
       assertFalse(generation.discard(), "an incomplete discard must not report success")
+    } finally {
+      dir.setWritable(true)
     }
-    dir.setWritable(true)
   }
+
+  /**
+   * Whether [dir] genuinely accepts new files.
+   *
+   * `createNewFile` **throws** in a read-only directory rather than returning false, which is
+   * exactly how the first version of this test passed locally (as root, where the throw never
+   * happened) and failed on CI.
+   */
+  private fun writable(dir: File): Boolean = runCatching {
+    val probe = File(dir, "probe")
+    probe.createNewFile().also { created -> if (created) probe.delete() }
+  }
+    .getOrDefault(false)
 
   // ---- two-tier cache -------------------------------------------------------------------------
 

--- a/deploy/cloudrun/entrypoint.sh
+++ b/deploy/cloudrun/entrypoint.sh
@@ -75,6 +75,14 @@ fi
 [[ -n "${SERVE_CATALOGS_UNLISTED:-}" ]] && args+=(--catalogs-unlisted "${SERVE_CATALOGS_UNLISTED}")
 [[ -n "${SERVE_CATALOG_FEED_IDLE:-}" ]] &&
   args+=(--catalog-feed-idle-timeout "${SERVE_CATALOG_FEED_IDLE}")
+
+# Warmed theme renders survive a container recreation when this points at a mounted volume.
+# Defaults beside catalogs.json (/config/theme-cache) — the server declines to persist at all
+# rather than fall back to a temp dir, since a theme cache thrown away with the container costs
+# disk and render time to buy nothing.
+[[ -n "${SERVE_THEME_CACHE_DIR:-}" ]] && args+=(--theme-cache-dir "${SERVE_THEME_CACHE_DIR}")
+[[ -n "${SERVE_THEME_CACHE_MAX_BYTES:-}" ]] &&
+  args+=(--theme-cache-max-bytes "${SERVE_THEME_CACHE_MAX_BYTES}")
 # Top-level sites (<host>=<system>[,…]): one of the catalogs above, additionally served on a
 # hostname of its own where it looks like the only thing here. A routing view over the same
 # sessions — no extra catalog, no extra render.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -179,11 +179,17 @@ services:
       SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
       # RSS feed history work sleeps after this many seconds without a feed request. Empty ⇒ 7 days.
       SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
-      # Warmed theme renders (the per-catalog theme cache) persist across container recreation when
-      # this points at a mounted volume. Defaults to `none` — OFF — deliberately: an unset value
-      # would otherwise derive a directory beside catalogs.json, which here is the durable
-      # `preview_config` volume, and quietly grow an up-to-8-GB render cache on the volume an
-      # operator keeps their configuration in. Point it at a volume of its own to turn it on.
+      # Warmed theme renders (the per-catalog theme cache) survive container recreation, which is
+      # what the rolling update below performs — so a restart no longer discards hours of background
+      # warming. Set SERVE_THEME_CACHE_DIR=/theme-cache in .env to turn it on; it lands on the
+      # dedicated `preview_theme_cache` volume mounted below.
+      #
+      # Defaults to `none` — OFF — deliberately, on two counts. An unset value would derive a
+      # directory beside catalogs.json, which here is the durable `preview_config` volume, quietly
+      # growing an up-to-8-GB cache on the volume holding the operator's configuration. And the
+      # reuse rules are new: a generation is keyed by a fingerprint of everything that decides the
+      # pixels, and an input that fingerprint misses would serve stale renders, so the conservative
+      # first-release posture is opt-in.
       SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-none}"
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
@@ -223,6 +229,11 @@ services:
       # (`- ./catalogs.json:/config/catalogs.json`) to keep it in version control.
       # The same volume carries producers.json (the trust store) for the same reasons.
       - preview_config:/config
+      # Warmed theme renders, on a volume of their OWN — never on preview_config, which is where
+      # the catalog set and trust store live and must not be crowded out by an up-to-8-GB render
+      # cache. Mounted unconditionally so turning the cache on is a one-line .env change
+      # (SERVE_THEME_CACHE_DIR=/theme-cache); while it stays `none` the volume is simply empty.
+      - preview_theme_cache:/theme-cache
     # To also pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:
     #   - ./producers.json:/trust/producers.json:ro
@@ -370,6 +381,7 @@ services:
       com.centurylinklabs.watchtower.enable: "true"
 
 volumes:
+  preview_theme_cache:
   # Runtime download caches for `preview` (resolved live-bundle dep jars + fonts), kept across
   # image rolls so a freshly-rolled replica reuses them instead of re-downloading. See the
   # `preview` service's volumes block for why the baked android-all / ~/.m2 are excluded.

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -179,6 +179,11 @@ services:
       SERVE_CATALOG_REFRESH: "${SERVE_CATALOG_REFRESH:-}"
       # RSS feed history work sleeps after this many seconds without a feed request. Empty ⇒ 7 days.
       SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
+      # Warmed theme renders (the per-catalog theme cache) persist across container recreation when
+      # this points at a mounted volume. Unset means memory-only: the server declines to persist to
+      # a temp dir rather than spend disk and render time on a cache thrown away with the container.
+      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-}"
+      SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
       SERVE_ACCEPT_BUNDLES: "${SERVE_ACCEPT_BUNDLES:-}"
       SERVE_ACCEPT_BUNDLES_FROM: "${SERVE_ACCEPT_BUNDLES_FROM:-}"

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -180,9 +180,11 @@ services:
       # RSS feed history work sleeps after this many seconds without a feed request. Empty ⇒ 7 days.
       SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
       # Warmed theme renders (the per-catalog theme cache) persist across container recreation when
-      # this points at a mounted volume. Unset means memory-only: the server declines to persist to
-      # a temp dir rather than spend disk and render time on a cache thrown away with the container.
-      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-}"
+      # this points at a mounted volume. Defaults to `none` — OFF — deliberately: an unset value
+      # would otherwise derive a directory beside catalogs.json, which here is the durable
+      # `preview_config` volume, and quietly grow an up-to-8-GB render cache on the volume an
+      # operator keeps their configuration in. Point it at a volume of its own to turn it on.
+      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-none}"
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
       SERVE_ACCEPT_BUNDLES: "${SERVE_ACCEPT_BUNDLES:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -375,5 +375,13 @@ fi
 [[ -n "${SERVE_CATALOG_FEED_IDLE:-}" ]] &&
   args+=(--catalog-feed-idle-timeout "${SERVE_CATALOG_FEED_IDLE}")
 
+# Warmed theme renders survive a container recreation when this points at a mounted volume.
+# Defaults beside catalogs.json (/config/theme-cache) — the server declines to persist at all
+# rather than fall back to a temp dir, since a theme cache thrown away with the container costs
+# disk and render time to buy nothing.
+[[ -n "${SERVE_THEME_CACHE_DIR:-}" ]] && args+=(--theme-cache-dir "${SERVE_THEME_CACHE_DIR}")
+[[ -n "${SERVE_THEME_CACHE_MAX_BYTES:-}" ]] &&
+  args+=(--theme-cache-max-bytes "${SERVE_THEME_CACHE_MAX_BYTES}")
+
 echo "entrypoint: compose-preview serve on 0.0.0.0:${PORT}" >&2
 exec compose-preview "${args[@]}"

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -39,6 +39,11 @@ services:
       SERVE_CATALOGS: "${SERVE_CATALOGS:-}"
       SERVE_CATALOGS_UNLISTED: "${SERVE_CATALOGS_UNLISTED:-}"
       SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
+      # Warmed theme renders (the per-catalog theme cache) persist under /config/theme-cache, on the
+      # named volume below. Without it the cache is memory-only and every deploy starts from zero:
+      # m3-catalog needs ~28h of background rendering to warm its 10,120 targets, against a box that
+      # is redeployed and whose catalogs regenerate several times a day.
+      SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Top-level sites (<host>=<system>[,…]): serve one of the catalogs above on a hostname
       # of its own, where it presents as the whole server. Caddy in front must route the name
       # here; catalogs.json's "sites" is the durable form of the same setting.
@@ -70,6 +75,10 @@ services:
       - ../preview.coo.ee/producers.json:/config/producers.json:ro
       # Generated RSS plus the partial Git object cache survive preview-container recreation.
       - catalog_feed_cache:/config/catalog-feeds
+      # Warmed theme renders survive preview-container recreation, which is the whole point: the
+      # cache is keyed by a fingerprint of the classpath + renderer version, so a new catalog
+      # revision or a new server build simply writes a new generation and the stale ones are swept.
+      - theme_cache:/config/theme-cache
     expose:
       - "8080"
     # One warm Desktop daemon fits comfortably in a few GB; this cap just keeps a
@@ -100,5 +109,6 @@ services:
 
 volumes:
   catalog_feed_cache:
+  theme_cache:
   caddy_data:
   caddy_config:

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       # named volume below. Without it the cache is memory-only and every deploy starts from zero:
       # m3-catalog needs ~28h of background rendering to warm its 10,120 targets, against a box that
       # is redeployed and whose catalogs regenerate several times a day.
+      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-}"
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Top-level sites (<host>=<system>[,…]): serve one of the catalogs above on a hostname
       # of its own, where it presents as the whole server. Caddy in front must route the name

--- a/deploy/vps/docker-compose.yml
+++ b/deploy/vps/docker-compose.yml
@@ -43,7 +43,9 @@ services:
       # named volume below. Without it the cache is memory-only and every deploy starts from zero:
       # m3-catalog needs ~28h of background rendering to warm its 10,120 targets, against a box that
       # is redeployed and whose catalogs regenerate several times a day.
-      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-}"
+      # Explicit rather than derived: this box opts IN to the disk tier, and it goes on the
+      # dedicated theme_cache volume below, never on the config volume.
+      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-/config/theme-cache}"
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
       # Top-level sites (<host>=<system>[,…]): serve one of the catalogs above on a hostname
       # of its own, where it presents as the whole server. Caddy in front must route the name

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -678,8 +678,29 @@ SERVE_THEME_CACHE_DIR=/theme-cache
 
 A named volume is what survives the container recreation the rolling update performs — replicas
 overlap during that rollout and share the volume, which is why the sweeper spares generations young
-enough to belong to the outgoing replica. `/status.json` reports the tier as `themeCache` —
-generation count, bytes, hits and writes.
+enough to belong to the outgoing replica.
+
+#### Telling a working cache from write amplification
+
+A disk cache that is earning its keep and one that is doing I/O for nothing fill the volume at the
+same rate. `/status.json` publishes the counters that separate them, in two places.
+
+Store-wide, as `themeCache`: `generations`, `bytes`, `writes`, `hits`, `misses`, and
+`generationsBySystem`. That last one is the churn detector — a catalog the box has only ever served
+one way should have **one** generation on disk, and a count that climbs with every restart means
+some input the fingerprint reads is unstable, so each process writes a fresh generation that nobody
+will ever adopt.
+
+Per catalog, on the `renderCache` row:
+
+| field | what a bad value means |
+| --- | --- |
+| `hitRate`, `memoryHits`, `diskHits`, `misses` | hits over reads. A `hitRate` near zero with writes climbing is a cache nothing reads. |
+| `withheld` | reads refused because the generation was adopted but not yet verified. Excluded from `misses` and from `hitRate`, so a cold start's low numbers are explainable rather than alarming. |
+| `persisted.fingerprint` | the generation directory this catalog reads and writes. If it differs across two restarts that changed nothing, the **key** moved. |
+| `persisted.adopted` | renders already on disk when this process opened the generation — the only evidence anything survived the restart. `0` after a restart that should have found a warm generation is the failure. |
+| `persisted.writes` | renders written this process. Climbing while `adopted` stays `0` on every restart *is* the write-amplification case, stated in two numbers. |
+| `persistenceOff` | this catalog has no disk tier and why (`launch descriptor unreadable`, `fingerprint unavailable …`). Absent when the server simply was not given a cache directory. |
 
 The cache can also be filled **ahead of the first visitor** — an idle pass that walks each catalog's
 `previews × declaredThemes` set and renders the missing entries — but that pass is **off by

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -660,12 +660,26 @@ re-renders a small sample and compares it to what was adopted from disk. A misma
 whole generation — an input the fingerprint missed makes every entry under that name suspect. A
 daemon that cannot answer yet verifies nothing rather than discarding anything.
 
-There is deliberately **no temp-directory fallback**: a theme cache thrown away with the container
-would cost disk and render time to buy nothing, so where there is no durable location the server
-runs memory-only and says so. On the Compose stack that durable location is a named volume
-(`theme_cache:/config/theme-cache` in `deploy/vps/docker-compose.yml`), which is what survives the
-container recreation a deploy performs. `/status.json` reports the tier as `themeCache` — generation
-count, bytes, hits and writes.
+The tier is **off by default and opt-in**, and unset does not mean off — `--theme-cache-dir none`
+does. On the prebuilt image an unset value would derive a directory beside `catalogs.json`, which is
+the durable `preview_config` volume, so the cache would quietly grow on the volume holding the
+operator's catalog set and trust store. There is also deliberately **no temp-directory fallback**: a
+cache thrown away with the container costs disk and render time to buy nothing, so where there is no
+durable location the server runs memory-only and says so.
+
+`preview.coo.ee` runs the **prebuilt image** profile, [`deploy/image`](../deploy/image) — not the
+from-source `deploy/vps` one. Its compose file mounts a dedicated `preview_theme_cache` volume at
+`/theme-cache`, kept separate from `preview_config` for the reason above, so enabling the cache is a
+one-line `.env` change:
+
+```
+SERVE_THEME_CACHE_DIR=/theme-cache
+```
+
+A named volume is what survives the container recreation the rolling update performs — replicas
+overlap during that rollout and share the volume, which is why the sweeper spares generations young
+enough to belong to the outgoing replica. `/status.json` reports the tier as `themeCache` —
+generation count, bytes, hits and writes.
 
 The cache can also be filled **ahead of the first visitor** — an idle pass that walks each catalog's
 `previews × declaredThemes` set and renders the missing entries — but that pass is **off by

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -629,10 +629,43 @@ declares themes gets a leading **Default** chip to return to. The choice persist
 
 Completed catalog-grid theme renders are cached on the catalog host, above the LRU pool of
 preview-scoped daemons. Re-selecting a theme therefore reuses its PNGs even if those daemons were
-evicted. Refreshing the catalog replaces the host, so the replacement starts with an empty cache;
-mixed theme-plus-knob renders remain in the daemon's bounded override cache rather than growing
-this catalog-lifetime cache. Dynamic theme URLs remain `no-store`, preventing a browser or shared
-proxy from replaying old-catalog pixels after refresh.
+evicted. Mixed theme-plus-knob renders remain in the daemon's bounded override cache rather than
+growing this catalog-lifetime cache. Dynamic theme URLs remain `no-store`, preventing a browser or
+shared proxy from replaying old-catalog pixels after refresh.
+
+### The cache can outlive the process (`--theme-cache-dir`)
+
+In memory alone that cache is dropped by two separate events — a server restart, and a catalog
+reload, since every load builds a fresh session state. On `preview.coo.ee` those fired **7–10 times
+a day** (on 2026-08-17: three delivery-branch regenerations and four releases) against an
+`m3-catalog` needing roughly **28 hours** of background rendering to warm its 10,120 targets. It had
+never once had a window long enough to finish, which reads on `/status` as a `cached` count that
+keeps returning to zero.
+
+Pointing `--theme-cache-dir` at a durable directory adds a disk tier under the memory one. Memory
+stays a 128 MB window onto it — a fully warmed catalog is several times that — so lookups fall
+through to disk and promote, and `cached` counts both tiers.
+
+Reuse is decided by a **fingerprint of what produced the pixels**, not by the cache key alone: the
+content hash of the classpath the daemon renders with, the daemon variant, the tool version, and the
+render config. Each `(system, fingerprint)` pair is its own directory, so a new catalog revision or
+a new server build simply writes a new generation and reads none of the old one — invalidation is
+structural rather than something a reader must remember to check. Generations nothing can read any
+more are swept once the catalog pass finishes; a live set that exceeds `--theme-cache-max-bytes` is
+reported rather than evicted, because deleting what is currently being warmed would just make the
+optimizer render it again.
+
+Because a fingerprint can only cover the inputs it was told about, the first optimizer pass
+re-renders a small sample and compares it to what was adopted from disk. A mismatch discards the
+whole generation — an input the fingerprint missed makes every entry under that name suspect. A
+daemon that cannot answer yet verifies nothing rather than discarding anything.
+
+There is deliberately **no temp-directory fallback**: a theme cache thrown away with the container
+would cost disk and render time to buy nothing, so where there is no durable location the server
+runs memory-only and says so. On the Compose stack that durable location is a named volume
+(`theme_cache:/config/theme-cache` in `deploy/vps/docker-compose.yml`), which is what survives the
+container recreation a deploy performs. `/status.json` reports the tier as `themeCache` — generation
+count, bytes, hits and writes.
 
 The cache can also be filled **ahead of the first visitor** — an idle pass that walks each catalog's
 `previews × declaredThemes` set and renders the missing entries — but that pass is **off by


### PR DESCRIPTION
Closes #4130.

## What was broken

The theme cache was process memory, and **two** separate events dropped it: a server restart, and a catalog reload — every load builds a fresh `ServeSessionState` and therefore a fresh `CatalogThemeCache`. For `m3-catalog` on the public box:

| day | regenerations | releases | resets |
|---|---|---|---|
| Aug 15 | 7 | 3 | 10 |
| Aug 16 | 5 | 4 | 9 |
| Aug 17 | 3 | 4 | 7 |

Against a catalog needing roughly **28 hours** of lane time to warm its 10,120 targets. It had never once had a window long enough to finish, on any day — which is what a `cached` count that keeps returning to zero actually means. #4143 got it warming again; this is what lets the work accumulate.

## Invalidation — the hard part

A cache key says **what was asked for**. A persisted entry outlives what rendered it, so it needs the other half: **what produced it**. You cannot enumerate every input with confidence, so the design is not "list the inputs and hope":

**Key on the coarsest cheap thing that provably covers content and renderer, then verify a sample against ground truth on load** so an unenumerated input surfaces as a cache miss rather than a wrong pixel.

`ThemeCacheFingerprint` covers:

- **The classpath's bytes**, not its paths — a load stages the same bundle into a fresh directory every time, so paths churn while content does not. Hashing the jars covers the catalog's code, theme definitions, resources *and* dependencies in one move. This is the one input derived from the thing itself rather than asserted about it.
- **The daemon variant** — desktop and Android/Robolectric read the same classpath and don't agree pixel-for-pixel.
- **The tool version** — covers the renderer, and stands proxy for the container image, hence JVM, Skia, fonts. **That proxying is an assumption, not a proof**, and it's the one a base-image bump without a release would defeat. It's recorded in the generation manifest, and the sample verification is what actually catches it.
- **The render config** — the server-side defaults that never appear in a cache key, and are therefore easiest to forget precisely *because* they're absent from it.

Nothing is asserted by hand: change the renderer and the version moves, change the catalog and the classpath moves. There is no cache-version constant to remember to bump, because a constant someone must remember is one that will eventually be wrong. An identity that can't be established returns null and **declines to persist** — every wrong pixel this cache could serve begins with two generations agreeing on a name.

Each `(system, fingerprint)` is its own directory, so invalidation is structural: a new revision or build writes a new generation and reads none of the old one.

**The verification.** The first optimizer pass re-renders a small sample and compares. A mismatch discards the *whole* generation, not the offending entry — a missed input makes every entry under that name suspect. It renders through `live` rather than `renderPrefetch`, because the prefetch path consults this very cache and the comparison would pass by construction; only a `DAEMON`-generation render counts as evidence, and a daemon that can't answer yet verifies nothing rather than wiping a warmed catalog.

## Two tiers, not a copy

Memory stays a 128 MB window onto disk rather than a preload — a fully warmed m3-catalog is several times that, so preloading would thrash the LRU and report `cached` as whatever happened to fit. Lookups fall through to disk and promote; every count asks both tiers. That also fixes a related trap: an eviction now only un-completes a catalog when the entry is gone from *both* tiers, or a fully warmed catalog would sit at `paused` forever and the optimizer would re-render what was already on disk.

## Sweeping

Dead generations are reclaimed once the catalog pass finishes — the only moment the live set is known; sweeping earlier would delete a generation a catalog further down the list was about to adopt. A live set over `--theme-cache-max-bytes` is **reported, never evicted**: deleting what is being warmed to fit a cap turns the cap into a treadmill where the optimizer re-renders exactly what the sweep discarded, forever, and the box looks busy while making no progress. That's a configuration answer, not something to paper over.

## Deployment

No temp-directory fallback, deliberately: a theme cache in `/tmp` is written once, read never, and thrown away with the container — disk and render time for nothing, while reporting itself as working. Where there's no durable location the server runs memory-only and logs it.

`deploy/vps/docker-compose.yml` gains `theme_cache:/config/theme-cache`, alongside the existing `catalog_feed_cache` volume — named volumes survive the container recreation a `docker compose pull` deploy performs, which is the entire premise. Both entrypoints pass `SERVE_THEME_CACHE_DIR` / `SERVE_THEME_CACHE_MAX_BYTES`. The default location is beside `catalogs.json`, matching the feed cache.

`/status.json` gains `themeCache` — generations, bytes, hits, writes — so "is warming accumulating?" is answerable directly instead of inferred from a count that keeps resetting.

## Test plan

`./gradlew :cli:test` green (2,450 tests), `./gradlew ktfmtCheckAll` clean, both entrypoints pass `bash -n`, the compose file parses.

New `ThemeCachePersistenceTest` — most of it asserts *when a generation must not be reused*, since that's where the risk is:

- the same bytes staged in a different directory are the same generation (the property the whole design rests on — a path-based fingerprint would call every load new and buy nothing);
- a changed jar, a changed version, a changed variant and a changed render config are each a different generation;
- classpath order doesn't invent one;
- exploded class directories are hashed by content, not skipped (a from-source catalog puts one on the classpath);
- an unreadable classpath declines to name the generation at all;
- a render written by one process is read by the next; a different fingerprint starts clean; two catalogs with identical keys don't share;
- sweeping reclaims dead generations, keeps live ones, and reports rather than evicts an over-cap live set;
- a name that could escape the store root is refused, not sanitised;
- a target evicted from memory still counts as cached while on disk;
- verification drops the generation on mismatch, keeps it on match, and does nothing when the renderer returns null.

Two flags-registry gates (`CliFlagsRegistryTest`) caught the new flags being unregistered; both are now in `CliFlags.VALUE_FLAGS` and the serve allowlist.

Text-only evidence: this changes background caching, a status block and deployment config — no rendered surface.

## What this does not do

The disk tier only helps where the directory is durable. On the public box that means the new volume has to be present — until the compose change is applied there, the server will log `theme cache disabled` or run memory-only and behave exactly as it does today.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTL61d6Gj1HAXJ4c1Kfpgn)_