### PR TITLE
feat(design-artifacts): let a catalog exempt semantics-less renders from the completeness gate

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -316,6 +316,11 @@ entry, including GIF/APNG artifacts. If two modules use the same preview functio
 spec-preferred/primary module keeps the unqualified name and later modules receive a stable
 `<module>::<function>` join key.
 
+Generated entries are held to the same completeness gate as authored ones, which is usually right and
+occasionally not: an app's synthetic Activity renders capture no semantics by their nature. Name them
+in [`completeness.exemptSemantics`](#renders-with-no-semantics-completenessexemptsemantics) rather
+than reaching for `--allow-incomplete`.
+
 Executable bundles retain distinct module classpaths, so repository-wide publication never merges
 them. With `publish-live-bundle: true`, `catalog.json` carries a `liveBundles[]` descriptor for each
 module (and the primary legacy `liveBundle` for older servers). Additional modules receive a stable,
@@ -1172,6 +1177,77 @@ questions. `priority: "deferred"` says *don't bake this one in CI — the live s
 can render it on demand*, and needs a live path to be legal. `capture: "none"` says
 *nothing can render this to a PNG at all*, live path or not. A deferred entry is
 still coverage the sheet can produce; a `"none"` entry is a recorded gap.
+Both differ again from `completeness.exemptSemantics` below, which excuses an entry
+that *did* produce its sticker and only lacks a semantics tree.
+
+## Renders with no semantics (`completeness.exemptSemantics`)
+
+The completeness gate has two halves: a spec entry that produced no PNG is a
+**missing render**, and a rendered entry whose capture carries no semantics tree is
+a **semantics-less render**. Either one refuses the publish, because both usually
+mean the render broke — no pixels, or pixels with no tokens/contrast/greenlines
+behind them.
+
+Repository-wide mode (`modules: all`) turns the second half into a standing false
+failure. Discovery sweeps every preview-enabled module's previews into the catalog
+as fallback inventory, and that inventory includes the app's **synthetic Activity
+renders** — `app/MainActivity`, `wear/WearMainActivity`, … — which legitimately
+capture nothing: the app cold-starts under the renderer with no data and no
+network, so the frame is near-empty and the semantics pass has nothing to walk.
+
+```text
+[meshcore-mobile] no semantics for: app/MainActivity, app/getting-started, wear/WearMainActivity, wear/LicenseActivity
+[meshcore-mobile] incomplete render — refusing to publish. Re-run the render, or pass --allow-incomplete to override.
+```
+
+Neither older escape hatch reaches it. There is no `components[]` line to withhold
+— discovery invented the entry, so nothing in the spec names it — and
+`--allow-incomplete` is all-or-nothing, so switching it on to tolerate an Activity
+frame also lets a genuinely broken *declared* component publish unnoticed. Declare
+the situation instead, on the cover sheet:
+
+```jsonc
+{
+  "system": "meshcore-mobile",
+  "title": "MeshCore",
+  "completeness": {
+    "exemptSemantics": ["*Activity", "app/getting-started"]
+  }
+}
+```
+
+- Matched against the **whole componentId**, exactly as the `no semantics for: …`
+  line prints it — so a failing run's output can be pasted straight in, and
+  `wear/WearMainActivity` and `mobile/MainActivity` are both addressable.
+- `*` is the only metacharacter and stands for **any run of characters, `/`
+  included** — so `*Activity` reaches a nested module's
+  `feature/home/LicenseActivity` without a second wildcard vocabulary to learn.
+  Patterns are anchored at both ends: a bare `Activity` matches only an id named
+  exactly that, because on an exclusion axis over-matching silently excuses work
+  nobody exempted.
+- An exempt entry **stays in `catalog.json` with its pixels** — the sticker is fine
+  and worth serving; it is only the semantics half of the gate it is excused from —
+  and is counted separately, the way `deferred` records are:
+
+  ```text
+  [meshcore-mobile] 4 render(s) exempt from the semantics gate (completeness.exemptSemantics): app/MainActivity, app/getting-started, wear/WearMainActivity, wear/LicenseActivity — kept in catalog.json, not counted against the completeness gate
+  ```
+
+- A pattern that matches **nothing** is named on every run, so an exemption left
+  behind by a renamed or deleted preview shows up rather than standing by to excuse
+  a render it was never written for:
+
+  ```text
+  [meshcore-mobile] completeness.exemptSemantics pattern(s) matched no semantics-less render: app/getting-started — every render they name either captured semantics or is no longer in the catalog, so the exemption can be dropped
+  ```
+
+Deliberately narrow on two axes. **Semantics only**: a missing render still fails,
+since no pixels at all is the failure the gate exists to catch (an entry that
+genuinely cannot rasterise declares `capture: "none"` above). And **opt-in per
+catalog**: exempting all discovery-supplied fallback inventory by default would be
+defensible — a fallback component was never promised by the catalog author — but it
+widens the blind spot for every repository-wide catalog at once, silently. A list in
+the spec says which ids, where a reviewer sees them.
 
 ## Theme specimens (`section: "Themes"` / `@FixedTheme`)
 

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -508,6 +508,9 @@ export function validateSpec(spec, opts = {}) {
   // `modePriority` is validated too, and so a bad value is reported once rather than per entry.
   errors.push(...modePriorityErrors(spec));
   warnings.push(...modePriorityWarnings(spec));
+  // Like `modePriority`, a cover-sheet-level block: checked before `groups` so an annotation-only
+  // catalog — which is exactly the repository-wide shape this exemption exists for — is checked too.
+  errors.push(...completenessErrors(spec));
   if (opts.liveBundle === false && specDefersAnything(spec)) {
     errors.push(
       "this spec defers coverage (`priority: \"deferred\"` / `modePriority`) but the publish has no " +
@@ -804,6 +807,46 @@ function priorityErrors(entry, path) {
     `${path}.priority must be one of ${PRIORITIES.map((p) => `"${p}"`).join(", ")} ` +
       `(got ${JSON.stringify(value)})`,
   ];
+}
+
+/**
+ * Structural checks for the `completeness` block (issue #4117).
+ *
+ * An ERROR rather than a lenient skip, on the same reasoning as `capture` and `priority`: the
+ * consumer ignores a malformed value (`exemptSemanticsPatterns` exempts nothing), so a typed-wrong
+ * exemption would present as the gate failing on the very entry it was written to excuse — with
+ * nothing pointing back at the spec.
+ */
+function completenessErrors(spec) {
+  const block = spec?.completeness;
+  if (block === undefined) return [];
+  if (typeof block !== "object" || block === null || Array.isArray(block)) {
+    return ["`completeness` must be an object (currently only `exemptSemantics` lives in it)"];
+  }
+  const errors = [];
+  for (const key of Object.keys(block)) {
+    if (key !== "exemptSemantics") {
+      errors.push(`completeness.${key} is not a known field (did you mean \`exemptSemantics\`?)`);
+    }
+  }
+  const exempt = block.exemptSemantics;
+  if (exempt === undefined) return errors;
+  if (!Array.isArray(exempt)) {
+    errors.push(
+      "`completeness.exemptSemantics` must be an array of componentId patterns " +
+        '(e.g. ["*Activity", "app/getting-started"])',
+    );
+    return errors;
+  }
+  exempt.forEach((pattern, i) => {
+    if (typeof pattern !== "string" || pattern.trim().length === 0) {
+      errors.push(
+        `completeness.exemptSemantics[${i}] must be a non-empty componentId pattern ` +
+          `(got ${JSON.stringify(pattern)})`,
+      );
+    }
+  });
+  return errors;
 }
 
 /** Structural checks for the `modePriority` axis table. */

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -886,6 +886,47 @@ test("validateSpec accepts modePriority on a cover-sheet spec with no groups", (
   assert.deepEqual(errors, []);
 });
 
+test("validateSpec accepts completeness.exemptSemantics, including on a cover-sheet spec", () => {
+  assert.deepEqual(
+    validateSpec(
+      prioritySpec([{ componentId: "A", preview: "Alpha" }], {
+        completeness: { exemptSemantics: ["*Activity", "app/getting-started"] },
+      }),
+    ).errors,
+    [],
+  );
+  // The repository-wide shape this exists for: inventory from annotations, cover sheet only here.
+  assert.deepEqual(
+    validateSpec({
+      system: "demo",
+      title: "Demo",
+      completeness: { exemptSemantics: ["*Activity"] },
+    }).errors,
+    [],
+  );
+});
+
+test("validateSpec rejects a malformed completeness block", () => {
+  // A consumer ignores what it can't read, so a typo would surface as the gate failing on the very
+  // entry the exemption was written to excuse.
+  assert.match(
+    validateSpec(prioritySpec([], { completeness: ["*Activity"] })).errors[0],
+    /`completeness` must be an object/,
+  );
+  assert.match(
+    validateSpec(prioritySpec([], { completeness: { exemptSemantics: "*Activity" } })).errors[0],
+    /`completeness.exemptSemantics` must be an array/,
+  );
+  assert.match(
+    validateSpec(prioritySpec([], { completeness: { exemptSemantics: ["", 3] } })).errors[0],
+    /completeness\.exemptSemantics\[0\] must be a non-empty componentId pattern/,
+  );
+  assert.match(
+    validateSpec(prioritySpec([], { completeness: { exemptMissing: ["*"] } })).errors[0],
+    /completeness\.exemptMissing is not a known field/,
+  );
+});
+
 // --- select: one breakpoint of a multipreview, without splitting the function ---
 
 const wearSpecWith = (components) => ({

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -84,6 +84,18 @@
       "description": "Optional display order for the groups, by name (e.g. [\"Buttons\", \"Selection\", \"Containment\", …]). Presentation config, like `display`: when the inventory is annotation-supplied, the annotation-derived order follows source declaration order, which may not match the intended catalog order — this pins it. Groups not named keep their relative order after the named ones. Ignored groups (no such group) are harmless.",
       "items": { "type": "string" }
     },
+    "completeness": {
+      "type": "object",
+      "description": "Escape hatches for the publish-time completeness gate, per entry rather than the wholesale `--allow-incomplete`.",
+      "additionalProperties": false,
+      "properties": {
+        "exemptSemantics": {
+          "type": "array",
+          "description": "componentIds whose render is expected to capture NO semantics tree, so their absence must not fail the publish (e.g. the synthetic Activity renders repository-wide discovery sweeps in: a cold-started app with no data and no network renders a near-empty frame). Matched against the whole componentId as the \"no semantics for: …\" report prints it, with `*` standing for any run of characters including `/` — e.g. [\"*Activity\", \"app/getting-started\"]. Exempt entries stay in catalog.json with their pixels and are reported separately; every other entry keeps the strict gate. Semantics only — a MISSING render still fails (declare `capture: \"none\"` for an entry that cannot rasterise). A pattern matching nothing is reported on every run so a stale exemption is visible.",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "groups": {
       "type": "array",
       "description": "The component inventory, grouped. Group order is the display order (or `groupOrder`, when set). OPTIONAL: a catalog can instead declare its inventory with `@CatalogComponent` / `@CatalogVariant` annotations next to the `@Preview`s (the design-artifacts export builds the inventory from them, layering any groups declared here on top as an override). Absent ⇒ the inventory is wholly annotation-supplied.",

--- a/scripts/design-artifacts/completeness-exemptions.mjs
+++ b/scripts/design-artifacts/completeness-exemptions.mjs
@@ -1,0 +1,133 @@
+/**
+ * `completeness.exemptSemantics` — the componentIds a catalog declares as expected to be
+ * sticker-only, so their absent semantics tree doesn't sink the publish (issue #4117).
+ *
+ * Under repository-wide discovery (`--generate-fallbacks`) every preview-enabled module's previews
+ * enter the catalog as fallback inventory, and that inventory includes **synthetic Activity
+ * renders** — `app/MainActivity`, `wear/WearMainActivity`, … — which legitimately capture no
+ * semantics: the app cold-starts with no data and no network under the renderer, so the frame is
+ * near-empty and the semantics pass has nothing to walk. `withoutSemantics` counted them anyway,
+ * and the completeness gate then refused to publish the whole system.
+ *
+ * Neither existing escape hatch reaches this:
+ *
+ *  - **Nothing to delete from the spec.** These entries are not declared — they arrive through
+ *    discovery, so there is no `components[]` line to withhold the way a hand-authored catalog can
+ *    withhold a blank preview.
+ *  - **`--allow-incomplete` is too blunt.** It switches the gate off wholesale, so a genuine
+ *    regression in a *declared* component stops failing the publish too — the exact trade-off
+ *    `deferred` was built to avoid.
+ *  - **The mode filter doesn't reach it.** `deferred-preview-ids.mjs` derives its exclusions from
+ *    spec-declared deferred modes, so it can only exempt what the spec names.
+ *
+ * So this follows the `deferred` precedent — recorded and reported separately, deliberately kept
+ * OUT of `withoutSemantics`, with the gate staying strict over everything else — rather than the
+ * all-or-nothing flag. The exempt entries keep their place in `catalog.json`: their pixels are fine
+ * and worth serving, it is only the semantics half of the gate they are excused from.
+ *
+ * Scope, deliberately narrow on two axes:
+ *
+ *  - **Semantics only.** A *missing render* is a different failure — no pixels at all, which is
+ *    what the gate exists to catch — and stays fatal. An entry that genuinely cannot rasterise
+ *    declares `"capture": "none"` instead (capture-mode.mjs).
+ *  - **Opt-in per catalog.** The alternative — exempting all discovery-supplied fallback inventory
+ *    by default, on the grounds that a fallback component was never promised by the catalog author
+ *    — silently widens the gate's blind spot for every repository-wide catalog at once. An explicit
+ *    list says which ids, in the spec, where a reviewer sees it.
+ *
+ * Drift is reported rather than tolerated: a pattern that matches nothing is named on every run
+ * ([unusedPatterns]), so an exemption left behind by a renamed or deleted preview shows up as a
+ * warning instead of quietly standing by to excuse something it was never written for.
+ *
+ * Pure and dependency-free (node built-ins only, no `@design-parity/*`, no I/O) so its unit tests
+ * run without an `npm ci`, like its siblings.
+ */
+
+/** The declared `completeness` block, or undefined when the spec doesn't carry one. */
+function completenessBlock(spec) {
+  const block = spec?.completeness;
+  return block && typeof block === "object" && !Array.isArray(block) ? block : undefined;
+}
+
+/**
+ * The `completeness.exemptSemantics` patterns a spec declares, cleaned up: non-strings and empty
+ * strings dropped, duplicates collapsed, declared order kept (the report reads back in the order
+ * the spec is written).
+ *
+ * Shape errors are the validator's business (`validateSpec`), not this module's — here a malformed
+ * value simply exempts nothing, which is the safe direction: the gate stays strict.
+ *
+ * @param {object} spec parsed `catalog.spec.json`.
+ * @returns {string[]}
+ */
+export function exemptSemanticsPatterns(spec) {
+  const declared = completenessBlock(spec)?.exemptSemantics;
+  if (!Array.isArray(declared)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const pattern of declared) {
+    if (typeof pattern !== "string") continue;
+    const trimmed = pattern.trim();
+    if (trimmed.length === 0 || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Whether one componentId matches one exemption pattern.
+ *
+ * The pattern is matched against the WHOLE id — the same `module/componentId` string the
+ * "no semantics for: …" warning prints, so an id can be copied straight out of a failing run — with
+ * `*` as the only metacharacter, standing for any run of characters **including `/`**. One
+ * wildcard rule, no `**` vocabulary to get wrong: a leading `*` before `/MainActivity` reaches a
+ * nested module's `feature/home/MainActivity` as well as `app/MainActivity`, and `*Activity`
+ * covers both without knowing how deep the module path goes.
+ *
+ * Anchored at both ends, because the alternative (substring matching, as the CLI's preview filters
+ * use) over-matches on an axis where over-matching silently excuses work nobody exempted — the same
+ * hazard `anchoredExclusions` exists for in `deferred-preview-ids.mjs`. `Activity` on its own
+ * therefore matches only an id named exactly that.
+ */
+export function matchesExemption(pattern, componentId) {
+  if (typeof pattern !== "string" || typeof componentId !== "string") return false;
+  const source = pattern
+    .split("*")
+    .map((literal) => literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  return new RegExp(`^${source}$`).test(componentId);
+}
+
+/**
+ * Split the semantics-less componentIds into the ones the gate still counts and the ones the spec
+ * excused, and name the patterns that matched nothing.
+ *
+ * @param {string[]} componentIds the `withoutSemantics` list from the candidate join.
+ * @param {string[]} patterns from [exemptSemanticsPatterns].
+ * @returns {{ counted: string[], exempt: string[], unusedPatterns: string[] }} `counted` and
+ *   `exempt` keep the input order; `unusedPatterns` keeps the spec's declared order.
+ */
+export function partitionExemptSemantics(componentIds, patterns) {
+  const ids = Array.isArray(componentIds) ? componentIds : [];
+  const list = Array.isArray(patterns) ? patterns : [];
+  if (list.length === 0) return { counted: [...ids], exempt: [], unusedPatterns: [] };
+
+  const used = new Set();
+  const counted = [];
+  const exempt = [];
+  for (const id of ids) {
+    const matched = list.filter((pattern) => matchesExemption(pattern, id));
+    if (matched.length === 0) {
+      counted.push(id);
+      continue;
+    }
+    for (const pattern of matched) used.add(pattern);
+    exempt.push(id);
+  }
+  return {
+    counted,
+    exempt,
+    unusedPatterns: list.filter((pattern) => !used.has(pattern)),
+  };
+}

--- a/scripts/design-artifacts/completeness-exemptions.test.mjs
+++ b/scripts/design-artifacts/completeness-exemptions.test.mjs
@@ -1,0 +1,102 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  exemptSemanticsPatterns,
+  matchesExemption,
+  partitionExemptSemantics,
+} from "./completeness-exemptions.mjs";
+
+test("a spec with no completeness block exempts nothing", () => {
+  assert.deepEqual(exemptSemanticsPatterns(undefined), []);
+  assert.deepEqual(exemptSemanticsPatterns({}), []);
+  assert.deepEqual(exemptSemanticsPatterns({ completeness: {} }), []);
+});
+
+test("declared patterns are cleaned up, deduped, and kept in spec order", () => {
+  assert.deepEqual(
+    exemptSemanticsPatterns({
+      completeness: {
+        exemptSemantics: ["*/MainActivity", " app/getting-started ", "*/MainActivity", "", 7, null],
+      },
+    }),
+    ["*/MainActivity", "app/getting-started"],
+  );
+});
+
+test("a malformed completeness block exempts nothing rather than everything", () => {
+  // Shape is the validator's business; here the safe direction is a strict gate.
+  assert.deepEqual(exemptSemanticsPatterns({ completeness: [1, 2] }), []);
+  assert.deepEqual(exemptSemanticsPatterns({ completeness: { exemptSemantics: "*" } }), []);
+});
+
+test("patterns are anchored, so a bare name is not a substring match", () => {
+  assert.equal(matchesExemption("app/MainActivity", "app/MainActivity"), true);
+  assert.equal(matchesExemption("MainActivity", "app/MainActivity"), false);
+  assert.equal(matchesExemption("Activity", "app/MainActivity"), false);
+  assert.equal(matchesExemption("app/Main", "app/MainActivity"), false);
+});
+
+test("`*` spans path separators, so one pattern reaches a nested module", () => {
+  assert.equal(matchesExemption("*/MainActivity", "app/MainActivity"), true);
+  assert.equal(matchesExemption("*/MainActivity", "feature/home/MainActivity"), true);
+  assert.equal(matchesExemption("*Activity", "wear/WearMainActivity"), true);
+  assert.equal(matchesExemption("*/*Activity", "wear/LicenseActivity"), true);
+  assert.equal(matchesExemption("*", "anything/at/all"), true);
+});
+
+test("regex metacharacters in a pattern are literal", () => {
+  assert.equal(matchesExemption("app/Getting.Started", "app/GettingXStarted"), false);
+  assert.equal(matchesExemption("app/Getting.Started", "app/Getting.Started"), true);
+  assert.equal(matchesExemption("app/Button+", "app/Button+"), true);
+  assert.equal(matchesExemption("app/Button+", "app/Buttonn"), false);
+});
+
+test("non-string inputs never match", () => {
+  assert.equal(matchesExemption(undefined, "app/MainActivity"), false);
+  assert.equal(matchesExemption("*", undefined), false);
+});
+
+test("the partition excuses only the matched ids, keeping input order", () => {
+  const { counted, exempt, unusedPatterns } = partitionExemptSemantics(
+    ["app/MainActivity", "Buttons/Filled", "wear/WearMainActivity", "app/getting-started"],
+    ["*/MainActivity", "*Activity", "app/getting-started"],
+  );
+  assert.deepEqual(counted, ["Buttons/Filled"]);
+  assert.deepEqual(exempt, ["app/MainActivity", "wear/WearMainActivity", "app/getting-started"]);
+  assert.deepEqual(unusedPatterns, []);
+});
+
+test("no patterns leaves the gate exactly as strict as before", () => {
+  const withoutSemantics = ["app/MainActivity", "Buttons/Filled"];
+  const { counted, exempt, unusedPatterns } = partitionExemptSemantics(withoutSemantics, []);
+  assert.deepEqual(counted, withoutSemantics);
+  assert.deepEqual(exempt, []);
+  assert.deepEqual(unusedPatterns, []);
+});
+
+test("a pattern that matches nothing is reported as drift", () => {
+  const { counted, exempt, unusedPatterns } = partitionExemptSemantics(
+    ["Buttons/Filled"],
+    ["*/MainActivity", "app/getting-started"],
+  );
+  assert.deepEqual(counted, ["Buttons/Filled"]);
+  assert.deepEqual(exempt, []);
+  assert.deepEqual(unusedPatterns, ["*/MainActivity", "app/getting-started"]);
+});
+
+test("an exemption is not drift merely because a broader pattern also covers the id", () => {
+  // Both patterns matched `app/MainActivity`, so neither is reported as stale.
+  const { unusedPatterns } = partitionExemptSemantics(
+    ["app/MainActivity"],
+    ["*Activity", "app/MainActivity"],
+  );
+  assert.deepEqual(unusedPatterns, []);
+});
+
+test("an empty withoutSemantics list makes every declared pattern drift", () => {
+  const { counted, exempt, unusedPatterns } = partitionExemptSemantics([], ["*Activity"]);
+  assert.deepEqual(counted, []);
+  assert.deepEqual(exempt, []);
+  assert.deepEqual(unusedPatterns, ["*Activity"]);
+});

--- a/scripts/design-artifacts/completeness-gate.mjs
+++ b/scripts/design-artifacts/completeness-gate.mjs
@@ -8,6 +8,11 @@
  * A spec made entirely of declared sticker-less or deferred entries has no
  * `missing` entries, so it is not mistaken for a failed render here.
  *
+ * `withoutSemanticsCount` arrives already net of the spec's
+ * `completeness.exemptSemantics` (see completeness-exemptions.mjs). The declaration
+ * is resolved by the caller so this stays one comparison over counts, the same way
+ * `capture: "none"` and `deferred` entries never reach `missingCount`.
+ *
  * @returns {"empty" | "incomplete" | null}
  */
 export function completenessFailure({

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -142,6 +142,10 @@ import { selectComponentImages, selectOf } from "./catalog-select.mjs";
 import { applyCatalogPreviewDeclarations } from "./catalog-preview-declarations.mjs";
 import { completenessFailure } from "./completeness-gate.mjs";
 import {
+  exemptSemanticsPatterns,
+  partitionExemptSemantics,
+} from "./completeness-exemptions.mjs";
+import {
   additionalBundleLiveConflict,
   bundleModulePath,
   claimedComponentIds,
@@ -1174,9 +1178,36 @@ if (noSticker.length > 0) {
       noSticker.join(", "),
   );
 }
-if (withoutSemantics.length > 0) {
+// Semantics-less renders a catalog declared as expected (issue #4117): repository-wide discovery
+// sweeps in synthetic Activity renders that capture no semantics by their nature, and there is no
+// `components[]` line to withhold for an entry discovery invented. The exempt ids keep their place
+// in the catalog — their pixels are fine — and are counted separately, so the gate stays strict over
+// everything else instead of being switched off wholesale with `--allow-incomplete`.
+const {
+  counted: countedWithoutSemantics,
+  exempt: exemptWithoutSemantics,
+  unusedPatterns: unusedExemptions,
+} = partitionExemptSemantics(withoutSemantics, exemptSemanticsPatterns(spec));
+if (countedWithoutSemantics.length > 0) {
   console.warn(
-    `[${spec.system}] no semantics for: ${withoutSemantics.join(", ")}`,
+    `[${spec.system}] no semantics for: ${countedWithoutSemantics.join(", ")}`,
+  );
+}
+if (exemptWithoutSemantics.length > 0) {
+  console.log(
+    `[${spec.system}] ${exemptWithoutSemantics.length} render(s) exempt from the semantics gate ` +
+      `(completeness.exemptSemantics): ${exemptWithoutSemantics.join(", ")} — kept in ` +
+      `catalog.json, not counted against the completeness gate`,
+  );
+}
+// A pattern matching nothing is named rather than tolerated: an exemption left behind by a renamed
+// or deleted preview would otherwise sit there silently, ready to excuse a render it was never
+// written for.
+if (unusedExemptions.length > 0) {
+  console.warn(
+    `[${spec.system}] completeness.exemptSemantics pattern(s) matched no semantics-less render: ` +
+      `${unusedExemptions.join(", ")} — every render they name either captured semantics or is no ` +
+      `longer in the catalog, so the exemption can be dropped`,
   );
 }
 if (deferred.length > 0) {
@@ -1197,7 +1228,7 @@ const completenessFailureReason = completenessFailure({
   allowIncomplete: values["allow-incomplete"],
   resolvedCount: catalog.components.length,
   missingCount: missing.length,
-  withoutSemanticsCount: withoutSemantics.length,
+  withoutSemanticsCount: countedWithoutSemantics.length,
 });
 if (completenessFailureReason === "empty") {
   console.error(
@@ -1211,6 +1242,16 @@ if (completenessFailureReason === "incomplete") {
     `[${spec.system}] incomplete render — refusing to publish. ` +
       `Re-run the render, or pass --allow-incomplete to override.`,
   );
+  // Point at the per-entry escape hatch before the wholesale one: a render that captures no
+  // semantics *by its nature* (a synthetic Activity frame with no data and no network) is declarable,
+  // and declaring it keeps the gate strict over everything else.
+  if (countedWithoutSemantics.length > 0) {
+    console.error(
+      `[${spec.system}] a render that legitimately captures no semantics (a synthetic Activity ` +
+        `frame, …) can be named in the spec's \`completeness.exemptSemantics\` — it then stays in ` +
+        `the catalog and is reported separately instead of failing this gate.`,
+    );
+  }
   process.exit(1);
 }
 


### PR DESCRIPTION
Closes #4117.

## Problem

Under `modules: all`, repository-wide discovery pulls every preview-enabled module's previews into the catalog as fallback inventory — including the **synthetic Activity renders** (`app/MainActivity`, `wear/WearMainActivity`, …), which legitimately have no semantics tree: the app cold-starts under the renderer with no data and no network, so the capture is a near-empty frame. `withoutSemantics` counted them anyway and the gate refused the whole publish, leaving `design-artifacts/meshcore-mobile` and several compose-samples catalogs stale.

Neither existing escape hatch fits. There is nothing to delete from the spec — discovery invented the entry, so no `components[]` line can be withheld. And `--allow-incomplete` is all-or-nothing: turning it on to tolerate an Activity frame also lets a genuine regression in a *declared* component publish unnoticed.

## Change

A cover-sheet `completeness.exemptSemantics` list, following the `deferred` precedent (recorded, reported, not counted — gate stays strict over everything else):

```jsonc
"completeness": { "exemptSemantics": ["*Activity", "app/getting-started"] }
```

- Matched against the **whole componentId**, exactly as the `no semantics for: …` line prints it, so a failing run's output pastes straight in and both `wear/WearMainActivity` and `mobile/MainActivity` are addressable.
- `*` is the only metacharacter and spans `/`, so one pattern reaches a nested module. Anchored at both ends — on an exclusion axis, over-matching silently excuses work nobody exempted.
- Exempt entries **stay in `catalog.json` with their pixels** and are counted separately:
  `N render(s) exempt from the semantics gate (completeness.exemptSemantics): … — kept in catalog.json, not counted against the completeness gate`
- Drift is loud: a pattern matching nothing is named on every run, so a stale exemption surfaces instead of standing by to excuse a render it was never written for.
- The gate's `incomplete` failure now points at this per-entry hatch before the wholesale one.

Deliberately narrow on two axes: **semantics only** (a missing render still fails — that is what the gate exists to catch; `capture: "none"` covers an entry that cannot rasterise), and **opt-in per catalog** rather than exempting all discovery-supplied fallback inventory by default, which would widen the blind spot for every repository-wide catalog at once.

New pure module [`completeness-exemptions.mjs`](scripts/design-artifacts/completeness-exemptions.mjs); shape errors are a spec-validation error (a malformed exemption would otherwise present as the gate failing on the very entry it was written to excuse), added to the JSON schema, and documented in [DESIGN_CATALOGS.md](docs/design/DESIGN_CATALOGS.md).

## Test plan

- `npm test` in `scripts/design-artifacts` — **802 tests, 795 pass, 0 fail** (7 skipped), including 12 new `completeness-exemptions.test.mjs` cases (anchoring, `*` spanning `/`, metacharacters literal, drift reporting, no-patterns = unchanged strictness) and 2 new `catalog-spec.test.mjs` validation cases.
- End-to-end through the CLI: a spec carrying `completeness.exemptSemantics` validates clean, and a malformed one fails with
  ``error: `completeness.exemptSemantics` must be an array of componentId patterns``.

**No visual surface is touched** — this is publish-gate plumbing in the design-artifacts driver, so there is no rendered output to diff. The behaviour is verified by the unit tests and the CLI runs above; the first real proof is the next `design-artifacts` run publishing the previously-blocked catalogs.

_Generated by [Claude Code](https://claude.ai/code)_