### PR TITLE
fix(rc-player): unrepresentable named types, colliding font identities, swallowed cancellation

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcHostFonts.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcHostFonts.kt
@@ -38,6 +38,17 @@ public class RcFontFaces(private val faces: List<RcFontFace>) {
 
   public constructor(face: RcFontFace) : this(listOf(face))
 
+  /**
+   * The identities of the underlying faces, in registration order.
+   *
+   * Test-only. Compose's font cache keys on the identity, so "these two faces are distinct as far
+   * as the cache is concerned" is a real property with no other observable: the resolved
+   * [FontFamily] does not expose it, and two colliding identities differ only in which bytes get
+   * drawn.
+   */
+  internal val identities: List<String>
+    get() = faces.map { it.identity }
+
   private fun instanceSuffix(axes: List<Pair<String, Float>>): String =
     axes.joinToString(separator = ",", prefix = "#") { (tag, value) -> "$tag=$value" }
 

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcManifestTypefaceLoader.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcManifestTypefaceLoader.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.rcplayer.compose
 
+import kotlin.coroutines.cancellation.CancellationException
+
 /**
  * Builds an [RcTypefaceLoader] from a `fonts.json` manifest and the faces it names.
  *
@@ -44,6 +46,7 @@ public class RcManifestTypefaceLoader(private val fetchBytes: suspend (url: Stri
     val entries = runCatching {
       parseFontManifest(fetchBytes(directory + MANIFEST_NAME).decodeToString())
     }
+      .rethrowCancellation()
       .getOrElse { emptyList() }
     if (entries.isEmpty()) return RcTypefaceLoader.Empty
     val faces = buildFaces(directory, entries)
@@ -60,7 +63,12 @@ public class RcManifestTypefaceLoader(private val fetchBytes: suspend (url: Stri
       RcFontFaces(
         group.map { entry ->
           RcFontFace(
-            identity = entry.file,
+            // The BASE belongs in the identity, not just the file name. Compose's font cache
+            // keys on it (see `RcFontFaces.family`, which appends the variation axes for the
+            // same reason), so two catalogs that both ship a `Roboto-Regular.ttf` would share
+            // one cached typeface in a process that loads both — and the second catalog would
+            // silently render the first one's bytes, even though `load` correctly refetched.
+            identity = directory + entry.file,
             data = fetchBytes(directory + entry.file),
             weight = entry.weight,
             italic = entry.italic,
@@ -68,6 +76,7 @@ public class RcManifestTypefaceLoader(private val fetchBytes: suspend (url: Stri
         }
       )
     }
+      .rethrowCancellation()
       .getOrNull()
 
     val byFamily = entries.groupBy { it.family }
@@ -105,11 +114,10 @@ internal data class RcManifestFace(
 /**
  * Reads the `{"families":[{"name","role","fonts":[{"file","weight","style"}]}]}` shape.
  *
- * File names are rejected rather than sanitised when they escape the manifest's own directory — a
- * `..` segment, or anything carrying a scheme. The manifest is fetched from a host-controlled base,
- * but a catalog's manifest is often generated, and a generated path that walks out of its directory
- * is a bug wherever it came from. Rejecting one face loses one family; following it fetches from
- * somewhere the host did not name.
+ * File names are rejected rather than sanitised when they escape the manifest's own directory — see
+ * [isSafeRelativePath] for the three shapes that counts as. The manifest is fetched from a
+ * host-controlled base, but a catalog's manifest is often generated, and a generated path that
+ * walks out of its directory is a bug wherever it came from.
  */
 internal fun parseFontManifest(json: String): List<RcManifestFace> =
   rcParseJson(json).array("families").flatMap { family ->
@@ -129,4 +137,61 @@ internal fun parseFontManifest(json: String): List<RcManifestFace> =
     }
   }
 
