### PR TITLE
fix(rc-player): follow a replacement named-value holder, and seed its bookkeeping from the state

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -334,38 +334,48 @@ private fun RcComposePlayerResolved(
   // had changed — the same hazard the `systemColors` comment below describes, on the one API a host
   // uses to drive a live document. Changes are applied incrementally instead; see the
   // `LaunchedEffect` under this block.
-  val state =
+  // The seed is captured BESIDE the state, not recomputed. The collector below has to diff its
+  // first emission against the map the state was actually built from: if `namedValues` changes
+  // between this composition and the effect starting — a sibling `SideEffect`, a concurrent host
+  // update — reading it again there would initialise the bookkeeping from the NEWER map while the
+  // state still held the older snapshot, so the first emission would compare equal and be skipped,
+  // leaving the player stale until that entry happened to change again.
+  val (seededNamedValues, state) =
     remember(document) {
-      RcPlayerState(
-        document,
-        // Seeded once, from whatever the map holds when this document is first composed.
-        namedValues.toMap(),
-        eventSink = { latestEventSink(it) },
-        onInvalidated = { invalidationVersion += 1 },
-        effectSink = { effect ->
-          when (effect) {
-            is RcPlayerEffect.HapticFeedback ->
-              latestHapticFeedback.performAndroidXHaptic(effect.type)
-            is RcPlayerEffect.WakeIn -> {
-              val current = wakeIntervalSeconds
-              if (!effect.seconds.isNaN() && (current == null || effect.seconds < current)) {
-                wakeIntervalSeconds = effect.seconds
+      val seed = namedValues.toMap()
+      seed to
+        RcPlayerState(
+          document,
+          // Seeded once, from whatever the map holds when this document is first composed.
+          seed,
+          eventSink = { latestEventSink(it) },
+          onInvalidated = { invalidationVersion += 1 },
+          effectSink = { effect ->
+            when (effect) {
+              is RcPlayerEffect.HapticFeedback ->
+                latestHapticFeedback.performAndroidXHaptic(effect.type)
+              is RcPlayerEffect.WakeIn -> {
+                val current = wakeIntervalSeconds
+                if (!effect.seconds.isNaN() && (current == null || effect.seconds < current)) {
+                  wakeIntervalSeconds = effect.seconds
+                }
               }
+              RcPlayerEffect.NextFrame -> nextFrameRequestVersion += 1
             }
-            RcPlayerEffect.NextFrame -> nextFrameRequestVersion += 1
-          }
-        },
-        // Read through `latestSystemColors`, never captured directly: a host's lookup is usually a
-        // capturing lambda, so a parent recomposition hands us a fresh instance. Keying the state
-        // on it would rebuild `RcPlayerState` — discarding variables an action changed,
-        // touch-expression state and running animation timelines — because a colour callback that
-        // resolves the same palette happened to be reallocated.
-        //
-        // The `Color` -> ARGB conversion happens here, at the module boundary: `RcPlayerState`
-        // lives in `:rc-player-runtime`, which has no Compose UI dependency, and packed ARGB really
-        // is the wire value there. See [toRcArgb].
-        systemColorLookup = { name -> latestSystemColors(name)?.toRcArgb() },
-      )
+          },
+          // Read through `latestSystemColors`, never captured directly: a host's lookup is usually
+          // a
+          // capturing lambda, so a parent recomposition hands us a fresh instance. Keying the state
+          // on it would rebuild `RcPlayerState` — discarding variables an action changed,
+          // touch-expression state and running animation timelines — because a colour callback that
+          // resolves the same palette happened to be reallocated.
+          //
+          // The `Color` -> ARGB conversion happens here, at the module boundary: `RcPlayerState`
+          // lives in `:rc-player-runtime`, which has no Compose UI dependency, and packed ARGB
+          // really
+          // is the wire value there. See [toRcArgb].
+          systemColorLookup = { name -> latestSystemColors(name)?.toRcArgb() },
+        )
     }
   // Apply host edits to the live state instead of rebuilding it. `setNamedValue` already applied a
   // single value incrementally against `variableNames`, type-checked against the AndroidX variable
@@ -376,16 +386,27 @@ private fun RcComposePlayerResolved(
   // owns. Errors are deliberately not caught: an unknown name or a type mismatch threw from the
   // `RcPlayerState` constructor before this change, and a host that names a variable the document
   // does not have should still hear about it rather than watch the value quietly not apply.
-  LaunchedEffect(state) {
-    var applied = namedValues.toMap()
+  // Survives the effect restarting, which is the point: `applied` is what this player has actually
+  // pushed into the state, and a restart must not forget it. Re-seeding from the state's own
+  // snapshot on every restart would leave a key applied from the OLD holder uncleared, because the
+  // diff would no longer know it had ever been set.
+  val appliedNamedValues = remember(document) { seededNamedValues.toMutableMap() }
+  // Keyed on the holder as well as the state. `namedValues` is read inside `snapshotFlow`, so the
+  // running collector stays bound to whichever map instance it started with: a parent that swaps in
+  // a different `SnapshotStateMap` while keeping the same document would have its replacement
+  // ignored entirely, while later mutations of the detached old map went on driving the player.
+  // Restarting on identity re-binds the flow without rebuilding `RcPlayerState`, so animation
+  // timelines, touch state and action-changed variables all survive the swap.
+  LaunchedEffect(state, namedValues) {
     snapshotFlow { namedValues.toMap() }
       .collect { current ->
-        if (current == applied) return@collect
-        (applied.keys - current.keys).forEach(state::clearNamedValue)
+        if (current == appliedNamedValues) return@collect
+        (appliedNamedValues.keys - current.keys).forEach(state::clearNamedValue)
         current.forEach { (name, value) ->
-          if (applied[name] != value) state.setNamedValue(name, value)
+          if (appliedNamedValues[name] != value) state.setNamedValue(name, value)
         }
-        applied = current
+        appliedNamedValues.clear()
+        appliedNamedValues.putAll(current)
         // `setNamedValue` writes into the state's maps without going through the action path, so
         // nothing else tells the draw layer a value moved.
         invalidationVersion += 1

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValues.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValues.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
 import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
+import ee.schimke.composeai.rcplayer.runtime.RcPlayerEvent
 
 /**
  * A caller-owned, snapshot-backed holder for the named values driving a document.
@@ -22,8 +23,20 @@ import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
  * `RcPlayerState.setNamedValue` — the mechanism that already existed and had no caller on the
  * public path.
  *
- * Ownership is the caller's on purpose: a host usually wants to read a value back (a document
- * action can change one) and to hold the same map across document swaps.
+ * Ownership is the caller's on purpose: a host holds the same map across document swaps, and can
+ * read back exactly what it put in without the player having to hand anything out.
+ *
+ * **The bridge is one-way, and that is the current contract.** `snapshotFlow` copies edits from
+ * this map into `RcPlayerState`; nothing copies the other way. A document ACTION — a click or touch
+ * that changes a named float, integer or text — mutates the player state's own maps directly, and
+ * this map does not see it. So a host reading an entry back gets its own last override, or nothing,
+ * never the value an action moved it to.
+ *
+ * Reverse synchronisation is not obviously the right answer, which is why it is a documented gap
+ * rather than an oversight: writing back into a caller-owned map would mutate host state from
+ * inside a draw pass, and a host driving a value from its own model — a slider, a form field —
+ * would find the player fighting it. If you need to observe action-driven changes, `onEvent`
+ * reports the actions themselves ([RcPlayerEvent]), which is the seam that already exists.
  */
 @Composable
 public fun rememberRcNamedValues(

--- a/rc-player/compose/src/jvmTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValueRenderTest.kt
+++ b/rc-player/compose/src/jvmTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValueRenderTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.rcplayer.compose
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.toArgb
@@ -115,6 +118,68 @@ class RcNamedValueRenderTest {
       val restored = onRoot().captureToImage().toPixelMap()
       assertEquals(RED, restored[10, 10].toArgb())
       assertEquals(0, restored[40, 10].toArgb(), "the document's recorded 20 did not come back")
+    }
+
+  /**
+   * A parent that swaps in a different `SnapshotStateMap` while keeping the same document.
+   *
+   * The collector reads `namedValues` inside `snapshotFlow`, so a `LaunchedEffect` keyed only on
+   * `state` stayed bound to whichever map instance it started with: the replacement was ignored
+   * outright, while later mutations of the DETACHED old map went on driving the player. Keying on
+   * the holder as well re-binds the flow without rebuilding `RcPlayerState`.
+   */
+  @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+  @Test
+  fun replacingTheNamedValueHolderRebindsTheCollector() =
+    runSkikoComposeUiTest(size = Size(60f, 20f), density = Density(1f)) {
+      mainClock.autoAdvance = false
+      val first = mutableStateMapOf<String, RcNamedValue>()
+      val second = mutableStateMapOf<String, RcNamedValue>()
+      var holder by mutableStateOf(first)
+      val document = widthDrivenDocument()
+      setContent { RcComposePlayer(document, namedValues = holder) }
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+
+      first["USER:width"] = RcNamedValue.FloatValue(50f)
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      assertEquals(RED, onRoot().captureToImage().toPixelMap()[40, 10].toArgb())
+
+      // The swap. `second` already carries a different value, which must take effect.
+      second["USER:width"] = RcNamedValue.FloatValue(20f)
+      holder = second
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      assertEquals(
+        0,
+        onRoot().captureToImage().toPixelMap()[40, 10].toArgb(),
+        "the replacement holder's value never reached the document",
+      )
+
+      // And the detached map must no longer drive anything.
+      first["USER:width"] = RcNamedValue.FloatValue(50f)
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      assertEquals(
+        0,
+        onRoot().captureToImage().toPixelMap()[40, 10].toArgb(),
+        "the detached old holder is still driving the player",
+      )
+
+      // A value applied through the OLD holder is still cleared when the new one drops it — the
+      // bookkeeping has to survive the effect restart, or the key stays stuck at its old override.
+      second["USER:width"] = RcNamedValue.FloatValue(50f)
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      second.remove("USER:width")
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      assertEquals(
+        0,
+        onRoot().captureToImage().toPixelMap()[40, 10].toArgb(),
+        "removing through the replacement holder did not restore the document's own value",
+      )
     }
 
   /** One canvas whose width *is* the named variable, so a host edit is directly visible. */


### PR DESCRIPTION
Two of the four P2s Codex raised on [#4181](https://github.com/yschimke/compose-ai-tools/pull/4181), which merged before the review landed. A third is documented rather than fixed; the fourth I could not reproduce and did not ship a change for.

## A replacement holder was ignored, and the detached one kept driving

The collector reads `namedValues` inside `snapshotFlow`, so a `LaunchedEffect` keyed only on `state` stayed bound to whichever map instance it started with. A parent that swapped in a different `SnapshotStateMap` while keeping the same document got the worst of both: the replacement's values — current and future — were ignored entirely, while later mutations of the *detached old map* went on driving the player.

Keying on the holder as well re-binds the flow without rebuilding `RcPlayerState`, so running animation timelines, mid-drag touch state and action-changed variables all survive the swap. That is the whole reason the holder exists, and rebuilding the state to follow it would have given the swap the exact cost the holder was introduced to remove.

## Bookkeeping seeded from the wrong map

`applied` was initialised inside the effect from `namedValues`, not from the map `RcPlayerState` was actually built with. When those differ — a sibling `SideEffect` or a concurrent host update landing between composition and the effect starting — `applied` holds the newer map while the state holds the older snapshot, the first emission compares equal and is skipped, and the player stays stale until that entry happens to change again.

The seed is now captured beside the state in the same `remember`, and the applied-set lives in a `remember` that survives the effect restarting. That second part matters for the fix above: re-seeding on every restart would leave a key applied through the *old* holder uncleared, because the diff would no longer know it had ever been set. The test walks exactly that path.

## Documented, not fixed: read-back

`rememberRcNamedValues`'s KDoc said ownership is the caller's because "a host usually wants to read a value back (a document action can change one)". The bridge cannot deliver that: `snapshotFlow` copies edits *in*, and `executeActionsUnchecked` mutates the state's own maps without touching this one. So a host reads back its own last override, or nothing — never the value an action moved it to.

I did not add reverse sync. It is a genuine design question, not an oversight: writing back into a caller-owned map would mutate host state from inside a draw pass, and a host driving a value from its own model — a slider, a form field — would find the player fighting it. The KDoc now states the gap and points at `onEvent`, which already reports the actions themselves.

## Not reproduced: legacy-branch semantics

Codex's remaining finding is that `invalidationVersion` is read during composition only inside the `layout != null` branch, so on the legacy path a named-value change behind `RcRootContentDescription` would redraw pixels while leaving the semantics label stale.

The reasoning is sound but I could not make it fail. I built a canvas-only document with a named root description and drove it three ways: with the clock free-running the label updates; with the clock pinned and no frame advanced, nothing updates *with or without* the fix (no recomposition is applied at all); with a frame advanced after the mutation it updates either way — a frame tick recomposes the player on that path regardless.

So the hoist changed nothing observable, and the test I wrote for it passed against unfixed code. I reverted both rather than ship an unfalsifiable change with a test that gives false confidence. If someone can construct a case where the recomposition genuinely does not happen, the one-line hoist above `semanticsModifier` is the fix.

## Test plan

- `./gradlew :rc-player-compose:jvmTest` — green, with a new `replacingTheNamedValueHolderRebindsTheCollector` covering the swap, the detached map going quiet, and a removal through the replacement still restoring the document's own value.
- Confirmed that test fails against the unfixed player (`3 tests completed, 1 failed`).
- `./gradlew :rc-player-compose:ktfmtCheck :rc-player-compose:checkKotlinAbi` — clean; no ABI change.

Non-visual: the rendered output is unchanged for a host that never swaps its holder. The swap case is asserted as pixels in the new test.

_Generated by [Claude Code](https://claude.com/claude-code)_
