### PR TITLE
fix(ci): a served directory has no staging lane, so its viewer is cacheable

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1645,14 +1645,26 @@ class ServeHttpRoutingTest {
       )
     }
 
-    // compose-m3 carries an RC document without a published comparison manifest. Its viewer can
-    // gain capabilities asynchronously, so serving it from a cache while staging is pending would
-    // preserve an incomplete page after those capabilities arrive.
+    // compose-m3 carries an RC document with no published comparison manifest — and, being a served
+    // directory, no lane that will ever stage one. That is exactly the case
+    // `ServeBundleHost.stagesRcCompare` exists to separate: `rcComparePending()` means "the lane
+    // has not landed yet", NOT "there is no manifest on disk". Reading it off the file alone made
+    // `pending()` permanently true for every uploaded bundle and served directory, dropping their
+    // viewer pages to `no-store` for the life of the host — fully baked pages, and precisely the
+    // ones edge caching is for. So this one is cacheable like any other static viewer.
+    //
+    // The genuinely-pending case (a catalog whose staging lane is still running, where caching an
+    // incomplete page would outlive the capabilities arriving) is covered at the seam that decides
+    // it: see `viewerCacheControl(stagedCapabilitiesPending = true)` in ServeAuthTest. It cannot be
+    // reached from this fixture, which has no lane to be pending on.
     val pendingViewerReq =
       Request.Builder().url("http://127.0.0.1:${server.port}/compose-m3/p/$previewId").build()
     client.newCall(pendingViewerReq).execute().use { response ->
       assertEquals("static-page", response.header(ServeHttpServer.GENERATION_HEADER))
-      assertEquals("no-store", response.header("Cache-Control"))
+      assertTrue(
+        response.header("Cache-Control")?.startsWith("public, max-age=60") == true,
+        "no staging lane means nothing to wait for; was ${response.header("Cache-Control")}",
+      )
     }
 
     val missingViewerReq =


### PR DESCRIPTION
`ServeHttpRoutingTest > public browse pages and baked previews advertise static generation` has failed on **every** run since [#4188](https://github.com/yschimke/compose-ai-tools/pull/4188), on `main` and on every PR branched from it. Reproduced locally at `origin/main`, so it is not a CI flake.

## The server is right; the assertion is wrong

#4188 added an assertion that the `compose-m3` viewer answers `no-store`, on the reasoning that "its viewer can gain capabilities asynchronously, so serving it from a cache while staging is pending would preserve an incomplete page."

That reasoning holds for a catalog with a staging lane. This fixture is a **served directory**, which has none. `rcComparePending()` is `stagesRcCompare && rcCompare.pending()`, and `stagesRcCompare` exists precisely to draw that line — only `ServeCatalogStore` schedules the lane, and only for a catalog with previews to re-key. `ServeBundleHost`'s KDoc records what happens without it, in as many words:

> Gating on the file alone made `pending()` permanently true for those, which dropped every one of their viewer pages to `no-store` for the life of the host: the pages are fully baked and exactly the ones edge caching is for.

Making the server satisfy the assertion means reintroducing that regression. So the assertion changes instead: a laneless session's viewer is cacheable like any other static viewer, and the comment now explains the distinction rather than restating the symptom.

## The pending case is not lost

It was already covered before #4188, at the seam that actually decides it — `viewerCacheControl(stagedCapabilitiesPending = true)` in `ServeAuthTest`, asserting `no-store` with the note "a viewer assembled before staged RC discovery completes must not be cached". That test passes and is untouched. The routing fixture simply cannot reach the pending branch, having no lane to be pending on.

## Test plan

- `./gradlew :cli:test --tests '*ServeHttpRoutingTest*' --tests '*ServeAuthTest*'` — green.
- `./gradlew :cli:ktfmtCheckTest` — clean.
- Confirmed the failure reproduces at `origin/main` before the change.

Non-visual: a test assertion and its comment.

_Generated by [Claude Code](https://claude.com/claude-code)_