-private fun String.isSafeRelativePath(): Boolean = ".." !in split('/') && !contains(':')
+/**
+ * Cancellation is not a failure to recover from.
+ *
+ * `runCatching` catches [CancellationException] along with everything else, so a host cancelling a
+ * screen load mid-fetch would come back as "this manifest has no fonts" — [load] returning
+ * [RcTypefaceLoader.Empty] and its caller carrying on with post-load state updates inside a
+ * coroutine that is already cancelled. The Wasm host additionally wraps this in an 8-second
+ * timeout, which is exactly that path. Ordinary fetch and parse failures still degrade quietly, as
+ * documented.
+ */
+private fun <T> Result<T>.rethrowCancellation(): Result<T> = also {
+  exceptionOrNull()?.let { if (it is CancellationException) throw it }
+}
+
+/**
+ * Whether a manifest's `file` stays inside the manifest's own directory.
+ *
+ * Three ways out, all rejected rather than sanitised:
+ * - `..` as a path segment, on **either** separator. A manifest consumed through a Windows
+ *   filesystem fetcher resolves `..\secret.ttf` as a parent segment even though `/` never appears.
+ * - a percent-encoded segment that *becomes* `..` once decoded. In the Wasm case the URL is handed
+ *   to the browser, which normalizes `%2e%2e/` as a parent segment after this check has run.
+ * - anything carrying a scheme.
+ *
+ * A single decode pass is enough because a doubly-encoded segment (`%252e%252e`) decodes to the
+ * literal text `%2e%2e`, which no fetcher treats as a parent — only one decode ever happens
+ * downstream. Rejecting one face loses one family; following it fetches from somewhere the host did
+ * not name.
+ */
+private fun String.isSafeRelativePath(): Boolean {
+  if (contains(':')) return false
+  val segments = split('/', '\\')
+  if (".." in segments) return false
+  return ".." !in segments.map { it.percentDecodedOrSelf() }
+}
+
+/**
+ * Decodes `%XX` escapes. Anything malformed is returned unchanged — this feeds a *rejection* test,
+ * so failing to decode must not be read as "safe"; the undecoded text is then compared as-is.
+ */
+private fun String.percentDecodedOrSelf(): String {
+  if ('%' !in this) return this
+  val bytes = mutableListOf<Byte>()
+  var index = 0
+  while (index < length) {
+    val char = this[index]
+    if (char == '%' && index + 2 < length) {
+      val decoded = substring(index + 1, index + 3).toIntOrNull(16)
+      if (decoded == null) return this
+      bytes += decoded.toByte()
+      index += 3
+    } else {
+      bytes += char.code.toByte()
+      index += 1
+    }
+  }
+  return bytes.toByteArray().decodeToString()
+}

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcTypefaceLoader.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcTypefaceLoader.kt
@@ -74,6 +74,9 @@ public class RcBundledTypefaceLoader(faces: Map<String, RcFontFaces>) : RcTypefa
 
   override fun typeface(family: String, settings: FontVariation.Settings?): FontFamily? =
     faces[family]?.family(settings)
