### PR TITLE
fix(preview): honour an exact settle coordinate, and widen the motion collision

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
@@ -45,8 +45,9 @@ package ee.schimke.composeai.preview
  * Only still captures are settled — a `@ScrollingPreview` LONG/GIF product, an `@AnimatedPreview`
  * GIF and an `@InteractionPreview` recording all drive the clock themselves and are left alone.
  *
- * Pairing this with `@AnimatedPreview` on the **same function** is reported and ignored, rather
- * than half-honoured. Both products render from one composition against one paused clock and want
+ * Pairing this with a motion product on the **same function** — `@AnimatedPreview`,
+ * `@InteractionPreview`, or `@FocusedPreview(gif = true)` — is reported and ignored, rather than
+ * half-honoured. Both products render from one composition against one paused clock and want
  * opposite things from it: the GIF needs the timeline from its start, the settled still needs a
  * coordinate near the end, and virtual time does not rewind. Put them on separate preview functions
  * — each then owns its own composition — and both get what they asked for. Serving both from one

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -89,7 +89,8 @@ It applies to **still** captures only — a scroll drive runs its own settle, an
 themselves, and an explicit `advanceTimeMillis` is a snapshot of a coordinate
 the author chose.
 
-Pairing it with `@AnimatedPreview` on the *same function* is reported as a
+Pairing it with a motion product on the *same function* — `@AnimatedPreview`,
+`@InteractionPreview`, or `@FocusedPreview(gif = true)` — is reported as a
 discovery warning and the settle is dropped, rather than half-honoured. Both
 products render from one composition against one paused clock and want opposite
 things from it: the GIF needs the timeline from its start, the settled still

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -673,6 +673,20 @@ const val SCROLL_GIF_COST: Float = 40.0f
 const val FOCUS_GIF_COST: Float = 40.0f
 const val ANIMATION_COST: Float = 50.0f
 const val INTERACTION_COST: Float = 60.0f
