### PR TITLE
fix(serve): resolve snapshot coordinates and record a bundle's repositories

### DIFF
--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/BundleLoader.kt
@@ -145,8 +145,16 @@ fun loadBundle(bundleFile: Path): LoadedBundle {
   // Default (coordinate-mode) bundles reference their deps by `maven` coordinate rather than
   // carrying them; resolve those from the machine's local Maven / Gradle caches (warn-not-fail) so
   // the preview's own third-party deps are available the same way embedded `libs/` jars are.
+  // (v9) A bundle names any repository beyond Central + Google that its coordinates need — the
+  // producing build's JitPack fork, internal mirror, or androidx.dev snapshot build. Without it
+  // those coordinates resolve nowhere and the preview loads on an incomplete classpath.
   val resolvedCoordJars =
-    CoordinateResolver.resolve(bundleManifest.classpath.filterIsInstance<ClasspathEntry.Maven>())
+    CoordinateResolver.resolve(
+      bundleManifest.classpath.filterIsInstance<ClasspathEntry.Maven>(),
+      remoteRepositories =
+        CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES +
+          bundleManifest.repositories.filter { it.isNotBlank() },
+    )
 
   val parentLoader = LoadedBundle::class.java.classLoader
   // app.jar first, then embedded lib jars (path-sorted), then resolved coordinate jars. The

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/CoordinateResolver.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.copyTo
 import java.util.UUID
@@ -189,16 +190,90 @@ internal object CoordinateResolver {
     downloadCacheDir: Path,
     fileSystem: FileSystem,
   ): Path? {
+    val versionDir = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}"
     for (fileName in candidateFileNames(coord)) {
-      val rel = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName"
-      val dest = downloadCacheDir / rel
+      // The cache always keys on the LITERAL `<artifact>-<version>.<ext>` name, even when the
+      // remote served a timestamped snapshot file, so [locate] finds the download next time.
+      val dest = downloadCacheDir / "$versionDir/$fileName"
       for (base in remoteRepositories) {
-        if (fetchTo(base.trimEnd('/') + "/" + rel, dest, fileSystem))
+        val remoteName = remoteFileName(base, coord, versionDir, fileName)
+        if (fetchTo(base.trimEnd('/') + "/" + versionDir + "/" + remoteName, dest, fileSystem))
           return materialize(dest, downloadCacheDir, fileSystem)
       }
     }
     return null
   }
+
+  /**
+   * The file name [base] actually serves for [coord] — [fileName] itself for a release, and for a
+   * **unique snapshot** the timestamped name its `maven-metadata.xml` names.
+   *
+   * A Maven snapshot repository does not serve `<artifact>-1.0.0-SNAPSHOT.aar`: it stores each
+   * publication as `<artifact>-1.0.0-<yyyyMMdd.HHmmss>-<n>.<ext>` and points at the current one
+   * from the version directory's `maven-metadata.xml`. Constructing the literal name 404s against
+   * every real snapshot repo, so a bundle carrying a `-SNAPSHOT` coordinate could not be rehydrated
+   * from the network at all (issues #4259 / #4265). Mirrors `:cli`'s `CoordinateResolver` — keep
+   * the two in sync.
+   *
+   * Falls back to [fileName] on anything unexpected (no metadata, unparseable metadata, transport
+   * error, or a repo publishing non-unique snapshots under the literal name), which is the old
+   * behaviour exactly.
+   */
+  private fun remoteFileName(
+    base: String,
+    coord: ClasspathEntry.Maven,
+    versionDir: String,
+    fileName: String,
+  ): String {
+    if (!isSnapshot(coord.version)) return fileName
+    val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
+    val metadata = fetchText(base.trimEnd('/') + "/" + versionDir + "/maven-metadata.xml")
+    val timestamped = metadata?.let { snapshotVersion(it, extension) } ?: return fileName
+    return "${coord.artifact}-$timestamped.$extension"
+  }
+
+  /** GET [url] as text, or null on a non-2xx / transport error. */
+  private fun fetchText(url: String): String? =
+    try {
+      HttpClient(OkHttp).use { client ->
+        runBlocking {
+          client.prepareGet(url).execute { response ->
+            if (response.status.isSuccess()) response.bodyAsText() else null
+          }
+        }
+      }
+    } catch (_: Exception) {
+      null
+    }
+
+  /** A Maven snapshot version — the only kind whose artifact file name isn't the version. */
+  internal fun isSnapshot(version: String): Boolean = version.endsWith("-SNAPSHOT")
+
+  /**
+   * The unique-snapshot version (`1.0.0-20260818.194125-1`) a version-level `maven-metadata.xml`
+   * publishes for [extension], or null when the document names none. Scanned rather than parsed to
+   * keep the viewer's module graph free of an XML parser: `<snapshotVersion>` blocks carrying a
+   * `<classifier>` are skipped (the `sources` / `javadoc` siblings publish the same extension), and
+   * the first remaining block whose `<extension>` matches wins — a version-level metadata document
+   * carries one classifier-free entry per extension, the current publication.
+   */
+  internal fun snapshotVersion(metadataXml: String, extension: String): String? =
+    SNAPSHOT_VERSION_BLOCK.findAll(metadataXml)
+      .map { it.groupValues[1] }
+      .filterNot { "<classifier>" in it }
+      .firstOrNull { tagValue(it, "extension").equals(extension, ignoreCase = true) }
+      ?.let { tagValue(it, "value") }
+      ?.takeIf { it.isNotBlank() }
+
+  private val SNAPSHOT_VERSION_BLOCK =
+    Regex("""<snapshotVersion>(.*?)</snapshotVersion>""", RegexOption.DOT_MATCHES_ALL)
+
+  private fun tagValue(block: String, tag: String): String? =
+    Regex("""<$tag>(.*?)</$tag>""", RegexOption.DOT_MATCHES_ALL)
+      .find(block)
+      ?.groupValues
+      ?.get(1)
+      ?.trim()
 
   /**
    * GET [url] into [dest] (parent dirs created); true only on a 2xx with a non-empty body. The

--- a/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
+++ b/bundle-viewer/src/main/kotlin/ee/schimke/composeai/viewer/Schema.kt
@@ -38,6 +38,13 @@ data class BundleManifest(
    * bundle was packed with `--include-data-extensions`.
    */
   val dataExtensions: List<BundleDataExtension> = emptyList(),
+  /**
+   * v9+: extra Maven repository base URLs (beyond Maven Central / Google Maven) needed to
+   * re-resolve this bundle's [ClasspathEntry.Maven] coordinates — a JitPack fork, an internal
+   * mirror, an androidx.dev snapshot build. Empty on a pre-v9 bundle and on any module whose deps
+   * all live on the two defaults.
+   */
+  val repositories: List<String> = emptyList(),
 )
 
 /** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1976,6 +1976,13 @@ internal object BundleReader {
     val externalResources: List<ExternalResource> = emptyList(),
     /** Whole classpath entries supplied by the sibling content-addressed pool. */
     val externalClasspath: List<ExternalClasspath> = emptyList(),
