### PR TITLE
fix(rc-player): follow a replaced named-value holder, and rebuild semantics on invalidation

### DIFF
--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcComposePlayer.kt
@@ -334,12 +334,16 @@ private fun RcComposePlayerResolved(
   // had changed — the same hazard the `systemColors` comment below describes, on the one API a host
   // uses to drive a live document. Changes are applied incrementally instead; see the
   // `LaunchedEffect` under this block.
+  // The exact map handed to the constructor, kept so the bridge below knows what the state
+  // actually holds rather than re-reading the holder. Computed in its own `remember` immediately
+  // before the state's, so both see the same snapshot of `namedValues`.
+  val seededNamedValues = remember(document) { namedValues.toMap() }
   val state =
     remember(document) {
       RcPlayerState(
         document,
         // Seeded once, from whatever the map holds when this document is first composed.
-        namedValues.toMap(),
+        seededNamedValues,
         eventSink = { latestEventSink(it) },
         onInvalidated = { invalidationVersion += 1 },
         effectSink = { effect ->
@@ -372,20 +376,34 @@ private fun RcComposePlayerResolved(
   // type; nothing on the public path called it. A removal means "stop overriding this", which needs
   // the pre-override value, so `clearNamedValue` is its inverse (see `RcPlayerState`).
   //
-  // Restarted on `state` rather than `document` so a swap re-seeds from the map the host still
-  // owns. Errors are deliberately not caught: an unknown name or a type mismatch threw from the
+  // Errors are deliberately not caught: an unknown name or a type mismatch threw from the
   // `RcPlayerState` constructor before this change, and a host that names a variable the document
   // does not have should still hear about it rather than watch the value quietly not apply.
-  LaunchedEffect(state) {
-    var applied = namedValues.toMap()
+  //
+  // `appliedNamedValues` tracks what the *state* holds, not what the holder holds, and is
+  // remembered on `state` so it survives the effect restarting. Two things need that:
+  //
+  //  * It is seeded from `seededNamedValues` — the map the constructor actually received — rather
+  //    than from a fresh read of the holder. A host that writes between the state's construction
+  //    and this effect starting would otherwise make the first emission compare equal to a value
+  //    the state never saw, and the player would stay stale until that entry moved again.
+  //  * The effect is keyed on the holder's identity as well as `state`, so a parent that swaps in a
+  //    *different* `SnapshotStateMap` for the same document is followed instead of leaving the
+  //    collector subscribed to the detached old one. Restarting the collector does not rebuild
+  //    `RcPlayerState`, which is the whole point of this bridge; because `appliedNamedValues`
+  //    outlives the restart, the new holder is diffed against what the state really has, so
+  //    entries the old holder had and the new one does not are cleared rather than left applied.
+  val appliedNamedValues = remember(state) { seededNamedValues.toMutableMap() }
+  LaunchedEffect(state, namedValues) {
     snapshotFlow { namedValues.toMap() }
       .collect { current ->
-        if (current == applied) return@collect
-        (applied.keys - current.keys).forEach(state::clearNamedValue)
+        if (current == appliedNamedValues) return@collect
+        (appliedNamedValues.keys - current.keys).forEach(state::clearNamedValue)
         current.forEach { (name, value) ->
-          if (applied[name] != value) state.setNamedValue(name, value)
+          if (appliedNamedValues[name] != value) state.setNamedValue(name, value)
         }
-        applied = current
+        appliedNamedValues.clear()
+        appliedNamedValues.putAll(current)
         // `setNamedValue` writes into the state's maps without going through the action path, so
         // nothing else tells the draw layer a value moved.
         invalidationVersion += 1
@@ -444,6 +462,25 @@ private fun RcComposePlayerResolved(
   val images = remember(document) { decodeInlineImages(document) }
   val fonts = remember(document) { decodeInlineFonts(document) }
   val textMeasurer = rememberTextMeasurer()
+  // Subscribe *composition* to invalidations, not just the draw layer below.
+  //
+  // `rootContentDescription` and the legacy click areas are read here, during composition, and both
+  // can be backed by a named text — so a host write, or a document action, changes what a screen
+  // reader should announce. Every such mutation raises `invalidationVersion`, but until this read
+  // existed the only composition that observed it was the `layout != null` branch further down; on
+  // a legacy canvas document `invalidationVersion` was read solely inside a `drawWithContent`
+  // lambda, which redraws without recomposing. The label went stale while the pixels were right —
+  // invisible to a pixel test, which is why `RcNamedValueSemanticsTest` asserts through the
+  // semantics tree.
+  //
+  // It also fixes an ordering hazard that has nothing to do with accessibility: when the *host*
+  // swaps in a different named-value holder, the recomposition that swap triggers runs before the
+  // bridge below has applied the new values, so a composition-time read of player state would
+  // otherwise show the previous holder's overrides and never be revisited.
+  //
+  // Cheap, because `invalidationVersion` is event-driven — actions, wake-ins, next-frame requests,
+  // host writes — and not bumped per frame; continuous animation drives `frameNanos` instead.
+  invalidationVersion
   val semanticsModifier =
     state.rootContentDescription?.let { description ->
       modifier.semantics { contentDescription = description }

--- a/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValues.kt
+++ b/rc-player/compose/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValues.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
 import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
+import ee.schimke.composeai.rcplayer.runtime.RcPlayerEvent
 
 /**
  * A caller-owned, snapshot-backed holder for the named values driving a document.
@@ -22,8 +23,16 @@ import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
  * `RcPlayerState.setNamedValue` — the mechanism that already existed and had no caller on the
  * public path.
  *
- * Ownership is the caller's on purpose: a host usually wants to read a value back (a document
- * action can change one) and to hold the same map across document swaps.
+ * Ownership is the caller's so the same holder can span document swaps, and so a host can drive the
+ * document from wherever its own state already lives.
+ *
+ * **The bridge is one-way: host to player.** A document action — `RcValueFloatChangeAction` and its
+ * siblings, a touch expression, an animation — mutates the player's variables directly and does
+ * *not* write back into this map. So after a click changes a named float, this map still holds the
+ * host's last override, or no entry at all. That is a real limitation rather than an oversight: the
+ * runtime has no change notification for a variable, so there is nothing to mirror from. A host
+ * that needs to observe what a document did to itself uses [RcPlayerEvent] — `HostNamedAction`
+ * carries a name and value — and a document that wants a value read back should emit one.
  */
 @Composable
 public fun rememberRcNamedValues(

--- a/rc-player/compose/src/jvmTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValueSemanticsTest.kt
+++ b/rc-player/compose/src/jvmTest/kotlin/ee/schimke/composeai/rcplayer/compose/RcNamedValueSemanticsTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.rcplayer.compose
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.Density
+import ee.schimke.composeai.rcplayer.protocol.RcDocument
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
+import ee.schimke.composeai.rcplayer.protocol.RcNamedVariable
+import ee.schimke.composeai.rcplayer.protocol.RcRootContentDescription
+import ee.schimke.composeai.rcplayer.protocol.RcTextData
+import ee.schimke.composeai.rcplayer.protocol.RcVersion
+import ee.schimke.composeai.rcplayer.runtime.RcNamedValue
+import kotlin.test.Test
+
+/**
+ * A named text can back the root content description, which means a host edit has to reach the
+ * *semantics* tree and not only the pixels.
+ *
+ * It nearly did not. `invalidationVersion` — the signal every non-action mutation raises — is read
+ * during composition only inside the `layout != null` branch; everywhere else it is read inside a
+ * `drawWithContent` lambda, which redraws without recomposing. So on a legacy canvas document the
+ * label a screen reader announces stayed at the document's original string while the render showed
+ * the new one. Silent, and invisible to a pixel test, which is why this one asserts through the
+ * semantics tree instead.
+ */
+class RcNamedValueSemanticsTest {
+
+  @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+  @Test
+  fun aNamedTextChangeUpdatesTheRootContentDescription() =
+    runSkikoComposeUiTest(size = Size(40f, 40f), density = Density(1f)) {
+      val namedValues = mutableStateMapOf<String, RcNamedValue>()
+      val document =
+        RcDocument(
+          RcHeader(RcVersion(1, 0, 0), legacyWidth = 40, legacyHeight = 40, modern = false),
+          listOf(
+            RcTextData(10, "Seventy-two degrees"),
+            RcNamedVariable(10, RcNamedVariable.STRING_TYPE, "USER:summary"),
+            RcRootContentDescription(10),
+          ),
+        )
+      setContent { RcComposePlayer(document, Modifier.fillMaxSize(), namedValues = namedValues) }
+      waitForIdle()
+      onNodeWithContentDescription("Seventy-two degrees").assertExists()
+
+      namedValues["USER:summary"] = RcNamedValue.Text("Sixty-four degrees")
+      waitForIdle()
+
+      onNodeWithContentDescription("Sixty-four degrees").assertExists()
+      onNodeWithContentDescription("Seventy-two degrees").assertDoesNotExist()
+    }
+
+  /**
+   * A parent may hand the same document a *different* holder — hoisting the map, or rebuilding it
+   * from a new screen state. The collector has to follow the replacement rather than stay
+   * subscribed to the detached one, and it has to do so without rebuilding `RcPlayerState`, which
+   * is the entire point of the bridge.
+   *
+   * Both halves are asserted: the new holder's value lands, and a key only the *old* holder carried
+   * is cleared rather than left applied — which only works because the effect tracks what the state
+   * holds rather than re-reading whichever map it happens to be looking at.
+   */
+  @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+  @Test
+  fun replacingTheHolderForTheSameDocumentIsFollowed() =
+    runSkikoComposeUiTest(size = Size(40f, 40f), density = Density(1f)) {
+      val first =
+        mutableStateMapOf<String, RcNamedValue>(
+          "USER:summary" to RcNamedValue.Text("From the first holder")
+        )
+      val second = mutableStateMapOf<String, RcNamedValue>()
+      var holder by mutableStateOf(first)
+      setContent { RcComposePlayer(document(), Modifier.fillMaxSize(), namedValues = holder) }
+      waitForIdle()
+      onNodeWithContentDescription("From the first holder").assertExists()
+
+      holder = second
+      waitForIdle()
+      // `second` is empty, so the first holder's override must be cleared back to the document's
+      // own text — not left in place, and not answered from the map nobody is holding any more.
+      onNodeWithContentDescription("From the first holder").assertDoesNotExist()
+      onNodeWithContentDescription("Seventy-two degrees").assertExists()
+
+      second["USER:summary"] = RcNamedValue.Text("From the second holder")
+      waitForIdle()
+      onNodeWithContentDescription("From the second holder").assertExists()
+
+      // Writes to the detached holder must not reach the player.
+      first["USER:summary"] = RcNamedValue.Text("Detached")
+      waitForIdle()
+      onNodeWithContentDescription("Detached").assertDoesNotExist()
+      onNodeWithContentDescription("From the second holder").assertExists()
+    }
+
+  private fun document(): RcDocument =
+    RcDocument(
+      RcHeader(RcVersion(1, 0, 0), legacyWidth = 40, legacyHeight = 40, modern = false),
+      listOf(
+        RcTextData(10, "Seventy-two degrees"),
+        RcNamedVariable(10, RcNamedVariable.STRING_TYPE, "USER:summary"),
+        RcRootContentDescription(10),
+      ),
+    )
+}

--- a/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcOperationInventory.kt
+++ b/rc-player/protocol/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/protocol/RcOperationInventory.kt
@@ -26,14 +26,22 @@ public data class RcOperationProfile(val name: String, val opcodes: Set<Int>) {
 /**
  * The operation sets each player can execute, as published API.
  *
- * **The `ALPHA16` in these names is a capture, not a version.** Each profile records which
- * operations a given player understood as of the AndroidX Remote Compose alpha16 registry — the
- * release this stack's inventory was built against. A newer AndroidX release adds a *sibling*
- * constant rather than changing what one of these means, so a consumer that pinned
- * `CMP_WASM_ALPHA16` keeps getting the set it tested against. Deciding that before the first
- * release rather than after was #4064's question; the alternative — making them internal — would
- * leave a host no way to ask `composeSupportReport` which player it is targeting, which is the one
- * thing these exist for.
+ * They are public rather than internal because a host has to tell `composeSupportReport` which
+ * player it is targeting, and that is the only thing these exist for. #4064 asked whether to make
+ * them internal before the first release; this is the answer.
+ *
+ * **`ALPHA16` names the registry generation, and these sets are not frozen at it.** Every profile
+ * is computed from [RcOperationInventory], which is generated from the checked-in
+ * `rc-operations.manifest`. Advancing that manifest — the normal way this stack tracks a new
+ * AndroidX release — changes what `CMP_WASM_ALPHA16` and `CMP_IOS_ALPHA16` contain, because a newly
+ * implemented operation joins `cmpImplementedOpcodes` below. The suffix records which AndroidX
+ * registry the manifest currently tracks; it is not a promise that the membership is pinned at
+ * today's contents.
+ *
+ * So: a consumer that needs an exact set pins the library version, which is the only thing that
+ * actually fixes the manifest. And when the manifest does advance to a later AndroidX release,
+ * these constants should be *renamed* to the new generation rather than silently kept — leaving
+ * `ALPHA16` on a set that no longer describes alpha16 is the failure mode worth avoiding.
  */
 public object RcOperationProfiles {
   private val cmpImplementedOpcodes: Set<Int> =


### PR DESCRIPTION
Four Codex review findings from #4181 and #4189 that the follow-up PRs (#4197, #4198) did not pick up. I swept every PR in the player series; the triage of all 14 comments is at the bottom.

## 1. A replaced holder was ignored — and a stale label survived it (P2, #4181)

The bridge's `LaunchedEffect` was keyed on `state` alone, so a parent handing the same document a **different** `SnapshotStateMap` left the collector subscribed to the detached one: the replacement's values never applied, and writes to the map nobody was holding any more still reached the player.

Now keyed on the holder's identity as well, which restarts the collector *without* rebuilding `RcPlayerState` — the whole point of the bridge. That needs the bookkeeping to outlive the restart, so `appliedNamedValues` is remembered on `state` and tracks what the **state** holds rather than what some holder holds.

## 2. …which also fixes the seeding race (P2, #4181)

Same change. `appliedNamedValues` is seeded from `seededNamedValues` — the map the constructor actually received — rather than a fresh read of the holder. A host writing between the state's construction and the effect starting could otherwise make the first emission compare equal to a value the state never saw, leaving the player stale until that entry moved again.

## 3. Composition never observed invalidation outside the layout branch (P2, #4181)

`rootContentDescription` and the legacy click areas are read during composition and can be backed by a named text. But on a legacy canvas document `invalidationVersion` was read only inside a `drawWithContent` lambda, which redraws without recomposing — so the label a screen reader announces went stale while the pixels were right.

**This one nearly got away.** My first test — mutate a named text, assert the new content description — *passed* against unfixed code, so I initially wrote the finding off. It only reproduced through the holder-swap case, where the recomposition the swap triggers runs **before** the bridge applies the new values, so a composition-time read of player state shows the previous holder's overrides and is never revisited. Same root cause, second symptom.

Fixed by reading `invalidationVersion` during composition, before the semantics modifier is built. Cheap: it is event-driven (actions, wake-ins, next-frame requests, host writes), not bumped per frame — continuous animation drives `frameNanos`.

## 4. Two KDocs claimed more than the code does (P2, #4181 and #4189)

- **`rememberRcNamedValues`** said a host "usually wants to read a value back (a document action can change one)". The bridge is one-way; a document action mutates the player's variables and nothing mirrors that back, because the runtime has no change notification for a variable. Now stated as the limitation it is, pointing at `RcPlayerEvent` as the mechanism that does exist. My wording, my error.
- **`RcOperationProfiles`** said `ALPHA16` was "a capture, not a version" and that pinning `CMP_WASM_ALPHA16` "keeps getting the set it tested against". It does not — both profiles are computed from `RcOperationInventory`, generated from the checked-in manifest, so advancing that manifest silently changes their membership. Now says so, says pinning the *library version* is what actually fixes the set, and records that these constants should be **renamed** when the manifest moves rather than left describing a registry they no longer track.

## Test plan

New `RcNamedValueSemanticsTest`, asserting through the **semantics tree** rather than pixels, because that is where both bugs are invisible otherwise:

- `aNamedTextChangeUpdatesTheRootContentDescription` — a host write reaches the announced label.
- `replacingTheHolderForTheSameDocumentIsFollowed` — the new holder's values land, the old holder's override is *cleared* back to the document's own text, and later writes to the detached holder do not reach the player.

Both mutation-checked, and the checks disagree in a way that matters:

| mutation | semantics test | render test |
|---|---|---|
| suppress `state.setNamedValue` | **fails** | fails |
| suppress `invalidationVersion += 1` in the bridge | passes | **fails** |
| remove the new composition-time `invalidationVersion` read | **fails** (swap case only) | passes |

That third row is the evidence the fix is load-bearing rather than defensive, and the second is why the semantics test is not just a restatement of the render test.

- `:rc-player-{compose,runtime,protocol,trace}:allTests` + `checkKotlinAbi` — green (no ABI change; the fixes are behavioural and doc-only).
- `:rc-player-wasm:wasmPlayerDist` — 23,601,391 / 23,780,000 bytes. `ktfmtCheckAll` — green.

Non-visual: the render output is unchanged by construction — these are semantics-tree and holder-lifecycle bugs — and the existing exact-pixel corpus stays green, which is the assertion that no pixel moved.

## Full triage of the 14 review comments

| # | PR | Finding | State |
|---|---|---|---|
| P1 | 4181 | unrepresentable named types crash construction | fixed by #4198 |
| P2 | 4181 | replaced holder not observed | **this PR** |
| P2 | 4181 | semantics not rebuilt on the non-layout branch | **this PR** |
| P2 | 4181 | read-back promised but not delivered | **this PR** (doc) |
| P2 | 4181 | collector seeded from the wrong map | **this PR** |
| P2 | 4185 | cancellation swallowed by `runCatching` | fixed by #4198 |
| P2 | 4185 | `..\` / `%2e%2e` bypass the path check | fixed by #4198 |
| P1 | 4185 | colliding font identities across bases | fixed by #4198 |
| P1 | 4189 | Apple variants published from a Linux runner | fixed by #4197 |
| P2 | 4189 | stale `iosX64` claim in the design doc | fixed |
| P2 | 4189 | `ALPHA16` profiles are not frozen | **this PR** (doc) |
| P2 | 4194 | `contents: read` blocks `gh release upload` | fixed |
| P2 | 4194 | fallback upload skipped after an npm failure | fixed |
| P2 | 4194 | `namedValues` documented in the wrong format | fixed |

_Generated by [Claude Code](https://claude.com/claude-code)_