### PR TITLE
fix(plugin): scope the skiko skew check to one resolved classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1089,8 +1089,15 @@ internal object ComposePreviewTasks {
       // The empty artifact view preserves the default resolution (same files as `from(config)`)
       // while
       // resolving lazily through a serializable view — mirrors `composePreviewDiscover` above.
-      classpath.from(toolClasspath.incoming.artifactView {}.files)
+      val toolFiles = toolClasspath.incoming.artifactView {}.files
+      classpath.from(toolFiles)
       pinnedConsumerClasspath(project, dependencyConfigName())?.let { classpath.from(it) }
+      // The same files again, on their own, so the skiko check can tell the tool's resolved pair
+      // apart from the consumer's instead of reading the concatenation as one skewed classpath
+      // (#4200, fixed in #4234). `classpath` stays the union: the AndroidX-artifact check wants to
+      // see the
+      // consumer's jars, and a substring scan gives the same answer over either shape.
+      this.toolClasspath.from(toolFiles)
     }
 
   /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
@@ -32,6 +32,15 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
   @get:Classpath abstract val classpath: ConfigurableFileCollection
 
   /**
+   * The TOOL half of [classpath] on its own — `composePreviewRenderer`, without the consumer's
+   * runtime classpath. Only the skiko check reads it, and only because that check is the one whose
+   * answer changes when two independently-resolved classpaths are concatenated: see [reportSkiko].
+   * [Classpath] for the same content-keyed reason as [classpath]; the files are also in
+   * [classpath], so hashing them twice costs a hash, not a resolve.
+   */
+  @get:Classpath abstract val toolClasspath: ConfigurableFileCollection
+
+  /**
    * Derived helper used by [validate] to feed the [androidxComposeArtifactsOnDesktopClasspath]
    * substring matcher. Intentionally `@Internal` — the cache key flows through [classpath]'s
    * content hash, not through these absolute path strings (which would otherwise pin the cache to a
@@ -40,6 +49,11 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
   @get:Internal
   val classpathPaths: List<String>
     get() = classpath.files.map { it.absolutePath }
+
+  /** [toolClasspath] as absolute paths. `@Internal` for the same reason as [classpathPaths]. */
+  @get:Internal
+  val toolClasspathPaths: List<String>
+    get() = toolClasspath.files.map { it.absolutePath }
 
   init {
     group = "compose preview"
@@ -50,7 +64,8 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
   fun validate() {
     if (platform.get() != "desktop") return
 
-    reportSkiko(skikoVersionsOnClasspath(classpathPaths))
+    val tool = toolClasspathPaths.toSet()
+    reportSkiko(skikoScopes(toolPaths = tool, allPaths = classpathPaths))
 
     val offenders = androidxComposeArtifactsOnDesktopClasspath(classpathPaths)
     if (offenders.isEmpty()) return
@@ -81,29 +96,64 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
   }
 
   /**
-   * Say which skiko this classpath resolved, and stop when it resolved more than one.
+   * Say which skiko each classpath resolved, and stop when ONE of them resolved a mismatched pair.
    *
    * skiko is where a Compose Multiplatform bump reaches the renderer's own call sites: 0.150.0
-   * changed `Image.encodeToData`'s parameter list, and because skiko resolves to a SINGLE version
-   * across the render classpath, a consumer on a newer Compose line silently decides which API the
-   * tool is running against (compose-ai-tools#4190). The encode itself binds late now, so this is a
-   * diagnostic and not a gate — but the version belongs in the log, because the next skiko change
-   * will be diagnosed from it.
+   * changed `Image.encodeToData`'s parameter list, and because skiko resolves to a single version
+   * within any one resolved classpath, a consumer on a newer Compose line silently decides which
+   * API the tool is running against (compose-ai-tools#4190). The encode itself binds late now, so
+   * that much is a diagnostic and not a gate — but the version belongs in the log, because the next
+   * skiko change will be diagnosed from it.
    *
-   * Two DIFFERENT versions is the one case that fails. The API jar and the platform's native
-   * runtime jar are a matched pair; a skew between them loads a `libskiko` whose exports the API
-   * does not have, and every render dies with `UnsatisfiedLinkError` at draw time instead.
+   * The failure is an API jar and a platform native runtime jar at different versions **inside one
+   * scope**: they are a matched pair, and a skew between them loads a `libskiko` whose exports the
+   * API does not declare, so every render dies with `UnsatisfiedLinkError` at draw time.
+   *
+   * Scope is the whole point, and #4200's first cut of this check did not have it (#4234). The
+   * render classpath this task validates is a CONCATENATION of two independently-resolved
+   * classpaths — the tool's `composePreviewRenderer` and the consumer's own `runtimeClasspath` (see
+   * `ComposePreviewTasks.registerDesktopClasspathGuard`). Each resolves its own coherent skiko
+   * pair, and any consumer whose Compose Multiplatform line differs from the tool's therefore puts
+   * two DIFFERENT but individually-matched pairs on one classpath. That is not the skew this guard
+   * exists for: the JVM loads the first `org.jetbrains.skia` class and the first `libskiko` it
+   * finds, both from whichever pair leads the classpath, and the trailing pair is shadowed whole.
+   * Counting distinct versions across the concatenation called that a skew and hard-failed every
+   * consumer on an older Compose line — including this plugin's own bundle E2E fixture, which pins
+   * `org.jetbrains.compose` 1.10.3 (skiko 0.9.37.4) against a tool on 1.11.1 (skiko 0.144.6) and
+   * had been rendering correctly for as long as that gap existed.
+   *
+   * So: check each scope on its own terms, and say — at `info`, not as a failure — when they
+   * disagree, because which pair leads the classpath is worth being able to read back out of a log.
    */
-  private fun reportSkiko(versions: List<String>) {
-    when (versions.size) {
+  private fun reportSkiko(scopes: List<SkikoScope>) {
+    val skewed = scopes.filter { it.versions.size > 1 }
+    if (skewed.isNotEmpty()) {
+      throw GradleException(
+        buildString {
+          skewed.forEach { scope ->
+            appendLine(
+              "The ${scope.label} classpath resolved more than one skiko version " +
+                "(${scope.versions.joinToString()}). The skiko API jar and its platform native " +
+                "runtime must match — a skew loads a libskiko whose exports the API does not " +
+                "declare, and every render fails at draw time."
+            )
+          }
+          append("Align them through a single Compose Multiplatform version.")
+        }
+      )
+    }
+    val resolved = scopes.filter { it.versions.isNotEmpty() }
+    when (resolved.map { it.versions.single() }.distinct().size) {
       0 -> Unit
-      1 -> logger.info("Compose Preview desktop classpath: skiko ${versions.single()}")
+      1 ->
+        logger.info(
+          "Compose Preview desktop classpath: skiko ${resolved.first().versions.single()}"
+        )
       else ->
-        throw GradleException(
-          "Compose Preview desktop classpath resolved more than one skiko version " +
-            "(${versions.joinToString()}). The skiko API jar and its platform native runtime must " +
-            "match — a skew loads a libskiko whose exports the API does not declare, and every " +
-            "render fails at draw time. Align them through a single Compose Multiplatform version."
+        logger.info(
+          "Compose Preview desktop classpath carries two coherent skiko pairs — " +
+            resolved.joinToString { "${it.label} ${it.versions.single()}" } +
+            ". The one earlier on the classpath is the one that loads; the other is shadowed."
         )
     }
   }
@@ -125,6 +175,33 @@ abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
 
     /** `skiko`, `skiko-awt`, `skiko-awt-runtime-<platform>` — anything but the version suffix. */
     private val SKIKO_ARTIFACT = Regex("""^skiko(?:-[a-z0-9]+)*-(\d[\w.\-]*)\.jar$""")
+
+    /**
+     * One independently-resolved classpath and the skiko versions it named. [label] is what the
+     * failure calls it, so it has to read as a place a version came from rather than as jargon.
+     */
+    internal data class SkikoScope(val label: String, val versions: List<String>)
+
+    /**
+     * Split the validated classpath back into the two scopes it was concatenated from — the tool's
+     * renderer classpath ([toolPaths]) and everything else, which is the consumer's runtime
+     * classpath — and read each one's skiko versions separately. See [reportSkiko] for why the
+     * split is what makes the answer correct.
+     *
+     * A caller that sets no tool classpath (nothing does today; the guard is registered in one
+     * place) degrades to a single "render" scope rather than mis-reporting the consumer's jars as
+     * the tool's.
+     */
+    fun skikoScopes(toolPaths: Set<String>, allPaths: Iterable<String>): List<SkikoScope> {
+      if (toolPaths.isEmpty()) {
+        return listOf(SkikoScope("render", skikoVersionsOnClasspath(allPaths)))
+      }
+      val consumerPaths = allPaths.filterNot { it in toolPaths }
+      return listOf(
+        SkikoScope("compose-preview renderer", skikoVersionsOnClasspath(toolPaths)),
+        SkikoScope("consumer runtime", skikoVersionsOnClasspath(consumerPaths)),
+      )
+    }
 
     fun androidxComposeArtifactsOnDesktopClasspath(paths: Iterable<String>): List<String> =
       paths

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SkikoVersionsOnClasspathTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SkikoVersionsOnClasspathTest.kt
@@ -41,6 +41,73 @@ class SkikoVersionsOnClasspathTest {
   }
 
   @Test
+  fun `two coherent pairs from the two scopes are not a skew`() {
+    // The shape of this plugin's own bundle E2E fixture, which #4200's check hard-failed: a
+    // consumer on
+    // org.jetbrains.compose 1.10.3 (skiko 0.9.37.4) against a tool on 1.11.1 (skiko 0.144.6). Each
+    // side resolved a matched API/native pair; the JVM loads whichever leads the classpath and
+    // shadows the other. Reading the concatenation as one classpath called this a skew and hard
+    // -failed every consumer off the tool's Compose line.
+    val tool =
+      setOf(cached("skiko-awt-0.144.6.jar"), cached("skiko-awt-runtime-linux-x64-0.144.6.jar"))
+    val consumer =
+      listOf(cached("skiko-awt-0.9.37.4.jar"), cached("skiko-awt-runtime-linux-x64-0.9.37.4.jar"))
+    val scopes =
+      ValidateComposePreviewClasspathTask.skikoScopes(
+        toolPaths = tool,
+        allPaths = tool.toList() + consumer,
+      )
+    assertThat(scopes.map { it.label })
+      .containsExactly("compose-preview renderer", "consumer runtime")
+      .inOrder()
+    assertThat(scopes.map { it.versions }).containsExactly(listOf("0.144.6"), listOf("0.9.37.4"))
+    // What the task acts on: no scope resolved more than one version, so nothing fails.
+    assertThat(scopes.filter { it.versions.size > 1 }).isEmpty()
+  }
+
+  @Test
+  fun `a mismatched pair inside one scope is still a skew`() {
+    // The case the guard exists for, unchanged: within a SINGLE resolved classpath the API jar and
+    // the platform native runtime disagree, so the loaded libskiko does not export what the API
+    // declares and every render dies at draw time.
+    val tool =
+      setOf(cached("skiko-awt-0.150.1.jar"), cached("skiko-awt-runtime-linux-x64-0.144.6.jar"))
+    val scopes =
+      ValidateComposePreviewClasspathTask.skikoScopes(toolPaths = tool, allPaths = tool.toList())
+    val skewed = scopes.filter { it.versions.size > 1 }
+    assertThat(skewed).hasSize(1)
+    assertThat(skewed.single().label).isEqualTo("compose-preview renderer")
+    assertThat(skewed.single().versions).containsExactly("0.144.6", "0.150.1").inOrder()
+  }
+
+  @Test
+  fun `a skew on the consumer side is attributed to the consumer`() {
+    val tool = setOf(cached("skiko-awt-0.144.6.jar"))
+    val consumer =
+      listOf(cached("skiko-awt-0.150.1.jar"), cached("skiko-awt-runtime-linux-x64-0.144.6.jar"))
+    val skewed =
+      ValidateComposePreviewClasspathTask.skikoScopes(
+          toolPaths = tool,
+          allPaths = tool.toList() + consumer,
+        )
+        .filter { it.versions.size > 1 }
+    assertThat(skewed.map { it.label }).containsExactly("consumer runtime")
+  }
+
+  @Test
+  fun `with no tool classpath set the whole thing is one scope`() {
+    // Nothing registers the guard without one, but degrading to a single scope keeps a caller that
+    // does from having the consumer's jars reported as the tool's.
+    val scopes =
+      ValidateComposePreviewClasspathTask.skikoScopes(
+        toolPaths = emptySet(),
+        allPaths = listOf(cached("skiko-awt-0.150.1.jar")),
+      )
+    assertThat(scopes.map { it.label }).containsExactly("render")
+    assertThat(scopes.single().versions).containsExactly("0.150.1")
+  }
+
+  @Test
   fun `a classpath with no skiko names none, and windows paths still parse`() {
     assertThat(
         ValidateComposePreviewClasspathTask.skikoVersionsOnClasspath(listOf("/a/kotlin.jar"))


### PR DESCRIPTION
Fixes #4234 — the second of the two failures blocking `main`. `Bundle Render E2E` fails with:

```
Compose Preview desktop classpath resolved more than one skiko version (0.144.6, 0.9.37.4).
```

## The check reads two classpaths as one

`registerDesktopClasspathGuard` feeds the task a **concatenation** of two independently-resolved classpaths — the tool's `composePreviewRenderer` and the consumer's own `runtimeClasspath`. Each resolves its own coherent skiko pair, so any gap between the tool's Compose Multiplatform line and the consumer's puts two *different but individually-matched* pairs on one classpath. `reportSkiko` counted distinct versions across the concatenation and called that a skew.

## Reproduced against the released plugin

A project with the bundle E2E fixture's own dependencies (`org.jetbrains.compose` 1.10.3, `compose.desktop.currentOs` / `material3` / `uiTooling` / `components.uiToolingPreview`) and the **1.15.0** plugin — i.e. before this check existed:

```
A. composePreviewRenderer (tool)         skiko-awt-0.144.6      skiko-awt-runtime-*-0.144.6
B. runtimeClasspath (consumer)           skiko-awt-0.9.37.4     skiko-awt-runtime-*-0.9.37.4
A + B union (what the guard inspected)   both versions of both artifacts
```

Both scopes are internally coherent. The two versions in the error are one from each scope, not a mismatched pair.

## Why it isn't the failure mode the guard describes

The JVM loads the first `org.jetbrains.skia` class and the first `libskiko` it finds, both from whichever pair leads the classpath; the trailing pair is shadowed whole. The fixture has pinned CMP 1.10.3 since #1224 and rendered correctly straight through the CMP 1.11.1 bump (#3462) — `Bundle Render E2E` passed at f1f4eb336, the commit immediately before #4200 added the check.

## The change

`reportSkiko` now takes scopes instead of a flat version list:

- **a mismatched API/native pair inside one resolved classpath still fails** — the real `UnsatisfiedLinkError` case, unchanged — and the message now names which side it came from (`the compose-preview renderer classpath …` / `the consumer runtime classpath …`);
- **two coherent pairs log at `info`** which one leads and which is shadowed, instead of failing.

The task gains a `toolClasspath` `@Classpath` input to tell the scopes apart. `classpath` stays the union: the AndroidX-artifact check wants the consumer's jars, and a substring scan reads either shape the same.

## Test plan

- [x] `:gradle-plugin:test --tests '*SkikoVersionsOnClasspathTest*'` — 7/7 pass. Four new cases: two coherent pairs are not a skew; a mismatched pair inside one scope still is; a consumer-side skew is attributed to the consumer; no tool classpath degrades to a single scope.
- [x] Version-parsing tests unchanged and still passing — `skikoVersionsOnClasspath` itself is untouched.
- [ ] `Bundle Render E2E` on `main` after merge. It is `if: github.event_name != 'pull_request'`, so it cannot run on this PR — which is exactly how #4200 shipped this without CI catching it. Worth watching the first push-to-main run after merge.

Text-only: the change is build plumbing, with no rendered surface. The evidence that renders were and are correct is the fixture E2E itself, which asserts real PNGs.

_Generated by [Claude Code](https://claude.com/claude-code)_
