### PR TITLE
fix(deploy,serve): address Codex review on the rollout and verification fixes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -430,7 +430,7 @@ class CatalogThemeCache(
         // adopted entries are withheld from the read path (see [get]) and the next verification
         // pass tries again, which is the quarantine this case needs.
         if (discarded) persistenceTrusted.set(true)
-        return VerifyOutcome.MISMATCH
+        return if (discarded) VerifyOutcome.MISMATCH else VerifyOutcome.MISMATCH_UNDISCARDED
       }
     }
     // Zero successful comparisons is NOT a pass. Every sampled render can come back Busy, Failed or
@@ -450,7 +450,20 @@ class CatalogThemeCache(
     /** The renderer answered nothing usable, so the question is still open. Ask again. */
     NO_EVIDENCE,
     /** A persisted render no longer matches; the generation has been discarded. */
-    MISMATCH;
+    MISMATCH,
+    /**
+     * A persisted render no longer matches, and the generation could **not** be discarded — its
+     * write lock stayed held through every retry.
+     *
+     * Separate from [MISMATCH] because the two need opposite treatment from the caller. After a
+     * successful discard the question is answered: the suspect bytes are gone and verification can
+     * latch. Here they are still on disk, so the caller must NOT latch — the adopted entries stay
+     * withheld from the read path and the next pass has to ask again. Latching would leave them
+     * quarantined for the life of the process while the optimizer, which reads `contains`, went on
+     * believing they were present: repeated foreground renders, stale files, and no further attempt
+     * to clear either.
+     */
+    MISMATCH_UNDISCARDED;
 
     /** Whether the persisted renders may be trusted from here on. */
     val settled: Boolean

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -591,6 +591,17 @@ class ServeCatalogLiveHost(
           "dropped the generation and re-warming from scratch"
       )
     }
+    // Deliberately NOT latched. The mismatch was detected but the generation is still on disk (its
+    // write lock stayed held), so the question is not answered and the next pass must ask again.
+    // Latching here would quarantine the adopted entries for the life of the process — withheld
+    // from reads, still reported by `contains`, so the optimizer skips re-warming them — with
+    // nothing left that would ever try the discard again.
+    if (outcome == CatalogThemeCache.VerifyOutcome.MISMATCH_UNDISCARDED) {
+      System.err.println(
+        "serve: catalog $label — persisted theme renders no longer match this renderer, and the " +
+          "generation could not be discarded (write lock held); withholding them and retrying"
+      )
+    }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import java.io.File
+import java.io.RandomAccessFile
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -628,6 +629,49 @@ class ThemeCachePersistenceTest {
     assertEquals(CatalogThemeCache.VerifyOutcome.MISMATCH, outcome)
     assertEquals(0, cache.snapshot().cached, "a failed verification leaves nothing behind")
     assertNull(cache.get("one"))
+  }
+
+  /**
+   * A discard the write lock refuses is not a discard, and must not be reported as one.
+   *
+   * `verifySample` used to set `persistenceTrusted` on any mismatch, ignoring whether `discard`
+   * actually succeeded — so PNGs it had just proved wrong stayed on disk and were immediately
+   * servable as verified. Honouring the result fixed that, but returning plain `MISMATCH` was still
+   * wrong one level up: `ServeCatalogLiveHost` latches `persistenceVerified` for MISMATCH, so the
+   * retry this case depends on would never come, and the entries would stay withheld from reads
+   * while `contains` kept the optimizer from re-warming them.
+   */
+  @Test
+  fun `a discard blocked by the write lock is not reported as settled`() {
+    val root = tempDir()
+    val fp = "b".repeat(64)
+    store(root).open("m3-catalog", fp, inputs(fp))!!.also {
+      it.put("one", byteArrayOf(1))
+      it.put("two", byteArrayOf(2))
+    }
+    val generation = store(root).open("m3-catalog", fp, inputs(fp))!!
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configureTargets(listOf("one", "two"))
+
+    // Hold the generation's write lock from another channel in this process, the way a foreground
+    // render publishing into the same generation does.
+    val lockFile = File(File(File(root, "m3-catalog"), fp), ".write.lock")
+    RandomAccessFile(lockFile, "rw").use { raf ->
+      raf.channel.lock().use {
+        val outcome = cache.verifySample { byteArrayOf(99) }
+
+        assertEquals(CatalogThemeCache.VerifyOutcome.MISMATCH_UNDISCARDED, outcome)
+        assertFalse(outcome.settled, "an undiscarded mismatch leaves verification unfinished")
+        // The suspect entries are withheld rather than served...
+        assertNull(cache.get("one"))
+        // ...and the bytes are still there, which is exactly why the caller must ask again.
+        val generationDir = File(File(root, "m3-catalog"), fp)
+        assertTrue(
+          generationDir.listFiles().orEmpty().any { it.name.endsWith(".png") },
+          "the suspect PNGs are still on disk, which is why the caller has to ask again",
+        )
+      }
+    }
   }
 
   @Test

