### PR TITLE
fix(serve): name the Skiko skew in the 409 a dead render lane returns

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
@@ -85,6 +85,19 @@ class RenderCircuitBreaker(
   /** How long a rate-tripped breaker stays shut before admitting one probe render. */
   private val probeCooldownMillis: Long = PROBE_COOLDOWN_MILLIS,
   private val clock: () -> Long = System::currentTimeMillis,
+  /**
+   * Given the failure text of a **fatal** trip, one extra sentence explaining it — or null when
+   * there is nothing to add.
+   *
+   * The open breaker's reason is what every refused render answers with, so it is the only
+   * diagnosis anyone outside the box ever sees. A bare `UnsatisfiedLinkError: 'int
+   * org.jetbrains.skia…'` names the missing symbol and nothing that explains it, which is how
+   * issue #4220 was reported and why its cause had to be inferred from outside; the serve path
+   * supplies [SkikoNativePairing.linkageDiagnosis] here so the same body also names the Skiko skew
+   * the daemon's own classpath carries. Called once, under the lock, on the trip only — never on
+   * the hot path. Anything it throws is dropped: a diagnosis must not cost the trip.
+   */
+  private val linkageDiagnosis: (String) -> String? = { null },
 ) {
   private val lock = Any()
 
@@ -147,9 +160,11 @@ class RenderCircuitBreaker(
       val marker = RenderFailureClassifier.fatalMarker(reason)
       if (marker != null) {
         fatal = true
+        val diagnosis = runCatching { linkageDiagnosis(reason) }.getOrNull()
         openReason =
           "render lane disabled after a non-recoverable $marker — retrying cannot help. " +
-            "Last failure: $reason"
+            "Last failure: $reason" +
+            diagnosis?.let { " $it" }.orEmpty()
         openedAtEpochMillis = clock()
         tripFailureRate = failureRate()
         return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -476,6 +476,13 @@ internal constructor(
    * deferred [Companion.open] path leaves this false.
    */
   private val sessionAlreadyOpen: Boolean = false,
+  /**
+   * One extra sentence appended to a **fatal** breaker trip, given the failure text — see
+   * [RenderCircuitBreaker]'s parameter of the same name. The [Companion.open] path supplies the
+   * daemon's own launch descriptor, so a Skia link error is answered with the Skiko pair that
+   * classpath resolves (#4220) rather than leaving the symbol name to speak for itself.
+   */
+  private val linkageDiagnosis: (String) -> String? = { null },
 ) : ServeHost {
 
   /**
@@ -745,7 +752,7 @@ internal constructor(
    * [RenderCircuitBreaker] and issue #3448 (3794 retries of one `UnsatisfiedLinkError` in 14
    * minutes).
    */
-  private val breaker = RenderCircuitBreaker()
+  private val breaker = RenderCircuitBreaker(linkageDiagnosis = linkageDiagnosis)
 
   override fun renderPerfStats(): RenderPerfSnapshot =
     perfStats.snapshot().copy(breaker = breaker.snapshot())
@@ -1812,6 +1819,9 @@ internal constructor(
         label = label,
         declaredThemes = declaredThemes,
         onLog = onLog,
+        linkageDiagnosis = { reason ->
+          SkikoNativePairing.linkageDiagnosis(reason, descriptorPath)
+        },
       )
     }
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.cli.BundleReader
+import java.io.File
 
 /**
  * Keeps a served bundle's Skiko **bindings** and the `libskiko` **native** they call at one
@@ -153,6 +154,33 @@ internal object SkikoNativePairing {
       "not share will fail with UnsatisfiedLinkError. Republish the catalog against a Compose " +
       "Multiplatform version whose Skiko this server ships."
   }
+
+  /**
+   * [classpathSkew] for the daemon launched from [descriptorPath], to be appended to a **fatal**
+   * linkage failure — or null when this failure is not Skia's, the descriptor is unreadable, or the
+   * classpath is coherent and the link error therefore has some other cause.
+   *
+   * The startup log already carries [classpathSkew], but nobody outside the box reads it. What they
+   * read is the open breaker's reason, which the host returns as the body of every `409` the dead
+   * lane answers with — and in compose-ai-tools#4220 that body was the whole report: it named the
+   * missing symbol and nothing that explains it, so the skew had to be inferred from the outside.
+   * Attaching the skew here means a lane that dies of a split Skiko says so to whoever finds it.
+   *
+   * Read at trip time rather than at host construction: the descriptor is a file the daemon already
+   * launched from, and a diagnosis nobody needs must not cost a read per host.
+   */
+  fun linkageDiagnosis(reason: String, descriptorPath: File): String? {
+    if (SKIA_PACKAGE !in reason) return null
+    val descriptor = ServeBundleDaemon.readLaunchDescriptor(descriptorPath) ?: return null
+    return classpathSkew(descriptor.classpath)
+  }
+
+  /**
+   * Enough of the package name to catch both halves — `org.jetbrains.skia.*` (the bindings whose
+   * `external` declarations fail to link) and `org.jetbrains.skiko.*` (the loader). A linkage error
+   * naming neither belongs to some other library, and the Skiko pair says nothing about it.
+   */
+  private const val SKIA_PACKAGE = "org.jetbrains.ski"
 
   /** `skiko`, `skiko-awt`, `skiko-awt-runtime-<platform>` — anything but the version suffix. */
   private val SKIKO_ARTIFACT = Regex("""^skiko(?:-[a-z0-9]+)*-(\d[\w.\-]*)\.jar$""")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreakerTest.kt
@@ -24,6 +24,38 @@ class RenderCircuitBreakerTest {
   }
 
   @Test
+  fun `a fatal trip carries the diagnosis the caller supplies`() {
+    // The open breaker's reason IS the body of every refused render, so it is the only diagnosis
+    // anyone outside the box sees — #4220 was reported from exactly that text, naming the missing
+    // symbol and nothing that explains it.
+    val breaker =
+      RenderCircuitBreaker(
+        linkageDiagnosis = { reason ->
+          "Skiko bindings 0.148.2 will link against libskiko 0.144.6"
+            .takeIf { "org.jetbrains.ski" in reason }
+        }
+      )
+
+    breaker.recordFailure(linkage)
+
+    val reason = assertNotNull(breaker.peekReason())
+    assertTrue(reason.endsWith("Skiko bindings 0.148.2 will link against libskiko 0.144.6"), reason)
+    assertTrue(reason.contains("UnsatisfiedLinkError"), "the raw failure is still there: $reason")
+  }
+
+  @Test
+  fun `a diagnosis that throws or declines costs the trip nothing`() {
+    val thrower = RenderCircuitBreaker(linkageDiagnosis = { error("boom") })
+    thrower.recordFailure(linkage)
+    assertTrue(assertNotNull(thrower.peekReason()).contains("UnsatisfiedLinkError"))
+
+    // A coherent classpath has nothing to add, and must not leave a dangling space behind.
+    val quiet = RenderCircuitBreaker(linkageDiagnosis = { null })
+    quiet.recordFailure(linkage)
+    assertTrue(assertNotNull(quiet.peekReason()).endsWith(linkage))
+  }
+
+  @Test
   fun `one fatal failure opens the breaker terminally`() {
     // The #3448 behaviour: 3794 retries of an UnsatisfiedLinkError in ~14 minutes. One is enough.
     var now = 0L

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
@@ -1,11 +1,15 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.mcp.DaemonLaunchDescriptor
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
 
 /**
  * The split-Skiko repair from #4220: a bundle's recorded coordinates name the bindings but not the
@@ -162,6 +166,82 @@ class SkikoNativePairingTest {
       )
 
     assertNull(SkikoNativePairing.classpathSkew(repaired))
+  }
+
+  @Test
+  fun `a fatal Skia link error is answered with the skew its daemon classpath carries`() {
+    val descriptor =
+      writeDescriptor(
+        listOf(
+          "/cache/org.jetbrains.skiko/skiko-awt/0.148.2/skiko-awt-0.148.2.jar",
+          "/opt/serve/lib-daemon-desktop/skiko-awt-runtime-linux-x64-0.144.6.jar",
+        )
+      )
+
+    val diagnosis =
+      assertNotNull(
+        SkikoNativePairing.linkageDiagnosis(
+          "render failed: UnsatisfiedLinkError: 'int " +
+            "org.jetbrains.skia.paragraph.ParagraphKt._nGetUnresolvedCodepointsCount(long)'",
+          descriptor,
+        )
+      )
+
+    assertContains(diagnosis, "bindings 0.148.2")
+    assertContains(diagnosis, "libskiko 0.144.6")
+  }
+
+  @Test
+  fun `a link error with nothing to add says nothing`() {
+    val coherent =
+      writeDescriptor(
+        listOf("/cache/skiko-awt-0.148.2.jar", "/cache/skiko-awt-runtime-linux-x64-0.148.2.jar")
+      )
+    val skewed =
+      writeDescriptor(
+        listOf("/cache/skiko-awt-0.148.2.jar", "/cache/skiko-awt-runtime-linux-x64-0.144.6.jar")
+      )
+    val skiaFailure =
+      "render failed: UnsatisfiedLinkError: 'int org.jetbrains.skia.paragraph.ParagraphKt._n(long)'"
+
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(skiaFailure, coherent),
+      "a matched pair means this link error has some other cause — don't invent one",
+    )
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(
+        "render failed: UnsatisfiedLinkError: 'void com.example.Native.init()'",
+        skewed,
+      ),
+      "a link error that is not Skia's says nothing about the Skiko pair",
+    )
+    assertNull(
+      SkikoNativePairing.linkageDiagnosis(skiaFailure, File("/no/such/daemon-launch.json")),
+      "an unreadable descriptor says nothing rather than guessing",
+    )
+  }
+
+  private fun writeDescriptor(classpath: List<String>): File {
+    val dir = Files.createTempDirectory("skiko-linkage-diagnosis").toFile()
+    val file = File(dir, "daemon-launch.json")
+    file.writeText(
+      Json.encodeToString(
+        DaemonLaunchDescriptor.serializer(),
+        DaemonLaunchDescriptor(
+          schemaVersion = 2,
+          modulePath = ":catalog",
+          variant = "desktop",
+          enabled = true,
+          mainClass = "ee.schimke.composeai.daemon.DaemonMain",
+          classpath = classpath,
+          jvmArgs = emptyList(),
+          systemProperties = emptyMap(),
+          workingDirectory = dir.absolutePath,
+          manifestPath = File(dir, "previews.json").absolutePath,
+        ),
+      )
+    )
+    return file
   }
 
   /** Nothing to compare is not a skew — an Android (Robolectric) daemon carries no Skiko at all. */

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2805,7 +2805,14 @@ a single render a minute and closes itself as soon as one succeeds.
 While the breaker is open the host:
 
 - answers `/render` with the **underlying failure reason** as a terminal `409`, not
-  `503 render busy; retry shortly` (the daemon isn't busy, and retrying will never help);
+  `503 render busy; retry shortly` (the daemon isn't busy, and retrying will never help). A fatal
+  `org.jetbrains.ski…` link error additionally carries the **Skiko skew read off the daemon's own
+  launch descriptor** — `Skiko bindings 0.148.2 will link against libskiko 0.144.6 …` — so the
+  refusal names the cause and not only the symbol that went missing. The startup log has carried
+  that line since [the split-Skiko repair](#trusted-server-side-re-render---allow-render-trusted),
+  but nobody outside the box reads the log: #4220 was reported from this response body, which said
+  only which symbol was absent. A coherent classpath adds nothing, so a link error with some other
+  cause reads exactly as it did before;
 - reports `live: false` for the catalog and publishes a `render-lane-broken` `degradation`, instead
   of advertising a healthy live lane at a 95% failure rate;
 - **pauses background theme optimization** for that catalog — it is the largest consumer of the


### PR DESCRIPTION
Follow-up to #4236, which fixed the split-Skiko cause of #4220. This closes the reporting half of that issue.

## The gap

The open breaker's reason is the body of every `409` a fatal render lane answers with, and it is the **only** diagnosis anyone outside the box gets. In #4220 that body read

```
render lane disabled after a non-recoverable UnsatisfiedLinkError — retrying cannot help.
Last failure: render failed: UnsatisfiedLinkError:
  'int org.jetbrains.skia.paragraph.ParagraphKt._nGetUnresolvedCodepointsCount(long)'
```

— the symbol that went missing, and nothing that explains it. The split-Skiko cause had to be inferred from outside the deployment. #4236 added `SkikoNativePairing.classpathSkew` and logs it at daemon startup, but nobody outside the box reads the server log, and the response body is where the report came from.

## The change

When a **fatal** linkage failure names `org.jetbrains.ski…`, `SkikoNativePairing.linkageDiagnosis` reads the daemon's own launch descriptor back and runs #4236's `classpathSkew` over the classpath it actually launched with. The result is appended to the breaker's reason, so the same `409` now also says:

```
Skiko bindings 0.148.2 will link against libskiko 0.144.6 — the daemon classpath resolves
them from different artifacts, and every render that touches a symbol the two do not share
will fail with UnsatisfiedLinkError. Republish the catalog against a Compose Multiplatform
version whose Skiko this server ships.
```

Deliberately quiet otherwise. A coherent classpath, a link error that is not Skia's, or an unreadable descriptor all add nothing, so every other refusal reads exactly as it did before — a matched pair means the link error has some other cause, and inventing one would be worse than silence. The descriptor is read at **trip time**, not at host construction, so a diagnosis nobody needs costs no file read; the hook runs once, under the breaker's lock, and anything it throws is dropped rather than costing the trip.

`RenderCircuitBreaker` takes the diagnosis as an injected `(String) -> String?`, so the breaker keeps knowing nothing about Skiko and stays unit-testable without a descriptor; `ServeRenderHost.open` is the only caller that supplies one, from the `descriptorPath` it already has.

## Test plan

- `./gradlew :cli:test :cli:ktfmtCheck` — **2564 tests, 0 failures**.
- New in `SkikoNativePairingTest`: the skew is reported for a fatal Skia link error; a matched pair, a non-Skia link error, and an unreadable descriptor each report nothing.
- New in `RenderCircuitBreakerTest`: the diagnosis is appended after the raw failure; a hook that throws or returns null leaves the reason byte-identical to today's.

Text-only change to a response body and to `docs/public-preview-server.md` § *Render circuit breaker* — no rendered surface moves, so there is nothing visual to diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B63GYPYc1yrz3zZQGsz4Ns)_