+    /**
+     * v9+: extra Maven repository base URLs (beyond Maven Central / Google Maven) needed to
+     * re-resolve this bundle's [ClasspathEntry.Maven] coordinates — a JitPack fork, an internal
+     * mirror, an androidx.dev snapshot build. Empty on a pre-v9 bundle and on any module whose deps
+     * all live on the two defaults. See `BundleManifest.repositories` in `PreviewBundleFormat.kt`.
+     */
+    val repositories: List<String> = emptyList(),
   )
 
   /** v8 mirror of `BundleExternalResource` in `PreviewBundleFormat.kt`. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -414,6 +414,11 @@ private fun perPreviewManifest(
       "coverPreviewId" -> put(key, JsonPrimitive(id))
       // View-only carries no re-render classpath, so record that honestly.
       "classpath" -> put(key, if (fullMode) value else JsonArray(emptyList()))
+      // (v9) The repositories exist to re-resolve `classpath` coordinates. A FULL split keeps them
+      // — that is the live lane a per-preview bundle serves, and dropping them is what leaves the
+      // daemon on an incomplete classpath. A view-only bundle has no coordinates to resolve, so
+      // carrying URLs would advertise a lane it doesn't have.
+      "repositories" -> if (fullMode) put(key, value)
       "resolution" -> put(key, if (fullMode) value else JsonPrimitive("view-only"))
       // The Android app-resource carriage rides the FULL re-render set (the `android/` entries
       // copied above); a VIEW_ONLY bundle ships none of it, so drop the manifest pointer too

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.jvm.javaio.copyTo
 import java.io.File
@@ -202,17 +203,66 @@ internal class CoordinateResolver(
    * bytes didn't match the bundle's hash and we want fresh bytes (which overwrite the stale copy).
    */
   private fun download(coord: BundleReader.ClasspathEntry.Maven): File? {
+    val versionDir = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}"
     // Try the recorded type, then `.aar` — same fallback as [locate], for the same reasons.
     for (fileName in candidateFileNames(coord)) {
-      val rel = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName"
+      val rel = "$versionDir/$fileName"
+      // The cache always keys on the LITERAL `<artifact>-<version>.<ext>` name, even when the
+      // remote served a timestamped snapshot file, so [locate] finds the download next time.
       val dest = File(downloadCacheDir, rel)
       for (base in remoteRepositories) {
-        val url = base.trimEnd('/') + "/" + rel
+        val remoteName = remoteFileName(base, coord, versionDir, fileName)
+        val url = base.trimEnd('/') + "/" + versionDir + "/" + remoteName
         if (fetchTo(url, dest)) return materialize(dest)
       }
     }
     return null
   }
