### PR TITLE
feat(design-map): read a breakpoint fan-out as a size axis, not an ambiguous mode

### DIFF
--- a/design-map/README.md
+++ b/design-map/README.md
@@ -137,6 +137,29 @@ Several modes with **no light among them** is the one case that stays unmapped. 
 guessing which of `Dark` and `Coral` the kit drew, so those components are reported
 (`diagnostics.ambiguousMode`, and a `--strict` failure) rather than paired at random.
 
+**A breakpoint fan-out is a size axis, not a mode.** A multipreview that draws one composable at
+several screen sizes — the Wear round breakpoints are the live case — publishes several captures of
+it, told apart by the *same* id segment a themed pair uses. Read as modes they are unresolvable
+(`Light` is nowhere among `wearos_small_round` / `wearos_large_round`), so a full-screen component
+used to drop out of the map entirely the moment it gained a second size.
+
+They are told apart by a fact the id does not carry: each capture names a `device`, and the devices
+have **different widths**. A palette does not change the frame's width, so captures whose modes map
+one-to-one onto distinct device widths are a size axis and one of them can be picked on the merits:
+
+- the **narrowest** is the base by default, because that is the size a kit draws — a kit publishes
+  its screen artwork at one size and leaves adaptation to the implementation, and the narrowest is
+  the one every larger screen is an adaptation *of*;
+- `--base-breakpoint <dp>` moves it, for a kit that draws somewhere else. A named base a given
+  composable does not render falls back to the narrowest rather than dropping it — rendering a
+  subset of the catalog's breakpoints is a legitimate thing for one screen to do;
+- the sizes the base did not take **fold under it as cells**, seeded `breakpoint=<dp>` and named
+  `<dp>dp`, so they are published rather than discarded.
+
+Two captures of the *same* width are still a mode, whatever devices they name: nothing orders them,
+so they stay `ambiguousMode`. An `@OverrideVariant` cell rides the base breakpoint only — the
+product of both axes would multiply the sheet by every size, and the base carries the matrix.
+
 **`overrides.props` beats `overrides.seeds` where both exist.** They are not the same list. `seeds`
 holds only the values that differ from the composable's defaults; `props` — emitted for a
 `@PreviewAxis` cross product — carries the full axis assignment, defaults included. A cell that

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -113,9 +113,51 @@ export function captureIdentity(preview) {
  * guessing which of `Dark` and `Coral` the kit drew, and pairing the wrong one diffs a whole
  * palette — so it is reported instead (`diagnostics.ambiguousMode`).
  */
-function preferredMode(modes) {
+function preferredMode(modes, widthByMode, baseBreakpointDp) {
   if (modes.has(LIGHT_MODE)) return LIGHT_MODE;
-  return modes.size === 1 ? [...modes][0] : null;
+  if (modes.size === 1) return [...modes][0];
+
+  // A BREAKPOINT FAN-OUT is not an ambiguous mode, and telling them apart is what this arm is for.
+  //
+  // A multipreview that renders one function at several screen sizes produces several captures of
+  // one composable, exactly like a themed pair does — and the id segment they are told apart by is
+  // the same segment. Read as modes they are unresolvable (`Light` is nowhere among
+  // `wearos_small_round` / `wearos_large_round`), so every full-screen component of a Wear catalog
+  // dropped out of the map the moment it gained a second size, and `--strict` failed on it.
+  //
+  // They are distinguishable by a fact the id does not carry: each capture names a `device`, and
+  // the devices have DIFFERENT WIDTHS. A palette does not change the frame's width, so a set of
+  // captures whose modes map one-to-one onto distinct device widths is a size axis rather than a
+  // colour one, and one of them can be picked on the merits.
+  const sized = [...modes].map((mode) => [mode, widthByMode.get(mode)]);
+  const widths = sized.map(([, width]) => width);
+  if (!widths.every((width) => Number.isFinite(width))) return null;
+  if (new Set(widths).size !== widths.length) return null;
+
+  // NARROWEST by default, because that is the size a kit draws: a design kit publishes its screen
+  // artwork at one size and leaves adaptation to the implementation, and the narrowest is the one
+  // every larger screen is an adaptation OF. `baseBreakpointDp` overrides it for a kit that draws
+  // somewhere else. A named base this composable does not render falls back to the narrowest
+  // rather than dropping the component: rendering a subset of the catalog's breakpoints is a
+  // legitimate thing for one screen to do, and it is not a reason to publish no map row for it.
+  sized.sort((a, b) => a[1] - b[1]);
+  const named = Number.isFinite(baseBreakpointDp)
+    ? sized.find(([, width]) => width === baseBreakpointDp)
+    : null;
+  return (named ?? sized[0])[0];
+}
+
+/**
+ * The device width a capture was drawn at, or `null` when it names no device.
+ *
+ * Read from `params.device` rather than `params.widthDp` alone: a device-less preview carries no
+ * width at all, and a `wrapSandbox` bound is not a screen size. Only a capture that names a device
+ * is claiming to be a picture of a screen.
+ */
+function deviceWidthDp(preview) {
+  const params = preview?.params;
+  if (!params?.device) return null;
+  return Number.isFinite(params.widthDp) ? params.widthDp : null;
 }
 
 /**
@@ -124,9 +166,10 @@ function preferredMode(modes) {
  *
  * @returns {{participates: (preview: object) => boolean, ambiguous: Array<object>}}
  */
-export function selectCaptures(previews) {
+export function selectCaptures(previews, { baseBreakpointDp } = {}) {
   const modesBySubject = new Map();
   const componentsBySubject = new Map();
+  const widthsBySubject = new Map();
   for (const preview of previews) {
     if (!preview?.catalog) continue;
     const { subject, mode } = captureIdentity(preview);
@@ -136,12 +179,18 @@ export function selectCaptures(previews) {
     const ids = componentsBySubject.get(subject) ?? new Set();
     if (preview.catalog.componentId) ids.add(preview.catalog.componentId);
     componentsBySubject.set(subject, ids);
+    const widths = widthsBySubject.get(subject) ?? new Map();
+    // A VARIANT capture rides the same device as its base, so it agrees rather than conflicts —
+    // but read the base's width first, since that is the one the fan-out is defined by.
+    if (!widths.has(mode)) widths.set(mode, deviceWidthDp(preview));
+    widthsBySubject.set(subject, widths);
   }
 
   const chosen = new Map();
   const ambiguous = [];
   for (const [subject, modes] of modesBySubject) {
-    const mode = preferredMode(modes);
+    const widths = widthsBySubject.get(subject) ?? new Map();
+    const mode = preferredMode(modes, widths, baseBreakpointDp);
     if (mode === null) {
       ambiguous.push({
         subject,
@@ -159,6 +208,22 @@ export function selectCaptures(previews) {
     participates(preview) {
       const { subject, mode } = captureIdentity(preview);
       return chosen.has(subject) && chosen.get(subject) === mode;
+    },
+    /**
+     * The device width of a capture that is a NON-BASE breakpoint of a fan-out, or `null`.
+     *
+     * This is what turns the sizes the base did not take into cells rather than into silence. A
+     * capture qualifies only when its subject resolved to some other mode and both that mode and
+     * this one name a device width — so a `Dark` capture standing beside a chosen `Light` one,
+     * which is a mode and not a size, is never mistaken for a breakpoint.
+     */
+    breakpointOf(preview) {
+      const { subject, mode } = captureIdentity(preview);
+      if (!chosen.has(subject) || chosen.get(subject) === mode) return null;
+      const widths = widthsBySubject.get(subject);
+      const base = widths?.get(chosen.get(subject));
+      const here = widths?.get(mode);
+      return Number.isFinite(base) && Number.isFinite(here) ? here : null;
     },
   };
 }
@@ -375,7 +440,25 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
     // mode its component's base reference pairs with.
     const isOverrideVariant = catalog.role === "COMPONENT" && isVariantCapture(preview);
     const isCatalogVariant = catalog.role === "VARIANT";
-    if (!isOverrideVariant && !isCatalogVariant) continue;
+
+    // A BREAKPOINT capture is the third form, and it is not an annotation at all — it is the same
+    // composable drawn on a wider screen by a multipreview. It folds under its component like any
+    // other cell, seeded with the width it was drawn at, so the sizes the base did not take are
+    // published rather than discarded.
+    //
+    // Taken BEFORE the `participates` gate, because a non-base breakpoint is by definition the
+    // capture that did not participate. An `@OverrideVariant` cell of a non-base breakpoint is
+    // skipped, though — that is the product of two axes and would multiply the sheet by every
+    // size; the base breakpoint carries the component's matrix.
+    if (!isOverrideVariant && !isCatalogVariant) {
+      const widthDp = catalog.role === "COMPONENT" ? selection.breakpointOf(preview) : null;
+      if (widthDp === null) continue;
+      const seeds = [{ key: "breakpoint", raw: String(widthDp) }];
+      const list = byComponent.get(catalog.componentId) ?? [];
+      list.push({ previewId: preview.id, name: `${widthDp}dp`, seeds });
+      byComponent.set(catalog.componentId, list);
+      continue;
+    }
     if (!selection.participates(preview)) continue;
 
     // A variant that names no axis says only "this is different", which is not enough to look
@@ -401,7 +484,7 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
  *   fact to report, not a failure.
  */
 export function projectDesignMap(previews, opts = {}) {
-  const selection = selectCaptures(previews);
+  const selection = selectCaptures(previews, { baseBreakpointDp: opts.baseBreakpointDp });
   const variantRenders = variantRendersByComponent(previews, selection);
 
   const components = [];

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -619,3 +619,105 @@ test("a cell overriding the fold's own knob keeps the fold's kit axis, not its v
     { key: "state", raw: "error", kitAxis: "Interaction state" },
   ]);
 });
+
+// BREAKPOINTS. A Wear multipreview draws one composable at several screen sizes, which produces
+// several captures of it told apart by the same id segment a themed pair uses. Read as colour
+// modes they are unresolvable and the component drops out of the map entirely — which is what
+// happened to every full-screen component of a Wear catalog the moment it gained a second size.
+const atWidth = (name, widthDp, catalog = {}) => ({
+  id: `com.example.CatalogKt.${name}_wearos_${widthDp}`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  params: { device: `id:wearos_${widthDp}`, widthDp },
+  catalog: { role: "COMPONENT", componentId: name, ...catalog },
+});
+
+test("a breakpoint fan-out maps from its narrowest capture, not as an ambiguous mode", () => {
+  const { map, diagnostics } = projectDesignMap([
+    atWidth("Picker", 227, { reference: ref("1:2") }),
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 240, { reference: ref("1:2") }),
+  ]);
+  assert.deepEqual(diagnostics.ambiguousMode, []);
+  assert.equal(map.components.length, 1);
+  assert.match(map.components[0].previewId, /_wearos_192$/);
+});
+
+test("--base-breakpoint names the width the kit draws, when it is not the narrowest", () => {
+  const previews = [
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, { reference: ref("1:2") }),
+  ];
+  const { map } = projectDesignMap(previews, { baseBreakpointDp: 225 });
+  assert.match(map.components[0].previewId, /_wearos_225$/);
+});
+
+test("a named base this composable does not render falls back rather than dropping it", () => {
+  const { map, diagnostics } = projectDesignMap(
+    [
+      atWidth("Picker", 192, { reference: ref("1:2") }),
+      atWidth("Picker", 240, { reference: ref("1:2") }),
+    ],
+    { baseBreakpointDp: 225 },
+  );
+  assert.deepEqual(diagnostics.ambiguousMode, []);
+  assert.match(map.components[0].previewId, /_wearos_192$/);
+});
+
+test("the sizes the base did not take fold under it as cells, seeded with their width", () => {
+  const { variants } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, { reference: ref("1:2") }),
+    atWidth("Picker", 240, { reference: ref("1:2") }),
+  ]);
+  const renders = variants.components[0].renders;
+  assert.deepEqual(
+    renders.map((r) => r.name).sort(),
+    ["225dp", "240dp"],
+  );
+  assert.deepEqual(renders.find((r) => r.name === "225dp").seeds, [
+    { key: "breakpoint", raw: "225" },
+  ]);
+});
+
+test("a themed pair is still a mode, never a breakpoint — neither capture names a device", () => {
+  const { diagnostics } = projectDesignMap([
+    { ...component("Themed", { reference: ref("1:2") }), id: "com.example.CatalogKt.Themed_Dark" },
+    { ...component("Themed", { reference: ref("1:2") }), id: "com.example.CatalogKt.Themed_Coral" },
+  ]);
+  assert.equal(diagnostics.ambiguousMode.length, 1);
+  assert.deepEqual(diagnostics.ambiguousMode[0].modes, ["Coral", "Dark"]);
+});
+
+test("same-width captures are a mode, not a size — two devices of one width cannot be ordered", () => {
+  const square = {
+    id: "com.example.CatalogKt.Screen_wearos_square",
+    functionName: "Screen",
+    sourceFile: "Catalog.kt",
+    params: { device: "id:wearos_square", widthDp: 192 },
+    catalog: { role: "COMPONENT", componentId: "Screen", reference: ref("1:2") },
+  };
+  const { diagnostics } = projectDesignMap([atWidth("Screen", 192, { reference: ref("1:2") }), square]);
+  assert.equal(diagnostics.ambiguousMode.length, 1);
+});
+
+test("an override cell rides the base breakpoint, and is not repeated at every size", () => {
+  const cell = (widthDp) => ({
+    id: `com.example.CatalogKt.Picker_wearos_${widthDp}_VARIANT_month`,
+    functionName: "Picker",
+    sourceFile: "Catalog.kt",
+    params: { device: `id:wearos_${widthDp}`, widthDp },
+    catalog: { role: "COMPONENT", componentId: "Picker" },
+    overrides: { name: "month", seeds: [{ key: "order", raw: "month" }] },
+  });
+  const { variants } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 240, { reference: ref("1:2") }),
+    cell(192),
+    cell(240),
+  ]);
+  assert.deepEqual(
+    variants.components[0].renders.map((r) => r.name).sort(),
+    ["240dp", "month"],
+  );
+});

