### PR TITLE
fix(a11y): roll a stop's label up by ancestry, not by geometry

### DIFF
--- a/cli/serve-web/src/inspect/entries.ts
+++ b/cli/serve-web/src/inspect/entries.ts
@@ -136,8 +136,13 @@ const boundsKey = (wire: string | null | undefined): string =>
  * of its own, then a subtitle announces "Title Subtitle" — stopping at the nested stop drops the
  * subtitle, ignoring it swallows the button's copy into the row.
  *
- * Mirrors `AccessibilityLabels.mergedDescendantLabel` in `:data-a11y-core`, which is where a
- * freshly rendered hierarchy gets this done before it reaches the wire.
+ * This is an APPROXIMATION, and deliberately the second line of defence: a freshly rendered
+ * hierarchy arrives with the label already on the stop, because `AccessibilityLabels` reads the
+ * real parent/child links during extraction, before the wire flattens them away. What is left here
+ * cannot be made exact — two rectangles that nest tell you nothing certain about ancestry, so a
+ * stop drawn over the whole of its parent will still swallow what follows it — and the payload has
+ * no ancestry to consult instead. Re-rendering the bundle is the fix for those; this keeps the
+ * common shapes readable until someone does.
  */
 function mergedDescendantLabel(nodes: A11yNode[], index: number): string {
     const parts: string[] = [];

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -172,6 +172,9 @@ object AccessibilityChecker {
       override val ownLabel: String
         get() = ownLabel(element)
 
+      override val isFocusStop: Boolean
+        get() = element.isScreenReaderFocusable
+
       override val mergesDescendants: Boolean
         get() = mergesDescendants(element.isScreenReaderFocusable, element.isScrollable == true)
 

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -93,10 +93,14 @@ object AccessibilityChecker {
       // Prefer contentDescription (what TalkBack actually announces);
       // fall back to visible text. Both are SpannableStrings — toString()
       // strips ATF's spans so we get plain UI copy.
-      val label =
-        (v.contentDescription?.toString()?.trim().orEmpty()).ifEmpty {
-          v.text?.toString()?.trim().orEmpty()
-        }
+      val ownLabel = ownLabel(v)
+      // What the element ANNOUNCES, which for a merging stop whose copy sits
+      // on the descendants it folds in (a Wear `Button(label = { Text(…) })`,
+      // an `IconButton` whose contentDescription is on the inner `Icon`) is
+      // not the copy it carries itself — issue #4253. Done here, where the
+      // walk still holds the ancestry: the wire format is flat, so a consumer
+      // reading it back can only approximate the subtree.
+      val label = AccessibilityLabels.announcement(v.rollUpElement())
       val role = simplifyRole(v.accessibilityClassName?.toString() ?: v.className?.toString())
       val states =
         buildStates(
@@ -123,16 +127,20 @@ object AccessibilityChecker {
       // a role beyond plain View, an actionable state, or clickability
       // is enough to keep them. Clickable-but-empty containers (a card
       // with text inside it that's already its own node) drop out.
+      // Deliberately the element's OWN copy, not its rolled-up announcement:
+      // the roll-up decides what a kept node says, never which nodes are
+      // kept, so it cannot quietly grow the legend with containers that used
+      // to fall out of it.
       val keep =
-        label.isNotEmpty() ||
+        ownLabel.isNotEmpty() ||
           states.isNotEmpty() ||
           (role != null && (v.isClickable || v.isLongClickable))
       if (!keep) continue
-      // The label is what reviewers scan for first. It can still be empty
-      // here — either the copy lives on merged descendants (rolled up
-      // below) or the element genuinely has no name, which is exactly the
-      // problem the legend should show; the overlay caller decides how to
-      // render that (we draw the role on its own line in the legend).
+      // The label is what reviewers scan for first. It can still be empty —
+      // an unlabelled clickable element with a known role, and nothing under
+      // it to borrow a name from, still surfaces with an empty `label` field.
+      // That is the problem the legend should show; the overlay caller
+      // decides how to render it (we draw the role on its own line).
       out +=
         AccessibilityNode(
           label = label,
@@ -142,13 +150,34 @@ object AccessibilityChecker {
           boundsInScreen = "${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}",
         )
     }
-    // ATF reports each element's own contentDescription / text, so a focus stop whose copy lives on
-    // the descendants it merges (a Wear `Button(label = { Text(...) })`, an `IconButton` whose
-    // contentDescription sits on the inner `Icon`) comes out of the walk blank. Roll those up so
-    // the
-    // node carries what TalkBack actually announces — issue #4253. Runs over the flat list rather
-    // than inside the walk because that is where the parent/child run is still legible.
-    return AccessibilityLabels.rollUpMergedLabels(out)
+    return out
+  }
+
+  /**
+   * The copy [v] carries itself — `contentDescription` else visible `text`, trimmed. Read twice per
+   * element (once by the keep filter, once by the roll-up), so it lives here rather than inline.
+   */
+  private fun ownLabel(v: ViewHierarchyElement): String =
+    (v.contentDescription?.toString()?.trim().orEmpty()).ifEmpty {
+      v.text?.toString()?.trim().orEmpty()
+    }
+
+  /**
+   * Adapts an ATF element to the three members [AccessibilityLabels] reads. Children are wrapped
+   * lazily, so an element that carries its own copy costs no traversal at all.
+   */
+  private fun ViewHierarchyElement.rollUpElement(): AccessibilityLabels.Element {
+    val element = this
+    return object : AccessibilityLabels.Element {
+      override val ownLabel: String
+        get() = ownLabel(element)
+
+      override val mergesDescendants: Boolean
+        get() = mergesDescendants(element.isScreenReaderFocusable, element.isScrollable == true)
+
+      override val children: List<AccessibilityLabels.Element>
+        get() = (0 until element.childViewCount).map { element.getChildView(it).rollUpElement() }
+    }
   }
 
   /**

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityLabels.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityLabels.kt
@@ -8,103 +8,68 @@ package ee.schimke.composeai.renderer
  * one TalkBack announcement. For the shapes where the clickable surface and the copy are different
  * elements — a Wear `Button(icon = …, label = { Text("Filled") })`, an `IconButton` whose
  * `contentDescription` lives on the inner `Icon` — that leaves the stop with an empty `label` and
- * the copy stranded on an unmerged child that no screen reader stops on. Every consumer then reads
- * the stop as unlabelled: the inspection layer prints `(unlabelled)`, the legend falls back to the
- * role, and [TalkBackUtterance] speaks the state with no name in front of it.
+ * the copy stranded on a child that no screen reader stops on. Every consumer then reads the stop
+ * as unlabelled: the inspection layer prints `(unlabelled)`, the legend falls back to the role, and
+ * [TalkBackUtterance] speaks the state with no name in front of it. What ATF reports for that
+ * button is measured in `:renderer-android`'s `WearButtonA11yHierarchyProbeTest`.
  *
- * TalkBack announces "Filled, double-tap to activate" for that button, so that is what the node
- * should carry. The CMP side already resolves this at the source
- * (`DesktopAccessibilityNodeExtractor.effectiveLabel` walks the merged subtree); ATF gives us no
- * such subtree handle after the walk has flattened it, so the equivalent runs here as a pure pass
- * over the emitted list.
+ * TalkBack announces "Filled, double-tap to activate" there, so that is what the node should carry.
+ * This is the same walk `DesktopAccessibilityNodeExtractor.effectiveLabel` does on the CMP side,
+ * and it reads the hierarchy the same way: **real ancestry**, taken while the walk still holds it.
+ * A nested focus stop owns its own announcement, so its subtree is pruned — but the walk carries on
+ * with the descendants after it, which is what lets a row that folds in a title, a button of its
+ * own, then a subtitle announce "Title Subtitle".
  *
- * **Reconstructing "which nodes did this stop fold in" from a flat list** takes both signals the
- * wire carries, and neither alone is enough:
- * - *Emission order* — nodes come out in pre-order, so a stop's descendants are the nodes that
- *   follow it, up to the point the walk leaves its subtree. This is the rule
- *   `AccessibilityOverlay.groupNodes` and the VS Code bundle presenter already group on.
- * - *Bounds containment* — which says where that subtree ends, and which of the nodes inside it
- *   belong to a **nested** focus stop instead. A row that folds in a title, then a button of its
- *   own, then a subtitle announces "Title Subtitle": the button owns its own announcement, but the
- *   subtitle after it is still the row's. Stopping at the nested stop (order alone) would drop the
- *   subtitle; ignoring it would swallow the button's copy into the row.
+ * Structural questions have to be answered here, at extraction, because the `a11y/hierarchy` wire
+ * format is flat: it has no parent link, so a consumer reading it back can only approximate the
+ * subtree from emission order and bounds (`cli/serve-web`'s `mergedDescendantLabel` does exactly
+ * that, for hierarchies baked before this walk started rolling labels up). Approximating is what
+ * this avoids.
  */
 object AccessibilityLabels {
 
   /**
-   * Returns [nodes] with every blank-labelled focus stop given the announcement its merged
-   * descendants supply, joined by `" "` in traversal order. Nodes that already carry a label are
-   * untouched, and a stop whose descendants supply nothing stays blank — an unlabelled clickable
-   * really is unlabelled, and that is a finding worth seeing, not one worth papering over.
-   *
-   * Pure and idempotent: running it twice yields the same list.
+   * The slice of a hierarchy element the roll-up reads. Kept to three members so the rule can be
+   * exercised against hand-built trees — ATF's own `ViewHierarchyElement` needs a real `View` graph
+   * to construct, which is why the projection used to be tested against flat node lists that could
+   * only prove its arithmetic, never its reading of the tree.
    */
-  fun rollUpMergedLabels(nodes: List<AccessibilityNode>): List<AccessibilityNode> {
-    if (nodes.none { it.merged && it.label.isBlank() }) return nodes
-    return nodes.mapIndexed { index, node ->
-      if (!node.merged || node.label.isNotBlank()) node
-      else {
-        val rolled = mergedDescendantLabel(nodes, index)
-        if (rolled.isEmpty()) node else node.copy(label = rolled)
-      }
-    }
+  interface Element {
+    /** The copy this element carries itself: `contentDescription` else `text`. */
+    val ownLabel: String
+
+    /**
+     * `true` when this element folds its descendants into a single announcement — ATF's
+     * `isScreenReaderFocusable` on a non-scrollable element
+     * ([AccessibilityChecker.mergesDescendants]), the analogue of Compose's
+     * `isMergingSemanticsOfDescendants`.
+     */
+    val mergesDescendants: Boolean
+
+    val children: List<Element>
   }
 
   /**
-   * The announcement the merged node at [index] gets from the descendants it folds in — the
-   * following nodes that sit inside its bounds, minus those a nested focus stop announces itself,
-   * in traversal order with blanks dropped.
+   * What a screen reader announces for [element]: the copy it carries itself, or — for a merging
+   * element that carries none — the copy of the descendants it folds in, joined by `" "` in
+   * traversal order.
    *
-   * A node whose bounds don't parse is skipped rather than treated as the end of the subtree: it
-   * describes nothing anyone can point at, and ending the scan there would silently truncate the
-   * announcement. A **parent** whose bounds don't parse has no subtree to test against, so it falls
-   * back to the plain following run.
+   * Empty when nothing supplies a name. An unlabelled clickable really is unlabelled, and that is a
+   * finding worth seeing, not one worth papering over.
    */
-  fun mergedDescendantLabel(nodes: List<AccessibilityNode>, index: Int): String {
-    val parent = parseBounds(nodes[index].boundsInScreen) ?: return followingRunLabel(nodes, index)
+  fun announcement(element: Element): String {
+    val own = element.ownLabel.trim()
+    if (own.isNotEmpty()) return own
+    if (!element.mergesDescendants) return ""
     val parts = mutableListOf<String>()
-    // The nested focus stop currently being skipped over, if any — what sits inside it is part of
-    // its announcement, not of ours.
-    var nested: Bounds? = null
-    for (i in index + 1 until nodes.size) {
-      val node = nodes[i]
-      val bounds = parseBounds(node.boundsInScreen) ?: continue
-      // Out of the parent's box: the walk has left its subtree, and what follows belongs to
-      // something else.
-      if (!parent.contains(bounds)) break
-      if (nested != null && nested.contains(bounds)) continue
-      nested = null
-      if (node.merged) {
-        nested = bounds
-        continue
-      }
-      node.label.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
+    fun collect(node: Element, isRoot: Boolean) {
+      // A nested stop is read as its own announcement, so its subtree is not part of this one —
+      // but what follows it still is.
+      if (!isRoot && node.mergesDescendants) return
+      node.ownLabel.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
+      for (child in node.children) collect(child, isRoot = false)
     }
+    collect(element, isRoot = true)
     return parts.joinToString(" ")
-  }
-
-  /**
-   * The plain following run of non-stops — the fallback for a parent whose bounds don't parse, and
-   * so has no box to test its descendants against.
-   */
-  private fun followingRunLabel(nodes: List<AccessibilityNode>, index: Int): String {
-    val parts = mutableListOf<String>()
-    for (i in index + 1 until nodes.size) {
-      if (nodes[i].merged) break
-      nodes[i].label.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
-    }
-    return parts.joinToString(" ")
-  }
-
-  private data class Bounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
-    fun contains(other: Bounds): Boolean =
-      left <= other.left && top <= other.top && right >= other.right && bottom >= other.bottom
-  }
-
-  private fun parseBounds(wire: String): Bounds? {
-    val parts = wire.split(',')
-    if (parts.size != 4) return null
-    val values = parts.map { it.trim().toIntOrNull() ?: return null }
-    return Bounds(values[0], values[1], values[2], values[3])
   }
 }

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityLabels.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityLabels.kt
@@ -29,20 +29,34 @@ package ee.schimke.composeai.renderer
 object AccessibilityLabels {
 
   /**
-   * The slice of a hierarchy element the roll-up reads. Kept to three members so the rule can be
-   * exercised against hand-built trees — ATF's own `ViewHierarchyElement` needs a real `View` graph
-   * to construct, which is why the projection used to be tested against flat node lists that could
+   * The slice of a hierarchy element the roll-up reads. Kept small so the rule can be exercised
+   * against hand-built trees — ATF's own `ViewHierarchyElement` needs a real `View` graph to
+   * construct, which is why the projection used to be tested against flat node lists that could
    * only prove its arithmetic, never its reading of the tree.
+   *
+   * [isFocusStop] and [mergesDescendants] are **not** the same question, and the roll-up asks each
+   * of them exactly once. A scrollable container is a stop a screen reader lands on, but it does
+   * not fold its rows into one announcement — each row stays independently reachable
+   * ([#1565](https://github.com/yschimke/compose-ai-tools/issues/1565)). Collapsing the two would
+   * let a clickable card that happens to contain a carousel announce every row in it.
    */
   interface Element {
     /** The copy this element carries itself: `contentDescription` else `text`. */
     val ownLabel: String
 
     /**
+     * `true` when a screen reader stops on this element in its own right — ATF's
+     * `isScreenReaderFocusable`. What an ancestor's announcement must stop at, whether or not this
+     * element goes on to fold anything of its own.
+     */
+    val isFocusStop: Boolean
+
+    /**
      * `true` when this element folds its descendants into a single announcement — ATF's
-     * `isScreenReaderFocusable` on a non-scrollable element
+     * `isScreenReaderFocusable` on a **non-scrollable** element
      * ([AccessibilityChecker.mergesDescendants]), the analogue of Compose's
-     * `isMergingSemanticsOfDescendants`.
+     * `isMergingSemanticsOfDescendants`. What decides whether this element has an announcement to
+     * roll up at all.
      */
     val mergesDescendants: Boolean
 
@@ -63,9 +77,11 @@ object AccessibilityLabels {
     if (!element.mergesDescendants) return ""
     val parts = mutableListOf<String>()
     fun collect(node: Element, isRoot: Boolean) {
-      // A nested stop is read as its own announcement, so its subtree is not part of this one —
-      // but what follows it still is.
-      if (!isRoot && node.mergesDescendants) return
+      // A nested stop is reached on its own, so neither it nor its subtree is part of this
+      // announcement — but what follows it still is. The test is "is it a stop", not "does it
+      // merge": a scrollable list is the case where those differ, and absorbing its rows here would
+      // announce the whole list as this element's name.
+      if (!isRoot && node.isFocusStop) return
       node.ownLabel.trim().takeIf { it.isNotEmpty() }?.let { parts += it }
       for (child in node.children) collect(child, isRoot = false)
     }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelDemoRender.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelDemoRender.kt
@@ -51,6 +51,9 @@ class AccessibilityLabelDemoRender {
     val size = BitmapFactory.decodeFile(source.absolutePath)
     val nodes = reportedNodes(size.width, size.height)
     size.recycle()
+    // The announcement the walk now produces for that button, from the same tree ATF hands it —
+    // not a string typed in here, so the two frames differ by exactly the change under review.
+    val announced = AccessibilityLabels.announcement(reportedTree())
 
     AccessibilityOverlay.generate(
       sourcePng = source,
@@ -61,7 +64,7 @@ class AccessibilityLabelDemoRender {
     AccessibilityOverlay.generate(
       sourcePng = source,
       findings = emptyList(),
-      nodes = AccessibilityLabels.rollUpMergedLabels(nodes),
+      nodes = nodes.mapIndexed { i, node -> if (i == 0) node.copy(label = announced) else node },
       destPng = File(outDir, "after.png"),
     )
   }
@@ -92,6 +95,29 @@ class AccessibilityLabelDemoRender {
       ),
     )
   }
+
+  /**
+   * The same button as [reportedNodes], as the tree the ATF walk reads: a merging, clickable
+   * surface holding a decorative icon and the label. `:renderer-android`'s
+   * `WearButtonA11yHierarchyProbeTest` is where this shape is measured against a real render rather
+   * than asserted.
+   */
+  private fun reportedTree(): AccessibilityLabels.Element =
+    element(
+      merges = true,
+      children = listOf(element(), element(own = "Filled")),
+    )
+
+  private fun element(
+    own: String = "",
+    merges: Boolean = false,
+    children: List<AccessibilityLabels.Element> = emptyList(),
+  ): AccessibilityLabels.Element =
+    object : AccessibilityLabels.Element {
+      override val ownLabel = own
+      override val mergesDescendants = merges
+      override val children = children
+    }
 
   /** A stand-in for the reported render: a filled Wear button with a leading icon and a label. */
   private fun paintMockButton(): Bitmap {

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelDemoRender.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelDemoRender.kt
@@ -115,6 +115,7 @@ class AccessibilityLabelDemoRender {
   ): AccessibilityLabels.Element =
     object : AccessibilityLabels.Element {
       override val ownLabel = own
+      override val isFocusStop = merges
       override val mergesDescendants = merges
       override val children = children
     }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelsTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelsTest.kt
@@ -18,6 +18,9 @@ class AccessibilityLabelsTest {
     override val ownLabel: String = "",
     override val mergesDescendants: Boolean = false,
     override val children: List<AccessibilityLabels.Element> = emptyList(),
+    // Every merging element is a stop; the interesting case is the stop that does NOT merge, which
+    // is why this is settable on its own.
+    override val isFocusStop: Boolean = mergesDescendants,
   ) : AccessibilityLabels.Element
 
   @Test
@@ -89,6 +92,26 @@ class AccessibilityLabelsTest {
       )
 
     assertEquals("Title Subtitle", AccessibilityLabels.announcement(row))
+  }
+
+  @Test
+  fun `a nested scrollable stop is left to announce its own rows`() {
+    // A clickable card holding a carousel. The carousel is a stop a screen reader lands on, but it
+    // folds nothing — each row stays independently reachable (#1565) — so the card must stop at it
+    // rather than announcing every row as its own name.
+    val carousel =
+      Node(
+        isFocusStop = true,
+        mergesDescendants = false,
+        children = listOf(Node(ownLabel = "Row one"), Node(ownLabel = "Row two")),
+      )
+    val card =
+      Node(
+        mergesDescendants = true,
+        children = listOf(Node(ownLabel = "Recently played"), carousel),
+      )
+
+    assertEquals("Recently played", AccessibilityLabels.announcement(card))
   }
 
   @Test

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelsTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityLabelsTest.kt
@@ -1,212 +1,134 @@
 package ee.schimke.composeai.renderer
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Test
 
 /**
- * Pure-JVM coverage of [AccessibilityLabels.rollUpMergedLabels] — the pass that gives a focus stop
- * the announcement its merged descendants carry (issue #4253). ATF itself needs a real `View`
- * graph, so the shapes it produces are written out here as the flat node list the walk emits,
- * bounds and all: which nodes a stop folded in is reconstructed from emission order **and** those
- * bounds.
+ * Pure-JVM coverage of [AccessibilityLabels.announcement] — what a screen reader says for an
+ * element, given the copy it carries and the copy of the descendants it folds in (issue #4253).
+ *
+ * ATF's own `ViewHierarchyElement` needs a real `View` graph to construct, so the trees here are
+ * hand-built through [AccessibilityLabels.Element]. That the shapes are the ones ATF really
+ * produces is measured separately, against a rendered Wear button, by `:renderer-android`'s
+ * `WearButtonA11yHierarchyProbeTest`.
  */
 class AccessibilityLabelsTest {
 
-  private fun node(
-    label: String,
-    bounds: String,
-    role: String? = null,
-    states: List<String> = emptyList(),
-    merged: Boolean = true,
-  ) =
-    AccessibilityNode(
-      label = label,
-      role = role,
-      states = states,
-      merged = merged,
-      boundsInScreen = bounds,
-    )
+  private class Node(
+    override val ownLabel: String = "",
+    override val mergesDescendants: Boolean = false,
+    override val children: List<AccessibilityLabels.Element> = emptyList(),
+  ) : AccessibilityLabels.Element
 
   @Test
-  fun `blank stop takes the label of the descendants it merges`() {
-    // A Wear `Button(icon = …, label = { Text("Filled") })`: the click lands on the merging
-    // surface, the copy on an unmerged Text child. The hierarchy issue #4253 reported, verbatim.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "16,16,209,120", states = listOf("clickable")),
-          node("Filled", "104,50,181,86", role = "TextView", merged = false),
-        )
+  fun `a merging stop announces the copy of the child holding it`() {
+    // A Wear `Button(icon = …, label = { Text("Filled") })`: the click and the focus stop are on
+    // the merging surface, the word on a child. The shape issue #4253 reported.
+    val button =
+      Node(
+        mergesDescendants = true,
+        children = listOf(Node(/* the decorative icon */ ), Node(ownLabel = "Filled")),
       )
 
-    assertEquals(listOf("Filled", "Filled"), rolled.map { it.label })
-    // Only the label moves — the stop keeps its own role, states and bounds.
-    assertEquals(listOf("clickable"), rolled[0].states)
-    assertEquals(null, rolled[0].role)
-    assertEquals("16,16,209,120", rolled[0].boundsInScreen)
+    assertEquals("Filled", AccessibilityLabels.announcement(button))
   }
 
   @Test
-  fun `a stop that already announces itself is untouched`() {
-    val nodes =
-      listOf(
-        node("Add to cart", "0,0,200,80", role = "Button", states = listOf("clickable")),
-        node("Add to cart", "20,20,180,60", role = "TextView", merged = false),
+  fun `an element that carries its own copy keeps it`() {
+    val button =
+      Node(
+        ownLabel = "Add to cart",
+        mergesDescendants = true,
+        children = listOf(Node(ownLabel = "Add to cart")),
       )
 
-    assertSame(nodes, AccessibilityLabels.rollUpMergedLabels(nodes))
+    assertEquals("Add to cart", AccessibilityLabels.announcement(button))
   }
 
   @Test
   fun `descendant copy is joined in traversal order`() {
-    // A clickable row folding a title + subtitle into one announcement.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,400,100", states = listOf("clickable")),
-          node("Jetnews", "8,8,200,40", merged = false),
-          node("3 min read", "8,50,200,90", merged = false),
-        )
+    val row =
+      Node(
+        mergesDescendants = true,
+        children =
+          listOf(
+            Node(children = listOf(Node(ownLabel = "Jetnews"))),
+            Node(ownLabel = "3 min read"),
+          ),
       )
 
-    assertEquals("Jetnews 3 min read", rolled[0].label)
+    assertEquals("Jetnews 3 min read", AccessibilityLabels.announcement(row))
   }
 
   @Test
-  fun `roll-up carries on past a nested focus stop`() {
-    // A row that folds in a title, then a button of its own, then a subtitle: the button owns its
-    // announcement ("Go"), but the subtitle after it is still the row's. Stopping at the nested
-    // stop would drop the subtitle; ignoring it would swallow "Go" into the row.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,400,100", states = listOf("clickable")),
-          node("Title", "8,8,200,40", merged = false),
-          node("", "300,10,390,90", states = listOf("clickable")),
-          node("Go", "310,20,380,80", role = "TextView", merged = false),
-          node("Subtitle", "8,50,200,90", merged = false),
-        )
+  fun `a nested stop's copy stays its own, and the walk carries on past it`() {
+    // A row folding in a title, a button of its own, then a subtitle. The button announces "Go";
+    // the subtitle after it is still the row's. Ending the walk at the nested stop would drop the
+    // subtitle, descending into it would swallow "Go" into the row.
+    val nested = Node(mergesDescendants = true, children = listOf(Node(ownLabel = "Go")))
+    val row =
+      Node(
+        mergesDescendants = true,
+        children = listOf(Node(ownLabel = "Title"), nested, Node(ownLabel = "Subtitle")),
       )
 
-    assertEquals("Title Subtitle", rolled[0].label)
-    assertEquals("Go", rolled[2].label)
+    assertEquals("Title Subtitle", AccessibilityLabels.announcement(row))
+    assertEquals("Go", AccessibilityLabels.announcement(nested))
   }
 
   @Test
-  fun `roll-up stops when the walk leaves the stop's box`() {
-    // Two sibling icon buttons: the second one's copy must not leak into the first.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,48,48", states = listOf("clickable")),
-          node("Open navigation drawer", "8,8,40,40", merged = false),
-          node("", "60,0,108,48", states = listOf("clickable")),
-          node("Search", "68,8,100,40", merged = false),
-        )
+  fun `a nested stop is pruned by ancestry, not by where it is drawn`() {
+    // The same shape with the nested stop covering the whole row — the case bounds cannot answer,
+    // because the subtitle's rectangle falls inside the nested action's. Ancestry has no such
+    // ambiguity: the subtitle is not underneath it.
+    val fullBleed = Node(mergesDescendants = true, children = listOf(Node(ownLabel = "Dismiss")))
+    val row =
+      Node(
+        mergesDescendants = true,
+        children = listOf(Node(ownLabel = "Title"), fullBleed, Node(ownLabel = "Subtitle")),
       )
 
-    assertEquals(
-      listOf("Open navigation drawer", "Open navigation drawer", "Search", "Search"),
-      rolled.map { it.label },
-    )
+    assertEquals("Title Subtitle", AccessibilityLabels.announcement(row))
   }
 
   @Test
-  fun `copy outside the stop's box is not its own`() {
-    // The unmerged node after the stop sits beside it, not inside it — a sibling text run the walk
-    // reached after leaving the button, and not something the button announces.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,48,48", role = "Button", states = listOf("clickable")),
-          node("Caption", "0,60,200,90", merged = false),
-        )
-      )
+  fun `an element that merges nothing borrows nothing`() {
+    // Not a merging element: its children are their own focus stops and it announces nothing of
+    // theirs, however much copy sits underneath.
+    val column = Node(children = listOf(Node(ownLabel = "First"), Node(ownLabel = "Second")))
 
-    assertEquals(listOf("", "Caption"), rolled.map { it.label })
+    assertEquals("", AccessibilityLabels.announcement(column))
   }
 
   @Test
   fun `a stop with nothing under it stays unlabelled`() {
     // An unlabelled clickable really is unlabelled — that is a finding worth seeing.
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,48,48", role = "Button", states = listOf("clickable")),
-          node("Next", "0,60,120,90"),
-        )
-      )
+    val iconButton = Node(mergesDescendants = true, children = listOf(Node()))
 
-    assertEquals(listOf("", "Next"), rolled.map { it.label })
+    assertEquals("", AccessibilityLabels.announcement(iconButton))
   }
 
   @Test
-  fun `blank descendants contribute nothing`() {
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,200,80", states = listOf("clickable")),
-          node("   ", "8,8,60,40", merged = false),
-          node("Play", "70,8,190,40", merged = false),
-        )
+  fun `blank copy contributes nothing`() {
+    val row =
+      Node(
+        ownLabel = "   ",
+        mergesDescendants = true,
+        children = listOf(Node(ownLabel = " "), Node(ownLabel = " Play ")),
       )
 
-    assertEquals("Play", rolled[0].label)
+    assertEquals("Play", AccessibilityLabels.announcement(row))
   }
 
   @Test
-  fun `a descendant with unreadable bounds does not truncate the announcement`() {
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "0,0,400,100", states = listOf("clickable")),
-          node("Title", "not,a,box", merged = false),
-          node("Subtitle", "8,50,200,90", merged = false),
-        )
+  fun `copy nested several levels deep still rolls up`() {
+    val card =
+      Node(
+        mergesDescendants = true,
+        children =
+          listOf(Node(children = listOf(Node(children = listOf(Node(ownLabel = "Buy now")))))),
       )
 
-    assertEquals("Subtitle", rolled[0].label)
-  }
-
-  @Test
-  fun `a stop with unreadable bounds falls back to the following run`() {
-    val rolled =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "", states = listOf("clickable")),
-          node("Filled", "104,50,181,86", merged = false),
-          node("Elsewhere", "0,200,100,260"),
-        )
-      )
-
-    assertEquals(listOf("Filled", "Filled", "Elsewhere"), rolled.map { it.label })
-  }
-
-  @Test
-  fun `running twice changes nothing`() {
-    val once =
-      AccessibilityLabels.rollUpMergedLabels(
-        listOf(
-          node("", "16,16,209,120", states = listOf("clickable")),
-          node("Filled", "104,50,181,86", merged = false),
-        )
-      )
-
-    assertEquals(once, AccessibilityLabels.rollUpMergedLabels(once))
-  }
-
-  @Test
-  fun `an unmerged run before any stop is left alone`() {
-    val nodes =
-      listOf(
-        node("Heading", "0,0,200,40", merged = false),
-        node("", "0,50,48,98", role = "Button", states = listOf("clickable")),
-      )
-
-    assertEquals(
-      listOf("Heading", ""),
-      AccessibilityLabels.rollUpMergedLabels(nodes).map { it.label },
-    )
+    assertEquals("Buy now", AccessibilityLabels.announcement(card))
   }
 }

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -382,12 +382,16 @@ The first kind to ship; mirrors the renderer-side type:
 copy the node itself holds: a focus stop whose text lives on the
 descendants it merges — a Wear `Button(label = { Text("Filled") })`, an
 icon button whose `contentDescription` sits on the inner `Icon` — carries
-that rolled-up copy (issue #4253). Both producers do this: the desktop
-extractor walks the merged subtree, and the ATF side rolls it up over the
-flattened list in `AccessibilityLabels`, since a hierarchy that reports
-each element's own text leaves the stop blank and every consumer then
-prints `(unlabelled)` over a plainly labelled button. A stop that stays
-blank after the roll-up genuinely has no name — that one is a finding.
+that rolled-up copy (issue #4253). Both producers do this, and both do it
+**during extraction**, while the hierarchy still has parent/child links:
+the desktop extractor walks the merged semantics subtree, the ATF side
+walks `ViewHierarchyElement` children through `AccessibilityLabels`, and
+each prunes a nested focus stop's subtree (it announces itself) without
+stopping there. It has to happen at that point, because this payload is
+**flat** — a consumer reading it back can only guess a stop's subtree from
+emission order and bounds, which is what `cli/serve-web` still does for
+bundles baked before this landed. A stop that stays blank after the
+roll-up genuinely has no name — that one is a finding.
 
 When subscribed, the renderer runs the existing a11y pass and writes
 JSON to `build/compose-previews/data/<id>/a11y-hierarchy.json`. When

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearButtonA11yHierarchyProbeTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearButtonA11yHierarchyProbeTest.kt
@@ -1,0 +1,66 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * What does ATF see for a Wear `Button(icon = …, label = { Text(…) })` — issue #4253.
+ *
+ * The reported hierarchy had the click on one element and the word on another, and nothing carrying
+ * both, so the inspection layer announced the button as `(unlabelled)`. Every rule that fixes that
+ * rests on a claim about the shape ATF actually produces here, and the `:data-a11y-core` unit tests
+ * assert against hand-written node lists — which prove the projection, not the shape.
+ *
+ * This is the shape, measured: run the real ATF walk over a real Wear button and report what comes
+ * out. It asserts the two properties the roll-up depends on — that the stop the user reaches
+ * carries the click, and that the word is on a node underneath it — plus the announcement the walk
+ * now produces end to end.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WearButtonA11yHierarchyProbeTest {
+
+  @get:Rule val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun `the stop carries the click and the label its child holds`() {
+    composeRule.setContent {
+      MaterialTheme {
+        Button(
+          onClick = {},
+          // The kit's `Icon=Yes` cell draws a decorative icon (`contentDescription = null`), so
+          // the icon slot contributes nothing to the announcement — an unlabelled box stands in.
+          icon = { Box(Modifier.size(24.dp)) },
+          label = { Text("Filled") },
+        )
+      }
+    }
+    composeRule.waitForIdle()
+
+    val nodes =
+      AccessibilityChecker.analyze("wear-button", composeRule.activity.window.decorView).nodes
+    println("[a11y-probe] " + nodes.joinToString("\n              "))
+
+    val stops = nodes.filter { it.merged }
+    val clickable = stops.filter { it.states.contains("clickable") }
+    assertEquals("expected exactly one clickable focus stop: $nodes", 1, clickable.size)
+    // The point of the fix: the stop a screen reader lands on announces the button's word, whether
+    // ATF put that word on the stop itself or on a child it merges.
+    assertEquals("Filled", clickable.single().label)
+  }
+}


### PR DESCRIPTION
Follow-up to #4255 (issue #4253), picking up the review point that landed after it merged: [the roll-up should track ancestry, not nested bounds](https://github.com/yschimke/compose-ai-tools/pull/4255#discussion_r3813784866).

## What was still wrong

#4255 reconstructed a focus stop's subtree from the flat node list — emission order for what follows the stop, bounds containment for where that subtree ends and which nodes inside it belong to a nested stop. Containment cannot answer ancestry: a nested stop drawn over the whole of its parent also contains the parent's **own** later copy, so it gets skipped and the row announces half of itself again. Identical rectangles are the same problem in a smaller form.

Nothing forced that question to be answered after the structure was gone. The ATF walk holds real parent/child links (`getChildViewCount` / `getChildView`); only the wire is flat.

## What changed

- **`AccessibilityLabels`** is now the walk it should have been: `announcement(element)` returns the element's own copy, or — for a merging element carrying none — the copy of the descendants it folds in, pruning a nested stop's subtree because that stop is reached on its own, and **carrying on with what follows it**. Same walk `DesktopAccessibilityNodeExtractor.effectiveLabel` does on the CMP side. Geometry no longer enters into it.
- **"Is it a stop" and "does it merge" are asked separately**, because they part company at a scrollable: a list is reached in its own right but folds nothing, since each row stays independently reachable (#1565). The walk descends only into what no screen reader reaches separately (`isFocusStop`) and rolls up only for an element that folds its descendants at all (`mergesDescendants`) — so a clickable card containing a carousel announces its own heading, not every row in it.
- It reads the hierarchy through a small `Element` interface, so the rule is exercised against hand-built trees. ATF's `ViewHierarchyElement` needs a real `View` graph to construct, which is why the previous tests could only assert the projection's arithmetic, never its reading of the tree.
- **`AccessibilityChecker.extractNodes`** adapts each element to it, lazily — an element that carries its own copy costs no traversal. The keep filter stays on the element's **own** copy: the roll-up decides what a kept node says, never which nodes are kept, so it cannot quietly grow the legend with containers that used to fall out of it.
- **`cli/serve-web`** keeps the flat approximation for bundles baked before this, now stated as what it is rather than as a mirror of the producer: the payload has no ancestry to consult, so the overlapping-rectangle case cannot be fixed there, and re-rendering the bundle is the real answer.

## Measured, not assumed

Every rule here rests on a claim about what ATF actually emits for the reported button, and the unit tests assert against trees I wrote. So the new `WearButtonA11yHierarchyProbeTest` (`:renderer-android`) renders a real Wear `Button(icon = …, label = { Text("Filled") })`, runs the real ATF walk over it, and asserts the property the roll-up depends on. It reproduces the issue's hierarchy node for node:

```
AccessibilityNode(label=Filled, role=null, states=[clickable], merged=true,  boundsInScreen=0,0,98,52)
AccessibilityNode(label=Filled, role=TextView, states=[], merged=false, boundsInScreen=44,17,84,35)
```

The same probe is what settled the design: instrumented to dump ATF's own flags, the button element reports `srf=true merges=true children=2`, and an ancestry roll-up over it yields `Filled` — so the structure needed to be exact was there at extraction all along. It also guards the prune predicate: widening it to every focus stop would have swallowed the fix if the label child were itself focusable, and the probe says it isn't.

## Visual evidence

Unchanged from #4255, and that is the claim being made: the legend output is identical, only the mechanism behind it moved. Regenerating both frames on this branch is byte-for-byte identical to the committed PNGs (`e1e9e2ca…` / `05d0d3d1…`), and the "after" frame's label now comes from `AccessibilityLabels.announcement` over the reported tree rather than a string typed into the generator.

![Accessibility overlay before the fix: the legend's first row reads (unlabelled)](https://raw.githubusercontent.com/yschimke/compose-ai-tools/d87f2d17169b75509d4fdb686b2616fa8802c36a/docs/evidence/a11y-merged-label/before.png)

![Accessibility overlay after the fix: the legend's first row reads Filled](https://raw.githubusercontent.com/yschimke/compose-ai-tools/d87f2d17169b75509d4fdb686b2616fa8802c36a/docs/evidence/a11y-merged-label/after.png)

## Test plan

- [x] `./gradlew :data-a11y-core:testDebugUnitTest` — green; 10 `AccessibilityLabelsTest` cases over hand-built trees, including a nested stop pruned by ancestry **while drawn over the whole parent** (the case bounds cannot answer), a nested **scrollable** stop left to announce its own rows, the walk carrying on past a nested stop, several-levels-deep copy, and a stop with nothing under it staying blank.
- [x] `./gradlew :renderer-android:testDebugUnitTest --tests '*WearButtonA11yHierarchyProbeTest*'` — green, output above, re-run after the prune predicate widened.
- [x] `npm --prefix cli/serve-web test` — 845 passing; `run typecheck` clean; committed bundle unchanged (comment-only edit).
- [x] `:data-a11y-core` + `:renderer-android` ktfmt, prettier on the touched TS.
- [x] Evidence PNGs regenerated: byte-identical to the committed ones.
