### PR TITLE
feat(design-map): let --strict accept an absence somebody wrote down

### DIFF
--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -406,29 +406,50 @@ export function projectDesignMap(previews, opts = {}) {
 
   const components = [];
   const declarations = [];
+  /**
+   * Whether a component reaches a design reference at all, and what it said if not.
+   *
+   * Read from the ANNOTATIONS, before and independently of capture selection — which is the whole
+   * point. A component publishing several modes with no Light among them is `ambiguousMode`, and
+   * `participates()` is false for every one of its captures; computing absence inside the capture
+   * loop therefore dropped such a component out of `unmapped` / `statedAbsent` entirely and
+   * reported it only as an ambiguous mode. A stated absence would then be fatal under
+   * `--strict --allow-stated-absence`, which is exactly the case that flag exists to accept.
+   *
+   * Keyed by componentId rather than pushed per preview, because a component's absence is one fact
+   * however many captures it publishes.
+   */
+  const unmappedIds = new Map();
+  const statedAbsentIds = new Map();
+  for (const preview of previews) {
+    const catalog = preview.catalog;
+    if (!catalog || catalog.role !== "COMPONENT" || catalog.reference) continue;
+    if (isVariantCapture(preview)) continue;
+    const id = catalog.componentId;
+    if (catalog.noReference) statedAbsentIds.set(id, catalog.noReference);
+    else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);
+  }
   /** Components carrying neither a reference nor a stated reason for its absence. */
-  const unmapped = [];
+  const unmapped = [...unmappedIds.keys()].filter((id) => !statedAbsentIds.has(id));
   /**
    * Components whose reference is absent for a STATED reason. Reported apart from `unmapped`
    * because they are the opposite situation: someone looked, and what they found is that the kit
    * has nothing live to point at. Rolling the two together is what made a retired pattern read as
    * neglect.
    */