--- a/design-map/emit-design-map.mjs
+++ b/design-map/emit-design-map.mjs
@@ -5,6 +5,7 @@
  *     npx @yschimke/compose-design-map [--previews <path>] [--out design-map.json]
  *                                      [--variants design-map-variants.json] [--prefix catalog]
  *                                      [--check] [--strict] [--allow-stated-absence]
+ *                                      [--base-breakpoint <dp>]
  *
  * Run `./gradlew :<module>:composePreviewDiscover` first so the manifest exists.
  *
@@ -60,6 +61,15 @@ const PREFIX = arg("prefix", "catalog");
 const CHECK = process.argv.includes("--check");
 const STRICT = process.argv.includes("--strict");
 const ALLOW_STATED_ABSENCE = process.argv.includes("--allow-stated-absence");
+/**
+ * The screen width, in dp, whose capture is the BASE of a breakpoint fan-out.
+ *
+ * A multipreview that draws one composable at several screen sizes publishes several captures of
+ * it, and exactly one can carry the component's design reference — the rest fold under it as size
+ * cells. Absent this flag the narrowest wins, which is the size a kit usually draws. Pass it when
+ * the kit draws somewhere else, so the base capture and the base reference are the same width.
+ */
+const BASE_BREAKPOINT = Number(arg("base-breakpoint", ""));
 
 if (!fs.existsSync(PREVIEWS)) {
   console.error(
@@ -72,6 +82,9 @@ if (!fs.existsSync(PREVIEWS)) {
 const manifest = JSON.parse(fs.readFileSync(PREVIEWS, "utf8"));
 const { map, variants, diagnostics } = projectDesignMap(manifest.previews ?? [], {
   prefix: PREFIX,
+  ...(Number.isFinite(BASE_BREAKPOINT) && BASE_BREAKPOINT > 0
+    ? { baseBreakpointDp: BASE_BREAKPOINT }
+    : {}),
 });
 
 // Gate BEFORE writing, not after. A run that fails should leave the committed map intact rather

--- a/design-map/emit-design-map.test.mjs
+++ b/design-map/emit-design-map.test.mjs
@@ -4,6 +4,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -40,7 +41,16 @@ function run(previews, ...flags) {
       ],
       { encoding: "utf8" },
     );
-    return { ...result, all: `${result.stdout}${result.stderr}` };
+    const read = (name) => {
+      const at = path.join(dir, name);
+      return fs.existsSync(at) ? JSON.parse(fs.readFileSync(at, "utf8")) : null;
+    };
+    return {
+      ...result,
+      all: `${result.stdout}${result.stderr}`,
+      map: read("design-map.json"),
+      variants: read("design-map-variants.json"),
+    };
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -144,4 +154,48 @@ test("an ambiguous mode is still fatal when the component HAS a reference to pai
   );
   assert.equal(status, 1);
   assert.match(all, /none of them Light/);
+});
+
+// The breakpoint arm through the CLI, because `--base-breakpoint` is what a catalog's wrapper
+// script passes and `--strict` is what decides whether its build goes red.
+const atWidth = (name, widthDp, catalog = {}) => ({
+  id: `com.example.CatalogKt.${name}_wearos_${widthDp}`,
+  functionName: name,
+  sourceFile: "Catalog.kt",
+  params: { device: `id:wearos_${widthDp}`, widthDp },
+  catalog: { role: "COMPONENT", componentId: name, ...catalog },
+});
+
+test("--strict passes a breakpoint fan-out, which is a size axis rather than a missing mode", () => {
+  const { status, all } = run(
+    [atWidth("Picker", 192, { reference: `figma:${FILE}/1:1` }), atWidth("Picker", 240, { reference: `figma:${FILE}/1:1` })],
+    "--strict",
+  );
+  assert.equal(status, 0, all);
+  assert.match(all, /1 mapped component\(s\)/);
+  assert.doesNotMatch(all, /none of them Light/);
+});
+
+test("--base-breakpoint picks the capture the kit's own artwork is drawn at", () => {
+  const previews = [
+    atWidth("Picker", 192, { reference: `figma:${FILE}/1:1` }),
+    atWidth("Picker", 225, { reference: `figma:${FILE}/1:1` }),
+  ];
+  const narrowest = run(previews, "--strict");
+  assert.equal(narrowest.status, 0, narrowest.all);
+  assert.match(narrowest.map.components[0].previewId, /_wearos_192$/);
+  assert.deepEqual(
+    narrowest.variants.components[0].renders.map((r) => r.name),
+    ["225dp"],
+  );
+
+  // The flag has to MOVE the base, not merely be accepted — an ignored flag would pass an
+  // exit-code assertion unchanged.
+  const named = run(previews, "--strict", "--base-breakpoint", "225");
+  assert.equal(named.status, 0, named.all);
+  assert.match(named.map.components[0].previewId, /_wearos_225$/);
+  assert.deepEqual(
+    named.variants.components[0].renders.map((r) => r.name),
+    ["192dp"],
+  );
 });


