### PR TITLE
test(rc-player): compile the Swift usage sample against the real framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,16 @@ jobs:
           ./gradlew :rc-player-compose:rcPlayerXcframeworkChecksum
           ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeWebTest
           ./gradlew ktfmtCheck
+      # The Swift usage sample in `docs/design/RC_PLAYER_SWIFT.md` is the only documentation of how
+      # to call the player from Swift, and everything awkward in it — the `…Kt.` file facade, all
+      # five arguments being required, `Data` not bridging to `ByteArray` — is a property of
+      # Kotlin/Native's Objective-C export rather than a choice. So it drifts silently whenever the
+      # export changes, and the first person to notice is a consumer whose project will not build.
+      # This compiles the doc's own code blocks against the framework the step above just
+      # assembled. macOS-only by nature, which is why it lives in this job; it skips loudly and
+      # passes anywhere the framework or Xcode is missing.
+      - name: Type-check the Swift usage sample against the framework
+        run: scripts/check-swift-sample.sh
       - name: Upload player test reports on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/design/RC_PLAYER_SWIFT.md
+++ b/docs/design/RC_PLAYER_SWIFT.md
@@ -62,6 +62,16 @@ them means adding a Swift wrapper target beside the binary target, which
 [#4068](https://github.com/yschimke/compose-ai-tools/issues/4068) leaves for after the first
 published framework.
 
+**"Works exactly as written" is checked, not asserted.** `scripts/check-swift-sample.sh` extracts
+the `swift` blocks above and type-checks them against the assembled XCFramework, and the
+`rc-player-tests` CI job runs it right after building one. This document is therefore the tested
+artifact — there is no second copy of the sample to keep in sync — and every property described
+here is a property of Kotlin/Native's Objective-C export rather than a choice made in this repo, so
+it can change under us without any Kotlin source changing. That is exactly the drift the check
+exists to catch: an earlier draft of this page called a bare `RcComposeViewController(...)` and a
+`KotlinByteArray.from(_:)` that does not exist, and nothing caught either until a reviewer read the
+generated header by hand.
+
 **Device and Apple-silicon simulator only.** There is no Intel-simulator slice anywhere in this
 stack: Compose Multiplatform 1.11 stopped publishing the variant, so `:rc-player-compose` cannot
 declare `iosX64` and its three siblings dropped theirs rather than publish a stack that resolves

--- a/scripts/check-swift-sample.sh
+++ b/scripts/check-swift-sample.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Type-check the Swift usage sample in docs/design/RC_PLAYER_SWIFT.md against the real XCFramework.
+#
+# The sample is the *only* documentation of how to call the player from Swift, and everything
+# awkward about it — the `RcComposeViewControllerKt.` file facade, all five arguments being
+# required, `Data` not bridging to `ByteArray` — is a property of Kotlin/Native's Objective-C export
+# rather than a choice made here. Which means the doc drifts silently whenever the export changes,
+# and the first person to notice is a consumer whose project will not build.
+#
+# So the doc is the tested artifact: the fenced `swift` blocks are extracted and compiled, with no
+# second copy of the code to keep in sync. Two kinds of block are skipped, both self-describing:
+#   * the `Package.swift` manifest fragment — a manifest, not app code;
+#   * any block containing `…`, which marks it as illustrative rather than complete.
+#
+# Type-check only (`-typecheck`): this proves every name, selector and type in the sample exists as
+# written, which is the failure mode. Linking a static Kotlin/Native framework would add minutes and
+# catch nothing extra at the API level.
+#
+# Skips loudly, and exits 0, when the toolchain or the framework is absent — the framework only
+# builds on macOS, so this is a no-op on a Linux runner rather than a failure.
+#
+# Usage: scripts/check-swift-sample.sh [path/to/RcComposePlayer.xcframework]
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+doc="docs/design/RC_PLAYER_SWIFT.md"
+xcframework="${1:-rc-player/compose/build/XCFrameworks/release/RcComposePlayer.xcframework}"
+
+if ! command -v xcrun > /dev/null 2>&1; then
+  echo "skip: no xcrun on this host; the Swift sample is only checkable on macOS" >&2
+  exit 0
+fi
+
+# Prefer the simulator slice: it builds for the host architecture, so no device signing is involved.
+slice="$xcframework/ios-arm64-simulator/RcComposePlayer.framework"
+if [ ! -d "$slice" ]; then
+  echo "skip: no assembled framework at $slice" >&2
+  echo "      build one with ./gradlew :rc-player-compose:assembleRcComposePlayerReleaseXCFramework" >&2
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+sample="$work/Sample.swift"
+
+# The preamble supplies only what the prose leaves to the reader — the document bytes and the two
+# handlers the sample calls. Everything the sample asserts about the *player's* API comes from the
+# doc itself.
+cat > "$sample" <<'PREAMBLE'
+import Foundation
+import UIKit
+
+let documentData = Data()
+func handle(_ event: RcPlayerEvent) {}
+func show(_ message: String) {}
+PREAMBLE
+
+python3 - "$doc" >> "$sample" <<'EXTRACT'
+import re, sys
+
+text = open(sys.argv[1]).read()
+blocks = re.findall(r"```swift\n(.*?)```", text, re.S)
+kept = 0
+for block in blocks:
+    if "// Package.swift" in block:
+        continue
+    if "…" in block:  # an illustrative block, not complete code
+        continue
+    sys.stdout.write(block)
+    sys.stdout.write("\n")
+    kept += 1
+if kept == 0:
+    sys.exit("error: no compilable swift blocks found in the doc — did the fences change?")
+EXTRACT
+
+sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+arch="$(uname -m)"
+target="$arch-apple-ios13.0-simulator"
+
+echo "type-checking $doc against $slice ($target)"
+# `-Xcc -Wno-...` is not used: the only warning the export produces today is Compose Multiplatform's
+# own nested-type mapping, and it should stay visible rather than be suppressed here.
+xcrun -sdk "$sdk" swiftc \
+  -target "$target" \
+  -F "$(dirname "$slice")" \
+  -typecheck "$sample"
+
+echo "swift sample: ok"


### PR DESCRIPTION
Fallout from sweeping the review comments on the player series. Independent of #4213.

## Why

`docs/design/RC_PLAYER_SWIFT.md` is the only documentation of how to call the player from Swift, and everything awkward in it is a property of **Kotlin/Native's Objective-C export**, not a choice made here:

- `RcComposeViewControllerKt.` — a top-level Kotlin function exports as a static member of a file facade, not a global function
- all five arguments required — Objective-C has no default arguments
- `Data` does not bridge to `ByteArray`

So the page can go wrong without any Kotlin source changing, and the first person to find out is a consumer whose project will not build.

**It already had gone wrong.** As I first wrote it, the page called a bare `RcComposeViewController(...)` and a `KotlinByteArray.from(_:)` that does not exist. Both were caught only because the Codex review on #4193 read the generated header by hand, and both were corrected in a follow-up — but nothing stopped it happening again, and nothing had ever *compiled* the corrected version.

## What

`scripts/check-swift-sample.sh` extracts the doc's own fenced `swift` blocks and type-checks them against the assembled XCFramework. The document is the tested artifact — there is no second copy of the sample to keep in sync. Blocks are skipped only where they say so themselves: the `Package.swift` manifest fragment, and any block containing `…` marking it illustrative.

Type-check rather than link: that proves every name, selector and type exists as written, which is the failure mode, without minutes spent linking a static Kotlin/Native framework to learn nothing extra.

It skips loudly and exits 0 where Xcode or the framework is absent, so it is a no-op on Linux. It runs in `rc-player-tests` immediately after `rcPlayerXcframeworkChecksum` — the one macOS lane, where both the toolchain and the framework already exist.

## Test plan

Verified against the framework built from this branch:

```
type-checking docs/design/RC_PLAYER_SWIFT.md against …/ios-arm64-simulator/RcComposePlayer.framework (arm64-apple-ios13.0-simulator)
swift sample: ok
```

**Mutation-checked against the two bugs it exists to catch** — re-introducing each into the doc:

| re-introduced | result |
|---|---|
| bare `RcComposeViewController(...)` | `error: cannot find 'RcComposeViewController' in scope` |
| `KotlinByteArray.from(documentData)` | `error: type 'KotlinByteArray' has no member 'from'` |

And the skip path, with no framework present:

```
skip: no assembled framework at /nonexistent/…/RcComposePlayer.framework
      build one with ./gradlew :rc-player-compose:assembleRcComposePlayerReleaseXCFramework
exit=0
```

`ktfmtCheckAll` — green. Docs-and-CI only; no production code changes, so no render evidence applies.

## One thing it surfaced

The export emits a warning a Swift consumer will see, from Compose Multiplatform rather than from the player:

```
warning: imported declaration 'RCPUi_textFontVariationSettings' could not be mapped to 'Ui_textFontVariation.Settings'
```

Left visible rather than suppressed — it is upstream's nested-type mapping, it is harmless, and hiding it would also hide the next one.

_Generated by [Claude Code](https://claude.com/claude-code)_