### PR TITLE
fix(serve): keep a shared-line scaffold annotation's declaration, and index extensions by callable name

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleaner.kt
@@ -249,8 +249,29 @@ object PlaygroundSourceCleaner {
    * annotation's continuation lines (` id = "Button/Filled",`) look like neither an annotation nor
    * a declaration.
    */
+  /**
+   * An EXTENSION declaration, captured by its callable name rather than its receiver.
+   *
+   * [DECLARATION] takes the first identifier after `fun`, which for `private fun
+   * Morph.toComposePath(...)` is `Morph` — the receiver type. Indexing the helper under that name
+   * meant a body calling `morph.toComposePath(progress)` never matched it: the checked-in
+   * `shape-morph` component does exactly that, so its cleaned snippet brought `ShapeMorphViewer`
+   * along and left `toComposePath` behind — an unresolved call, and not in residue either, because
+   * the residue check reads the same index.
+   *
+   * Tried before [DECLARATION] and only for `fun`, since only a function can be an extension here;
+   * a declaration with no receiver does not match (there is no `.`) and falls through unchanged.
+   */
+  private val EXTENSION_DECLARATION =
+    Regex(
+      """^$ANNOTATION_RUN(?:[a-z]+\s+)*fun\s+(?:<[^>]*>\s+)?[A-Za-z_][A-Za-z0-9_]*(?:<[^>]*>)?\??\.([A-Za-z_][A-Za-z0-9_]*)\s*\("""
+    )
+
   private fun declaredName(text: String): String? =
-    text.lines().firstNotNullOfOrNull { DECLARATION.find(it)?.groupValues?.get(1) }
+    text.lines().firstNotNullOfOrNull { line ->
+      EXTENSION_DECLARATION.find(line)?.groupValues?.get(1)
+        ?: DECLARATION.find(line)?.groupValues?.get(1)
+    }
 
   // ---------------------------------------------------------------------------------------------
   // Header
@@ -523,10 +544,62 @@ object PlaygroundSourceCleaner {
       val end = annotationEnd(lines, i)
       if (!isScaffoldAnnotation(annotationName(line), imports, rules)) {
         for (j in i..end) out.add(lines[j])
+      } else if (end == i) {
+        // A scaffold annotation can SHARE its line with the rest of the declaration — legal Kotlin,
+        // and checked in: `CatalogText.kt:42` is
+        // `@CatalogModes @Composable fun TextBrandedSpecimen() = Sticker("text-branded")`.
+        // Dropping the whole line took `@Composable` and the function with it, leaving the cleaner
+        // nothing to emit and falling back to the verbatim wrapper — the exact snippet this class
+        // exists to replace. Remove only the matched annotation's own span; whatever the line
+        // carries after it survives. Single-line only: a wrapped annotation owns every line of its
+        // argument list, so the old whole-span drop is right there.
+        val remainder = lineWithoutLeadingAnnotation(line)
+        if (remainder.isNotBlank()) out.add(remainder)
       }
       i = end + 1
     }
     return out.joinToString("\n")
+  }
+
+  /**
+   * [line] with its leading `@Annotation(...)` removed, indentation preserved.
+   *
+   * Returns blank when the annotation was the whole line, which is the ordinary case — the caller
+   * then drops it as before.
+   */
+  private fun lineWithoutLeadingAnnotation(line: String): String {
+    val indent = line.takeWhile { it.isWhitespace() }
+    val body = line.substring(indent.length)
+    if (!body.startsWith("@")) return line
+    var index = 1
+    if (body.startsWith("@file:")) index = "@file:".length
+    while (index < body.length && (body[index].isLetterOrDigit() || body[index] == '_')) index++
+    // Skip a balanced argument list, if any. Nesting and string literals both matter: an argument
+    // can itself be an annotation (`@OptIn(A::class, B::class)`) and a string can hold a bracket.
+    if (index < body.length && body[index] == '(') {
+      var depth = 0
+      var inString = false
+      while (index < body.length) {
+        val char = body[index]
+        when {
+          inString && char == '\\' -> index++
+          char == '"' -> inString = !inString
+          !inString && char == '(' -> depth++
+          !inString && char == ')' -> {
+            depth--
+            if (depth == 0) {
+              index++
+              break
+            }
+          }
+        }
+        index++
+      }
+      // Unbalanced — not something to guess at. Leave the line to the caller's whole-span drop.
+      if (depth != 0) return ""
+    }
+    val rest = body.substring(index).trimStart()
+    return if (rest.isEmpty()) "" else indent + rest
   }
 
   /** `@file:OptIn(...)` / `@CatalogComponent(...)` → `OptIn` / `CatalogComponent`. */
