### PR TITLE
docs(design-artifacts): allow a $comment beside the semantics exemptions

### DIFF
--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -1211,6 +1211,7 @@ the situation instead, on the cover sheet:
   "system": "meshcore-mobile",
   "title": "MeshCore",
   "completeness": {
+    "$comment": "Synthetic Activity renders: the app cold-starts with no data, so the frame is near-empty.",
     "exemptSemantics": ["*Activity", "app/getting-started"]
   }
 }

--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -824,8 +824,11 @@ function completenessErrors(spec) {
     return ["`completeness` must be an object (currently only `exemptSemantics` lives in it)"];
   }
   const errors = [];
+  // `$comment` is allowed alongside the fields, as it is at the top level: an exemption is a
+  // judgement call ("these renders capture nothing by their nature") and the reason belongs next to
+  // the list, not in a distant header — JSON has nowhere else to put it.
   for (const key of Object.keys(block)) {
-    if (key !== "exemptSemantics") {
+    if (key !== "exemptSemantics" && key !== "$comment") {
       errors.push(`completeness.${key} is not a known field (did you mean \`exemptSemantics\`?)`);
     }
   }

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -927,6 +927,21 @@ test("validateSpec rejects a malformed completeness block", () => {
   );
 });
 
+test("validateSpec accepts a $comment beside the exemptions", () => {
+  // The reason an entry is exempt belongs next to the list; JSON has nowhere else to put it.
+  assert.deepEqual(
+    validateSpec(
+      prioritySpec([{ componentId: "A", preview: "Alpha" }], {
+        completeness: {
+          $comment: "Synthetic Activity renders: cold start, no data, near-empty frame.",
+          exemptSemantics: ["*Activity"],
+        },
+      }),
+    ).errors,
+    [],
+  );
+});
+
 // --- select: one breakpoint of a multipreview, without splitting the function ---
 
 const wearSpecWith = (components) => ({

--- a/scripts/design-artifacts/catalog.spec.schema.json
+++ b/scripts/design-artifacts/catalog.spec.schema.json
@@ -89,6 +89,7 @@
       "description": "Escape hatches for the publish-time completeness gate, per entry rather than the wholesale `--allow-incomplete`.",
       "additionalProperties": false,
       "properties": {
+        "$comment": { "type": "string" },
         "exemptSemantics": {
           "type": "array",
           "description": "componentIds whose render is expected to capture NO semantics tree, so their absence must not fail the publish (e.g. the synthetic Activity renders repository-wide discovery sweeps in: a cold-started app with no data and no network renders a near-empty frame). Matched against the whole componentId as the \"no semantics for: …\" report prints it, with `*` standing for any run of characters including `/` — e.g. [\"*Activity\", \"app/getting-started\"]. Exempt entries stay in catalog.json with their pixels and are reported separately; every other entry keeps the strict gate. Semantics only — a MISSING render still fails (declare `capture: \"none\"` for an entry that cannot rasterise). A pattern matching nothing is reported on every run so a stale exemption is visible.",


### PR DESCRIPTION
Follow-up to #4175, found while applying `completeness.exemptSemantics` to the registered catalogs that need it.

`completeness` was sealed with `additionalProperties: false`, so a spec author had nowhere to record *why* an id is exempt. That reason is the whole judgement — "these renders capture nothing by their nature" is a claim a reviewer should be able to check — and pushing it into the file's top-level `$comment`, paragraphs away from the list, is how it stops being read. JSON has no comments; `$comment` is the convention this schema already uses at the top level.

So `completeness` now accepts a `$comment` alongside `exemptSemantics`, in both the JSON schema and `validateSpec`. Every other unknown key still errors.

```jsonc
"completeness": {
  "$comment": "Synthetic Activity renders: the app cold-starts with no data, so the frame is near-empty.",
  "exemptSemantics": ["*Activity", "app/getting-started"]
}
```

## Test plan

- `node --test catalog-spec.test.mjs completeness-exemptions.test.mjs` — 80 pass, 0 fail, including a new case asserting the `$comment` form validates clean and the existing case asserting `completeness.exemptMissing` still errors.

Non-visual (spec validation + schema), so there is no rendered output to diff.

_Generated by [Claude Code](https://claude.ai/code)_