+
+  /** Test-only; see [RcFontFaces.identities] for why the identities need to be observable. */
+  internal fun facesFor(family: String): RcFontFaces? = faces[family.lowercase()]
 }
 
 /**

--- a/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcManifestTypefaceLoaderTest.kt
+++ b/rc-player/compose/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcManifestTypefaceLoaderTest.kt
@@ -1,8 +1,10 @@
 package ee.schimke.composeai.rcplayer.compose
 
 import androidx.compose.ui.text.font.FontFamily
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -137,6 +139,84 @@ class RcManifestTypefaceLoaderTest {
       )
 
     assertEquals(listOf("ok.ttf"), faces.map { it.file })
+  }
+
+  /**
+   * The `/`-only, undecoded check above let two shapes through that a real fetcher still resolves
+   * as a parent segment: a Windows filesystem fetcher walks out of `..\secret.ttf`, and the browser
+   * normalizes `%2e%2e/` as a parent *after* this check has already passed the name.
+   */
+  @Test
+  fun aFaceEscapingByBackslashOrPercentEncodingIsAlsoDropped() {
+    val faces =
+      parseFontManifest(
+        """
+        {"families":[{"name":"Escape","role":"named","fonts":[
+          {"file":"..\\secret.ttf"},
+          {"file":"sub\\..\\..\\secret.ttf"},
+          {"file":"%2e%2e/secret.ttf"},
+          {"file":"%2E%2E/secret.ttf"},
+          {"file":"ok.ttf"},
+          {"file":"sub/ok.ttf"},
+          {"file":"not%2Ea%2Eparent.ttf"}
+        ]}]}
+        """
+          .trimIndent()
+      )
+
+    // The last two are legitimate: a subdirectory, and a name whose decoded form is not `..` at
+    // all. Rejecting every `%` outright would cost a catalog faces it is entitled to ship.
+    assertEquals(listOf("ok.ttf", "sub/ok.ttf", "not%2Ea%2Eparent.ttf"), faces.map { it.file })
+  }
+
+  /**
+   * Compose's font cache keys on the identity, so a filename-only identity made two catalogs that
+   * both ship `Roboto-Regular.ttf` share one cached typeface — the second silently rendering the
+   * first's bytes even though the loader had refetched the right ones. `RcFontFaces` already
+   * appends the variation axes for exactly this reason.
+   */
+  @Test
+  fun facesFromDifferentBasesGetDifferentIdentities() = runTest {
+    val shared =
+      """{"families":[{"name":"Shared","role":"default","fonts":[""" +
+        """{"file":"Roboto-Regular.ttf","weight":400}]}]}"""
+    val fetcher: suspend (String) -> ByteArray = { url ->
+      if (url.endsWith("fonts.json")) shared.encodeToByteArray() else ByteArray(4)
+    }
+    val a = RcManifestTypefaceLoader(fetcher).load("./catalog-a/fonts/")
+    val b = RcManifestTypefaceLoader(fetcher).load("./catalog-b/fonts/")
+
+    assertEquals(
+      listOf("./catalog-a/fonts/Roboto-Regular.ttf"),
+      (a as RcBundledTypefaceLoader).facesFor("shared")?.identities,
+    )
+    assertEquals(
+      listOf("./catalog-b/fonts/Roboto-Regular.ttf"),
+      (b as RcBundledTypefaceLoader).facesFor("shared")?.identities,
+    )
+  }
+
+  /**
+   * `runCatching` catches `CancellationException` too, so a host cancelling a screen load mid-fetch
+   * used to come back as "this manifest has no fonts" — the caller then carrying on with post-load
+   * state updates inside an already-cancelled coroutine.
+   */
+  @Test
+  fun cancellingTheManifestFetchPropagatesRatherThanYieldingAnEmptyLoader() = runTest {
+    val loader = RcManifestTypefaceLoader { throw CancellationException("host navigated away") }
+
+    assertFailsWith<CancellationException> { loader.load("./fonts/") }
+  }
+
+  /** Same for a *face* fetch, whose ordinary failures deliberately drop only one family. */
+  @Test
+  fun cancellingAFaceFetchPropagatesRatherThanDroppingTheFamily() = runTest {
+    val loader = RcManifestTypefaceLoader { url ->
+      if (url.endsWith("fonts.json")) manifest.encodeToByteArray()
+      else throw CancellationException("host navigated away")
+    }
+
+    assertFailsWith<CancellationException> { loader.load("./fonts/") }
   }
 
   @Test

--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -187,7 +187,17 @@ public class RcPlayerState(
     // Snapshot what the *document* recorded for each named variable, before any host override is
     // applied. `setNamedValue` has no inverse, so without this a host that stops supplying a value
     // has no way back — see [clearNamedValue].
-    variableNames.keys.forEach { name -> documentNamedValues[name] = readNamedValue(name) }
+    //
+    // Only the types `RcNamedValue` can represent. `RcNamedVariable` also defines `IMAGE_TYPE` and
+    // `FLOAT_ARRAY_TYPE`, which no `RcNamedValue` case models, so `readNamedValue` throws for them
+    // — and doing that here would fail *construction* of every document that merely declares such a
+    // variable, override or not, turning a renderable document into a hard error. There is nothing
+    // to restore for a variable a host cannot set in the first place.
+    variableNames.forEach { (name, variable) ->
+      if (variable.type.namedVariableCarriesHostValue()) {
+        documentNamedValues[name] = readNamedValue(name)
+      }
+    }
     namedValues.forEach { (name, value) -> setNamedValue(name, value) }
     beginFrame()
   }
