### PR TITLE
feat(rc-player): ship the iOS player as an XCFramework consumable from Swift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,13 @@ jobs:
             :rc-player-runtime:compileTestKotlinIosSimulatorArm64 \
             :rc-player-compose:compileTestKotlinIosArm64 \
             :rc-player-compose:compileTestKotlinIosSimulatorArm64
+          # Link and package the XCFramework the Swift distribution ships (#4068). This is the only
+          # place CI *links* a release framework — every other iOS entry above stops at compiling —
+          # and `release.yml` runs the same task, so a linker failure surfaces on the PR rather than
+          # mid-release. Separate invocation because the two release links are the heaviest thing in
+          # this job and running them alongside the test compiles has died on memory before (see the
+          # note at the top of this job).
+          ./gradlew :rc-player-compose:rcPlayerXcframeworkChecksum
           ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebTest
           ./gradlew ktfmtCheck
       - name: Upload player test reports on failure
@@ -1182,6 +1189,11 @@ jobs:
       # fail silently in production (a delivery branch just stops regenerating).
       - name: Run design-artifacts scope-step tests
         run: scripts/design-artifacts/test-scope-step.sh
+      # Rewrites the two values in `Package.swift` that SPM verifies. A release that silently
+      # left the placeholder checksum in place would publish a package no consumer can resolve,
+      # and the failure would land on them rather than on us.
+      - name: Run Package.swift rewriter tests
+        run: scripts/update-package-swift.sh --self-test
       # The reusable catalog workflow and preview-host images share this installer. It must keep
       # the pre-Noto generic families while supplying broad missing-glyph coverage.
       - name: Run Linux font-fallback installer tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,73 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             publishAndReleaseToMavenCentral
+  # Ship the iOS player as an XCFramework a Swift project can consume (#4068).
+  #
+  # Two artifacts, and the order between them is load-bearing. SPM's `binaryTarget` addresses a zip
+  # by URL and pins it by SHA-256, so `Package.swift` can only be written *after* the asset it
+  # describes exists. This job therefore: assembles and zips, uploads the zip to the Release, then
+  # rewrites `Package.swift` on `main` with that Release's URL and the checksum of the exact bytes
+  # uploaded, and tags that commit `swift/<version>`.
+  #
+  # The Swift tag is why this works at all. `Package.swift` at the `v<version>` tag necessarily
+  # still points at the *previous* release — the file is committed before the asset exists — so a
+  # consumer resolving `v<version>` would get the wrong binary. `swift/<version>` points at the
+  # commit made after the upload, which is the first commit where the two agree. Consumers depend on
+  # the Swift tags.
+  #
+  # macOS-only: `xcodebuild -create-xcframework` and the Kotlin/Native Apple linker both need it.
+  # This is also the first time CI links a release framework at all — `ci.yml` only ever compiled
+  # the iOS *test* targets — so treat a failure here as real rather than flaky, and see the Xcode
+  # selection step, which exists because CMP 1.11's `ui-uikit` needs the iOS 26 SDK.
+  publish-xcframework:
+    needs: [build-applications, build-vscode-extension]
+    runs-on: macos-15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: true
+      - name: Derive version from tag
+        run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
+      - uses: ./.github/actions/setup
+        with:
+          cache-read-only: 'true'
+      - name: Select an Xcode with the iOS 26 SDK
+        run: |
+          set -euo pipefail
+          xcode="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -n 1)"
+          if [ -z "$xcode" ]; then
+            echo "No Xcode 26 on this image; Compose Multiplatform's iOS targets need its SDK." >&2
+            exit 1
+          fi
+          sudo xcode-select --switch "$xcode/Contents/Developer"
+      - name: Assemble and package the XCFramework
+        run: ./gradlew :rc-player-compose:rcPlayerXcframeworkChecksum
+      - name: Upload the XCFramework to the Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "$TAG_NAME" \
+            rc-player/compose/build/distributions/RcComposePlayer.xcframework.zip --clobber
+      - name: Point Package.swift at the uploaded asset and tag it
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          checksum="$(cat rc-player/compose/build/distributions/RcComposePlayer.xcframework.zip.sha256)"
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/RcComposePlayer.xcframework.zip"
+          scripts/update-package-swift.sh "$url" "$checksum"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          git commit -m "chore(release): point Package.swift at ${TAG_NAME}"
+          git push origin HEAD:main
+          git tag "swift/${PLUGIN_VERSION}"
+          git push origin "swift/${PLUGIN_VERSION}"
+
   # Build the runnable applications shipped on each GitHub Release: the CLI
   # (`compose-preview-*`) and the standalone MCP server (`compose-preview-mcp-*`).
   # The CLI tarball already implementation-bundles `:mcp`, so the standalone MCP

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.9
+//
+// Swift Package Manager distribution for the Remote Compose player's iOS framework (#4068).
+//
+// This file is REWRITTEN BY `release.yml` on every release: the job assembles
+// `RcComposePlayer.xcframework.zip`, attaches it to the GitHub Release, and commits the new `url`
+// and `checksum` back to `main` before tagging `swift/<version>`. Editing the two values by hand is
+// never right — they have to describe an asset that already exists, and SPM verifies the checksum
+// at resolve time.
+//
+// Consume a released version by its Swift tag:
+//
+//     .package(url: "https://github.com/yschimke/compose-ai-tools.git", from: "1.15.1")
+//
+// Coverage: `iosArm64` (device) and `iosSimulatorArm64` (Apple-silicon simulator) only. There is no
+// Intel-simulator slice anywhere in this stack — Compose Multiplatform 1.11 stopped publishing the
+// variant — so Intel Macs cannot build against this. Stated here rather than discovered at link
+// time. See docs/design/RC_PLAYER_SWIFT.md.
+import PackageDescription
+
+let package = Package(
+  name: "RcComposePlayer",
+  platforms: [.iOS(.v13)],
+  products: [
+    .library(name: "RcComposePlayer", targets: ["RcComposePlayer"])
+  ],
+  targets: [
+    .binaryTarget(
+      name: "RcComposePlayer",
+      url:
+        "https://github.com/yschimke/compose-ai-tools/releases/download/v0.0.0/RcComposePlayer.xcframework.zip",
+      // Placeholder until the first release job runs. A resolve against this fails loudly with a
+      // checksum mismatch rather than silently fetching something else.
+      checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+    )
+  ]
+)

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -103,7 +103,8 @@ is no list to keep in step.
 
 `:rc-player-wasm` (an executable), `:rc-player-profile` (an application), `:rc-player-metrics` and
 `:rc-player-compat-tests` (fixture generators) are not published. The Wasm *distribution* is a
