### PR TITLE
fix(design-artifacts): stop split-mode taking the expensive default in silence

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -128,15 +128,15 @@ on:
         type: boolean
         default: false
       split-per-preview:
-        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only unless extra-split-mode says otherwise. full mode requires publish-live-bundle (see split-mode).'
+        description: 'After generate, split the render into one addressable bundle per preview under bundle/previews/<id>, for the serve host per-preview live lane. The extra module (if any) is split --view-only unless extra-split-mode says otherwise. Live modes require publish-live-bundle (see split-mode).'
         required: false
         type: boolean
         default: false
       split-mode:
-        description: "Per-preview split mode when split-per-preview is set: 'full' (self-contained), 'full-shared-classpath' (opt-in: app.jar once in bundle/res and server-hydrated), or 'view-only' (baked, no classpath). Live modes require publish-live-bundle."
+        description: "Per-preview split mode when split-per-preview is set: 'auto' (the default — renders as 'full', and FAILS the publish, naming both options with the measured numbers, once the repeated shared carriage crosses half the split output; a small catalog never sees it), 'full' (self-contained, and a deliberate acceptance of the N× carriage at any size), 'full-shared-classpath' (app.jar once in bundle/res, server-hydrated, live lane intact), or 'view-only' (baked, no classpath). Live modes require publish-live-bundle."
         required: false
         type: string
-        default: 'full'
+        default: 'auto'
       extra-split-mode:
         description: "Per-preview split mode for the extra-module render: 'view-only' (the default — its previews are pixels-only, with no live lane) or 'full' (the extra bundle is split per preview WITH its re-render classpath, self-contained, and the driver aliases its extra-ONLY functions to daemon ids so the viewer offers real overrides on them instead of the 'Pre-rendered snapshot' note). 'full' requires publish-live-bundle and split-per-preview. Functions the extra bundle OVERRIDES rather than adds stay baked-only either way — the primary daemon would draw them differently."
         required: false
@@ -412,6 +412,27 @@ jobs:
     outputs:
       ref: ${{ steps.driver.outputs.ref }}
     steps:
+      # Typo'd modes used to be discovered by the `else` branch of the split step — after the render
+      # — where an unknown value silently meant `full`. Every job needs this one, so rejecting it
+      # here costs seconds and gates the whole pipeline.
+      - name: Validate split-mode
+        run: |
+          set -euo pipefail
+          case "$INPUT_SPLIT_MODE" in
+            auto|full|full-shared-classpath|view-only) ;;
+            *)
+              echo "::error title=split-mode::unknown split-mode '$INPUT_SPLIT_MODE' — use auto, full, full-shared-classpath or view-only."
+              exit 1
+              ;;
+          esac
+          case "$INPUT_EXTRA_SPLIT_MODE" in
+            full|view-only) ;;
+            *)
+              echo "::error title=extra-split-mode::unknown extra-split-mode '$INPUT_EXTRA_SPLIT_MODE' — use full or view-only."
+              exit 1
+              ;;
+          esac
+
       - id: driver
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1348,15 +1369,24 @@ jobs:
           JAVA_OPTS: -XX:MaxRAMPercentage=75
         run: |
           set -euo pipefail
+          # The carriage report is what the next step gates on. It is written for every mode (a
+          # view-only split reports zero), so the gate reads one shape and the number is on the log
+          # of a green run either way.
+          carriage_report="$GITHUB_WORKSPACE/split-carriage.json"
           if [ "$INPUT_SPLIT_MODE" = "view-only" ]; then
             compose-preview bundle split "$GITHUB_WORKSPACE/bundle.png" --view-only \
+              --carriage-report "$carriage_report" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           elif [ "$INPUT_SPLIT_MODE" = "full-shared-classpath" ]; then
             compose-preview bundle split "$GITHUB_WORKSPACE/bundle.png" \
               --shared-classpath-out "$GITHUB_WORKSPACE/out/bundle/res" \
+              --carriage-report "$carriage_report" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           else
+            # `auto` and `full` split identically; they differ only in whether the carriage bound
+            # below is a failure or a recorded, deliberate cost.
             compose-preview bundle split "$GITHUB_WORKSPACE/out/bundle/bundle.png" \
+              --carriage-report "$carriage_report" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           fi
           if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
@@ -1383,6 +1413,34 @@ jobs:
                 -o "$GITHUB_WORKSPACE/out/bundle/previews"
             fi
           fi
+
+      # The silent half of #4211. A FULL split pays the shared carriage once per preview, so its
+      # cost scales with the preview COUNT — and because any catalog edit rewrites `app.jar`, every
+      # publish rewrites all N copies and lays down a fresh delta chain. The delivery branch grows
+      # by the repeated size forever, while the branch tip (which git deltas near-identical
+      # polyglots well within one snapshot) keeps looking fine. m3-catalog took the default for 76
+      # green publishes and reached a 2.52 GiB clone.
+      #
+      # `auto` splits exactly as `full` always did, so no existing delivery branch changes shape
+      # underneath its consumers — pooled bundles are not offline-executable from a bare download,
+      # and trading that away is the catalog owner's call, not a threshold's. What the bound buys is
+      # that above it the call has to be *made*: the publish fails with the measured numbers until
+      # someone writes `full` or `full-shared-classpath` into the inputs. An explicit mode is never
+      # failed, only reported.
+      #
+      # Measured on the PRIMARY split, which is the one that scales: the additional/extra-module
+      # splits are self-contained by design (they owe nothing to the primary's resource pool) and
+      # carry a fraction of the previews.
+      - name: Check the split carriage bound
+        if: ${{ inputs.split-per-preview }}
+        env:
+          SYSTEM: ${{ inputs.system }}
+        run: |
+          set -euo pipefail
+          node compose-ai-tools/scripts/design-artifacts/split-carriage-gate.mjs \
+            --report "$GITHUB_WORKSPACE/split-carriage.json" \
+            --mode "$INPUT_SPLIT_MODE" \
+            --system "$SYSTEM"
 
       - name: Download section bundle to fold in
         if: ${{ inputs.fold-artifact != '' }}

--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -481,9 +481,18 @@ jobs:
       # The CMP tier (a `wasmModule` ⇒ a carried desktop `liveBundle`) splits **FULL**: each
       # per-preview bundle carries its re-render classpath so `serve` can re-render that preview from
       # its OWN bundle (ServePerPreviewLiveHost) — a `?knob.<key>=…` edit re-renders per preview
