### PR TITLE
build(rc-player): publish the player stack to Maven Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,11 +391,12 @@ jobs:
           sudo xcode-select --switch "$xcode/Contents/Developer"
           xcodebuild -version
           xcodebuild -showsdks | grep -i iphonesimulator
-      # `:rc-player-compose` has no `iosX64` compile task: it is the only `:rc-player-*` module that
-      # depends on Compose Multiplatform, and CMP 1.11 dropped the Intel-iOS-simulator variant (see
-      # that module's build.gradle.kts). Its non-Compose siblings still declare `iosX64()`, so they
-      # keep their entries below. Naming a task that no longer exists fails the whole invocation
-      # ("Cannot locate tasks that match ..."), not just that one target.
+      # No `iosX64` anywhere in this list. `:rc-player-compose` never had one — CMP 1.11 dropped
+      # the Intel-iOS-simulator variant (see that module's build.gradle.kts) — and its three
+      # siblings dropped theirs when the stack became publishable, because publishing a stack that
+      # resolves three of four artifacts on one target is worse than not offering it (#4066).
+      # Naming a task that no longer exists fails the whole invocation ("Cannot locate tasks that
+      # match ..."), not just that one target.
       # `checkKotlinAbi` diffs each library module's real public ABI against the dumps committed
       # under `rc-player/*/api/` (see #4062). It runs here rather than anywhere else because the
       # klib dump covers the iOS targets, and those klibs only build on macOS — this is the repo's
@@ -417,10 +418,8 @@ jobs:
             :rc-player-wasm:wasmPlayerTestDist \
             :rc-player-protocol:compileTestKotlinIosArm64 \
             :rc-player-protocol:compileTestKotlinIosSimulatorArm64 \
-            :rc-player-protocol:compileTestKotlinIosX64 \
             :rc-player-runtime:compileTestKotlinIosArm64 \
             :rc-player-runtime:compileTestKotlinIosSimulatorArm64 \
-            :rc-player-runtime:compileTestKotlinIosX64 \
             :rc-player-compose:compileTestKotlinIosArm64 \
             :rc-player-compose:compileTestKotlinIosSimulatorArm64
           ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebTest

--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -100,6 +100,37 @@ JVM/desktop consumer classpaths — a pure-Android KMP fallback
 exists, and that classpath can't feed the JVM renderer anyway). Covered by
 `DesktopRendererGraphAlignmentFunctionalTest`.
 
