### PR TITLE
test(renderer): bind against the real skiko whose signature changed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -210,6 +210,19 @@ mcp-kotlin-sdk = "0.15.0"
 okio = "3.18.1"
 fontbox = "3.0.8"
 junit = "4.13.2"
+# A skiko resolved ONLY into `:renderer-desktop`'s `skikoEncodeProbe` configuration — never onto a
+# compile, runtime or test classpath — so `SkikoBridgeShapeTest` can bind against the real
+# `Image.encodeToData` shape of a version this repo does not otherwise resolve.
+#
+# 0.150.0 is where that shape changed (`(format, quality)` → `(format, quality, compressionLevel)`),
+# which is what stopped every desktop capture encoding against Compose Multiplatform 1.12.0-beta01+
+# (#4190). `compose-multiplatform` above cannot be raised to reach it: that ref is a CEILING on every
+# catalog the serve host renders live, so bumping it is a serve-host release decision. Probing the
+# jar in isolation gets the coverage without touching what anything actually runs against.
+#
+# A Renovate bump here is WELCOME and is the point: it re-points the probe at the newest skiko, and
+# the test then says whether the late binding still holds against it.
+skiko-encode-probe = "0.150.1"
 truth = "1.4.5"
 maven-publish = "0.37.0"
 # Google's host-side screenshot testing plugin (Layoutlib-backed). Used only
