### PR TITLE
fix(serve): clarify status health and capacity

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStats.kt
@@ -33,6 +33,7 @@ class RenderPerfStats {
   private var maxMs = 0L
   private var totalMs = 0L
   private var lastMs: Long? = null
+  private var lastRenderFailed = false
   private var lastFailureReason: String? = null
   private var lastFailureAtEpochMillis: Long? = null
   private val recentFailures = ArrayDeque<RenderFailureSample>()
@@ -65,6 +66,7 @@ class RenderPerfStats {
     synchronized(lock) {
       renders++
       failed++
+      lastRenderFailed = true
       if (timeout) timedOut++
       lastMs = durationMs
       if (reason != null) {
@@ -91,6 +93,7 @@ class RenderPerfStats {
     synchronized(lock) {
       renders++
       ok++
+      lastRenderFailed = false
       if (cold) {
         coldOk++
         if (firstRenderMs == null) firstRenderMs = durationMs
@@ -128,6 +131,7 @@ class RenderPerfStats {
         p50Ms = pct(0.5),
         p95Ms = pct(0.95),
         windowSize = windowCount,
+        lastRenderFailed = lastRenderFailed,
         lastFailureReason = lastFailureReason,
         lastFailureAtEpochMillis = lastFailureAtEpochMillis,
         recentFailures = recentFailures.toList().asReversed(),
@@ -193,6 +197,8 @@ data class RenderPerfSnapshot(
   val p50Ms: Long? = null,
   val p95Ms: Long? = null,
   val windowSize: Int = 0,
+  /** Current lane signal: true only when the most recently completed daemon render failed. */
+  val lastRenderFailed: Boolean = false,
   /**
    * The most recent failure's reason text (truncated) + when it happened — the "why" behind a
    * non-zero [failed] counter, so a catalog whose live lane silently falls back to baked is
@@ -235,6 +241,7 @@ data class RenderPerfSnapshot(
         p50Ms = null,
         p95Ms = null,
         windowSize = snapshots.sumOf { it.windowSize },
+        lastRenderFailed = snapshots.any { it.lastRenderFailed },
         // Most recent failure across daemons (by timestamp) so the roll-up carries a "why" too.
         lastFailureReason =
           snapshots

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4195,12 +4195,16 @@ class ServeHttpServer(
     /** Live daemons (a render daemon is up), excluding pinned static baked hosts. */
     val liveDaemons: List<ServeSessionRegistry.RunningDaemon> = running.filter { it.hasLiveStream }
     val activeStreams: Int = liveDaemons.sumOf { it.activeStreams }
-    val currentLiveRenderFailureCount: Int = liveDaemons.count {
-      it.renderStats?.lastRenderFailed == true
+    val openRenderBreakerCount: Int = running.count { it.renderStats?.breaker?.open == true }
+    val currentLiveRenderFailureCount: Int = running.count {
+      it.renderStats?.let { stats -> stats.breaker?.open != true && stats.lastRenderFailed } == true
     }
     val catalogLoadFailureCount: Int = catalogs.count { it.loadError != null }
     val overallOk: Boolean =
-      failures.isEmpty() && catalogLoadFailureCount == 0 && currentLiveRenderFailureCount == 0
+      failures.isEmpty() &&
+        catalogLoadFailureCount == 0 &&
+        openRenderBreakerCount == 0 &&
+        currentLiveRenderFailureCount == 0
 
     private fun backendOf(weight: Int): String = if (weight >= 2) "android" else "desktop"
 
@@ -4505,6 +4509,8 @@ class ServeHttpServer(
               if (catalogLoadFailureCount > 0)
                 add(countLabel(catalogLoadFailureCount, "catalog load failure"))
               if (failures.isNotEmpty()) add(countLabel(failures.size, "daemon startup failure"))
+              if (openRenderBreakerCount > 0)
+                add(countLabel(openRenderBreakerCount, "open live render breaker"))
               if (currentLiveRenderFailureCount > 0)
                 add(countLabel(currentLiveRenderFailureCount, "current live render failure"))
             }
@@ -4514,6 +4520,7 @@ class ServeHttpServer(
           when {
             catalogLoadFailureCount > 0 -> "#catalogs"
             failures.isNotEmpty() -> "#recent-daemon-failures"
+            openRenderBreakerCount > 0 -> "#recent-render-failures"
             currentLiveRenderFailureCount > 0 -> "#recent-render-failures"
             else -> null
           },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4195,12 +4195,12 @@ class ServeHttpServer(
     /** Live daemons (a render daemon is up), excluding pinned static baked hosts. */
     val liveDaemons: List<ServeSessionRegistry.RunningDaemon> = running.filter { it.hasLiveStream }
     val activeStreams: Int = liveDaemons.sumOf { it.activeStreams }
-    val recentLiveRenderFailureCount: Int = liveDaemons.sumOf {
-      it.renderStats?.recentFailures?.size ?: 0
+    val currentLiveRenderFailureCount: Int = liveDaemons.count {
+      it.renderStats?.lastRenderFailed == true
     }
     val catalogLoadFailureCount: Int = catalogs.count { it.loadError != null }
     val overallOk: Boolean =
-      failures.isEmpty() && catalogLoadFailureCount == 0 && recentLiveRenderFailureCount == 0
+      failures.isEmpty() && catalogLoadFailureCount == 0 && currentLiveRenderFailureCount == 0
 
     private fun backendOf(weight: Int): String = if (weight >= 2) "android" else "desktop"
 
@@ -4505,8 +4505,8 @@ class ServeHttpServer(
               if (catalogLoadFailureCount > 0)
                 add(countLabel(catalogLoadFailureCount, "catalog load failure"))
               if (failures.isNotEmpty()) add(countLabel(failures.size, "daemon startup failure"))
-              if (recentLiveRenderFailureCount > 0)
-                add(countLabel(recentLiveRenderFailureCount, "recent live render failure"))
+              if (currentLiveRenderFailureCount > 0)
+                add(countLabel(currentLiveRenderFailureCount, "current live render failure"))
             }
             .takeIf { it.isNotEmpty() }
             ?.joinToString(" · "),
@@ -4514,7 +4514,7 @@ class ServeHttpServer(
           when {
             catalogLoadFailureCount > 0 -> "#catalogs"
             failures.isNotEmpty() -> "#recent-daemon-failures"
-            recentLiveRenderFailureCount > 0 -> "#recent-render-failures"
+            currentLiveRenderFailureCount > 0 -> "#recent-render-failures"
             else -> null
           },
         summary = summary,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4195,17 +4195,23 @@ class ServeHttpServer(
     /** Live daemons (a render daemon is up), excluding pinned static baked hosts. */
     val liveDaemons: List<ServeSessionRegistry.RunningDaemon> = running.filter { it.hasLiveStream }
     val activeStreams: Int = liveDaemons.sumOf { it.activeStreams }
+    val recentLiveRenderFailureCount: Int = liveDaemons.sumOf {
+      it.renderStats?.recentFailures?.size ?: 0
+    }
+    val catalogLoadFailureCount: Int = catalogs.count { it.loadError != null }
+    val overallOk: Boolean =
+      failures.isEmpty() && catalogLoadFailureCount == 0 && recentLiveRenderFailureCount == 0
 
     private fun backendOf(weight: Int): String = if (weight >= 2) "android" else "desktop"
+
+    private fun countLabel(count: Int, singular: String): String =
+      "$count $singular${if (count == 1) "" else "s"}"
 
     fun toResponse(): StatusResponse =
       StatusResponse(
         version = BUNDLE_VERSION,
         public = isPublic,
-        status =
-          if (failures.isEmpty() && catalogs.none { it.loadError != null || it.failedRenders > 0 })
-            "ok"
-          else "degraded",
+        status = if (overallOk) "ok" else "degraded",
         uptimeSeconds = uptimeSeconds,
         catalogs =
           CatalogSummaryDto(
@@ -4388,34 +4394,83 @@ class ServeHttpServer(
             .filter { it.renders + it.cacheHits + it.busy > 0 }
         )
       val summary = buildList {
-        add(ServeWeb.Stat("Catalogs", "${catalogs.count { it.available }}/${catalogs.size} loaded"))
+        val loadedCatalogs = catalogs.count { it.available }
+        add(
+          ServeWeb.Stat(
+            "Catalogs",
+            "$loadedCatalogs/${catalogs.size} loaded",
+            ServeWeb.Meter(
+              catalogs.size.toLong(),
+              listOf(
+                ServeWeb.MeterSegment("loaded", loadedCatalogs.toLong(), "primary"),
+                ServeWeb.MeterSegment(
+                  "unavailable",
+                  (catalogs.size - loadedCatalogs).toLong(),
+                  "warning",
+                ),
+              ),
+            ),
+          )
+        )
         val published = catalogs.sumOf { it.previews ?: 0 }
         val publishedFailures = catalogs.sumOf { it.failedRenders }
         val publishedDeferred = catalogs.sumOf { it.deferredPreviews }
+        val publishedRendered = (published - publishedFailures - publishedDeferred).coerceAtLeast(0)
         add(
           ServeWeb.Stat(
-            "Catalog renders",
-            "${(published - publishedFailures - publishedDeferred).coerceAtLeast(0)} rendered · " +
+            "Published catalog renders",
+            "$publishedRendered rendered · " +
               "$publishedFailures failed · $publishedDeferred deferred",
+            ServeWeb.Meter(
+              published.toLong(),
+              listOf(
+                ServeWeb.MeterSegment("rendered", publishedRendered.toLong(), "primary"),
+                ServeWeb.MeterSegment("failed", publishedFailures.toLong(), "warning"),
+                ServeWeb.MeterSegment("deferred", publishedDeferred.toLong(), "muted"),
+              ),
+            ),
           )
         )
         add(ServeWeb.Stat("Live daemons running", liveDaemons.size.toString()))
         add(ServeWeb.Stat("Active streams", activeStreams.toString()))
-        add(ServeWeb.Stat("Live seats", seatsText))
+        add(
+          ServeWeb.Stat(
+            "Live seats",
+            seatsText,
+            if (liveSeats.unbounded) null
+            else {
+              val free = liveSeats.availablePermits().toLong()
+              val total = liveSeats.totalPermits.toLong()
+              ServeWeb.Meter(
+                total,
+                listOf(
+                  ServeWeb.MeterSegment("in use", (total - free).coerceAtLeast(0), "secondary"),
+                  ServeWeb.MeterSegment("free", free, "primary"),
+                ),
+              )
+            },
+          )
+        )
         add(ServeWeb.Stat("Known sessions", knownSessions.toString()))
         add(ServeWeb.Stat("Uptime", formatDuration(uptimeSeconds)))
         if (renderAgg != null) {
-          // One-line human roll-up; full per-daemon detail (cold counts, p50/p95, first-render
-          // latency) is on /status.json → runningServers[].renderStats.
-          val avg = renderAgg.avgMs?.let { " · avg ${it}ms" } ?: ""
-          val worstFirst = renderAgg.firstRenderMs?.let { " · worst first ${it}ms" } ?: ""
           add(
             ServeWeb.Stat(
               "Live renders",
               "${renderAgg.ok} ok · ${renderAgg.failed} failed · " +
-                "${renderAgg.cacheHits} cached$avg$worstFirst",
+                "${renderAgg.cacheHits} cached",
+              ServeWeb.Meter(
+                renderAgg.ok + renderAgg.failed + renderAgg.cacheHits,
+                listOf(
+                  ServeWeb.MeterSegment("ok", renderAgg.ok, "primary"),
+                  ServeWeb.MeterSegment("failed", renderAgg.failed, "warning"),
+                  ServeWeb.MeterSegment("cached", renderAgg.cacheHits, "secondary"),
+                ),
+              ),
             )
           )
+          renderAgg.avgMs?.let { add(ServeWeb.Stat("Average render latency", "${it}ms")) }
+          renderAgg.firstRenderMs?.let { add(ServeWeb.Stat("Worst first render", "${it}ms")) }
         }
       }
       val config =
@@ -4444,8 +4499,24 @@ class ServeHttpServer(
         version = BUNDLE_VERSION,
         public = isPublic,
         nowMillis = nowMillis,
-        overallOk =
-          failures.isEmpty() && catalogs.none { it.loadError != null || it.failedRenders > 0 },
+        overallOk = overallOk,
+        healthReason =
+          buildList {
+              if (catalogLoadFailureCount > 0)
+                add(countLabel(catalogLoadFailureCount, "catalog load failure"))
+              if (failures.isNotEmpty()) add(countLabel(failures.size, "daemon startup failure"))
+              if (recentLiveRenderFailureCount > 0)
+                add(countLabel(recentLiveRenderFailureCount, "recent live render failure"))
+            }
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(" · "),
+        healthHref =
+          when {
+            catalogLoadFailureCount > 0 -> "#catalogs"
+            failures.isNotEmpty() -> "#recent-daemon-failures"
+            recentLiveRenderFailureCount > 0 -> "#recent-render-failures"
+            else -> null
+          },
         summary = summary,
         config = config,
         catalogs =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -6187,7 +6187,20 @@ $noteBlock        <div class="cp-site-footer-links">
   /** Generation times use one relative format; the exact ISO instant remains in the title. */
   private fun friendlyGeneratedAt(iso: String, nowMillis: Long): String {
     val generated = runCatching { Instant.parse(iso) }.getOrNull() ?: return prettyDate(iso)
-    val ageSeconds = ((nowMillis - generated.toEpochMilli()) / 1000).coerceAtLeast(0)
+    val ageMillis = nowMillis - generated.toEpochMilli()
+    if (ageMillis < 0) {
+      val futureSeconds = (-ageMillis + 999) / 1000
+      return when {
+        futureSeconds < 60 -> "in less than a minute"
+        futureSeconds < 3_600 -> relativeTime(futureSeconds / 60, "minute", future = true)
+        futureSeconds < 86_400 -> relativeTime(futureSeconds / 3_600, "hour", future = true)
+        futureSeconds < 2_592_000 -> relativeTime(futureSeconds / 86_400, "day", future = true)
+        futureSeconds < 31_536_000 ->
+          relativeTime(futureSeconds / 2_592_000, "month", future = true)
+        else -> relativeTime(futureSeconds / 31_536_000, "year", future = true)
+      }
+    }
+    val ageSeconds = ageMillis / 1000
     return when {
       ageSeconds < 60 -> "just now"
       ageSeconds < 3_600 -> relativeTime(ageSeconds / 60, "minute")
@@ -6198,8 +6211,10 @@ $noteBlock        <div class="cp-site-footer-links">
     }
   }
 
-  private fun relativeTime(amount: Long, unit: String): String =
-    "$amount $unit${if (amount == 1L) "" else "s"} ago"
+  private fun relativeTime(amount: Long, unit: String, future: Boolean = false): String {
+    val duration = "$amount $unit${if (amount == 1L) "" else "s"}"
+    return if (future) "in $duration" else "$duration ago"
+  }
 
   /**
    * Per-system **display policy** — the single source of truth for what background surface each

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -4,8 +4,6 @@ import ee.schimke.composeai.data.overrides.PreviewOverrideOption
 import ee.schimke.composeai.designpages.DesignPage
 import ee.schimke.composeai.designpages.PageNode
 import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -5664,8 +5662,14 @@ $noteBlock        <div class="cp-site-footer-links">
    */
   private val JSON_COMPACT = Json { encodeDefaults = true }
 
-  /** A labelled figure (a stat tile / config row) on the [statusPage]. */
-  data class Stat(val key: String, val value: String)
+  /** One coloured part of a [Meter]. */
+  data class MeterSegment(val label: String, val value: Long, val tone: String)
+
+  /** Part-of-whole data rendered underneath a status stat's human-readable value. */
+  data class Meter(val total: Long, val segments: List<MeterSegment>)
+
+  /** A labelled figure on the [statusPage], optionally backed by a capacity/progress meter. */
+  data class Stat(val key: String, val value: String, val meter: Meter? = null)
 
   /** One published catalog's row on the [statusPage] — its trust, size, liveness, provenance. */
   data class StatusCatalog(
@@ -5739,8 +5743,11 @@ $noteBlock        <div class="cp-site-footer-links">
     val public: Boolean,
     /** Wall-clock instant used to turn recent catalog generation times into relative labels. */
     val nowMillis: Long,
-    /** No catalog load or recent daemon startup failures (drives the header badge). */
+    /** No catalog-load, daemon-startup, or recent live-render failures. */
     val overallOk: Boolean,
+    /** Human explanation for a degraded badge, with an in-page diagnostic target. */
+    val healthReason: String? = null,
+    val healthHref: String? = null,
     val summary: List<Stat>,
     val config: List<Stat>,
     val catalogs: List<StatusCatalog>,
@@ -5782,16 +5789,50 @@ $noteBlock        <div class="cp-site-footer-links">
     fun esc(s: String) = WebEscaping.htmlEscape(s)
     // Gated-link suffix: token-gated ⇒ carry the token; public ⇒ nothing (routes are open).
     val suffix = if (view.public) "" else "?token=" + WebEscaping.urlEncodeSegment(token)
-    fun stat(s: Stat) =
-      "<div class=\"cp-stat\"><div class=\"cp-stat-key\">${esc(s.key)}</div>" +
-        "<div class=\"cp-stat-val\">${esc(s.value)}</div></div>"
+    fun stat(s: Stat): String {
+      val meter =
+        s.meter?.let { meter ->
+          val total = meter.total.coerceAtLeast(0)
+          val segments =
+            meter.segments.joinToString("") { segment ->
+              val width =
+                if (total == 0L) 0.0
+                else segment.value.coerceIn(0, total).toDouble() * 100.0 / total
+              "<span class=\"cp-meter-segment cp-meter-segment--${esc(segment.tone)}\" " +
+                "style=\"width:${"%.3f".format(Locale.ROOT, width)}%\" " +
+                "title=\"${esc(segment.label)}: ${segment.value}\"></span>"
+            }
+          "<div class=\"cp-meter\" role=\"img\" aria-label=\"${esc(s.value)}\">$segments</div>"
+        } ?: ""
+      return "<div class=\"cp-stat\"><div class=\"cp-stat-key\">${esc(s.key)}</div>" +
+        "<div class=\"cp-stat-val\">${esc(s.value)}</div>$meter</div>"
+    }
+
+    fun inlineMeter(label: String, value: Long, total: Long, tone: String): String {
+      val percent = if (total <= 0L) 0.0 else value.coerceIn(0, total).toDouble() * 100.0 / total
+      return "<span class=\"cp-inline-meter\" role=\"img\" aria-label=\"${esc(label)}\">" +
+        "<span class=\"cp-inline-meter-fill cp-inline-meter-fill--${esc(tone)}\" " +
+        "style=\"width:${"%.3f".format(Locale.ROOT, percent)}%\"></span></span>"
+    }
 
     val healthBadge =
       if (view.overallOk) " <span class=\"cp-badge cp-badge--trusted\">✓ healthy</span>"
-      else " <span class=\"cp-badge cp-badge--unverified\">⚠ degraded</span>"
+      else {
+        val reason = view.healthReason?.takeIf { it.isNotBlank() }
+        val title = reason?.let { " title=\"${esc(it)}\"" } ?: ""
+        val label = "⚠ degraded" + reason?.let { ": ${esc(it)}" }.orEmpty()
+        view.healthHref
+          ?.takeIf { it.isNotBlank() }
+          ?.let { href ->
+            " <a class=\"cp-badge cp-badge--unverified\" href=\"${esc(href)}\"$title>$label</a>"
+          } ?: " <span class=\"cp-badge cp-badge--unverified\"$title>$label</span>"
+      }
 
     val summaryGrid = view.summary.joinToString("\n") { stat(it) }
-    val configGrid = view.config.joinToString("\n") { stat(it) }
+    val configGrid =
+      view.config.joinToString("\n") {
+        "<div class=\"cp-status-config-row\"><dt>${esc(it.key)}</dt><dd>${esc(it.value)}</dd></div>"
+      }
 
     val catalogRows =
       if (view.catalogs.isEmpty())
@@ -5850,7 +5891,13 @@ $noteBlock        <div class="cp-site-footer-links">
                     "${optimization.cached}/${optimization.total} cached" +
                     if (optimization.failed > 0) " · ${optimization.failed} failed" else ""
                 }
-              "<div class=\"cp-muted\">${esc(detail)}</div>"
+              "<div class=\"cp-muted\">${esc(detail)}</div>" +
+                inlineMeter(
+                  detail,
+                  optimization.cached.toLong(),
+                  optimization.total.toLong(),
+                  if (optimization.failed > 0) "warning" else "primary",
+                )
             } ?: ""
           val renderCache =
             c.renderCache?.let { cache ->
@@ -5858,7 +5905,8 @@ $noteBlock        <div class="cp-site-footer-links">
                 "preview cache ${cache.entries} entries · " +
                   "${humanBytes(cache.bytes)} / ${humanBytes(cache.maxBytes)}" +
                   if (cache.evictions > 0) " · ${cache.evictions} evicted" else ""
-              "<div class=\"cp-muted\">${esc(detail)}</div>"
+              "<div class=\"cp-muted\">${esc(detail)}</div>" +
+                inlineMeter(detail, cache.bytes, cache.maxBytes, "secondary")
             } ?: ""
           // An idle catalog's facts are last-known, not live — say so next to the badge rather than
           // leaving the cell blank, which would read as untrusted.
@@ -5889,8 +5937,9 @@ $noteBlock        <div class="cp-site-footer-links">
           "start on demand and suspend when idle.</td></tr>"
       else
         view.servers.joinToString("\n") { s ->
+          val id = if (s.id == s.label) "" else "<div class=\"cp-muted\">${esc(s.id)}</div>"
           "<tr>" +
-            "<td>${esc(s.label)}<div class=\"cp-muted\">${esc(s.id)}</div></td>" +
+            "<td>${esc(s.label)}$id</td>" +
             "<td><code>${esc(s.backend)}</code></td>" +
             "<td>${s.activeStreams}</td>" +
             "<td>${esc(s.upForText)}</td>" +
@@ -5945,7 +5994,7 @@ $noteBlock        <div class="cp-site-footer-links">
       $summaryGrid
       </div>
 
-      <p class="cp-status-sec">Catalogs</p>
+      <p class="cp-status-sec" id="catalogs">Catalogs</p>
       <div class="cp-status-scroll"><table class="cp-table">
         <thead><tr><th>Catalog</th><th>Trust</th><th>Previews</th><th>State</th></tr></thead>
         <tbody>
@@ -5962,14 +6011,14 @@ $noteBlock        <div class="cp-site-footer-links">
       </table></div>
 
       <p class="cp-status-sec">Configuration</p>
-      <div class="cp-status-grid">
+      <dl class="cp-status-config">
       $configGrid
-      </div>
+      </dl>
 
-      <p class="cp-status-sec">Recent daemon startup failures</p>
+      <p class="cp-status-sec" id="recent-daemon-failures">Recent daemon startup failures</p>
       $failureSection
 
-      <p class="cp-status-sec">Recent render failures</p>
+      <p class="cp-status-sec" id="recent-render-failures">Recent live render failures</p>
       $renderFailureSection
       """
         .trimIndent()
@@ -6135,28 +6184,22 @@ $noteBlock        <div class="cp-site-footer-links">
   /** One titled group of `key → value` diagnostics on [bugReportPage]. */
   data class BugReportSection(val title: String, val rows: List<Pair<String, String>>)
 
-  /** Recent generation times read naturally; older builds use a compact, unambiguous UTC date. */
+  /** Generation times use one relative format; the exact ISO instant remains in the title. */
   private fun friendlyGeneratedAt(iso: String, nowMillis: Long): String {
     val generated = runCatching { Instant.parse(iso) }.getOrNull() ?: return prettyDate(iso)
-    val ageSeconds = (nowMillis - generated.toEpochMilli()) / 1000
-    if (ageSeconds >= 0 && ageSeconds < 86_400) {
-      return when {
-        ageSeconds < 60 -> "just now"
-        ageSeconds < 3_600 -> {
-          val minutes = ageSeconds / 60
-          "$minutes ${if (minutes == 1L) "minute" else "minutes"} ago"
-        }
-        else -> {
-          val hours = ageSeconds / 3_600
-          "$hours ${if (hours == 1L) "hour" else "hours"} ago"
-        }
-      }
+    val ageSeconds = ((nowMillis - generated.toEpochMilli()) / 1000).coerceAtLeast(0)
+    return when {
+      ageSeconds < 60 -> "just now"
+      ageSeconds < 3_600 -> relativeTime(ageSeconds / 60, "minute")
+      ageSeconds < 86_400 -> relativeTime(ageSeconds / 3_600, "hour")
+      ageSeconds < 2_592_000 -> relativeTime(ageSeconds / 86_400, "day")
+      ageSeconds < 31_536_000 -> relativeTime(ageSeconds / 2_592_000, "month")
+      else -> relativeTime(ageSeconds / 31_536_000, "year")
     }
-    return STATUS_DATE_FORMAT.format(generated)
   }
 
-  private val STATUS_DATE_FORMAT: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm 'UTC'", Locale.ENGLISH).withZone(ZoneOffset.UTC)
+  private fun relativeTime(amount: Long, unit: String): String =
+    "$amount $unit${if (amount == 1L) "" else "s"} ago"
 
   /**
    * Per-system **display policy** — the single source of truth for what background surface each

--- a/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -1051,8 +1051,8 @@ cp-parity-scores { display: contents; }
   font-size: var(--md-sys-typescale-body-small-size);
   line-height: var(--md-sys-typescale-body-small-line); }
 /* Status page (GET /status): stat tiles, config grid, and the catalog/daemon/failure tables. */
-.cp-status-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-  gap: 10px; margin: 0 0 22px; max-width: 860px; }
+.cp-status-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px; margin: 0 0 22px; width: 100%; max-width: 860px; }
 /* Stat tiles are M3 filled cards at the medium corner: tonal fill, no keyline. */
 .cp-stat { border: 0; border-radius: var(--md-sys-shape-corner-medium);
   background: var(--md-sys-color-surface-container-low); padding: 14px 16px; }
@@ -1061,6 +1061,28 @@ cp-parity-scores { display: contents; }
   letter-spacing: 0.06em; font-weight: 500; color: var(--cp-fg-faint); }
 .cp-stat-val { margin-top: 4px; font-size: var(--md-sys-typescale-title-large-size);
   line-height: var(--md-sys-typescale-title-large-line); font-weight: 400; color: var(--cp-fg); }
+.cp-meter { display: flex; overflow: hidden; height: 8px; margin-top: 12px;
+  border-radius: 999px; background: var(--md-sys-color-surface-container-highest); }
+.cp-meter-segment { display: block; min-width: 0; }
+.cp-meter-segment--primary, .cp-inline-meter-fill--primary {
+  background: var(--md-sys-color-primary); }
+.cp-meter-segment--secondary, .cp-inline-meter-fill--secondary {
+  background: var(--md-sys-color-secondary); }
+.cp-meter-segment--warning, .cp-inline-meter-fill--warning {
+  background: var(--md-sys-color-error); }
+.cp-meter-segment--muted, .cp-inline-meter-fill--muted {
+  background: var(--md-sys-color-outline); }
+.cp-inline-meter { display: block; overflow: hidden; width: min(220px, 100%); height: 5px;
+  margin-top: 5px; border-radius: 999px;
+  background: var(--md-sys-color-surface-container-highest); }
+.cp-inline-meter-fill { display: block; height: 100%; border-radius: inherit; }
+.cp-status-config { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0 24px; width: 100%; max-width: 860px; margin: 0 0 22px; }
+.cp-status-config-row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px;
+  padding: 7px 0; border-bottom: 1px solid var(--md-sys-color-outline-variant); }
+.cp-status-config dt { color: var(--cp-fg-muted); }
+.cp-status-config dd { margin: 0; color: var(--cp-fg); font-variant-numeric: tabular-nums;
+  text-align: right; }
 .cp-status-sec { margin: 26px 0 12px; font-size: var(--md-sys-typescale-title-medium-size);
   line-height: var(--md-sys-typescale-title-medium-line);
   letter-spacing: var(--md-sys-typescale-title-medium-tracking); font-weight: 500; }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderPerfStatsTest.kt
@@ -2,8 +2,10 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class RenderPerfStatsTest {
 
@@ -74,6 +76,20 @@ class RenderPerfStatsTest {
     assertEquals(RenderPerfStats.FAILURE_WINDOW_SIZE, failures.size)
     assertEquals("failure 11", failures.first().reason)
     assertEquals("failure 2", failures.last().reason)
+  }
+
+  @Test
+  fun successfulRenderClearsCurrentFailureButPreservesDiagnostics() {
+    val stats = RenderPerfStats()
+    stats.recordFailed(500, timeout = false, reason = "transient failure")
+
+    assertTrue(stats.snapshot().lastRenderFailed)
+
+    stats.recordOk(100, cold = false)
+    val recovered = stats.snapshot()
+    assertFalse(recovered.lastRenderFailed)
+    assertEquals("transient failure", recovered.lastFailureReason)
+    assertEquals("transient failure", recovered.recentFailures.single().reason)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -74,6 +74,7 @@ class ServeStatusTest {
     catalogLoads: CatalogLoadTracker? = null,
     failedCatalogPreviews: List<String> = emptyList(),
     deferredCatalogPreviews: List<String> = emptyList(),
+    recordDaemonFailure: Boolean = true,
     playgroundHealth: (() -> PlaygroundHealth)? = null,
   ): ServeHttpServer {
     registry.register(
@@ -107,7 +108,7 @@ class ServeStatusTest {
       pinned = true,
     )
     // A recorded startup failure, so the status shows the degraded state + failure row.
-    daemonLog.record("wear-m3", "daemon launch timed out")
+    if (recordDaemonFailure) daemonLog.record("wear-m3", "daemon launch timed out")
     return ServeHttpServer(
         host = "127.0.0.1",
         requestedPort = 0,
@@ -343,7 +344,62 @@ class ServeStatusTest {
     assertTrue(body.contains("design-parity <code>0.1.25</code>"), body)
     // The recent failure surfaces the degraded badge + row.
     assertTrue(body.contains("degraded"), body)
+    assertTrue(body.contains("href=\"#recent-daemon-failures\""), body)
+    assertTrue(body.contains("1 daemon startup failure"), body)
     assertTrue(body.contains("daemon launch timed out"), body)
+  }
+
+  @Test
+  fun `status uses relative catalog times and omits a repeated server id`() {
+    val now = Instant.parse("2026-08-18T12:00:00Z")
+    val html =
+      ServeWeb.statusPage(
+        token = "unused",
+        view =
+          ServeWeb.StatusView(
+            version = "test",
+            public = true,
+            nowMillis = now.toEpochMilli(),
+            overallOk = true,
+            summary = emptyList(),
+            config = emptyList(),
+            catalogs =
+              listOf(
+                ServeWeb.StatusCatalog(
+                  id = "old-catalog",
+                  title = "Old catalog",
+                  listed = true,
+                  trust = "unverified",
+                  previews = 1,
+                  live = false,
+                  running = false,
+                  degradation = null,
+                  provenance =
+                    ServeWeb.CatalogProvenance(
+                      repo = "example/catalog",
+                      branch = "published",
+                      generatedAt = now.minusSeconds(2 * 86_400).toString(),
+                    ),
+                )
+              ),
+            servers =
+              listOf(
+                ServeWeb.StatusServer(
+                  id = "same-session-x",
+                  label = "same-session-x",
+                  backend = "desktop",
+                  activeStreams = 0,
+                  upForText = "1m",
+                )
+              ),
+            failures = emptyList(),
+          ),
+      )
+
+    assertTrue(html.contains(">2 days ago</span>"), html)
+    assertTrue(html.contains("title=\"2026-08-16T12:00:00Z\""), html)
+    assertTrue(html.contains("<td>same-session-x</td>"), html)
+    assertFalse(html.contains("<div class=\"cp-muted\">same-session-x</div>"), html)
   }
 
   @Test
@@ -354,15 +410,19 @@ class ServeStatusTest {
         token = "unused",
         failedCatalogPreviews = listOf("render-failed--button-filled"),
         deferredCatalogPreviews = listOf("live-only-one", "live-only-two"),
+        recordDaemonFailure = false,
       )
     val (_, json) = get("/status.json")
     assertTrue(json.contains("\"failedRenders\":1"), json)
     assertTrue(json.contains("\"deferredPreviews\":2"), json)
-    assertTrue(json.contains("\"status\":\"degraded\""), json)
+    assertTrue(json.contains("\"status\":\"ok\""), json)
 
     val (_, html) = get("/status")
     assertTrue(html.contains("2 rendered · 1 failed · 2 deferred"), html)
-    assertTrue(html.contains("Catalog renders"), html)
+    assertTrue(html.contains("Published catalog renders"), html)
+    assertTrue(html.contains("✓ healthy"), html)
+    assertTrue(html.contains("No recent render failures."), html)
+    assertTrue(html.contains("cp-meter-segment--warning"), html)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -380,7 +380,23 @@ class ServeStatusTest {
                       branch = "published",
                       generatedAt = now.minusSeconds(2 * 86_400).toString(),
                     ),
-                )
+                ),
+                ServeWeb.StatusCatalog(
+                  id = "future-catalog",
+                  title = "Future catalog",
+                  listed = true,
+                  trust = "unverified",
+                  previews = 1,
+                  live = false,
+                  running = false,
+                  degradation = null,
+                  provenance =
+                    ServeWeb.CatalogProvenance(
+                      repo = "example/future-catalog",
+                      branch = "published",
+                      generatedAt = now.plusSeconds(2 * 86_400).toString(),
+                    ),
+                ),
               ),
             servers =
               listOf(
@@ -398,6 +414,8 @@ class ServeStatusTest {
 
     assertTrue(html.contains(">2 days ago</span>"), html)
     assertTrue(html.contains("title=\"2026-08-16T12:00:00Z\""), html)
+    assertTrue(html.contains(">in 2 days</span>"), html)
+    assertTrue(html.contains("title=\"2026-08-20T12:00:00Z\""), html)
     assertTrue(html.contains("<td>same-session-x</td>"), html)
     assertFalse(html.contains("<div class=\"cp-muted\">same-session-x</div>"), html)
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -379,6 +379,65 @@ class ServeStatusTest {
   }
 
   @Test
+  fun `status health includes a resident daemon whose render breaker disabled its live stream`() {
+    val stats =
+      RenderPerfStats()
+        .snapshot()
+        .copy(
+          breaker =
+            RenderBreakerSnapshot(
+              open = true,
+              fatal = true,
+              reason = "render linkage failure",
+            )
+        )
+    val broken =
+      object : ServeHost {
+        override val previews: List<ServePreview> = listOf(ServePreview("a", "A"))
+        override val label: String = "broken"
+        override val hasLiveStream: Boolean = false
+
+        override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+          RenderOutcome.Failed("render linkage failure")
+
+        override fun activeStreamCount(): Int = 0
+
+        override fun subscribeStream(
+          previewId: String,
+          overrides: PreviewOverrides,
+          codec: StreamCodec?,
+          maxFps: Int?,
+          onUnavailable: ((String) -> Unit)?,
+          onFrame: (StreamFrameParams) -> Unit,
+        ): StreamHandle? = null
+
+        override fun renderPerfStats(): RenderPerfSnapshot = stats
+
+        override fun close() {}
+      }
+    registry.register("broken", host = broken)
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "broken",
+          isPublic = true,
+        )
+        .also { it.start() }
+
+    val (jsonCode, json) = get("/status.json")
+    assertEquals(200, jsonCode)
+    assertTrue(json.contains("\"status\":\"degraded\""), json)
+
+    val (htmlCode, html) = get("/status")
+    assertEquals(200, htmlCode)
+    assertTrue(html.contains("1 open live render breaker"), html)
+    assertTrue(html.contains("href=\"#recent-render-failures\""), html)
+  }
+
+  @Test
   fun `status serves a styled html page`() {
     server = newServer(public = true, token = "unused")
     val (code, body) = get("/status")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -324,6 +324,61 @@ class ServeStatusTest {
   }
 
   @Test
+  fun `status health recovers after a successful live render while retaining failure history`() {
+    val stats = RenderPerfStats()
+    val live =
+      object : ServeHost {
+        override val previews: List<ServePreview> = listOf(ServePreview("a", "A"))
+        override val label: String = "live"
+        override val hasLiveStream: Boolean = true
+
+        override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome =
+          RenderOutcome.Ok(png())
+
+        override fun activeStreamCount(): Int = 1
+
+        override fun subscribeStream(
+          previewId: String,
+          overrides: PreviewOverrides,
+          codec: StreamCodec?,
+          maxFps: Int?,
+          onUnavailable: ((String) -> Unit)?,
+          onFrame: (StreamFrameParams) -> Unit,
+        ): StreamHandle? = null
+
+        override fun renderPerfStats(): RenderPerfSnapshot = stats.snapshot()
+
+        override fun close() {}
+      }
+    registry.register("live", host = live)
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "live",
+          isPublic = true,
+        )
+        .also { it.start() }
+
+    stats.recordFailed(500, timeout = false, reason = "transient render failure")
+    val (_, failedJson) = get("/status.json")
+    assertTrue(failedJson.contains("\"status\":\"degraded\""), failedJson)
+    assertTrue(failedJson.contains("\"lastRenderFailed\":true"), failedJson)
+
+    stats.recordOk(100, cold = false)
+    val (_, recoveredJson) = get("/status.json")
+    assertTrue(recoveredJson.contains("\"status\":\"ok\""), recoveredJson)
+    assertTrue(recoveredJson.contains("\"lastRenderFailed\":false"), recoveredJson)
+    assertTrue(recoveredJson.contains("transient render failure"), recoveredJson)
+
+    val (_, recoveredHtml) = get("/status")
+    assertTrue(recoveredHtml.contains("✓ healthy"), recoveredHtml)
+    assertTrue(recoveredHtml.contains("transient render failure"), recoveredHtml)
+  }
+
+  @Test
   fun `status serves a styled html page`() {
     server = newServer(public = true, token = "unused")
     val (code, body) = get("/status")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2533,14 +2533,61 @@ class ServeWebFixtureTest {
             // Exactly two hours after the fixed catalog generation time.
             nowMillis = 1_784_287_800_000,
             overallOk = false,
+            healthReason = "1 daemon startup failure · 1 recent live render failure",
+            healthHref = "#recent-daemon-failures",
             summary =
               listOf(
-                ServeWeb.Stat("Catalogs", "4"),
+                ServeWeb.Stat(
+                  "Catalogs",
+                  "4/4 loaded",
+                  ServeWeb.Meter(
+                    total = 4,
+                    segments = listOf(ServeWeb.MeterSegment("loaded", 4, "primary")),
+                  ),
+                ),
+                ServeWeb.Stat(
+                  "Published catalog renders",
+                  "76 rendered · 1 failed · 0 deferred",
+                  ServeWeb.Meter(
+                    total = 77,
+                    segments =
+                      listOf(
+                        ServeWeb.MeterSegment("rendered", 76, "primary"),
+                        ServeWeb.MeterSegment("failed", 1, "warning"),
+                      ),
+                  ),
+                ),
                 ServeWeb.Stat("Live daemons running", "1"),
                 ServeWeb.Stat("Active streams", "2"),
-                ServeWeb.Stat("Live seats", "3 free / 5"),
+                ServeWeb.Stat(
+                  "Live seats",
+                  "3 free / 5",
+                  ServeWeb.Meter(
+                    total = 5,
+                    segments =
+                      listOf(
+                        ServeWeb.MeterSegment("in use", 2, "secondary"),
+                        ServeWeb.MeterSegment("free", 3, "primary"),
+                      ),
+                  ),
+                ),
                 ServeWeb.Stat("Known sessions", "4"),
                 ServeWeb.Stat("Uptime", "3d 4h"),
+                ServeWeb.Stat(
+                  "Live renders",
+                  "1630 ok · 1 failed · 42 cached",
+                  ServeWeb.Meter(
+                    total = 1673,
+                    segments =
+                      listOf(
+                        ServeWeb.MeterSegment("ok", 1630, "primary"),
+                        ServeWeb.MeterSegment("failed", 1, "warning"),
+                        ServeWeb.MeterSegment("cached", 42, "secondary"),
+                      ),
+                  ),
+                ),
+                ServeWeb.Stat("Average render latency", "741ms"),
+                ServeWeb.Stat("Worst first render", "13679ms"),
               ),
             config =
               listOf(
@@ -2576,6 +2623,13 @@ class ServeWebFixtureTest {
                       fullyOptimized = true,
                       startedAtEpochMillis = 1_721_209_800_000,
                       completedAtEpochMillis = 1_721_209_920_000,
+                    ),
+                  renderCache =
+                    CatalogRenderCacheSnapshot(
+                      entries = 1448,
+                      bytes = 13L * 1024 * 1024,
+                      maxBytes = 128L * 1024 * 1024,
+                      evictions = 0,
                     ),
                 ),
                 ServeWeb.StatusCatalog(
@@ -2618,6 +2672,7 @@ class ServeWebFixtureTest {
                   listed = false,
                   trust = "unverified",
                   previews = 11,
+                  failedRenders = 1,
                   live = true,
                   running = false,
                   degradation = null,
@@ -3433,7 +3488,7 @@ class ServeWebFixtureTest {
         "href=\"https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3\""
       ) &&
         serveStatus.contains("2 hours ago") &&
-        serveStatus.contains("15 Jul 2026, 08:05 UTC") &&
+        serveStatus.contains("2 days ago") &&
         serveStatus.contains("compose-ai-tools <code>0.16.54</code>") &&
         serveStatus.contains("design-parity <code>0.1.25</code>"),
       "catalog status links its delivery branch and shows friendly build provenance",

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -66,7 +66,7 @@
   </nav>
 </header>
         <main class="cp-main">
-              <h1 class="cp-head">Server status <span class="cp-badge cp-badge--unverified">⚠ degraded</span></h1>
+              <h1 class="cp-head">Server status <a class="cp-badge cp-badge--unverified" href="#recent-daemon-failures" title="1 daemon startup failure · 1 recent live render failure">⚠ degraded: 1 daemon startup failure · 1 recent live render failure</a></h1>
       <p class="cp-sub">compose-preview serve · public (open) <span class="cp-about-ver">v0.0.0-fixture</span></p>
       <details class="cp-about cp-disclosure">
         <summary>
@@ -85,22 +85,26 @@
       </details>
 
       <div class="cp-status-grid">
-      <div class="cp-stat"><div class="cp-stat-key">Catalogs</div><div class="cp-stat-val">4</div></div>
+      <div class="cp-stat"><div class="cp-stat-key">Catalogs</div><div class="cp-stat-val">4/4 loaded</div><div class="cp-meter" role="img" aria-label="4/4 loaded"><span class="cp-meter-segment cp-meter-segment--primary" style="width:100.000%" title="loaded: 4"></span></div></div>
+<div class="cp-stat"><div class="cp-stat-key">Published catalog renders</div><div class="cp-stat-val">76 rendered · 1 failed · 0 deferred</div><div class="cp-meter" role="img" aria-label="76 rendered · 1 failed · 0 deferred"><span class="cp-meter-segment cp-meter-segment--primary" style="width:98.701%" title="rendered: 76"></span><span class="cp-meter-segment cp-meter-segment--warning" style="width:1.299%" title="failed: 1"></span></div></div>
 <div class="cp-stat"><div class="cp-stat-key">Live daemons running</div><div class="cp-stat-val">1</div></div>
 <div class="cp-stat"><div class="cp-stat-key">Active streams</div><div class="cp-stat-val">2</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Live seats</div><div class="cp-stat-val">3 free / 5</div></div>
+<div class="cp-stat"><div class="cp-stat-key">Live seats</div><div class="cp-stat-val">3 free / 5</div><div class="cp-meter" role="img" aria-label="3 free / 5"><span class="cp-meter-segment cp-meter-segment--secondary" style="width:40.000%" title="in use: 2"></span><span class="cp-meter-segment cp-meter-segment--primary" style="width:60.000%" title="free: 3"></span></div></div>
 <div class="cp-stat"><div class="cp-stat-key">Known sessions</div><div class="cp-stat-val">4</div></div>
 <div class="cp-stat"><div class="cp-stat-key">Uptime</div><div class="cp-stat-val">3d 4h</div></div>
+<div class="cp-stat"><div class="cp-stat-key">Live renders</div><div class="cp-stat-val">1630 ok · 1 failed · 42 cached</div><div class="cp-meter" role="img" aria-label="1630 ok · 1 failed · 42 cached"><span class="cp-meter-segment cp-meter-segment--primary" style="width:97.430%" title="ok: 1630"></span><span class="cp-meter-segment cp-meter-segment--warning" style="width:0.060%" title="failed: 1"></span><span class="cp-meter-segment cp-meter-segment--secondary" style="width:2.510%" title="cached: 42"></span></div></div>
+<div class="cp-stat"><div class="cp-stat-key">Average render latency</div><div class="cp-stat-val">741ms</div></div>
+<div class="cp-stat"><div class="cp-stat-key">Worst first render</div><div class="cp-stat-val">13679ms</div></div>
       </div>
 
-      <p class="cp-status-sec">Catalogs</p>
+      <p class="cp-status-sec" id="catalogs">Catalogs</p>
       <div class="cp-status-scroll"><table class="cp-table">
         <thead><tr><th>Catalog</th><th>Trust</th><th>Previews</th><th>State</th></tr></thead>
         <tbody>
-        <tr><td><a href="/compose-m3/">Compose Material 3</a><div class="cp-muted">compose-m3</div><div class="cp-muted"><a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3">yschimke/compose-ai-tools@design-artifacts/compose-m3</a> · <span title="2026-07-17T09:30:00.000Z">2 hours ago</span></div><div class="cp-muted">compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></div></td><td><span class="cp-muted">—</span></td><td>42</td><td><span class="cp-ok">live · running</span><div class="cp-muted">themes optimized 168/168</div></td></tr>
-<tr><td><a href="/remote-m3/">Remote Compose Material 3</a><div class="cp-muted">remote-m3</div><div class="cp-muted"><a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/remote-m3">yschimke/compose-ai-tools@design-artifacts/remote-m3</a> · <span title="2026-07-15T08:05:00.000Z">15 Jul 2026, 08:05 UTC</span></div><div class="cp-muted">compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></div></td><td><span class="cp-muted">—</span></td><td>6</td><td><span class="cp-muted">baked PNG</span><div class="cp-muted">this delivery branch publishes no live bundle this server can run</div></td></tr>
+        <tr><td><a href="/compose-m3/">Compose Material 3</a><div class="cp-muted">compose-m3</div><div class="cp-muted"><a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/compose-m3">yschimke/compose-ai-tools@design-artifacts/compose-m3</a> · <span title="2026-07-17T09:30:00.000Z">2 hours ago</span></div><div class="cp-muted">compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></div></td><td><span class="cp-muted">—</span></td><td>42</td><td><span class="cp-ok">live · running</span><div class="cp-muted">themes optimized 168/168</div><span class="cp-inline-meter" role="img" aria-label="themes optimized 168/168"><span class="cp-inline-meter-fill cp-inline-meter-fill--primary" style="width:100.000%"></span></span><div class="cp-muted">preview cache 1448 entries · 13 MiB / 128 MiB</div><span class="cp-inline-meter" role="img" aria-label="preview cache 1448 entries · 13 MiB / 128 MiB"><span class="cp-inline-meter-fill cp-inline-meter-fill--secondary" style="width:10.156%"></span></span></td></tr>
+<tr><td><a href="/remote-m3/">Remote Compose Material 3</a><div class="cp-muted">remote-m3</div><div class="cp-muted"><a href="https://github.com/yschimke/compose-ai-tools/tree/design-artifacts/remote-m3">yschimke/compose-ai-tools@design-artifacts/remote-m3</a> · <span title="2026-07-15T08:05:00.000Z">2 days ago</span></div><div class="cp-muted">compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></div></td><td><span class="cp-muted">—</span></td><td>6</td><td><span class="cp-muted">baked PNG</span><div class="cp-muted">this delivery branch publishes no live bundle this server can run</div></td></tr>
 <tr><td><a href="/confetti-wear/">Confetti Wear</a><div class="cp-muted">confetti-wear</div><div class="cp-muted"><a href="https://github.com/joreilly/Confetti/tree/design-artifacts/confetti-wear">joreilly/Confetti@design-artifacts/confetti-wear</a> · <span title="2026-07-17T09:30:00.000Z">2 hours ago</span></div><div class="cp-muted">compose-ai-tools <code>0.16.54</code> · design-parity <code>0.1.25</code></div></td><td><span class="cp-muted">—</span><div class="cp-muted">last known</div></td><td>18</td><td>live · idle</td></tr>
-<tr><td><a href="/cadence/">Cadence</a> <span class="cp-muted">(unlisted)</span><div class="cp-muted">cadence</div></td><td> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ untrusted</span></td><td>11</td><td>live · idle</td></tr>
+<tr><td><a href="/cadence/">Cadence</a> <span class="cp-muted">(unlisted)</span><div class="cp-muted">cadence</div></td><td> <span class="cp-badge cp-badge--unverified" title="producer trust: unverified">⚠ untrusted</span></td><td>11 total<div class="cp-muted">10 rendered · 1 failed · 0 deferred</div></td><td>live · idle</td></tr>
         </tbody>
       </table></div>
 
@@ -113,21 +117,21 @@
       </table></div>
 
       <p class="cp-status-sec">Configuration</p>
-      <div class="cp-status-grid">
-      <div class="cp-stat"><div class="cp-stat-key">Access</div><div class="cp-stat-val">public (open)</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Bind</div><div class="cp-stat-val">0.0.0.0:8080</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Trusted re-render</div><div class="cp-stat-val">on</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Trust store</div><div class="cp-stat-val">configured</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Catalog refresh</div><div class="cp-stat-val">600s</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Live seats</div><div class="cp-stat-val">5</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Render slots</div><div class="cp-stat-val">4</div></div>
-<div class="cp-stat"><div class="cp-stat-key">Accept uploads</div><div class="cp-stat-val">off</div></div>
-      </div>
+      <dl class="cp-status-config">
+      <div class="cp-status-config-row"><dt>Access</dt><dd>public (open)</dd></div>
+<div class="cp-status-config-row"><dt>Bind</dt><dd>0.0.0.0:8080</dd></div>
+<div class="cp-status-config-row"><dt>Trusted re-render</dt><dd>on</dd></div>
+<div class="cp-status-config-row"><dt>Trust store</dt><dd>configured</dd></div>
+<div class="cp-status-config-row"><dt>Catalog refresh</dt><dd>600s</dd></div>
+<div class="cp-status-config-row"><dt>Live seats</dt><dd>5</dd></div>
+<div class="cp-status-config-row"><dt>Render slots</dt><dd>4</dd></div>
+<div class="cp-status-config-row"><dt>Accept uploads</dt><dd>off</dd></div>
+      </dl>
 
-      <p class="cp-status-sec">Recent daemon startup failures</p>
+      <p class="cp-status-sec" id="recent-daemon-failures">Recent daemon startup failures</p>
       <div class="cp-status-scroll"><table class="cp-table"><thead><tr><th>When</th><th>Session</th><th>Reason</th></tr></thead><tbody><tr><td>2026-07-17 09:41 UTC</td><td>wear-m3</td><td>daemon launch timed out after 300s</td></tr></tbody></table></div>
 
-      <p class="cp-status-sec">Recent render failures</p>
+      <p class="cp-status-sec" id="recent-render-failures">Recent live render failures</p>
       <div class="cp-status-scroll"><table class="cp-table"><thead><tr><th>When</th><th>Session</th><th>Duration</th><th>Reason</th></tr></thead><tbody><tr><td>2026-07-17 09:43 UTC</td><td>compose-m3 (live bundle)</td><td>120000ms (timeout)</td><td>timed out waiting for renderFinished</td></tr></tbody></table></div>
         </main>
         <footer class="cp-site-footer">


### PR DESCRIPTION
## Summary

- make the status badge reflect current host failures instead of published catalog render quality, and link degraded health to its explanation
- render denominator-backed summary and per-catalog values as accessible capacity/progress meters
- separate render latency from the live-render composition, replace configuration cards with a dense definition list, and widen the summary grid
- use relative catalog timestamps consistently and omit a running server ID when it duplicates its label
- update route regressions and the committed visual fixture

## Root cause

Published catalog render failures and recent live render failures were both described as “render failures,” while published failures also drove the host-level degraded state. The presentation model flattened ratios, capacity, and progress into prose, and the timestamp formatter switched formats after 24 hours.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests '*ServeStatusTest*' --tests '*ServeWebFixtureTest*'`
- 44 focused tests passed
- `git diff --check`

Fixes #4137
Fixes #4138
Fixes #4139