+### The published Remote Compose player pins its Compose Multiplatform version in its POM
+
+`ee.schimke.composeai:rc-player-compose` is the one published artifact in this repo that depends on
+Compose Multiplatform, so its POM is a compatibility surface in its own right. As of the first
+release it records:
+
+| dependency | scope | version |
+|---|---|---|
+| `org.jetbrains.compose.runtime:runtime` | compile (`api`) | 1.11.1 |
+| `org.jetbrains.compose.ui:ui` | compile (`api`) | 1.11.1 |
+| `org.jetbrains.compose.foundation:foundation` | runtime | 1.11.1 |
+
+The first two are `api` because they appear in `RcComposePlayer`'s signature — `Modifier`, `Color`,
+`FontFamily`, `Composer`, `SnapshotStateMap` — and a consumer needs them on its *compile* classpath
+to call it. `foundation` does not reach the surface and stays `implementation`.
+
+What a consumer has to know:
+
+- **Compose Multiplatform and the Compose compiler plugin are a matched pair**, and the pairing is
+  the consumer's to satisfy, not this artifact's. Gradle will conflict-resolve the CMP versions to
+  one coherent graph, as it does for the desktop renderer above; a consumer whose CMP is *newer* is
+  fine for the same additive reason.
+- **A consumer on an older CMP than 1.11.1 is not supported.** Not a policy so much as a fact about
+  the target set: 1.11 is the release that replaced the `uikitX64`/`uikitArm64`/`uikitSimArm64`
+  triple with `iosArm64` + `iosSimulatorArm64`, and this artifact declares the latter.
+- **There is no `iosX64` variant, anywhere in the stack.** CMP 1.11 stopped publishing the Intel
+  iOS simulator, so `:rc-player-compose` cannot have one; its three siblings dropped theirs rather
+  than publish a stack that resolves three of four artifacts on that target. Intel Macs are out.
+  Device (`iosArm64`) and the Apple-silicon simulator are what the stack offers, alongside `jvm`
+  and `wasmJs`.
+
 ### The serve host is a version FLOOR for every catalog it renders live
 
 The graph-alignment mitigation above works because Gradle resolves one graph and

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -87,6 +87,29 @@ Create original code outside `third_party`:
   installs an androidx.tracing driver and profiles four reference documents headlessly
 ```
 
+### Published coordinates
+
+The four library modules publish to Maven Central under `ee.schimke.composeai`, through the same
+`composeai.maven-publishing` convention and the same release chain as every other artifact here —
+the root-level `publishAndReleaseToMavenCentral` fans out to whatever applies the plugin, so there
+is no list to keep in step.
+
+| module | artifact | targets |
+|---|---|---|
+| `:rc-player-trace` | `rc-player-trace` | `jvm`, `wasmJs`, `iosArm64`, `iosSimulatorArm64` |
+| `:rc-player-protocol` | `rc-player-protocol` | same |
+| `:rc-player-runtime` | `rc-player-runtime` | same |
+| `:rc-player-compose` | `rc-player-compose` | same |
+
+`:rc-player-wasm` (an executable), `:rc-player-profile` (an application), `:rc-player-metrics` and
+`:rc-player-compat-tests` (fixture generators) are not published. The Wasm *distribution* is a
+different problem and is tracked in #4067; the iOS framework in #4068.
+
+One target set across all four, deliberately: `iosX64` is gone everywhere rather than present on the
+three non-Compose modules, because CMP 1.11 dropped the Intel iOS simulator and a stack that
+resolves three of its four artifacts on one target is worse than one that offers none. See
+[RENDERER_COMPATIBILITY.md](../RENDERER_COMPATIBILITY.md) for what the published POMs pin.
+
 Tracing and profiling are written up separately in
 [RC_PLAYER_PROFILING.md](RC_PLAYER_PROFILING.md) — what each span covers, why the tracing seam is an
 `expect`/`actual` facade (androidx.tracing 2.x ships no wasmJs or Apple klib), and the current

--- a/rc-player/compose/api/rc-player-compose.klib.api
+++ b/rc-player/compose/api/rc-player-compose.klib.api
@@ -6,7 +6,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <compose-ai-tools:rc-player-compose>
+// Library unique name: <ee.schimke.composeai:rc-player-compose>
 final enum class ee.schimke.composeai.rcplayer.compose/RcPlayerTheme : kotlin/Enum<ee.schimke.composeai.rcplayer.compose/RcPlayerTheme> { // ee.schimke.composeai.rcplayer.compose/RcPlayerTheme|null[0]
     enum entry Dark // ee.schimke.composeai.rcplayer.compose/RcPlayerTheme.Dark|null[0]
     enum entry Light // ee.schimke.composeai.rcplayer.compose/RcPlayerTheme.Light|null[0]

--- a/rc-player/compose/build.gradle.kts
+++ b/rc-player/compose/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("composeai.base-conventions")
   id("org.jetbrains.kotlin.multiplatform")
+  id("composeai.maven-publishing")
   alias(libs.plugins.compose.multiplatform)
   id("org.jetbrains.kotlin.plugin.compose")
 }
@@ -52,9 +53,16 @@ kotlin {
   sourceSets {
     commonMain.dependencies {
       api(project(":rc-player-runtime"))
-      @Suppress("DEPRECATION") implementation(compose.runtime)
+      // `api`, not `implementation`, for the two that appear in this module's public surface —
+      // the ABI dump names `androidx.compose.runtime` (`Composer`, `SnapshotStateMap`) and
+      // `androidx.compose.ui` (`Modifier`, `Color`, `FontFamily`, `FontVariation.Settings`) in
+      // `RcComposePlayer`'s signature. A consumer needs both on its *compile* classpath to call it,
+      // and a published POM that records them as runtime-scope would compile fine for a Compose app
+      // that happens to depend on them anyway and fail for one that does not. `compose.foundation`
+      // is genuinely internal — nothing from it reaches the surface — so it stays `implementation`.
+      @Suppress("DEPRECATION") api(compose.runtime)
+      @Suppress("DEPRECATION") api(compose.ui)
       @Suppress("DEPRECATION") implementation(compose.foundation)
-      @Suppress("DEPRECATION") implementation(compose.ui)
     }
     commonTest.dependencies { implementation(kotlin("test")) }
     jvmTest.dependencies {
@@ -67,3 +75,12 @@ kotlin {
 // `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
 // change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
 tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "rc-player-compose",
