### PR TITLE
test(rc-player): make the top-level colour test exercise ID-backed evaluation

### DIFF
--- a/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcTopLevelContentStateTest.kt
+++ b/rc-player/runtime/src/commonTest/kotlin/ee/schimke/composeai/rcplayer/runtime/RcTopLevelContentStateTest.kt
@@ -13,7 +13,6 @@ import ee.schimke.composeai.rcplayer.protocol.RcTheme
 import ee.schimke.composeai.rcplayer.protocol.RcVersion
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 /**
  * The document ROOT is a content scope, like the layout and canvas scopes nested inside it.
@@ -37,8 +36,20 @@ class RcTopLevelContentStateTest {
     val operations = mutableListOf<RcOperation>()
     operations += RcColorConstant(40, opaqueTeal)
     // Declared at top level rather than inside the RootLayout below.
+    //
+    // `ID_ID_INTERPOLATE`, not mode 0: mode 0 is COLOR_COLOR_INTERPOLATE, where `first`/`second`
+    // are literal ARGB rather than ids. Under that mode this expression computes 0x00000028 from
+    // the raw number 40 — non-zero, and still fully transparent — so a bare `assertNotEquals(0, …)`
+    // would pass while proving nothing about ID-backed evaluation, which is the whole mechanism
+    // under test. Reading a stored colour id is what top-level evaluation has to get right.
     operations +=
-      RcColorExpression(outId = 41, modeAndAlpha = 0, first = 40, second = 40, third = 0)
+      RcColorExpression(
+        outId = 41,
+        modeAndAlpha = RcColorExpression.ID_ID_INTERPOLATE,
+        first = 40,
+        second = 40,
+        third = 0,
+      )
     operations += RcRootLayout(1)
     operations += RcLayoutContent(2)
     operations += RcNoArg(RcOpcodes.CONTAINER_END)
@@ -56,10 +67,12 @@ class RcTopLevelContentStateTest {
       RcTheme.UNSPECIFIED,
     )
 
-    // 0 is the tell: an unset colour id and "fully transparent black" are the same value, which is
-    // why this failed silently. The literal it is computed from is asserted alongside, so a change
-    // that broke ordinary constants could not make this pass by accident.
+    // The EXACT value, not merely non-zero. Interpolating a colour with itself is that colour, so
+    // an evaluated expression can only be `opaqueTeal` — and asserting it pins that the id was
+    // actually READ, rather than that something was written. `assertNotEquals(0, …)` would be
+    // satisfied by an expression resolving its inputs as raw numbers into some other transparent
+    // colour, which is exactly the false pass this test exists to avoid.
     assertEquals(opaqueTeal, state.color(40), "the literal it reads from")
-    assertNotEquals(0, state.color(41), "the top-level expression was never evaluated")
+    assertEquals(opaqueTeal, state.color(41), "the top-level expression was never evaluated")
   }
 }


### PR DESCRIPTION
Codex reviewed [#4221](https://github.com/yschimke/compose-ai-tools/pull/4221) after it merged, and it is right: **the regression test I added there passed for the wrong reason.**

## The test proved less than it claimed

`RcColorExpression(modeAndAlpha = 0, first = 40, second = 40, third = 0)` — mode 0 is `COLOR_COLOR_INTERPOLATE`, where `first` and `second` are **literal ARGB values, not colour ids**. So the expression interpolated the raw number `40` with itself and produced `0x00000028`: non-zero, therefore satisfying `assertNotEquals(0, state.color(41))`, and still **fully transparent** — the exact rendering failure the test was written to prevent.

It asserted that *something* had been written to the out id, not that a top-level operation had read a stored colour id. Since ID-backed evaluation is the entire mechanism #4221 fixed, a regression that broke it would have left this green.

## What it asserts now

`ID_ID_INTERPOLATE`, and the **exact** expected value rather than merely non-zero. Interpolating a colour with itself is that colour, so an evaluated expression can only be the opaque teal stored under id 40 — which pins that the id was genuinely *read*. `assertNotEquals(0, …)` would still be satisfied by an expression that resolved its inputs as raw numbers into some other transparent colour, which is precisely the false pass being removed.

The comment now records why mode 0 is wrong here, so the next person to reach for a `ColorExpression` in a test does not repeat it.

## Test plan

- `./gradlew :rc-player-runtime:jvmTest --tests '*RcTopLevelContentStateTest*' --rerun-tasks` — green with the strengthened assertion.
- Reverted `applyDirect = true` back to `false` and re-ran: the strengthened test still fails, so it continues to discriminate on the thing it is meant to.
- `./gradlew :rc-player-runtime:ktfmtCheck` — clean.

Test-only; no production change.

_Generated by [Claude Code](https://claude.com/claude-code)_
