### PR TITLE
feat(serve): make catalog startup load order configurable

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -150,9 +150,11 @@ echo "Reconciling catalogs from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
 while IFS= read -r entry; do
   [[ -n "${entry}" ]] || continue
   system=$(printf '%s' "${entry}" | jq -r '.system')
-  # Preserve the declared shape — an unlisted catalog must stay off the front page, and a group
-  # claim has to survive or the card lands under the owner fallback instead of its section.
-  body=$(printf '%s' "${entry}" | jq -c '{system, repo, listed, group, attributionRepos}
+  # Preserve the declared shape — an unlisted catalog must stay off the front page, a group
+  # claim has to survive or the card lands under the owner fallback instead of its section, and
+  # loadPriority has to reach the box or the committed startup fetch order never takes effect
+  # there (the box boots from its own /config/catalogs.json, which this is what rewrites).
+  body=$(printf '%s' "${entry}" | jq -c '{system, repo, listed, group, attributionRepos, loadPriority}
     | with_entries(select(.value != null))')
   post /admin/catalogs "${body}" "catalog ${system}" || {
     if [[ $? == 2 ]]; then

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -4,8 +4,9 @@
 # Drives the --dry-run seam so the rules that actually matter are pinned without a server:
 #   1. trust is reconciled BEFORE catalogs (a catalog published ahead of its producer would
 #      register as `unverified` and stay that way until its branch moved);
-#   2. the declared entry shape survives — `listed: false` and `group` are not dropped, since
-#      either being lost silently changes where a card renders;
+#   2. the declared entry shape survives — `listed: false`, `group` and `loadPriority` are not
+#      dropped, since the first two being lost silently changes where a card renders and the last
+#      one decides which catalogs a rollout fetches first;
 #   3. null/absent optional fields are omitted rather than sent as JSON null.
 set -uo pipefail
 
@@ -33,7 +34,8 @@ cat > "${tmp}/catalogs.json" <<'JSON'
 {
   "groups": [{ "id": "ds", "heading": "Design Systems" }],
   "catalogs": [
-    { "system": "compose-m3", "repo": "yschimke/compose-ai-tools", "listed": true, "group": "ds" },
+    { "system": "compose-m3", "repo": "yschimke/compose-ai-tools", "listed": true, "group": "ds",
+      "loadPriority": 20 },
     { "system": "cadence", "repo": "yschimke/cadence", "listed": false },
     { "system": "jetnews", "repo": "yschimke/compose-samples", "listed": true,
       "attributionRepos": ["android/compose-samples"] }
@@ -80,6 +82,14 @@ printf '%s' "${out}" | grep -q '"system":"cadence".*"listed":false' ||
 # 4. a group claim survives.
 printf '%s' "${out}" | grep -q '"system":"compose-m3".*"group":"ds"' ||
   fail "compose-m3 must keep its group claim"
+
+# 4b. loadPriority survives — it is what decides which catalogs a rollout fetches first, and the
+#     box boots from the config this rewrites, so dropping it here makes the committed order a
+#     no-op on the deployed server.
+printf '%s' "${out}" | grep -q '"system":"compose-m3".*"loadPriority":20' ||
+  fail "compose-m3 must keep its loadPriority"
+printf '%s' "${out}" | grep -q '"system":"cadence".*"loadPriority"' &&
+  fail "an undeclared loadPriority must be omitted, not sent: ${out}"
 
 # 5. attributionRepos survives (it's what lets a fork-served catalog keep its upstream section).
 printf '%s' "${out}" | grep -q '"attributionRepos":\["android/compose-samples"\]' ||

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1011,6 +1011,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
      * publisher, so its card is grouped by its source repo's owner.
      */
     val group: ServeWeb.HomeGroup? = null,
+    /**
+     * Startup fetch order, highest first ([ServeCatalogsConfig.Entry.loadPriority]). Only a
+     * `--catalogs-file` entry can raise it; a bare flag entry takes the default, which is the order
+     * it was named in.
+     */
+    val loadPriority: Int = 0,
   )
 
   /**
@@ -1043,6 +1049,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           repo = repo,
           listed = entry.listed,
           group = ServeCatalogAdmin.homeGroup(entry, repo, catalogsConfig.groups),
+          loadPriority = entry.loadPriority,
         )
       }
 
@@ -3032,7 +3039,9 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       executor.execute {
         val loaded = linkedSetOf<String>()
         try {
-          for (seed in loads.snapshot().map { it.config }) {
+          // Fetch order, not front-page order: a box's load-bearing catalogs come back first
+          // after a restart even though their cards stay where the operator put them (#4231).
+          for (seed in loads.loadOrder().map { it.config }) {
             if (closed.get()) return@execute
             val (config, result) =
               synchronized(catalogRegistrationLock) {
@@ -3100,6 +3109,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             repo = ref.repo,
             branch = "$catalogBranchPrefix${ref.system}",
             group = ref.group,
+            loadPriority = ref.loadPriority,
           )
         }
       )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -36,6 +36,12 @@ class CatalogLoadTracker(
      * including the home index, which needs the grouping to be config rather than code.
      */
     val group: ServeWeb.HomeGroup? = null,
+    /**
+     * Startup fetch order, highest first ([ServeCatalogsConfig.Entry.loadPriority]). Kept beside
+     * the rest of the configured entry because [loadOrder] is the one consumer, and it reads the
+     * same snapshot every other consumer does.
+     */
+    val loadPriority: Int = 0,
   )
 
   /** Immutable snapshot of one catalog's current availability and latest attempt. */
@@ -85,8 +91,9 @@ class CatalogLoadTracker(
     }
 
   /**
-   * Replace [system]'s **listing** metadata — where it appears, not where it comes from — keeping
-   * its load state and its registered content untouched. Returns false when it isn't tracked.
+   * Replace [system]'s **listing** metadata — where it appears and when it is fetched, not where it
+   * comes from — keeping its load state and its registered content untouched. Returns false when it
+   * isn't tracked.
    *
    * Needed because a catalog's front-page placement is resolved once, at registration, into a
    * [ServeWeb.HomeGroup] snapshot. So a group defined *after* a catalog was published would never
@@ -100,10 +107,17 @@ class CatalogLoadTracker(
    * with its own provenance (and its trust verdict). Re-pointing a catalog is a retire plus a
    * publish.
    */
-  fun relist(system: String, listed: Boolean, group: ServeWeb.HomeGroup?): Boolean =
+  fun relist(
+    system: String,
+    listed: Boolean,
+    group: ServeWeb.HomeGroup?,
+    // Deliberately not defaulted: every caller states it, so none can silently reset it to 0.
+    loadPriority: Int,
+  ): Boolean =
     synchronized(lock) {
       val existing = states[system] ?: return false
-      val updated = existing.config.copy(listed = listed, group = group)
+      val updated =
+        existing.config.copy(listed = listed, group = group, loadPriority = loadPriority)
       states[system] = existing.copy(config = updated)
       val at = ordered.indexOfFirst { it.system == system }
       if (at >= 0) ordered[at] = updated
@@ -158,6 +172,18 @@ class CatalogLoadTracker(
    */
   fun snapshot(): List<State> =
     synchronized(lock) { ordered.toList() }.mapNotNull { states[it.system] }
+
+  /**
+   * The same catalogs as [snapshot], in the order the **initial fetch** should walk them: highest
+   * [Config.loadPriority] first, ties keeping configured order (the sort is stable).
+   *
+   * Separate from [snapshot] on purpose. Configured order is the front page's, and the two wants
+   * genuinely differ: the queue wants the box's load-bearing catalogs back first after a restart,
+   * while the index wants sections and cards where the operator put them. Sorting the tracker
+   * itself would have moved the cards — and moved [firstAvailableSystem], which is the session the
+   * readiness probe renders — as a side effect of a fetch-order preference (issue #4231).
+   */
+  fun loadOrder(): List<State> = snapshot().sortedByDescending { it.config.loadPriority }
 
   /** Catalogs with a usable registered copy; used to seed only successful branch heads. */
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
@@ -129,8 +129,23 @@ class ServeCatalogAdmin(
     for (entry in declared.catalogs) {
       val current = tracker.configFor(entry.system) ?: continue
       val resolved = homeGroup(entry, current.repo, table)
-      if (current.group == resolved && current.listed == entry.listed) continue
-      if (tracker.relist(entry.system, listed = entry.listed, group = resolved)) changed++
+      if (
+        current.group == resolved &&
+          current.listed == entry.listed &&
+          current.loadPriority == entry.loadPriority
+      ) {
+        continue
+      }
+      if (
+        tracker.relist(
+          entry.system,
+          listed = entry.listed,
+          group = resolved,
+          loadPriority = entry.loadPriority,
+        )
+      ) {
+        changed++
+      }
     }
     return changed
   }
@@ -157,6 +172,10 @@ class ServeCatalogAdmin(
     // forever.
     // The content is untouched — no re-fetch, no dropped load state — and a repo change is still
     // refused, since that decides what bytes get served (retire and re-publish for that).
+    // `loadPriority` converges the same way: it changes nothing about a catalog already registered,
+    // but the point of writing it back is the NEXT boot's fetch order, and the deployment reconcile
+    // (.github/scripts/publish-config-to-box.sh) is additive — without this, re-declaring a
+    // priority on an already-published catalog would 409 and never reach the box's config.
     tracker.configFor(entry.system)?.let { current ->
       if (current.repo != repo) {
         return Result.Conflict(
@@ -165,10 +184,19 @@ class ServeCatalogAdmin(
         )
       }
       val resolved = homeGroup(entry, repo, declared)
-      if (current.group == resolved && current.listed == entry.listed) {
+      if (
+        current.group == resolved &&
+          current.listed == entry.listed &&
+          current.loadPriority == entry.loadPriority
+      ) {
         return Result.Conflict("catalog '${entry.system}' is already published")
       }
-      tracker.relist(entry.system, listed = entry.listed, group = resolved)
+      tracker.relist(
+        entry.system,
+        listed = entry.listed,
+        group = resolved,
+        loadPriority = entry.loadPriority,
+      )
       onLog("serve: catalog ${entry.system} listing updated via admin API")
       return Result.Ok(entry.system, persist { it.withEntry(entry.copy(repo = repo)) })
     }
@@ -219,6 +247,7 @@ class ServeCatalogAdmin(
       repo = repo,
       branch = "$branchPrefix${entry.system}",
       group = homeGroup(entry, repo, declaredGroups),
+      loadPriority = entry.loadPriority,
     )
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfig.kt
@@ -75,6 +75,23 @@ data class ServeCatalogsConfig(
      * under the heading.
      */
     val attributionRepos: List<String> = emptyList(),
+    /**
+     * **Startup load order**, highest first; ties keep the order they appear in here. Default 0, so
+     * a config that says nothing loads exactly as it always did — front-page order.
+     *
+     * The initial fetch is one sequential pass over the configured set, and a big catalog takes
+     * minutes to fetch, verify and register. Which catalog that pass reaches first is therefore
+     * what a rollout's first few minutes serve — and the order was purely positional, which for a
+     * catalog published through the admin API means *last*, since a runtime registration is
+     * appended ([CatalogLoadTracker.add]). So the catalogs a box most wants back after a restart
+     * were reliably the ones it got back last (issue #4231). This decouples the two orders: the
+     * list stays the front page's, this decides the queue.
+     *
+     * It does **not** change what is served, or where a card renders — only what gets fetched
+     * first. Nothing here is a guarantee of availability either: loading stays best-effort per
+     * catalog, and a prioritised catalog that fails to fetch just fails earlier.
+     */
+    val loadPriority: Int = 0,
   )
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2944,6 +2944,7 @@ class ServeHttpServer(
             branch = state.config.branch,
             listed = state.config.listed,
             group = state.config.group?.heading,
+            loadPriority = state.config.loadPriority,
             state = state.loadState,
             error = state.error,
           )
@@ -8025,6 +8026,12 @@ private data class AdminCatalogDto(
   val listed: Boolean,
   /** The front-page section heading this catalog is published under; null ⇒ grouped by owner. */
   val group: String? = null,
+  /**
+   * Startup fetch order, highest first ([ServeCatalogsConfig.Entry.loadPriority]). Reported so a
+   * deployment reconcile can see what the box will actually load first on its next boot, rather
+   * than having to read the box's `catalogs.json`.
+   */
+  val loadPriority: Int = 0,
   /** `pending` / `loaded` / `failed` / `stale` ([CatalogLoadTracker.State.loadState]). */
   val state: String,
   val error: String? = null,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
@@ -78,4 +78,64 @@ class CatalogLoadTrackerTest {
     assertEquals("stale", reply.loadState)
     assertEquals("new branch content is malformed", reply.error)
   }
+
+  @Test
+  fun `load order is by priority, leaving configured order to the front page`() {
+    val tracker = tracker()
+    tracker.add(
+      CatalogLoadTracker.Config(
+        system = "m3-catalog",
+        listed = true,
+        repo = "yschimke/m3-catalog",
+        branch = "design-artifacts/m3-catalog",
+        loadPriority = 20,
+      )
+    )
+    tracker.add(
+      CatalogLoadTracker.Config(
+        system = "wear-m3-catalog",
+        listed = true,
+        repo = "yschimke/wear-m3-catalog",
+        branch = "design-artifacts/wear-m3-catalog",
+        loadPriority = 10,
+      )
+    )
+
+    // A runtime registration is APPENDED, which is exactly how the two catalogs a box most wants
+    // back ended up loading last (#4231): fetch order now leads with them...
+    assertEquals(
+      listOf("m3-catalog", "wear-m3-catalog", "jetnews", "reply"),
+      tracker.loadOrder().map { it.config.system },
+    )
+    // ...while everything driven by configured order — the front page, and the session
+    // firstAvailableSystem hands the readiness probe — is untouched.
+    assertEquals(
+      listOf("jetnews", "reply", "m3-catalog", "wear-m3-catalog"),
+      tracker.snapshot().map { it.config.system },
+    )
+    tracker.recordSuccess("jetnews")
+    tracker.recordSuccess("m3-catalog")
+    assertEquals("jetnews", tracker.firstAvailableSystem())
+  }
+
+  @Test
+  fun `equal priorities keep configured order`() {
+    val tracker = tracker()
+
+    assertEquals(listOf("jetnews", "reply"), tracker.loadOrder().map { it.config.system })
+  }
+
+  @Test
+  fun `relisting carries the new load priority without touching load state`() {
+    val tracker = tracker()
+    tracker.recordSuccess("reply")
+
+    assertTrue(tracker.relist("reply", listed = false, group = null, loadPriority = 5))
+
+    val reply = tracker.snapshot().single { it.config.system == "reply" }
+    assertEquals(5, reply.config.loadPriority)
+    assertFalse(reply.config.listed)
+    assertTrue(reply.available, "a listing change must not drop the registered copy")
+    assertEquals(listOf("reply", "jetnews"), tracker.loadOrder().map { it.config.system })
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
@@ -125,6 +125,23 @@ class ServeCatalogAdminTest {
   }
 
   @Test
+  fun `re-publishing with a new load priority converges it instead of conflicting`() {
+    seedConfig(ServeCatalogsConfig(catalogs = listOf(ServeCatalogsConfig.Entry("m3-catalog"))))
+    val tracker =
+      tracker(CatalogLoadTracker.Config("m3-catalog", true, "yschimke/compose-ai-tools", "b"))
+    tracker.recordSuccess("m3-catalog")
+
+    val result = admin(tracker).register(ServeCatalogsConfig.Entry("m3-catalog", loadPriority = 20))
+
+    assertTrue(result is ServeCatalogAdmin.Result.Ok, "$result")
+    assertEquals(emptyList(), loaded, "the running catalog is never re-fetched behind its back")
+    assertTrue(tracker.snapshot().single().available, "and keeps its load state")
+    assertEquals(20, tracker.configFor("m3-catalog")?.loadPriority)
+    // The point of the write-back: it is the NEXT boot's fetch order that changes.
+    assertEquals(20, file.load().catalogs.single().loadPriority)
+  }
+
+  @Test
   fun `a catalog that will not fetch is not left half-published`() {
     val tracker = tracker()
     val result =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfigTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogsConfigTest.kt
@@ -42,6 +42,32 @@ class ServeCatalogsConfigTest {
   }
 
   @Test
+  fun `load priority defaults to zero and survives a round trip`() {
+    val config =
+      ServeCatalogsConfig.parse(
+        """
+        {
+          "catalogs": [
+            { "system": "m3-catalog", "loadPriority": 20 },
+            { "system": "cadence" }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(listOf(20, 0), config.catalogs.map { it.loadPriority })
+    assertEquals(emptyList(), config.problems())
+    // The admin API rewrites this file, so a priority an operator declared has to survive that.
+    assertEquals(
+      listOf(20, 0),
+      ServeCatalogsConfig.parse(ServeCatalogsConfig.encode(config)).catalogs.map {
+        it.loadPriority
+      },
+    )
+  }
+
+  @Test
   fun `unknown keys are ignored so a newer config still boots an older server`() {
     val config =
       ServeCatalogsConfig.parse(

--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "preview.coo.ee's PUBLISHED CATALOG SET \u2014 deployment config for one specific box, NOT image content. Kept out of deploy/image/ deliberately: baking it there made every adopter of the prebuilt image open on these catalogs (see the seed's comment). Changes on main are applied directly by publish-preview-config.yml; image publishes reconcile the same file as a fallback. Both paths use .github/scripts/publish-config-to-box.sh additively over POST /admin/catalogs, so this never needs an image rebuild. Another deployment adopting the preview server keeps its own copy of this shape and points DEPLOY_CONFIG_DIR at it. Every entry's design-artifacts/<system> branch must be trusted by producers.json beside this file. cadence is listed:false \u2014 reachable at /cadence/ but off the front-page index. compose-m3 and wear-m3 are listed:false for the same reason from the other direction: they are compose-ai-tools' own in-repo harness catalogs \u2014 they exist to exercise the preview pipeline's features, not to be a design system. m3-catalog is the real Material 3 reference and wear-m3-catalog will be the Wear one, so the two harness catalogs stay reachable at /compose-m3/ and /wear-m3/ as a live smoke target without presenting as design systems on the front page. NOTE the reconcile is additive (see publish-config-to-box.sh): a system already registered on the box comes back 409, so flipping listed here does NOT relist/unlist a live entry on its own \u2014 DELETE /admin/catalogs/<system> on the box and let the next publish re-add it from this file.",
+  "_comment": "preview.coo.ee's PUBLISHED CATALOG SET \u2014 deployment config for one specific box, NOT image content. Kept out of deploy/image/ deliberately: baking it there made every adopter of the prebuilt image open on these catalogs (see the seed's comment). Changes on main are applied directly by publish-preview-config.yml; image publishes reconcile the same file as a fallback. Both paths use .github/scripts/publish-config-to-box.sh additively over POST /admin/catalogs, so this never needs an image rebuild. Another deployment adopting the preview server keeps its own copy of this shape and points DEPLOY_CONFIG_DIR at it. Every entry's design-artifacts/<system> branch must be trusted by producers.json beside this file. cadence is listed:false \u2014 reachable at /cadence/ but off the front-page index. compose-m3 and wear-m3 are listed:false for the same reason from the other direction: they are compose-ai-tools' own in-repo harness catalogs \u2014 they exist to exercise the preview pipeline's features, not to be a design system. m3-catalog is the real Material 3 reference and wear-m3-catalog will be the Wear one, so the two harness catalogs stay reachable at /compose-m3/ and /wear-m3/ as a live smoke target without presenting as design systems on the front page. loadPriority (default 0, highest first) is the startup FETCH order and nothing else \u2014 the list order above still decides the front page. m3-catalog and wear-m3-catalog are the two reference design systems this box exists to serve, and being published late left them last in the queue (a runtime registration is appended), so a rollout served everything else first; they now lead it (#4231). NOTE the reconcile is additive (see publish-config-to-box.sh): it never deletes. Re-posting an entry whose listed, group or loadPriority changed converges it in place; an otherwise-unchanged one comes back 409. What it cannot change is repo \u2014 that decides what bytes get served, so re-pointing a catalog is DELETE /admin/catalogs/<system> on the box, then let the next publish re-add it from this file.",
   "groups": [
     {
       "id": "design-systems",
@@ -50,13 +50,15 @@
       "system": "m3-catalog",
       "repo": "yschimke/m3-catalog",
       "listed": true,
-      "group": "design-systems"
+      "group": "design-systems",
+      "loadPriority": 20
     },
     {
       "system": "wear-m3-catalog",
       "repo": "yschimke/wear-m3-catalog",
       "listed": true,
-      "group": "design-systems"
+      "group": "design-systems",
+      "loadPriority": 10
     },
     {
       "system": "meshcore-mobile",

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2263,6 +2263,28 @@ the **front-page section** it appears under. Nothing in the server knows any par
 grouping is entirely this config, and a catalog that declares no group is sectioned by its source
 repo's owner (`joreilly org`), with unattributed catalogs in `Other`.
 
+#### Which catalogs come back first
+
+`"loadPriority": 20` on an entry moves it up the **startup fetch queue** — highest first, ties in
+list order, default `0`. The initial load is one sequential pass, and a big catalog takes minutes to
+fetch, verify and register, so on a rollout the queue's tail is unavailable for a while. Order used
+to be positional only, which meant a catalog published through the admin API loaded *last* (a
+runtime registration is appended), and on `preview.coo.ee` that was `m3-catalog` and
+`wear-m3-catalog` — the two reference design systems the box most exists to serve (#4231). They now
+lead the queue:
+
+```json
+{ "system": "m3-catalog", "repo": "yschimke/m3-catalog", "group": "design-systems",
+  "loadPriority": 20 }
+```
+
+It changes **fetch order only** — not what is served, and not where a card renders: the list order
+above is still the front page's, and the landing session `/` resolves to is still the first *listed*
+entry in it. Loading stays best-effort per catalog too, so a prioritised catalog that can't be
+fetched just fails earlier. `GET /admin/catalogs` reports each entry's `loadPriority` alongside its
+load state, and re-POSTing an already-published entry with a changed priority converges it (see
+below), so the deployment reconcile can change the order of a live box without a retire.
+
 A `group` is a **claim checked against provenance**. The section applies only when the fetched bytes
 really came from the entry's `repo` (or one of its `attributionRepos` — which is how Android's
 samples, fetched from preview branches in the `yschimke/compose-samples` fork, are still credited to
@@ -2339,8 +2361,10 @@ defining a section after its catalogs were published would collect nothing, and 
 under the owner fallback until a restart.
 
 For the same reason `POST /admin/catalogs` on an id that's already published **converges its
-listing** rather than refusing: re-posting an entry whose `group` or `listed` has changed updates it
-in place, with no re-fetch and no dropped load state. Re-posting an *unchanged* entry is still `409`,
+listing** rather than refusing: re-posting an entry whose `group`, `listed` or `loadPriority` has
+changed updates it in place, with no re-fetch and no dropped load state. (A changed `loadPriority`
+does nothing to the running catalog — it is written back so the *next* boot fetches in the declared
+order, which is the only way an additive reconcile can reorder a live box.) Re-posting an *unchanged* entry is still `409`,
 so a duplicate stays visible, and a changed `repo` is still refused — that decides what bytes get
 served, so re-pointing a catalog is a retire plus a publish.
 


### PR DESCRIPTION
Fixes #4231.

## The problem

The initial catalog fetch is one sequential pass over the configured set (`InitialCatalogLoader`), and each catalog takes real time to fetch, verify and register — so on a rollout, the tail of that queue is `pending` for minutes. The order was purely positional, and a catalog published through the admin API is **appended** (`CatalogLoadTracker.add`), which is how `m3-catalog` and `wear-m3-catalog` — the two reference design systems the box most exists to serve, one of them also fronting `m3.preview.coo.ee` — ended up last in line. That is exactly what the report shows: everything else loaded, those two still `pending` at 3m uptime.

## The change

- **`loadPriority` on a `catalogs.json` entry** — default `0`, highest first, ties keeping list order. The startup pass now walks `CatalogLoadTracker.loadOrder()` instead of `snapshot()`.
- **Fetch order only.** The tracker's configured order is unchanged, so the front-page sections/cards, the landing session `/` resolves to, and `firstAvailableSystem()` (the readiness probe's session) all stay where they were — sorting the tracker itself would have moved those as a side effect of a queue preference. Loading stays best-effort per catalog: a prioritised catalog that can't be fetched just fails earlier.
- **The declared order can actually reach a live box.** Re-POSTing an already-published entry with a changed `loadPriority` now converges it in place (like `listed`/`group`) rather than 409ing, and `publish-config-to-box.sh` forwards the field. Without both halves the committed order would be a no-op on the deployed server — the reconcile is additive, and the box boots from its own `/config/catalogs.json`. `GET /admin/catalogs` reports `loadPriority` so a reconcile can verify what the next boot will fetch first.
- **`deploy/preview.coo.ee/catalogs.json`**: `m3-catalog` → 20, `wear-m3-catalog` → 10. Also corrected a now-stale line in that file's `_comment` claiming a re-post can never change a live entry's listing (the converge path already handles `listed`/`group`).
- Docs: a "Which catalogs come back first" subsection in `docs/public-preview-server.md`, plus the converge note.

## Test plan

- `./gradlew :cli:test :cli:ktfmtCheck` — green (full CLI suite, on this branch rebased on `main`).
- New tests: `CatalogLoadTrackerTest` (priority order vs. configured order, ties, `relist` carrying priority without dropping load state), `ServeCatalogsConfigTest` (default 0 + round-trip through the admin rewrite), `ServeCatalogAdminTest` (re-publish with a new priority converges, no re-fetch, persisted).
- `bash .github/scripts/test-publish-config-to-box.sh` — green, with a new assertion that `loadPriority` survives to the wire and an undeclared one is omitted rather than sent as `null`.

No visual surface is touched — this is server-side startup ordering, so there is nothing for the preview pipeline to render.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zzJbg5Ni1t2HJksvsd6kk)_