+    displayName = "Remote Compose Player — Compose Multiplatform",
+    description =
+      "RcComposePlayer, a Compose Multiplatform renderer for Remote Compose (.rc) documents on JVM, wasmJs and iOS.",
+  )
+}

--- a/rc-player/compose/src/iosMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewController.kt
+++ b/rc-player/compose/src/iosMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposeViewController.kt
@@ -16,6 +16,11 @@ import platform.UIKit.UIViewController
  * always resolved to — `rcResolveSystemTheme` answers both from `isSystemInDarkTheme()`.
  * `RcPlayerThemeRenderTest` asserts the three spellings resolve identically inside a real
  * composition rather than trusting that reading.
+ *
+ * **Reaching this from Swift needs an XCFramework, which is not published yet — see #4068.** This
+ * entry point ships inside `ee.schimke.composeai:rc-player-compose`'s iOS klibs, so a Kotlin
+ * Multiplatform consumer can call it today; a Swift-only project cannot until the framework is
+ * packaged and distributed.
  */
 public fun RcComposeViewController(
   bytes: ByteArray,

--- a/rc-player/protocol/api/rc-player-protocol.klib.api
+++ b/rc-player/protocol/api/rc-player-protocol.klib.api
@@ -1,11 +1,11 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <compose-ai-tools:rc-player-protocol>
+// Library unique name: <ee.schimke.composeai:rc-player-protocol>
 final enum class ee.schimke.composeai.rcplayer.protocol/RcMultiClickType : kotlin/Enum<ee.schimke.composeai.rcplayer.protocol/RcMultiClickType> { // ee.schimke.composeai.rcplayer.protocol/RcMultiClickType|null[0]
     enum entry DOUBLE // ee.schimke.composeai.rcplayer.protocol/RcMultiClickType.DOUBLE|null[0]
     enum entry LONG // ee.schimke.composeai.rcplayer.protocol/RcMultiClickType.LONG|null[0]

--- a/rc-player/protocol/build.gradle.kts
+++ b/rc-player/protocol/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("composeai.base-conventions")
   id("org.jetbrains.kotlin.multiplatform")
+  id("composeai.maven-publishing")
 }
 
 abstract class GenerateRcOperationManifest : org.gradle.api.DefaultTask() {
@@ -105,7 +106,11 @@ kotlin {
   // task is `:rc-player-<module>:jvmTest`; nothing in `ci.yml` named the old paths (it runs
   // `allTests`), so the rename is contained to this repo's source layout. See #4063.
   jvm()
-  iosX64()
+  // No `iosX64()`. `:rc-player-compose` cannot declare one — CMP 1.11 dropped the Intel iOS
+  // simulator variant (see that module's build comment) — and these three are published as one
+  // stack with it. Keeping `iosX64` here would publish a stack that resolves three of its four
+  // artifacts on that target and fails on the fourth, which is the worst of the options #4066
+  // lists. Intel Macs are out; device and the Apple-silicon simulator are what remain.
   iosArm64()
   iosSimulatorArm64()
 
@@ -113,7 +118,19 @@ kotlin {
 
   sourceSets {
     commonMain {
-      kotlin.srcDir(layout.buildDirectory.dir("generated/rcOperations/commonMain"))
+      // `.builtBy(...)`, not a bare directory. The generated opcode table is read by more tasks
+      // than the compilers — publishing (#4064) added the per-target sources jars, and the
+      // metadata compile has its own name — and Gradle rejects any of them that reads the
+      // directory without a declared producer ("uses this output of task
+      // ':generateRcOperationManifest' without declaring an explicit or implicit dependency").
+      // Attaching the producer to the source directory itself covers every consumer, present and
+      // future, instead of a task-name pattern that has already needed widening twice. It is right
+      // to be strict here: the quiet failure is a sources jar with a hole where
+      // `RcOperationInventory` should be.
+      kotlin.srcDir(
+        files(layout.buildDirectory.dir("generated/rcOperations/commonMain"))
+          .builtBy(generateRcOperationManifest)
+      )
       // `api`, not `implementation`: the tracing seam is the base of the player's dependency graph
       // (`trace <- protocol <- runtime <- compose <- wasm host`), and every module above opens
       // spans
@@ -124,10 +141,15 @@ kotlin {
   }
 }
 
-tasks
-  .matching { it.name.startsWith("compileKotlin") }
-  .configureEach { dependsOn(generateRcOperationManifest) }
-
 // `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
 // change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
 tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "rc-player-protocol",
+    displayName = "Remote Compose Player — Protocol",
+    description =
+      "The .rc wire codec and operation model for Remote Compose documents: reader, writer, immutable operation IR and the AndroidX operation inventory. Consumable without any Compose dependency.",
+  )
+}

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcModel.kt
@@ -349,6 +349,15 @@ public data class RcPaintData(val words: List<Int>) : RcOperation {
   override val opcode: Int = RcOpcodes.PAINT_VALUES
 }
 
+/**
+ * The `Theme` operation a document records, carrying the wire constants below.
+ *
+ * **This is what comes *out* of a document, not what a host passes *in*.** A host asking the player
+ * to render a document light or dark wants `RcPlayerTheme` in `ee.schimke.composeai:
+ * rc-player-compose` — a three-case enum with no wire values in it. The two names are similar and
+ * both artifacts are consumable, so: if you are holding an `RcDocument` and inspecting what it
+ * asked for, this is the type; if you are calling `RcComposePlayer`, it is not.
+ */
 public data class RcTheme(val theme: Int) : RcOperation {
   override val opcode: Int = RcOpcodes.THEME
 

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcOperationInventory.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcOperationInventory.kt
@@ -23,6 +23,18 @@ public data class RcOperationProfile(val name: String, val opcodes: Set<Int>) {
   public fun supports(opcode: Int): Boolean = opcode in opcodes
 }
 
+/**
+ * The operation sets each player can execute, as published API.
+ *
+ * **The `ALPHA16` in these names is a capture, not a version.** Each profile records which
+ * operations a given player understood as of the AndroidX Remote Compose alpha16 registry — the
+ * release this stack's inventory was built against. A newer AndroidX release adds a *sibling*
+ * constant rather than changing what one of these means, so a consumer that pinned
+ * `CMP_WASM_ALPHA16` keeps getting the set it tested against. Deciding that before the first
+ * release rather than after was #4064's question; the alternative — making them internal — would
+ * leave a host no way to ask `composeSupportReport` which player it is targeting, which is the one
+ * thing these exist for.
+ */
 public object RcOperationProfiles {
   private val cmpImplementedOpcodes: Set<Int> =
     RcOperationInventory.entries

--- a/rc-player/runtime/api/rc-player-runtime.klib.api
+++ b/rc-player/runtime/api/rc-player-runtime.klib.api
@@ -1,11 +1,11 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <compose-ai-tools:rc-player-runtime>
+// Library unique name: <ee.schimke.composeai:rc-player-runtime>
 final enum class ee.schimke.composeai.rcplayer.runtime/RcClickActionType : kotlin/Enum<ee.schimke.composeai.rcplayer.runtime/RcClickActionType> { // ee.schimke.composeai.rcplayer.runtime/RcClickActionType|null[0]
     enum entry CLICK // ee.schimke.composeai.rcplayer.runtime/RcClickActionType.CLICK|null[0]
     enum entry DOUBLE // ee.schimke.composeai.rcplayer.runtime/RcClickActionType.DOUBLE|null[0]

--- a/rc-player/runtime/build.gradle.kts
+++ b/rc-player/runtime/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("composeai.base-conventions")
   id("org.jetbrains.kotlin.multiplatform")
+  id("composeai.maven-publishing")
 }
 
 kotlin {
@@ -28,7 +29,11 @@ kotlin {
   // task is `:rc-player-<module>:jvmTest`; nothing in `ci.yml` named the old paths (it runs
   // `allTests`), so the rename is contained to this repo's source layout. See #4063.
   jvm()
-  iosX64()
+  // No `iosX64()`. `:rc-player-compose` cannot declare one — CMP 1.11 dropped the Intel iOS
+  // simulator variant (see that module's build comment) — and these three are published as one
+  // stack with it. Keeping `iosX64` here would publish a stack that resolves three of its four
+  // artifacts on that target and fails on the fourth, which is the worst of the options #4066
+  // lists. Intel Macs are out; device and the Apple-silicon simulator are what remain.
   iosArm64()
   iosSimulatorArm64()
 
@@ -46,3 +51,12 @@ kotlin {
 // `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
 // change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
 tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "rc-player-runtime",
+    displayName = "Remote Compose Player — Runtime",
+    description =
+      "The Remote Compose interpreter: expression evaluation, animation timelines, layout tree and player state, with no Compose UI dependency.",
+  )
+}

--- a/rc-player/trace/api/rc-player-trace.klib.api
+++ b/rc-player/trace/api/rc-player-trace.klib.api
@@ -1,11 +1,11 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <compose-ai-tools:rc-player-trace>
+// Library unique name: <ee.schimke.composeai:rc-player-trace>
 final class ee.schimke.composeai.rcplayer.trace/RcTraceEvent { // ee.schimke.composeai.rcplayer.trace/RcTraceEvent|null[0]
     constructor <init>(kotlin/String, kotlin/String, kotlin/Long, kotlin/Long) // ee.schimke.composeai.rcplayer.trace/RcTraceEvent.<init>|<init>(kotlin.String;kotlin.String;kotlin.Long;kotlin.Long){}[0]
 

--- a/rc-player/trace/build.gradle.kts
+++ b/rc-player/trace/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("composeai.base-conventions")
   id("org.jetbrains.kotlin.multiplatform")
+  id("composeai.maven-publishing")
 }
 
 // `:rc-player-trace` — the tracing seam the whole CMP Remote Compose player stack writes through.
@@ -54,7 +55,11 @@ kotlin {
   // task is `:rc-player-<module>:jvmTest`; nothing in `ci.yml` named the old paths (it runs
   // `allTests`), so the rename is contained to this repo's source layout. See #4063.
   jvm()
-  iosX64()
+  // No `iosX64()`. `:rc-player-compose` cannot declare one — CMP 1.11 dropped the Intel iOS
+  // simulator variant (see that module's build comment) — and these three are published as one
+  // stack with it. Keeping `iosX64` here would publish a stack that resolves three of its four
+  // artifacts on that target and fails on the fourth, which is the worst of the options #4066
+  // lists. Intel Macs are out; device and the Apple-silicon simulator are what remain.
   iosArm64()
   iosSimulatorArm64()
 
@@ -69,3 +74,12 @@ kotlin {
 // `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
 // change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
 tasks.named("check") { dependsOn("checkKotlinAbi") }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "rc-player-trace",
+    displayName = "Remote Compose Player — Tracing",
+    description =
+      "Multiplatform tracing facade for the Compose Multiplatform Remote Compose player: opens spans on androidx.tracing on the JVM, the browser's User Timing API on wasmJs, and nothing on Apple targets.",
+  )
+}


### PR DESCRIPTION
Closes #4063, #4064, #4065, #4066.

**One PR rather than four.** The four artifacts are only useful together — publishing three of them is not a shippable state — and one repo version releases them atomically, which is what the issues' "depends on #4063 being published first" sequencing actually needed. The per-module blockers each issue named are addressed individually below.

```
ee.schimke.composeai:rc-player-trace
ee.schimke.composeai:rc-player-protocol
ee.schimke.composeai:rc-player-runtime
ee.schimke.composeai:rc-player-compose
```

Targets: `jvm`, `wasmJs`, `iosArm64`, `iosSimulatorArm64`. No release-chain wiring — root-level `publishAndReleaseToMavenCentral` already fans out to whatever applies `composeai.maven-publishing`, exactly as #4063 expected.

## #4063 — `androidx.tracing` must stay off the compile classpath

Confirmed from the generated POM, not assumed:

```
androidx.tracing:tracing-desktop  scope=runtime
```

and the ABI dump names no androidx type on the public surface, so a consumer tracing through `rcTrace`/`RcTrace` needs nothing else.

## #4064 — generated sources must reach the sources jar

They did not, and Gradle refused rather than shipping a hole:

```
Task ':rc-player-protocol:iosArm64SourcesJar' uses this output of task
':rc-player-protocol:generateRcOperationManifest' without declaring an explicit
or implicit dependency.
```

Fixed at the **source directory** — `kotlin.srcDir(files(...).builtBy(generateRcOperationManifest))` — rather than by widening the existing task-name pattern. That pattern had already needed widening twice while I was on it: `sourcesJar` and `compileCommonMainKotlinMetadata` both fall outside `compileKotlin*` / `*SourcesJar`. Attaching the producer to the directory covers every consumer, present and future.

Verified in the locally published jar:

```
commonMain/ee/schimke/composeai/rcplayer/protocol/RcOperationManifest.kt   18601 bytes
```

## #4065 — is `kotlinx.datetime` on the public surface?

No. The ABI dump names no datetime type (`grep -c kotlinx.datetime` → 0 in both dumps), `RcTimeSource` exposes only `Long` and its own `RcTimeSnapshot`, and the POM records `kotlinx-datetime-jvm` as `runtime`. `implementation` was correct.

The issue also said not to publish this module until #4062's surface list was triaged. It has been: the dumps landed in #4173 and `RcPlayerState`'s full surface is written down. #4059 then *added* to it deliberately (`namedValue`, `clearNamedValue`), which is the host contract it needed.

## #4066 — the CMP dependency, and the target asymmetry

**The asymmetry is resolved by dropping `iosX64` from the whole stack**, not by documenting it. `:rc-player-compose` cannot have one — CMP 1.11 replaced the `uikitX64`/`uikitArm64`/`uikitSimArm64` triple with `iosArm64` + `iosSimulatorArm64` — and the issue is right that publishing a stack resolving three of its four artifacts on a target is the worst of the three options. Intel Macs are out, stated rather than discovered. `ci.yml` drops the two `compileTestKotlinIosX64` entries with it.

**The CMP dependency was also wrong for publishing.** `compose.runtime` and `compose.ui` were `implementation`, but the ABI dump names `Modifier`, `Color`, `FontFamily`, `Composer` and `SnapshotStateMap` in `RcComposePlayer`'s signature — a consumer needs them on its *compile* classpath. Both are now `api`; `compose.foundation` reaches nothing public and stays `implementation`. The published POM:

```
org.jetbrains.compose.runtime:runtime-desktop:1.11.1     scope=compile
org.jetbrains.compose.ui:ui-desktop:1.11.1               scope=compile
org.jetbrains.compose.foundation:foundation-desktop:1.11.1  scope=runtime
```

This would have compiled fine for any Compose app that happened to depend on those anyway, and failed for one that did not — the kind of thing that is free to fix now and breaking after the first release. `docs/RENDERER_COMPATIBILITY.md` gains a section on what the pinned 1.11.1 means for a consumer.

## The two naming questions, answered where a consumer will meet them

- **`RcTheme` vs `RcPlayerTheme`** (#4064): `RcTheme`'s KDoc now says plainly that it is what comes *out* of a document, and points at `RcPlayerTheme` for anyone calling `RcComposePlayer`.
- **`RcOperationProfiles.CMP_WASM_ALPHA16` / `CMP_IOS_ALPHA16`** (#4064): they stay public. The `ALPHA16` is a *capture* of the AndroidX registry they were built against, not a version that will move — a newer release adds a sibling constant rather than changing what one of these means. Making them internal would leave a host no way to tell `composeSupportReport` which player it targets, which is the only reason they exist. Recorded in KDoc so the name does not read as a version.

`RcComposeViewController`'s KDoc now states it is unreachable from Swift until #4068 packages a framework, since it ships inside the published klibs either way.

## Test plan

- `./gradlew :rc-player-{trace,protocol,runtime,compose}:publishToMavenLocal` — green, and the artifacts inspected by hand: per-target POMs, `.module` metadata, `.klib` for iOS and wasmJs, sources and javadoc jars, and the `-jvm` classifier from #4183.
- Dependency scopes read out of the generated POMs (quoted above) rather than inferred from the build files.
- `:rc-player-{trace,protocol,runtime,compose}:allTests` + `checkKotlinAbi`, `:rc-player-wasm:wasmPlayerDist` (23,582,925 / 23,780,000 bytes), `:rc-player-profile:build`, `:rc-player-metrics:test`, `:rc-player-compat-tests:test`, `ktfmtCheckAll` — green.
- iOS compile tasks for the remaining targets — green.
- The ABI dumps move in two intended ways, both committed: `iosX64` leaves the klib target list, and the klib "Library unique name" becomes `ee.schimke.composeai:rc-player-*` now that the publishing plugin sets `project.group`.

Non-visual change (build wiring, POM scopes, docs, KDoc), so no render evidence applies.

_Generated by [Claude Code](https://claude.com/claude-code)_