### PR TITLE
fix(serve): improve UI issue reports

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBugReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBugReport.kt
@@ -38,6 +38,9 @@ internal object ServeBugReport {
    */
   const val REPO: String = "yschimke/compose-ai-tools"
 
+  /** Labels pre-applied to reports opened by the server UI. */
+  const val LABELS: String = "ui-report,bug,daemon"
+
   /** The report page's path, offered from the site footer on every browser-facing page. */
   const val PATH: String = "/report-bug"
 
@@ -141,8 +144,9 @@ internal object ServeBugReport {
         append("![render](").append(render).append(")\n\n")
         append(
           "<!-- That image is a LIVE render: it re-renders if the catalog changes, so it may " +
-            "stop showing what you saw. A pasted screenshot of the page stays put — GitHub " +
-            "hosts those pixels itself. -->\n\n\n"
+            "stop showing what you saw. GitHub displays it through Camo, but Camo proxies the " +
+            "source URL; it does not make a versioned snapshot. A pasted screenshot of the " +
+            "page stays put because GitHub hosts those pixels itself. -->\n\n\n"
         )
       } else {
         append(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -180,9 +180,10 @@ internal object ServeIssueReport {
         append("![${altText(ctx)}]($render)\n\n")
         append(
           "<!-- That image is a LIVE render: it re-renders if the catalog changes, so it may " +
-            "stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer's " +
-            "\"Export & direct links\" panel and paste it here — GitHub then hosts the pixels " +
-            "itself. -->\n\n\n"
+            "stop showing what you saw. GitHub displays it through Camo, but Camo proxies the " +
+            "source URL; it does not make a versioned snapshot. For a copy that stays put, use " +
+            "Copy PNG in the viewer's \"Export & direct links\" panel and paste it here — " +
+            "GitHub then hosts the pixels itself. -->\n\n\n"
         )
       } else {
         append(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -6086,7 +6086,11 @@ $noteBlock        <div class="cp-site-footer-links">
 
       <form class="cp-report-bug-form" method="get" target="_blank" rel="noopener"
         action="${esc(report.action)}">
-        <input type="hidden" name="title" value="${esc(report.title)}">
+        <label class="cp-bug-summary">Summary
+          <input class="cp-bug-summary-input" type="text" name="title" required
+            autocomplete="off" placeholder="Briefly describe the problem">
+        </label>
+        <input type="hidden" name="labels" value="${esc(ServeBugReport.LABELS)}">
         <input type="hidden" name="body" id="cp-bug-body" value="${esc(report.body)}"
           data-report-template="${esc(report.bodyTemplate)}">
         <button type="submit" class="cp-doc-btn cp-bug-submit">$GITHUB_ICON

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -2304,10 +2304,15 @@ html.cp-bg-transparent .cp-viewer[data-mode="source"] .cp-stage { background: tr
   transition: box-shadow var(--md-sys-motion-duration-short2) var(--md-sys-motion-easing-standard); }
 .cp-doc-btn:hover, .cp-bug-submit:hover { background: var(--md-sys-color-primary);
   box-shadow: var(--md-sys-elevation-level1); }
-/* The bug-report page. The submit row keeps the button and its "nothing is sent from here" caveat
-   on one line, because the caveat is the answer to the question the button raises. */
+/* The bug-report page. The required summary prevents a queue of indistinguishable generic titles;
+   the remaining controls wrap naturally below it on narrow screens. */
 .cp-report-bug-form { display: flex; flex-wrap: wrap; align-items: center; gap: 12px 16px;
   margin: 0 0 8px; }
+.cp-bug-summary { flex: 1 0 100%; display: grid; gap: 6px; font-weight: 500; }
+.cp-bug-summary-input { width: min(100%, 720px); min-height: 44px; box-sizing: border-box;
+  padding: 10px 14px; font: inherit; border: 1px solid var(--cp-border);
+  border-radius: var(--md-sys-shape-corner-small);
+  background: var(--md-sys-color-surface-container-low); color: inherit; }
 .cp-bug-submit { display: inline-flex; align-items: center; gap: 8px; }
 /* The facts table is a two-column key/value sheet rather than the status page's headed grid: it has
    no column meanings to declare, so the row headers carry the whole structure. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportRouteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportRouteTest.kt
@@ -106,6 +106,13 @@ class ServeBugReportRouteTest {
       body,
     )
     assertTrue(body.contains("Report a bug in the preview server"), body)
+    assertTrue(
+      body.contains("type=\"text\" name=\"title\" required") &&
+        body.contains("placeholder=\"Briefly describe the problem\""),
+      body,
+    )
+    assertTrue(body.contains("name=\"labels\" value=\"ui-report,bug,daemon\""), body)
+    assertFalse(body.contains("type=\"hidden\" name=\"title\""), body)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportTest.kt
@@ -36,6 +36,7 @@ class ServeBugReportTest {
     // The whole point of the split from ServeIssueReport: a catalog's repo cannot fix the server.
     assertEquals("yschimke/compose-ai-tools", ServeBugReport.REPO)
     assertEquals("https://github.com/yschimke/compose-ai-tools/issues/new", ServeBugReport.action())
+    assertEquals("ui-report,bug,daemon", ServeBugReport.LABELS)
   }
 
   @Test
@@ -91,7 +92,10 @@ class ServeBugReportTest {
 
   @Test
   fun `a publicly reachable render is embedded, a local one is only linked`() {
-    assertTrue(ServeBugReport.body(server, page).contains("![render](https://preview.coo.ee/"))
+    val embedded = ServeBugReport.body(server, page)
+    assertTrue(embedded.contains("![render](https://preview.coo.ee/"))
+    assertTrue(embedded.contains("Camo proxies the source URL"), embedded)
+    assertTrue(embedded.contains("does not make a versioned snapshot"), embedded)
 
     val local =
       page.copy(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -134,6 +134,8 @@ class ServeIssueReportTest {
     assertFalse(body.contains("[PNG at these settings]"), body)
     // The embed is honest about what it is: a live render that moves when the catalog does.
     assertTrue(body.contains("LIVE render"), body)
+    assertTrue(body.contains("Camo proxies the source URL"), body)
+    assertTrue(body.contains("does not make a versioned snapshot"), body)
     assertTrue(body.contains("Copy PNG"), "the durable paste path is still offered")
   }
 

--- a/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-reference-compare.html
@@ -101,7 +101,7 @@
 
 ![Button · Filled (light)](https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__light.png?fontScale=1.5&amp;knob.label=Send%3Bnow%3Dx)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -134,7 +134,7 @@ revision: yschimke/compose-ai-tools@design-artifacts/compose-m3
 
 ![Button · Filled (light)]({{render}})
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview

--- a/vscode-extension/preview-harness/fixtures/pages/serve-report-bug.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-report-bug.html
@@ -74,7 +74,11 @@
 
       <form class="cp-report-bug-form" method="get" target="_blank" rel="noopener"
         action="https://github.com/yschimke/compose-ai-tools/issues/new">
-        <input type="hidden" name="title" value="Preview server issue: compose-m3">
+        <label class="cp-bug-summary">Summary
+          <input class="cp-bug-summary-input" type="text" name="title" required
+            autocomplete="off" placeholder="Briefly describe the problem">
+        </label>
+        <input type="hidden" name="labels" value="ui-report,bug,daemon">
         <input type="hidden" name="body" id="cp-bug-body" value="### What went wrong
 
 &lt;!-- What were you doing, what did you expect, and what happened instead? --&gt;
@@ -84,7 +88,7 @@
 
 ![render](https://preview.coo.ee/compose-m3/render/button-filled.png?uiMode=dark)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. A pasted screenshot of the page stays put — GitHub hosts those pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. A pasted screenshot of the page stays put because GitHub hosts those pixels itself. --&gt;
 
 
 ### Server
@@ -130,7 +134,7 @@
 
 ![render](https://preview.coo.ee/compose-m3/render/button-filled.png?uiMode=dark)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. A pasted screenshot of the page stays put — GitHub hosts those pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. A pasted screenshot of the page stays put because GitHub hosts those pixels itself. --&gt;
 
 
 ### Server
@@ -233,7 +237,7 @@
 
 ![render](https://preview.coo.ee/compose-m3/render/button-filled.png?uiMode=dark)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. A pasted screenshot of the page stays put — GitHub hosts those pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. A pasted screenshot of the page stays put because GitHub hosts those pixels itself. --&gt;
 
 
 ### Server

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer-catalog-knobs.html
@@ -305,7 +305,7 @@
 
 ![Button · Filled (light)](https://preview.coo.ee/compose-m3/render/button-filled__ideal__default__light.png)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -328,7 +328,7 @@
 
 ![Button · Filled (light)]({{render}})
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview

--- a/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-viewer.html
@@ -231,7 +231,7 @@
 
 ![Profile screen](https://preview.coo.ee/compose-m3/render/com.example.ProfileScreenPreview.png)
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview
@@ -254,7 +254,7 @@
 
 ![Profile screen]({{render}})
 
-&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
+&lt;!-- That image is a LIVE render: it re-renders if the catalog changes, so it may stop showing what you saw. GitHub displays it through Camo, but Camo proxies the source URL; it does not make a versioned snapshot. For a copy that stays put, use Copy PNG in the viewer&#39;s &quot;Export &amp; direct links&quot; panel and paste it here — GitHub then hosts the pixels itself. --&gt;
 
 
 ### Which preview


### PR DESCRIPTION
## What changed

- require a human-written summary for preview-server UI bug reports
- pre-apply `ui-report`, `bug`, and `daemon` labels
- explain that GitHub Camo proxies the live render URL and does not create a versioned snapshot
- refresh the affected serve-web fixtures

## Validation

- targeted `:cli:test` suite for report builders, route wiring, and web rendering
- `:cli:ktfmtCheck`
- regenerated and verified `ServeWebFixtureTest`

Closes #4150
Closes #4148