### PR TITLE
fix(release): check the Swift tag before writing, and compute one snapshot version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,28 @@ jobs:
   # consumer resolving `v<version>` would get the wrong binary. The Swift tag points at the commit
   # made after the upload, which is the first commit where the two agree. Consumers depend on it.
   #
-  # It is a BARE `<version>` tag (`1.16.0`), not `swift/<version>`. SwiftPM only recognizes a tag as
-  # a semantic version when the whole ref is `X.Y.Z` or `vX.Y.Z`; a `swift/1.16.0` ref is invisible
-  # to `.package(..., from: "1.16.0")`, which is the only consumption syntax this repo documents. A
-  # bare tag is resolvable and cannot collide with the `v<version>` release tag, and `release.yml`'s
-  # own push trigger is `v*`, so tagging it here does not re-enter this workflow.
+  # It is a BARE `<version>` tag (`1.16.0`), not `swift/<version>`. SwiftPM reads a ref as a semantic
+  # version only when the whole ref is `X.Y.Z` or `vX.Y.Z`, so `swift/1.16.0` is invisible to
+  # `.package(..., from: "1.16.0")` — the only consumption syntax this repo documents.
+  #
+  # Note what that means for `v<version>`: it IS visible to SwiftPM, and its `Package.swift`
+  # necessarily still describes the PREVIOUS release. So `from:` did not resolve nothing — it
+  # resolved the WRONG framework. Measured against Swift 6.3: with both refs present SwiftPM picks
+  # the bare tag, in both tag orderings (bare older and bare newer), so once this job has run the
+  # bare tag governs. Two consequences worth stating plainly:
+  #
+  #   * There is a window. `v<version>` exists from the moment the release chain tags it until this
+  #     job pushes the bare tag, and a `from:` resolve inside that window gets the stale framework.
+  #     Minutes in the normal case, since both happen in one release run.
+  #   * If this job FAILS, the window never closes. That is the case to watch — the release chain
+  #     will have already written `v<version>`, and it is SwiftPM-visible and wrong. Re-run this
+  #     job; it is idempotent (see the tag step).
+  #
+  # Closing the window entirely needs `Package.swift` at `v<version>` to already be correct, which
+  # the checksum ordering forbids, or the Swift package to live in its own repository. #4068.
+  #
+  # `release.yml`'s own push trigger is `v*`, so tagging a bare version here does not re-enter this
+  # workflow.
   #
   # The BUILD comes from `TAG_NAME`, not from `main`. `main` can advance between the tag being cut
   # and this job starting, and an XCFramework built from a newer `main` would be attached to — and
@@ -259,9 +276,34 @@ jobs:
           checksum="$(cat rc-player/compose/build/distributions/RcComposePlayer.xcframework.zip.sha256)"
           url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/RcComposePlayer.xcframework.zip"
 
-          # The build above ran against $TAG_NAME; the commit has to land on main.
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Bare `<version>`, which is what SwiftPM resolves. See the job comment.
+          swift_tag="${PLUGIN_VERSION}"
+
+          # THE EXISTING TAG IS CHECKED FIRST, before anything is written. A `workflow_dispatch`
+          # re-release of an older version runs against a `main` that has since advanced, so
+          # rewriting and pushing first would commit this release's (older) url and checksum over a
+          # newer `Package.swift` and only then discover the tag was already there. Deciding from
+          # the TAG's own `Package.swift` — not from `main`'s — is also what makes the idempotent
+          # case honest: "already released, and the file at that tag describes this exact asset."
+          # `--refs` drops the peeled `^{}` line, so a lightweight tag yields exactly one SHA.
+          existing="$(git ls-remote --refs --tags origin "refs/tags/${swift_tag}" | cut -f1)"
+          if [ -n "$existing" ]; then
+            git fetch --no-tags --depth 1 origin "$existing"
+            tagged="$(git show "${existing}:Package.swift")"
+            if printf '%s' "$tagged" | grep -qF "\"$url\"" &&
+              printf '%s' "$tagged" | grep -qF "checksum: \"$checksum\""; then
+              echo "tag ${swift_tag} already describes this asset; nothing to do"
+              exit 0
+            fi
+            echo "tag ${swift_tag} exists at ${existing} but its Package.swift describes a" >&2
+            echo "different asset than ${TAG_NAME}'s. Refusing to move it." >&2
+            exit 1
+          fi
+
+          # The build above ran against $TAG_NAME; the commit has to land on main.
           git fetch --no-tags origin main
           git checkout -B release-package-swift FETCH_HEAD
 