+
+  /**
+   * The file name [base] actually serves for [coord] — [fileName] itself for a release, and for a
+   * **unique snapshot** the timestamped name its `maven-metadata.xml` names.
+   *
+   * A Maven snapshot repository does not serve `<artifact>-1.0.0-SNAPSHOT.aar`: it stores each
+   * publication under `<artifact>-1.0.0-<yyyyMMdd.HHmmss>-<n>.<ext>` and points at the current one
+   * from the version directory's `maven-metadata.xml`. Constructing the literal name — which is
+   * what this resolver did before — therefore 404s against every real snapshot repo, so a bundle
+   * carrying a `-SNAPSHOT` coordinate could never be rehydrated from the network at all. That is
+   * what stranded `remote-m3`, whose whole Remote Compose runtime resolves from an androidx.dev
+   * snapshot build (issues #4259 / #4265): the live daemon came up with no
+   * `androidx.compose.remote:remote-player-view` on its classpath and every render died with
+   * `NoClassDefFoundError: androidx/compose/remote/player/view/RemoteComposePlayer`.
+   *
+   * Falls back to [fileName] on anything unexpected (no metadata, unparseable metadata, transport
+   * error, or a repo publishing non-unique snapshots under the literal name) — the caller then just
+   * tries that URL, which is exactly the old behaviour.
+   */
+  private fun remoteFileName(
+    base: String,
+    coord: BundleReader.ClasspathEntry.Maven,
+    versionDir: String,
+    fileName: String,
+  ): String {
+    if (!isSnapshot(coord.version)) return fileName
+    val extension = fileName.substringAfterLast('.', missingDelimiterValue = "")
+    val metadata = fetchText(base.trimEnd('/') + "/" + versionDir + "/maven-metadata.xml")
+    val timestamped = metadata?.let { snapshotVersion(it, extension) } ?: return fileName
+    return "${coord.artifact}-$timestamped.$extension"
+  }
+
+  /** GET [url] as text, or null on a non-2xx / transport error. */
+  private fun fetchText(url: String): String? =
+    try {
+      HttpClient(OkHttp).use { client ->
+        runBlocking {
+          client.prepareGet(url).execute { response ->
+            if (response.status.isSuccess()) response.bodyAsText() else null
+          }
+        }
+      }
+    } catch (_: Exception) {
+      null
+    }
 
   /**
    * An `.aar` isn't classpath-loadable, so extract its `classes.jar` to a stable cache path and
@@ -301,6 +351,37 @@ internal class CoordinateResolver(
       listOf(coord.type.ifBlank { "jar" }, "aar").distinct().map {
         "${coord.artifact}-${coord.version}.$it"
       }
+
+    /** A Maven snapshot version — the only kind whose artifact file name isn't the version. */
+    internal fun isSnapshot(version: String): Boolean = version.endsWith("-SNAPSHOT")
+
+    /**
+     * The unique-snapshot version (`1.0.0-20260818.194125-1`) a version-level `maven-metadata.xml`
+     * publishes for [extension], or null when the document names none.
+     *
+     * Read with a scan rather than an XML parser to keep `:cli` free of one: each
+     * `<snapshotVersion>` block is matched whole, blocks carrying a `<classifier>` are skipped (the
+     * `sources` / `javadoc` siblings publish the same extension), and the first remaining block
+     * whose `<extension>` matches wins — a version-level metadata document carries one classifier-
+     * free entry per extension, the current publication.
+     */
+    internal fun snapshotVersion(metadataXml: String, extension: String): String? =
+      SNAPSHOT_VERSION_BLOCK.findAll(metadataXml)
+        .map { it.groupValues[1] }
+        .filterNot { "<classifier>" in it }
+        .firstOrNull { tagValue(it, "extension").equals(extension, ignoreCase = true) }
+        ?.let { tagValue(it, "value") }
+        ?.takeIf { it.isNotBlank() }
+
+    private val SNAPSHOT_VERSION_BLOCK =
+      Regex("""<snapshotVersion>(.*?)</snapshotVersion>""", RegexOption.DOT_MATCHES_ALL)
+
+    private fun tagValue(block: String, tag: String): String? =
+      Regex("""<$tag>(.*?)</$tag>""", RegexOption.DOT_MATCHES_ALL)
+        .find(block)
+        ?.groupValues
+        ?.get(1)
+        ?.trim()
 
     /**
      * Default local repositories searched when a caller doesn't pass its own. Honours the standard

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
@@ -1,0 +1,171 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * The coordinates a catalog's bundle recorded that this server could not resolve — written beside
+ * the daemon launch descriptor at materialization time, read back when a render dies of a linkage
+ * error so the failure can name its cause.
+ *
+ * ## Why
+ *
+ * [CoordinateResolver][ee.schimke.composeai.cli.CoordinateResolver] warns and drops a coordinate it
+ * can't find rather than failing, and that is right: most misses are harmless (a dependency no
+ * render path touches), and a slightly-thin classpath still beats no catalog. What it cost was
+ * attribution. `remote-m3` publishes a `coordinates` bundle whose whole Remote Compose runtime is
+ * an androidx.dev snapshot build; the server resolved none of it, logged thirteen separate warnings
+ * at startup, stood the daemon up, and every render then died with `NoClassDefFoundError:
+ * androidx/compose/remote/player/view/RemoteComposePlayer`. That is the text the circuit breaker
+ * latched and the viewer showed, and it names a class, not a cause — so issues #4259 and #4265 were
+ * both filed against the symptom.
+ *
+ * ## What
+ *
+ * [record] persists the gap as `classpath-gaps.json` next to `daemon-launch.json`.
+ * [linkageDiagnosis] reads it at trip time and returns one sentence for [RenderCircuitBreaker] to
+ * append to the open breaker's reason — the only diagnosis anyone outside the box ever sees. When
+ * the missing class's package matches one of the unresolved coordinates, the sentence names that
+ * artifact specifically; otherwise it reports the gap and lets the reader draw the line.
+ *
+ * Read at trip time rather than held in memory, mirroring [SkikoNativePairing.linkageDiagnosis]: a
+ * diagnosis nobody needs must not cost anything on the healthy path.
+ */
+internal object BundleClasspathGaps {
+
+  /** File name written beside the launch descriptor. */
+  private const val FILE_NAME = "classpath-gaps.json"
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** One unresolved coordinate, flattened to what a diagnosis needs. */
+  @Serializable
+  data class Gap(
+    /** `group:artifact:version`, as the bundle recorded it. */
+    val coordinate: String,
+    /** Kept apart from [coordinate] so a missing class can be matched back to its artifact. */
+    val group: String,
+    val artifact: String,
+  )
+
+  @Serializable
+  data class Gaps(
+    val unresolved: List<Gap> = emptyList(),
+    /** How many Maven coordinates the bundle recorded in total, for proportion. */
+    val total: Int = 0,
+  )
+
+  /**
+   * Persist [unresolved] beside the launch descriptor in [destDir] and log the aggregate. A no-op
+   * (and no file) when everything resolved, so the diagnosis can never fire on a healthy catalog.
+   */
+  fun record(
+    destDir: File,
+    unresolved: List<BundleReader.ClasspathEntry.Maven>,
+    total: Int,
+    system: String,
+    onLog: (String) -> Unit,
+    fileSystem: FileSystem = SystemFileSystem,
+  ) {
+    if (unresolved.isEmpty()) return
+    onLog(
+      "catalog $system: ${unresolved.size} of $total classpath coordinate(s) did not resolve — " +
+        "the live daemon starts with an incomplete classpath and any render that needs one of " +
+        "them will fail with a linkage error. Unresolved: " +
+        unresolved.joinToString { "${it.group}:${it.artifact}:${it.version}" }
+    )
+    val gaps =
+      Gaps(
+        unresolved =
+          unresolved.map {
+            Gap(
+              coordinate = "${it.group}:${it.artifact}:${it.version}",
+              group = it.group,
+              artifact = it.artifact,
+            )
+          },
+        total = total,
+      )
+    runCatching {
+      fileSystem.write(File(destDir, FILE_NAME).path.toPath()) {
+        writeUtf8(json.encodeToString(Gaps.serializer(), gaps))
+      }
+    }
+  }
+
+  /**
+   * One sentence attributing a **fatal** linkage [reason] to this catalog's unresolved coordinates,
+   * or null when the classpath was complete, the record is unreadable, or the failure isn't the
+   * kind an absent artifact explains.
+   *
+   * [descriptorPath] is the daemon's `daemon-launch.json`; the record sits beside it.
+   */
+  fun linkageDiagnosis(
+    reason: String,
+    descriptorPath: File,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): String? {
+    if (MISSING_TYPE_MARKERS.none { it in reason }) return null
+    val file = File(descriptorPath.parentFile ?: return null, FILE_NAME)
+    val gaps =
+      runCatching {
+        fileSystem
+          .read(file.path.toPath()) { readUtf8() }
+          .let { json.decodeFromString(Gaps.serializer(), it) }
+      }
+        .getOrNull() ?: return null
+    if (gaps.unresolved.isEmpty()) return null
+    val dotted = reason.replace('/', '.')
+    val culprit =
+      gaps.unresolved
+        .maxByOrNull { attributionScore(dotted, it) }
+        ?.takeIf { attributionScore(dotted, it) > 0 }
+    val head =
+      "This catalog's bundle records ${gaps.total} Maven coordinate(s) and this server could not " +
+        "resolve ${gaps.unresolved.size} of them, so the daemon is running on an incomplete " +
+        "classpath"
+    val attribution =
+      culprit?.let { " — including ${it.coordinate}, which is where the missing type lives" }
+        ?: " — one of them is likely where the missing type lives"
+    return "$head$attribution. Unresolved: ${gaps.unresolved.joinToString { it.coordinate }}. " +
+      "Republish the catalog from a build whose repositories the bundle records, or give this " +
+      "server access to them (--extra-maven-repos)."
+  }
+
+  /**
+   * How well [gap] explains the type named in [dottedReason] (the failure text with `/` rewritten
+   * to `.`, since a `NoClassDefFoundError` prints the internal form). Zero means "says nothing".
+   *
+   * The group has to appear at all — the naming convention every AndroidX / JetBrains / Square
+   * artifact follows — and then each hyphen-separated token of the artifact id that also appears
+   * breaks the tie between siblings in one group. So for
+   * `androidx/compose/remote/player/view/RemoteComposePlayer` the group `androidx.compose.remote`
+   * matches five unresolved artifacts, and `remote-player-view` (whose `player` and `view` tokens
+   * are both in the package) outscores `remote-core`. When nothing scores, the diagnosis stays
+   * general rather than naming an artifact it can't stand behind.
+   */
+  private fun attributionScore(dottedReason: String, gap: Gap): Int {
+    if (!dottedReason.contains(gap.group)) return 0
+    val tokenHits = gap.artifact.split('-').count { it.length > 2 && dottedReason.contains(it) }
+    return 1 + tokenHits
+  }
+
+  /**
+   * Linkage markers an absent artifact explains. Deliberately narrower than
+   * [RenderFailureClassifier]'s fatal set: a `VerifyError` or an `UnsatisfiedLinkError` is a
+   * different fault (bad bytecode, a native pairing — see [SkikoNativePairing]) and an unresolved
+   * coordinate says nothing useful about it.
+   */
+  private val MISSING_TYPE_MARKERS =
+    listOf(
+      "NoClassDefFoundError",
+      "ClassNotFoundException",
+      "NoSuchMethodError",
+      "NoSuchFieldError",
+    )
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -191,18 +191,45 @@ internal object ServeBundleDaemon {
       onLog("catalog $system: ${SkikoNativePairing.repairLog(skikoNativeRepair)}")
     }
     val mavenCoords = recordedCoords + listOfNotNull(skikoNativeRepair)
-    val resolvedDependencies =
+    // (v9) The bundle names the repositories its own coordinates resolve from — a JitPack fork, an
+    // internal mirror, the androidx.dev snapshot build a Remote Compose catalog is built against.
+    // Consulted after the operator's `--extra-maven-repos`, so a box that pins a mirror still wins,
+    // and a pre-v9 bundle contributes nothing. The recorded `sha256` still decides whether the
+    // bytes that come back are the ones the producer packed.
+    val bundleRepositories = manifest.repositories.filter { it.isNotBlank() }
+    if (bundleRepositories.isNotEmpty()) {
+      onLog(
+        "catalog $system: bundle declares ${bundleRepositories.size} extra Maven " +
+          "repository(s) — ${bundleRepositories.joinToString()}"
+      )
+    }
+    val resolutions =
       CoordinateResolver(
           warn = { onLog("catalog $system: $it") },
           networkEnabled = if (offline) false else CoordinateResolver.defaultNetworkEnabled(),
           remoteRepositories =
             CoordinateResolver.DEFAULT_REMOTE_REPOSITORIES +
-              extraMavenRepos.filter { it.isNotBlank() },
+              extraMavenRepos.filter { it.isNotBlank() } +
+              bundleRepositories,
         )
         .resolveAll(mavenCoords)
-        .mapNotNull { resolution ->
-          resolution.file?.let { file -> ResolvedBundleDependency(resolution.coordinate, file) }
-        }
+    val resolvedDependencies = resolutions.mapNotNull { resolution ->
+      resolution.file?.let { file -> ResolvedBundleDependency(resolution.coordinate, file) }
+    }
+    // A coordinate the resolver couldn't find is dropped with a per-coordinate warning and the
+    // daemon starts anyway — correct, because most misses are harmless (a dep nothing on the render
+    // path touches). What was missing is the *aggregate*: 13 unresolved coordinates read as 13
+    // unrelated warnings, and the consequence only surfaced later as an unattributable
+    // `NoClassDefFoundError` that tripped the breaker terminally (issues #4259 / #4265). Record the
+    // gap beside the launch descriptor so a linkage trip can name it — see [BundleClasspathGaps].
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = resolutions.filter { it.file == null }.map { it.coordinate },
+      total = mavenCoords.size,
+      system = system,
+      onLog = onLog,
+      fileSystem = fileSystem,
+    )
     // The resolver warns and returns null rather than throwing, so an unresolvable repair would
     // otherwise be indistinguishable from one that was never needed — and the daemon would launch
     // straight back into the split-Skiko classpath this repair exists to close.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1826,8 +1826,13 @@ internal constructor(
         label = label,
         declaredThemes = declaredThemes,
         onLog = onLog,