-  const statedAbsent = [];
+  const statedAbsent = [...statedAbsentIds].map(([componentId, reason]) => ({
+    componentId,
+    reason,
+  }));
+  /** Every component that reaches no reference, however its absence was spelled. */
+  const referencelessIds = new Set([...unmapped, ...statedAbsentIds.keys()]);
 
   for (const preview of previews) {
     const catalog = preview.catalog;
     if (!catalog || catalog.role !== "COMPONENT") continue;
     if (isVariantCapture(preview) || !selection.participates(preview)) continue;
 
-    if (!catalog.reference) {
-      if (catalog.noReference) {
-        statedAbsent.push({ componentId: catalog.componentId, reason: catalog.noReference });
-      } else {
-        unmapped.push(catalog.componentId);
-      }
-      continue;
-    }
+    if (!catalog.reference) continue;
 
     const code = codeHandle(preview, opts);
     components.push({
@@ -478,7 +499,14 @@ export function projectDesignMap(previews, opts = {}) {
       // Composables whose captures name no mode a reference could pair with — several modes, none
       // of them light. Reported rather than guessed at: pairing `Dark` when the kit drew `Coral`
       // diffs a whole palette.
-      ambiguousMode: selection.ambiguous,
+      // An ambiguous mode is only ever a problem BECAUSE a reference needs one capture to pair
+      // with. A component that reaches no reference has nothing to pair, so which of its captures
+      // the kit drew is not a question anyone is asking — reporting it would be noise on top of the
+      // absence already reported above, and under --strict it would be a second, unfixable failure
+      // for the same component.
+      ambiguousMode: selection.ambiguous.filter(
+        (a) => !a.componentIds.length || a.componentIds.some((id) => !referencelessIds.has(id)),
+      ),
       variantRenders: declarations.reduce((n, d) => n + d.renders.length, 0),
       withSet: components.filter((c) => c.refSet).length,
     },

--- a/design-map/emit-design-map.mjs
+++ b/design-map/emit-design-map.mjs
@@ -4,7 +4,7 @@
  *
  *     npx @yschimke/compose-design-map [--previews <path>] [--out design-map.json]
  *                                      [--variants design-map-variants.json] [--prefix catalog]
- *                                      [--check] [--strict]
+ *                                      [--check] [--strict] [--allow-stated-absence]
  *
  * Run `./gradlew :<module>:composePreviewDiscover` first so the manifest exists.
  *
@@ -32,6 +32,14 @@
  * whose captures name no mode the reference could pair with. The annotation still earns its keep in
  * the default mode, where the three are reported apart so a retired pattern does not read as
  * neglect; `--strict` simply says there are no exceptions.
+ *
+ * `--allow-stated-absence` narrows `--strict` back to what it is usually wanted for: it still fails
+ * on a missing `reference` and on an ambiguous mode, but accepts a component whose absence a
+ * `noReference` explains. That is the posture of a catalog with two doors — one for the components
+ * that reproduce a kit set, one for the components of its own library the kit never published —
+ * where an exception is a fact about the kit rather than a gap. Without it such a catalog has to
+ * drop `--strict` altogether and loses the guard against silence as well. No effect without
+ * `--strict`.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -51,6 +59,7 @@ const VARIANTS_OUT = arg("variants", "design-map-variants.json");
 const PREFIX = arg("prefix", "catalog");
 const CHECK = process.argv.includes("--check");
 const STRICT = process.argv.includes("--strict");
+const ALLOW_STATED_ABSENCE = process.argv.includes("--allow-stated-absence");
 
 if (!fs.existsSync(PREVIEWS)) {
   console.error(
@@ -71,7 +80,16 @@ const { map, variants, diagnostics } = projectDesignMap(manifest.previews ?? [],
 if (STRICT) {
   const missing = [
     ...diagnostics.unmapped.map((id) => `${id} — no reference, and no reason given`),
-    ...diagnostics.statedAbsent.map((s) => `${s.componentId} — ${s.reason}`),
+    // A STATED absence is a gap under plain --strict and not under
+    // `--strict --allow-stated-absence`. The two postures are both real: a catalog whose inventory
+    // is exactly the kit's wants no exceptions at all, while one that also publishes components of
+    // its own library that the kit never drew (wear-m3-catalog's `ButtonGroup`, `Scaffold`) wants
+    // strictness about SILENCE without being failed by the four cases somebody already looked at
+    // and wrote down. Without the opt-in those catalogs cannot use --strict at all, which costs
+    // them the guard against silence too — the thing --strict was actually for.
+    ...(ALLOW_STATED_ABSENCE
+      ? []
+      : diagnostics.statedAbsent.map((s) => `${s.componentId} — ${s.reason}`)),
     // An ambiguous mode is the third way a component ends up outside the map, and the quietest:
     // the reference is there, but nothing says which capture it pairs with, so the component is
     // simply absent. Under --strict that is as much a gap as a missing reference.
@@ -90,7 +108,10 @@ if (STRICT) {
     for (const line of missing) console.error(`  - ${line}`);
     console.error(
       `A catalog that reproduces a kit has nothing to compare these against — remove them, ` +
-        `or drop --strict to publish them unmapped.`,
+        `or drop --strict to publish them unmapped` +
+        (ALLOW_STATED_ABSENCE
+          ? `.`
+          : `, or pass --allow-stated-absence to accept the ones a noReference explains.`),
     );
     process.exit(1);
   }

--- a/design-map/emit-design-map.test.mjs
+++ b/design-map/emit-design-map.test.mjs
@@ -84,3 +84,64 @@ test("a dark-only catalog maps under --strict, having no Light capture to pair w
   assert.equal(status, 0, all);
   assert.match(all, /1 mapped component\(s\)/);
 });
+
+// A component publishing several modes with none of them Light is `ambiguousMode`, and
+// `participates()` is false for every one of its captures. Absence used to be read inside that
+// filter, so such a component fell out of the absence diagnostics entirely and was reported only as
+// an ambiguous mode — making a STATED absence fatal under the flag that exists to accept it.
+const statedTwoModes = (mode) => ({
+  id: `com.example.CatalogKt.ButtonGroup_${mode}`,
+  functionName: "ButtonGroup",
+  sourceFile: "Catalog.kt",
+  catalog: {
+    role: "COMPONENT",
+    componentId: "ButtonGroup",
+    noReference: "The kit publishes no button-group set.",
+  },
+});
+
+test("a stated absence survives an ambiguous mode, and the flag still accepts it", () => {
+  const previews = [MAPPED, statedTwoModes("Dark"), statedTwoModes("Coral")];
+
+  const strict = run(previews, "--strict");
+  assert.equal(strict.status, 1);
+  assert.match(strict.all, /ButtonGroup — The kit publishes no button-group set\./);
+  // Reported ONCE, as the absence it is — not a second time as an unpairable capture.
+  assert.doesNotMatch(strict.all, /none of them Light/);
+
+  const allowed = run(previews, "--strict", "--allow-stated-absence");
+  assert.equal(allowed.status, 0, allowed.all);
+});
+
+test("an unexplained absence is unmapped, not ambiguous, however many modes it draws", () => {
+  const silentTwoModes = (mode) => ({
+    id: `com.example.CatalogKt.Mystery_${mode}`,
+    functionName: "Mystery",
+    sourceFile: "Catalog.kt",
+    catalog: { role: "COMPONENT", componentId: "Mystery" },
+  });
+  const { status, all } = run(
+    [MAPPED, silentTwoModes("Dark"), silentTwoModes("Coral")],
+    "--strict",
+    "--allow-stated-absence",
+  );
+  assert.equal(status, 1);
+  assert.match(all, /Mystery — no reference, and no reason given/);
+  assert.doesNotMatch(all, /none of them Light/);
+});
+
+test("an ambiguous mode is still fatal when the component HAS a reference to pair", () => {
+  const themed = (mode) => ({
+    id: `com.example.CatalogKt.Themed_${mode}`,
+    functionName: "Themed",
+    sourceFile: "Catalog.kt",
+    catalog: { role: "COMPONENT", componentId: "Themed", reference: `figma:${FILE}/2:2` },
+  });
+  const { status, all } = run(
+    [MAPPED, themed("Dark"), themed("Coral")],
+    "--strict",
+    "--allow-stated-absence",
+  );
+  assert.equal(status, 1);
+  assert.match(all, /none of them Light/);
+});

--- a/design-map/emit-design-map.test.mjs
+++ b/design-map/emit-design-map.test.mjs
@@ -1,0 +1,86 @@
+// The CLI's FAILURE POSTURE, which is the part of this package a catalog's CI depends on and the
+// part the pure-projection tests in design-map.test.mjs cannot reach: `--strict` decides whether a
+// build goes red, and it decides it from `diagnostics`, not from the map.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(new URL("./emit-design-map.mjs", import.meta.url));
+const FILE = "AbCdEf";
+
+/** A dark-only capture: no mode segment in the id, which is what a Wear catalog publishes. */
+const component = (name, catalog) => ({
+  id: `com.example.CatalogKt.${name}`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  catalog: { role: "COMPONENT", componentId: name, ...catalog },
+});
+
+/** Run the CLI over `previews` in a throwaway directory. */
+function run(previews, ...flags) {
+  const dir = mkdtempSync(path.join(tmpdir(), "emit-design-map-"));
+  try {
+    const manifest = path.join(dir, "previews.json");
+    writeFileSync(manifest, JSON.stringify({ previews }));
+    const result = spawnSync(
+      process.execPath,
+      [
+        CLI,
+        "--previews",
+        manifest,
+        "--out",
+        path.join(dir, "design-map.json"),
+        "--variants",
+        path.join(dir, "design-map-variants.json"),
+        ...flags,
+      ],
+      { encoding: "utf8" },
+    );
+    return { ...result, all: `${result.stdout}${result.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const MAPPED = component("FilledButton", { reference: `figma:${FILE}/1:1` });
+const STATED = component("ButtonGroup", { noReference: "The kit publishes no button-group set." });
+const SILENT = component("Mystery", {});
+
+test("--strict fails on a stated absence, because it says there are no exceptions", () => {
+  const { status, all } = run([MAPPED, STATED], "--strict");
+  assert.equal(status, 1);
+  assert.match(all, /ButtonGroup — The kit publishes no button-group set\./);
+  // The remedy has to be discoverable from the message, or the only way to find the opt-in is to
+  // read this package's source.
+  assert.match(all, /--allow-stated-absence/);
+});
+
+test("--strict --allow-stated-absence accepts an absence somebody wrote down", () => {
+  const { status, all } = run([MAPPED, STATED], "--strict", "--allow-stated-absence");
+  assert.equal(status, 0, all);
+  assert.match(all, /1 mapped component\(s\)/);
+});
+
+test("--allow-stated-absence does NOT excuse silence — that is what strictness is for", () => {
+  const { status, all } = run([MAPPED, STATED, SILENT], "--strict", "--allow-stated-absence");
+  assert.equal(status, 1);
+  assert.match(all, /Mystery — no reference, and no reason given/);
+  // The one it was told to allow must not be listed beside the one it was not.
+  assert.doesNotMatch(all, /ButtonGroup/);
+});
+
+test("--allow-stated-absence alone changes nothing: absences are reported, never fatal", () => {
+  const { status, all } = run([MAPPED, STATED, SILENT], "--allow-stated-absence");
+  assert.equal(status, 0, all);
+  assert.match(all, /1 component\(s\) have no reference for a stated reason/);
+});
+
+test("a dark-only catalog maps under --strict, having no Light capture to pair with", () => {
+  const { status, all } = run([MAPPED], "--strict");
+  assert.equal(status, 0, all);
+  assert.match(all, /1 mapped component\(s\)/);
+});


### PR DESCRIPTION
## Summary

`--strict` gates on **every** kind of absence — a missing `reference`, an ambiguous capture mode,
and an absence a `noReference` explains. That is the right posture for a catalog whose inventory is
exactly the kit's (m3-catalog, which has zero `noReference` components). It is the wrong one for a
catalog with **two doors**, where a component of the library that the kit never published enters
with the reason recorded.

`wear-m3-catalog` has four such components — `ButtonGroup`, `TransformingLazyColumn`, `Scaffold`,
`ArcProgressIndicator` — so `--strict` failed it on components that are exactly as intended:

```
::error::--strict: 4 component(s) reach no design reference …
  - ButtonGroup — The kit publishes no button-group set …
```

The only escape was to drop `--strict` altogether, which also gives up its guard against **silence**
— a component with neither a reference nor a reason — and that guard is what the flag was actually
for.

`--allow-stated-absence` narrows the gate accordingly: still fatal on a missing reference and on an
ambiguous mode, permissive about a stated one. It has no effect without `--strict`, so **no existing
caller changes behaviour** — m3-catalog keeps failing on a `noReference` it never wanted.

The failure message now names the flag; otherwise the opt-in is discoverable only by reading this
package's source.

## Also: the CLI had no tests

`design-map.test.mjs` covers `projectDesignMap` — the pure projection. The **failure posture** is
what a downstream repo's CI actually hangs on, and nothing exercised it. `emit-design-map.test.mjs`
adds five cases over the real binary, including a regression pin for the dark-only fallback from
#4196.

## Test plan

- `node --test` in `design-map/` — 5 new tests pass, existing suite unchanged. Already wired into
  CI (`Run design-map package tests`).
- Verified against the real `wear-m3-catalog` manifest (53 components, 4 of them stated-absent):
  - `--strict` → exit 1, listing the four.
  - `--strict --allow-stated-absence` → exit 0, `49 mapped component(s)`.
  - `--strict --allow-stated-absence` with an unexplained component added → exit 1, naming only that
    component.

Text-only change: the CLI's exit codes and stderr, no rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FnnYDMBa6NXnEwNguEB2p)_