@@ -1106,6 +1116,21 @@ public class RcPlayerState(
     }
     documentNamedValues[name]?.let { setNamedValue(name, it) }
   }
+
+  /**
+   * Whether an `RcNamedVariable.type` is one [RcNamedValue] models, and therefore one a host can
+   * read or override.
+   *
+   * `IMAGE_TYPE` and `FLOAT_ARRAY_TYPE` are valid AndroidX types with no host-value counterpart.
+   * They stay loadable — a document declaring one renders — but neither [namedValue] nor
+   * [setNamedValue] can speak about them.
+   */
+  private fun Int.namedVariableCarriesHostValue(): Boolean =
+    this == RcNamedVariable.STRING_TYPE ||
+      this == RcNamedVariable.FLOAT_TYPE ||
+      this == RcNamedVariable.COLOR_TYPE ||
+      this == RcNamedVariable.INT_TYPE ||
+      this == RcNamedVariable.LONG_TYPE
 
   private fun readNamedValue(name: String): RcNamedValue {
     val variable = requireNotNull(variableNames[name]) { "Unknown named variable '$name'" }

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcNamedValueLifecycleTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcNamedValueLifecycleTest.kt
@@ -94,4 +94,54 @@ class RcNamedValueLifecycleTest {
     assertFailsWith<IllegalArgumentException> { state.clearNamedValue("USER:nothing") }
     assertFailsWith<IllegalArgumentException> { state.namedValue("USER:nothing") }
   }
+
+  /**
+   * `RcNamedVariable` defines `IMAGE_TYPE` and `FLOAT_ARRAY_TYPE` as valid types that no
+   * `RcNamedValue` case models. Capturing the document's recorded value for *every* declared
+   * variable therefore threw during construction, so a document that merely *declared* one — with
+   * no host override anywhere in sight — stopped rendering entirely. It used to load fine.
+   */
+  @Test
+  fun aDocumentDeclaringATypeWithNoHostValueStillConstructs() {
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(0, 1, 0)),
+        listOf(
+          RcFloatConstant(9, RcFloatWord.literal(21.5f)),
+          RcNamedVariable(9, RcNamedVariable.FLOAT_TYPE, "USER:temperature"),
+          RcNamedVariable(12, RcNamedVariable.IMAGE_TYPE, "USER:avatar"),
+          RcNamedVariable(13, RcNamedVariable.FLOAT_ARRAY_TYPE, "USER:series"),
+        ),
+      )
+
+    val state = RcPlayerState(document)
+
+    // The representable variable beside them is unaffected, including its clear-to-document path.
+    state.setNamedValue("USER:temperature", RcNamedValue.FloatValue(-4f))
+    state.clearNamedValue("USER:temperature")
+    assertEquals(RcNamedValue.FloatValue(21.5f), state.namedValue("USER:temperature"))
+
+    // Reading or overriding one of the unrepresentable variables is still a loud error — the host
+    // API genuinely cannot speak about them. Only *loading* the document had to stop failing.
+    assertFailsWith<IllegalArgumentException> { state.namedValue("USER:avatar") }
+    assertFailsWith<IllegalArgumentException> {
+      state.setNamedValue("USER:series", RcNamedValue.FloatValue(1f))
+    }
+    // Clearing is a no-op rather than a throw: nothing was ever captured to restore.
+    state.clearNamedValue("USER:avatar")
+  }
+
+  /** A host override supplied at construction for an unrepresentable type is still rejected. */
+  @Test
+  fun seedingAnUnrepresentableTypeAtConstructionFailsLoudly() {
+    val document =
+      RcDocument(
+        RcHeader(RcVersion(0, 1, 0)),
+        listOf(RcNamedVariable(12, RcNamedVariable.IMAGE_TYPE, "USER:avatar")),
+      )
+
+    assertFailsWith<IllegalArgumentException> {
+      RcPlayerState(document, mapOf("USER:avatar" to RcNamedValue.Integer(1)))
+    }
+  }
 }