--- a/deploy/image/docker-rollout
+++ b/deploy/image/docker-rollout
@@ -226,16 +226,29 @@ main() {
   # shellcheck disable=SC2086 # DOCKER_ARGS and OLD_CONTAINER_IDS must be unquoted to allow multiple arguments
   docker $DOCKER_ARGS rm $OLD_CONTAINER_IDS || true
 
+  # Three outcomes per container, and only one of them is success. A failed `inspect` is NOT proof
+  # the container is gone: if the daemon or socket went away — the same thing that would have made
+  # `stop`/`rm` fail a moment ago — every inspect fails too, and reading that as "gone" hands back
+  # the clean bill of health this check exists to withhold. So the CONFIRMED absence is matched
+  # explicitly, and anything else counts as unverified.
   SURVIVING_CONTAINER_IDS=""
+  UNVERIFIED_CONTAINER_IDS=""
   for OLD_CONTAINER_ID in $OLD_CONTAINER_IDS; do
     # shellcheck disable=SC2086 # DOCKER_ARGS must be unquoted to allow multiple arguments
-    if docker $DOCKER_ARGS inspect --format='{{.Id}}' "$OLD_CONTAINER_ID" >/dev/null 2>&1; then
+    if INSPECT_ERROR="$(docker $DOCKER_ARGS inspect --format='{{.Id}}' "$OLD_CONTAINER_ID" 2>&1 >/dev/null)"; then
       SURVIVING_CONTAINER_IDS="$SURVIVING_CONTAINER_IDS $OLD_CONTAINER_ID"
+    elif ! echo "$INSPECT_ERROR" | grep -qiE 'no such (object|container)'; then
+      UNVERIFIED_CONTAINER_IDS="$UNVERIFIED_CONTAINER_IDS $OLD_CONTAINER_ID"
     fi
   done
   if [ -n "$SURVIVING_CONTAINER_IDS" ]; then
     echo "==> ERROR: old containers survived cleanup:$SURVIVING_CONTAINER_IDS" >&2
     echo "==> The new replicas are healthy but the old ones are still running. Remove them by hand." >&2
+    exit 1
+  fi
+  if [ -n "$UNVERIFIED_CONTAINER_IDS" ]; then
+    echo "==> ERROR: could not confirm old containers were removed:$UNVERIFIED_CONTAINER_IDS" >&2
+    echo "==> Last inspect error: $INSPECT_ERROR" >&2
     exit 1
   fi
 }