-      # instead of routing through one monolithic catalog daemon. Because the classpath is
-      # maven-coordinate (re-resolved at serve time) and fonts resolve from the shared `bundle/res`
-      # pool, a FULL split bundle stays small — only `classes/app.jar` repeats per preview.
+      # instead of routing through one monolithic catalog daemon.
+      #
+      # This block used to conclude that a FULL split "stays small — only `classes/app.jar` repeats
+      # per preview", because the classpath is maven-coordinate (re-resolved at serve time) and
+      # fonts resolve from the shared `bundle/res` pool. Both premises are true and the conclusion
+      # was not: "only app.jar repeats" is ~600 KB *per preview*, so the bound is a function of the
+      # PREVIEW COUNT, not of the backend. At 88 previews that is 17 MB; m3-catalog's ~1,300 made it
+      # 790 MB, and since any catalog edit rewrites app.jar every publish re-wrote all of them
+      # (#4211). That is why this tier splits `full-shared-classpath` — app.jar published once into
+      # `bundle/res`, each manifest carrying a hash-verified `externalClasspath`, live lane intact —
+      # and why the reusable workflow's `split-mode: auto` now fails a publish that would take the
+      # `full` cost at scale without saying so.
       #
       # An Android tier without `androidLiveBundle` has no runnable desktop daemon, so it stays
       # `--view-only`: the re-render classpath is dropped, keeping the baked image + every captured

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -106,7 +106,7 @@ class BundleCommand(args: List<String>) : Command(args) {
       Usage:
         compose-preview bundle pack [--module <name>] [--id <preview>...] [-o <file.png>] [--no-render] [--with-semantics]
         compose-preview bundle pack --per-preview [--module <name>] [--id <preview>...] [-o <dir>]
-        compose-preview bundle split   <sheet.png | URL> -o <dir> [--view-only | --shared-classpath-out <pool>]
+        compose-preview bundle split   <sheet.png | URL> -o <dir> [--view-only | --shared-classpath-out <pool>] [--carriage-report <file.json>]
         compose-preview bundle inspect <bundle.png | URL>
         compose-preview bundle extract <bundle.png | URL> [-o <dir>]
         compose-preview bundle embed   <bundle.png | URL> [-o <dir|file.png>] [--title T] [--external-images] [--in-bundle]
@@ -197,6 +197,11 @@ class BundleCommand(args: List<String>) : Command(args) {
                             server hydrates it for daemon execution and executable downloads. The
                             existing full mode remains self-contained. Cannot combine with
                             --view-only.
+        --carriage-report <file.json>
+                            Write the measured shared carriage — bytes repeated in every bundle,
+                            and its share of the whole split — as JSON, for a publisher that gates
+                            on it. The same numbers are printed either way, and reported loudly
+                            once the repetition is at least half the output.
 
       Inspect / extract / render flags:
         -o, --output <dir>  Directory to extract / render into. Default: alongside the bundle.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -38,10 +38,17 @@ import kotlinx.serialization.json.jsonPrimitive
  * semantics with **no daemon and no re-render**.
  *
  * [SplitMode.FULL] copies the shared re-render classpath (`classes/app.jar` + `libs/`) into every
- * bundle so each can live-re-render — correct but heavier (the shared jars repeat N times).
- * [SplitMode.VIEW_ONLY] drops that classpath: the result is a baked, self-describing sticker
- * (image + sidecars + manifest) that any PNG viewer / detached reader opens, typically tens of KB.
- * View-only is the right unit for a delivery branch of addressable stickers.
+ * bundle so each can live-re-render — correct, and heavier by a factor of the **preview count**:
+ * the carriage is a fixed per-bundle cost, so the output grows N× with it and every catalog edit
+ * rewrites all N copies. [SplitMode.FULL_SHARED_CLASSPATH] keeps the live lane and publishes
+ * `classes/app.jar` once into a content-addressed pool, with each manifest carrying a hash-verified
+ * `externalClasspath`. [SplitMode.VIEW_ONLY] drops the classpath entirely: the result is a baked,
+ * self-describing sticker (image + sidecars + manifest) that any PNG viewer / detached reader
+ * opens, typically tens of KB. View-only is the right unit for a delivery branch of addressable
+ * stickers that never re-render.
+ *
+ * Whichever mode is chosen, the split measures the carriage and says so ([SplitCarriageSummary]) —
+ * `--carriage-report <file.json>` writes the same numbers for a publisher that gates on them.
  */
 internal enum class SplitMode {
   FULL,
@@ -51,6 +58,131 @@ internal enum class SplitMode {
 
 /** One whole bundle entry published once into the split output's content-addressed pool. */
 internal data class SharedClasspathEntry(val path: String, val sha256: String, val size: Long)
+
+/** One entry of the shared re-render carriage, sized as it sits in the source sheet. */
+internal data class SplitCarriageEntry(val path: String, val bytes: Long)
+
+/**
+ * The shared re-render payload a live split copies into **every** per-preview bundle:
+ * `classes/app.jar` (unless pooled), `libs/`, `report.json`, and the Android `android/` payload.
+ *
+ * [bytesPerBundle] is what it costs *as written* — the same entries deflated into one zip — not the
+ * sum of their raw sizes, because the written number is the one that lands on a delivery branch.
+ */
+internal data class SplitCarriage(
+  val bytesPerBundle: Long,
+  val entries: List<SplitCarriageEntry>,
+) {
+  companion object {
+    val NONE = SplitCarriage(0L, emptyList())
+  }
+}
+
+/** A zip with no entries: end-of-central-directory record only. */
+private const val EMPTY_ZIP_BYTES = 22L
+
+/**
+ * One decimal place, locale-independent — a runner in a comma-decimal locale must not print 97,8.
+ */
+private fun formatPercent(value: Double): String =
+  String.format(java.util.Locale.ROOT, "%.1f", value)
+
+/**
+ * Report the carriage once it is at least this share of everything the split wrote.
+ *
+ * Half is already the point where publishing the payload once is a bigger lever than every other
+ * byte in the output combined, and the failure mode this guards is unbounded rather than
+ * proportional: any catalog edit rewrites `classes/app.jar`, so a FULL split re-writes all N copies
+ * and the delivery branch grows by the *repeated* size on every publish. m3-catalog sat at 97.8%
+ * for 76 publishes and reached a 2.52 GiB clone.
+ */
+internal const val SPLIT_CARRIAGE_REPORT_PERCENT = 50.0
+
+/**
+ * What the shared carriage cost, measured against what the split actually wrote — the number that
+ * decides whether a delivery branch is publishing one payload or N copies of it.
+ */
+internal class SplitCarriageSummary(
+  val mode: SplitMode,
+  val carriage: SplitCarriage,
+  val bundles: Int,
+  val totalBytes: Long,
+) {
+  /** Bytes of the output that are the same payload repeated. */
+  val repeatedBytes: Long = carriage.bytesPerBundle * bundles
+
+  /** [repeatedBytes] as a percentage of [totalBytes], 0 when nothing was written. */
+  val sharePercent: Double = if (totalBytes <= 0L) 0.0 else repeatedBytes * 100.0 / totalBytes
+
+  /** True once the carriage dominates the output enough to be worth saying out loud. */
+  val dominates: Boolean = bundles > 1 && sharePercent >= SPLIT_CARRIAGE_REPORT_PERCENT
+
+  /**
+   * The loud line, or null when the carriage is not the story. It names the remedy that fits **this
+   * mode** — the previous size warning always suggested `--view-only`, which is no remedy at all
+   * for a tier whose whole point is a live re-render, so every run of a live catalog printed advice
+   * it could not take and the signal was learned as noise.
+   */
+  fun warning(): String? {
+    if (!dominates) return null
+    val largest = carriage.entries.firstOrNull()
+    val remedy =
+      when (mode) {
+        SplitMode.FULL ->
+          "publish it once with --shared-classpath-out <pool-dir> — each bundle keeps a " +
+            "hash-verified externalClasspath, so the live re-render lane survives — or " +
+            "--view-only if this tier never re-renders"
+        SplitMode.FULL_SHARED_CLASSPATH ->
+          "classes/app.jar is already pooled; what repeats is libs/ + android/, which only " +
+            "--view-only drops (at the cost of the live re-render lane)"
+        // VIEW_ONLY carries nothing, so it can never dominate; kept exhaustive rather than
+        // reachable.
+        SplitMode.VIEW_ONLY -> "--view-only already carries nothing"
+      }
+    return "bundle split: shared carriage is ${carriage.bytesPerBundle} bytes in each of " +
+      "$bundles bundle(s) — $repeatedBytes of $totalBytes total bytes " +
+      "(${formatPercent(sharePercent)}%) is the same payload repeated; $remedy." +
+      (largest?.let { " Largest carried entry: ${it.path} (${it.bytes} bytes)." } ?: "")
+  }
+
+  /** Machine-readable form, for a publisher that gates on the measurement. */
+  fun toJson(): String =
+    SPLIT_JSON.encodeToString(
+      JsonObject.serializer(),
+      buildJsonObject {
+        put(
+          "mode",
+          JsonPrimitive(
+            when (mode) {
+              SplitMode.VIEW_ONLY -> "view-only"
+              SplitMode.FULL -> "full"
+              SplitMode.FULL_SHARED_CLASSPATH -> "full-shared-classpath"
+            }
+          ),
+        )
+        put("bundles", JsonPrimitive(bundles))
+        put("carriageBytesPerBundle", JsonPrimitive(carriage.bytesPerBundle))
+        put("repeatedBytes", JsonPrimitive(repeatedBytes))
+        put("totalBytes", JsonPrimitive(totalBytes))
+        put("sharePercent", JsonPrimitive(kotlin.math.round(sharePercent * 10.0) / 10.0))
+        put("reportThresholdPercent", JsonPrimitive(SPLIT_CARRIAGE_REPORT_PERCENT))
+        put("dominates", JsonPrimitive(dominates))
+        put(
+          "carriageEntries",
+          buildJsonArray {
+            for (entry in carriage.entries) {
+              add(
+                buildJsonObject {
+                  put("path", JsonPrimitive(entry.path))
+                  put("bytes", JsonPrimitive(entry.bytes))
+                }
+              )
+            }
+          },
+        )
+      },
+    )
+}
 
 /**
  * One split output: the preview id, its cover PNG (polyglot leading bytes), and the appended zip.
@@ -118,6 +250,7 @@ internal fun forEachSplitPreview(
   mode: SplitMode,
   crop: Boolean = true,
   onSharedClasspath: (SharedClasspathEntry, ByteArray) -> Unit = { _, _ -> },
+  onCarriage: (SplitCarriage) -> Unit = {},
   onPreview: (SplitPreview) -> Unit,
 ): Int {
   val entries = readZipEntries(sheetZip)
@@ -175,6 +308,23 @@ internal fun forEachSplitPreview(
         if (mode == SplitMode.FULL_SHARED_CLASSPATH) carriage - "classes/app.jar" else carriage
       }
   val fullMode = mode != SplitMode.VIEW_ONLY
+
+  // Measure what the carriage costs per bundle before writing any of them, deflated exactly as it
+  // will land, so the caller can report (or gate on) the repetition rather than discovering it as a
+  // delivery-branch size months later. VIEW_ONLY copies none of it, so its carriage is zero.
+  onCarriage(
+    if (fullMode) {
+      SplitCarriage(
+        bytesPerBundle = writeDeterministicZip(shared).size.toLong() - EMPTY_ZIP_BYTES,
+        entries =
+          shared
+            .map { (path, bytes) -> SplitCarriageEntry(path, bytes.size.toLong()) }
+            .sortedByDescending { it.bytes },
+      )
+    } else {
+      SplitCarriage.NONE
+    }
+  )
 
   var emitted = 0
   for (id in ids) {
@@ -480,9 +630,13 @@ private fun writeDeterministicZip(entries: Map<String, ByteArray>): ByteArray {
 
 internal class SplitSubcommand(private val args: List<String>) {
   fun run() {
-    val path = args.firstOrNull { !it.startsWith("-") }
+    // The bare token that is not some flag's value — `-o <dir>` / `--carriage-report <file>` write
+    // paths that do not start with `-`, so a naive "first non-flag token" reads whichever came
+    // first as the sheet.
+    val path = CliFlags.firstPositional(args)
     val outDirArg = args.flagValue("--output") ?: args.flagValue("-o")
     val sharedClasspathOut = args.flagValue("--shared-classpath-out")
+    val carriageReportOut = args.flagValue("--carriage-report")
     if ("--view-only" in args && sharedClasspathOut != null) {
       System.err.println("bundle split: --view-only cannot be combined with --shared-classpath-out")
       exitProcess(64)
@@ -499,7 +653,8 @@ internal class SplitSubcommand(private val args: List<String>) {
     if (path == null) {
       System.err.println(
         "Usage: compose-preview bundle split <bundle.png | URL> -o <dir> " +
-          "[--view-only | --shared-classpath-out <pool-dir>] [--no-crop]"
+          "[--view-only | --shared-classpath-out <pool-dir>] [--no-crop] " +
+          "[--carriage-report <file.json>]"
       )
       exitProcess(64)
     }
@@ -524,6 +679,7 @@ internal class SplitSubcommand(private val args: List<String>) {
     val usedStems = HashSet<String>()
     val written = ArrayList<File>()
     val sharedPool = sharedClasspathOut?.let(::File)?.absoluteFile
+    var carriage = SplitCarriage.NONE
     // Write each bundle as it is produced and let it go. Collecting them first meant holding every
     // per-preview bundle — each carrying the shared classpath + Android resource table — in memory
     // simultaneously, which OOM'd on a 181-preview catalog. Only the File handles are kept, for the
@@ -546,6 +702,7 @@ internal class SplitSubcommand(private val args: List<String>) {
               target.writeBytes(bytes)
             }
           },
+          onCarriage = { carriage = it },
         ) { preview ->
           val base = sanitizeSplitFileName(preview.id)
           var stem = base
@@ -581,13 +738,28 @@ internal class SplitSubcommand(private val args: List<String>) {
         "  total:   $total bytes\n" +
         "  size:    min ${sizes.minOrNull() ?: 0} / avg ${if (written.isNotEmpty()) total / written.size else 0} / max ${sizes.maxOrNull() ?: 0} bytes"
     )
-    val over = written.filter { it.length() > 100 * 1024 }
-    if (over.isNotEmpty()) {
-      System.err.println(
-        "bundle split: ${over.size} bundle(s) exceed 100 KB " +
-          "(largest ${over.maxByOrNull { it.length() }!!.length()} bytes) — usually a full-screen " +
-          "render, or --view-only was not set so the shared classpath repeats in each bundle."
-      )
+    val summary = SplitCarriageSummary(mode, carriage, bundles = written.size, totalBytes = total)
+    if (carriageReportOut != null) {
+      val reportFile = File(carriageReportOut).absoluteFile
+      reportFile.parentFile?.mkdirs()
+      reportFile.writeText(summary.toJson())
+    }
+    // The carriage, when it dominates, IS the explanation for the size — say that instead of the
+    // generic "some bundles are big", which named `--view-only` as the only remedy and so was
+    // unactionable (hence ignorable) on every live catalog. Only when the carriage is NOT the story
+    // does an outsized bundle mean what the old warning claimed: a genuinely large render.
+    val carriageWarning = summary.warning()
+    if (carriageWarning != null) {
+      System.err.println(carriageWarning)
+    } else {
+      val over = written.filter { it.length() > 100 * 1024 }
+      if (over.isNotEmpty()) {
+        System.err.println(
+          "bundle split: ${over.size} bundle(s) exceed 100 KB " +
+            "(largest ${over.maxByOrNull { it.length() }!!.length()} bytes) — usually a full-screen " +
+            "render; the shared carriage is only ${formatPercent(summary.sharePercent)}% of the output."
+        )
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -227,6 +227,7 @@ internal object CliFlagValidation {
             "--json",
             "--key",
             "--key-id",
+            "--carriage-report",
             "--knob",
             "--no-crop",
             "--no-render",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -159,6 +159,8 @@ internal object CliFlags {
       "--ext",
       // bundle split — content-addressed pool dir for the opt-in shared app classpath
       "--shared-classpath-out",
+      // bundle split — where to write the measured shared-carriage report a publisher gates on
+      "--carriage-report",
       // bundle render — repeatable theme override (theme.colors=scheme:…) applied via the daemon
       "--knob",
       // bundle render — content-addressed pool dir for a published bundle's externalized resources

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -272,4 +272,136 @@ class BundleSplitTest {
     assertEquals(viaList.map { it.id }, seen, "in the same order")
     assertTrue(everyBundleCarriedItsZip, "each emitted bundle is complete when handed over")
   }
+
+  private fun carriageOf(zip: ByteArray, mode: SplitMode): SplitCarriage {
+    var carriage = SplitCarriage.NONE
+    forEachSplitPreview(zip, mode, onCarriage = { carriage = it }) {}
+    return carriage
+  }
+
+  /**
+   * The size of a FULL split is a function of the **preview count**, not of the backend — the
+   * carriage is a fixed per-bundle cost paid N times. Nothing measured that, so the growth was
+   * invisible on a green run; the split now reports it before it writes anything.
+   */
+  @Test
+  fun `full split measures the carriage it copies into every bundle`() {
+    val carriage = carriageOf(sheetZip(), SplitMode.FULL)
+
+    assertEquals(
+      listOf("libs/dep.jar", "classes/app.jar", "report.json"),
+      carriage.entries.map { it.path },
+      "every shared entry is reported, largest first",
+    )
+    assertEquals(4096L, carriage.entries.first().bytes)
+    assertTrue(carriage.bytesPerBundle > 0, "the carriage costs something in each bundle")
+    // Measured as written (deflated), so it must not exceed what a whole bundle carrying it weighs.
+    val fullBundle = splitBundleZip(sheetZip(), SplitMode.FULL).first()
+    assertTrue(
+      carriage.bytesPerBundle <= fullBundle.zipBytes.size,
+      "carriage ${carriage.bytesPerBundle} exceeds the bundle that carries it " +
+        "(${fullBundle.zipBytes.size})",
+    )
+  }
+
+  @Test
+  fun `view-only split carries nothing, so its carriage is zero`() {
+    assertEquals(SplitCarriage.NONE, carriageOf(sheetZip(), SplitMode.VIEW_ONLY))
+  }
+
+  @Test
+  fun `pooling app jar takes it out of the per-bundle carriage`() {
+    val carriage = carriageOf(sheetZip(), SplitMode.FULL_SHARED_CLASSPATH)
+
+    assertFalse(
+      carriage.entries.any { it.path == "classes/app.jar" },
+      "the pooled jar is published once, not carried per bundle",
+    )
+    assertTrue(carriage.entries.any { it.path == "libs/dep.jar" }, "libs/ still repeats")
+    assertTrue(
+      carriage.bytesPerBundle < carriageOf(sheetZip(), SplitMode.FULL).bytesPerBundle,
+      "pooling lowers the per-bundle carriage",
+    )
+  }
+
+  /**
+   * The old warning fired on bundle size and named `--view-only`, which a tier that exists to
+   * re-render cannot take — so it was noise on exactly the catalogs it should have caught. The
+   * signal now fires on the carriage share and names the remedy that fits the mode.
+   */
+  @Test
+  fun `a dominant carriage is reported with the remedy for its mode`() {
+    val carriage = SplitCarriage(625_114L, listOf(SplitCarriageEntry("classes/app.jar", 620_000L)))
+    val summary =
+      SplitCarriageSummary(SplitMode.FULL, carriage, bundles = 1296, totalBytes = 828_091_478L)
+
+    assertTrue(summary.dominates)
+    assertEquals(810_147_744L, summary.repeatedBytes)
+    val warning = summary.warning()!!
+    assertTrue(warning.contains("625114 bytes in each of 1296 bundle(s)"), warning)
+    assertTrue(warning.contains("--shared-classpath-out"), warning)
+    assertTrue(warning.contains("classes/app.jar (620000 bytes)"), warning)
+
+    val pooled =
+      SplitCarriageSummary(
+        SplitMode.FULL_SHARED_CLASSPATH,
+        carriage,
+        bundles = 1296,
+        totalBytes = 828_091_478L,
+      )
+    assertTrue(pooled.warning()!!.contains("already pooled"), "the remedy fits the mode")
+  }
+
+  @Test
+  fun `a carriage that is not the story stays quiet`() {
+    val summary =
+      SplitCarriageSummary(
+        SplitMode.FULL,
+        SplitCarriage(1_000L, listOf(SplitCarriageEntry("classes/app.jar", 900L))),
+        bundles = 40,
+        totalBytes = 10_000_000L,
+      )
+
+    assertFalse(summary.dominates)
+    assertEquals(null, summary.warning())
+  }
+
+  /** A single-bundle split repeats nothing by definition, whatever the share arithmetic says. */
+  @Test
+  fun `one bundle never counts as repetition`() {
+    val summary =
+      SplitCarriageSummary(
+        SplitMode.FULL,
+        SplitCarriage(900_000L, listOf(SplitCarriageEntry("classes/app.jar", 900_000L))),
+        bundles = 1,
+        totalBytes = 1_000_000L,
+      )
+
+    assertFalse(summary.dominates)
+  }
+
+  /** The publisher gates on this JSON, so its shape is part of the contract. */
+  @Test
+  fun `the carriage report carries the numbers a publisher gates on`() {
+    val summary =
+      SplitCarriageSummary(
+        SplitMode.FULL,
+        SplitCarriage(625_114L, listOf(SplitCarriageEntry("classes/app.jar", 620_000L))),
+        bundles = 1296,
+        totalBytes = 828_091_478L,
+      )
+
+    val report = json.parseToJsonElement(summary.toJson()).jsonObject
+    assertEquals("full", report["mode"]!!.jsonPrimitive.content)
+    assertEquals(1296, report["bundles"]!!.jsonPrimitive.content.toInt())
+    assertEquals(625_114L, report["carriageBytesPerBundle"]!!.jsonPrimitive.content.toLong())
+    assertEquals(810_147_744L, report["repeatedBytes"]!!.jsonPrimitive.content.toLong())
+    assertEquals(828_091_478L, report["totalBytes"]!!.jsonPrimitive.content.toLong())
+    assertEquals(97.8, report["sharePercent"]!!.jsonPrimitive.content.toDouble())
+    assertEquals(true, report["dominates"]!!.jsonPrimitive.content.toBoolean())
+    assertEquals(
+      "classes/app.jar",
+      report["carriageEntries"]!!.jsonArray.single().jsonObject["path"]!!.jsonPrimitive.content,
+    )
+  }
 }

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -331,9 +331,10 @@ Module artifacts use a Gradle-path-derived key (for example `:tv` → `module_3a
 discovery-list index, so adding or reordering an unrelated module does not move existing bundle or
 per-preview URLs.
 
-`split-per-preview: true` may use `full` or `full-shared-classpath` for this mode. Each additional
-module's split remains self-contained—the primary module's external-resource pool is not a shared
-classpath. Static repository-wide publication still supports `split-mode: view-only` without live
+`split-per-preview: true` may use `full` or `full-shared-classpath` for this mode (see
+[Per-preview split modes](#per-preview-split-modes) for what each costs, and the bound the default
+enforces). Each additional module's split remains self-contained—the primary module's
+external-resource pool is not a shared classpath. Static repository-wide publication still supports `split-mode: view-only` without live
 bundles. Repository-wide mode continues to require `render-shards: 1` and does not combine with
 `extra-module`, since both are separate fan-out mechanisms.
 
@@ -350,6 +351,51 @@ top-level section after generate. A caller runs its bespoke lane (e.g. re-themin
 a sibling catalog) in a prior job that uploads the bundle artifact, then passes it
 to the reusable workflow — so the render/generate/publish stays shared while the
 bespoke step lives in the caller. A Wasm tier still needs a bespoke workflow.
+
+### Per-preview split modes
+
+`split-per-preview: true` writes one addressable bundle per preview under
+`bundle/previews/<id>.png`. `split-mode` decides what each of them carries:
+
+| mode | each bundle carries | live re-render | cost |
+| --- | --- | --- | --- |
+| `auto` (default) | as `full` | yes | as `full`, but the publish **fails** above the carriage bound (below) |
+| `full` | its own copy of the shared re-render carriage | yes | carriage × preview count |
+| `full-shared-classpath` | a hash-verified `externalClasspath` pointer; `classes/app.jar` is published once into `bundle/res/` | yes, server-hydrated | carriage once |
+| `view-only` | baked image + sidecars, no classpath | no | tens of KB per bundle |
+
+The live modes require `publish-live-bundle: true`.
+
+**Why the default fails instead of adapting.** A `full` split copies the shared carriage —
+`classes/app.jar`, `libs/`, the Android `resources.ap_` payload — into every bundle, so its size is
+a function of the **preview count**, not of the backend. "Only `app.jar` repeats" is ~600 KB per
+preview: 17 MB at 88 previews, 790 MB at ~1,300. And because any catalog edit rewrites `app.jar`,
+each publish rewrites all N copies and lays down a fresh git delta chain, so the delivery branch
+grows by the repeated size *every time* — while the branch tip keeps looking fine, because git
+deltas near-identical polyglots well within one snapshot. m3-catalog took the default for 76 green
+publishes and reached a 2.52 GiB clone (#4211).
+
+So `bundle split` measures the carriage and the workflow gates on it: once the repeated payload is
+**≥ 50% of everything the split wrote**, `split-mode: auto` fails the publish with the numbers and
+the two options. `auto` splits exactly as `full` always did — nothing about an existing delivery
+branch changes shape underneath its consumers — and an explicit mode is never failed, only
+reported. What the bound buys is that a large catalog cannot take the expensive default without
+someone deciding to.
+
+The decision is genuinely the catalog owner's, which is why it is forced rather than made: pooled
+per-preview bundles are **not offline-executable from a bare download** (see
+`docs/portable-bundles.md`, "Shared per-preview classpath"), so a consumer that fetches one preview
+and expects it to run would break on a threshold crossing it never opted into. On m3-catalog the
+trade was 15.7× (789.7 MB → 50.4 MB) with the live lane intact.
+
+Measure it yourself on any packed sheet:
+
+```bash
+compose-preview bundle split sheet.png -o /tmp/split --carriage-report /tmp/carriage.json
+```
+
+The command prints the carriage share and names the remedy for the mode it ran in; the JSON is what
+the workflow gate reads.
 
 #### Giving `extra-module` its own live lane
 

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -171,8 +171,13 @@ jar. Idempotent — re-running finds the fonts already gone and changes nothing.
 ### Shared per-preview classpath (opt-in)
 
 The ordinary `bundle split` full mode remains self-contained: every per-preview
-bundle carries `classes/app.jar`. For delivery trees where that repetition is
-too expensive, the explicitly opt-in form
+bundle carries `classes/app.jar`. That repetition costs the carriage once per
+preview, so it scales with the preview count rather than the backend — `bundle
+split` measures it and says so, and above 50% of the split's output the design
+catalog workflow refuses to take it by default (see
+[DESIGN_CATALOGS.md — Per-preview split modes](design/DESIGN_CATALOGS.md#per-preview-split-modes)).
+For delivery trees where the repetition is too expensive, the explicitly opt-in
+form
 
 ```
 compose-preview bundle split sheet.png -o bundle/previews \

--- a/scripts/design-artifacts/split-carriage-gate.mjs
+++ b/scripts/design-artifacts/split-carriage-gate.mjs
@@ -1,0 +1,188 @@
+/**
+ * The bound that stops `split-mode` from taking an expensive default in silence.
+ *
+ * A FULL per-preview split copies the shared re-render carriage — `classes/app.jar`, `libs/`, the
+ * Android `resources.ap_` payload — into every bundle. That is correct, and its cost is a function
+ * of the **preview count**, not of the backend: the carriage is a fixed per-bundle price paid N
+ * times. At 88 previews that is a rounding error; at ~1,300 it was 790 MB.
+ *
+ * Worse, the cost is not paid once. Any catalog change rewrites `app.jar`, hence all N bundles,
+ * hence a fresh git delta chain on the delivery branch — ~33 MB per publish for m3-catalog, ~230
+ * MB/day, unbounded. None of it shows in the branch tip (which packs to 71.5 MB, because git deltas
+ * near-identical polyglots well *within* a snapshot), so 76 green publishes took that clone to
+ * 2.52 GiB before anyone looked.
+ *
+ * This gate makes the crossing loud. `split-mode: auto` — the default — splits exactly as `full`
+ * always did, so no delivery branch changes shape underneath its consumers; what changes is that
+ * once the carriage passes [CARRIAGE_GATE_THRESHOLD_PERCENT] of the output, the publish fails and
+ * the caller has to write down which trade they want:
+ *
+ *   - `full-shared-classpath` publishes `app.jar` once into a content-addressed pool and keeps the
+ *     live re-render lane (each manifest carries a hash-verified `externalClasspath`). 15.7× smaller
+ *     on m3-catalog. The trade is real and belongs to the catalog owner: pooled per-preview bundles
+ *     are not offline-executable from a bare download (docs/portable-bundles.md), so anything that
+ *     fetches one preview and expects it to run breaks — which is exactly why this is a forced
+ *     choice and not an adaptive default that flips underneath such a consumer.
+ *   - `full` keeps self-contained bundles and accepts the cost, on the record, in the workflow file.
+ *
+ * An explicit mode is never failed — the point is that the choice is written down, not that one
+ * answer is right. Pure and dependency-free so it unit-tests without an `npm ci`.
+ */
+
+import fs from "node:fs";
+
+/**
+ * Report the carriage as a failure once it is at least this share of everything the split wrote.
+ * Mirrors `SPLIT_CARRIAGE_REPORT_PERCENT` in the CLI's BundleSplit.kt, which is the threshold the
+ * same measurement warns at; the two are the same number on purpose, so a run that warns is the run
+ * that fails.
+ */
+export const CARRIAGE_GATE_THRESHOLD_PERCENT = 50;
+
+/** Every `split-mode` the reusable workflow accepts. */
+export const SPLIT_MODES = ["auto", "full", "full-shared-classpath", "view-only"];
+
+const MODE_DOC = "docs/design/DESIGN_CATALOGS.md#per-preview-split-modes";
+
+/** Raw bytes, with a MiB gloss once the number stops being readable as bytes. */
+function bytes(n) {
+  const mib = n / (1024 * 1024);
+  return mib >= 1 ? `${n} bytes (${mib.toFixed(1)} MiB)` : `${n} bytes`;
+}
+
+/**
+ * Decide what a split's carriage report means for the chosen [mode].
+ *
+ * @param {object} args
+ * @param {string} args.mode one of [SPLIT_MODES]
+ * @param {object|null} args.report parsed `--carriage-report` JSON, or null when the CLI wrote none
+ * @param {string} [args.system] the delivery system, for the message
+ * @returns {{level: "ok"|"notice"|"warning"|"error", title: string, headline: string,
+ *   details: string[]}}
+ */
+export function evaluateSplitCarriage({ mode, report, system = "<system>" }) {
+  if (!SPLIT_MODES.includes(mode)) {
+    return {
+      level: "error",
+      title: "split-mode",
+      headline: `unknown split-mode '${mode}' — use ${SPLIT_MODES.join(", ")}.`,
+      details: [],
+    };
+  }
+
+  if (!report) {
+    // An older released CLI has no `--carriage-report`, so it wrote nothing. Refusing to publish
+    // over that would break every caller pinned below the release that added it, for a measurement
+    // rather than a defect — so say it out loud and carry on with the historic behaviour.
+    if (mode !== "auto") return { level: "ok", title: "", headline: "", details: [] };
+    return {
+      level: "warning",
+      title: "split carriage unmeasured",
+      headline:
+        "the installed compose-preview CLI has no 'bundle split --carriage-report', so " +
+        "split-mode: auto ran as 'full' without checking what the shared carriage costs.",
+      details: [
+        "Raise cli-version (or the version-catalog pin behind cli-version: catalog) to a release " +
+          "that carries it, or set split-mode explicitly to record the choice.",
+      ],
+    };
+  }
+
+  const {
+    bundles = 0,
+    carriageBytesPerBundle = 0,
+    repeatedBytes = 0,
+    totalBytes = 0,
+    sharePercent = 0,
+  } = report;
+  const share = `${sharePercent.toFixed(1)}%`;
+  const measured =
+    `shared carriage is ${carriageBytesPerBundle} bytes in each of ${bundles} bundle(s) — ` +
+    `${bytes(repeatedBytes)} of ${bytes(totalBytes)} written (${share}).`;
+  const dominates = bundles > 1 && sharePercent >= CARRIAGE_GATE_THRESHOLD_PERCENT;
+
+  if (mode === "auto" && dominates) {
+    return {
+      level: "error",
+      title: "split-mode",
+      headline: `split-mode defaulted to 'full' and the carriage now dominates: ${measured}`,
+      details: [
+        `Every catalog edit rewrites that payload in all ${bundles} bundles, so ` +
+          `design-artifacts/${system} grows by ${bytes(repeatedBytes)} on EVERY publish — ` +
+          "unbounded, and invisible in the branch tip.",
+        "The default will not choose for you, because the choice changes what a delivery branch " +
+          "promises. Write one of these into the workflow inputs:",
+        "  split-mode: full-shared-classpath   # app.jar published once into bundle/res; the live " +
+          "re-render lane stays intact (each manifest keeps a hash-verified externalClasspath). " +
+          "Per-preview bundles are then NOT offline-executable from a bare download.",
+        "  split-mode: full                    # keep self-contained bundles and accept the cost.",
+        `See ${MODE_DOC}.`,
+      ],
+    };
+  }
+
+  if (dominates) {
+    return {
+      level: "notice",
+      title: "split carriage",
+      headline: `split-mode: ${mode} — ${measured}`,
+      details: [
+        mode === "full"
+          ? "Chosen explicitly, so the repetition is accepted rather than accidental; " +
+            "full-shared-classpath would publish that payload once."
+          : "app.jar is already pooled; what repeats is libs/ + the Android payload.",
+      ],
+    };
+  }
+
+  return {
+    level: "notice",
+    title: "split carriage",
+    headline:
+      `split-mode: ${mode}${mode === "auto" ? " (resolved to full)" : ""} — ${measured} ` +
+      `Bound is ${CARRIAGE_GATE_THRESHOLD_PERCENT}%.`,
+    details: [],
+  };
+}
+
+/** Read a carriage report, or null when the CLI that ran the split wrote none. */
+export function readCarriageReport(path) {
+  if (!path || !fs.existsSync(path)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function flag(argv, name, fallback = "") {
+  const i = argv.indexOf(name);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : fallback;
+}
+
+function main(argv) {
+  const mode = flag(argv, "--mode");
+  const system = flag(argv, "--system", "<system>");
+  const result = evaluateSplitCarriage({
+    mode,
+    report: readCarriageReport(flag(argv, "--report")),
+    system,
+  });
+  if (result.level === "ok") return 0;
+
+  const lines = [result.headline, ...result.details];
+  for (const line of lines) console.log(line);
+  // One annotation, so the run's summary carries the headline; the body is above it in the log.
+  console.log(`::${result.level} title=${result.title}::${result.headline}`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `\n**${result.title}** — ${lines.join("\n\n")}\n`,
+    );
+  }
+  return result.level === "error" ? 1 : 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/design-artifacts/split-carriage-gate.test.mjs
+++ b/scripts/design-artifacts/split-carriage-gate.test.mjs
@@ -1,0 +1,110 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CARRIAGE_GATE_THRESHOLD_PERCENT,
+  SPLIT_MODES,
+  evaluateSplitCarriage,
+} from "./split-carriage-gate.mjs";
+
+/** m3-catalog's measured numbers — the run this gate exists because of. */
+const M3 = {
+  mode: "full",
+  bundles: 1296,
+  carriageBytesPerBundle: 625114,
+  repeatedBytes: 810147744,
+  totalBytes: 828091478,
+  sharePercent: 97.8,
+};
+
+/** A small catalog: the carriage is there, but it is not the story. */
+const SMALL = {
+  mode: "full",
+  bundles: 88,
+  carriageBytesPerBundle: 600000,
+  repeatedBytes: 52800000,
+  totalBytes: 220000000,
+  sharePercent: 24,
+};
+
+test("the default fails once the carriage dominates, and names both explicit options", () => {
+  const result = evaluateSplitCarriage({ mode: "auto", report: M3, system: "m3" });
+
+  assert.equal(result.level, "error");
+  const text = [result.headline, ...result.details].join("\n");
+  assert.match(text, /625114 bytes in each of 1296 bundle\(s\)/);
+  assert.match(text, /97\.8%/);
+  assert.match(text, /split-mode: full-shared-classpath/);
+  assert.match(text, /split-mode: full\b/);
+  assert.match(text, /design-artifacts\/m3/);
+});
+
+test("the default is unchanged for a catalog below the bound", () => {
+  const result = evaluateSplitCarriage({ mode: "auto", report: SMALL });
+
+  assert.equal(result.level, "notice");
+  assert.match(result.headline, /resolved to full/);
+  assert.match(result.headline, /Bound is 50%/);
+});
+
+test("an explicit mode is never failed — the point is that the choice is recorded", () => {
+  for (const mode of ["full", "full-shared-classpath", "view-only"]) {
+    const result = evaluateSplitCarriage({ mode, report: { ...M3, mode } });
+    assert.equal(result.level, "notice", `${mode} must not fail`);
+    assert.match(result.headline, new RegExp(`split-mode: ${mode}`));
+  }
+});
+
+test("explicit full still says what it is paying, so the acceptance stays visible", () => {
+  const result = evaluateSplitCarriage({ mode: "full", report: M3 });
+
+  assert.match(result.details.join(" "), /Chosen explicitly/);
+  assert.match(result.details.join(" "), /full-shared-classpath/);
+});
+
+test("a single-bundle split repeats nothing, whatever the share arithmetic says", () => {
+  const result = evaluateSplitCarriage({
+    mode: "auto",
+    report: {
+      bundles: 1,
+      carriageBytesPerBundle: 900000,
+      repeatedBytes: 900000,
+      totalBytes: 1000000,
+      sharePercent: 90,
+    },
+  });
+
+  assert.equal(result.level, "notice");
+});
+
+test("exactly at the bound fails — the threshold is inclusive on both sides of the pair", () => {
+  const atBound = {
+    bundles: 100,
+    carriageBytesPerBundle: 1000,
+    repeatedBytes: 100000,
+    totalBytes: 200000,
+    sharePercent: CARRIAGE_GATE_THRESHOLD_PERCENT,
+  };
+  assert.equal(evaluateSplitCarriage({ mode: "auto", report: atBound }).level, "error");
+});
+
+test("a CLI too old to measure warns instead of blocking the publish", () => {
+  const result = evaluateSplitCarriage({ mode: "auto", report: null });
+
+  assert.equal(result.level, "warning");
+  assert.match(result.headline, /--carriage-report/);
+  assert.match(result.details.join(" "), /cli-version/);
+});
+
+test("no report and an explicit mode has nothing to say", () => {
+  assert.equal(evaluateSplitCarriage({ mode: "full", report: null }).level, "ok");
+  assert.equal(evaluateSplitCarriage({ mode: "view-only", report: null }).level, "ok");
+});
+
+test("an unknown mode is rejected rather than treated as the default", () => {
+  const result = evaluateSplitCarriage({ mode: "shared", report: SMALL });
+
+  assert.equal(result.level, "error");
+  assert.match(result.headline, /unknown split-mode 'shared'/);
+  assert.deepEqual(SPLIT_MODES, ["auto", "full", "full-shared-classpath", "view-only"]);
+});


### PR DESCRIPTION
Closes #4211.

Takes option **(2)** from the issue — keep `full` as the *behaviour*, but refuse to take it by default above a measured bound — and, since `fix/split-carriage-3036` never landed here, also brings the "already addressed" half: the missing signal and the wrong design note.

## What changed

**`bundle split` measures the carriage.** The shared re-render payload (`classes/app.jar`, `libs/`, `report.json`, the Android `android/` payload) is now sized *as it will land* — the same entries deflated into one zip — before any bundle is written, and reported against what the split actually wrote:

```
bundle split: shared carriage is 2956 bytes in each of 60 bundle(s) — 177360 of 221479 total
bytes (80.1%) is the same payload repeated; publish it once with --shared-classpath-out
<pool-dir> — each bundle keeps a hash-verified externalClasspath, so the live re-render lane
survives — or --view-only if this tier never re-renders. Largest carried entry: classes/app.jar
(400000 bytes).
```

The remedy is chosen per mode: under `full-shared-classpath` it says app.jar is already pooled and what remains is `libs/` + `android/`. The old ">100 KB, try `--view-only`" warning survives only for the case it actually described — an outsized render when the carriage is *not* the story — so it stops firing 1,296 times per run on a live catalog with advice that tier cannot take.

`--carriage-report <file.json>` writes the same numbers machine-readably.

**`split-mode` defaults to `auto`.** It splits *exactly* as `full` always did, so no existing delivery branch changes shape underneath its consumers. What changes: once the repeated payload is ≥ 50% of the split output, `scripts/design-artifacts/split-carriage-gate.mjs` fails the publish with the measurement and both options written out —

```
::error title=split-mode::split-mode defaulted to 'full' and the carriage now dominates:
shared carriage is 625114 bytes in each of 1296 bundle(s) — 810147744 bytes (772.6 MiB) of
828091478 bytes (789.7 MiB) written (97.8%).
…
  split-mode: full-shared-classpath   # app.jar published once into bundle/res; the live
                                      # re-render lane stays intact. Per-preview bundles are
                                      # then NOT offline-executable from a bare download.
  split-mode: full                    # keep self-contained bundles and accept the cost.
```

An explicit mode is never failed, only reported — the trade is the catalog owner's, which is why (1) was rejected: an adaptive default would flip `full` → pooled underneath a consumer that fetches one preview and expects it to run offline, on a threshold crossing it never opted into. A CLI too old to have `--carriage-report` warns rather than blocking, so external callers pinned below the next release keep publishing.

**Two things the issue also named.** An unknown `split-mode` is now rejected in the 5-minute `driver` job instead of silently meaning `full` after the render; and the `design-artifacts.yml` note asserting a FULL split "stays small — only `classes/app.jar` repeats per preview" is corrected in place, since both its premises are true and its conclusion is what kept this tier out of #3036's audit.

## Test plan

- `./gradlew :cli:test` — green. New `BundleSplitTest` coverage: carriage measured per mode (`full` / `view-only` / pooled), the dominance threshold, the mode-specific remedy, the single-bundle case, and the report JSON shape a publisher gates on.
- `node --test split-carriage-gate.test.mjs` — 9 tests, green (runs in CI's existing **Design Artifacts Driver Tests** job). Covers the m3-catalog numbers failing under `auto`, a small catalog passing, every explicit mode passing, the exact-bound case, the too-old-CLI warning, and an unknown mode.
- End-to-end against a synthetic 60-preview sheet with the built CLI, all three modes: `full` → 80.1% and a failing gate under `auto`; `full-shared-classpath` → 106,717 B total vs `full`'s 221,479 B, gate passes with a notice; `view-only` → zero carriage.
- `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — clean. Both workflows parse.

Non-visual change (CLI plumbing + workflow gating), so no rendered before/after applies; the reproduced CLI and gate output above is the evidence.

## Follow-up for the maintainer

m3-catalog currently omits `split-mode`, so its next publish will fail this gate by design — that is the forcing function. It needs `split-mode: full-shared-classpath` (15.7× smaller, live lane intact) or an explicit `split-mode: full` written into its caller workflow.

_Generated by [Claude Code](https://claude.ai/code)_