@@ -421,6 +434,7 @@ roborazzi-accessibility-check = { module = "io.github.takahirom.roborazzi:robora
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
 roborazzi-annotations = { module = "io.github.takahirom.roborazzi:roborazzi-annotations", version.ref = "roborazzi" }
 junit = { module = "junit:junit", version.ref = "junit" }
+skiko-awt-encode-probe = { module = "org.jetbrains.skiko:skiko-awt", version.ref = "skiko-encode-probe" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 # ASM — used by `:daemon:harness`'s `S3_5RecompileSaveLoopRealModeTest` to mint two
 # `.class` files with the same FQN (`ee.schimke.composeai.daemon.MutableSquare`) but different

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -9,6 +9,21 @@ plugins {
   alias(libs.plugins.compose.compiler)
 }
 
+/**
+ * A second skiko, resolved for inspection only.
+ *
+ * The renderer compiles against whatever `compose-multiplatform` brings (0.144.6 today), so its own
+ * test classpath can only ever demonstrate ONE `Image.encodeToData` shape — and the shape that
+ * broke every desktop capture is the other one (#4190). This configuration resolves the newer jar
+ * beside it without letting it near anything that runs, so the shape can be read off the real
+ * artifact rather than off a hand-written stand-in.
+ */
+val skikoEncodeProbe: Configuration by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+  description = "A skiko resolved for reflection only, never on a compile or runtime classpath."
+}
+
 dependencies {
   implementation(compose.desktop.currentOs)
   implementation(libs.jetbrains.compose.ui)
@@ -67,6 +82,24 @@ dependencies {
   implementation(project(":data-preview-overrides-runtime"))
 
   testImplementation(libs.junit)
+
+  // Deliberately NOT a test dependency: it is resolved into its own configuration and handed to the
+  // test as a path, so `SkikoBridgeShapeTest` can load it in an isolated classloader. Putting it on
+  // the test runtime classpath instead would let conflict resolution pick ONE skiko for the whole
+  // module, which is precisely the mechanism being guarded against.
+  skikoEncodeProbe(libs.skiko.awt.encode.probe)
+}
+
+tasks.withType<Test>().configureEach {
+  // A lazily-resolved, content-keyed view rather than the live Configuration: the same reason
+  // `ComposePreviewTasks` feeds its guards `incoming.artifactView { }.files` — a Configuration on a
+  // task field is not serializable by the configuration cache.
+  val probeJars = skikoEncodeProbe.incoming.artifactView {}.files
+  inputs
+    .files(probeJars)
+    .withPropertyName("skikoEncodeProbe")
+    .withNormalizer(ClasspathNormalizer::class)
+  doFirst { systemProperty("composeai.test.skikoEncodeProbe", probeJars.asPath) }
 }
 
 composeAiMavenPublishing {

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SkikoBridgeShapeTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SkikoBridgeShapeTest.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import java.net.URLClassLoader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Bind against the `Image.encodeToData` of a skiko this repo does not otherwise resolve.
+ *
+ * [SkiaPngEncoderTest] proves the binding rule against hand-written stand-ins, which is the only
+ * way to exercise both shapes in one JVM — but a stand-in only ever demonstrates that the rule
+ * matches what its author BELIEVED skiko looks like. The belief is the part worth checking: #4190
+ * was precisely a wrong belief about a signature.
+ *
+ * So this reads the shape off the real artifact. `skiko-awt` 0.150.1 is resolved into
+ * `:renderer-desktop`'s `skikoEncodeProbe` configuration — never a compile, runtime or test
+ * classpath, because a second skiko on any of those would be conflict-resolved down to one and
+ * destroy the thing being measured — and handed here as a path.
+ *
+ * The class is loaded **uninitialized** (`Class.forName(…, initialize = false, …)`) under a
+ * bootstrap-parented loader. Uninitialized because `Image`'s static initializer calls
+ * `Library.staticLoad()`, which would drag in the platform `libskiko`; reflection over the method
+ * table needs none of that. Bootstrap-parented because a normal parent would delegate
+ * `org.jetbrains.skia.Image` straight back to the 0.144 copy already on this test's classpath, and
+ * the test would silently measure the wrong jar.
+ */
+class SkikoBridgeShapeTest {
+
+  private fun probeJars(): List<File> {
+    val path = System.getProperty("composeai.test.skikoEncodeProbe").orEmpty()
+    assertTrue(
+      "composeai.test.skikoEncodeProbe was not set — run this through Gradle, which resolves the " +
+        "skikoEncodeProbe configuration and passes it in",
+      path.isNotBlank(),
+    )
+    return path.split(File.pathSeparator).filter { it.isNotBlank() }.map(::File)
+  }
+
+  private fun probeImageClass(): Class<*> {
+    val urls = probeJars().map { it.toURI().toURL() }.toTypedArray()
+    // Null parent: bootstrap only, so nothing resolves back to this module's own skiko.
+    val isolated = URLClassLoader(urls, null)
+    return Class.forName("org.jetbrains.skia.Image", false, isolated)
+  }
+
+  @Test
+  fun `the probe jar really is the version whose signature changed`() {
+    // Guards the guard: if the probe silently resolved to the same skiko the module compiles
+    // against, every assertion below would pass while proving nothing.
+    val probeMethod =
+      probeImageClass().methods.single { it.name == "encodeToData" }.parameterTypes.size
+    val compiledMethod =
+      org.jetbrains.skia.Image::class
+        .java
+        .methods
+        .single { it.name == "encodeToData" }
+        .parameterTypes
+        .size
+    assertEquals("the probe jar should carry the three-parameter form", 3, probeMethod)
+    assertEquals(
+      "this module should still compile against the two-parameter form",
+      2,
+      compiledMethod,
+    )
+  }
+
+  @Test
+  fun `binds the real three-parameter bridge, not just the stand-in modelled on it`() {
+    val binding = SkiaPngEncoder.bind(probeImageClass())
+    assertEquals("Image.encodeToData(EncodedImageFormat, int, int)", binding.description)
+  }
+
+  @Test
+  fun `binds the shape this module compiles against too, from the same rule`() {
+    val binding = SkiaPngEncoder.bind(org.jetbrains.skia.Image::class.java)
+    assertEquals("Image.encodeToData(EncodedImageFormat, int)", binding.description)
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to [#4200](https://github.com/yschimke/compose-ai-tools/pull/4200) / #4190, closing the one
gap that fix left: **nothing in this repo resolves the skiko that broke it.**

The late `Image.encodeToData` binding was covered only by hand-written stand-ins. Those are the only
way to exercise both signatures in a single JVM, so they earn their place — but a stand-in
demonstrates that the binding rule matches *what its author believed skiko looks like*, and #4190 was
precisely a wrong belief about a signature. This checks the belief against the artifact.

## How

`skiko-awt:0.150.1` is resolved into a new **`skikoEncodeProbe`** configuration on `:renderer-desktop`
and handed to the test as a path. Three deliberate choices, each guarding a way this could quietly
prove nothing:

- **Off every compile, runtime and test classpath.** A second skiko on any of those would be
  conflict-resolved down to one — the exact mechanism #4190 is about.
- **`compose-multiplatform` is not raised to reach it.** The catalog is explicit that this ref is a
  *ceiling on every catalog the serve host renders live* (#3447), so bumping it is a serve-host
  release decision, not a test convenience. Probing the jar in isolation gets the coverage without
  changing what anything actually runs against.
- **Loaded uninitialized, under a bootstrap-parented loader.** Uninitialized because `Image`'s static
  initializer calls `Library.staticLoad()` and would drag in the platform `libskiko`, which
  reflection over the method table does not need. Bootstrap-parented because a normal parent would
  delegate `org.jetbrains.skia.Image` straight back to the 0.144 copy already on the test classpath —
  the test would pass while measuring the wrong jar.

## Test plan

Three tests in `SkikoBridgeShapeTest`:

1. **The probe really is a different skiko** — 3 parameters on the probe, 2 on the compiled one. This
   guards the guard: without it, a probe that silently resolved to the same version would let
   everything below pass vacuously.
2. **The real three-parameter bridge binds** — `Image.encodeToData(EncodedImageFormat, int, int)`,
   read off `skiko-awt-0.150.1.jar` rather than off a stand-in modelled on it.
3. **The compiled two-parameter shape binds from the same rule** — one rule, both shapes.

Verified **load-bearing**, not just green: repointing the probe at `0.148.2` fails tests 1 and 2.
`:renderer-desktop:test` passes in full, and the configuration cache stores and reuses the entry
(`Configuration cache entry reused`) — the probe is fed through a lazily-resolved `artifactView`
rather than a live `Configuration`, the same pattern `ComposePreviewTasks` uses for its guards.

A Renovate bump of `skiko-encode-probe` is **welcome and is the point**: it re-aims the probe at the
newest skiko and reports whether the late binding still holds against it.

Non-visual change (a test plus build wiring), so there is no rendered output to diff.

_Generated by [Claude Code](https://claude.com/claude-code)_