### PR DESCRIPTION
Codex reviewed #4181 and #4185 as each merged, so both sets of findings landed on `main` unaddressed. Four fixes, each with a regression test that fails without it.

## A declared image or float-array named variable stopped documents from loading (P1)

`RcPlayerState`'s `init` snapshots what the document recorded for every named variable, so `clearNamedValue` has something to restore. It looped over *all* of them and called `readNamedValue`, which throws for the two `RcNamedVariable` types no `RcNamedValue` models — `IMAGE_TYPE` and `FLOAT_ARRAY_TYPE`. A document that merely **declared** one therefore failed construction outright, with no host override anywhere in sight. It rendered fine before #4181.

It now snapshots only the representable types. Reading or overriding one of the others is still a loud `IllegalArgumentException` — the host API genuinely cannot speak about them — and clearing one is a no-op, since nothing was captured. Only *loading* had to stop failing.

## Two catalogs could share one cached typeface (P1)

`RcManifestTypefaceLoader` set each face's identity to `entry.file`. Compose's font cache keys on the identity — `RcFontFaces.family` already appends the variation axes for precisely this reason — so a process loading two catalogs that both ship, say, `Roboto-Regular.ttf` got one cached typeface for both, and the second catalog silently rendered the first's bytes even though `load` had correctly refetched. The identity is now `directory + entry.file`.

## Cancellation came back as "this manifest has no fonts"

`runCatching` catches `CancellationException` along with everything else. A host cancelling a screen or page load mid-fetch got `RcTypefaceLoader.Empty` and carried on with post-load state updates inside an already-cancelled coroutine — and the Wasm host wraps this in an 8-second timeout, which is exactly that path. Cancellation is now rethrown from both the manifest fetch and the per-face fetch; ordinary fetch and parse failures still degrade quietly, as documented.

## The containment check missed two ways out of the base directory

`isSafeRelativePath` split on `/` only and never decoded, so both of these passed and then resolved as parent segments downstream:

- `..\secret.ttf` — a manifest consumed through a Windows filesystem fetcher, where `/` never appears.
- `%2e%2e/secret.ttf` — the browser normalizes it as a parent *after* this check has run.

It now checks both separators and one percent-decode pass. One pass is enough: `%252e%252e` decodes to the literal text `%2e%2e`, which no fetcher treats as a parent. A subdirectory (`sub/ok.ttf`) and a name whose decoded form simply is not `..` (`not%2Ea%2Eparent.ttf`) are still accepted — rejecting every `%` would cost catalogs faces they are entitled to ship.

## Test hooks

`RcFontFaces.identities` and `RcBundledTypefaceLoader.facesFor` are new `internal` accessors. Identity collision has no other observable: the resolved `FontFamily` does not expose the identity, and two colliding identities differ only in which bytes end up drawn. Being `internal`, they stay off the published ABI — `checkKotlinAbi` passes unchanged on both modules.

## Test plan

- `./gradlew :rc-player-runtime:jvmTest :rc-player-compose:jvmTest` — green, including seven new cases (two in `RcNamedValueLifecycleTest`, five in `RcManifestTypefaceLoaderTest`).
- Confirmed the named-variable test fails against the unfixed `RcPlayerState`.
- `./gradlew :rc-player-{compose,runtime}:ktfmtCheck` and `:checkKotlinAbi` — clean; no ABI dump change needed.

Non-visual: no rendered surface changes. The font-identity fix affects *which* bytes a second catalog draws in a process that loads two, which the existing render fixtures (one catalog per process) cannot capture; `facesFromDifferentBasesGetDifferentIdentities` asserts it directly instead.

_Generated by [Claude Code](https://claude.com/claude-code)_
