### PR TITLE
fix(preview): coordinate rollouts and optimizer load

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -138,6 +138,7 @@ internal object CliFlagValidation {
             "--catalog-feed-cache",
             "--theme-cache-dir",
             "--theme-cache-max-bytes",
+            "--theme-optimizer-coordination-dir",
             "--catalog-feed-idle-timeout",
             "--catalog-max-images",
             "--catalog-refresh-interval",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -109,6 +109,7 @@ internal object CliFlags {
       "--catalog-feed-cache",
       "--theme-cache-dir",
       "--theme-cache-max-bytes",
+      "--theme-optimizer-coordination-dir",
       "--catalog-source-root",
       "--wasm-dir",
       "--rc-player-wasm-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -5,11 +5,15 @@ import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.CatalogRefreshResult
 import ee.schimke.composeai.cli.serve.CatalogThemeCache
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
+import ee.schimke.composeai.cli.serve.FileOptimizerHostCoordinator
 import ee.schimke.composeai.cli.serve.GenerationInputs
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.GradleRevisionBuilder
+import ee.schimke.composeai.cli.serve.LinuxHostResourceSampler
 import ee.schimke.composeai.cli.serve.LiveSeatLimiter
 import ee.schimke.composeai.cli.serve.MutableTrustStore
+import ee.schimke.composeai.cli.serve.OptimizerHostCoordinator
+import ee.schimke.composeai.cli.serve.OptimizerPressureGate
 import ee.schimke.composeai.cli.serve.PlaygroundAndroidRenderService
 import ee.schimke.composeai.cli.serve.PlaygroundAndroidSessionOpener
 import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
@@ -745,8 +749,32 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * The lane is derived from [liveSeatLimiter] because widening it is only safe where something
    * else bounds daemon count: an unbounded budget (the CLI default) keeps the single lane.
    */
-  private val backgroundWork =
-    ServeBackgroundWork(maxConcurrentRenders = ServeBackgroundWork.renderLaneFor(liveSeatLimiter))
+  private val optimizerCoordinationDirectory: File? by lazy {
+    val explicit =
+      args.flagValue("--theme-optimizer-coordination-dir")?.takeIf { it.isNotBlank() }?.let(::File)
+    explicit
+      ?: catalogsFile
+        ?.displayPath
+        ?.let(::File)
+        ?.absoluteFile
+        ?.parentFile
+        ?.resolve("optimizer-locks")
+  }
+
+  private val backgroundWork by lazy {
+    val pressureSampler = LinuxHostResourceSampler()
+    ServeBackgroundWork(
+      maxConcurrentRenders = ServeBackgroundWork.renderLaneFor(liveSeatLimiter),
+      hostCoordinator =
+        optimizerCoordinationDirectory?.let {
+          FileOptimizerHostCoordinator(
+            directory = it,
+            lanes = ServeBackgroundWork.DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
+          )
+        } ?: OptimizerHostCoordinator.NONE,
+      pressureGate = OptimizerPressureGate(sample = pressureSampler::sample),
+    )
+  }
 
   /**
    * Durable home for warmed theme renders (`--theme-cache-dir`), or null to keep the cache in
@@ -4190,6 +4218,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
                           ${ThemeCacheStore.DEFAULT_MAX_BYTES / (1024L * 1024 * 1024)} GB). Superseded
                           generations are reclaimed; generations still in use are never evicted, so
                           exceeding this is reported rather than acted on.
+        --theme-optimizer-coordination-dir <dir>
+                          Shared directory used to coordinate background optimizer lanes across
+                          server replicas. Defaults to optimizer-locks beside --catalogs-file; set
+                          this explicitly when replicas do not share that directory.
         --wasm-dir <system>=<dir>[,<system>=<dir>…]
                           In-browser CMP tier: map a design system to its assembled Kotlin/Wasm
                           catalog app (./gradlew :samples:cmp-wasm-catalog:wasmCatalogDist →

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -1,0 +1,267 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.Serializable
+
+/** One observation of the host resources background optimization must yield to. */
+data class HostResourceSample(
+  val loadPerCpu: Double?,
+  val cpuUtilization: Double?,
+  val memoryAvailableFraction: Double?,
+)
+
+/** Thresholds deliberately have separate stop/resume sides so a busy host cannot flap. */
+data class OptimizerPressureThresholds(
+  val stopLoadPerCpu: Double = 0.85,
+  val resumeLoadPerCpu: Double = 0.60,
+  val stopCpuUtilization: Double = 0.85,
+  val resumeCpuUtilization: Double = 0.70,
+  val stopMemoryAvailableFraction: Double = 0.15,
+  val resumeMemoryAvailableFraction: Double = 0.25,
+  val resumeQuietMillis: Long = 30_000L,
+  val sampleIntervalMillis: Long = 2_000L,
+)
+
+/** Host-pressure state published on `/status.json` with the optimizer admission counters. */
+@Serializable
+data class OptimizerPressureSnapshot(
+  val constrained: Boolean,
+  val reason: String? = null,
+  val loadPerCpu: Double? = null,
+  val cpuUtilization: Double? = null,
+  val memoryAvailableFraction: Double? = null,
+  val sampledAtEpochMillis: Long? = null,
+)
+
+/**
+ * Hysteretic host-resource gate for best-effort optimization.
+ *
+ * A high reading stops admission immediately. Resumption requires every available reading to be on
+ * the safe side for [OptimizerPressureThresholds.resumeQuietMillis], so a render finishing does not
+ * instantly admit another cold daemon while the host is still recovering.
+ */
+class OptimizerPressureGate(
+  private val sample: () -> HostResourceSample?,
+  private val thresholds: OptimizerPressureThresholds = OptimizerPressureThresholds(),
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val lock = Any()
+  private var cached = OptimizerPressureSnapshot(constrained = false)
+  private var nextSampleAt = Long.MIN_VALUE
+  private var safeSince = Long.MIN_VALUE
+
+  fun snapshot(): OptimizerPressureSnapshot =
+    synchronized(lock) {
+      val now = clock()
+      if (now < nextSampleAt) return@synchronized cached
+      nextSampleAt = now + thresholds.sampleIntervalMillis.coerceAtLeast(0L)
+      val current = runCatching(sample).getOrNull() ?: return@synchronized cached
+      val reasons = buildList {
+        current.loadPerCpu
+          ?.takeIf { it >= thresholds.stopLoadPerCpu }
+          ?.let { add("load ${formatRatio(it)} per CPU") }
+        current.cpuUtilization
+          ?.takeIf { it >= thresholds.stopCpuUtilization }
+          ?.let { add("CPU ${formatPercent(it)}") }
+        current.memoryAvailableFraction
+          ?.takeIf { it <= thresholds.stopMemoryAvailableFraction }
+          ?.let { add("memory available ${formatPercent(it)}") }
+      }
+      val safe =
+        current.loadPerCpu?.let { it <= thresholds.resumeLoadPerCpu } != false &&
+          current.cpuUtilization?.let { it <= thresholds.resumeCpuUtilization } != false &&
+          current.memoryAvailableFraction?.let { it >= thresholds.resumeMemoryAvailableFraction } !=
+            false
+      val constrained =
+        if (reasons.isNotEmpty()) {
+          safeSince = Long.MIN_VALUE
+          true
+        } else if (!cached.constrained) {
+          false
+        } else if (!safe) {
+          safeSince = Long.MIN_VALUE
+          true
+        } else {
+          if (safeSince == Long.MIN_VALUE) safeSince = now
+          now - safeSince < thresholds.resumeQuietMillis
+        }
+      cached =
+        OptimizerPressureSnapshot(
+          constrained = constrained,
+          reason =
+            when {
+              reasons.isNotEmpty() -> reasons.joinToString(", ")
+              constrained -> "host recovering"
+              else -> null
+            },
+          loadPerCpu = current.loadPerCpu,
+          cpuUtilization = current.cpuUtilization,
+          memoryAvailableFraction = current.memoryAvailableFraction,
+          sampledAtEpochMillis = now,
+        )
+      cached
+    }
+
+  private fun formatRatio(value: Double): String = "%.2f".format(java.util.Locale.ROOT, value)
+
+  private fun formatPercent(value: Double): String =
+    "%.0f%%".format(java.util.Locale.ROOT, value * 100.0)
+}
+
+/** Reads Linux host load, CPU time and available memory through the proc filesystem. */
+class LinuxHostResourceSampler(private val procRoot: File = File("/proc")) {
+  private val previousCpu = AtomicReference<CpuTimes?>()
+
+  fun sample(): HostResourceSample? {
+    if (!procRoot.isDirectory) return null
+    val statLines = runCatching { File(procRoot, "stat").readLines() }.getOrNull().orEmpty()
+    val cpuCount =
+      statLines
+        .count { it.startsWith("cpu") && it.length > 3 && it[3].isDigit() }
+        .coerceAtLeast(Runtime.getRuntime().availableProcessors().coerceAtLeast(1))
+    val load = runCatching {
+      File(procRoot, "loadavg").readText().trim().substringBefore(' ').toDouble() / cpuCount
+    }
+      .getOrNull()
+    val cpu = statLines.firstOrNull()?.takeIf { it.startsWith("cpu ") }?.let(::cpuUtilization)
+    val memory = runCatching {
+      val values =
+        File(procRoot, "meminfo").useLines { lines ->
+          lines
+            .mapNotNull { line ->
+              val key = line.substringBefore(':', missingDelimiterValue = "")
+              val value = line.substringAfter(':', "").trim().substringBefore(' ').toLongOrNull()
+              value?.let { key to it }
+            }
+            .toMap()
+        }
+      val total = values["MemTotal"]?.takeIf { it > 0 } ?: return@runCatching null
+      values["MemAvailable"]?.toDouble()?.div(total)
+    }
+      .getOrNull()
+      ?.let { it }
+    if (load == null && cpu == null && memory == null) return null
+    return HostResourceSample(load, cpu, memory)
+  }
+
+  private fun cpuUtilization(line: String): Double? {
+    val values = line.trim().split(Regex("\\s+")).drop(1).mapNotNull(String::toLongOrNull)
+    if (values.size < 4) return null
+    val idle = values[3] + values.getOrElse(4) { 0L }
+    val total = values.sum()
+    val now = CpuTimes(total, idle)
+    val before = previousCpu.getAndSet(now) ?: return null
+    val totalDelta = now.total - before.total
+    if (totalDelta <= 0) return null
+    return (1.0 - (now.idle - before.idle).toDouble() / totalDelta).coerceIn(0.0, 1.0)
+  }
+
+  private data class CpuTimes(val total: Long, val idle: Long)
+}
+
+/** A host-wide optimizer lease. Closing it releases both the catalog and lane locks. */
+fun interface OptimizerHostLease : AutoCloseable
+
+/** Cross-process admission used by every preview replica sharing one coordination directory. */
+fun interface OptimizerHostCoordinator {
+  fun tryAcquire(system: String): OptimizerHostLease?
+
+  companion object {
+    val NONE = OptimizerHostCoordinator { OptimizerHostLease {} }
+  }
+}
+
+/**
+ * Coordinates optimizer work across server replicas with advisory file locks.
+ *
+ * A per-system lock prevents two replicas warming the same generation concurrently. A lane lock
+ * caps all optimizer passes on the physical host, rather than multiplying the configured lane count
+ * by the number of replicas. Locks are released by the kernel if a replica exits or is OOM-killed.
+ */
+class FileOptimizerHostCoordinator(
+  private val directory: File,
+  private val lanes: Int,
+) : OptimizerHostCoordinator, AutoCloseable {
+  @Volatile private var leaderLock: HeldFileLock? = null
+
+  init {
+    Runtime.getRuntime().addShutdownHook(Thread({ close() }, "optimizer-host-lock-release"))
+  }
+
+  override fun tryAcquire(system: String): OptimizerHostLease? {
+    if (!(directory.isDirectory || directory.mkdirs())) return null
+    // One replica owns optimization for its lifetime. A pass-sized system lock alone prevents
+    // simultaneous work, but the next slice could move to a replica whose in-memory view predates
+    // the first replica's writes and redundantly warm the same generation. Leadership keeps the
+    // cache/index view coherent; the kernel hands it to a survivor if the owner exits or is killed.
+    if (!ensureLeader()) return null
+    val systemLock = tryLock(File(directory, "system-${digest(system)}.lock")) ?: return null
+    for (lane in 0 until lanes.coerceAtLeast(1)) {
+      val laneLock = tryLock(File(directory, "lane-$lane.lock"))
+      if (laneLock != null) {
+        return OptimizerHostLease {
+          laneLock.close()
+          systemLock.close()
+        }
+      }
+    }
+    systemLock.close()
+    return null
+  }
+
+  @Synchronized
+  private fun ensureLeader(): Boolean {
+    if (leaderLock != null) return true
+    leaderLock = tryLock(File(directory, "leader.lock"))
+    return leaderLock != null
+  }
+
+  @Synchronized
+  override fun close() {
+    leaderLock?.close()
+    leaderLock = null
+  }
+
+  private fun tryLock(file: File): HeldFileLock? {
+    val randomAccess = runCatching { RandomAccessFile(file, "rw") }.getOrNull() ?: return null
+    val channel = randomAccess.channel
+    val lock =
+      try {
+        channel.tryLock()
+      } catch (_: OverlappingFileLockException) {
+        null
+      } catch (_: Exception) {
+        null
+      }
+    if (lock == null) {
+      runCatching { channel.close() }
+      runCatching { randomAccess.close() }
+      return null
+    }
+    return HeldFileLock(randomAccess, channel, lock)
+  }
+
+  private fun digest(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(value.toByteArray(Charsets.UTF_8))
+      .take(12)
+      .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+  private class HeldFileLock(
+    private val randomAccess: RandomAccessFile,
+    private val channel: FileChannel,
+    private val lock: FileLock,
+  ) : AutoCloseable {
+    override fun close() {
+      runCatching { lock.release() }
+      runCatching { channel.close() }
+      runCatching { randomAccess.close() }
+    }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -56,6 +56,8 @@ class ServeBackgroundWork(
    * instead of parked expensively.
    */
   maxConcurrentOptimizers: Int = DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
+  private val hostCoordinator: OptimizerHostCoordinator = OptimizerHostCoordinator.NONE,
+  private val pressureGate: OptimizerPressureGate? = null,
 ) {
   private val loadsInFlight = AtomicInteger()
   private val initialLoadPending = AtomicBoolean(false)
@@ -89,6 +91,7 @@ class ServeBackgroundWork(
   private val optimizerAdmissionWaitMillis = AtomicLong()
   private val optimizerPausedUntil = AtomicLong(Long.MIN_VALUE)
   private val optimizerPauseReason = ConcurrentHashMap<String, String>()
+  private val optimizerHostRefusals = AtomicLong()
 
   /**
    * True while the server is bringing catalogs up: the startup pass hasn't finished, or a refresh /
@@ -165,6 +168,13 @@ class ServeBackgroundWork(
       optimizerRefusals.incrementAndGet()
       return null
     }
+    val hostLease = acquireHostLease(system, waitMillis)
+    if (hostLease == null) {
+      releaseOptimizerLane(system)
+      optimizerHostRefusals.incrementAndGet()
+      optimizerRefusals.incrementAndGet()
+      return null
+    }
     optimizerAdmissions.incrementAndGet()
     optimizerRunning.computeIfAbsent(system) { AtomicInteger() }.incrementAndGet()
     return try {
@@ -173,8 +183,26 @@ class ServeBackgroundWork(
       optimizerRunning.computeIfPresent(system) { _, count ->
         if (count.decrementAndGet() == 0) null else count
       }
+      hostLease.close()
       releaseOptimizerLane(system)
     }
+  }
+
+  private fun acquireHostLease(system: String, waitMillis: Long): OptimizerHostLease? {
+    val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(waitMillis.coerceAtLeast(0L))
+    while (!optimizersPaused()) {
+      hostCoordinator.tryAcquire(system)?.let {
+        return it
+      }
+      if (System.nanoTime() >= deadline) return null
+      try {
+        Thread.sleep(HOST_COORDINATION_RETRY_MILLIS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return null
+      }
+    }
+    return null
   }
 
   /**
@@ -296,12 +324,15 @@ class ServeBackgroundWork(
   }
 
   /** Whether optimizer passes are currently stood down. Cheap enough for a per-batch check. */
-  fun optimizersPaused(): Boolean = clock() < optimizerPausedUntil.get()
+  fun optimizersPaused(): Boolean =
+    clock() < optimizerPausedUntil.get() || pressureGate?.snapshot()?.constrained == true
 
   /** Counters for `/status.json`; see [ThemeOptimizerAdmissionSnapshot]. */
   fun optimizerAdmissionSnapshot(): ThemeOptimizerAdmissionSnapshot {
     val until = optimizerPausedUntil.get()
-    val paused = clock() < until
+    val manuallyPaused = clock() < until
+    val pressure = pressureGate?.snapshot()
+    val paused = manuallyPaused || pressure?.constrained == true
     val queued = admissionLock.run {
       lock()
       try {
@@ -318,10 +349,17 @@ class ServeBackgroundWork(
       waitingSystems = queued,
       admissions = optimizerAdmissions.get(),
       refusals = optimizerRefusals.get(),
+      hostRefusals = optimizerHostRefusals.get(),
       admissionWaitMillis = optimizerAdmissionWaitMillis.get(),
       paused = paused,
-      pausedUntilEpochMillis = if (paused) until else null,
-      pauseReason = if (paused) optimizerPauseReason["reason"] else null,
+      pausedUntilEpochMillis = if (manuallyPaused) until else null,
+      pauseReason =
+        when {
+          manuallyPaused -> optimizerPauseReason["reason"]
+          pressure?.constrained == true -> pressure.reason
+          else -> null
+        },
+      pressure = pressure,
     )
   }
 
@@ -353,6 +391,8 @@ class ServeBackgroundWork(
      * another's renders without recreating the free-for-all.
      */
     const val DEFAULT_MAX_CONCURRENT_OPTIMIZERS: Int = 2
+
+    const val HOST_COORDINATION_RETRY_MILLIS: Long = 100L
 
     /** Pause reasons are bounded before they reach a status page. */
     const val MAX_PAUSE_REASON_CHARS: Int = 200
@@ -424,8 +464,10 @@ data class ThemeOptimizerAdmissionSnapshot(
   val waitingSystems: List<String> = emptyList(),
   val admissions: Long,
   val refusals: Long,
+  val hostRefusals: Long = 0,
   val admissionWaitMillis: Long,
   val paused: Boolean,
   val pausedUntilEpochMillis: Long? = null,
   val pauseReason: String? = null,
+  val pressure: OptimizerPressureSnapshot? = null,
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import java.io.File
 import java.io.IOException
+import java.io.RandomAccessFile
+import java.nio.channels.OverlappingFileLockException
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -336,6 +338,11 @@ class ThemeCacheStore(
       // keys
       // the read path would serve it again the moment the fresh copy fell out of memory.
       if (name in present && !(replaceExisting && name in adopted)) return
+      // Optimizer admission prevents duplicate warming, but foreground renders can still complete
+      // on two zero-downtime replicas at once. Serialize writes for the whole generation across
+      // processes. This is try-lock rather than lock: persistence is best-effort and a visitor must
+      // never wait for another replica's disk write.
+      val generationWriteLock = tryGenerationWriteLock() ?: return
       val target = File(dir, "$name$PNG_SUFFIX")
       // Writer-unique, because the zero-downtime rollout puts two processes on this volume at once.
       // A temp path shared by cache key lets one replica rename the inode while the other is still
@@ -363,6 +370,8 @@ class ThemeCacheStore(
       } catch (e: IOException) {
         runCatching { temp.delete() }
         recordFailure(system, e.message ?: e::class.simpleName ?: "write failed")
+      } finally {
+        generationWriteLock.close()
       }
     }
 
@@ -375,26 +384,61 @@ class ThemeCacheStore(
      * the same broken identity that just proved untrustworthy.
      */
     fun discard(): Boolean {
-      present.clear()
-      adopted.clear()
-      // Measured before the delete and subtracted, or the census would carry the discarded
-      // generation's bytes plus its rebuilt replacement until the next sweep — making the one
-      // number an operator uses to judge occupancy roughly twice the truth.
-      knownBytes.addAndGet(-dir.sizeOnDisk())
-      return runCatching {
-          // The PNGs go; the DIRECTORY stays. This generation object remains attached to a live
-          // CatalogThemeCache, and deleting the directory under it would make every later `put`
-          // fail its temp write, catch the IOException and persist nothing — so the optimizer would
-          // re-render the whole catalog into memory alone and lose it all again at restart. The
-          // point of discarding is to stop trusting these bytes, not to stop writing new ones.
-          // EVERY child must go. A partial discard leaves stale PNGs under a fingerprint this
-          // process has already decided it cannot trust, and the next restart adopts them again —
-          // reproducing the exact mismatch that triggered the discard, indefinitely.
-          val cleared = dir.listFiles()?.all { it.deleteRecursively() } ?: true
-          if (!cleared) recordFailure(system, "could not fully discard ${dir.name}")
-          cleared && (dir.isDirectory || dir.mkdirs())
+      val generationWriteLock = tryGenerationWriteLock() ?: return false
+      try {
+        present.clear()
+        adopted.clear()
+        // Measured before the delete and subtracted, or the census would carry the discarded
+        // generation's bytes plus its rebuilt replacement until the next sweep — making the one
+        // number an operator uses to judge occupancy roughly twice the truth.
+        knownBytes.addAndGet(-dir.sizeOnDisk())
+        return runCatching {
+            // The PNGs go; the DIRECTORY stays. This generation object remains attached to a live
+            // CatalogThemeCache, and deleting the directory under it would make every later `put`
+            // fail its temp write, catch the IOException and persist nothing — so the optimizer
+            // would
+            // re-render the whole catalog into memory alone and lose it all again at restart. The
+            // point of discarding is to stop trusting these bytes, not to stop writing new ones.
+            // EVERY child must go. A partial discard leaves stale PNGs under a fingerprint this
+            // process has already decided it cannot trust, and the next restart adopts them again —
+            // reproducing the exact mismatch that triggered the discard, indefinitely.
+            val cleared =
+              dir
+                .listFiles()
+                ?.filterNot { it.name == GENERATION_WRITE_LOCK }
+                ?.all { it.deleteRecursively() } ?: true
+            if (!cleared) recordFailure(system, "could not fully discard ${dir.name}")
+            cleared && (dir.isDirectory || dir.mkdirs())
+          }
+          .getOrDefault(false)
+      } finally {
+        generationWriteLock.close()
+      }
+    }
+
+    private fun tryGenerationWriteLock(): AutoCloseable? {
+      val randomAccess =
+        runCatching { RandomAccessFile(File(dir, GENERATION_WRITE_LOCK), "rw") }.getOrNull()
+          ?: return null
+      val channel = randomAccess.channel
+      val lock =
+        try {
+          channel.tryLock()
+        } catch (_: OverlappingFileLockException) {
+          null
+        } catch (_: IOException) {
+          null
         }
-        .getOrDefault(false)
+      if (lock == null) {
+        runCatching { channel.close() }
+        runCatching { randomAccess.close() }
+        return null
+      }
+      return AutoCloseable {
+        runCatching { lock.release() }
+        runCatching { channel.close() }
+        runCatching { randomAccess.close() }
+      }
     }
 
     /**
@@ -437,6 +481,7 @@ class ThemeCacheStore(
     const val MAX_REASON_CHARS: Int = 200
     private const val PNG_SUFFIX = ".png"
     private const val TEMP_SUFFIX = ".png.tmp"
+    private const val GENERATION_WRITE_LOCK = ".write.lock"
 
     /**
      * Names that may become a directory under the store root.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -1,0 +1,112 @@
+package ee.schimke.composeai.cli.serve
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HostOptimizerAdmissionTest {
+  @Test
+  fun `file coordinator caps the whole host and excludes duplicate systems`() {
+    val directory = Files.createTempDirectory("optimizer-host-locks").toFile()
+    try {
+      val firstReplica = FileOptimizerHostCoordinator(directory, lanes = 2)
+      val secondReplica = FileOptimizerHostCoordinator(directory, lanes = 2)
+      val first = assertNotNull(firstReplica.tryAcquire("catalog-a"))
+      assertNull(
+        secondReplica.tryAcquire("catalog-a"),
+        "the same catalog must not warm in two replicas",
+      )
+      assertNull(
+        secondReplica.tryAcquire("catalog-b"),
+        "only the elected replica may warm, so its cache index stays coherent",
+      )
+      val second = assertNotNull(firstReplica.tryAcquire("catalog-b"))
+      assertNull(firstReplica.tryAcquire("catalog-c"), "the two lanes belong to the whole host")
+
+      first.close()
+      assertNotNull(firstReplica.tryAcquire("catalog-c")).close()
+      second.close()
+      firstReplica.close()
+      assertNotNull(secondReplica.tryAcquire("catalog-a"), "leadership fails over on exit").close()
+      secondReplica.close()
+    } finally {
+      directory.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `pressure stops immediately and resumes only after a quiet recovery window`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.2, cpuUtilization = 0.2, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(resumeQuietMillis = 1_000, sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(cpuUtilization = 0.9)
+    assertTrue(gate.snapshot().constrained)
+    assertTrue(gate.snapshot().reason.orEmpty().contains("CPU"))
+
+    now = 100
+    sample = sample.copy(cpuUtilization = 0.2)
+    assertTrue(gate.snapshot().constrained, "one safe sample must not flap the optimizer back on")
+    assertTrue(gate.snapshot().reason.orEmpty().contains("recovering"))
+    now = 1_099
+    assertTrue(gate.snapshot().constrained)
+    now = 1_100
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `load and memory independently constrain optimization`() {
+    var sample =
+      HostResourceSample(loadPerCpu = 0.9, cpuUtilization = 0.1, memoryAvailableFraction = 0.8)
+    val loadGate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    assertTrue(loadGate.snapshot().constrained)
+    assertTrue(loadGate.snapshot().reason.orEmpty().contains("load"))
+
+    sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.1)
+    val memoryGate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    assertTrue(memoryGate.snapshot().constrained)
+    assertTrue(memoryGate.snapshot().reason.orEmpty().contains("memory"))
+  }
+
+  @Test
+  fun `background work reports automatic pressure as a pause`() {
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 1.2,
+            cpuUtilization = 0.95,
+            memoryAvailableFraction = 0.05,
+          )
+        },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+      )
+    val work = ServeBackgroundWork(pressureGate = gate)
+
+    assertNull(work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    val snapshot = work.optimizerAdmissionSnapshot()
+    assertTrue(snapshot.paused)
+    assertTrue(snapshot.pressure?.constrained == true)
+    assertTrue(snapshot.pauseReason.orEmpty().contains("load"))
+  }
+}

--- a/deploy/image/docker-rollout
+++ b/deploy/image/docker-rollout
@@ -166,17 +166,24 @@ main() {
         echo "==> Health check status for container $NEW_CONTAINER_ID"
 
         # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
-        docker $DOCKER_ARGS inspect --format='{{json .State.Health}}' "$NEW_CONTAINER_ID"
+        # A concurrently-removed or self-restarting container is itself useful failure evidence,
+        # but it must not abort this script before the rollback below gets a chance to clean up the
+        # remaining new replicas.
+        docker $DOCKER_ARGS inspect --format='{{json .State.Health}}' "$NEW_CONTAINER_ID" || true
 
         echo "==> Logs for container $NEW_CONTAINER_ID"
         # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
-        docker $DOCKER_ARGS logs "$NEW_CONTAINER_ID"
+        docker $DOCKER_ARGS logs "$NEW_CONTAINER_ID" || true
       done
 
       echo "==> New containers are not healthy. Rolling back." >&2
 
-      docker $DOCKER_ARGS stop $NEW_CONTAINER_IDS
-      docker $DOCKER_ARGS rm $NEW_CONTAINER_IDS
+      # Idempotent cleanup: some ids may already have disappeared. Stop/remove each survivor and
+      # continue through missing ids instead of leaking the rest of the failed rollout.
+      for NEW_CONTAINER_ID in $NEW_CONTAINER_IDS; do
+        docker $DOCKER_ARGS stop "$NEW_CONTAINER_ID" >/dev/null 2>&1 || true
+        docker $DOCKER_ARGS rm -f "$NEW_CONTAINER_ID" >/dev/null 2>&1 || true
+      done
 
       exit 1
     fi
@@ -210,9 +217,9 @@ main() {
   echo "==> Stopping and removing old containers"
 
   # shellcheck disable=SC2086 # DOCKER_ARGS and OLD_CONTAINER_IDS must be unquoted to allow multiple arguments
-  docker $DOCKER_ARGS stop $OLD_CONTAINER_IDS
+  docker $DOCKER_ARGS stop $OLD_CONTAINER_IDS || true
   # shellcheck disable=SC2086 # DOCKER_ARGS and OLD_CONTAINER_IDS must be unquoted to allow multiple arguments
-  docker $DOCKER_ARGS rm $OLD_CONTAINER_IDS
+  docker $DOCKER_ARGS rm $OLD_CONTAINER_IDS || true
 }
 
 while [ $# -gt 0 ]; do

--- a/deploy/image/rollout.sh
+++ b/deploy/image/rollout.sh
@@ -25,8 +25,39 @@ INTERVAL="${ROLLOUT_INTERVAL:-1200}"
 # that, so give it room before rollout would wrongly declare the new replica
 # unhealthy and roll back.
 HEALTH_TIMEOUT="${ROLLOUT_HEALTH_TIMEOUT:-300}"
+LOCK_NAME="${ROLLOUT_LOCK_NAME:-compose-preview-rollout-lock}"
+# The lock is a tiny Docker container because the polling and webhook runners are separate
+# containers and their only already-shared coordination primitive is the Docker daemon. Docker
+# reserves container names atomically. A crashed caller leaves the marker running only until this
+# TTL; the next attempt then removes the exited marker and can proceed.
+# A rollout can legitimately take several health-timeout windows while replicas start and drain.
+# Keep the crash-recovery TTL comfortably above that so a slow rollout cannot lose exclusivity.
+LOCK_TTL="${ROLLOUT_LOCK_TTL:-$((HEALTH_TIMEOUT * 4 + 600))}"
 
 log() { echo "rollout: $*"; }
+
+release_rollout_lock() {
+  docker rm -f "$LOCK_NAME" >/dev/null 2>&1 || true
+}
+
+acquire_rollout_lock() {
+  if docker run -d --name "$LOCK_NAME" --entrypoint sleep docker:29-cli "$LOCK_TTL" \
+    >/dev/null 2>&1; then
+    trap release_rollout_lock EXIT INT TERM
+    return 0
+  fi
+  state="$(docker inspect --format '{{.State.Status}}' "$LOCK_NAME" 2>/dev/null || true)"
+  if [ "$state" = "exited" ] || [ "$state" = "dead" ]; then
+    docker rm -f "$LOCK_NAME" >/dev/null 2>&1 || true
+    if docker run -d --name "$LOCK_NAME" --entrypoint sleep docker:29-cli "$LOCK_TTL" \
+      >/dev/null 2>&1; then
+      trap release_rollout_lock EXIT INT TERM
+      return 0
+    fi
+  fi
+  log "another rollout is active — skipping"
+  return 1
+}
 
 # The `rollout` service runs on docker:*-cli, which bundles the compose plugin on
 # current images; fall back to installing it (Alpine) if a slimmer base is used.
@@ -57,15 +88,25 @@ pulled_image_id() {
 
 roll_once() {
   ensure_compose
+  # The hook and poller can notice the same image seconds apart. Without one host-wide lock both
+  # call docker-rollout, each treats the other's new replica as an old replica, and the steady-state
+  # count doubles. A skipped contender is success: the lock holder is already deploying that image.
+  if ! acquire_rollout_lock; then
+    return 0
+  fi
   docker compose pull "$SERVICE" >/dev/null 2>&1 || log "pull failed (using cached image)"
   before="$(running_image_id)"
   after="$(pulled_image_id)"
   if [ -z "$after" ]; then
     log "could not resolve pulled image for '$SERVICE' — skipping"
+    release_rollout_lock
+    trap - EXIT INT TERM
     return 0
   fi
   if [ -n "$before" ] && [ "$before" = "$after" ]; then
     log "'$SERVICE' already up to date"
+    release_rollout_lock
+    trap - EXIT INT TERM
     return 0
   fi
   if [ -z "$before" ]; then
@@ -80,10 +121,14 @@ roll_once() {
   # rollout as rolled. Inside the `else`, `$?` still holds the rollout exit code.
   if docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"; then
     log "'$SERVICE' rolled"
+    release_rollout_lock
+    trap - EXIT INT TERM
     return 0
   else
     rc=$?
     log "docker rollout failed (exit $rc)"
+    release_rollout_lock
+    trap - EXIT INT TERM
     return "$rc"
   fi
 }


### PR DESCRIPTION
## Summary

- serialize webhook and polling rollouts with a Docker-daemon-wide lock
- make failed rollout diagnostics and cleanup tolerate containers that already disappeared
- gate theme optimization on host load, CPU, and available RAM with hysteresis
- elect one optimizer replica and enforce host-wide lanes/per-catalog exclusion
- serialize persistent theme-cache generation writes across replicas

## Root cause

Webhook and polling rollouts could overlap. Each rollout counted the other rollout's replacement as an existing replica, causing the steady-state replica count to multiply from 1 to 2, then 4. Each replica then ran process-local optimizer lanes and wrote/warmed the same persistent cache, multiplying daemon pressure.

On preview.coo.ee this produced load around 50, 36 GiB RAM plus 16 GiB swap usage, repeated kernel OOM kills, and render latency reaching 20,548 ms.

The live service was separately scaled back to one healthy replica. After recovery, load fell to 0.17, RAM use to 9 GiB, and swap use to 452 MiB.

## Validation

- `./gradlew :cli:ktfmtFormat`
- focused host admission, background optimizer, cache persistence, and status tests pass
- `sh -n deploy/image/rollout.sh`
- `sh -n deploy/image/docker-rollout`
- `git diff --check`
- full `:cli:test`: 2,512/2,514 pass; the two remaining failures are pre-existing static-generation/ServeWeb fixture failures in untouched files