### PR TITLE
fix(serve): show the component a delegating sticker delegates to

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -263,7 +263,13 @@ class PlaygroundSeedResolver(
         if (where.bodyLine == null) null
         else {
           val rules = rulesFor(where)
-          PlaygroundSourceCleaner.clean(text, where.bodyLine, rules, stringsFor(where, rules))
+          PlaygroundSourceCleaner.clean(
+            source = text,
+            bodyLine = where.bodyLine,
+            rules = rules,
+            strings = stringsFor(where, rules),
+            helperSources = helperSourcesFor(where, rules),
+          )
         }
       } catch (e: Exception) {
         // A seed is a convenience. A cleaner bug must degrade to the verbatim slice that worked
@@ -310,6 +316,8 @@ class PlaygroundSeedResolver(
 
   private val stringsCache =
     ConcurrentHashMap<Pair<String, String>, Pair<Map<String, String>, Long>>()
+
+  private val helperCache = ConcurrentHashMap<Pair<String, String>, Pair<List<String>, Long>>()
 
   private fun rulesFor(where: Location): UsageRules {
     val key = where.repo to where.ref
@@ -359,7 +367,12 @@ class PlaygroundSeedResolver(
       ?.let {
         return it.first
       }
-    val url = ServeUrls.githubRawUrl(where.repo, where.ref, where.module, path)
+    // A leading `/` means the repo root rather than the catalog's own module — the resources a
+    // shared component module owns are not under the module the previews live in, and every
+    // existing (module-relative) rules file is unaffected because none of them starts with one.
+    val url =
+      if (path.startsWith("/")) ServeUrls.githubRawUrl(where.repo, where.ref, null, path)
+      else ServeUrls.githubRawUrl(where.repo, where.ref, where.module, path)
     val text =
       url
         ?.let { u ->
@@ -380,6 +393,57 @@ class PlaygroundSeedResolver(
     evictExpired(stringsCache, now)
     if (stringsCache.size < maxEntries) stringsCache[key] = strings to now
     return strings
+  }
+
+  /**
+   * The catalog's declared scaffold sources ([UsageRules.scaffoldSources]), read repo-root-relative
+   * at the same `ref` as the preview's own file, so a sticker and the shared component it delegates
+   * to are always from one revision.
+   *
+   * Cached per `(repo, ref)` beside the rules that named them: one catalog has one set, every
+   * preview in it wants the same set, and a browse of a catalog must not re-read a shared module on
+   * every card. Capped at [MAX_SCAFFOLD_SOURCES] files — the whole point is a handful of
+   * scaffolding files, and a rules file naming hundreds would turn one page load into a crawl of
+   * the repo.
+   */
+  private fun helperSourcesFor(where: Location, rules: UsageRules): List<String> {
+    val paths = rules.scaffoldSources.map { it.trim() }.filter { it.isNotEmpty() }.distinct()
+    if (paths.isEmpty()) return emptyList()
+    if (paths.size > MAX_SCAFFOLD_SOURCES) {
+      onLog(
+        "compose-usage.json names ${paths.size} scaffold sources; reading the first $MAX_SCAFFOLD_SOURCES"
+      )
+    }
+    val wanted = paths.take(MAX_SCAFFOLD_SOURCES)
+    val key = where.repo to "${where.ref}:${wanted.joinToString("|")}"
+    val now = clock()
+    helperCache[key]
+      ?.takeIf { now - it.second < ttlSeconds * 1000 }
+      ?.let {
+        return it.first
+      }
+    val texts = wanted.mapNotNull { path ->
+      val url = ServeUrls.githubRawUrl(where.repo, where.ref, null, path) ?: return@mapNotNull null
+      val bytes =
+        try {
+          fetch(url)
+        } catch (e: Exception) {
+          onLog("fetching scaffold source $url failed (${e.message})")
+          null
+        }
+      if (bytes == null) {
+        onLog("could not read scaffold source $url")
+        return@mapNotNull null
+      }
+      if (bytes.size > maxBytes) {
+        onLog("$url is ${bytes.size} bytes, over the ${maxBytes}-byte cap")
+        return@mapNotNull null
+      }
+      bytes.decodeToString().takeIf { !it.contains('\uFFFD') }
+    }
+    evictExpired(helperCache, now)
+    if (helperCache.size < maxEntries) helperCache[key] = texts to now
+    return texts
   }
 
   /** Drops every entry past its TTL. Called before an insert, so the caps stay reachable. */
@@ -411,6 +475,13 @@ class PlaygroundSeedResolver(
         .replace("&apos;", "'")
         .replace("&amp;", "&")
         .trim()
+
+    /**
+     * How many [UsageRules.scaffoldSources] a catalog may have read. A catalog's scaffolding is a
+     * handful of files by construction (m3-catalog: 17 helpers across three); this is the bound
+     * that keeps a mistaken rules file from turning one Source panel into a repo crawl.
+     */
+    const val MAX_SCAFFOLD_SOURCES = 12
 
     /** A preview source file. Well above any real one, well below "somebody linked a blob". */
     const val DEFAULT_MAX_BYTES = 256 * 1024

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -85,12 +85,15 @@ object PlaygroundSourceCleaner {
     rules: UsageRules,
     strings: Map<String, String> = emptyMap(),
     parser: UsageSourceParser? = UsageSourceParser.of(),
+    helperSources: List<String> = emptyList(),
   ): Result? {
     if (bodyLine == null) return null
     val lines = source.lines()
     if (bodyLine < 1 || bodyLine > lines.size) return null
     if (lines[bodyLine - 1].isBlank()) return null
 
+    val helpers = helperIndex(helperSources)
+    val extraImports = LinkedHashSet<Import>()
     val imports = importMap(lines)
     val blocks = topLevelBlocks(lines)
     val entryIndex =
@@ -120,12 +123,33 @@ object PlaygroundSourceCleaner {
           residue = residue,
           addedImports = addedImports,
           parser = parser,
+          helpers = helpers,
+          extraImports = extraImports,
         )
       cleanedByIndex[index] = cleaned
       for ((name, at) in declaredAt) {
         if (at != index && at !in seen && mentionsWord(cleaned, name)) queue.addLast(at)
       }
     }
+
+    // Then the same closure across the declared scaffold sources. A catalog whose component
+    // bodies live in a shared module leaves the cleaned text calling `StatefulCheckbox` or
+    // `CardContentSlot` — names as unresolvable to a reader as the sticker frame was, and which
+    // the same-file pass structurally cannot reach. Bounded, unlike the same-file loop: these
+    // files are somebody else's whole module, and a snippet dragging a hundred declarations
+    // behind it has stopped being an example of anything.
+    val cleanedHelpers =
+      closeOverHelpers(
+        seeds = cleanedByIndex.values,
+        helpers = helpers,
+        skip = declaredAt.keys + rules.scaffolds.keys,
+        rules = rules,
+        strings = strings,
+        residue = residue,
+        addedImports = addedImports,
+        parser = parser,
+        extraImports = extraImports,
+      )
 
     // Entry first, then its helpers in file order — a reader wants the composable they clicked at
     // the top, not after two private helpers they did not ask about.
@@ -135,11 +159,12 @@ object PlaygroundSourceCleaner {
         .sorted()
         .filter { it != entryIndex }
         .forEach { add(cleanedByIndex.getValue(it)) }
+      addAll(cleanedHelpers)
     }
     val body = bodies.joinToString("\n\n").trimEnd()
     if (body.isBlank()) return null
 
-    val header = headerFor(lines, imports, body, addedImports, rules, residue)
+    val header = headerFor(lines, imports, body, addedImports, rules, residue, extraImports)
     val text = if (header.isEmpty()) body else "$header\n\n$body"
     return Result(text, blocks[entryIndex].name, residue.toList())
   }
@@ -192,9 +217,17 @@ object PlaygroundSourceCleaner {
    * harmless here: the pattern is still anchored at column 0 and still has to reach a real
    * declaration keyword.
    */
+  /**
+   * The leading annotations a one-line declaration carries — `@Composable fun Sticker(id: String) =
+   * …`, which is what ktfmt emits whenever the whole thing fits. Without this the declaration has
+   * no *name* as far as [declaredName] is concerned, so it is invisible to both closure passes: a
+   * one-line helper simply never came along, and the snippet called something it never brought.
+   */
+  private const val ANNOTATION_RUN = """(?:@[A-Za-z_][A-Za-z0-9_.]*(?:\([^)\n]*\))?\s+)*"""
+
   private val DECLARATION =
     Regex(
-      """^(?:[a-z]+\s+)*(?:fun|val|var|class|object|interface|typealias)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
+      """^$ANNOTATION_RUN(?:[a-z]+\s+)*(?:fun|val|var|class|object|interface|typealias)\s+(?:<[^>]*>\s+)?([A-Za-z_][A-Za-z0-9_]*)"""
     )
 
   /**
@@ -256,6 +289,7 @@ object PlaygroundSourceCleaner {
     addedImports: Set<String>,
     rules: UsageRules,
     residue: MutableSet<String>,
+    extraImports: Set<Import> = emptySet(),
   ): String {
     // Kept whole, by paren balance rather than by line. A ktfmt-wrapped
     // `@file:OptIn(\n  A::class,\n  B::class,\n)` is one annotation across five lines, and a
@@ -265,22 +299,49 @@ object PlaygroundSourceCleaner {
       annotationBlocks(lines.takeWhile { !it.trimStart().startsWith("package ") })
         .filterNot { isScaffoldAnnotation(it.name, imports, rules) }
         .map { it.text }
-    val kept =
-      importsOf(lines).filter { import ->
-        if (isScaffoldPackage(import.fqn, rules)) {
-          // A scaffold import that is still referenced means a rule is missing, not that the import
-          // should be kept — record it and drop it, so the residue names the gap.
-          if (mentionsIdentifier(body, import.name)) residue.add(import.name)
-          false
-        } else {
-          mentionsIdentifier(body, import.name) ||
-            fileAnnotations.any { mentionsIdentifier(it, import.name) }
-        }
+    // The preview file's own imports, plus the ones the scaffold sources contributed for whatever
+    // was expanded or closed over out of them. An extra whose simple name the preview file already
+    // binds to something else is dropped rather than emitted alongside it: two imports of the same
+    // name do not compile, and the file being cleaned is the one whose meaning must win.
+    val ownNames = importsOf(lines).map { it.name }.toSet()
+    val candidates =
+      importsOf(lines) + extraImports.filter { it.name !in ownNames }.distinctBy { it.name }
+    val kept = candidates.filter { import ->
+      if (isScaffoldPackage(import.fqn, rules)) {
+        // A scaffold import that is still referenced means a rule is missing, not that the import
+        // should be kept — record it and drop it, so the residue names the gap.
+        if (mentionsIdentifier(body, import.name)) residue.add(import.name)
+        false
+      } else if (import.fqn in DELEGATION_IMPORTS) {
+        // `var checked by remember { mutableStateOf(…) }` needs `getValue`/`setValue` and names
+        // neither, so the mention test prunes exactly the two imports that make the delegation
+        // compile. Keep them whenever the body delegates — an unused import is a warning, a
+        // missing one is a snippet advertised as runnable that does not build.
+        usesPropertyDelegation(body)
+      } else {
+        mentionsIdentifier(body, import.name) ||
+          fileAnnotations.any { mentionsIdentifier(it, import.name) }
       }
+    }
     val all = (kept.map { it.render() } + addedImports.map { "import $it" }).distinct().sorted()
     return (fileAnnotations + (if (fileAnnotations.isEmpty()) emptyList() else listOf("")) + all)
       .joinToString("\n")
       .trim()
+  }
+
+  /**
+   * The two imports a `by` property delegation needs and never mentions. Compose's `MutableState`
+   * delegation is the reason: `import androidx.compose.runtime.getValue` is what makes `var x by
+   * remember { mutableStateOf(0) }` resolve, and nothing in that line says `getValue`.
+   */
+  private val DELEGATION_IMPORTS =
+    setOf("androidx.compose.runtime.getValue", "androidx.compose.runtime.setValue")
+
+  private fun usesPropertyDelegation(body: String): Boolean {
+    val mask = codeMask(body)
+    return Regex("""\b(?:val|var)\s+[A-Za-z_][A-Za-z0-9_]*\s+by\s""").findAll(body).any {
+      mask[it.range.first]
+    }
   }
 
   private data class AnnotationBlock(val name: String, val text: String)
@@ -322,8 +383,15 @@ object PlaygroundSourceCleaner {
     residue: MutableSet<String>,
     addedImports: MutableSet<String>,
     parser: UsageSourceParser?,
+    helpers: Map<String, Helper> = emptyMap(),
+    extraImports: MutableSet<Import> = mutableSetOf(),
   ): String {
     var out = stripScaffoldAnnotations(text, imports, rules)
+    // Before every other pass: a delegating sticker has no component in it *to* clean until what it
+    // delegates to has been spliced in, and everything below — the string inliner, the knob
+    // substitutions, the import prune — then runs over the real body rather than over a one-line
+    // wrapper. See [UsageRules.Kind.EXPAND].
+    out = expandDelegates(out, rules, helpers, residue, extraImports)
     out = inlineStringResources(out, strings)
     // Before anything matches on a helper name: a call written fully qualified is the same call.
     out = unqualifyScaffoldCalls(out, rules)
@@ -409,6 +477,10 @@ object PlaygroundSourceCleaner {
     imports: Map<String, String>,
     rules: UsageRules,
   ): Boolean {
+    // The bare-name list first: an annotation the catalog declares in the previews' own package
+    // (`@CatalogModes`) is written with no import at all, so there is nothing for the package rule
+    // below to resolve. See [UsageRules.scaffoldAnnotationNames].
+    if (simpleName in rules.scaffoldAnnotationNames) return true
     val fqn = imports[simpleName] ?: return false
     return isScaffoldPackage(fqn, rules)
   }
@@ -564,14 +636,13 @@ object PlaygroundSourceCleaner {
       if (scaffold.kind != UsageRules.Kind.UNWRAP) continue
       var guard = 0
       while (guard++ < MAX_REWRITES) {
-        val call = findCall(out, name) ?: break
-        val lambdaOpen = out.indexOf('{', call.argsEnd).takeIf { it >= 0 } ?: break
+        val (callStart, lambdaOpen) = findWrapperCall(out, name) ?: break
         val lambdaClose = matchBrace(out, lambdaOpen) ?: break
         val inner = out.substring(lambdaOpen + 1, lambdaClose)
-        val callIndent = indentOf(out, call.start)
-        val lineStart = out.lastIndexOf('\n', call.start - 1) + 1
-        val prefix = out.substring(lineStart, call.start)
-        val body = dedent(inner, callIndent)
+        val callIndent = indentOf(out, callStart)
+        val lineStart = out.lastIndexOf('\n', callStart - 1) + 1
+        val prefix = out.substring(lineStart, callStart)
+        val body = reindent(inner, callIndent)
         // Where the splice starts depends on what precedes the call on its own line.
         //
         // When the line is only indentation, splice from the line start: that indent is already the
@@ -584,10 +655,33 @@ object PlaygroundSourceCleaner {
         // body's own first-line indent, which the prefix now supplies.
         out =
           if (prefix.isBlank()) out.substring(0, lineStart) + body + out.substring(lambdaClose + 1)
-          else out.substring(0, call.start) + body.trimStart() + out.substring(lambdaClose + 1)
+          else out.substring(0, callStart) + body.trimStart() + out.substring(lambdaClose + 1)
       }
     }
     return out
+  }
+
+  /**
+   * A wrapper call and the `{` opening its trailing lambda — `Frame(size) { … }` **or** `Frame { …
+   * }`.
+   *
+   * The paren-less form is not an edge case, it is how most Compose wrappers are written, and
+   * [findCall] cannot see it: it requires a `(` after the name. So a catalog declaring its
+   * argument-free sticker frame as UNWRAP got no rewrite at all and the frame in its residue —
+   * which reads as "this rule needs writing" for a rule that was written correctly.
+   */
+  private fun findWrapperCall(text: String, name: String): Pair<Int, Int>? {
+    for (at in wordOccurrences(text, name)) {
+      var k = at + name.length
+      while (k < text.length && text[k].isWhitespace()) k++
+      if (k < text.length && text[k] == '(') {
+        val close = matchParen(text, k) ?: continue
+        k = close + 1
+        while (k < text.length && text[k].isWhitespace()) k++
+      }
+      if (k < text.length && text[k] == '{') return at to k
+    }
+    return null
   }
 
   /** A `name = value` argument, as distinct from a positional one. */
@@ -828,6 +922,547 @@ object PlaygroundSourceCleaner {
     lines.add(insertAt, "@$simple")
     addedImports.add(rules.previewAnnotation)
     return lines.joinToString("\n")
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Cross-file scaffolding: the declared scaffold sources, what may be expanded out of them, and
+  // what may be closed over from them. See [UsageRules.scaffoldSources] and
+  // [UsageRules.Kind.EXPAND].
+  // ---------------------------------------------------------------------------------------------
+
+  /** One top-level declaration read out of a scaffold source, carrying its file's imports. */
+  private data class Helper(
+    val text: String,
+    val imports: List<Import>,
+    val importMap: Map<String, String>,
+  )
+
+  /**
+   * At most this many declarations are pulled in from the scaffold sources. The same-file closure
+   * is deliberately unbounded — a preview file is the catalog author's own unit of code and all of
+   * it is about the preview — but these files are a whole shared module, and a snippet that drags a
+   * hundred declarations behind it has stopped being an example of the component.
+   */
+  private const val MAX_HELPER_CLOSURES = 8
+
+  /** And no single one larger than this: past it the helper *is* the snippet. */
+  private const val MAX_HELPER_BYTES = 4_000
+
+  /**
+   * Name → declaration across every scaffold source.
+   *
+   * A name declared more than once — in two of the files, or twice in one as an overload set — is
+   * removed rather than resolved by order. A repo that publishes several catalogs lists all of
+   * their scaffolding here, and quietly splicing one catalog's `counted` into another's snippet
+   * would produce code that never ran anywhere.
+   */
+  private fun helperIndex(sources: List<String>): Map<String, Helper> {
+    if (sources.isEmpty()) return emptyMap()
+    val out = LinkedHashMap<String, Helper>()
+    val ambiguous = mutableSetOf<String>()
+    for (source in sources) {
+      val lines = source.lines()
+      val imports = importsOf(lines)
+      val importMap = imports.associate { it.name to it.fqn }
+      for (block in topLevelBlocks(lines)) {
+        val name = block.name ?: continue
+        if (out.put(name, Helper(block.text, imports, importMap)) != null) ambiguous.add(name)
+      }
+    }
+    ambiguous.forEach { out.remove(it) }
+    return out
+  }
+
+  /**
+   * Clean whatever the seeds still call that a scaffold source declares, breadth-first, and return
+   * those bodies in the order they were pulled in.
+   *
+   * [skip] carries the names that are somebody else's business: what the preview's own file already
+   * declares (the same-file closure has it), and what the rules describe (a declared scaffold is
+   * rewritten, never copied in — copying it would defeat the rule and re-introduce the machinery).
+   */
+  private fun closeOverHelpers(
+    seeds: Collection<String>,
+    helpers: Map<String, Helper>,
+    skip: Set<String>,
+    rules: UsageRules,
+    strings: Map<String, String>,
+    residue: MutableSet<String>,
+    addedImports: MutableSet<String>,
+    parser: UsageSourceParser?,
+    extraImports: MutableSet<Import>,
+  ): List<String> {
+    if (helpers.isEmpty()) return emptyList()
+    val cleaned = LinkedHashMap<String, String>()
+    val queue = ArrayDeque<String>()
+    val queued = mutableSetOf<String>()
+    fun enqueue(text: String) {
+      for (name in helpers.keys) {
+        if (name in skip || name in queued) continue
+        if (mentionsWord(text, name)) {
+          queued.add(name)
+          queue.addLast(name)
+        }
+      }
+    }
+    seeds.forEach(::enqueue)
+    while (queue.isNotEmpty() && cleaned.size < MAX_HELPER_CLOSURES) {
+      val name = queue.removeFirst()
+      val helper = helpers.getValue(name)
+      // Too big to be an example. Left uncopied and named in the residue, so the note says the
+      // snippet still refers to something it did not bring along.
+      if (helper.text.length > MAX_HELPER_BYTES) {
+        residue.add(name)
+        continue
+      }
+      val body =
+        cleanBlock(
+          text = helper.text,
+          rules = rules,
+          imports = helper.importMap,
+          strings = strings,
+          isEntry = false,
+          residue = residue,
+          addedImports = addedImports,
+          parser = parser,
+          helpers = helpers,
+          extraImports = extraImports,
+        )
+      cleaned[name] = body
+      extraImports.addAll(helper.imports)
+      enqueue(body)
+    }
+    // Whatever the cap left in the queue is still referenced and still not here; say so rather than
+    // let the note claim a snippet that closes over everything it uses.
+    queue.forEach { residue.add(it) }
+    return cleaned.values.toList()
+  }
+
+  /**
+   * Replace every call to a declared [UsageRules.Kind.EXPAND] helper with the helper's own body,
+   * its parameters bound to the call's arguments.
+   *
+   * Iterative rather than recursive: an expansion may itself call another delegating helper
+   * (`Sticker(id)` → `CatalogSticker { CatalogComponent(id) }` → the component), and each pass over
+   * the text picks the next one up. A helper whose expansion still calls itself is declined instead
+   * — that is a recursion this cannot terminate, and the guard alone would only bound how large the
+   * damage got.
+   */
+  private fun expandDelegates(
+    text: String,
+    rules: UsageRules,
+    helpers: Map<String, Helper>,
+    residue: MutableSet<String>,
+    extraImports: MutableSet<Import>,
+  ): String {
+    val expandable =
+      rules.scaffolds
+        .filterValues { it.kind == UsageRules.Kind.EXPAND }
+        .keys
+        .filter { helpers.containsKey(it) }
+    if (expandable.isEmpty()) return text
+    var out = text
+    if (expandable.any { findCall(out, it) != null }) out = blockBodyForm(out)
+    val declined = mutableSetOf<String>()
+    var guard = 0
+    while (guard++ < MAX_REWRITES) {
+      val name = expandable.firstOrNull { it !in declined && findCall(out, it) != null } ?: break
+      val helper = helpers.getValue(name)
+      val call = findCall(out, name) ?: break
+      val expansion = expandCall(helper, out.substring(call.argsStart + 1, call.argsEnd))
+      if (expansion == null || mentionsWord(expansion, name)) {
+        declined.add(name)
+        residue.add(name)
+        continue
+      }
+      out = spliceExpansion(out, call, expansion)
+      extraImports.addAll(helper.imports)
+    }
+    return out
+  }
+
+  /**
+   * `@Composable fun X() = Sticker("id")` → `@Composable fun X() { Sticker("id") }`.
+   *
+   * An expression body is a fine shape for a one-line delegation and an impossible one for what the
+   * delegation expands *to*: a component body is several statements, and splicing them after an `=`
+   * produces Kotlin that does not parse. Converting first is safe only where the declaration
+   * returns `Unit`, so this requires a `@Composable` with **no declared return type** and leaves
+   * every other expression body exactly as written.
+   */
+  private fun blockBodyForm(text: String): String {
+    if (!mentionsWord(text, "@Composable")) return text
+    val mask = codeMask(text)
+    val head = findFunctionHead(text, mask) ?: return text
+    val open = head.range.last
+    val close = matchParen(text, open) ?: return text
+    var i = close + 1
+    while (i < text.length && text[i].isWhitespace()) i++
+    // A `:` here is a declared return type, and `{` is already a block body. Only a bare `=` is the
+    // Unit-returning expression body this may rewrite.
+    if (i >= text.length || text[i] != '=' || text.getOrNull(i + 1) == '=') return text
+    val body = text.substring(i + 1).trim()
+    if (body.isEmpty()) return text
+    val indent = head.range.first - (text.lastIndexOf('\n', head.range.first - 1) + 1)
+    return text.substring(0, i) +
+      "{\n" +
+      reindent(body, indent + 2) +
+      "\n" +
+      " ".repeat(indent) +
+      "}"
+  }
+
+  /**
+   * Anchored at a line start ([RegexOption.MULTILINE]), which is not cosmetic: `fun` is three
+   * lowercase letters, so the unanchored pattern's optional modifier run happily consumes it and
+   * matches from the middle of the *previous* line — `@Composable\nfun X(` matched at `omposable`.
+   * [Regex.findAll] returns non-overlapping matches, so that phantom swallowed the real declaration
+   * and every helper came back unparseable.
+   */
+  private val FUNCTION_HEAD =
+    Regex(
+      """^$ANNOTATION_RUN(?:[a-z]+\s+)*fun\s+(?:<[^>]*>\s+)?[A-Za-z_][A-Za-z0-9_]*\s*\(""",
+      RegexOption.MULTILINE,
+    )
+
+  /**
+   * The declaration's own `fun Name(` — at a **code** position and at the start of its own line, so
+   * a `fun` written in the KDoc above it is never mistaken for the thing that KDoc documents.
+   */
+  private fun findFunctionHead(text: String, mask: BooleanArray): MatchResult? =
+    FUNCTION_HEAD.findAll(text).firstOrNull { match ->
+      val at = match.range.first
+      mask[at] && text.lastIndexOf('\n', at - 1) + 1 == at
+    }
+
+  /** A declared parameter: the name a body refers to it by, and its default if it has one. */
+  private data class Param(val name: String, val default: String?)
+
+  private data class FunctionDecl(val params: List<Param>, val body: String)
+
+  /**
+   * The body of the helper [helper] declares, with its parameters bound to [argsText].
+   *
+   * Null whenever the answer would be a guess — a declaration this cannot parse, an argument list
+   * that does not bind, a parameter left with neither an argument nor a default, or a `when`
+   * dispatch whose subject is not a literal. The caller then leaves the call alone and reports it.
+   */
+  private fun expandCall(helper: Helper, argsText: String): String? {
+    val decl = parseFunction(helper.text) ?: return null
+    val args =
+      bindArguments(splitTopLevel(argsText).map { it.trim() }, decl.params.map { it.name })
+        ?: return null
+    val bound =
+      decl.params.mapIndexed { i, p -> p.name to (args.getOrNull(i) ?: p.default) }.toMap()
+    if (bound.values.any { it == null }) return null
+    // A dispatch is all-or-nothing: either the one branch the call selects, or no expansion. Left
+    // to fall through, a key this cannot pin to a literal would splice the *entire* component set
+    // in — every branch of it — which is the one outcome worse than not expanding.
+    val dispatch = loneWhen(decl.body)
+    var body = if (dispatch == null) decl.body else dispatchBranch(dispatch, bound) ?: return null
+    for ((name, value) in bound) body = replaceWord(body, name, value!!)
+    // Normalised to column 0 as a block, never `trim`ped: trimming would strip the *first* line's
+    // indent and leave every continuation line carrying the helper file's original column, so the
+    // spliced body came out with its second line hanging eight spaces off its first.
+    return reindent(body, 0).ifBlank { null }
+  }
+
+  private val WHEN_SUBJECT = Regex("""^when\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*\{""")
+
+  private val STRING_LITERAL = Regex("""^"(?:[^"\\]|\\.)*"$""")
+
+  /** A body that is nothing but `when (<subject>) { … }` — a shared component set's dispatch. */
+  private data class LoneWhen(val subject: String, val entries: List<Pair<String, String>>)
+
+  /**
+   * [body] read as a dispatch, or null when it is not one.
+   *
+   * *Lone* is the requirement: anything after the `when`'s closing brace means the helper does more
+   * than dispatch, and keeping one branch of it would silently drop the rest.
+   */
+  private fun loneWhen(body: String): LoneWhen? {
+    val trimmed = body.trim()
+    val head = WHEN_SUBJECT.find(trimmed) ?: return null
+    val open = head.range.last
+    val close = matchBrace(trimmed, open) ?: return null
+    if (trimmed.substring(close + 1).isNotBlank()) return null
+    return LoneWhen(head.groupValues[1], whenEntries(trimmed.substring(open + 1, close)))
+  }
+
+  /**
+   * The one branch of a shared component set's `when (id)` that [bound] selects, or null when it
+   * selects none — a subject the call did not bind to a string literal, or a key with no branch and
+   * no `else`.
+   *
+   * A catalog's component set is one such dispatch over several hundred branches, so this is the
+   * difference between the snippet being the component and the snippet being the catalog.
+   */
+  private fun dispatchBranch(dispatch: LoneWhen, bound: Map<String, String?>): String? {
+    val key = bound[dispatch.subject]?.trim() ?: return null
+    if (!STRING_LITERAL.matches(key)) return null
+    val match =
+      dispatch.entries.firstOrNull { (conditions, _) ->
+        splitTopLevel(conditions).any { it.trim() == key }
+      } ?: dispatch.entries.firstOrNull { it.first.trim() == "else" } ?: return null
+    // Normalised, not trimmed: `trim` would take the *first* line's indentation with it and leave
+    // the rest of the branch carrying the component set's original column, which is the difference
+    // between a branch that reads as code and one whose second line hangs eight spaces to the
+    // right of its first.
+    val branch = reindent(match.second, 0)
+    // A braced branch body contributes its statements, not its braces.
+    return if (branch.startsWith("{") && matchBrace(branch, 0) == branch.length - 1)
+      branch.substring(1, branch.length - 1)
+    else branch
+  }
+
+  /**
+   * The `<conditions> -> <body>` entries of a `when` body, as text.
+   *
+   * A braced branch ends at its matching brace. An unbraced one ends at the next line indented no
+   * further than the entry itself — ktfmt's own rule for continuing an expression, and the only
+   * signal available without a parse. Comments between entries are skipped, which the m3 component
+   * set has plenty of.
+   */
+  private fun whenEntries(body: String): List<Pair<String, String>> {
+    val mask = codeMask(body)
+    val out = mutableListOf<Pair<String, String>>()
+    var i = 0
+    while (i < body.length) {
+      i = skipTrivia(body, i)
+      if (i >= body.length) break
+      val conditionStart = i
+      val entryIndent = conditionStart - (body.lastIndexOf('\n', conditionStart - 1) + 1)
+      val arrow = topLevelArrow(body, mask, i) ?: break
+      val conditions = body.substring(conditionStart, arrow)
+      var j = arrow + 2
+      while (j < body.length && body[j].isWhitespace()) j++
+      if (j >= body.length) break
+      // A branch written *below* its `->` keeps its own line's indentation: the entry text starts
+      // at the beginning of that line, not at its first token, so the dedent downstream can still
+      // see what column the branch was written in.
+      if (body[j] != '{') {
+        val lineStart = body.lastIndexOf('\n', j - 1)
+        if (lineStart > arrow) j = lineStart + 1
+      }
+      val end =
+        if (body[j] == '{') (matchBrace(body, j) ?: break) + 1
+        else expressionEnd(body, mask, j, entryIndent)
+      out.add(conditions to body.substring(j, end))
+      i = end
+    }
+    return out
+  }
+
+  /** Advances past whitespace and comments. */
+  private fun skipTrivia(text: String, from: Int): Int {
+    var i = from
+    while (i < text.length) {
+      when {
+        text[i].isWhitespace() -> i++
+        text.startsWith("//", i) -> i = text.indexOf('\n', i).takeIf { it >= 0 } ?: text.length
+        text.startsWith("/*", i) -> i = blockCommentEnd(text, i)
+        else -> return i
+      }
+    }
+    return i
+  }
+
+  /** The `->` separating an entry's conditions from its body — at depth 0, so no lambda's. */
+  private fun topLevelArrow(text: String, mask: BooleanArray, from: Int): Int? {
+    var depth = 0
+    var i = from
+    while (i < text.length - 1) {
+      if (mask[i]) {
+        when (text[i]) {
+          '(',
+          '[',
+          '{' -> depth++
+          ')',
+          ']',
+          '}' -> depth--
+          '-' -> if (depth == 0 && text[i + 1] == '>') return i
+        }
+      }
+      i++
+    }
+    return null
+  }
+
+  private fun expressionEnd(
+    text: String,
+    mask: BooleanArray,
+    from: Int,
+    entryIndent: Int,
+  ): Int {
+    var depth = 0
+    var i = from
+    while (i < text.length) {
+      if (mask[i]) {
+        when (text[i]) {
+          '(',
+          '[',
+          '{' -> depth++
+          ')',
+          ']',
+          '}' -> {
+            depth--
+            if (depth < 0) return i
+          }
+        }
+      }
+      if (text[i] == '\n' && depth == 0) {
+        val next = nextNonBlankIndent(text, i + 1)
+        if (next == null || next <= entryIndent) return i
+      }
+      i++
+    }
+    return text.length
+  }
+
+  private fun nextNonBlankIndent(text: String, from: Int): Int? {
+    var j = from
+    while (j < text.length) {
+      val end = text.indexOf('\n', j).takeIf { it >= 0 } ?: text.length
+      val line = text.substring(j, end)
+      if (line.isNotBlank()) return line.takeWhile { it == ' ' }.length
+      j = end + 1
+    }
+    return null
+  }
+
+  /**
+   * `fun Name(<params>) = <expr>` / `fun Name(<params>) { <body> }`, as parameters and body text.
+   *
+   * The declaration is found at a **code** position and at the start of its own line, so a `fun`
+   * written inside the KDoc above it is not mistaken for the declaration it documents.
+   */
+  private fun parseFunction(text: String): FunctionDecl? {
+    val mask = codeMask(text)
+    val head = findFunctionHead(text, mask) ?: return null
+    val open = head.range.last
+    val close = matchParen(text, open) ?: return null
+    val params =
+      splitTopLevel(text.substring(open + 1, close))
+        .mapNotNull { parseParam(it) }
+        .ifEmpty { if (text.substring(open + 1, close).isBlank()) emptyList() else return null }
+    var i = close + 1
+    while (i < text.length && text[i].isWhitespace()) i++
+    // Skip a declared return type: it may itself contain `->` and `<…>`, neither of which is the
+    // body, so scan to the first `=` or `{` that is not inside one.
+    if (i < text.length && text[i] == ':') {
+      var depth = 0
+      i++
+      while (i < text.length) {
+        if (mask[i]) {
+          when (text[i]) {
+            '(',
+            '[',
+            '<' -> depth++
+            ')',
+            ']',
+            '>' -> depth--
+            '{' -> if (depth <= 0) break
+            '=' -> if (depth <= 0 && text.getOrNull(i + 1) != '=') break
+          }
+        }
+        i++
+      }
+    }
+    if (i >= text.length) return null
+    return when (text[i]) {
+      '=' -> FunctionDecl(params, text.substring(i + 1).trim())
+      '{' -> {
+        val end = matchBrace(text, i) ?: return null
+        FunctionDecl(params, text.substring(i + 1, end))
+      }
+      else -> null
+    }
+  }
+
+  /** `id: String`, `index: Int? = null`, `content: @Composable () -> Unit`. */
+  private fun parseParam(text: String): Param? {
+    val trimmed = text.trim()
+    if (trimmed.isEmpty()) return null
+    val mask = codeMask(trimmed)
+    val colon =
+      trimmed.indices.firstOrNull { trimmed[it] == ':' && mask[it] && !inBrackets(trimmed, it) }
+        ?: return null
+    val name =
+      Regex("""([A-Za-z_][A-Za-z0-9_]*)\s*$""")
+        .find(trimmed.substring(0, colon))
+        ?.groupValues
+        ?.get(1) ?: return null
+    val rest = trimmed.substring(colon + 1)
+    val restMask = codeMask(rest)
+    val eq =
+      rest.indices.firstOrNull {
+        rest[it] == '=' &&
+          restMask[it] &&
+          rest.getOrNull(it + 1) != '=' &&
+          rest.getOrNull(it - 1) !in listOf('=', '!', '<', '>', '-') &&
+          !inBrackets(rest, it)
+      }
+    return Param(name, eq?.let { rest.substring(it + 1).trim() })
+  }
+
+  private fun inBrackets(text: String, at: Int): Boolean {
+    val mask = codeMask(text)
+    var depth = 0
+    for (i in 0 until at) {
+      if (!mask[i]) continue
+      when (text[i]) {
+        '(',
+        '[',
+        '<',
+        '{' -> depth++
+        ')',
+        ']',
+        '>',
+        '}' -> depth--
+      }
+    }
+    return depth > 0
+  }
+
+  /**
+   * Put [expansion] where the call was, indented to where the call sat.
+   *
+   * A one-line expansion replaces the call expression in place, as any substitution does. A
+   * multi-line one cannot: the call may share its line with a lambda brace that opened before it
+   * and closes after it (`CatalogSticker { CatalogComponent("x") }`), and simply pasting statements
+   * into the middle of that line produces something that parses only by accident. So the line is
+   * broken around it — what preceded the call, the expansion indented one level in, then what
+   * followed.
+   */
+  private fun spliceExpansion(text: String, call: Call, expansion: String): String {
+    val after = call.argsEnd + 1
+    if (!expansion.contains('\n')) {
+      return text.substring(0, call.start) + expansion + text.substring(after)
+    }
+    val lineStart = text.lastIndexOf('\n', call.start - 1) + 1
+    val lineEnd = text.indexOf('\n', after).takeIf { it >= 0 } ?: text.length
+    val prefix = text.substring(lineStart, call.start)
+    val suffix = text.substring(after, lineEnd)
+    val indent = prefix.takeWhile { it == ' ' }.length
+    val head = if (prefix.isBlank()) "" else prefix.trimEnd() + "\n"
+    val bodyIndent = if (prefix.isBlank()) indent else indent + 2
+    val tail = if (suffix.isBlank()) "" else "\n" + " ".repeat(indent) + suffix.trimStart()
+    return text.substring(0, lineStart) +
+      head +
+      reindent(expansion, bodyIndent) +
+      tail +
+      text.substring(lineEnd)
+  }
+
+  /** Re-indents a lifted body to [column], preserving its own internal shape. */
+  private fun reindent(text: String, column: Int): String {
+    val lines = text.lines().dropWhile { it.isBlank() }.dropLastWhile { it.isBlank() }
+    if (lines.isEmpty()) return ""
+    val common =
+      lines.filter { it.isNotBlank() }.minOfOrNull { line -> line.takeWhile { it == ' ' }.length }
+        ?: 0
+    val pad = " ".repeat(column)
+    return lines.joinToString("\n") { if (it.isBlank()) "" else (pad + it.drop(common)).trimEnd() }
   }
 
   // ---------------------------------------------------------------------------------------------
@@ -1140,17 +1775,6 @@ object PlaygroundSourceCleaner {
   private fun indentOf(text: String, at: Int): Int {
     val lineStart = text.lastIndexOf('\n', at - 1) + 1
     return text.substring(lineStart, at).takeWhile { it == ' ' }.length
-  }
-
-  /** Re-indents a lambda body lifted out of its wrapper, to the column the wrapper sat at. */
-  private fun dedent(inner: String, toColumn: Int): String {
-    val lines = inner.lines().filter { it.isNotBlank() }
-    if (lines.isEmpty()) return ""
-    val common = lines.minOf { line -> line.takeWhile { it == ' ' }.length }
-    val shift = common - toColumn
-    return lines.joinToString("\n") { line ->
-      if (shift > 0) line.drop(minOf(shift, line.takeWhile { it == ' ' }.length)) else line
-    }
   }
 
   private fun removeLines(text: String, range: IntRange): String {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -53,6 +53,43 @@ data class UsageRules(
   val scaffoldAnnotationPackages: List<String> = emptyList(),
 
   /**
+   * Catalog annotations by **bare simple name**, for the ones an import can never resolve: an
+   * annotation a catalog declares in the *same package* as the previews that stack it
+   * (`@CatalogModes`) is referenced with no import line at all, so [scaffoldAnnotationPackages] —
+   * which resolves a simple name through the file's own imports — structurally cannot see it. That
+   * is not a corner case: it is where a catalog's own multipreview normally lives, and it is why
+   * the m3 sticker sheet's snippets kept showing `@CatalogModes` above a `@Preview` that had just
+   * been stamped to replace it.
+   *
+   * Matched on the name alone, so it is the blunter of the two and the catalog opts into it by
+   * naming each annotation exactly. Prefer [scaffoldAnnotationPackages] whenever the annotation is
+   * imported.
+   */
+  @SerialName("scaffoldAnnotationNames") val scaffoldAnnotationNames: List<String> = emptyList(),
+
+  /**
+   * **Repo-root-relative** Kotlin files whose declarations the cleaner may read — the catalog's own
+   * scaffolding sources, so a sticker that *delegates* can be followed to what it delegates to.
+   *
+   * The cleaner's closure pass only ever reached declarations in the preview's **own file**, which
+   * is the right default and is exactly wrong for a catalog whose component bodies deliberately
+   * live in one shared place. `fun FilledButton() = Sticker("button-filled")` is the whole of the
+   * m3 sticker sheet's `Button/Filled`, and the honest reduction of it — `Button(onClick = {}) {
+   * Text("Filled") }` — is two files away. Without these the Source panel showed the wrapper and
+   * nothing else: a snippet with no component in it (issue #4169).
+   *
+   * Repo-root-relative rather than module-relative because the point is to cross a module boundary:
+   * the m3 catalog's stickers are in `:samples:design-catalog-m3` and their bodies are in
+   * `:samples:design-catalog-m3-shared`. Read at the same `ref` as the preview's own source, so a
+   * helper and the sticker citing it are never from different revisions.
+   *
+   * A name declared by more than one of these files is **ambiguous and dropped**, not first-wins —
+   * a repo publishing several catalogs lists every catalog's scaffolding here, and silently picking
+   * one repo-mate's `counted` for another's would rewrite a snippet into something that never ran.
+   */
+  @SerialName("scaffoldSources") val scaffoldSources: List<String> = emptyList(),
+
+  /**
    * Packages the [scaffolds] themselves live in, so a **package-qualified** call
    * (`ee.schimke.composeai.overrides.previewOverrideString(…)`) is recognised as the same call.
    *
@@ -193,6 +230,24 @@ data class UsageRules(
      * on a named argument.
      */
     SUBSTITUTE,
+
+    /**
+     * The helper **delegates**: replace the call with the helper's own body, its parameters bound
+     * to the call's arguments, and let every other pass run over what that produced.
+     *
+     * This is the one kind that reads a file other than the preview's — the declaration is looked
+     * up in [UsageRules.scaffoldSources] — and it exists because a catalog is allowed to keep its
+     * component bodies in one place. `Sticker("button-filled")` says nothing about a button; it
+     * says "the shared component set's `button-filled`", and the reader wants what that is.
+     *
+     * **String-keyed dispatch is part of the kind, not a second one.** A shared component set is
+     * normally a single `when (id)` over a few hundred branches, so expanding it verbatim would
+     * substitute the entire catalog for the one component asked about. When the body is a lone
+     * `when` over a parameter the call bound to a **string literal**, only the matching branch
+     * survives. Anything less certain — a computed key, a `when` this cannot read, an argument that
+     * is not a literal — is left exactly as the catalog wrote it and reported as residue.
+     */
+    EXPAND,
 
     /**
      * A kind this build does not know — a rule kind that has since been retired, or one a newer
@@ -342,6 +397,8 @@ data class UsageRules(
       copy(
         scaffoldAnnotationPackages =
           (scaffoldAnnotationPackages + GENERIC.scaffoldAnnotationPackages).distinct(),
+        scaffoldAnnotationNames =
+          (scaffoldAnnotationNames + GENERIC.scaffoldAnnotationNames).distinct(),
         scaffoldPackages = (scaffoldPackages + GENERIC.scaffoldPackages).distinct(),
         scaffolds = GENERIC.scaffolds + scaffolds,
       )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogUsageRulesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogUsageRulesTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 Yuri Schimke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * This repo's **own** `compose-usage.json`, run over this repo's **own** catalog source.
+ *
+ * [PlaygroundSourceCleanerTest] pins the machinery against fixtures; this pins the thing a visitor
+ * actually gets, and it is the pairing that matters here. The rules file and the catalog it
+ * describes live in one repository and are edited by different hands: renaming `Sticker`, moving
+ * `CatalogComponents.kt`, or adding a knob wrapper all break the Source panel silently, because the
+ * cleaner's contract is to degrade rather than fail. A served preview whose "source" is
+ * `Sticker("button-filled")` and nothing else is exactly what issue #4169 reported.
+ *
+ * So this reads the real files off disk at the paths the rules name, and asserts the reduction
+ * reaches the component.
+ */
+class CatalogUsageRulesTest {
+
+  private val root = repoRoot()
+
+  private val rules =
+    assertNotNull(
+      UsageRules.parse(File(root, "compose-usage.json").readText()),
+      "compose-usage.json at the repo root must parse as usage rules",
+    )
+
+  private val helperSources by lazy {
+    rules.scaffoldSources.map { path ->
+      val file = File(root, path)
+      assertTrue(file.isFile, "compose-usage.json names a scaffold source that is not there: $path")
+      file.readText()
+    }
+  }
+
+  private val strings by lazy {
+    val path = assertNotNull(rules.stringsPath).removePrefix("/")
+    val file = File(root, path)
+    assertTrue(file.isFile, "compose-usage.json names a strings file that is not there: $path")
+    Regex("""<string\s+name="([A-Za-z0-9_]+)"\s*>(.*?)</string>""", RegexOption.DOT_MATCHES_ALL)
+      .findAll(file.readText())
+      .associate { it.groupValues[1] to it.groupValues[2].trim() }
+  }
+
+  private val buttonsKt =
+    File(
+      root,
+      "samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogButtons.kt",
+    )
+
+  /** The 1-based line of `fun <name>` in [file] — the anchor discovery records per preview. */
+  private fun anchor(file: File, name: String): Int =
+    file.readLines().indexOfFirst { Regex("""^fun $name\(""").containsMatchIn(it) } + 1
+
+  private fun cleanPreview(file: File, name: String): PlaygroundSourceCleaner.Result =
+    assertNotNull(
+      PlaygroundSourceCleaner.clean(
+        source = file.readText(),
+        bodyLine = anchor(file, name),
+        rules = rules,
+        strings = strings,
+        // The staged PSI sidecar is not present in a plain `./gradlew test`; the text passes are
+        // what this asserts, and they are also what a host without the sidecar serves.
+        parser = null,
+        helperSources = helperSources,
+      ),
+      "the cleaner declined $name",
+    )
+
+  @Test
+  fun `the m3 sticker sheet reduces to the component it delegates to`() {
+    val result = cleanPreview(buttonsKt, "FilledButton")
+
+    // The whole of issue #4169: the snippet must contain the component, not the wrapper that
+    // fetches it. Neither the sticker helper nor the shared component set may survive.
+    assertTrue(result.text.contains("Button("), "no Button in:\n${result.text}")
+    assertFalse(result.text.contains("Sticker("), "the sticker wrapper survived:\n${result.text}")
+    assertFalse(
+      result.text.contains("CatalogComponent("),
+      "the shared component dispatch survived:\n${result.text}",
+    )
+
+    // The label the render actually shows, not the resource lookup that produces it.
+    assertTrue(result.text.contains("\"Filled\""), "label not inlined:\n${result.text}")
+
+    // The catalog's own machinery is gone, including the multipreview it declares in the previews'
+    // own package — the one an import can never resolve.
+    assertFalse(result.text.contains("@CatalogModes"), "annotation survived:\n${result.text}")
+    assertFalse(result.text.contains("@CatalogComponent"), "annotation survived:\n${result.text}")
+    assertTrue(result.text.contains("@Preview"), "no runnable preview:\n${result.text}")
+
+    // The imports the expansion needs come from the file the expansion came from.
+    assertTrue(
+      result.text.contains("import androidx.compose.material3.Button"),
+      "expanded body's imports missing:\n${result.text}",
+    )
+    assertEquals(emptyList(), result.residue, "residue:\n${result.text}")
+  }
+
+  @Test
+  fun `a stateful component brings its shared helper along`() {
+    val selectionKt =
+      File(
+        root,
+        "samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogSelection.kt",
+      )
+    val result = cleanPreview(selectionKt, "CheckboxChecked")
+
+    // `checkbox-checked` dispatches to `StatefulCheckbox(…)`, which is declared in the shared
+    // module — so the closure has to cross the file boundary the same way the expansion did, or the
+    // snippet names something the reader cannot see.
+    assertTrue(result.text.contains("StatefulCheckbox"), "helper not called:\n${result.text}")
+    assertTrue(
+      result.text.contains("fun StatefulCheckbox"),
+      "helper not closed over:\n${result.text}",
+    )
+    assertTrue(result.text.contains("Checkbox("), "no Checkbox in:\n${result.text}")
+  }
+
+  @Test
+  fun `every scaffold source and strings path the rules name exists`() {
+    // Cheap, and it is the failure mode that made this whole thing worth a test: a moved file turns
+    // the Source panel back into a one-line wrapper with nothing to say it regressed.
+    assertTrue(helperSources.all { it.isNotBlank() })
+    assertTrue(strings.isNotEmpty())
+    assertTrue(
+      rules.scaffoldSources.size <= PlaygroundSeedResolver.MAX_SCAFFOLD_SOURCES,
+      "more scaffold sources than the resolver will read",
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -1466,6 +1466,189 @@ class PlaygroundSourceCleanerTest {
     assertEquals(listOf("counted"), result.residue)
   }
 
+  // -----------------------------------------------------------------------------------------------
+  // Delegating catalogs: scaffold sources, EXPAND, and the string-keyed `when` dispatch (#4169).
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * A sticker sheet whose previews are one-line delegations, as `:samples:design-catalog-m3` is.
+   */
+  private val delegatingPreviews =
+    """
+    package demo.catalog
+
+    import androidx.compose.runtime.Composable
+    import demo.catalog.shared.CatalogComponent
+    import ee.schimke.composeai.preview.CatalogComponent
+
+    @CatalogComponent(id = "Button/Filled", group = "Buttons")
+    @CatalogModes
+    @Composable
+    fun FilledButton() = Sticker("button-filled")
+    """
+      .trimIndent()
+
+  private val stickerHelper =
+    """
+    package demo.catalog
+
+    import androidx.compose.runtime.Composable
+    import demo.catalog.shared.CatalogComponent
+
+    @Composable fun Sticker(id: String) = CatalogSticker { CatalogComponent(id) }
+    """
+      .trimIndent()
+
+  private val sharedComponents =
+    """
+    package demo.catalog.shared
+
+    import androidx.compose.material3.Button
+    import androidx.compose.material3.Text
+    import androidx.compose.runtime.Composable
+
+    @Composable
+    fun CatalogComponent(id: String) {
+      when (id) {
+        // The tally is what makes a stateless button do something visible.
+        "button-filled" -> {
+          val label = "Filled"
+          Button(onClick = {}) { Text(label) }
+        }
+        "button-text" ->
+          TextButton(onClick = {}) {
+            Text("Text")
+          }
+        else -> Text("unknown")
+      }
+    }
+    """
+      .trimIndent()
+
+  private val delegatingRules =
+    UsageRules(
+      scaffoldAnnotationPackages = listOf("ee.schimke.composeai.preview"),
+      scaffoldAnnotationNames = listOf("CatalogModes"),
+      scaffoldSources = listOf("a/Stickers.kt", "b/Components.kt"),
+      scaffolds =
+        mapOf(
+          "Sticker" to UsageRules.Scaffold(kind = UsageRules.Kind.EXPAND),
+          "CatalogComponent" to UsageRules.Scaffold(kind = UsageRules.Kind.EXPAND),
+          "CatalogSticker" to UsageRules.Scaffold(kind = UsageRules.Kind.UNWRAP),
+        ),
+    )
+
+  private fun cleanDelegating(
+    needle: String,
+    rules: UsageRules = delegatingRules,
+    helpers: List<String> = listOf(stickerHelper, sharedComponents),
+  ) =
+    PlaygroundSourceCleaner.clean(
+      source = delegatingPreviews,
+      bodyLine = lineIn(delegatingPreviews, needle),
+      rules = rules,
+      parser = null,
+      helperSources = helpers,
+    )
+
+  /**
+   * The reported bug: a preview that is only a delegation has no component in it, so the whole
+   * reduction has to cross into the file the component actually lives in.
+   */
+  @Test
+  fun `a delegating preview expands to the component the shared set dispatches to`() {
+    val result = assertNotNull(cleanDelegating("fun FilledButton"))
+
+    assertTrue(result.text.contains("""Button(onClick = {}) { Text(label) }"""), result.text)
+    // Only the branch that was asked for: expanding the dispatch whole would substitute the entire
+    // catalog for the one component.
+    assertFalse(result.text.contains("TextButton"), result.text)
+    assertFalse(result.text.contains("unknown"), result.text)
+    assertFalse(result.text.contains("when ("), result.text)
+    // Neither wrapper survives, and the expression body became a block one so two statements fit.
+    assertFalse(result.text.contains("Sticker"), result.text)
+    assertFalse(result.text.contains("CatalogComponent"), result.text)
+    assertTrue(result.text.contains("fun FilledButton() {"), result.text)
+    // The annotation the catalog declares in the previews' own package — no import to resolve it
+    // through — comes off too, and a real `@Preview` replaces it.
+    assertFalse(result.text.contains("@CatalogModes"), result.text)
+    assertTrue(result.text.contains("@Preview"), result.text)
+    // The imports the spliced body needs come from the file the body came from.
+    assertTrue(result.text.contains("import androidx.compose.material3.Button"), result.text)
+    assertEquals(emptyList(), result.residue, result.text)
+  }
+
+  /**
+   * A repo publishing several catalogs lists every catalog's scaffolding, so one name may be
+   * declared twice. Picking either would splice one catalog's helper into another's snippet.
+   */
+  @Test
+  fun `a name two scaffold sources both declare is not expanded`() {
+    val rival =
+      """
+      package demo.other
+
+      import androidx.compose.runtime.Composable
+
+      @Composable fun Sticker(id: String) = Text("some other catalog's sticker")
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        cleanDelegating(
+          "fun FilledButton",
+          helpers = listOf(stickerHelper, sharedComponents, rival),
+        )
+      )
+
+    assertTrue(result.text.contains("""Sticker("button-filled")"""), result.text)
+    assertFalse(result.text.contains("some other catalog"), result.text)
+    assertTrue(result.residue.contains("Sticker"), result.residue.toString())
+  }
+
+  /** No scaffold sources ⇒ exactly the behaviour that shipped before EXPAND existed. */
+  @Test
+  fun `an EXPAND rule with nothing to read leaves the call alone`() {
+    val result = assertNotNull(cleanDelegating("fun FilledButton", helpers = emptyList()))
+
+    assertTrue(result.text.contains("""Sticker("button-filled")"""), result.text)
+    assertFalse(result.text.contains("fun FilledButton() {"), result.text)
+  }
+
+  /**
+   * A dispatch key the call does not pin to a literal cannot be resolved to one branch, and
+   * guessing would put a component in front of a reader that the render never composed.
+   */
+  @Test
+  fun `a dispatch whose key is not a literal is declined and reported`() {
+    val computed =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+      import demo.catalog.shared.CatalogComponent
+
+      @Composable
+      fun FilledButton(slug: String) {
+        CatalogComponent(slug)
+      }
+      """
+        .trimIndent()
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = computed,
+          bodyLine = lineIn(computed, "CatalogComponent(slug)"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, sharedComponents),
+        )
+      )
+
+    assertTrue(result.text.contains("CatalogComponent(slug)"), result.text)
+    assertTrue(result.residue.contains("CatalogComponent"), result.residue.toString())
+  }
+
   private fun lineIn(text: String, needle: String): Int =
     text.lines().indexOfFirst { it.contains(needle) } + 1
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/UsageSnippetCorpusTest.kt
@@ -151,6 +151,21 @@ class UsageSnippetCorpusTest {
       }
   }
 
+  /**
+   * The catalog's declared scaffold sources, read repo-root-relative out of the checkout — what the
+   * server fetches from GitHub for the same rules file. Without them a delegating catalog's samples
+   * would be cleaned differently here than in production, which is the one thing this corpus must
+   * not do.
+   */
+  private fun helperSourcesFor(root: File, rules: UsageRules): List<String> =
+    rules.scaffoldSources
+      .map { it.trim().removePrefix("/") }
+      .filter { it.isNotEmpty() }
+      .take(PlaygroundSeedResolver.MAX_SCAFFOLD_SOURCES)
+      .mapNotNull { path ->
+        File(root, path).takeIf { it.isFile }?.let { runCatching { it.readText() }.getOrNull() }
+      }
+
   /** Annotation-first (m3-catalog): the samples come from the annotations themselves. */
   private fun annotationSamples(system: String, root: File, perKind: Int): List<Sample> {
     val out = mutableListOf<Sample>()
@@ -280,6 +295,7 @@ class UsageSnippetCorpusTest {
       val files = sources(root)
       val (rules, declared) = rulesFor(root)
       val strings = stringsFor(root, rules)
+      val helperSources = helperSourcesFor(root, rules)
       // Which sampler by the catalog's *shape*, not its name — keying on the name would silently
       // mis-sample the next catalog somebody points this at. Annotations first, spec as the
       // fallback, rather than branching on the spec file's presence: m3-catalog ships **both**, so
@@ -300,7 +316,13 @@ class UsageSnippetCorpusTest {
         }
         val (file, anchor) = found
         val cleaned = runCatching {
-          PlaygroundSourceCleaner.clean(file.readText(), anchor, rules, strings)
+          PlaygroundSourceCleaner.clean(
+            source = file.readText(),
+            bodyLine = anchor,
+            rules = rules,
+            strings = strings,
+            helperSources = helperSources,
+          )
         }
           .getOrElse { e ->
             report.appendLine("- ${sample.kind}/${sample.function}: THREW ${e::class.simpleName}")

--- a/compose-usage.json
+++ b/compose-usage.json
@@ -1,0 +1,71 @@
+{
+  "_comment": [
+    "What this repo's own design catalogs use as scaffolding, so the preview server's Source panel",
+    "(and the playground handoff) can reduce a sticker to the plain Compose that produced the",
+    "render. Read by `PlaygroundSeedResolver` from the repo root at the same `ref` a catalog was",
+    "published from; see `cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt`.",
+    "",
+    "CatalogSticker is UNWRAPped rather than expanded into a stock MaterialTheme: it is the render",
+    "frame (a transparent Surface and 16dp of padding around a component silhouette), so keeping it",
+    "would put a 200-character theme expression in front of the one line the reader came for. The",
+    "full-screen template wrapper keeps its theme, because a screen example without one is not the",
+    "thing it is showing.",
+    "",
+    "The m3 sticker sheet is a *delegating* catalog: every preview is a one-line",
+    "`Sticker(\"<slug>\")` over the shared component set in :samples:design-catalog-m3-shared, so",
+    "without `scaffoldSources` + EXPAND the Source panel showed the wrapper and no component at",
+    "all (issue #4169). The wear and remote catalogs compose their components inline and need",
+    "nothing here beyond the generic rules they already inherit."
+  ],
+  "scaffoldAnnotationPackages": [
+    "com.example.designcatalogm3"
+  ],
+  "scaffoldAnnotationNames": [
+    "CatalogModes",
+    "CatalogTemplate"
+  ],
+  "scaffoldSources": [
+    "samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogStickers.kt",
+    "samples/design-catalog-m3/src/main/kotlin/com/example/designcatalogm3/CatalogTheme.kt",
+    "samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt"
+  ],
+  "scaffolds": {
+    "Sticker": { "kind": "EXPAND" },
+    "CatalogComponent": { "kind": "EXPAND" },
+    "CatalogSticker": { "kind": "UNWRAP" },
+    "PreviewSlot": { "kind": "UNWRAP" },
+    "FullScreenM3": {
+      "kind": "RENAME",
+      "renameTo": "MaterialTheme",
+      "special": "MATERIAL3_SYSTEM_THEME"
+    },
+    "counted": { "kind": "SUBSTITUTE", "plain": "$0 to {}", "params": ["base"] },
+    "catalogOverrideString": {
+      "kind": "SUBSTITUTE",
+      "plain": "$1",
+      "params": ["key", "default", "index"]
+    },
+    "catalogOverrideInt": {
+      "kind": "SUBSTITUTE",
+      "plain": "$1",
+      "params": ["key", "default", "index"]
+    },
+    "catalogOverrideFloat": {
+      "kind": "SUBSTITUTE",
+      "plain": "$1",
+      "params": ["key", "default", "index"]
+    },
+    "catalogOverrideBoolean": {
+      "kind": "SUBSTITUTE",
+      "plain": "$1",
+      "params": ["key", "default", "index"]
+    },
+    "catalogOverrideColor": {
+      "kind": "SUBSTITUTE",
+      "plain": "$1",
+      "params": ["key", "default", "index"]
+    }
+  },
+  "stringsPath": "/samples/design-catalog-m3-shared/src/commonMain/composeResources/values/strings.xml",
+  "previewAnnotation": "androidx.compose.ui.tooling.preview.Preview"
+}

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -105,6 +105,58 @@ So for a catalog like meshcore the Source panel shows *the preview, sliced and i
 usage code, and the panel already says so when a catalog has declared no rules. That is the correct
 outcome, and worth knowing before anyone tries to fix it with rules.
 
+### A third shape: the catalog that *delegates*
+
+This repo's own `:samples:design-catalog-m3` is neither of the two above. Every preview in it is a
+one-line wrapper —
+
+```kotlin
+@CatalogComponent(id = "Button/Filled", …)
+@CatalogModes
+@Composable
+fun FilledButton() = Sticker("button-filled")
+```
+
+— over a shared component set in `:samples:design-catalog-m3-shared`, which is a single `when (id)`
+over every component the sheet publishes. That is a deliberate design (one id, one composable, every
+lane) and it broke the Source panel completely: the cleaner's closure pass only ever reached
+declarations in the preview's **own file**, so the honest reduction of that preview was the wrapper
+and nothing else. A visitor opening `Button/Filled` got a snippet with no button in it — [issue
+#4169](https://github.com/yschimke/compose-ai-tools/issues/4169).
+
+Two pieces of vocabulary close it, both declared in [`compose-usage.json`](../../compose-usage.json)
+at the repo root:
+
+- **`scaffoldSources`** — repo-root-relative Kotlin files the cleaner may read, fetched at the same
+  `ref` as the preview's own source. This is what lets it cross a module boundary at all.
+- **`EXPAND`** — a rule kind meaning *the helper delegates*: replace the call with the helper's body,
+  parameters bound to the call's arguments. When that body is a lone `when` over a parameter the
+  call bound to a **string literal**, only the matching branch survives — otherwise expanding the
+  shared component set would substitute the whole catalog for the one component asked about.
+
+Chained, `Sticker("button-filled")` → `CatalogSticker { CatalogComponent("button-filled") }` → the
+`button-filled` branch, which the ordinary passes then reduce the rest of the way:
+
+```kotlin
+@Preview
+@Composable
+fun FilledButton() {
+  val (label, onClick) = "Filled" to {}
+  Button(onClick = onClick, enabled = true) { Text(label) }
+}
+```
+
+Whatever the expanded body still calls that a scaffold source declares (`StatefulCheckbox`,
+`CardContentSlot`) is closed over from those files too, capped — unlike the same-file closure, which
+is unbounded because a preview file is all about the preview. 30 of the sheet's 36 previews come out
+with empty residue; the remainder are the `stringResource` gap below and this repo's own
+`LocalSlotMode`, both reported rather than hidden.
+
+[`CatalogUsageRulesTest`](../../cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogUsageRulesTest.kt)
+runs the real rules file over the real catalog source on every build, because the two are edited by
+different hands and the cleaner's contract is to degrade quietly — a renamed helper or a moved file
+puts the wrapper back with nothing to say it regressed.
+
 ### Known gap: an override *variant* still shows the author's default
 
 Substituting `previewOverride*(key, default, …)` with `default` is right for the default render and


### PR DESCRIPTION
## The bug

`compose-preview`'s **Source** panel reduced `Button/Filled` to this and stopped:

```kotlin
import androidx.compose.runtime.Composable
import androidx.compose.ui.tooling.preview.Preview

@CatalogModes
@Preview
@Composable
fun FilledButton() = Sticker("button-filled")
```

A snippet with no button in it, above a `@CatalogModes` the stamped `@Preview` had just replaced.

The cleaner's closure pass only ever reached declarations in the preview's **own file** — the right
default, and exactly wrong for `:samples:design-catalog-m3`, which deliberately keeps every
component body in `:samples:design-catalog-m3-shared` behind a single `when (id)`. There was nothing
in the preview's file to reduce.

## The fix

Two pieces of vocabulary, declared by the catalog rather than hard-coded here:

- **`scaffoldSources`** — repo-root-relative Kotlin files the cleaner may read, fetched at the same
  `ref` as the preview's own source and cached per `(repo, ref)` beside the rules that named them.
  Capped at 12 files, each under the existing byte cap.
- **`EXPAND`** — a rule kind meaning *the helper delegates*: replace the call with the helper's body,
  parameters bound to the call's arguments. When that body is a lone `when` over a parameter the
  call bound to a **string literal**, only the matching branch survives. Anything less certain — a
  computed key, a `when` this cannot read — is declined and reported as residue rather than splicing
  the entire component set in.

Chained, `Sticker("button-filled")` → `CatalogSticker { CatalogComponent("button-filled") }` → the
one branch, and the ordinary passes take it the rest of the way. Whatever the expanded body still
calls that a scaffold source declares (`StatefulCheckbox`, `CardContentSlot`) is closed over from
those files too, bounded at 8 declarations — unlike the same-file closure, which stays unbounded
because a preview file is all about the preview.

[`compose-usage.json`](https://github.com/yschimke/compose-ai-tools/blob/agent/missing-component-source-d5e5db/compose-usage.json)
at the repo root declares it for the m3 catalog. **30 of the sheet's 36 previews now clean with
empty residue**; the rest are the known `stringResource` gap and this repo's own `LocalSlotMode`,
both reported rather than hidden.

Four smaller bugs surfaced on the way, each fixed and each its own defect:

- **`scaffoldAnnotationNames`** — an annotation a catalog declares in the previews' *own package*
  (`@CatalogModes`) is written with no import, so `scaffoldAnnotationPackages`, which resolves a
  simple name through the file's imports, structurally could not see it.
- **UNWRAP now sees a paren-less trailing-lambda call** (`Frame { … }`), which is how most Compose
  wrappers are written. `findCall` requires a `(`, so a correctly written rule got no rewrite at all
  and its helper landed in residue.
- **`getValue`/`setValue` survive a `by` delegation.** `var checked by remember { mutableStateOf(…) }`
  names neither, so the mention test pruned exactly the two imports that make it compile.
- **One-line `@Composable fun X() = …` declarations are recognised** — the shape ktfmt emits whenever
  it fits. They had no *name* as far as the block splitter was concerned, so they were invisible to
  both closure passes.

## Before / after

The change is the **text the Source panel serves**; the panel's markup, CSS and chrome are untouched
(no diff in `ServeWeb.kt` or `viewer.ts`), so there are no pixels to diff — the whole of the change is
below, and it is pinned by a test that runs the real rules over the real catalog source.

`Button/Filled` — before is the report above; after:

```kotlin
import androidx.compose.material3.Button
import androidx.compose.material3.Text
import androidx.compose.runtime.Composable
import androidx.compose.ui.tooling.preview.Preview

@Preview
@Composable
fun FilledButton() {
  val (label, onClick) =
    "Filled" to {}
  // `enabled` is a knob so the disabled state rides this component as an `@OverrideVariant`
  // rather than a second slug — the same shape the selection controls use for `checked`.
  Button(onClick = onClick, enabled = true) { Text(label) }
}
```

`Selection/Checkbox` — before was `fun CheckboxChecked() = Sticker("checkbox-checked")`; after, the
cross-file closure brings the shared helper along:

```kotlin
import androidx.compose.material3.Checkbox
import androidx.compose.runtime.Composable
import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.remember
import androidx.compose.runtime.setValue
import androidx.compose.ui.tooling.preview.Preview

@Preview
@Composable
fun CheckboxChecked() {
  StatefulCheckbox(true)
}

@Composable
fun StatefulCheckbox(initial: Boolean) {
  var checked by remember { mutableStateOf(initial) }
  Checkbox(checked = checked, onCheckedChange = { checked = it })
}
```

`Containment/Card/Slots` — the slot markers unwrap and the card comes through whole:

```kotlin
@Preview
@Composable
fun SlottedCardSlotsSticker() {
  CompositionLocalProvider(LocalSlotMode provides true) {
    ElevatedCard {
      Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
        Box(Modifier.size(40.dp).background(Color(0xFF6750A4)))
        Column(Modifier.padding(start = 12.dp)) {
          Text("Headline")
          Text("Supporting text")
        }
      }
    }
  }
}
```

## Test plan

- `CatalogUsageRulesTest` (new) runs the repo's **real** `compose-usage.json` over the repo's **real**
  catalog source. That pairing is the point: the rules file and the catalog it describes are edited
  by different hands, and the cleaner's contract is to degrade quietly — a renamed helper or a moved
  file would put the wrapper back with nothing to say it regressed.
- `PlaygroundSourceCleanerTest` gains four fixture cases: the dispatch expansion, a name two scaffold
  sources both declare (not expanded — a repo publishing several catalogs lists all of them, and
  picking either would splice one catalog's helper into another's snippet), an `EXPAND` rule with no
  sources to read (byte-identical to what shipped before), and a non-literal dispatch key (declined
  and reported).
- `UsageSnippetCorpusTest` now passes `scaffoldSources` too, so the compile corpus cleans a
  delegating catalog exactly the way the server does.
- `./gradlew ktfmtCheckAll` clean; `:cli:test` — 2513 tests, the only failures being
  `ServeWebFixtureTest` and `ServeHttpRoutingTest`, **both of which fail identically on a pristine
  tree at this base** (verified by stashing the whole change). Neither touches anything in this diff.

Closes #4169

_Generated by [Claude Code](https://claude.com/claude-code)_