@@ -273,21 +315,8 @@ jobs:
             git commit -m "chore(release): point Package.swift at ${TAG_NAME}"
             git push origin HEAD:main
           fi
-
-          # Bare `<version>`: the only shape SwiftPM resolves. See the job comment.
-          swift_tag="${PLUGIN_VERSION}"
-          head="$(git rev-parse HEAD)"
-          # `--refs` drops the peeled `^{}` line, so a lightweight tag yields exactly one SHA.
-          existing="$(git ls-remote --refs --tags origin "refs/tags/${swift_tag}" | cut -f1)"
-          if [ -z "$existing" ]; then
-            git tag "$swift_tag"
-            git push origin "$swift_tag"
-          elif [ "$existing" = "$head" ]; then
-            echo "tag ${swift_tag} already points at ${head}"
-          else
-            echo "tag ${swift_tag} already exists at ${existing} but this release resolves to ${head}" >&2
-            exit 1
-          fi
+          git tag "$swift_tag"
+          git push origin "$swift_tag"
 
   # Build the runnable applications shipped on each GitHub Release: the CLI
   # (`compose-preview-*`) and the standalone MCP server (`compose-preview-mcp-*`).

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,8 +27,17 @@ permissions:
   contents: read
 
 jobs:
-  publish-snapshot:
+  # The snapshot coordinate, computed ONCE and handed to both publishers.
+  #
+  # Sharing `scripts/snapshot-version.sh` was not enough: each job does its own full-depth checkout
+  # and its own `git describe`, so they see whatever tags exist at their own start time. Both this
+  # workflow and release-please fire on a release-PR merge to `main`, and a `v*` tag created between
+  # the two checkouts would have one job computing from the previous tag and the other from the new
+  # one — publishing half the stack under a coordinate nothing resolves. One job, one answer.
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,18 +46,22 @@ jobs:
           persist-credentials: false
       - id: version
         name: Compute snapshot version
-        # Extracted to a script so this job and `publish-player-snapshot` compute the SAME version
-        # from the same code — two copies of this arithmetic would eventually disagree and publish
-        # half a stack under a different coordinate. `scripts/snapshot-version.sh --self-test`
-        # covers it, and CI runs that.
         env:
           REF_NAME: ${{ github.ref_name }}
           INPUT_SUFFIX: ${{ inputs.suffix || '' }}
         run: scripts/snapshot-version.sh
+
+  publish-snapshot:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Publish -SNAPSHOT to Maven Central snapshots
         env:
-          PLUGIN_VERSION: ${{ steps.version.outputs.version }}
+          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
@@ -78,19 +91,12 @@ jobs:
   # there: its Apple klibs only build on a Mac. Kept as its own job rather than moving the whole
   # snapshot to macOS, so the ordinary Linux publish stays on the cheaper, already-proven runner.
   publish-player-snapshot:
+    needs: version
     runs-on: macos-15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Need tags to compute the next snapshot version.
-          fetch-depth: 0
           persist-credentials: false
-      - id: version
-        name: Compute snapshot version
-        env:
-          REF_NAME: ${{ github.ref_name }}
-          INPUT_SUFFIX: ${{ inputs.suffix || '' }}
-        run: scripts/snapshot-version.sh
       - uses: ./.github/actions/setup
       # See `release.yml`'s `publish-xcframework`: CMP 1.11's `ui-uikit` needs the iOS 26 SDK.
       - name: Select an Xcode with the iOS 26 SDK
@@ -104,7 +110,7 @@ jobs:
           sudo xcode-select --switch "$xcode/Contents/Developer"
       - name: Publish the rc-player stack -SNAPSHOT
         env:
-          PLUGIN_VERSION: ${{ steps.version.outputs.version }}
+          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -8,11 +8,12 @@
 // hand is never right — they have to describe an asset that already exists, and SPM verifies the
 // checksum at resolve time.
 //
