### PR TITLE
fix(build): stop publishing the vendored embedded player, and record its package collision

### DIFF
--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -22,6 +22,43 @@ There is **no published artifact** for this player. Upstream declares the module
 `SoftwareType.TEST_APPLICATION` — an integration-test app — so the player ships only as sources
 inside it. Vendoring is the only way to depend on it.
 
+### That premise has expired, and the collision is live
+
+`androidx.compose.remote:remote-player-compose:1.0.0-SNAPSHOT` — which this module takes as an
+`implementation` dependency, and which every Android consumer of it resolves since the catalog moved
+to the androidx.dev snapshot line — **now ships the embedded player itself**: 138 class files under
+`androidx/compose/remote/player/compose/embedded/`, the very package these sources are vendored into.
+
+Eight of them collide by fully-qualified name with the vendored copies:
+
+```
+AndroidColorThemeResolver     GraphContext         RcImageLoader
+DrawablePainter               GraphPaintContext    RemoteImageSupport
+EmbeddedPlayerTypefaceResolver                     SnapshotRemoteComposeState
+```
+
+**`AndroidColorThemeResolver` is on that list, and it is one of the local modifications below** —
+the theme-fallback fix. So which bytes run is decided by classpath ordering, not by this directory:
+if the upstream class wins, the local delta silently is not there, and the embedded lane's pixels
+change with nothing in any log to say why. `:samples:remotecompose:assembleDebug` still *builds*
+(measured), so there is no error to notice either.
+
+Reproduce the overlap:
+
+```bash
+./gradlew :third-party-rc-embedded-player:assembleDebug
+jar=$(find ~/.gradle/caches -path '*remote-player-compose-1.0.0-SNAPSHOT*' -name classes.jar | head -1)
+unzip -l "$jar" | grep -c 'compose/embedded'
+```
+
+**This needs a decision, and it is not a small one.** Upstream publishing the player is exactly the
+condition under which vendoring stops being justified — but the local modifications listed below are
+rendering fixes, so adopting upstream wholesale changes the embedded lane's output. The three ways
+out: retire this module for the published artifact (and re-baseline `rc-compare`), relocate the
+vendored package (which costs the verbatim `diff -r` refresh this file is built around), or strip
+the upstream `embedded/` package from the dependency. Tracked as a follow-up to
+[#4184](https://github.com/yschimke/compose-ai-tools/pull/4184).
+
 ## What is vendored
 
 The player proper: the package root plus `layout/`, `modifier/`, and `state/` (42 upstream files,

--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -38,10 +38,24 @@
 
 plugins {
   id("composeai.base-conventions")
-  // Published for TESTING only — see `composeAiMavenPublishing` below. This is a vendored AOSP
-  // snapshot, not a supported API; the coordinates exist so the embedded render lane can be pulled
-  // as an artifact. `composeai.maven-publishing` also applies `composeai.android-conventions`.
-  id("composeai.maven-publishing")
+  // NOT PUBLISHED. It used to apply `composeai.maven-publishing`, so it joined the root
+  // `publishAndReleaseToMavenCentral` aggregation — and it exposes `libs.compose.remote.core` and
+  // `libs.compose.remote.player.core` through `api`. Those moved to `1.0.0-SNAPSHOT` on
+  // androidx.dev, so the next release POM would have required
+  // `androidx.compose.remote:*:1.0.0-SNAPSHOT`: coordinates a consumer cannot resolve (the
+  // androidx.dev repository is declared in this project's `settings.gradle.kts` and cannot be
+  // inherited), absent from Google Maven and Central, and eventually swept from androidx.dev
+  // altogether. A published artifact nobody can resolve is worse than no artifact.
+  //
+  // Unpublishing rather than pinning, because there is nothing to pin to — upstream ships this
+  // player only as integration-test sources — and because nothing consumed the coordinates: every
+  // user in this repo (`:samples:remotecompose`, `:samples:design-catalog-remote-m3`,
+  // `:data-remotecompose-connector`, and the JVM sibling via `:cli`) depends on the PROJECT. The
+  // module's own note already called it "a testing artifact ... not intended for external use".
+  //
+  // `composeai.maven-publishing` also applied `composeai.android-conventions`, so that is named
+  // directly now.
+  id("composeai.android-conventions")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
@@ -77,26 +91,6 @@ android {
   // The player reaches `androidx.compose.remote.core.*` members marked `@RestrictTo(LIBRARY_GROUP)`
   // — unavoidable for an out-of-tree copy of in-tree code. Upstream's module disables it too.
   lint { disable += "RestrictedApi" }
-}
-
-// Published under the compose-ai-tools group (`ee.schimke.composeai`, set by the convention plugin)
-// deliberately, NOT under `androidx.*` — that package name is only the vendored code's namespace,
-// kept verbatim so a snapshot refresh stays a plain `diff -r` (see PROVENANCE.md). This is a
-// testing
-// artifact for the embedded render lane, not a library intended for external consumption; the POM's
-// Apache-2.0 license and the retained AOSP source headers keep the vendored snapshot compliant.
-composeAiMavenPublishing {
-  coordinates(
-    artifactId = "third-party-rc-embedded-player",
-    displayName = "Compose Preview — Embedded Remote Compose Player (vendored, testing)",
-    description =
-      "Vendored snapshot of AndroidX's experimental Compose embedded Remote Compose player " +
-        "(RcPlayer), lifted from an androidx integration-test app that publishes no artifact of its " +
-        "own. Backs the embedded render/compare lane in compose-ai-tools. Published under " +
-        "ee.schimke.composeai for testing only — not a supported API and not intended for external " +
-        "use.",
-  )
-  inceptionYear.set("2026")
 }
 
 // Hand the render harness its input/output directories. Gradle properties rather than ambient env,


### PR DESCRIPTION
The two P1s Codex raised on [#4184](https://github.com/yschimke/compose-ai-tools/pull/4184), which merged before the review landed. One is fixed; the second is real, verified, and needs a decision I have deliberately not made in passing.

## Fixed: a release POM that would have required `1.0.0-SNAPSHOT`

`:third-party-rc-embedded-player` applied `composeai.maven-publishing`, so it joined the root `publishAndReleaseToMavenCentral` aggregation — while exposing `libs.compose.remote.core` and `libs.compose.remote.player.core` through **`api`**. #4184 moved those to `1.0.0-SNAPSHOT` on androidx.dev, so the next release would have published a POM requiring `androidx.compose.remote:*:1.0.0-SNAPSHOT`: coordinates a consumer cannot resolve (the androidx.dev repository is declared in this project's `settings.gradle.kts` and is not inheritable), absent from Google Maven and Central, and eventually swept from androidx.dev. Confirmed against the resolved graph — `debugRuntimeClasspath` carries all three at `1.0.0-SNAPSHOT`.

**Unpublished** rather than pinned, because there is nothing to pin to and nothing consumed the coordinates. Every user is a Gradle *project* dependency — `:samples:remotecompose`, `:samples:design-catalog-remote-m3`, `:data-remotecompose-connector`, and the JVM sibling via `:cli` — and the module's own note already called it "a testing artifact ... not intended for external use". `composeai.maven-publishing` also applied `composeai.android-conventions`, so that is now named directly.

## Verified, not fixed: the vendored package collides with upstream

Codex's second P1 is correct and the numbers are worse than the description. `remote-player-compose:1.0.0-SNAPSHOT` now ships **138 class files** under `androidx/compose/remote/player/compose/embedded/` — the exact package these sources are vendored into — and **eight collide by fully-qualified name**:

```
AndroidColorThemeResolver     GraphContext         RcImageLoader
DrawablePainter               GraphPaintContext    RemoteImageSupport
EmbeddedPlayerTypefaceResolver                     SnapshotRemoteComposeState
```

`AndroidColorThemeResolver` is one of the **local modifications** PROVENANCE.md lists — the theme-fallback fix. So classpath ordering, not this directory, decides whether that fix is in effect, and if upstream wins the embedded lane's pixels change with nothing in any log to say why. I built `:samples:remotecompose:assembleDebug` to check: it succeeds, so there is no dexing error to notice either.

I did not pick a resolution. Upstream publishing the player is precisely the condition that ends the justification for vendoring — PROVENANCE's opening claim, "there is no published artifact", has expired — but the local deltas are rendering fixes, so adopting upstream wholesale moves the embedded lane's output and needs an `rc-compare` re-baseline. The three ways out (retire the module, relocate the package at the cost of the verbatim `diff -r` refresh, or strip the upstream `embedded/` package from the dependency) all have consequences someone should choose between deliberately.

PROVENANCE.md now carries the evidence, the collision list, and a copy-pasteable reproduction, so the next person to touch this meets it immediately instead of losing an afternoon to a fix that silently is not applied.

## Test plan

- `./gradlew :third-party-rc-embedded-player:assembleDebug` — green after removing the publishing plugin.
- `./gradlew :samples:remotecompose:assembleDebug` — green; an Android app build, so it dexes.
- `./gradlew :third-party-rc-embedded-player:dependencies --configuration debugRuntimeClasspath` — confirms the three `1.0.0-SNAPSHOT` coordinates that would have reached the POM.
- Overlap computed by listing the transformed snapshot `classes.jar` against the vendored source file names.

Non-visual: build wiring and documentation. No renderer change — which is exactly the point of the second finding: whether the *current* pixels come from the vendored classes or the upstream ones is not currently pinned by anything.

_Generated by [Claude Code](https://claude.com/claude-code)_
