### PR TITLE
feat(rc-player): distribute the Wasm player as a consumable npm bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,6 +471,74 @@ jobs:
           fi
           npm publish "${flags[@]}"
 
+  # Publish the CMP/Wasm Remote Compose player bundle to npm (#4067), so a web page can embed it
+  # without cloning this repo and running Gradle.
+  #
+  # Same posture as `publish-design-map` above, and for the same reasons — including the
+  # `continue-on-error` and the "re-run this job, do not re-dispatch" recovery note, which is about
+  # npm's Trusted Publisher binding to the entry-point workflow rather than about this package.
+  #
+  # `rcPlayerNpmPackage` only *stages* the directory; `npm` runs here and nowhere else. Keeping Node
+  # out of the Gradle build is the constraint that made the CLI vendor a prebuilt JS player in the
+  # first place (docs/design/RC_CMP_WASM_PLAYER.md), and it still holds.
+  publish-wasm-player:
+    needs: [build-applications, build-vscode-extension]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      id-token: write # OIDC trusted publishing + provenance
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.TAG_NAME }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          cache-read-only: 'true'
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+      - name: Upgrade npm (OIDC trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@latest
+      # The size budget in `wasmPlayerDist` is the gate in front of an irreversible publish: npm
+      # refuses to overwrite a version, so a bundle that ballooned would have to be superseded.
+      - name: Stage the npm package
+        run: ./gradlew :rc-player-wasm:rcPlayerNpmPackage
+      - name: Set version from the tag
+        working-directory: rc-player/wasm/build/npmPackage
+        # The committed version is the 0.0.0 placeholder, as in `design-map`. Read from $TAG_NAME in
+        # the env rather than templating it, so a tag name cannot inject arguments.
+        run: npm version --no-git-tag-version --allow-same-version "${TAG_NAME#v}"
+      - name: Publish
+        env:
+          IS_RECOVERY: ${{ github.event_name == 'workflow_dispatch' }}
+        working-directory: rc-player/wasm/build/npmPackage
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          if npm view "@yschimke/remote-compose-player-cmp@${version}" version >/dev/null 2>&1; then
+            echo "skip @yschimke/remote-compose-player-cmp@${version} (already published)"
+            exit 0
+          fi
+          flags=(--access public)
+          if [ "${IS_RECOVERY}" = "true" ]; then
+            flags+=(--provenance=false)
+            echo "recovery publish: provenance disabled (ref does not name the built tree)"
+          fi
+          npm publish "${flags[@]}"
+      # Also attach the raw bundle to the Release, for a consumer who wants the files without npm.
+      # Cheap, and it means a failed npm publish still leaves the release usable.
+      - name: Attach the bundle to the Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          (cd rc-player/wasm/build && zip -qr rc-player-wasm.zip wasmDist)
+          gh release upload "$TAG_NAME" rc-player/wasm/build/rc-player-wasm.zip --clobber
+
   release:
     # The GitHub Release asset upload depends ONLY on the build jobs that produce the assets — it is
     # deliberately NOT gated on `publish-gradle-plugin`. The Maven Central publish is slow and

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -116,10 +116,11 @@ If the automatic chain ever leaves a release half-published (e.g. Maven Central 
 
 Both fallbacks share the same concurrency group as the primary path, so they can't race each other. The final upload step is idempotent — it uploads onto an existing Release (or creates one if none exists).
 
-**One exception: npm.** Neither fallback can publish `@yschimke/compose-design-map`, because both
+**One exception: npm.** Neither fallback can publish `@yschimke/compose-design-map` or
+`@yschimke/remote-compose-player-cmp`, because both
 enter through `release.yml` and the npm trusted publisher is bound to `release-please.yml` (see the
 trusted-publishing note under "What the `release.yml` workflow does" — npm permits one binding per
-package). If `publish-design-map` failed, re-run *that job* in the original **Release PR** run
+package). If `publish-design-map` or `publish-wasm-player` failed, re-run *that job* in the original **Release PR** run
 instead: Actions → the run → **Re-run failed jobs**. An `E404 Not Found - PUT` from `npm publish`
 means the OIDC token did not match the trusted publisher, not that the package or version is
 missing.
@@ -148,7 +149,9 @@ republishing the release.
    - `compose-preview-mcp-<ver>.{zip,tar.gz}` — the MCP server standalone for consumers who want to wire it into an MCP client without dragging the CLI in.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
 4. Publishes **`@yschimke/compose-design-map`** (the `design-map/` package — the annotations→`design-map.json` projection) to **npm**, at the tag's version. Uses npm Trusted Publishing (OIDC), so there is no npm token to rotate; provenance is attached automatically. Like the marketplace publishes it is tolerated rather than blocking, and it skips a version already on npm, so re-running it is safe. Unlike the other steps, its recovery is **re-running the failed job in the original release run**, not a `workflow_dispatch` of `release.yml` — see the trusted-publisher note below.
-5. Uploads the CLI, MCP, XR compositor, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
+5. Publishes **`@yschimke/remote-compose-player-cmp`** (the CMP/Wasm Remote Compose player bundle, staged by `:rc-player-wasm:rcPlayerNpmPackage`) to **npm**, at the tag's version, and attaches the same bundle to the Release as `rc-player-wasm.zip` for consumers who do not want npm. Same OIDC trusted-publishing arrangement, same tolerated-not-blocking posture, same re-run-the-job recovery as the design map. Its **embed contract** — `?src=`, `window.rcPlayerLoad`, the readiness marker — is versioned separately from the release; see [docs/design/RC_PLAYER_EMBED.md](design/RC_PLAYER_EMBED.md).
+6. Publishes the **iOS XCFramework**: uploads `RcComposePlayer.xcframework.zip` to the Release, rewrites `Package.swift` to point at it, and tags that commit `swift/<version>`. The Swift tag exists because SPM verifies a checksum that can only be written *after* the asset is uploaded; see [docs/design/RC_PLAYER_SWIFT.md](design/RC_PLAYER_SWIFT.md).
+7. Uploads the CLI, MCP, XR compositor, and VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 
 Alongside `release.yml`, the automatic release chain starts
 `preview-host-image.yml` immediately after tag creation. That job builds only

--- a/docs/design/RC_CMP_WASM_PLAYER.md
+++ b/docs/design/RC_CMP_WASM_PLAYER.md
@@ -103,7 +103,9 @@ is no list to keep in step.
 
 `:rc-player-wasm` (an executable), `:rc-player-profile` (an application), `:rc-player-metrics` and
 `:rc-player-compat-tests` (fixture generators) are not published. The Wasm *distribution* is a
-different problem and is tracked in #4067. The iOS framework is packaged as an XCFramework and
+different problem: the browser bundle ships as the npm package
+`@yschimke/remote-compose-player-cmp`, with its embed contract written down and versioned separately
+in [RC_PLAYER_EMBED.md](RC_PLAYER_EMBED.md). The iOS framework is packaged as an XCFramework and
 distributed through Swift Package Manager — see [RC_PLAYER_SWIFT.md](RC_PLAYER_SWIFT.md).
 
 One target set across all four, deliberately: `iosX64` is gone everywhere rather than present on the

--- a/docs/design/RC_PLAYER_EMBED.md
+++ b/docs/design/RC_PLAYER_EMBED.md
@@ -1,0 +1,128 @@
+# The Wasm player's embed contract
+
+What a page that embeds the Compose Multiplatform Remote Compose player may rely on, and how that
+set of promises is versioned. Companion to [RC_CMP_WASM_PLAYER.md](RC_CMP_WASM_PLAYER.md), which
+covers the player itself, and to [RC_PLAYER_SWIFT.md](RC_PLAYER_SWIFT.md), which does the same job
+for iOS.
+
+Implements #4067. Before it, this contract existed — `Main.kt` has always defined it — but only in
+the source, which is a poor place for something two other repositories drive.
+
+## Distribution
+
+`@yschimke/remote-compose-player-cmp` on npm. The bundle is a set of static files served as their
+own document, not something imported into an application bundle:
+
+```html
+<iframe src="/rc-player/index.html?src=/documents/watch-face.rc&theme=dark"></iframe>
+```
+
+`:rc-player-wasm:rcPlayerNpmPackage` stages the package directory; `release.yml` runs `npm publish`
+from it. **No Node enters the Gradle build** — a `Sync` task is all the staging needs, which keeps
+the coupling the CLI's vendored JS player was specifically arranged to avoid.
+
+The GitHub Release also carries the raw `wasmDist` as an asset, for a consumer who wants the files
+without npm.
+
+## Which player should an external user reach for?
+
+There are two, and the honest answer is not "the newest one".
+
+| | this bundle | the vendored TypeScript player |
+|---|---|---|
+| renderer | Compose Multiplatform, the same one Android and iOS run | a separate browser implementation |
+| operation coverage | narrower today | **wider today** |
+| pixels | identical to the Android/iOS players by construction | close, but a second implementation |
+| size | ~23 MB, nearly all Skiko | small |
+
+Reach for **this** when cross-platform parity is the point — one renderer, one set of pixels
+everywhere. Reach for the **TypeScript** player when coverage matters more, or when 23 MB is
+disqualifying. `RC_CMP_WASM_PLAYER.md` tracks the gates that remain before this one replaces it;
+until then the vendored player stays, and this document exists so the answer does not depend on
+which page someone found first.
+
+## Versioning
+
+The contract carries **its own integer version**, separate from the repo's release version:
+
+- `window.rcPlayerContractVersion`
+- `document.documentElement.dataset.rcPlayerContract`
+
+The bundle ships on every release, but a host cares whether `?src=` and `window.rcPlayerLoad` still
+mean what it coded against — not which release it happens to have. The npm package's **major**
+tracks this number.
+
+**Bump it** for anything a host could observe breaking: a query parameter's meaning, a
+`data-rc-player-state` value, a `postMessage` payload's shape, `window.rcPlayerLoad`'s behaviour.
+**Do not bump it** for additions — a new parameter or a new message type is feature-detected.
+
+Current version: **1**.
+
+## Query parameters
+
+| parameter | meaning |
+|---|---|
+| `src` | URL of the `.rc` document. **Required**; absent is an `error` state, not an empty render. |
+| `theme` | `light` or `dark` forces a mode. Any other value, or none, follows the browser's `prefers-color-scheme`. |
+| `fontsBase` | Directory holding `fonts.json` and its faces. Default `./fonts/`. Rejected unless relative or `http(s):` — a page-supplied parameter must not become an arbitrary scheme. |
+| `namedValues` | Host overrides for the document's named variables, as `type\0name\0value` rows. Types: `string`, `float`, `dp`, `int`, `bool`, `color`, `long`. Names are prefixed `USER:` internally. |
+| `rcTrace` | `1` emits User Timing marks, so the player's spans land in a DevTools performance profile under the same names the desktop player writes to Perfetto. Off by default: `performance`'s entry buffer is finite and shared with the embedding page. |
+| `allowExternalImagePlaceholders` | `1` renders a placeholder instead of refusing a document that names an external image. |
+| `handoffDelayMs` | Cold-start tail before `ready`, clamped to 0–10 000, default 1 500. **Only lower it if you composite the result yourself** — the default guards a human seeing a blank frame, and the failure it guards against cannot be reproduced under CDP capture. |
+
+`theme` and `namedValues` belong to the *page* and are **not** re-read on a document swap. A host
+that needs different ones navigates.
+
+## The `window` surface
+
+**`window.rcPlayerLoad(src)`** shows another document in the player that is already running, instead
+of navigating the page again. A navigation is the honest way to load the *first* document and a poor
+way to load the next one: it discards the instantiated Wasm module, the Compose runtime and the
+fetched fonts, then rebuilds all three to draw a document that is usually a few dozen operations
+long. Requests are last-one-wins.
+
+The marker returns to `loading` **synchronously** inside that call, so a host waiting for `ready`
+cannot read the outgoing render's marker and screenshot the document it just replaced.
+
+**`window.rcPlayerContractVersion`** — the integer above.
+
+## The readiness marker
+
+`document.documentElement.dataset.rcPlayerState`:
+
+| value | meaning |
+|---|---|
+| `loading` | a document is being fetched or decoded |
+| `ready` | the document has rendered and the surface has been presented |
+| `error` | the load failed; `dataset.rcPlayerError` carries the message |
+
+Wait for `ready` before revealing the frame. `ready` is deliberately later than "the composition
+ran": Compose schedules Skiko's raster work after composition, so the player waits three browser
+frames plus `handoffDelayMs` before setting it. Chromium can acknowledge frames before the Skiko
+surface reaches the compositor.
+
+## `postMessage`
+
+All same-origin, to `window.parent`:
+
+| message | when |
+|---|---|
+| `'cp-rc-wasm-ready'` | alongside the `ready` marker |
+| `'cp-rc-wasm-error:<message>'` | alongside the `error` marker |
+| `{type: 'cp-rc-debug-message', message, value, flags}` | the document executed `DebugMessage` |
+| `{type: 'cp-rc-host-action', actionId}` | a host action fired |
+| host-metadata and host-named-action variants | as documented in `Main.kt` |
+
+Host actions also accumulate on `dataset.rcPlayerActionTrace`, comma-separated, for a driver that
+polls rather than listens.
+
+## Size
+
+~23 MB, nearly all of it the Skiko WebAssembly runtime — the cost of running the real Compose
+renderer in a browser rather than a reimplementation of it.
+
+`wasmPlayerDist` enforces a byte budget. **That budget is a ratchet, not a published guarantee**, and
+this document says so deliberately rather than letting the number be inherited as a promise: it
+exists to make an unintended jump fail the build, and it moves when a deliberate payload lands (it
+already has, twice — a Compose Multiplatform bump and a vendored font family). A consumer should
+treat the size as "tens of megabytes", not as a number to assert against.

--- a/rc-player/wasm/build.gradle.kts
+++ b/rc-player/wasm/build.gradle.kts
@@ -104,3 +104,23 @@ tasks.register<Sync>("wasmPlayerTestDist") {
   from(project(":rc-player-compat-tests").layout.buildDirectory.file("fixtures/androidx-scroll.rc"))
   into(layout.buildDirectory.dir("wasmTestDist"))
 }
+
+// npm package staging (#4067).
+//
+// `wasmPlayerDist` produces the browser bundle; this lays it out the way npm expects — package
+// metadata and README at the root, the bundle under `dist/` — into a directory the release workflow
+// runs `npm publish` from. **No Node in the Gradle build**, deliberately: the CLI vendors a
+// prebuilt JS player for exactly that reason (docs/design/RC_CMP_WASM_PLAYER.md), and a Sync task
+// is all this needs. `npm` only ever runs in CI, on a directory that is already assembled.
+//
+// The committed `version` is the `0.0.0` placeholder the `design-map` package uses; the release job
+// sets it from the tag. The package *major* tracks the embed contract's version, which is a
+// different number and lives in `Main.kt` — see docs/design/RC_PLAYER_EMBED.md.
+tasks.register<Sync>("rcPlayerNpmPackage") {
+  description = "Stage the Wasm player bundle as an npm package directory."
+  group = "distribution"
+  dependsOn("wasmPlayerDist")
+  from(layout.projectDirectory.dir("npm"))
+  from(layout.buildDirectory.dir("wasmDist")) { into("dist") }
+  into(layout.buildDirectory.dir("npmPackage"))
+}

--- a/rc-player/wasm/npm/README.md
+++ b/rc-player/wasm/npm/README.md
@@ -1,0 +1,70 @@
+# @yschimke/remote-compose-player-cmp
+
+The Compose Multiplatform / Wasm [Remote Compose](https://developer.android.com/jetpack/androidx/releases/compose-remote)
+player, as a browser bundle. It renders a `.rc` document into a page, driven entirely by query
+parameters and one `window` function — no JavaScript API to learn and no bundler step.
+
+```html
+<iframe src="/rc-player/index.html?src=/documents/watch-face.rc&theme=dark"></iframe>
+```
+
+## Install
+
+```
+npm install @yschimke/remote-compose-player-cmp
+```
+
+The package ships a `dist/` directory: `index.html`, the compiled Wasm module, the Skiko runtime,
+and a fonts manifest. Serve it as static files — copy `dist/` into your public directory, or point
+your server at `node_modules/@yschimke/remote-compose-player-cmp/dist`. Nothing here is meant to be
+imported into an app bundle; the player runs in its own document.
+
+Every file must be served from the same directory, and `.wasm` must be served as
+`application/wasm` — the module is instantiated by streaming.
+
+## Which player is this?
+
+**There are two.** This one is the Compose Multiplatform renderer. The other is a TypeScript player
+vendored inside `compose-preview`'s CLI, and today **it supports more operations**. Reach for this
+package when you want the same renderer that runs on Android and iOS — one implementation, one set
+of pixels across platforms. Reach for the TypeScript player when coverage matters more than
+cross-platform parity. `RC_CMP_WASM_PLAYER.md` in the repository tracks which gates remain before
+this one replaces it.
+
+## The embed contract
+
+Versioned separately from the release it ships in, because a host cares whether `?src=` still means
+what it coded against — not which release it happens to have. `window.rcPlayerContractVersion` and
+`document.documentElement.dataset.rcPlayerContract` both carry it, and this package's **major**
+tracks it.
+
+Full reference: [RC_PLAYER_EMBED.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RC_PLAYER_EMBED.md).
+Summary:
+
+| parameter | meaning |
+|---|---|
+| `?src=` | URL of the `.rc` document. Required. |
+| `?theme=light\|dark` | Force a mode. Anything else follows `prefers-color-scheme`. |
+| `?fontsBase=` | Directory holding `fonts.json` and its faces. Default `./fonts/`. |
+| `?namedValues=` | Host overrides for the document's named variables. |
+| `?rcTrace=1` | Emit User Timing marks for a DevTools performance profile. |
+| `?allowExternalImagePlaceholders=1` | Render a placeholder instead of failing on an external image. |
+| `?handoffDelayMs=` | Cold-start tail before `ready`. Only lower it if you composite the result yourself. |
+
+- `window.rcPlayerLoad(src)` swaps the document without reloading the page, keeping the Wasm module,
+  the Compose runtime and the fetched fonts warm.
+- `document.documentElement.dataset.rcPlayerState` is `loading`, `ready` or `error`. Wait for
+  `ready` before revealing the frame; `rcPlayerError` carries the message on `error`.
+- The player also `postMessage`s `cp-rc-wasm-ready` / `cp-rc-wasm-error:<message>` and structured
+  host-action and debug-message events to `window.parent`, same-origin.
+
+## Size
+
+The bundle is around 23 MB, nearly all of it the Skiko WebAssembly runtime. That is the cost of
+running the real Compose renderer in a browser rather than a reimplementation of it. The repository
+enforces a budget so an unintended jump fails the build; the budget is **not** a published
+guarantee, and it moves when a deliberate payload lands.
+
+## License
+
+Apache 2.0.

--- a/rc-player/wasm/npm/package.json
+++ b/rc-player/wasm/npm/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@yschimke/remote-compose-player-cmp",
+  "version": "0.0.0",
+  "description": "The Compose Multiplatform / Wasm Remote Compose player, as a drop-in browser bundle. Renders .rc documents in an iframe driven by query parameters and window.rcPlayerLoad.",
+  "keywords": [
+    "remote-compose",
+    "compose-multiplatform",
+    "wasm",
+    "player",
+    "androidx"
+  ],
+  "license": "Apache-2.0",
+  "author": "Yuri Schimke",
+  "homepage": "https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/RC_PLAYER_EMBED.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yschimke/compose-ai-tools.git",
+    "directory": "rc-player/wasm"
+  },
+  "bugs": {
+    "url": "https://github.com/yschimke/compose-ai-tools/issues"
+  },
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    "./index.html": "./dist/index.html",
+    "./dist/*": "./dist/*"
+  },
+  "sideEffects": true,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
+++ b/rc-player/wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/rcplayer/wasm/Main.kt
@@ -71,6 +71,13 @@ public fun main() {
   // whatever else the embedding page measures, so a player embedded in someone's dashboard should
   // not be filling it on every frame. `?rcTrace=1` turns the player's spans on for a session; the
   // span names match the ones the desktop player writes into Perfetto.
+  // Publish the embed contract's version before anything else, so a host that loaded this bundle
+  // from npm can tell what it is talking to. The npm package's major tracks this number; the
+  // contract itself is written up in docs/design/RC_PLAYER_EMBED.md (#4067). It is a separate
+  // number from the repo's release version deliberately: the bundle ships on every release, and a
+  // host cares about whether `?src=` and `window.rcPlayerLoad` still mean what it coded against,
+  // not about which release it happens to have.
+  publishContractVersion(RC_PLAYER_EMBED_CONTRACT_VERSION)
   setRcPlatformTracingEnabled(queryParameter("rcTrace") == "1")
   loadRequest = LoadRequest(queryParameter("src"), generation = 0)
   installDocumentSwap()
@@ -365,6 +372,21 @@ private fun flattenNamedValuesFromLocation(): JsString? =
 private fun decodeUriComponent(value: String): String = decodeUriComponentJs(value).toString()
 
 private fun decodeUriComponentJs(value: String): JsString = js("decodeURIComponent(value)")
+
+/**
+ * The embed contract's version — see docs/design/RC_PLAYER_EMBED.md.
+ *
+ * Bump on any change a host could observe: a query parameter's meaning, the `data-rc-player-state`
+ * values, the `postMessage` payloads, or `window.rcPlayerLoad`'s behaviour. Adding a parameter or a
+ * message type is additive and does not bump it; a host feature-detects those.
+ */
+private const val RC_PLAYER_EMBED_CONTRACT_VERSION: Int = 1
+
+private fun publishContractVersion(version: Int): Unit =
+  js(
+    "(window.rcPlayerContractVersion = version, " +
+      "document.documentElement.dataset.rcPlayerContract = String(version))"
+  )
 
 private fun postReady(): Unit =
   js(


### PR DESCRIPTION
Closes #4067.

## The three things the issue said to decide

**1. npm, GitHub Release, or both? — npm, plus a Release asset.**

`@yschimke/remote-compose-player-cmp`. The Release also carries `rc-player-wasm.zip`, which is cheap and means a failed npm publish still leaves the release usable.

The constraint the issue flags — *"whatever is chosen should not reintroduce"* the Node/Gradle coupling the CLI's vendored JS player exists to avoid — is respected exactly. `:rc-player-wasm:rcPlayerNpmPackage` is a `Sync` task that lays `wasmPlayerDist` out the way npm expects and stops there. `npm` runs in `release.yml` and nowhere else, on a directory that is already assembled.

The publish job mirrors the existing `publish-design-map` down to the details: OIDC trusted publishing (no token to rotate), `continue-on-error` so a registry outage cannot strand the release, a skip when the version is already up, and the same "re-run *this job* in the original release-please run, do not re-dispatch" recovery — because npm binds a Trusted Publisher to the *entry-point* workflow and permits one binding per package.

**2. What is the embed contract? — written down, and versioned separately.**

`Main.kt` has always defined one. It existed only in the source, which is a poor place for something two other repositories drive. [`docs/design/RC_PLAYER_EMBED.md`](docs/design/RC_PLAYER_EMBED.md) is now the reference: every query parameter (`src`, `theme`, `fontsBase`, `namedValues`, `rcTrace`, `allowExternalImagePlaceholders`, `handoffDelayMs`), `window.rcPlayerLoad(src)`, the `data-rc-player-state` marker's three values, and the `postMessage` payloads — including *why* `ready` is deliberately later than "the composition ran".

It carries **its own integer version**, published as `window.rcPlayerContractVersion` and `dataset.rcPlayerContract`, and the npm package's **major** tracks it. Separate from the release version on purpose: the bundle ships on every release, and a host cares whether `?src=` still means what it coded against — not which release it happens to have. Additions (a new parameter, a new message type) do not bump it; a host feature-detects those.

**3. Size budget — deliberately *not* promoted to a guarantee.**

The issue is right that publishing risks the budget being inherited as a promise. It stays a ratchet: it exists so an unintended jump fails the build, and it has already moved twice for deliberate payloads (a CMP bump, a vendored font family). Both the docs and the package README say to treat the size as "tens of megabytes", not as a number to assert against.

## The sequencing note — which player should someone reach for?

The issue asks for a clear statement, since this bundle is currently the *less* capable of the two players. Both the contract doc and the package README carry it as a table:

| | this bundle | the vendored TypeScript player |
|---|---|---|
| renderer | Compose Multiplatform — the same one Android and iOS run | a separate browser implementation |
| operation coverage | narrower today | **wider today** |
| pixels | identical to the Android/iOS players by construction | close, but a second implementation |
| size | ~23 MB, nearly all Skiko | small |

So: cross-platform parity → this; coverage or size → the TypeScript player. `RC_CMP_WASM_PLAYER.md` tracks the gates that remain before this one replaces it, and the answer no longer depends on which document someone found first.

## Test plan

- `./gradlew :rc-player-wasm:rcPlayerNpmPackage` — stages `package.json`, `README.md` and `dist/` (23 MB: `index.html`, `rcPlayer.mjs`, `rcPlayer.wasm`, `skiko.mjs`, `skiko.wasm`, `js-joda.esm.js`, `fonts/`). Verified the contract marker reaches the compiled output: `rcPlayerContractVersion = version` is present in `dist/rcPlayer.import-object.mjs`.
- `:rc-player-wasm:wasmPlayerDist` and `wasmPlayerTestDist` — green, budget respected.
- `ktfmtCheckAll` — green.
- The npm job is modelled directly on the working `publish-design-map` job rather than invented, including the placeholder-`0.0.0`-plus-`npm version`-from-tag arrangement.

The only production code change is `publishContractVersion(...)` at startup, which writes two values a host reads and touches nothing that renders — so the existing browser lanes (`wasmPlayerTestDist`, the CMP/Wasm parity job) are the relevant net, and they are green. No pixels move, so no render evidence applies.

`docs/RELEASING.md` gains the new step; `RC_CMP_WASM_PLAYER.md` points at the contract doc.

_Generated by [Claude Code](https://claude.com/claude-code)_