### PR DESCRIPTION
Breakpoints were unpublishable: adding a second screen size cost a component its map row.

## The bug

A multipreview that draws one composable at several screen sizes publishes several captures of it, and discovery tells them apart with **the same id segment a themed pair uses**:

```
…DialogsKt.AlertDialogSticker_wearos_small_round
…DialogsKt.AlertDialogSticker_wearos_large_round
```

`preferredMode` read that segment as a colour mode. `Light` is nowhere among `wearos_small_round` / `wearos_large_round`, and there is more than one, so it returned `null` — the component landed in `diagnostics.ambiguousMode`, dropped out of `design-map.json` entirely, and failed `--strict` with "several modes, none of them Light".

So a Wear catalog could publish its full-screen components at one size or lose them from the map. That is what blocked yschimke/wear-m3-catalog from covering the screen sizes its kit declares.

## The separation

The two are distinguishable by a fact the id does not carry: each capture names a `device`, and the devices have **different widths**. A palette does not change the frame's width, so a set of captures whose modes map one-to-one onto distinct device widths is a size axis rather than a colour one — and one of them can be picked on the merits instead of guessed at.

- **The narrowest is the base by default**, because that is the size a kit draws: a kit publishes its screen artwork at one size and leaves adaptation to the implementation, and the narrowest is the one every larger screen is an adaptation *of*.
- **`--base-breakpoint <dp>`** moves it, for a kit that draws somewhere else.
- A named base a given composable does not render **falls back to the narrowest** rather than dropping it — rendering a subset of the catalog's breakpoints is a legitimate thing for one screen to do, not a reason to publish no map row for it.
- The sizes the base did not take **fold under it as cells**, seeded `breakpoint=<dp>` and named `<dp>dp`, so they are published rather than discarded.

