### PR TITLE
fix(rc-player): evaluate content-state operations declared at the document root

### DIFF
--- a/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
+++ b/rc-player/runtime/src/commonMain/kotlin/ee/schimke/composeai/rcplayer/runtime/RcPlayerState.kt
@@ -668,7 +668,13 @@ public class RcPlayerState(
       }
     }
 
-    applyScope(children, RcTheme.UNSPECIFIED, applyDirect = false)
+    // The document root is itself a content scope. AndroidX executes one FLAT operation list in
+    // wire order, so an operation declared at top level — a `ColorExpression` over two constants, a
+    // `ColorTheme` pair — runs there exactly like one nested in a layout. Skipping the root left
+    // those out ids unset, so `color(outId)` answered 0 and a `CoreText` reading one rendered fully
+    // transparent — while `composeSupportReport` counted the id as declared and passed the document
+    // as renderable. Same shape as the canvas-scope bug the comment above records, one level up.
+    applyScope(children, RcTheme.UNSPECIFIED, applyDirect = true)
   }
 
   private fun applyContentStateOperation(

--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcTopLevelContentStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcTopLevelContentStateTest.kt
@@ -1,0 +1,65 @@
+package ee.schimke.composeai.rcplayer.runtime
+
+import ee.schimke.composeai.rcplayer.protocol.RcColorConstant
+import ee.schimke.composeai.rcplayer.protocol.RcColorExpression
+import ee.schimke.composeai.rcplayer.protocol.RcDocument
+import ee.schimke.composeai.rcplayer.protocol.RcHeader
+import ee.schimke.composeai.rcplayer.protocol.RcLayoutContent
+import ee.schimke.composeai.rcplayer.protocol.RcNoArg
+import ee.schimke.composeai.rcplayer.protocol.RcOpcodes
+import ee.schimke.composeai.rcplayer.protocol.RcOperation
+import ee.schimke.composeai.rcplayer.protocol.RcRootLayout
+import ee.schimke.composeai.rcplayer.protocol.RcTheme
+import ee.schimke.composeai.rcplayer.protocol.RcVersion
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * The document ROOT is a content scope, like the layout and canvas scopes nested inside it.
+ *
+ * `applyLayoutContentStateOperations` used to start with `applyDirect = false`, so an operation
+ * declared at top level — legal, and what AndroidX executes first, since it runs one flat operation
+ * list in wire order — was never evaluated. Its out id stayed unset, `color(outId)` answered 0, and
+ * anything reading it drew fully transparent.
+ *
+ * The reason that is worth a test rather than a comment: it is **invisible from both ends**.
+ * `composeSupportReport` counts a `ColorExpression`'s `outId` as a declared colour, so the document
+ * passes the renderability gate; and transparent text on a coloured container reads as a rendering
+ * bug in the text, not as an unevaluated colour. Same shape as the canvas-scope bug
+ * `applyLayoutContentStateOperations` already records, one level up.
+ */
+class RcTopLevelContentStateTest {
+
+  private val opaqueTeal = 0xFF008080.toInt()
+
+  private fun documentWithTopLevelExpression(): RcDocument {
+    val operations = mutableListOf<RcOperation>()
+    operations += RcColorConstant(40, opaqueTeal)
+    // Declared at top level rather than inside the RootLayout below.
+    operations +=
+      RcColorExpression(outId = 41, modeAndAlpha = 0, first = 40, second = 40, third = 0)
+    operations += RcRootLayout(1)
+    operations += RcLayoutContent(2)
+    operations += RcNoArg(RcOpcodes.CONTAINER_END)
+    operations += RcNoArg(RcOpcodes.CONTAINER_END)
+    return RcDocument(RcHeader(RcVersion(0, 1, 0)), operations)
+  }
+
+  @Test
+  fun aTopLevelColorExpressionIsEvaluatedRatherThanLeftAtZero() {
+    val document = documentWithTopLevelExpression()
+    val state = RcPlayerState(document)
+
+    state.applyLayoutContentStateOperations(
+      RcDocumentLinker.link(document).operations,
+      RcTheme.UNSPECIFIED,
+    )
+
+    // 0 is the tell: an unset colour id and "fully transparent black" are the same value, which is
+    // why this failed silently. The literal it is computed from is asserted alongside, so a change
+    // that broke ordinary constants could not make this pass by accident.
+    assertEquals(opaqueTeal, state.color(40), "the literal it reads from")
+    assertNotEquals(0, state.color(41), "the top-level expression was never evaluated")
+  }
+}


### PR DESCRIPTION
Codex's first P2 on [#4171](https://github.com/yschimke/compose-ai-tools/pull/4171), which merged before the review landed. The second is verified but deliberately not fixed here — see below.

## The document root was not treated as a content scope

`applyLayoutContentStateOperations` began its walk with `applyDirect = false`, so an operation declared at the **top level** — a `ColorExpression` over two constants, a `ColorTheme` pair — was never evaluated. AndroidX executes one flat operation list in wire order, where such an operation runs exactly like a nested one, so this was a scope the player skipped rather than a shape the wire forbids.

The consequence: the out id stayed unset, `color(outId)` answered `0`, and a `CoreText` or `TextLayout` reading it drew fully transparent.

Measured directly against a document with a top-level `ColorExpression`:

```
before: top-level ColorExpression outId 41 resolves to: 0      fully renderable: true
after:  top-level ColorExpression outId 41 resolves to: <computed>
```

**It is invisible from both ends**, which is why it earns a test rather than a comment. `composeSupportReport` counts a `ColorExpression`'s `outId` among the declared colour ids — correctly; the id genuinely is declared — so the document sails through the renderability gate. And transparent text over a correctly-painted container reads as a bug in the text, not as a colour that was never computed. `0` is doubly unhelpful here: an unset colour id and "fully transparent black" are the same value.

This is the same shape as the canvas-scope bug the function's own comment already records — the one that made `remote-m3`'s disabled button label render at zero alpha — one level up.

I took Codex's first option (evaluate the legal top-level declarations) over its second (narrow the gate to executed scopes), because the gate was not wrong: the colour *is* declared, and the player simply was not computing it. Narrowing the gate would have turned a wrong render into a refusal to render; this makes the render right.

## Not fixed here: `ColorAttribute` in the vendored player

Codex's other P2 — `ColorAttribute` wrapping the real store rather than the `read` context, so it sees a stale colour and does not subscribe to a computed input — is in `third_party/rc-embedded-player/.../RcPlayerDrawing.kt`.

That file's package was just shown to collide with 138 upstream classes now shipped by `remote-player-compose:1.0.0-SNAPSHOT` ([#4217](https://github.com/yschimke/compose-ai-tools/pull/4217)). Until that is resolved, which copy of `RcPlayerDrawing` actually runs is decided by classpath ordering — so a rendering change there could not be attributed, and the `rc-compare` embedded lane could not tell you whether it took effect. It also contradicts a comment directly above it that argues for the current choice, so it deserves the attention of whoever settles the vendoring question rather than a drive-by edit.

## Test plan

- `./gradlew :rc-player-runtime:jvmTest :rc-player-compose:jvmTest :rc-player-protocol:jvmTest :rc-player-compat-tests:test --rerun-tasks` — all four green, unchanged.
- New `RcTopLevelContentStateTest` asserts a top-level expression is evaluated, and asserts the literal it reads from alongside so a change that broke ordinary constants could not make it pass by accident. Confirmed it fails against the unfixed runtime.
- `./gradlew :rc-player-runtime:ktfmtCheck :rc-player-runtime:checkKotlinAbi` — clean; no ABI change.

Visual: no checked-in fixture exercises a top-level computed colour, so the render suites are unchanged — a document that hit this drew transparent text and none of ours does. The pixel evidence is the before/after resolution above.

_Generated by [Claude Code](https://claude.com/claude-code)_