@@ -1098,7 +1171,11 @@ object PlaygroundSourceCleaner {
     fun enqueue(text: String) {
       for (name in helpers.keys) {
         if (name in skip || name in queued) continue
-        if (mentionsWord(text, name)) {
+        // `mentionsWord` rejects a name preceded by `.`, which is right for a plain call — a
+        // receiver chain must not be mistaken for a reference — and exactly wrong for an EXTENSION,
+        // whose only call shape is `receiver.name(...)`. Both are checked, so an extension helper
+        // is pulled in by the call that actually appears.
+        if (mentionsWord(text, name) || mentionsExtensionCall(text, name)) {
           queued.add(name)
           queue.addLast(name)
         }
@@ -1679,6 +1756,34 @@ object PlaygroundSourceCleaner {
 
   internal fun mentionsWord(text: String, word: String): Boolean =
     wordOccurrences(text, word).isNotEmpty()
+
+  /**
+   * Whether [text] calls [name] as an extension — `receiver.name(`, at any depth of receiver chain.
+   *
+   * Deliberately narrow: it requires the call parentheses, so a plain property read on an unrelated
+   * receiver (`state.morph`) does not drag a same-named function in. Over-matching here costs a
+   * helper the snippet did not need; under-matching costs an unresolved call reported as clean,
+   * which is the failure this class exists to prevent.
+   */
+  internal fun mentionsExtensionCall(text: String, name: String): Boolean {
+    val mask = codeMask(text)
+    var from = 0
+    while (true) {
+      val at = text.indexOf(name, from).takeIf { it >= 0 } ?: return false
+      from = at + 1
+      if (!mask[at]) continue
+      if (text.getOrNull(at - 1) != '.') continue
+      // The character before the `.` has to end an expression, or this is a package qualifier.
+      val beforeDot = text.getOrNull(at - 2)
+      if (
+        beforeDot != null && !isIdentifierChar(beforeDot) && beforeDot != ')' && beforeDot != ']'
+      ) {
+        continue
+      }
+      val gap = text.drop(at + name.length).takeWhile { it.isWhitespace() }
+      if (text.getOrNull(at + name.length + gap.length) == '(') return true
+    }
+  }
 
   /**
    * Whether [text] still calls [name] through **any** qualifier — `com.acme.counted(…)`.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSourceCleanerTest.kt
@@ -1779,6 +1779,198 @@ class PlaygroundSourceCleanerTest {
     assertFalse(result.text.contains("FilledButtonComponent"), result.text)
   }
 
+  /**
+   * A scaffold annotation sharing its physical line with the rest of the declaration.
+   *
+   * Legal Kotlin, and checked in: `CatalogText.kt:42` is `@CatalogModes @Composable fun
+   * TextBrandedSpecimen() = Sticker("text-branded")`. The stripper worked line-by-line, so
+   * recognising `@CatalogModes` discarded the whole line — `@Composable` and the function with it —
+   * leaving nothing to emit and falling back to the verbatim wrapper, which is the snippet this
+   * class exists to replace.
+   */
+  @Test
+  fun `a scaffold annotation sharing a line with the declaration takes only itself`() {
+    val source =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+
+      @CatalogModes @Composable fun TextBrandedSpecimen() = Sticker("text-branded")
+      """
+        .trimIndent()
+    val components =
+      """
+      package demo.catalog.shared
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CatalogComponent(id: String) {
+        when (id) {
+          "text-branded" -> Text("Branded")
+          else -> Text("unknown")
+        }
+      }
+      """
+        .trimIndent()
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = source,
+          bodyLine = lineIn(source, "fun TextBrandedSpecimen"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, components),
+        )
+      )
+
+    // The scaffold annotation goes, everything else on that line stays, and the delegation still
+    // reduces to the component behind it.
+    assertFalse(result.text.contains("@CatalogModes"), result.text)
+    assertTrue(result.text.contains("@Composable"), result.text)
+    assertTrue(result.text.contains("fun TextBrandedSpecimen()"), result.text)
+    assertTrue(result.text.contains("""Text("Branded")"""), result.text)
+    assertFalse(result.text.contains("Sticker("), result.text)
+  }
+
+  /** An annotation with arguments on a shared line — the span to remove is not just a word. */
+  @Test
+  fun `only the matched annotation span is removed when it carries arguments`() {
+    val source =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+      import ee.schimke.composeai.preview.CatalogComponent
+
+      @CatalogComponent(id = "Text/Branded", group = "Text") @Composable fun Branded() = Sticker("text-branded")
+      """
+        .trimIndent()
+    val components =
+      """
+      package demo.catalog.shared
+
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CatalogComponent(id: String) {
+        when (id) {
+          "text-branded" -> Text("Branded")
+          else -> Text("unknown")
+        }
+      }
+      """
+        .trimIndent()
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = source,
+          bodyLine = lineIn(source, "fun Branded"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, components),
+        )
+      )
+
+    assertFalse(result.text.contains("""id = "Text/Branded""""), result.text)
+    assertTrue(result.text.contains("@Composable"), result.text)
+    assertTrue(result.text.contains("fun Branded()"), result.text)
+    assertTrue(result.text.contains("""Text("Branded")"""), result.text)
+  }
+
+  /**
+   * An extension helper in a scaffold source, called the only way an extension can be.
+   *
+   * `helperIndex` keys on `declaredName`, which took the first identifier after `fun` — so `private
+   * fun Morph.toComposePath(...)` was recorded under `Morph`, the RECEIVER. A body calling
+   * `morph.toComposePath(progress)` matched neither that key (wrong word) nor, once keyed properly,
+   * `mentionsWord` (which rejects a name preceded by `.`, correctly, for plain calls). The
+   * checked-in `shape-morph` component is exactly this shape: its snippet carried
+   * `ShapeMorphViewer` and left `toComposePath` behind — unresolved, and absent from residue too,
+   * because the residue check reads the same index.
+   */
+  @Test
+  fun `an extension helper is indexed by its callable name and followed through a receiver call`() {
+    val source =
+      """
+      package demo.catalog
+
+      import androidx.compose.runtime.Composable
+
+      @CatalogModes
+      @Composable
+      fun ShapeMorph() = Sticker("shape-morph")
+      """
+        .trimIndent()
+    val components =
+      """
+      package demo.catalog.shared
+
+      import androidx.compose.runtime.Composable
+
+      @Composable
+      fun CatalogComponent(id: String) {
+        when (id) {
+          "shape-morph" -> ShapeMorphViewer()
+          else -> Unit
+        }
+      }
+
+      @Composable
+      fun ShapeMorphViewer() {
+        val morph = rememberMorph()
+        val path = morph.toComposePath(0.5f)
+        Draw(path)
+      }
+
+      private fun Morph.toComposePath(progress: Float): String = "path at " + progress
+      """
+        .trimIndent()
+
+    val result =
+      assertNotNull(
+        PlaygroundSourceCleaner.clean(
+          source = source,
+          bodyLine = lineIn(source, "fun ShapeMorph"),
+          rules = delegatingRules,
+          parser = null,
+          helperSources = listOf(stickerHelper, components),
+        )
+      )
+
+    assertTrue(result.text.contains("fun ShapeMorphViewer"), result.text)
+    assertTrue(
+      result.text.contains("fun Morph.toComposePath"),
+      "the extension the snippet calls was left behind:\n${result.text}",
+    )
+    assertEquals(emptyList(), result.residue, result.text)
+  }
+
+  /**
+   * The receiver-aware check must not drag in a same-named helper that is only read, not called.
+   */
+  @Test
+  fun `a property read on a receiver does not pull in a same-named function`() {
+    assertTrue(
+      PlaygroundSourceCleaner.mentionsExtensionCall("morph.toComposePath(0.5f)", "toComposePath")
+    )
+    assertTrue(
+      PlaygroundSourceCleaner.mentionsExtensionCall("a.b().toComposePath (x)", "toComposePath")
+    )
+    assertFalse(
+      PlaygroundSourceCleaner.mentionsExtensionCall("state.toComposePath", "toComposePath")
+    )
+    // A package qualifier is not a receiver call.
+    assertFalse(
+      PlaygroundSourceCleaner.mentionsExtensionCall("\"morph.toComposePath(1f)\"", "toComposePath")
+    )
+  }
+
   private fun lineIn(text: String, needle: String): Int =
     text.lines().indexOfFirst { it.contains(needle) } + 1
 }


### PR DESCRIPTION
Two more of the P2s Codex raised on [#4179](https://github.com/yschimke/compose-ai-tools/pull/4179). Both reproduce against the **checked-in m3 catalog**, and both are silent — the Source panel reports a clean snippet either way.

## A scaffold annotation sharing a line took the declaration with it

`stripScaffoldAnnotations` worked line-by-line, so recognising a scaffold annotation dropped its whole *physical* line. `CatalogText.kt:42` is legal Kotlin that puts everything on one:

```kotlin
@CatalogModes @Composable fun TextBrandedSpecimen() = Sticker("text-branded")
```

Cleaning that discarded `@Composable` and the function along with `@CatalogModes`, leaving nothing to emit — so the cleaner fell back to the verbatim wrapper, which is precisely the snippet this class exists to replace.

Only the matched annotation's own span is removed now, arguments included (the scan tracks nesting and string literals, so `@OptIn(A::class, B::class)` and an argument containing a bracket both survive). A *wrapped* annotation still owns every line of its argument list, so the whole-span drop is kept there and only the single-line case changed.

## Extension helpers were indexed by their receiver

`declaredName` takes the first identifier after `fun`, which for `private fun Morph.toComposePath(...)` is `Morph` — the **receiver type**. So `helperIndex` filed the helper under `Morph`, and a body calling `morph.toComposePath(progress)` matched nothing.

Keying it correctly is not sufficient on its own: `mentionsWord` deliberately rejects a name preceded by `.`, which is right for a plain call (a receiver chain must not be read as a reference) and exactly wrong for an extension, whose only call shape *is* `receiver.name(...)`. Both halves are fixed.

The checked-in `shape-morph` component is this shape — `CatalogComponents.kt:392` calls `morph.toComposePath(progress)` against `private fun Morph.toComposePath` at line 403 — so its snippet carried `ShapeMorphViewer` and left `toComposePath` behind: an unresolved call, and absent from residue too, because the residue check reads the same index.

The receiver-aware match is deliberately narrow: it requires the call parentheses, so a property read on an unrelated receiver (`state.morph`) does not drag a same-named function in. Over-matching costs a helper the snippet did not need; under-matching costs an unresolved call reported as clean, and only one of those is worth avoiding.

## Test plan

- `./gradlew :cli:test --tests '*PlaygroundSourceCleanerTest*' --rerun-tasks` — green, with four new cases: the shared-line annotation, the shared-line annotation *with arguments*, the extension helper followed end-to-end, and unit coverage of `mentionsExtensionCall`'s boundaries.
- Confirmed all three integration cases fail against the unfixed cleaner (`53 tests completed, 3 failed`).
- `./gradlew :cli:ktfmtCheck` — clean.

**One thing to know about local verification:** the full `:cli:test` run crashes on my machine with a Gradle test-worker `java.io.EOFException` — no test reports a failure, the worker dies. I ran the same command against unmodified `origin/main` and it produces the identical crash, so it is this environment (a long session with many concurrent Gradle daemons), not this change. CI runs the suite on a clean machine, which is the check that counts here.

Non-visual: the Source panel's snippet text, not a rendered surface.

_Generated by [Claude Code](https://claude.com/claude-code)_
