### PR TITLE
fix(serve): rename a helper colliding with the preview, and scope usage rules per module

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.serve.UsageRules.Companion.appliesToModule
 import ee.schimke.composeai.cli.serve.UsageRules.Companion.declaresCatalogScaffolds
 import java.util.concurrent.ConcurrentHashMap
 
@@ -325,7 +326,8 @@ class PlaygroundSeedResolver(
     rulesCache[key]
       ?.takeIf { now - it.second < ttlSeconds * 1000 }
       ?.let {
-        return it.first
+        return it.first.takeIf { rules -> rules.appliesToModule(where.module) }
+          ?: UsageRules.GENERIC
       }
     val url = ServeUrls.githubRawUrl(where.repo, where.ref, null, USAGE_RULES_FILE)
     val rules =
@@ -347,7 +349,9 @@ class PlaygroundSeedResolver(
     // parsed rules object and (below) up to the fetch cap of string data.
     evictExpired(rulesCache, now)
     if (rulesCache.size < maxEntries) rulesCache[key] = rules to now
-    return rules
+    // Cached by `(repo, ref)` because that is what was FETCHED; scoped by module on the way out,
+    // because a repo can publish several catalogs from one rules file. See [UsageRules.modules].
+    return rules.takeIf { it.appliesToModule(where.module) } ?: UsageRules.GENERIC
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -132,6 +132,19 @@ object PlaygroundSourceCleaner {
       }
     }
 
+    // A cross-file helper whose name equals the ENTRY's is not satisfied by the entry declaration,
+    // and treating it as satisfied produces a preview that calls itself. Renamed before the helper
+    // closure runs, so the reference below resolves to a declaration that will actually be emitted.
+    val collision =
+      resolveEntryNameCollision(
+        blocks[entryIndex].name,
+        cleanedByIndex[entryIndex],
+        helpers,
+        declaredAt.keys + rules.scaffolds.keys,
+      )
+    val closureHelpers = collision?.helpers ?: helpers
+    collision?.let { cleanedByIndex[entryIndex] = it.entryBody }
+
     // Then the same closure across the declared scaffold sources. A catalog whose component
     // bodies live in a shared module leaves the cleaned text calling `StatefulCheckbox` or
     // `CardContentSlot` — names as unresolvable to a reader as the sticker frame was, and which
@@ -141,7 +154,7 @@ object PlaygroundSourceCleaner {
     val cleanedHelpers =
       closeOverHelpers(
         seeds = cleanedByIndex.values,
-        helpers = helpers,
+        helpers = closureHelpers,
         skip = declaredAt.keys + rules.scaffolds.keys,
         rules = rules,
         strings = strings,
@@ -981,6 +994,92 @@ object PlaygroundSourceCleaner {
    * declares (the same-file closure has it), and what the rules describe (a declared scaffold is
    * rewritten, never copied in — copying it would defeat the rule and re-introduce the machinery).
    */
+  /**
+   * The rename applied when a cross-file helper shares the entry preview's name.
+   *
+   * [helpers] is re-keyed so the closure emits the helper under [renamedTo]; [entryBody] is the
+   * entry with its *calls* rewritten to match, its own declaration left alone.
+   */
+  private class EntryNameCollision(
+    val helpers: Map<String, Helper>,
+    val entryBody: String,
+    val renamedTo: String,
+  )
+
+  /**
+   * Rename a scaffold-source helper that collides with the entry preview's own name, or null when
+   * there is nothing to rename.
+   *
+   * `skip` in [closeOverHelpers] carries every name the preview file declares, on the sound
+   * reasoning that a local declaration already satisfies the reference. The entry is the one name
+   * that reasoning fails for. After EXPAND runs, the entry's body is the *sticker's* body, and the
+   * sticker's body calls the component — which in a delegating catalog can be the same name as the
+   * preview that shows it. The checked-in m3 catalog is exactly this: `CatalogStates.kt` declares
+   * `fun SegmentedToggle() = Sticker("segmentedbutton")`, and that slug's branch in
+   * `CatalogComponents.kt` calls `SegmentedToggle()`. Treating the entry declaration as satisfying
+   * the call emitted a preview whose body calls itself — unbounded recursion, reported as clean
+   * with no residue.
+   *
+   * Renaming rather than inlining: the helper keeps its own shape, so a reader sees the component
+   * as its author wrote it, and only the name moves. Inlining would flatten a component body into
+   * the preview and lose that.
+   */
+  private fun resolveEntryNameCollision(
+    entryName: String?,
+    entryBody: String?,
+    helpers: Map<String, Helper>,
+    taken: Set<String>,
+  ): EntryNameCollision? {
+    if (entryName == null || entryBody == null) return null
+    val helper = helpers[entryName] ?: return null
+    // Declaring the name is not the problem; CALLING it is. A preview that merely shares a name
+    // with something in the shared module, and never references it, needs nothing done.
+    val callSites = callOccurrences(entryBody, entryName)
+    if (callSites.isEmpty()) return null
+
+    val renamed = freshName(entryName, taken + helpers.keys)
+    // Every word occurrence in the helper — its declaration, and any recursion inside it.
+    val renamedText =
+      replaceAt(helper.text, wordOccurrences(helper.text, entryName), entryName, renamed)
+    return EntryNameCollision(
+      helpers = helpers - entryName + (renamed to helper.copy(text = renamedText)),
+      entryBody = replaceAt(entryBody, callSites, entryName, renamed),
+      renamedTo = renamed,
+    )
+  }
+
+  /**
+   * Offsets in [text] where [name] is *called* — followed by `(`, and not itself the `fun` header.
+   *
+   * The distinction is the whole point: the entry's own `fun SegmentedToggle()` must keep its name
+   * (it is the preview the reader clicked), while the call that EXPAND put in its body must move to
+   * the renamed helper.
+   */
+  private fun callOccurrences(text: String, name: String): List<Int> =
+    wordOccurrences(text, name).filter { at ->
+      val after = text.drop(at + name.length).takeWhile { it.isWhitespace() || it == '(' }
+      if (!after.contains('(')) return@filter false
+      val before = text.take(at).trimEnd()
+      !before.endsWith("fun")
+    }
+
+  /** [text] with each offset in [at] (which must all start [from]) replaced by [to]. */
+  private fun replaceAt(text: String, at: List<Int>, from: String, to: String): String {
+    if (at.isEmpty()) return text
+    val builder = StringBuilder(text)
+    for (offset in at.sortedDescending()) builder.replace(offset, offset + from.length, to)
+    return builder.toString()
+  }
+
+  /** `Name`, `NameComponent`, `NameComponent2`, … — the first not already spoken for. */
+  private fun freshName(base: String, taken: Set<String>): String {
+    val preferred = base + "Component"
+    if (preferred !in taken) return preferred
+    var suffix = 2
+    while ("$preferred$suffix" in taken) suffix++
+    return "$preferred$suffix"
+  }
+
   private fun closeOverHelpers(
     seeds: Collection<String>,
     helpers: Map<String, Helper>,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageRules.kt
@@ -49,6 +49,25 @@ data class UsageRules(
    * through the file's own imports, so a rule here can never strike an unrelated annotation that
    * happens to share a name.
    */
+  /**
+   * Gradle module paths these rules describe — `["samples:design-catalog-m3", …]`.
+   *
+   * **Empty means every module in the repo**, which is what a single-catalog repo wants and what
+   * every existing rules file gets.
+   *
+   * It matters for a repo that publishes SEVERAL catalogs, as this one does. The rules file is read
+   * once per `(repo, ref)`, so without scoping the m3 sticker sheet's `Sticker`/`CatalogComponent`
+   * scaffolds and its `scaffoldSources` were also handed to the Wear and Remote catalogs, whose
+   * helpers are not declared there at all. Two consequences, both silent: their snippets could not
+   * resolve a helper the rules never named (Wear previews call the cross-file `wearCounted`), and
+   * `declaresCatalogScaffolds` — the Source panel's "the catalog declared its scaffolding, so what
+   * is left is usage code" note — answered *true* for catalogs that had declared nothing, dressing
+   * an unresolved snippet in the stronger claim.
+   *
+   * A location whose module is not listed falls back to [GENERIC], the same path a catalog with no
+   * rules file takes.
+   */
+  @SerialName("modules") val modules: List<String> = emptyList(),
   @SerialName("scaffoldAnnotationPackages")
   val scaffoldAnnotationPackages: List<String> = emptyList(),
 
@@ -371,6 +390,18 @@ data class UsageRules(
      * claim a declaration it never made.
      */
     fun UsageRules.declaresCatalogScaffolds(): Boolean = catalogScaffolds().isNotEmpty()
+
+    /**
+     * Whether these rules describe [module] — see [UsageRules.modules].
+     *
+     * An unscoped file (the common case, and every file written before scoping existed) applies
+     * everywhere. A scoped file applies only where it says. A location with no module at all is
+     * treated as covered: the alternative is silently dropping to [GENERIC] on a catalog published
+     * before discovery recorded the field, which would be a regression for the very catalog the
+     * rules were written for.
+     */
+    fun UsageRules.appliesToModule(module: String?): Boolean =
+      modules.isEmpty() || module == null || module in modules
 
     /**
      * The scaffolds a catalog declared itself — the merged map minus the generic ones it inherited.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogUsageRulesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogUsageRulesTest.kt
@@ -15,6 +15,7 @@
  */
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.cli.serve.UsageRules.Companion.appliesToModule
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -147,5 +148,63 @@ class CatalogUsageRulesTest {
       rules.scaffoldSources.size <= PlaygroundSeedResolver.MAX_SCAFFOLD_SOURCES,
       "more scaffold sources than the resolver will read",
     )
+  }
+
+  /**
+   * The rules are scoped to the modules they were written for, and the scope actually covers the
+   * catalog they describe.
+   *
+   * Both halves matter and they fail in opposite directions. Too WIDE (the old unscoped file) and
+   * the m3 sticker sheet's scaffolds reach the Wear and Remote catalogs, whose helpers these rules
+   * never name — their snippets then carry unresolved calls under `declaresCatalogScaffolds`'s
+   * stronger "the catalog declared its scaffolding" note. Too NARROW — a module renamed here but
+   * not in `catalog.spec.json` — and the m3 catalog silently drops to the generic rules, which is
+   * issue #4169 all over again with nothing to say it regressed.
+   */
+  @Test
+  fun `the rules are scoped to the m3 modules they describe`() {
+    assertEquals(
+      listOf("samples:design-catalog-m3", "samples:design-catalog-m3-shared"),
+      rules.modules,
+    )
+
+    // The scope has to include the module the m3 catalog actually publishes under, read from the
+    // spec rather than repeated here.
+    val declared =
+      Regex(""""module"\s*:\s*"([^"]+)"""")
+        .find(File(root, "samples/design-catalog-m3/catalog.spec.json").readText())
+        ?.groupValues
+        ?.get(1)
+    assertTrue(
+      declared != null && rules.appliesToModule(declared),
+      "compose-usage.json does not cover the module the m3 catalog publishes under ($declared)",
+    )
+    // Every scaffold source lives in one of the scoped modules — a source outside them would be
+    // read for a catalog these rules no longer apply to.
+    assertTrue(
+      rules.scaffoldSources.all { path ->
+        rules.modules.any { path.startsWith(it.replace(':', '/') + "/") }
+      },
+      "a scaffold source lives outside the scoped modules: ${rules.scaffoldSources}",
+    )
+
+    // The sibling catalogs published from this same repo must NOT inherit them.
+    assertFalse(rules.appliesToModule("samples:design-catalog-wear-m3"))
+    assertFalse(rules.appliesToModule("samples:design-catalog-remote-m3"))
+  }
+
+  /**
+   * An unscoped rules file — every one written before scoping existed — still applies everywhere.
+   */
+  @Test
+  fun `rules naming no modules apply to every module`() {
+    val unscoped =
+      assertNotNull(UsageRules.parse("""{"scaffolds":{"Sticker":{"kind":"EXPAND"}}}"""))
+
+    assertTrue(unscoped.appliesToModule("samples:design-catalog-wear-m3"))
+    assertTrue(unscoped.appliesToModule(null))
+    // A scoped file still covers a location with no module at all: a catalog published before
+    // discovery recorded the field must not lose the rules that were written for it.
+    assertTrue(rules.appliesToModule(null))
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -1649,6 +1649,136 @@ class PlaygroundSourceCleanerTest {
     assertTrue(result.residue.contains("CatalogComponent"), result.residue.toString())
   }
 
+  /**
+   * The checked-in m3 catalog's shape, reduced: `CatalogStates.kt` declares `fun SegmentedToggle()
+   * = Sticker("segmentedbutton")`, and that slug's branch in `CatalogComponents.kt` calls
+   * `SegmentedToggle()` — a cross-file helper with the same name as the preview showing it.
+   *
+   * `skip` carries every name the preview file declares, on the reasoning that a local declaration
+   * satisfies the reference. The entry is the one name that fails for: after EXPAND, its body is
+   * the *sticker's* body, so the call is to the component, not to itself. Treating the entry as
+   * satisfying it emitted a preview whose body called itself — unbounded recursion, reported clean
+   * with no residue, and handed to the playground as a runnable snippet.
+   */
+  @Test
+  fun `a helper sharing the entry preview's name is renamed rather than skipped`() {
+    val previews =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+
+      @CatalogModes
+      @Composable
+      fun SegmentedToggle() = Sticker("segmentedbutton")
+      """
+        .trimIndent()
+    val components =
+      """
+      package demo.catalog.shared
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CatalogComponent(id: String) {
+        when (id) {
+          "segmentedbutton" -> SegmentedToggle()
+          else -> Text("unknown")
+        }
+      }
+
+      @Composable
+      fun SegmentedToggle() {
+        Text("Segmented")
+      }
+      """
+        .trimIndent()
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = previews,
+          bodyLine = lineIn(previews, "fun SegmentedToggle"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, components),
+        )
+      )
+
+    // The component came along, under a name that does not collide...
+    assertTrue(result.text.contains("fun SegmentedToggleComponent"), result.text)
+    assertTrue(result.text.contains("""Text("Segmented")"""), result.text)
+    // ...the preview keeps the name the reader clicked...
+    assertTrue(result.text.contains("fun SegmentedToggle()"), result.text)
+    // ...and it calls the component rather than itself.
+    assertTrue(result.text.contains("SegmentedToggleComponent()"), result.text)
+    assertFalse(
+      result.text.substringAfter("fun SegmentedToggle()").contains("\n  SegmentedToggle()"),
+      "the preview must not call itself:\n${result.text}",
+    )
+    assertEquals(emptyList(), result.residue, result.text)
+  }
+
+  /**
+   * A preview merely SHARING a name with a shared-module declaration it never calls is untouched.
+   */
+  @Test
+  fun `a name shared with an uncalled helper is left alone`() {
+    val previews =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+
+      @CatalogModes
+      @Composable
+      fun FilledButton() = Sticker("button-filled")
+      """
+        .trimIndent()
+    val components =
+      """
+      package demo.catalog.shared
+
+      import androidx.compose.material3.Button
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CatalogComponent(id: String) {
+        when (id) {
+          "button-filled" -> {
+            val label = "Filled"
+            Button(onClick = {}) { Text(label) }
+          }
+          else -> Text("unknown")
+        }
+      }
+
+      @Composable
+      fun FilledButton() {
+        Text("not the one the sticker dispatches to")
+      }
+      """
+        .trimIndent()
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = previews,
+          bodyLine = lineIn(previews, "fun FilledButton"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, components),
+        )
+      )
+
+    // The branch inlines the button directly, so nothing calls `FilledButton` and no rename
+    // happens.
+    assertTrue(result.text.contains("fun FilledButton() {"), result.text)
+    assertFalse(result.text.contains("FilledButtonComponent"), result.text)
+  }
+
   private fun lineIn(text: String, needle: String): Int =
     text.lines().indexOfFirst { it.contains(needle) } + 1
 }

--- a/compose-usage.json
+++ b/compose-usage.json
@@ -15,7 +15,18 @@
     "`Sticker(\"<slug>\")` over the shared component set in :samples:design-catalog-m3-shared, so",
     "without `scaffoldSources` + EXPAND the Source panel showed the wrapper and no component at",
     "all (issue #4169). The wear and remote catalogs compose their components inline and need",
-    "nothing here beyond the generic rules they already inherit."
+    "nothing here beyond the generic rules they already inherit.",
+    "",
+    "`modules` is what keeps that true. The server reads ONE compose-usage.json per (repo, ref),",
+    "so without it these m3-only rules reached the wear and remote catalogs too: scaffoldSources",
+    "naming files their previews never touch, and `declaresCatalogScaffolds` claiming on the",
+    "Source panel that they had declared scaffolding they had not. Both silent. A catalog whose",
+    "module is not listed falls back to the generic rules, exactly as a repo shipping no",
+    "compose-usage.json does."
+  ],
+  "modules": [
+    "samples:design-catalog-m3",
+    "samples:design-catalog-m3-shared"
   ],
   "scaffoldAnnotationPackages": [
     "com.example.designcatalogm3"


### PR DESCRIPTION
The two P1s Codex raised on [#4179](https://github.com/yschimke/compose-ai-tools/pull/4179), which merged before the review landed. Both are silent — the Source panel reports a clean snippet with no residue either way.

## A preview that calls itself

`closeOverHelpers` skips every name the preview file declares, on the sound reasoning that a local declaration already satisfies the reference. The **entry** is the one name that reasoning fails for. After EXPAND runs, the entry's body is the *sticker's* body, so the call in it is to the component — and in a delegating catalog the component can carry the preview's own name.

The checked-in m3 catalog is exactly that shape:

- `CatalogStates.kt:67` — `fun SegmentedToggle() = Sticker("segmentedbutton")`
- `CatalogComponents.kt:342` — `"segmentedbutton" -> SegmentedToggle()`

So the cleaned snippet was `fun SegmentedToggle()` whose body calls `SegmentedToggle()`, with the shared component never emitted. Unbounded recursion, handed to the playground as runnable.

The colliding helper is now renamed — `SegmentedToggleComponent` — and the entry's **calls** rewritten to match, while its own `fun` header keeps the name the reader clicked. Renaming rather than inlining, so the component keeps the shape its author gave it and only the name moves. A preview that merely *shares* a name with a shared-module declaration it never calls is left alone.

## M3 rules were reaching the Wear and Remote catalogs

`PlaygroundSeedResolver` reads one `compose-usage.json` per `(repo, ref)`, and this repo publishes three catalogs. The m3 sticker sheet's `Sticker`/`CatalogComponent` scaffolds and its `scaffoldSources` were therefore also applied to Wear and Remote, whose helpers those rules never name — Wear previews call the cross-file `wearCounted`, which is neither in the scaffold sources nor in residue. Worse, `declaresCatalogScaffolds()` answered **true** for them, so the Source panel dressed an unresolved snippet in the stronger claim that the catalog had declared its own scaffolding.

`UsageRules.modules` scopes a rules file to the modules it describes, and this repo's file now names the two m3 modules. **Empty means every module**, so every rules file written before this — here and in any downstream catalog repo — behaves exactly as it did. A location whose module is not listed falls back to `GENERIC`, the same path a repo with no rules file takes; a location with no module at all is treated as covered, so a catalog published before discovery recorded the field does not silently lose the rules written for it.

The test pins both failure directions: too wide (Wear and Remote must not inherit) and too narrow (the scope must still cover the module `samples/design-catalog-m3/catalog.spec.json` actually declares, read from the spec rather than repeated), plus that every scaffold source lives inside a scoped module.

## Test plan

- `./gradlew :cli:test` — 2526 tests, one failure: `ServeHttpRoutingTest > public browse pages and baked previews advertise static generation`, which is inherited from `main` and fixed separately in [#4204](https://github.com/yschimke/compose-ai-tools/pull/4204). Everything else green.
- Confirmed the collision test fails against the unfixed cleaner (self-recursive output) and passes with it.
- `./gradlew :cli:ktfmtCheck` — clean.

Non-visual: the Source panel's snippet text, not a rendered surface.

_Generated by [Claude Code](https://claude.com/claude-code)_
