### PR TITLE
feat: serve the Wear M3 design-kit catalog on preview.coo.ee

### DIFF
--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -53,6 +53,12 @@
       "group": "design-systems"
     },
     {
+      "system": "wear-m3-catalog",
+      "repo": "yschimke/wear-m3-catalog",
+      "listed": true,
+      "group": "design-systems"
+    },
+    {
       "system": "meshcore-mobile",
       "repo": "yschimke/meshcore-mobile",
       "listed": true

--- a/deploy/preview.coo.ee/producers.json
+++ b/deploy/preview.coo.ee/producers.json
@@ -10,6 +10,10 @@
       "branch": "design-artifacts/*"
     },
     {
+      "repo": "yschimke/wear-m3-catalog",
+      "branch": "design-artifacts/*"
+    },
+    {
       "repo": "yschimke/meshcore-mobile",
       "branch": "design-artifacts/*"
     },


### PR DESCRIPTION
Registers [yschimke/wear-m3-catalog](https://github.com/yschimke/wear-m3-catalog) — the M3 Wear OS Apps Design Kit rebuilt as design-led Compose previews, the Wear-side sibling of `m3-catalog`.

- `catalogs.json` — listed under **Design Systems**, beside `m3-catalog`. The slug is distinct from the existing `wear-m3` sample, which is the *code-led* Wear catalog published from this repo; this one reproduces a published kit.
- `producers.json` — trusts `design-artifacts/*` on that repo, so it badges `Trusted(Branch)` instead of serving as `unverified`.

It is an Android (Robolectric) catalog publishing a live bundle with `split-mode: full`, same shape as `wear-m3`, so the live re-render lane wants the box's Android daemon; baked pixels serve either way. `SystemDisplay.isDarkFirst`'s Wear id heuristic should stage its hero on dark — worth a look on the front door once the first bundle lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)