+
+/**
+ * Extra cost per second of `@SettledPreview` window, on top of [STATIC_COST].
+ *
+ * A settle is not a one-pass capture: both backends walk the window a frame at a time, so a default
+ * 1000ms settle is ~62 rendered frames. Sized so that default lands at 6.0 — just above
+ * [HEAVY_COST_THRESHOLD], which keeps it out of the on-every-save fast tier and lets shard balancing
+ * see the work — while a short explicit window (say `afterMs = 300`, ~19 frames) stays cheap.
+ */
+const val SETTLE_COST_PER_SECOND: Float = 5.0f
+
+/** Per-capture cost of a still carrying a settle of [windowMs]. See [SETTLE_COST_PER_SECOND]. */
+fun settleCaptureCost(windowMs: Int): Float =
+  STATIC_COST + (windowMs.coerceAtLeast(0) / 1000f) * SETTLE_COST_PER_SECOND
 const val ACCESSIBILITY_COST_PER_CAPTURE: Float = 4.0f
 const val HEAVY_COST_THRESHOLD: Float = 5.0f
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1925,10 +1925,20 @@ object PreviewDiscovery {
     // second composition for the still, a change to the render loop rather than to this plan, so
     // the still keeps its unsettled behaviour here and the pairing is reported rather than faked.
     val rawSettleSpec = extractSettleSpec(annotations)
+    // Every product that *records a timeline* collides the same way, not just `@AnimatedPreview`:
+    // an `@InteractionPreview` recording and a `@FocusedPreview(gif = true)` walk each replay from
+    // the shared clock too, and the Android renderer deliberately sorts them after the stills.
+    val motionProduct =
+      when {
+        animationSpec != null -> "@AnimatedPreview"
+        interactionSpec != null -> "@InteractionPreview"
+        focusGifSpec != null -> "@FocusedPreview(gif = true)"
+        else -> null
+      }
     val settleSpec =
-      if (rawSettleSpec != null && animationSpec != null) {
+      if (rawSettleSpec != null && motionProduct != null) {
         warnings.add(
-          "@SettledPreview on '${classInfo.name}.${method.name}' is ignored: @AnimatedPreview on " +
+          "@SettledPreview on '${classInfo.name}.${method.name}' is ignored: $motionProduct on " +
             "the same function drives the same paused clock, and the still and the motion capture " +
             "cannot both own one timeline. Split them onto separate preview functions to settle " +
             "the still."
@@ -2924,9 +2934,14 @@ object PreviewDiscovery {
     // (Lottie / SVG / tile asset) has nothing to spend — same reasoning as ambient above.
     //
     // A settle that collides with a motion capture on the same function has already been dropped
-    // by `extractSettleSpec`'s caller, which owns the warning; the `effectiveAnimation` guard here
-    // is only a backstop so a future caller cannot reintroduce the pairing silently.
-    val effectiveSettle = if (nonComposable || effectiveAnimation != null) null else settle
+    // by `extractSettleSpec`'s caller, which owns the warning; the guards here are only a backstop
+    // so a future caller cannot reintroduce the pairing silently.
+    val effectiveSettle =
+      if (nonComposable || effectiveAnimation != null || interaction != null || focusGif != null) {
+        null
+      } else {
+        settle
+      }
     // `@GestureHintPreview` force-shows the Wear one-handed-gesture indicator, which lives in the
     // Compose composition — same reasoning as ambient: a no-op for non-composable previews.
     val effectiveGestureHint = if (nonComposable) null else gestureHint
@@ -3016,7 +3031,9 @@ object PreviewDiscovery {
           glimmerEnvironment = effectiveGlimmerEnvironment,
           settle = effectiveSettle,
           renderOutput = "renders/${previewId}_RESIZE_${w}x${h}.png",
-          cost = STATIC_COST,
+          // Same reasoning as the still fan-out below: a settle walks its window frame by frame,
+          // so it is not the one-pass capture STATIC_COST describes.
+          cost = effectiveSettle?.let { settleCaptureCost(it.windowMs) } ?: STATIC_COST,
         )
       }
       val focusGifCaptures: List<Capture> =
@@ -3165,9 +3182,12 @@ object PreviewDiscovery {
               // fan-out is in the *count*, which lives in the captures
               // list itself. Focus drive is similar: one moveFocus call
               // per stop, fixed-time work, no extra cost bucket.
+              val settleForRow = if (scroll == null && ms == null) effectiveSettle else null
               val captureCost =
                 when (scroll?.mode) {
-                  null -> STATIC_COST
+                  // A settled still walks its window a frame at a time, so it is not the one-pass
+                  // capture STATIC_COST describes — see `settleCaptureCost`.
+                  null -> settleForRow?.let { settleCaptureCost(it.windowMs) } ?: STATIC_COST
                   ScrollMode.TOP -> SCROLL_TOP_COST
                   ScrollMode.END -> SCROLL_END_COST
                   ScrollMode.LONG -> SCROLL_LONG_COST
@@ -3185,7 +3205,7 @@ object PreviewDiscovery {
                 // timing is an exact snapshot of a chosen coordinate — settling either would move a
                 // capture off the frame it was asked for. So the settle rides only on the plain
                 // still, which is the capture the reveal actually spoils.
-                settle = if (scroll == null && ms == null) effectiveSettle else null,
+                settle = settleForRow,
                 launcherWidget = effectiveLauncherWidget,
                 renderOutput =
                   "renders/${previewId}${scrollSuffix}${timeSuffix}${focusSuffix}.${ext}",

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1058,6 +1058,14 @@ abstract class RobolectricRenderTestBase(
      */
     val settleTargetMs: Long?
       get() = null
+
+    /**
+     * Whether [settleTargetMs] came from `@SettledPreview(afterMs = …)` rather than auto mode — an
+     * exact coordinate, which the visual-quiescence probe must not move off. See
+     * [shouldAdvanceClockForVisualSettling].
+     */
+    val hasExactSettle: Boolean
+      get() = false
   }
 
   private data class CaptureRenderJob(
@@ -1068,6 +1076,7 @@ abstract class RobolectricRenderTestBase(
     override val scroll: ScrollCapture? = capture.scroll
     override val settleTargetMs: Long? =
       capture.settle?.let { settleCaptureTargetMs(it.afterMs, it.maxMs, CAPTURE_ADVANCE_MS) }
+    override val hasExactSettle: Boolean = (capture.settle?.afterMs ?: 0) > 0
   }
 
   private data class ProductRenderJob(
@@ -1589,6 +1598,7 @@ abstract class RobolectricRenderTestBase(
               shouldAdvanceClockForVisualSettling(
                 advanceTimeMillis = job.advanceTimeMillis,
                 hasFollowingJobs = jobIndex < jobs.lastIndex,
+                hasExactSettle = job.hasExactSettle,
               )
             // When the job has no explicit `advanceTimeMillis`, default
             // to `CAPTURE_ADVANCE_MS` *or* the current virtual time —
@@ -2814,10 +2824,20 @@ internal const val VISUAL_SETTLE_FRAME_MS = 16L
 public fun settleCaptureTargetMs(afterMs: Int, maxMs: Int, captureAdvanceMs: Long): Long =
   if (afterMs > 0) afterMs.toLong() else captureAdvanceMs + maxMs.toLong()
 
+/**
+ * Whether a job may spend extra clock on the adaptive pixel-quiescence probe before capturing.
+ *
+ * Allowed only for an untimed final job. An explicit `advanceTimeMillis` is a snapshot of a chosen
+ * coordinate, and [hasExactSettle] — `@SettledPreview(afterMs = …)` — is the same promise written a
+ * different way: the probe always spends at least one more 16ms frame and up to
+ * [VISUAL_SETTLE_MAX_SAMPLES] of them, which would publish an "exact 350ms" capture from somewhere
+ * in 366–414ms (issue #4202 review). Auto settle keeps the probe: it names a bound, not a moment.
+ */
 internal fun shouldAdvanceClockForVisualSettling(
   advanceTimeMillis: Long?,
   hasFollowingJobs: Boolean,
-): Boolean = advanceTimeMillis == null && !hasFollowingJobs
+  hasExactSettle: Boolean = false,
+): Boolean = advanceTimeMillis == null && !hasExactSettle && !hasFollowingJobs
 
 /**
  * Captures [file] twice and returns immediately if both decoded frames have identical pixels. After

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/CaptureVisuallySettledFrameTest.kt
@@ -11,6 +11,28 @@ import org.junit.Test
 class CaptureVisuallySettledFrameTest {
 
   @Test
+  fun `an exact settle is a snapshot and skips the quiescence probe`() {
+    // `@SettledPreview(afterMs = N)` names an instant, exactly as `advanceTimeMillis` does. The
+    // probe spends at least one more frame and up to the sample budget, which would publish an
+    // "exact 350ms" capture from somewhere in 366-414ms.
+    assertFalse(
+      shouldAdvanceClockForVisualSettling(
+        advanceTimeMillis = null,
+        hasFollowingJobs = false,
+        hasExactSettle = true,
+      )
+    )
+    // Auto settle names a bound, not a moment, so it keeps the probe.
+    assertTrue(
+      shouldAdvanceClockForVisualSettling(
+        advanceTimeMillis = null,
+        hasFollowingJobs = false,
+        hasExactSettle = false,
+      )
+    )
+  }
+
+  @Test
   fun `settling may advance only an untimed final job`() {
     assertTrue(
       shouldAdvanceClockForVisualSettling(

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -166,17 +166,22 @@ fun renderFocusPreview(
   maxWidthPx: Int? = null,
   maxHeightPx: Int? = null,
   /**
-   * `@SettledPreview`'s window, in milliseconds, or `0` for none. Discovery attaches a settle to a
-   * focused *still* row just as it does to a plain one, so a focused capture of a component whose
-   * content arrives on a timer needs the same wait — without it the focus walk runs against an
-   * empty container and the capture publishes one.
+   * `@SettledPreview`'s target **coordinate** in milliseconds, or `0` for none. Discovery attaches
+   * a settle to a focused *still* row just as it does to a plain one, so a focused capture of a
+   * component whose content arrives on a timer needs the same wait — without it the focus walk runs
+   * against an empty container and the capture publishes one.
+   *
+   * A coordinate rather than a window because the two setup frames below already spend clock: an
+   * exact `afterMs` has to mean the same instant here as on the plain path, so those frames count
+   * toward it instead of being added on top (issue #4202 review). Auto mode's target already
+   * carries the same two-frame base, so it still walks its whole window.
    *
    * Spent on `mainClock` before the walk rather than after it: content that has not arrived yet has
    * nothing focusable in it, so settling first is what gives the walk something to land on. This
    * path drives a real `mainClock`, so `delay` is already on virtual time and no
    * [DesktopSettleClock] is needed here.
    */
-  settleWindowMs: Long = 0L,
+  settleTargetMs: Long = 0L,
   fileSystem: FileSystem = SystemFileSystem,
 ): Boolean {
   require(focus != null || hoverIndex != null) { "focus or hover intent required" }
@@ -298,8 +303,10 @@ fun renderFocusPreview(
       mainClock.advanceTimeByFrame()
       mainClock.advanceTimeByFrame()
 
-      // `@SettledPreview` on a focused capture — see [settleWindowMs].
-      if (settleWindowMs > 0) mainClock.advanceTimeBy(settleWindowMs)
+      // `@SettledPreview` on a focused capture — see [settleTargetMs]. The two frames above are
+      // already on the clock, so only the remainder to the coordinate is owed.
+      val settleRemainderMs = settleTargetMs - SETUP_FRAMES_MS
+      if (settleRemainderMs > 0) mainClock.advanceTimeBy(settleRemainderMs)
 
       // `@ScrollingPreview(END)` + `@FocusedPreview` on one capture: land the scroll first, then
       // walk focus in the same scene. Order matters — focus first would be undone by the scroll
@@ -549,3 +556,10 @@ private fun InvokeFocusWrappedComposable(wrapperFqn: String, body: @Composable (
   val resolved = androidx.compose.runtime.remember(wrapperFqn) { resolveWrapper(wrapperFqn) }
   resolved.first.invoke(currentComposer, resolved.second, body)
 }
+
+/**
+ * Virtual time the two setup frames above spend before any drive runs — two 60Hz frames, the same
+ * base `CAPTURE_ADVANCE_MS` gives the Android lane. A `@SettledPreview` coordinate is measured from
+ * the same zero, so this is what a settle target already has behind it.
+ */
+private const val SETUP_FRAMES_MS = 32L

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -607,10 +607,12 @@ fun main(args: Array<String>) {
             maxWidthPx = maxWidthPx,
             maxHeightPx = maxHeightPx,
             // Discovery attaches a settle to a focused still just as it does to a plain one, so
-            // the succeeding focus path has to honour it too — not only the fallback below.
-            settleWindowMs =
+            // the succeeding focus path has to honour it too — not only the fallback below. Passed
+            // as a coordinate, matching the plain path: exact names the instant, auto carries the
+            // same two-frame base underneath its bound.
+            settleTargetMs =
               if (settleAfterMs < 0) 0L
-              else if (settleAfterMs > 0) settleAfterMs.toLong() else settleMaxMs.toLong(),
+              else if (settleAfterMs > 0) settleAfterMs.toLong() else 32L + settleMaxMs.toLong(),
           )
         if (!didCapture) {
           renderPreview(

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopSettleClock.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopSettleClock.kt
@@ -83,6 +83,18 @@ internal class DesktopSettleClock : CoroutineDispatcher(), Delay {
   /** Whether any `delay` is still outstanding — the half of quiescence pixels cannot see. */
   fun hasScheduledWork(): Boolean = scheduled.isNotEmpty()
 
+  /**
+   * Whether anything at all is still owed: a delay not yet due, **or** a runnable already
+   * dispatched but not yet executed.
+   *
+   * The second half matters because `scene.render(...)` itself can dispatch work — a recomposition
+   * that conditionally introduces a `LaunchedEffect` queues it *after* the preceding [advanceTo]
+   * drained. With nothing scheduled and no invalidation left, a quiescence check that only
+   * consulted [hasScheduledWork] would stop right there and capture the pre-reveal frame
+   * (issue #4202 review).
+   */
+  fun hasPendingWork(): Boolean = ready.isNotEmpty() || scheduled.isNotEmpty()
+
   /** Runs everything dispatched but not yet executed, including work those runnables dispatch. */
   fun drain() {
     while (true) ready.removeFirstOrNull()?.run() ?: break
@@ -134,7 +146,10 @@ internal fun settleScene(
     // Closed rather than left to a cleaner: each frame owns a Skia surface, and a pooled render
     // worker walks this loop once per settled capture for the life of the JVM.
     scene.render(t * 1_000_000L).close()
-    if (autoDetect && !clock.hasScheduledWork() && !scene.hasInvalidations()) return t
+    // Drain what the render itself dispatched before judging the frame, so an effect the
+    // recomposition just queued counts against quiescence rather than being missed entirely.
+    clock.drain()
+    if (autoDetect && !clock.hasPendingWork() && !scene.hasInvalidations()) return t
   }
   return bound
 }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSettleClockTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopSettleClockTest.kt
@@ -65,4 +65,20 @@ class DesktopSettleClockTest {
 
     assertFalse("a cancelled delay must not hold the settle open", clock.hasScheduledWork())
   }
+
+  @Test
+  fun `work dispatched but not yet run counts against quiescence`() {
+    // `scene.render(...)` can dispatch a newly-introduced `LaunchedEffect` after the preceding
+    // advance already drained. Nothing is scheduled and nothing is invalidated at that instant, so
+    // a check that only consulted `hasScheduledWork` would stop and capture the pre-reveal frame.
+    val clock = DesktopSettleClock()
+    val scope = CoroutineScope(clock)
+    scope.launch { /* resumes immediately, but only once drained */ }
+
+    assertFalse("no delay is outstanding", clock.hasScheduledWork())
+    assertTrue("but a runnable is still queued", clock.hasPendingWork())
+
+    clock.drain()
+    assertFalse("drained, so nothing is owed", clock.hasPendingWork())
+  }
 }


### PR DESCRIPTION
Follow-up to #4242 (issue #4202), which merged while these were still in validation. Five Codex findings on that PR, all reproduced in the code before fixing.

## An exact `afterMs` was not exact, on three paths

`@SettledPreview(afterMs = N)` names an instant — the same promise `advanceTimeMillis` makes. Three places moved the shutter off it:

* **Android still** — the job still had `advanceTimeMillis == null`, so it was classified for the adaptive pixel-quiescence probe. That probe always spends at least one more 16ms frame and up to the sample budget, so an "exact 350ms" capture was actually written from somewhere in **366–414ms**. `shouldAdvanceClockForVisualSettling` now takes `hasExactSettle` and declines, exactly as it declines for an explicit `advanceTimeMillis`.
* **Desktop focus/hover** — `renderFocusPreview` advanced its two setup frames and *then* the whole window on top, landing at **N+32**. It now receives a coordinate rather than a window, and spends only the remainder; the setup frames count toward it, mirroring `CAPTURE_ADVANCE_MS` on the Android side.
* (The `+32` on the plain Android path was fixed in #4242 itself.)

Auto mode is untouched in all three: it names a bound, not a moment, so it keeps the probe and keeps walking its full window.

## Desktop auto settle could stop one frame early

`settleScene`'s quiescence check consulted the delay queue and scene invalidations, but not runnables already dispatched. `scene.render(...)` can queue a newly-introduced `LaunchedEffect` *after* the preceding `advanceTo` drained — at that instant nothing is scheduled and nothing is invalidated, so the walk returned on the pre-reveal frame. The render's own dispatches are now drained and counted (`hasPendingWork`).

## The motion collision guard was too narrow

#4242 dropped the settle when `@AnimatedPreview` shared the function, because both products replay from one composition against one paused clock and virtual time does not rewind. `@InteractionPreview` and `@FocusedPreview(gif = true)` collide identically — they replay from the same clock and are deliberately sorted after the stills for the same reason. All three now drop the settle and name themselves in the warning.

## A settled still was costed as a one-pass capture

Both backends walk the settle window a frame at a time, so a default 1000ms settle is ~62 rendered frames — but `captureCost` still stamped `STATIC_COST`. That let a catalog of settled previews stay in the on-every-save fast tier and concentrate into a single Android shard. `settleCaptureCost(windowMs)` scales with the window, putting the default just above `HEAVY_COST_THRESHOLD` while a short explicit window stays cheap.

## Not fixed, deliberately

**Preserving `Capture`'s pre-settle `copy` / `copy$default` descriptors.** The descriptor analysis is right, but `copy$default` is compiler-synthesised from the primary constructor — it cannot be hand-written or overloaded from Kotlin source, and a `fun copy(...)` of the old arity does not recreate the descriptor existing binaries call. The only real remedies are dropping `data` from `Capture` or accepting the change. `preview-data-api` already accepts exactly this break for `CatalogEntry` (pre-`kitValue`) and `PreviewResult` (pre-`projectDirectory`) — both preserved constructors only, and the module contains zero `copy` overloads. Changing that is a module-wide policy call, worth its own PR alongside `binary-compatibility-validator`, which the repo does not currently run.

**Consumer docs in [`yschimke/skills`](https://github.com/yschimke/skills)** (`skills/compose-preview/references/capture-modes.md`) still need `@SettledPreview` and its motion-product incompatibility added. That repo is not reachable from this session, so it remains a follow-up — same note as on #4242.

## Test plan

Run in this session on the cloud container (Linux, headless), green:

| Command | Result |
| --- | --- |
| `:gradle-plugin:test` | 459 tests, 0 failures |
| `:gradle-plugin:functionalTest` | 95 tests, 0 failures |
| `:renderer-android:testDebugUnitTest` | 252 tests, 0 failures — includes the new `an exact settle is a snapshot and skips the quiescence probe` |
| `:renderer-desktop:test` | 155 tests, 0 failures — includes the new `work dispatched but not yet run counts against quiescence` |
| `:daemon:core:test` | 552 tests, 0 failures |
| `:preview-data-api:test` | 30 tests, 0 failures |
| `ktfmtCheckAll` | clean |

**No render moves.** `:samples:android:composePreviewRenderAll` re-rendered all four committed settled fixtures **byte-identical** to what #4242 landed — including `DeferredValueSettledPreview`, which is the `afterMs = 300` case the probe-skip touches. The exact-mode fixes change where the shutter lands for coordinates the probe was overshooting, not the sample's resting frames, so this is a text-only change by the repo's visual-evidence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_011BnQSKS218vZqT8GtpfvS1)_