-// Consume a released version by its Swift tag — a BARE `<version>` (e.g. `1.16.0`), which is what
-// makes `from:` work. SwiftPM only reads a tag as a semantic version when the whole ref is `X.Y.Z`
-// or `vX.Y.Z`, so a prefixed ref such as `swift/1.16.0` is invisible to the syntax below. The bare
-// tag is distinct from the `v<version>` release tag, whose `Package.swift` still describes the
-// PREVIOUS release (see docs/design/RC_PLAYER_SWIFT.md):
+// Consume a released version by its Swift tag — a BARE `<version>` (e.g. `1.16.0`). SwiftPM only
+// reads a tag as a semantic version when the whole ref is `X.Y.Z` or `vX.Y.Z`, so a prefixed ref
+// such as `swift/1.16.0` is invisible to the syntax below. The `v<version>` release tag IS visible,
+// and its copy of this file still describes the PREVIOUS release — SwiftPM prefers the bare tag
+// once it exists, which is why the release job writes one. See docs/design/RC_PLAYER_SWIFT.md for
+// the window before it does:
 //
 //     .package(url: "https://github.com/yschimke/compose-ai-tools.git", from: "1.15.1")
 //

--- a/docs/design/RC_PLAYER_EMBED.md
+++ b/docs/design/RC_PLAYER_EMBED.md
@@ -83,14 +83,20 @@ const namedValues = [
 const src = `player.html?src=doc.rc&namedValues=${encodeURIComponent(JSON.stringify(namedValues))}`;
 ```
 
-`value` is stringified, so a number or boolean may be passed unquoted. `bool` is `true`/`false`;
-`color` accepts `#RRGGBB`/`#AARRGGBB` with or without the leading `#`.
+`value` is stringified, so a number or boolean may be passed unquoted. `color` accepts
+`#RRGGBB`/`#AARRGGBB` with or without the leading `#`.
 
-**A malformed array is silently ignored, not reported.** The player's parser returns no overrides on
-any JSON error, and an element whose `kind` is unrecognized or whose `value` does not parse as its
-kind is dropped on its own — the document still renders, with its own defaults. Nothing appears in
-`data-rc-player-error`, because failing to *style* a document is not failing to *load* one. A host
-that cannot tolerate a silently-defaulted override should validate before building the URL.
+**`bool` is `"true"` or nothing.** It is the one kind that does not validate: the parser tests for
+the exact string `true` and maps *everything else* — `"1"`, `"TRUE"`, `"yes"`, a typo — to `false`.
+So a malformed boolean does not fall back to the document's own value, it actively overrides the
+variable to false. Send `true`/`false` and nothing else.
+
+**Otherwise, a malformed array is silently ignored rather than reported.** The parser returns no
+overrides at all on any JSON error, and an element whose `kind` is unrecognized or whose `value`
+does not parse as its kind is dropped on its own — the document still renders, with its own
+defaults. Nothing appears in `data-rc-player-error`, because failing to *style* a document is not
+failing to *load* one. A host that cannot tolerate a silently-defaulted (or, for `bool`, silently
+falsified) override should validate before building the URL.
 
 (The NUL-and-`\u0001`-delimited rows in `Main.kt`'s `flattenNamedValuesFromLocation` are an internal
 shape used to hand the parsed array across the JS/Wasm boundary. They are not the wire format, and

--- a/docs/design/RC_PLAYER_SWIFT.md
+++ b/docs/design/RC_PLAYER_SWIFT.md
@@ -86,11 +86,28 @@ points at the commit made after the upload, which is the first commit where the 
 agree.
 
 **Why the Swift tag is bare `1.16.0` and not `swift/1.16.0`.** SwiftPM reads a ref as a semantic
-version only when the *entire* ref is `X.Y.Z` or `vX.Y.Z`; a leading `v` is the only decoration
-it strips. A `swift/1.16.0` ref is therefore not a version at all: `.package(..., from: "1.16.0")`
-reports that no versions match the requirement, and the only consumption syntax this document
-advertises resolves nothing. A bare tag is a version SwiftPM accepts, does not collide with the
-`v<version>` release tag, and does not re-enter `release.yml`, whose push trigger is `v*`.
+version only when the *entire* ref is `X.Y.Z` or `vX.Y.Z`; a leading `v` is the only decoration it
+strips. A `swift/1.16.0` ref is therefore not a version at all, and `.package(..., from: "1.16.0")`
+never saw it.
+
+It did, however, see **`v1.16.0`** — the release tag, whose `Package.swift` describes the *previous*
+release by construction. So the old scheme did not make `from:` resolve nothing; it made it resolve
+the **wrong framework**, which is worse and quieter. Measured against Swift 6.3: with both refs
+present SwiftPM selects the bare tag, in both orderings (bare on the older commit and on the newer),
+so once `publish-xcframework` has run the bare tag governs.
+
+Two things follow, and they are the reason this is a mitigation rather than a cure:
+
+- **There is a window.** `v<version>` exists from the moment the release chain writes it until
+  `publish-xcframework` pushes the bare tag. A `from:` resolve inside it gets the stale framework.
+  Normally minutes, since both happen in one release run.
+- **A failed `publish-xcframework` leaves the window open indefinitely**, with a SwiftPM-visible
+  `v<version>` pointing at the wrong binary. Re-run the job — it is idempotent, and it refuses to
+  move an existing Swift tag that describes a different asset.
+
+Closing it properly needs `Package.swift` at `v<version>` to be correct *already*, which the
+checksum-after-upload ordering forbids, or the Swift package to live in its own repository where the
+version tags are its own. Tracked on [#4068](https://github.com/yschimke/compose-ai-tools/issues/4068).
 
 **And the binary is built from `v<version>`, not from `main`.** `main` can advance between the tag
 being cut and `publish-xcframework` starting; building from the branch would attach a framework of


### PR DESCRIPTION
Codex reviewed [#4197](https://github.com/yschimke/compose-ai-tools/pull/4197) after it merged. Three findings are correct and fixed here; one is not, and a claim in that PR's own description was wrong.

## Correcting #4197: `from:` resolved the *wrong* framework, not nothing

#4197 said `swift/<version>` left `.package(..., from: "1.15.1")` resolving no versions. Codex pointed out that SwiftPM strips a leading `v`, so **`v<version>` was visible all along** — and its `Package.swift` describes the *previous* release by construction. The old scheme did not break resolution; it silently resolved a stale binary under the new version number, which is worse.

Measured against Swift 6.3 with a local package and both refs present:

| bare tag | `v` tag | resolved |
|---|---|---|
| older commit | newer commit | **bare** |
| newer commit | older commit | **bare** |

So the bare tag governs once it exists — the fix holds — but it is a mitigation, not a cure:

- **There is a window**, from the release chain writing `v<version>` until `publish-xcframework` pushes the bare tag. Minutes in the normal case, since both happen in one release run.
- **A failed `publish-xcframework` leaves it open indefinitely**, with a SwiftPM-visible `v<version>` pointing at the wrong binary.

Closing it properly needs `Package.swift` at `v<version>` to already be correct — which the checksum-after-upload ordering forbids — or the Swift package in its own repository. Both are now written down in `RC_PLAYER_SWIFT.md`, the job comment and `Package.swift` itself, rather than implied. Worth a decision on [#4068](https://github.com/yschimke/compose-ai-tools/issues/4068); it is not one to make in a follow-up sweep.

## Fixed

**The tag is checked before anything is written.** A `workflow_dispatch` re-release of an older version runs against a `main` that has since advanced, so the old order committed this release's (older) url and checksum over a newer `Package.swift` and only *then* discovered the tag existed. The check now runs first, and reads the **tag's own** `Package.swift` rather than main's — which is also what makes the idempotent case honest: an existing tag describing this exact asset exits success without touching `main`, and one describing a different asset fails before any write.

**One snapshot version, computed once.** Sharing `scripts/snapshot-version.sh` did not fix the race, only the duplication: each job did its own full-depth checkout and its own `git describe`. This workflow and release-please both fire on a release-PR merge, so a `v*` tag created between the two checkouts would have one job computing from the previous tag and the other from the new one — publishing half the stack under a coordinate nothing resolves. A prerequisite `version` job now feeds both publishers.

**`bool` does not validate.** The embed doc said an unparseable value is dropped and the document's own default kept. True for every kind except `bool`, where the parser tests for the exact string `true` and maps everything else — `"1"`, `"TRUE"`, `"yes"`, a typo — to `false`, actively overriding the variable. Documented as the exception it is.

## Not a defect

Codex flagged `sort -V` as a GNU option BSD sort rejects, claiming it aborts both macOS jobs under `set -euo pipefail`. macOS `sort` supports `-V` — verified on macOS 26.5, and the pre-existing `publish-xcframework` job has been running that exact line on `macos-15` since #4193.

## Test plan

- `scripts/update-package-swift.sh --self-test` and `scripts/snapshot-version.sh --self-test` — both pass.
- Both workflows parse as YAML; `snapshot.yml`'s job graph is `version` → `publish-snapshot`, `publish-player-snapshot`, each reading `needs.version.outputs.version`.
- The SwiftPM precedence table above was produced by resolving a real local package against a repo carrying both tags, in both orderings — not read off documentation.

Non-visual: workflows and documentation.

_Generated by [Claude Code](https://claude.com/claude-code)_