-different problem and is tracked in #4067; the iOS framework in #4068.
+different problem and is tracked in #4067. The iOS framework is packaged as an XCFramework and
+distributed through Swift Package Manager — see [RC_PLAYER_SWIFT.md](RC_PLAYER_SWIFT.md).
 
 One target set across all four, deliberately: `iosX64` is gone everywhere rather than present on the
 three non-Compose modules, because CMP 1.11 dropped the Intel iOS simulator and a stack that

--- a/docs/design/RC_PLAYER_SWIFT.md
+++ b/docs/design/RC_PLAYER_SWIFT.md
@@ -1,0 +1,117 @@
+# The Remote Compose player from Swift
+
+How `ee.schimke.composeai:rc-player-compose`'s iOS entry point is packaged, what it looks like from
+Swift, and the two places where the Kotlin API reads worse across the boundary than it does in
+Kotlin. Companion to [RC_CMP_WASM_PLAYER.md](RC_CMP_WASM_PLAYER.md), which covers the player itself.
+
+Implements #4068.
+
+## Consuming it
+
+```swift
+// Package.swift
+.package(url: "https://github.com/yschimke/compose-ai-tools.git", from: "1.15.1")
+```
+
+```swift
+import RcComposePlayer
+import UIKit
+
+let controller = RcComposeViewController(
+  bytes: KotlinByteArray.from(documentData),
+  theme: .system,
+  onEvent: { event in handle(event) },
+  typefaces: RcTypefaceLoaderCompanion.shared.Default,
+  onError: { message in show(message) }
+)
+```
+
+**Device and Apple-silicon simulator only.** There is no Intel-simulator slice anywhere in this
+stack: Compose Multiplatform 1.11 stopped publishing the variant, so `:rc-player-compose` cannot
+declare `iosX64` and its three siblings dropped theirs rather than publish a stack that resolves
+three of its four artifacts on one target ([#4066](https://github.com/yschimke/compose-ai-tools/issues/4066)).
+Intel Macs cannot build against this. Stated here rather than discovered at link time.
+
+## How it is built and shipped
+
+| step | where |
+|---|---|
+| `iosArm64` + `iosSimulatorArm64` static frameworks | `rc-player/compose/build.gradle.kts` |
+| combined into `RcComposePlayer.xcframework` | `assembleRcComposePlayerReleaseXCFramework` (registered by `XCFrameworkConfig`) |
+| zipped reproducibly + SHA-256 | `:rc-player-compose:rcPlayerXcframeworkChecksum` |
+| attached to the GitHub Release | `release.yml` → `publish-xcframework` |
+| `Package.swift` pointed at it, `swift/<version>` tagged | same job, via `scripts/update-package-swift.sh` |
+
+**Why a `swift/<version>` tag rather than the `v<version>` release tag.** SPM's `binaryTarget`
+addresses a zip by URL and pins it by checksum, verified at resolve time. Both values can only be
+written *after* the asset exists — so `Package.swift` at `v<version>` necessarily still describes the
+*previous* release, and a consumer resolving that tag would download the wrong binary. The Swift tag
+points at the commit made after the upload, which is the first commit where the file and the asset
+agree.
+
+**The zip is built reproducibly** (`isPreserveFileTimestamps = false`, `isReproducibleFileOrder =
+true`) because the checksum has to match the bytes a consumer downloads. Without it, a re-run of the
+release job would produce a `Package.swift` that no longer matches the already-uploaded asset.
+
+**CI links it.** Until this landed, `ci.yml` compiled the iOS *test* targets and never linked or
+packaged a framework, so framework assembly was entirely unexercised — and the note at the top of
+the `rc-player-tests` job records that `linkDebugTestIosSimulatorArm64` has died before. The player
+job now runs `rcPlayerXcframeworkChecksum` as a separate Gradle invocation, deliberately: the two
+release links are the heaviest work in the job and running them alongside the test compiles is what
+has failed in the past.
+
+## What the Kotlin API actually looks like from Swift
+
+#4068 asked whether the retyped parameters from #4058 and #4060 read *worse* across the boundary
+than the `Int` and `Map` they replaced. Read out of the generated Objective-C header rather than
+guessed:
+
+**`RcPlayerTheme` — better.** It exports as an Obj-C enum class with `light` / `dark` / `system`
+class properties, so Swift writes `theme: .system`. That is a plain improvement on passing `-2`.
+
+**`RcTypefaceLoader` — better.** It exports as an Obj-C *protocol*, so a Swift host implements
+`families` and `typeface(family:settings:)` directly rather than assembling a dictionary of Kotlin
+objects. The companion values are reachable as `RcTypefaceLoaderCompanion.shared.Default` /
+`.Empty` — slightly awkward, and the one place the Kotlin form is nicer.
+
+**`RcPlayerEvent` — worse, and unavoidably so.** A Kotlin `sealed interface` flattens to a bare
+Obj-C protocol with no members:
+
+```objc
+__attribute__((swift_name("RcPlayerEvent")))
+@protocol RCPRcPlayerEvent
+@required
+@end
+```
+
+so Swift gets no exhaustive `switch`, only casts against the concrete classes:
+
+```swift
+func handle(_ event: RcPlayerEvent) {
+  if let action = event as? RcPlayerEventHostAction {
+    …
+  } else if let named = event as? RcPlayerEventHostNamedAction {
+    …
+  } else if let debug = event as? RcPlayerEventDebugMessage {
+    …
+  }
+  // No compiler error when a new case is added — see below.
+}
+```
+
+The cost is real: adding a case to `RcPlayerEvent` is a source-compatible change in Kotlin that
+compiles fine in Swift and silently does nothing at runtime. Nothing in Kotlin/Native's Obj-C export
+fixes that today. What it argues for is treating a new `RcPlayerEvent` case as a **minor-version,
+release-noted** change rather than an additive one, since Swift consumers cannot be told by their
+compiler.
+
+**Type names are clean because the stack is exported.** The frameworks `export(...)`
+`:rc-player-runtime`, `:rc-player-protocol` and `:rc-player-trace`, which is legal because each
+module already depends on the next with `api`. Without it, Kotlin/Native prefixes every transitively
+sourced type with its module name and a Swift consumer sees `Rc_player_runtimeRcPlayerEvent` and
+`Rc_player_protocolRcDocument` in the callbacks and parameters it has to name.
+
+## Not covered here
+
+CocoaPods. SPM reuses the release chain that already exists; a podspec is a second artifact and a
+second publish path to keep in step, and nothing has asked for it yet.

--- a/rc-player/compose/build.gradle.kts
+++ b/rc-player/compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.security.MessageDigest
+
 plugins {
   id("composeai.base-conventions")
   id("org.jetbrains.kotlin.multiplatform")
@@ -40,11 +42,27 @@ kotlin {
   // resolution outright ("Couldn't resolve dependency 'org.jetbrains.compose.runtime:runtime' in
   // 'iosMain' for all target platforms") rather than degrading. Device (`iosArm64`) and the
   // Apple-silicon simulator (`iosSimulatorArm64`) are the targets that still exist; the non-Compose
-  // siblings keep `iosX64` because nothing constrains them.
+  // siblings dropped theirs so the published stack has one target set (#4066).
+  //
+  // The two frameworks are collected into an XCFramework so Swift can consume them — see
+  // `rcPlayerXcframeworkZip` below and #4068. `XCFramework(...)` registers
+  // `assemble{Debug,Release}RcComposePlayerXCFramework`; nothing else changes about how the
+  // frameworks themselves are built.
+  val xcframework =
+    org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig(project, "RcComposePlayer")
   listOf(iosArm64(), iosSimulatorArm64()).forEach { target ->
     target.binaries.framework {
       baseName = "RcComposePlayer"
       isStatic = true
+      // Export the rest of the stack into the framework. Without this, Kotlin/Native prefixes every
+      // type that arrives from a transitive module with the module's own name — a Swift consumer
+      // sees `Rc_player_runtimeRcPlayerEvent` and `Rc_player_protocolRcDocument` in the callbacks
+      // and parameters it actually has to name. Exporting is only legal because each module already
+      // depends on the next with `api`, which is what those declarations were for.
+      export(project(":rc-player-runtime"))
+      export(project(":rc-player-protocol"))
+      export(project(":rc-player-trace"))
+      xcframework.add(this)
     }
   }
 
@@ -89,4 +107,46 @@ composeAiMavenPublishing {
     description =
       "RcComposePlayer, a Compose Multiplatform renderer for Remote Compose (.rc) documents on JVM, wasmJs and iOS.",
   )
+}
+
+// --- Swift distribution (#4068) -------------------------------------------------------------
+//
+// `assembleRcComposePlayerReleaseXCFramework` (registered by the `XCFrameworkConfig` above) puts
+// `RcComposePlayer.xcframework` under `build/XCFrameworks/release`. Swift Package Manager consumes
+// a *zip* of that, addressed by URL and pinned by a SHA-256 checksum, so the packaging step is part
+// of the build rather than something the release workflow improvises.
+//
+// The zip is built reproducibly — no file timestamps, stable entry order — because the checksum in
+// `Package.swift` has to match the bytes a consumer downloads. A zip that differs run-to-run would
+// make every re-run of the release job produce a `Package.swift` that no longer matches the asset
+// already uploaded.
+val rcPlayerXcframeworkZip =
+  tasks.register<Zip>("rcPlayerXcframeworkZip") {
+    description = "Package the iOS XCFramework as a Swift Package Manager binary target."
+    group = "distribution"
+    dependsOn("assembleRcComposePlayerReleaseXCFramework")
+    from(layout.buildDirectory.dir("XCFrameworks/release"))
+    archiveFileName.set("RcComposePlayer.xcframework.zip")
+    destinationDirectory.set(layout.buildDirectory.dir("distributions"))
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+  }
+
+tasks.register("rcPlayerXcframeworkChecksum") {
+  description = "Write the SPM binary-target checksum for the packaged XCFramework."
+  group = "distribution"
+  val zip = rcPlayerXcframeworkZip.flatMap { it.archiveFile }
+  val checksumFile =
+    layout.buildDirectory.file("distributions/RcComposePlayer.xcframework.zip.sha256")
+  inputs.file(zip)
+  outputs.file(checksumFile)
+  doLast {
+    // Plain SHA-256 of the archive — the same value `swift package compute-checksum` prints, which
+    // is what `Package.swift`'s `binaryTarget(checksum:)` is compared against at resolve time.
+    val digest = MessageDigest.getInstance("SHA-256")
+    val hex =
+      digest.digest(zip.get().asFile.readBytes()).joinToString("") { byte -> "%02x".format(byte) }
+    checksumFile.get().asFile.writeText(hex + "\n")
+    logger.lifecycle("RcComposePlayer.xcframework.zip sha256: $hex")
+  }
 }

--- a/scripts/update-package-swift.sh
+++ b/scripts/update-package-swift.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Point `Package.swift`'s binary target at a released XCFramework zip.
+#
+# Swift Package Manager pins a `binaryTarget` by URL *and* SHA-256, and verifies the checksum when a
+# consumer resolves the package. So these two values can only be written once the asset exists —
+# which is why `release.yml` calls this after uploading the zip, not before.
+#
+# It rewrites exactly the two values and nothing else, so the comments in `Package.swift` (which
+# explain the Intel-simulator gap and the `swift/<version>` tag scheme) survive a release.
+#
+# Usage: scripts/update-package-swift.sh <url> <sha256> [package-swift-path]
+#        scripts/update-package-swift.sh --self-test
+set -euo pipefail
+
+rewrite() {
+  local file="$1" url="$2" checksum="$3"
+  local before after
+  before="$(cat "$file")"
+  # `url:` may sit on its own line (swift-format wraps long URLs), so match across the newline.
+  after="$(
+    printf '%s' "$before" |
+      perl -0pe "s{url:\\s*\"[^\"]*\"}{url:\n        \"$url\"}s" |
+      perl -0pe "s{checksum: \"[0-9a-f]*\"}{checksum: \"$checksum\"}s"
+  )"
+  if [ "$before" = "$after" ]; then
+    echo "error: $file has no binaryTarget url/checksum to rewrite" >&2
+    return 1
+  fi
+  printf '%s\n' "$after" > "$file"
+}
+
+self_test() {
+  local dir
+  dir="$(mktemp -d)"
+  trap 'rm -rf "$dir"' RETURN
+  cat > "$dir/Package.swift" <<'FIXTURE'
+// A comment that must survive.
+    .binaryTarget(
+      name: "RcComposePlayer",
+      url:
+        "https://example.invalid/old/RcComposePlayer.xcframework.zip",
+      checksum: "0000000000000000000000000000000000000000000000000000000000000000"
+    )
+FIXTURE
+  rewrite "$dir/Package.swift" "https://example.invalid/new/RcComposePlayer.xcframework.zip" "abc123"
+
+  grep -q 'https://example.invalid/new/RcComposePlayer.xcframework.zip' "$dir/Package.swift" ||
+    { echo "self-test: url was not rewritten" >&2; return 1; }
+  grep -q 'checksum: "abc123"' "$dir/Package.swift" ||
+    { echo "self-test: checksum was not rewritten" >&2; return 1; }
+  grep -q 'A comment that must survive' "$dir/Package.swift" ||
+    { echo "self-test: the file was clobbered rather than edited" >&2; return 1; }
+  grep -q 'old/RcComposePlayer' "$dir/Package.swift" &&
+    { echo "self-test: the previous url is still present" >&2; return 1; }
+
+  # A file with nothing to rewrite must fail loudly: a release that silently left the placeholder
+  # checksum in place would publish a Package.swift no consumer can resolve.
+  printf 'nothing here\n' > "$dir/Empty.swift"
+  if rewrite "$dir/Empty.swift" "https://example.invalid/x.zip" "abc" 2>/dev/null; then
+    echo "self-test: a file with no binary target should have failed" >&2
+    return 1
+  fi
+
+  echo "update-package-swift self-test: ok"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit 0
+fi
+
+if [ $# -lt 2 ]; then
+  sed -n '2,12p' "$0" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rewrite "${3:-$repo_root/Package.swift}" "$1" "$2"


### PR DESCRIPTION
Closes #4068. **Stacked on #4189** (the Maven publishing PR), which shares `rc-player/compose/build.gradle.kts`.

## Today → now

The iOS story was *designed* — a static framework per target, `RcComposeViewController` as a purpose-built UIKit entry point — but had no delivery mechanism: no XCFramework task, no `Package.swift`, no podspec. A Swift consumer had to add this Gradle build to their project.

| step | where |
|---|---|
| `iosArm64` + `iosSimulatorArm64` frameworks | `rc-player/compose/build.gradle.kts` |
| combined into `RcComposePlayer.xcframework` | `assembleRcComposePlayerReleaseXCFramework` |
| zipped reproducibly + SHA-256 | `:rc-player-compose:rcPlayerXcframeworkChecksum` |
| attached to the GitHub Release | `release.yml` → `publish-xcframework` |
| `Package.swift` repointed, `swift/<version>` tagged | same job, via `scripts/update-package-swift.sh` |

**SPM, not CocoaPods**, per the issue's "decide which": SPM reuses the release chain that already exists; a podspec is a second artifact and a second publish path to keep in step, and nothing has asked for it.

## The bit that is easy to get subtly wrong

SPM pins a `binaryTarget` by URL **and** checksum, and verifies the checksum at resolve time. Both values can only be written *after* the asset exists — so `Package.swift` at the `v<version>` tag necessarily still describes the **previous** release, and a consumer resolving that tag downloads the wrong binary. Hence `swift/<version>`, tagged on the commit made after the upload: the first commit where the file and the asset agree.

For the same reason the zip is built reproducibly (`isPreserveFileTimestamps = false`, `isReproducibleFileOrder = true`) — otherwise a re-run of the release job yields a `Package.swift` that no longer matches the asset already uploaded. **Verified**: two clean builds produce `dfca75a6f0a0c1142c210910b85f04b5c7690d8d46c66d252a1786f8536f5183` both times.

`scripts/update-package-swift.sh` carries a self-test and CI runs it, including the case where there is nothing to rewrite. A release that silently left the placeholder checksum in place would publish a package no consumer can resolve, and the failure would land on them rather than on us.

## CI now links a framework — it never did

`ci.yml` compiled the iOS *test* targets and stopped there, so framework assembly was entirely unexercised, exactly as #4068 flagged. The player job now runs `rcPlayerXcframeworkChecksum` as a **separate** Gradle invocation: the two release links are the heaviest work in that job, and the note already at the top of it records that `linkDebugTestIosSimulatorArm64` has died before. It died again while developing this — two concurrent release links on one machine — which is why they are not batched with the test compiles.

## The surface questions, answered from the generated header

#4068 asked whether #4058's and #4060's retyped parameters read *worse* from Swift. Read out of `RcComposePlayer.h`, not guessed:

- **`RcPlayerTheme` — better.** Exports as an Obj-C enum class with `light` / `dark` / `system` class properties, so Swift writes `theme: .system`. A plain improvement on passing `-2`.
- **`RcTypefaceLoader` — better.** Exports as a *protocol*, so a Swift host implements `families` and `typeface(family:settings:)` rather than assembling a dictionary of Kotlin objects. The companion values read as `RcTypefaceLoaderCompanion.shared.Default`, which is the one place the Kotlin form is nicer.
- **`RcPlayerEvent` — worse, and unavoidably.** The sealed hierarchy flattens exactly as feared:

```objc
__attribute__((swift_name("RcPlayerEvent")))
@protocol RCPRcPlayerEvent
@required
@end
```

  Swift gets casts against `RcPlayerEventHostAction` and friends, not an exhaustive `switch`. So adding a case is source-compatible in Kotlin, compiles fine in Swift, and silently does nothing at runtime. Nothing in Kotlin/Native's Obj-C export fixes that, so it is recorded as a **versioning constraint** instead: a new `RcPlayerEvent` case is a release-noted change, not an additive one.

The entry point itself comes out clean:

```
RcComposeViewController(bytes:theme:onEvent:typefaces:onError:)
```

but only because the frameworks now `export` `:rc-player-runtime`, `:rc-player-protocol` and `:rc-player-trace` — legal precisely because each module already depends on the next with `api`. Without it, Swift sees `Rc_player_runtimeRcPlayerEvent` and `Rc_player_protocolRcDocument` in the callbacks and parameters it has to name. That was the shape before the export was added, confirmed in the header.

## Test plan

- `./gradlew :rc-player-compose:rcPlayerXcframeworkChecksum` — builds `RcComposePlayer.xcframework` (both slices present: `ios-arm64`, `ios-arm64-simulator`), a 76 MB zip, and the digest. Run twice from clean with identical output.
- `scripts/update-package-swift.sh --self-test` — rewrites both values, preserves surrounding comments, leaves no trace of the previous URL, and fails on a file with no binary target.
- `:rc-player-compose:allTests`, `ktfmtCheckAll` — green.
- The generated Obj-C header inspected by hand for the three types above.

Non-visual change (packaging, release wiring, docs), so no render evidence applies. `docs/design/RC_PLAYER_SWIFT.md` is new and carries the consumer snippet, the Intel-Mac exclusion, and the `RcPlayerEvent` caveat with the Swift code a consumer actually has to write.

_Generated by [Claude Code](https://claude.com/claude-code)_