--- a/deploy/image/rollout.sh
+++ b/deploy/image/rollout.sh
@@ -47,11 +47,38 @@ release_rollout_lock() {
 # terminate; EXIT keeps the plain cleanup, and `trap - EXIT` stops it running twice (harmless, since
 # the release is idempotent, but it would log a second removal attempt).
 on_rollout_signal() {
+  # Kill whatever this runner is blocked on first. See [run_interruptible].
+  if [ -n "${rollout_child:-}" ]; then
+    kill -TERM "$rollout_child" 2>/dev/null || true
+    wait "$rollout_child" 2>/dev/null || true
+    rollout_child=""
+  fi
   release_rollout_lock
   trap - EXIT
   # 128 + signal number: the conventional status for a signal-terminated process, so a supervisor
   # can tell an interrupted rollout from a failed one.
   exit "$((128 + $1))"
+}
+
+# Run a command so a trapped signal reaches the handler NOW rather than after it finishes.
+#
+# A POSIX shell defers a trapped signal until the running FOREGROUND child returns. This script is
+# PID 1 in the `rollout` compose service, where the two things it blocks on are exactly the long
+# ones: `docker rollout` can sit in its health timeout (default 300s) and the poll loop sleeps for
+# `$ROLLOUT_INTERVAL` (default 1200s). A plain foreground call therefore meant `docker stop` on the
+# service would hit its grace period and SIGKILL the shell before the handler ever ran — leaving the
+# lock CONTAINER alive for its whole TTL and blocking both the poller and the webhook runner from
+# deploying, which is the failure the lock exists to avoid, arrived at from the other side.
+#
+# Backgrounding and `wait`ing fixes it: `wait` is interruptible, so the handler runs immediately and
+# can take the child down with it.
+run_interruptible() {
+  "$@" &
+  rollout_child=$!
+  rc=0
+  wait "$rollout_child" || rc=$?
+  rollout_child=""
+  return "$rc"
 }
 
 arm_rollout_lock_traps() {
@@ -139,7 +166,7 @@ roll_once() {
   # loop below) or in an `if` condition, so a failed `docker rollout` would
   # otherwise fall through to the success log and a 0 return — reporting a failed
   # rollout as rolled. Inside the `else`, `$?` still holds the rollout exit code.
-  if docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"; then
+  if run_interruptible docker rollout --timeout "$HEALTH_TIMEOUT" "$SERVICE"; then
     log "'$SERVICE' rolled"
     release_rollout_lock
     trap - EXIT INT TERM
@@ -157,7 +184,10 @@ if [ "${1:-}" = "--loop" ]; then
   log "polling '$SERVICE' every ${INTERVAL}s for zero-downtime updates"
   while true; do
     roll_once || log "roll attempt failed — will retry next cycle"
-    sleep "$INTERVAL"
+    # Interruptible for the same reason the rollout is: at the default interval this shell spends
+    # almost all of its life right here, so a foreground `sleep` is where a shutdown signal would
+    # most often be swallowed.
+    run_interruptible sleep "$INTERVAL" || true
   done
 else
   roll_once

--- a/deploy/image/test-rollout-cleanup.sh
+++ b/deploy/image/test-rollout-cleanup.sh
@@ -42,6 +42,13 @@ cat > "${work}/bin/docker" <<'STUB'
 case "$1" in
   inspect)
     id="${!#}"
+    # $DAEMON_DOWN stands in for the daemon or socket having gone away — the same condition that
+    # would have failed the stop/rm a moment earlier. Inspect cannot answer, and must not be read
+    # as an answer.
+    if [ -n "${DAEMON_DOWN:-}" ]; then
+      echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock." >&2
+      exit 1
+    fi
     for survivor in ${SURVIVORS:-}; do
       if [ "$survivor" = "$id" ]; then echo "$id"; exit 0; fi
     done
@@ -67,13 +74,20 @@ cleanup_tail() {
   docker rm $OLD_CONTAINER_IDS || true
 
   SURVIVING_CONTAINER_IDS=""
+  UNVERIFIED_CONTAINER_IDS=""
   for OLD_CONTAINER_ID in $OLD_CONTAINER_IDS; do
-    if docker inspect --format='{{.Id}}' "$OLD_CONTAINER_ID" >/dev/null 2>&1; then
+    if INSPECT_ERROR="$(docker inspect --format='{{.Id}}' "$OLD_CONTAINER_ID" 2>&1 >/dev/null)"; then
       SURVIVING_CONTAINER_IDS="$SURVIVING_CONTAINER_IDS $OLD_CONTAINER_ID"
+    elif ! echo "$INSPECT_ERROR" | grep -qiE 'no such (object|container)'; then
+      UNVERIFIED_CONTAINER_IDS="$UNVERIFIED_CONTAINER_IDS $OLD_CONTAINER_ID"
     fi
   done
   if [ -n "$SURVIVING_CONTAINER_IDS" ]; then
     echo "==> ERROR: old containers survived cleanup:$SURVIVING_CONTAINER_IDS" >&2
+    exit 1
+  fi
+  if [ -n "$UNVERIFIED_CONTAINER_IDS" ]; then
+    echo "==> ERROR: could not confirm removal:$UNVERIFIED_CONTAINER_IDS" >&2
     exit 1
   fi
 }
@@ -93,9 +107,21 @@ status=0
 ( cleanup_tail ) >/dev/null 2>&1 || status=$?
 check "a surviving old container fails the cleanup" "1" "$status"
 
+# A daemon that cannot answer is not a daemon saying "gone". Reading a failed inspect as absence
+# reinstates exactly the clean bill of health the survivor check exists to withhold.
+export SURVIVORS="" DAEMON_DOWN=1
+status=0
+( cleanup_tail ) >/dev/null 2>&1 || status=$?
+check "an unverifiable inspect fails rather than passing" "1" "$status"
+unset DAEMON_DOWN
+
 grep -q 'SURVIVING_CONTAINER_IDS' "${here}/docker-rollout" &&
   survivor_check=present || survivor_check=missing
 check "docker-rollout still carries the survivor check" "present" "$survivor_check"
+
+grep -q 'UNVERIFIED_CONTAINER_IDS' "${here}/docker-rollout" &&
+  unverified_check=present || unverified_check=missing
+check "docker-rollout distinguishes unverifiable from gone" "present" "$unverified_check"
 
 # --- 2. rollout.sh's signal traps ------------------------------------------------------------
 # A shell that installs the same traps, then signals itself mid-"rollout". The marker file stands
@@ -124,6 +150,62 @@ LOG="${work}/signal.log" status=0
 LOG="$LOG" "${work}/signal-case.sh" || status=$?
 check "a signalled runner exits rather than resuming" "released" "$(cat "${work}/signal.log")"
 check "and reports 128 + SIGTERM" "143" "$status"
+
+# The PID-1 case the plain self-signal above does NOT cover: a POSIX shell defers a trapped signal
+# until the running FOREGROUND child returns, and this script blocks on `docker rollout` (up to its
+# 300s health timeout) and on the poll `sleep` (1200s by default). Backgrounding and `wait`ing is
+# what lets the handler run at once — otherwise `docker stop` on the rollout service SIGKILLs the
+# shell before cleanup, stranding the lock container for its whole TTL.
+cat > "${work}/interruptible-case.sh" <<'CASE'
+#!/bin/sh
+set -eu
+rollout_child=""
+release_rollout_lock() { echo released >> "$LOG"; }
+on_rollout_signal() {
+  if [ -n "${rollout_child:-}" ]; then
+    kill -TERM "$rollout_child" 2>/dev/null || true
+    wait "$rollout_child" 2>/dev/null || true
+    rollout_child=""
+  fi
+  release_rollout_lock
+  trap - EXIT
+  exit "$((128 + $1))"
+}
+run_interruptible() {
+  "$@" &
+  rollout_child=$!
+  rc=0
+  wait "$rollout_child" || rc=$?
+  rollout_child=""
+  return "$rc"
+}
+trap release_rollout_lock EXIT
+trap 'on_rollout_signal 2' INT
+trap 'on_rollout_signal 15' TERM
+
+# Signal ourselves from a detached child, then block on a long "rollout". `self` is captured
+# before backgrounding: in a POSIX subshell `$PPID` still names THIS script's parent, so using it
+# would signal the test harness instead.
+self=$$
+(sleep 0.3; kill -TERM "$self") &
+run_interruptible sleep 30 || true
+echo resumed >> "$LOG"
+CASE
+chmod +x "${work}/interruptible-case.sh"
+
+LOG="${work}/interruptible.log" status=0
+start=$(date +%s)
+LOG="$LOG" "${work}/interruptible-case.sh" || status=$?
+elapsed=$(( $(date +%s) - start ))
+check "a signal during a long child is handled at once" "released" "$(cat "${work}/interruptible.log")"
+check "and still reports 128 + SIGTERM" "143" "$status"
+[ "$elapsed" -lt 10 ] && promptly=yes || promptly=no
+check "without waiting out the child (${elapsed}s)" "yes" "$promptly"
+
+grep -q 'run_interruptible docker rollout' "${here}/rollout.sh" && rolls=present || rolls=missing
+check "rollout.sh runs the rollout interruptibly" "present" "$rolls"
+grep -q 'run_interruptible sleep' "${here}/rollout.sh" && sleeps=present || sleeps=missing
+check "rollout.sh sleeps interruptibly" "present" "$sleeps"
 
 # The real script must arm the traps this way, and never re-introduce the resuming form.
 grep -q "trap 'on_rollout_signal 15' TERM" "${here}/rollout.sh" && armed=present || armed=missing


### PR DESCRIPTION
Codex reviewed [#4199](https://github.com/yschimke/compose-ai-tools/pull/4199) after it merged, and all three findings are correct. Each one is the *same* class of bug the merged PR set out to fix — a failure path that reports success — surviving one level up from where it was patched.

## A failed `inspect` is not proof the container is gone

The survivor check read any non-zero `docker inspect` as absence. But if the daemon or socket went away — the same condition that would have failed the `stop`/`rm` a moment earlier — every `inspect` fails too, `SURVIVING_CONTAINER_IDS` stays empty, and the rollout exits successfully with none of the old replicas cleaned up. Exactly the clean bill of health the check exists to withhold.

The confirmed absence (`no such object` / `no such container`) is now matched explicitly; anything else is unverified and fails with the inspect error attached.

## The signal handler could not run when it mattered

`rollout.sh` is PID 1 in the `rollout` compose service, and a POSIX shell defers a trapped signal until the running **foreground** child returns. The two things this script blocks on are the long ones: `docker rollout` inside its 300-second health timeout, and the poll `sleep` at 1200 seconds by default — where the shell spends nearly all of its life. So `docker stop` on the service would hit its grace period and SIGKILL the shell before `on_rollout_signal` ever ran, stranding the lock *container* for its full TTL and blocking both the poller and the webhook runner. The lock's own failure mode, reached from the other side.

Both now go through `run_interruptible`, which backgrounds the command and `wait`s: `wait` is interruptible, so the handler runs immediately and takes the child down with it.

## `MISMATCH` after a failed discard still latched verification

The merged PR stopped `verifySample` trusting persistence when `discard()` failed, and said the next verification pass would try again. It would not: `ServeCatalogLiveHost.verifyPersistedRenders` latches `persistenceVerified` for **every** `MISMATCH`. Under sustained write-lock contention the adopted entries stayed withheld from reads for the life of the process while `contains` kept the optimizer from re-warming them — repeated foreground renders, stale files on disk, and nothing left that would ever retry the discard.

A failed discard now returns `MISMATCH_UNDISCARDED`: unsettled, not latched, logged distinctly. The two cases genuinely need opposite treatment — after a successful discard the question is answered, and here it is not.

## Test plan

- `deploy/image/test-rollout-cleanup.sh` — 14 assertions, up from 7. New: an unverifiable inspect fails rather than passing, and a signal arriving during a 30-second child is handled in under 10 seconds (with the 143 status), plus greps pinning `run_interruptible` on both blocking calls.
- `./gradlew :cli:test --tests '*ThemeCachePersistenceTest*'` — green, including a new case that holds the generation's write lock from another channel and asserts `MISMATCH_UNDISCARDED`, `!settled`, entries withheld, and the PNGs still on disk.
- `./gradlew :cli:ktfmtCheck` — clean. `sh -n` on both scripts.

Non-visual: deployment scripts and server-side verification.

_Generated by [Claude Code](https://claude.com/claude-code)_