## What deliberately stays as it was

- **A themed pair.** Neither of its captures names a device, so it never reaches the new arm and `Dark`/`Coral` is still reported rather than guessed.
- **Two captures of the same width**, whatever devices they name — nothing orders them, so they stay `ambiguousMode`.
- **`@OverrideVariant` cells ride the base breakpoint only.** The product of both axes would multiply the sheet by every size; the base carries the component's matrix.

## Test plan

`npm test` in `design-map/` — **56 pass, 0 fail** (46 projector + 10 CLI), up from 47.

Nine new tests, and I checked they actually bite rather than merely pass:

| mutation | result |
| --- | --- |
| drop `baseBreakpointDp` from the `selectCaptures` call (flag silently ignored) | CLI suite **1 fail** |
| remove the distinct-width guard (same-width captures treated as a size axis) | projector suite **1 fail** |

The CLI test reads the written `design-map.json` and `design-map-variants.json` back rather than asserting on the exit code, because an ignored flag would pass an exit-code assertion unchanged: it asserts the base moves `192 → 225` **and** that the leftover cell moves the other way, `225dp → 192dp`.

## Downstream

`wear-m3-catalog` needs this released before it can add its breakpoints; nothing there changes until then. Its kit (`.WatchPuck`) declares five sizes — 192 (legacy), 204, 216, **225 (the breakpoint)**, 240 — while drawing its screen artwork at 192, so it will take the default narrowest base. Worth noting for that work: **custom `spec:` devices do render** — I verified `spec:width=225dp,height=225dp,dpi=320,isRound=true` produces a 450×450 PNG through this repo's own render pipeline — so the comment in `samples/design-catalog-wear-m3/CatalogTheme.kt` claiming "the render pipeline only exercises named-id devices, not custom `spec:` strings" is out of date. Not touched here; flagging it rather than fixing it in an unrelated diff.

Projection-only change — no renders move, so there is no visual before/after to show.

---
_Generated by [Claude Code](https://claude.ai/code/session_019FnnYDMBa6NXnEwNguEB2p)_