+        // Two causes, tried in order of specificity: a split Skiko pair (which names the exact
+        // versions), then a classpath the bundle asked for and this server could not assemble.
+        // Either turns the open breaker's reason — the only report anyone outside the box reads —
+        // from a bare missing symbol into something that says what to do about it.
         linkageDiagnosis = { reason ->
           SkikoNativePairing.linkageDiagnosis(reason, descriptorPath)
+            ?: BundleClasspathGaps.linkageDiagnosis(reason, descriptorPath)
         },
       )
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -29,8 +30,9 @@ class BundleSplitTest {
       linkedMapOf(
         "bundle.json" to
           """
-          {"schemaVersion":8,"backend":"desktop","previewIds":["A","B","C"],
+          {"schemaVersion":9,"backend":"desktop","previewIds":["A","B","C"],
            "coverPreviewId":"A","resolution":"coordinates",
+           "repositories":["https://androidx.dev/snapshots/builds/16113093/artifacts/repository"],
            "classpath":[{"kind":"module","path":"classes/app.jar"}],
            "intermediateRepresentations":[],"dataExtensions":[{"extensionId":"a11y","path":"extensions/a11y.json"}]}
           """
@@ -71,6 +73,25 @@ class BundleSplitTest {
     }
     return out
   }
+
+  @Test
+  fun `a full split keeps the bundle repositories and a view-only split drops them`() {
+    // The per-preview bundles ARE the live lane for a `split-mode: full` catalog, so a repository
+    // list the sheet needed to resolve its coordinates has to survive the split — dropping it puts
+    // the daemon back on the incomplete classpath of #4259 / #4265. A view-only bundle carries no
+    // coordinates, so it must not advertise repositories for them either.
+    val full = manifestOf(splitBundleZip(sheetZip(), SplitMode.FULL).first().zipBytes)
+    assertEquals(
+      listOf("https://androidx.dev/snapshots/builds/16113093/artifacts/repository"),
+      full.getValue("repositories").jsonArray.map { it.jsonPrimitive.content },
+    )
+
+    val viewOnly = manifestOf(splitBundleZip(sheetZip(), SplitMode.VIEW_ONLY).first().zipBytes)
+    assertNull(viewOnly["repositories"])
+  }
+
+  private fun manifestOf(zip: ByteArray) =
+    json.parseToJsonElement(readEntries(zip).getValue("bundle.json").decodeToString()).jsonObject
 
   @Test
   fun `full split emits one re-renderable bundle per preview with a baked image`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -380,6 +380,127 @@ class CoordinateResolverTest {
     assertTrue(File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar").isFile)
   }
 
+  @Test
+  fun `snapshot metadata yields the timestamped file name for the matching extension`() {
+    val metadata =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <metadata modelVersion="1.1.0">
+        <versioning>
+          <snapshotVersions>
+            <snapshotVersion>
+              <extension>aar</extension>
+              <value>1.0.0-20260818.194125-1</value>
+            </snapshotVersion>
+            <snapshotVersion>
+              <classifier>sources</classifier>
+              <extension>jar</extension>
+              <value>1.0.0-20260818.194125-1</value>
+            </snapshotVersion>
+            <snapshotVersion>
+              <extension>pom</extension>
+              <value>1.0.0-20260818.194125-1</value>
+            </snapshotVersion>
+          </snapshotVersions>
+        </versioning>
+      </metadata>
+      """
+        .trimIndent()
+
+    assertEquals("1.0.0-20260818.194125-1", CoordinateResolver.snapshotVersion(metadata, "aar"))
+    assertEquals("1.0.0-20260818.194125-1", CoordinateResolver.snapshotVersion(metadata, "pom"))
+    // The only `jar` block carries a `sources` classifier, so it must NOT be taken for the
+    // artifact.
+    assertNull(CoordinateResolver.snapshotVersion(metadata, "jar"))
+    assertNull(CoordinateResolver.snapshotVersion("<metadata/>", "aar"))
+  }
+
+  @Test
+  fun `isSnapshot only trips on a SNAPSHOT version`() {
+    assertTrue(CoordinateResolver.isSnapshot("1.0.0-SNAPSHOT"))
+    assertFalse(CoordinateResolver.isSnapshot("1.0.0"))
+    assertFalse(CoordinateResolver.isSnapshot("1.0.0-alpha10"))
+    // An already-resolved unique snapshot is a concrete version, not a `-SNAPSHOT` request.
+    assertFalse(CoordinateResolver.isSnapshot("1.0.0-20260818.194125-1"))
+  }
+
+  @Test
+  fun `a SNAPSHOT coordinate resolves through the version metadata`() {
+    // Regression for #4259 / #4265: a real snapshot repo serves
+    // `widgets-1.0.0-<timestamp>-1.jar`, never `widgets-1.0.0-SNAPSHOT.jar`. Constructing the
+    // literal name 404'd, so every `-SNAPSHOT` coordinate a bundle recorded was unresolvable and
+    // the live daemon came up without it. This repo serves ONLY what a real one serves.
+    val jar = byteArrayOf(7, 7, 7)
+    val timestamped = "1.0.0-20260818.194125-1"
+    val base =
+      startRoutedRepo(
+        mapOf(
+          "/com/example/foo/widgets/1.0.0-SNAPSHOT/maven-metadata.xml" to
+            snapshotMetadata(timestamped, "jar").toByteArray(),
+          "/com/example/foo/widgets/1.0.0-SNAPSHOT/widgets-$timestamped.jar" to jar,
+        )
+      )
+
+    val r = networkResolver(base).resolve(snapshotCoord())
+
+    val file = assertNotNull(r.file, "a snapshot coordinate must resolve from its metadata")
+    assertEquals(jar.toList(), file.readBytes().toList())
+    // Cached under the LITERAL coordinate name so the next (possibly offline) run finds it in
+    // `locate`, which only ever looks for `<artifact>-<version>.<ext>`.
+    assertTrue(
+      File(cacheDir, "com/example/foo/widgets/1.0.0-SNAPSHOT/widgets-1.0.0-SNAPSHOT.jar").isFile
+    )
+  }
+
+  @Test
+  fun `a snapshot repo with no metadata falls back to the literal file name`() {
+    // Non-unique snapshots (and any repo that just publishes the literal name) must keep working —
+    // the metadata lookup is a best-effort addition, not a new requirement.
+    val jar = byteArrayOf(1, 2, 3)
+    val base =
+      startRoutedRepo(
+        mapOf("/com/example/foo/widgets/1.0.0-SNAPSHOT/widgets-1.0.0-SNAPSHOT.jar" to jar)
+      )
+
+    val file = assertNotNull(networkResolver(base).resolve(snapshotCoord()).file)
+    assertEquals(jar.toList(), file.readBytes().toList())
+  }
+
+  private fun snapshotCoord() =
+    BundleReader.ClasspathEntry.Maven(
+      group = "com.example.foo",
+      artifact = "widgets",
+      version = "1.0.0-SNAPSHOT",
+      type = "jar",
+      sha256 = null,
+    )
+
+  private fun snapshotMetadata(value: String, extension: String) =
+    """
+    <metadata modelVersion="1.1.0"><versioning><snapshotVersions>
+      <snapshotVersion><extension>$extension</extension><value>$value</value></snapshotVersion>
+    </snapshotVersions></versioning></metadata>
+    """
+      .trimIndent()
+
+  /** A loopback Maven repo that serves [routes] by exact path and 404s everything else. */
+  private fun startRoutedRepo(routes: Map<String, ByteArray>): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/") { exchange ->
+      val body = routes[exchange.requestURI.path]
+      if (body == null) {
+        exchange.sendResponseHeaders(404, -1)
+      } else {
+        exchange.sendResponseHeaders(200, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+      }
+      exchange.close()
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}"
+  }
+
   private fun assertNotNullFile(f: File?) =
     assertTrue(f != null && f.isFile, "expected a resolved jar")
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.cli.BundleReader
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [BundleClasspathGaps] — the record that lets a fatal linkage trip name the
+ * coordinates this server could not resolve, instead of only the class the JVM couldn't find
+ * (issues #4259 / #4265).
+ */
+class BundleClasspathGapsTest {
+
+  private val destDir = Files.createTempDirectory("classpath-gaps-test-").toFile()
+  private val descriptor = File(destDir, "daemon-launch.json")
+  private val logs = mutableListOf<String>()
+
+  @AfterTest fun cleanup() = destDir.deleteRecursively().let {}
+
+  private fun maven(group: String, artifact: String, version: String = "1.0.0-SNAPSHOT") =
+    BundleReader.ClasspathEntry.Maven(
+      group = group,
+      artifact = artifact,
+      version = version,
+      type = "aar",
+      sha256 = null,
+    )
+
+  /** The real shape from the reports: the whole Remote Compose runtime unresolved. */
+  private fun recordRemoteComposeGap() =
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved =
+        listOf(
+          maven("androidx.compose.remote", "remote-core"),
+          maven("androidx.compose.remote", "remote-player-view"),
+          maven("androidx.wear.compose.remote", "remote-material3"),
+        ),
+      total = 84,
+      system = "remote-m3",
+      onLog = { logs += it },
+    )
+
+  @Test
+  fun `a complete classpath records nothing and diagnoses nothing`() {
+    BundleClasspathGaps.record(
+      destDir = destDir,
+      unresolved = emptyList(),
+      total = 84,
+      system = "remote-m3",
+      onLog = { logs += it },
+    )
+
+    assertTrue(logs.isEmpty(), "a healthy catalog must not log a gap")
+    assertEquals(emptyList(), destDir.listFiles()?.toList() ?: emptyList())
+    assertNull(
+      BundleClasspathGaps.linkageDiagnosis("render failed: NoClassDefFoundError: a/B", descriptor)
+    )
+  }
+
+  @Test
+  fun `an unresolved coordinate whose group owns the missing type is named`() {
+    recordRemoteComposeGap()
+
+    val diagnosis =
+      BundleClasspathGaps.linkageDiagnosis(
+        "render failed: NoClassDefFoundError: " +
+          "androidx/compose/remote/player/view/RemoteComposePlayer",
+        descriptor,
+      )
+
+    val text = requireNotNull(diagnosis) { "a linkage failure with a recorded gap must diagnose" }
+    // The artifact whose id tokens (`player`, `view`) also appear in the package wins over its
+    // siblings in the same group — otherwise the sentence would blame `remote-core`.
+    assertContains(text, "androidx.compose.remote:remote-player-view:1.0.0-SNAPSHOT, which is")
+    assertContains(text, "3 of them")
+    assertContains(text, "84 Maven coordinate(s)")
+  }
+
+  @Test
+  fun `a linkage failure the gap cannot attribute still reports the gap`() {
+    recordRemoteComposeGap()
+
+    val text =
+      requireNotNull(
+        BundleClasspathGaps.linkageDiagnosis(
+          "render failed: NoClassDefFoundError: com/example/other/Thing",
+          descriptor,
+        )
+      )
+
+    assertContains(text, "one of them is likely")
+    assertContains(text, "androidx.compose.remote:remote-core:1.0.0-SNAPSHOT")
+  }
+
+  @Test
+  fun `failures an absent artifact does not explain are left alone`() {
+    recordRemoteComposeGap()
+
+    // Skiko's split-native fault has its own diagnosis; a VerifyError is bad bytecode, not a
+    // missing jar. Neither is made clearer by listing unresolved coordinates.
+    assertNull(
+      BundleClasspathGaps.linkageDiagnosis(
+        "render failed: UnsatisfiedLinkError: 'long org.jetbrains.skia.Foo._nMake()'",
+        descriptor,
+      )
+    )
+    assertNull(BundleClasspathGaps.linkageDiagnosis("render failed: VerifyError: bad", descriptor))
+  }
+
+  @Test
+  fun `the aggregate is logged once with every unresolved coordinate`() {
+    recordRemoteComposeGap()
+
+    assertEquals(1, logs.size)
+    assertContains(logs.single(), "3 of 84 classpath coordinate(s) did not resolve")
+    assertContains(logs.single(), "androidx.wear.compose.remote:remote-material3:1.0.0-SNAPSHOT")
+  }
+}

--- a/docs/portable-bundles.md
+++ b/docs/portable-bundles.md
@@ -230,6 +230,26 @@ BundleManifest(
   (Bazel/Amper, or any "make it truly portable" pack). Bigger file.
 - `mixed` — embed what has no coordinate, reference the rest.
 
+A `coordinates` bundle is only re-renderable where its coordinates resolve, so
+v9 adds one more field:
+
+```kotlin
+BundleManifest(
+  ...
+  repositories: List<String> = emptyList()  // extra Maven repo base URLs, beyond Central + Google
+)
+```
+
+Maven Central and Google Maven are what every player already tries; anything
+else the producing build declared — a JitPack fork, an internal mirror, an
+androidx.dev snapshot build — is recorded here. Without it a coordinate served
+by none of the defaults simply went missing: the resolver warned, dropped it,
+and the player rendered (or a live server's daemon started) on an incomplete
+classpath, failing later with a linkage error that named a class rather than a
+cause (issues #4259 / #4265). The recorded `sha256` still decides whether the
+bytes that come back are the ones the producer packed, and an operator's own
+`--extra-maven-repos` is consulted first.
+
 All additive: v2 readers (`ignoreUnknownKeys = true` in `BundleLoader` and
 `BundlePngMetadata`) keep working against a v3 bundle, and a v3-aware player
 treats a v2 bundle as `resolution = "coordinates"`.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2530,7 +2530,18 @@ There are two ways to stand that daemon up, both fail-closed on the `Trusted` ve
    back to baked PNGs (`livebundle-unavailable`), or — when the missing class is only linked at
    render time rather than at daemon bootstrap — every render fails with `NoClassDefFoundError`
    while the daemon itself stays up. Only list repos you trust; the server fetches
-   artifacts from them when resolving a trusted catalog's live bundle. Both backends are supported
+   artifacts from them when resolving a trusted catalog's live bundle.
+   **Since schema v9 a bundle carries its own repository list** (`BundleManifest.repositories` —
+   the extra repos its producing build declared), consulted after `--extra-maven-repos`, so a
+   catalog whose deps live elsewhere no longer needs the box reconfigured to match it. That is what
+   `remote-m3` needed: its whole Remote Compose runtime resolves from a pinned androidx.dev
+   **snapshot** build, and a `-SNAPSHOT` coordinate was doubly unreachable — not declared anywhere
+   the box knew about, and constructed as `<artifact>-<version>-SNAPSHOT.<ext>`, which no real
+   snapshot repo serves (they publish the timestamped `<artifact>-<version>-<yyyyMMdd.HHmmss>-<n>`
+   name via the version directory's `maven-metadata.xml`). Both are fixed; issues #4259 / #4265.
+   When coordinates still don't resolve, the count and the list are logged at materialization and
+   appended to the render circuit breaker's reason, so the `409` a dead lane answers with names the
+   unresolved artifacts instead of only the class the JVM couldn't find. Both backends are supported
    ([`ServeBundleDaemon.materialize`](../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt)):
    a **desktop** bundle spawns the Skiko desktop daemon, and an **android** bundle spawns the
    Robolectric daemon **on a box that carries the Android sidecar + SDK** — the prebuilt `deploy/image`

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/BundleFunctionalTest.kt
@@ -907,6 +907,49 @@ class BundleFunctionalTest {
   }
 
   @Test
+  fun `bundle manifest records the extra repositories its coordinates need`() {
+    // A coordinate is only re-resolvable where its repository is known, and until v9 a bundle
+    // carried no way to say. `remote-m3`'s Remote Compose runtime resolves from an androidx.dev
+    // snapshot build, so every player looked for it on Central/Google, found nothing, and rendered
+    // on an incomplete classpath (#4259 / #4265). Scoped by `content { includeGroup }` to a group
+    // nothing here depends on, so the repository is *declared* (and therefore recorded) without
+    // ever being consulted during resolution.
+    val projectDir = createTestProject()
+    val settings = File(projectDir, "settings.gradle.kts")
+    settings.appendText(
+      """
+
+      dependencyResolutionManagement {
+          repositories {
+              maven {
+                  url = uri("https://androidx.dev/snapshots/builds/16113093/artifacts/repository")
+                  content { includeGroup("com.example.nothing") }
+              }
+          }
+      }
+      """
+        .trimIndent()
+    )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewBundle", "-PbundlePreviewIds=test.RedKt.RedBoxPreview")
+      .withPluginClasspath()
+      .build()
+
+    val bundle = File(projectDir, "build/compose-previews/bundle.png")
+    val manifest =
+      json
+        .parseToJsonElement(readZipEntry(bundle, "bundle.json")!!.toString(Charsets.UTF_8))
+        .jsonObject
+    val repositories = manifest["repositories"]!!.jsonArray.map { it.jsonPrimitive.content }
+
+    // Only the extra one: Central and Google are what every player already tries.
+    assertThat(repositories)
+      .containsExactly("https://androidx.dev/snapshots/builds/16113093/artifacts/repository")
+  }
+
+  @Test
   fun `embed-deps pack carries reachable jars in libs and marks resolution embedded`() {
     val projectDir = createTestProject()
     val redId = "test.RedKt.RedBoxPreview"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -284,6 +284,20 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Input @get:Optional abstract val embedDeps: Property<Boolean>
 
   /**
+   * Maven repository base URLs the producing build resolves from **beyond** Maven Central and
+   * Google Maven, recorded into the manifest as [BundleManifest.repositories] so a player can
+   * re-resolve coordinates those two don't serve.
+   *
+   * A `coordinates` bundle is only re-renderable where its coordinates resolve, and a module that
+   * takes a dependency from a JitPack fork, an internal mirror, or an androidx.dev snapshot build
+   * records coordinates no player could find — it dropped them with a warning and rendered (or
+   * failed to) on an incomplete classpath. Populated by the plugin from the project's declared
+   * repositories; empty for the common all-Central/Google module, which keeps the manifest field
+   * absent-equivalent.
+   */
+  @get:Input @get:Optional abstract val extraMavenRepositories: ListProperty<String>
+
+  /**
    * Include-data-extensions mode (`-PbundleIncludeDataExtensions=true`, schema-v7
    * [BundleManifest.dataExtensions]). When true, the per-extension data reports (a11y findings,
    * theme tokens, drawn strings, …) — those named by `previews.json`'s `dataExtensionReports` plus
@@ -520,6 +534,12 @@ abstract class BundlePreviewTask : DefaultTask() {
         intermediateRepresentations = irEntries,
         androidResources = androidResources,
         dataExtensions = dataExtensionEntries,
+        // Only a coordinate needs a repository to come back from; an embed-mode pack carries the
+        // bytes and would just be publishing URLs nobody reads.
+        repositories =
+          if (classpathEntries.any { it is ClasspathEntry.Maven })
+            extraMavenRepositories.getOrElse(emptyList())
+          else emptyList(),
       )
 
     // Bake one PNG per selected preview into `previews/<id>.png` so the bundle renders detached
@@ -653,6 +673,26 @@ abstract class BundlePreviewTask : DefaultTask() {
         "  Project deps inlined: $projectInlined\n" +
         "  deps dropped:         $depsDropped (no reachable classes)"
     )
+
+    // A recorded coordinate is a promise the bytes can be re-attached later, and a snapshot
+    // version is the one coordinate that can quietly stop being true: publications age out of the
+    // repository that served them (androidx.dev keeps a build for a few weeks), so a bundle that
+    // outlives its snapshot build becomes unrenderable with no change on either side. The manifest
+    // now records where they came from, which is what makes them resolvable at all — say so, and
+    // name the escape hatch for a bundle meant to last.
+    val snapshotCoords =
+      classpathEntries.filterIsInstance<ClasspathEntry.Maven>().filter {
+        it.version.endsWith("-SNAPSHOT")
+      }
+    if (snapshotCoords.isNotEmpty()) {
+      logger.warn(
+        "composePreviewBundle: ${snapshotCoords.size} classpath coordinate(s) are -SNAPSHOT " +
+          "(${snapshotCoords.take(3).joinToString { "${it.group}:${it.artifact}" }}" +
+          "${if (snapshotCoords.size > 3) ", …" else ""}). The bundle records the repositories " +
+          "they resolve from, but a snapshot publication is perishable — pack with --embed-deps " +
+          "if this bundle has to keep rendering after the snapshot build ages out."
+      )
+    }
 
     // Bundles are meant to be small and shareable — a detached `coordinates` pack is typically
     // ~100 KB. Embedding (`--embed-deps`) trades that for offline self-containment, but a fat

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -6,6 +6,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.ArtifactRepository
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
@@ -166,6 +167,73 @@ internal object ComposePreviewTasks {
       }
       .files
   }
+
+  /**
+   * Maven repository base URLs [project] resolves from beyond the two every player already tries
+   * (Maven Central and Google Maven), recorded into the bundle as `BundleManifest.repositories`.
+   *
+   * A `coordinates` bundle only re-renders where its coordinates resolve. A module that takes a
+   * dependency from a JitPack fork, an internal mirror, or an androidx.dev snapshot build therefore
+   * records coordinates no player can find: the resolver warns, drops them, and the daemon comes up
+   * on an incomplete classpath — which is how `:samples:design-catalog-remote-m3` (whose entire
+   * Remote Compose runtime is an androidx.dev snapshot) served a live lane that died on its first
+   * render with `NoClassDefFoundError: androidx/compose/remote/player/view/RemoteComposePlayer`
+   * (issues #4259 / #4265). Carrying the URLs makes the bundle self-describing, and keeps a pinned
+   * snapshot build id honest: bump it here and the next pack records the new one.
+   *
+   * **Both** repository sources are read, because a build declares them in either place and this
+   * repo uses the one a project-level read misses: `project.repositories` holds what the build
+   * script declared, and settings' `dependencyResolutionManagement.repositories` holds what the
+   * settings script declared — under `PREFER_SETTINGS` / `FAIL_ON_PROJECT_REPOS` the project
+   * handler is simply empty, so reading it alone records nothing for exactly the builds that need
+   * this most. The settings block is reached through the one internal accessor there is
+   * (`GradleInternal.settings`, then the public `Settings.dependencyResolutionManagement`), wrapped
+   * so a Gradle that no longer offers it degrades to the project-level list rather than failing the
+   * pack.
+   *
+   * Read through a [Provider] so the list is sampled after both scripts have finished declaring
+   * repositories, while still being a configuration-time read — nothing pins `project` into the
+   * configuration cache at execution. Non-HTTP repositories (`mavenLocal()`, `file:` mirrors) are
+   * skipped: they name a path on the producing machine, which is worse than useless to a player
+   * elsewhere.
+   */
+  private fun extraMavenRepositoryUrls(project: Project): Provider<List<String>> =
+    project.provider {
+      (project.repositories + settingsRepositories(project))
+        .filterIsInstance<org.gradle.api.artifacts.repositories.MavenArtifactRepository>()
+        .map { it.url.toString().trimEnd('/') }
+        .filter { it.startsWith("https://") || it.startsWith("http://") }
+        .filterNot { url -> DEFAULT_PLAYER_REPOSITORIES.any { url.startsWith(it) } }
+        .distinct()
+    }
+
+  /**
+   * The repositories declared by settings' `dependencyResolutionManagement`, or empty when this
+   * Gradle doesn't expose them (or there is no settings object at all — `ProjectBuilder` in unit
+   * tests). `Settings.getDependencyResolutionManagement()` is public API; only reaching the
+   * `Settings` from a project plugin isn't, hence the guarded cast.
+   */
+  private fun settingsRepositories(project: Project): List<ArtifactRepository> = runCatching {
+    (project.gradle as org.gradle.api.internal.GradleInternal)
+      .settings
+      .dependencyResolutionManagement
+      .repositories
+      .toList()
+  }
+    .getOrElse { emptyList() }
+
+  /**
+   * The repositories every player tries before consulting `BundleManifest.repositories`, so
+   * recording them again would be noise. Kept in lockstep with `CoordinateResolver`'s
+   * `DEFAULT_REMOTE_REPOSITORIES` (both host names each serves under).
+   */
+  private val DEFAULT_PLAYER_REPOSITORIES =
+    listOf(
+      "https://repo1.maven.org/maven2",
+      "https://repo.maven.apache.org/maven2",
+      "https://dl.google.com/dl/android/maven2",
+      "https://maven.google.com",
+    )
 
   /** Builds the [DependencyClasspathBinding] for consumer runtime config [configName]. */
   private fun dependencyClasspathBinding(
@@ -659,6 +727,9 @@ internal object ComposePreviewTasks {
       catalogTokenFiles.from(previewOutputDir.map { it.dir("data/catalog-tokens") })
       previewIds.set(previewIdsProperty.orElse(emptyList()))
       embedDeps.set(embedDepsProperty.orElse(false))
+      // (v9) Where this module's coordinates actually resolve from, for a player that has to
+      // re-attach them. See [extraMavenRepositoryUrls].
+      extraMavenRepositories.set(extraMavenRepositoryUrls(project))
       includeDataExtensions.set(includeDataExtensionsProperty.orElse(false))
       // Track the aggregated extension report sidecars (the render task writes them as top-level
       // `*.json` under the preview output dir) so a content change re-packs the bundle. The bundle

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -258,6 +258,32 @@ data class BundleManifest(
    * shared-classpath split mode populates this field.
    */
   val externalClasspath: List<BundleExternalClasspath> = emptyList(),
+  /**
+   * (v9) Extra Maven repository base URLs a player needs to re-resolve this bundle's
+   * [ClasspathEntry.Maven] coordinates — the repositories the producing build declared beyond Maven
+   * Central and Google Maven, which every player already tries.
+   *
+   * A coordinate is only a promise that the bytes can be re-attached from *somewhere*, and that
+   * promise silently breaks the moment a module resolves a dependency from anywhere else: a JitPack
+   * fork, an internal mirror, or — the case that produced this field — the androidx.dev snapshot
+   * build `:samples:design-catalog-remote-m3` takes its entire Remote Compose runtime from. The
+   * player found nothing for those coordinates, dropped them with a warning, and stood a daemon up
+   * on an incomplete classpath; the first render then died with `NoClassDefFoundError:
+   * androidx/compose/remote/player/view/RemoteComposePlayer` and the catalog fell back to baked
+   * PNGs (issues #4259 / #4265). Recording the repositories makes the bundle say where its bytes
+   * live instead of leaving a server operator to guess it into `--extra-maven-repos`, and keeps a
+   * pinned snapshot build id correct by construction: bump it in the producing build and the next
+   * pack carries the new URL.
+   *
+   * Only *extra* repositories are recorded — the two defaults are omitted so a bundle whose deps
+   * are all on Central/Google keeps an empty list, and so does a pre-v9 bundle. Purely additive: a
+   * player that ignores the field resolves exactly as it did before.
+   *
+   * These URLs are producer-declared, so a player must treat them with the trust it already extends
+   * to the bundle's executable classes — the recorded [ClasspathEntry.Maven.sha256] still governs
+   * whether the fetched bytes are the ones the producer packed.
+   */
+  val repositories: List<String> = emptyList(),
 )
 
 /** One whole bundle classpath entry stored at `bundle/res/<sha256>` instead of inline. */
@@ -648,6 +674,13 @@ val CONVENTIONAL_DATA_EXTENSION_REPORTS: Map<String, String> = mapOf("a11y" to "
  *   field), present only for previews that opted in. Additive — the sidecar is ignored by older
  *   readers and absent for previews that declare no knobs, so a v7 reader opening a v8 bundle still
  *   works; only a reader that wants the editable knobs needs to be v8-aware.
+ * - v9 — adds [BundleManifest.repositories]: the extra Maven repository base URLs (beyond Maven
+ *   Central and Google Maven) a player must consult to re-resolve this bundle's coordinates. A
+ *   coordinate resolved from a JitPack fork, an internal mirror, or an androidx.dev snapshot build
+ *   was unfindable to every player before this, so the bundle stood a daemon up on an incomplete
+ *   classpath and the first render died with a linkage error (issues #4259 / #4265). Additive — the
+ *   field defaults to empty (which is also what a v8 bundle and any all-Central module carry), so a
+ *   v8 reader opening a v9 bundle resolves exactly as it did before.
  *
  * Orthogonal to the version sequence above, the optional `signatures.json`
  * ([BUNDLE_SIGNATURES_PATH], [BundleSignatures]) carries detached producer signatures over the
@@ -656,7 +689,7 @@ val CONVENTIONAL_DATA_EXTENSION_REPORTS: Map<String, String> = mapOf("a11y" to "
  * **not** bump [schemaVersion] (signing is a post-pack step, like `bundle embed`); an unsigned
  * bundle has no such entry and an unaware reader ignores it.
  */
-const val BUNDLE_SCHEMA_VERSION: Int = 8
+const val BUNDLE_SCHEMA_VERSION: Int = 9
 
 /**
  * File extension of the per-preview override sidecar the render step writes next to the PNG

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormatTest.kt
@@ -23,8 +23,42 @@ class PreviewBundleFormatTest {
   }
 
   @Test
-  fun `current schema version is 8`() {
-    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(8)
+  fun `current schema version is 9`() {
+    assertThat(BUNDLE_SCHEMA_VERSION).isEqualTo(9)
+  }
+
+  @Test
+  fun `v9 repositories round-trip and default empty on an older manifest`() {
+    val original =
+      BundleManifest(
+        schemaVersion = BUNDLE_SCHEMA_VERSION,
+        backend = "android",
+        previewIds = listOf("pkg.Foo"),
+        coverPreviewId = "pkg.Foo",
+        classpath = listOf(ClasspathEntry.Module(path = "classes/app.jar")),
+        modulePath = ":sample",
+        producedBy = "test",
+        repositories =
+          listOf("https://androidx.dev/snapshots/builds/16113093/artifacts/repository"),
+      )
+
+    val decoded =
+      json.decodeFromString(
+        BundleManifest.serializer(),
+        json.encodeToString(BundleManifest.serializer(), original),
+      )
+    assertThat(decoded).isEqualTo(original)
+
+    // A v8 manifest omits the field entirely — it must decode as "no extra repositories", which is
+    // exactly the pre-v9 resolution behaviour.
+    val v8 =
+      """
+      {"schemaVersion":8,"backend":"android","previewIds":["pkg.Foo"],"coverPreviewId":"pkg.Foo",
+       "classpath":[{"kind":"module","path":"classes/app.jar"}],"modulePath":":sample",
+       "producedBy":"test"}
+      """
+        .trimIndent()
+    assertThat(json.decodeFromString(BundleManifest.serializer(), v8).repositories).isEmpty()
   }
 
   @Test

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RegisterBundleTaskBackendTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RegisterBundleTaskBackendTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -19,6 +22,20 @@ class RegisterBundleTaskBackendTest {
 
   @get:Rule val tmp = TemporaryFolder()
 
+  /**
+   * Declare a Maven repository by URL. Spelled as an explicit [Action] rather than a Kotlin lambda
+   * because `RepositoryHandler.maven` is overloaded and this source set has no Kotlin DSL
+   * extensions to disambiguate it.
+   */
+  private fun Project.addMavenRepo(url: String) =
+    repositories.maven(
+      object : Action<MavenArtifactRepository> {
+        override fun execute(repo: MavenArtifactRepository) {
+          repo.setUrl(url)
+        }
+      }
+    )
+
   private fun registerBundle(backendId: String): BundlePreviewTask {
     val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
@@ -32,6 +49,55 @@ class RegisterBundleTaskBackendTest {
       backendId = backendId,
     )
     return project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+  }
+
+  @Test
+  fun `only non-default http maven repositories are recorded for the player`() {
+    // The bundle records where its coordinates come from so a player can re-resolve them (#4259 /
+    // #4265). Central and Google are what every player already tries, and `mavenLocal()` names a
+    // path on THIS machine — recording either is noise at best.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.repositories.mavenCentral()
+    project.repositories.google()
+    project.repositories.mavenLocal()
+    project.addMavenRepo("https://androidx.dev/snapshots/builds/16113093/artifacts/repository/")
+    project.addMavenRepo("https://jitpack.io")
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+
+    assertThat(task.extraMavenRepositories.get())
+      .containsExactly(
+        "https://androidx.dev/snapshots/builds/16113093/artifacts/repository",
+        "https://jitpack.io",
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `a project on the default repositories records none`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.repositories.mavenCentral()
+    project.repositories.google()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    val task = project.tasks.getByName("composePreviewBundle") as BundlePreviewTask
+
+    assertThat(task.extraMavenRepositories.get()).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
Fixes #4259. Fixes #4265.

## What was broken

Both reports are the same fault, seen from two pages: `remote-m3`'s live render lane trips its
circuit breaker terminally on

```
render failed: NoClassDefFoundError: androidx/compose/remote/player/view/RemoteComposePlayer
```

and the catalog serves baked PNGs until it is republished.

The missing class is not a bug in the render path — it was never on the classpath. Reading the
published bundle (`design-artifacts/remote-m3`, `bundle/bundle.png`, schema v8,
`resolution: "coordinates"`) shows 84 Maven coordinates, **13 of them `1.0.0-SNAPSHOT`**:

```
androidx.compose.remote:remote-player-view:1.0.0-SNAPSHOT
androidx.compose.remote:remote-player-compose:1.0.0-SNAPSHOT
androidx.compose.remote:remote-core:1.0.0-SNAPSHOT
androidx.wear.compose.remote:remote-material3:1.0.0-SNAPSHOT
androidx.glance.wear:wear:1.0.0-SNAPSHOT                      … 8 more
```

That is the whole Remote Compose runtime, and it resolves only from the androidx.dev snapshot build
pinned in `settings.gradle.kts` (`androidxSnapshotBuildId = "16113093"`). Two independent things
then stopped the serve box from ever getting it:

1. **Nothing told the box where those coordinates live.** A bundle records coordinates but not
   repositories, and the box tries Maven Central + Google Maven plus its own
   `--extra-maven-repos` (jitpack / apollo / a8c). None of them serve androidx.dev snapshots.
2. **Even pointed at the right repo, the resolver could not have fetched them.**
   `CoordinateResolver.download()` built `<artifact>-1.0.0-SNAPSHOT.<ext>`. A Maven snapshot
   repository does not serve that name — it publishes `<artifact>-1.0.0-<timestamp>-<n>.<ext>` and
   names the current one in the version directory's `maven-metadata.xml`. Verified against the live
   repo: the literal URL is a 404, the metadata-resolved one is a 200 (90 578 bytes for
   `remote-player-view`).

So the resolver warned thirteen times, dropped all thirteen, and `ServeBundleDaemon` stood the
daemon up on an incomplete classpath. The first render then reflected over the connector's replay
class — and `getDeclaredComposableMethod` resolves **every** declared method's descriptor, including
the synthetic one Kotlin emits for the `init = { player -> … }` lambda. Straight out of the
published bundle's own `libs/full-1.jar`:

```
$ javap -p ee.schimke.composeai.daemon.RemoteComposeIrReplay
  public final void Replay(byte[], androidx.compose.runtime.Composer, int);
  private static final kotlin.Unit Replay$lambda$1$0(
      java.util.Map, androidx.compose.remote.player.view.RemoteComposePlayer);
```

Enumerating that method table without `remote-player-view` on the classpath is the reported stack
exactly (`Class.getDeclaredMethods0` ← `getDeclaredComposableMethod`
← `RenderEngineKt.InvokeIrReplay`). The breaker classified `NoClassDefFoundError` as fatal
(correctly — it is), latched, and the reason it latched named a class rather than a cause. That
reason is the whole report a visitor sees, which is why both issues were filed against the symptom.

## What this changes

**Snapshot coordinates are resolvable at all** (`CoordinateResolver`, both the `:cli` and
`:bundle-viewer` copies). For a `-SNAPSHOT` version the resolver reads the version directory's
`maven-metadata.xml` and fetches the timestamped file it names, caching it under the literal
coordinate name so `locate()` finds it offline next time. Anything unexpected — no metadata,
unparseable metadata, a repo publishing non-unique snapshots — falls back to the old literal URL,
so no existing resolution changes.

**Bundles record where their coordinates come from** (schema v9, `BundleManifest.repositories`).
The pack task records the Maven repositories the producing build declares beyond Central and Google,
read from the build script **and** settings' `dependencyResolutionManagement` (`mavenLocal()` and
other non-HTTP repos are skipped — they name a path on the producing machine). Reading only
`project.repositories` records nothing under `PREFER_SETTINGS` / `FAIL_ON_PROJECT_REPOS` — which is
this repo, and every build this fix exists for; the new functional test is what caught that.
`ServeBundleDaemon` and the viewer's `BundleLoader` consult them after the operator's
`--extra-maven-repos`, so the box no longer has to be reconfigured to match each catalog, and a
bumped `androidxSnapshotBuildId` reaches the delivery branch by itself on the next pack. Additive:
the field defaults to empty, which is exactly what a v8 bundle and any all-Central module carry.
A `full` split propagates it (those per-preview bundles *are* remote-m3's live lane); a view-only
split drops it along with the classpath it would serve.

**An unresolvable classpath is attributable** (`BundleClasspathGaps`). Materialization logs the
aggregate once — `13 of 84 classpath coordinate(s) did not resolve … Unresolved: …` — and records it
beside `daemon-launch.json`. When a linkage error then trips the breaker, the open breaker's reason
carries a sentence naming the gap and, where the missing type's package matches, the specific
artifact. The lane still comes up (a miss is usually harmless, and refusing would take working
catalogs down); it just stops being silent about what it is missing. Same read-at-trip-time shape as
`SkikoNativePairing.linkageDiagnosis`, which it chains after.

**Pack warns on perishable coordinates.** A `-SNAPSHOT` publication ages out of the repository that
served it, so a bundle can become unrenderable with no change on either side. The pack step now says
so and names `--embed-deps` for a bundle that has to outlive its snapshot build.

Embedding was the other candidate fix and is the wrong one here: `remote-m3` is `split-mode: full`
over 58 previews, so the ~4 MiB Remote Compose runtime would be copied 58× into the delivery branch
on every publish — the bloat `split-carriage-gate` exists to catch.

## Test plan

- `:cli:test` — new `CoordinateResolverTest` cases: snapshot metadata parsing (classifier blocks
  skipped, extension matched), a loopback repo that serves **only** what a real snapshot repo serves
  (metadata + timestamped file) resolving a `-SNAPSHOT` coordinate, the literal-name fallback, and
  the cache landing under the literal coordinate name. New `BundleClasspathGapsTest`: attribution
  picks `remote-player-view` over its same-group siblings for
  `androidx/compose/remote/player/view/RemoteComposePlayer`, stays general when it cannot attribute,
  declines `UnsatisfiedLinkError` / `VerifyError`, and does nothing when the classpath was complete.
  New `BundleSplitTest` case for repository propagation.
- `:gradle-plugin:test` — `PreviewBundleFormatTest` v9 round-trip + v8-decodes-empty;
  `RegisterBundleTaskBackendTest` cases for which repositories get recorded.
- `:gradle-plugin:functionalTest --tests BundleFunctionalTest` — 19/19, including a new case that
  declares an androidx.dev repository in settings and asserts a real packed `bundle.json` records
  exactly it (scoped by `content { includeGroup }` to a group nothing resolves, so it is declared
  without ever being consulted). This is also the configuration-cache check on the new task input.
- Full `:cli:test`, `:gradle-plugin:test`, `:bundle-viewer:test` green.
- The snapshot URL shapes were checked against the live androidx.dev repo (literal → 404,
  metadata-resolved → 200), not mocked into existence.

Text-only evidence: nothing here changes rendered output — this is bundle-format, dependency
resolution, and serve-side diagnosis.

## Rollout

This is a two-sided fix and neither side is automatic:

1. The box needs a CLI carrying the resolver change (release → image publish).
2. `remote-m3` needs a **republish** so its bundle carries `repositories` — `cli/` and
   `gradle-plugin/` are excluded from `design-artifacts.yml`'s push trigger, so it needs a manual
   `workflow_dispatch` (or the Monday cron) after the release lands.

Until both, `remote-m3` keeps serving baked PNGs.

One residual, called out rather than hidden: androidx.dev build ids age out after a few weeks. Once
one does, a box that has not already cached those jars cannot resolve them even with the recorded
URL — but the failure now says so instead of naming a class. The producing build hits the same wall
first (the pin has to be bumped to build at all), so a republish carries a live URL forward.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HtgKMGGktAqeMPgC6vKGTs)_