### PR TITLE
fix(design-artifacts): type-check completeness.$comment

### DIFF
--- a/scripts/design-artifacts/catalog-spec.mjs
+++ b/scripts/design-artifacts/catalog-spec.mjs
@@ -832,6 +832,14 @@ function completenessErrors(spec) {
       errors.push(`completeness.${key} is not a known field (did you mean \`exemptSemantics\`?)`);
     }
   }
+  // Allowed is not the same as untyped. The schema declares `$comment` a string, and
+  // `validate-catalog-spec.mjs` runs THIS validator rather than the schema — so without the check a
+  // number, object, array or null sails through the advertised structural pre-flight and is
+  // rejected later by whatever schema-aware tooling the author reaches for, which is the worst
+  // possible order to learn it in.
+  if ("$comment" in block && typeof block.$comment !== "string") {
+    errors.push("`completeness.$comment` must be a string");
+  }
   const exempt = block.exemptSemantics;
   if (exempt === undefined) return errors;
   if (!Array.isArray(exempt)) {

--- a/scripts/design-artifacts/catalog-spec.test.mjs
+++ b/scripts/design-artifacts/catalog-spec.test.mjs
@@ -942,6 +942,20 @@ test("validateSpec accepts a $comment beside the exemptions", () => {
   );
 });
 
+test("validateSpec rejects a non-string completeness $comment", () => {
+  // The schema declares it a string, and `validate-catalog-spec.mjs` runs this validator rather
+  // than the schema — so a whitelist with no type check lets a malformed spec pass the advertised
+  // pre-flight and fail later in schema-aware tooling, which is the worst order to learn it in.
+  for (const bad of [3, { why: "x" }, ["x"], null, true]) {
+    assert.match(
+      validateSpec(prioritySpec([], { completeness: { $comment: bad, exemptSemantics: ["*"] } }))
+        .errors[0],
+      /`completeness\.\$comment` must be a string/,
+      `expected a type error for ${JSON.stringify(bad)}`,
+    );
+  }
+});
+
 // --- select: one breakpoint of a multipreview, without splitting the function ---
 
 const wearSpecWith = (components) => ({


### PR DESCRIPTION
Codex review finding on #4182, which merged before the review landed.

The whitelist that admitted `completeness.$comment` alongside `exemptSemantics` accepted it at **any** type, while `catalog.spec.schema.json` declares it `{"type": "string"}`. `validate-catalog-spec.mjs` invokes this manual validator rather than the schema, so a number, object, array, or `null` passed the advertised structural pre-flight and was then rejected by whatever schema-aware tooling the author reached for next — the worst possible order to learn it in, and the same class of "allowed but silently ignored" problem the surrounding `capture`/`priority` checks exist to prevent.

Now a type check beside the whitelist entry.

## Test plan

`node --test scripts/design-artifacts/catalog-spec.test.mjs` — 69 pass, 0 fail, including a new case asserting the error for `3`, `{}`, `[]`, `null` and `true`.

Non-visual: spec validation only.

_Generated by [Claude Code](https://claude.com/claude-code)_
