### PR TITLE
fix(design-artifacts): pool the split classpath for wear-m3 and remote-m3

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -581,8 +581,8 @@ jobs:
   # external consumers use), building the CLI from source (cli-source: build) so
   # they still publish HEAD's renderer output. They're Android (Robolectric)
   # renders with no Wasm tier, so they fit the common pipeline; both now carry a
-  # live bundle (full split) — the Robolectric daemon a serve host with the Android
-  # sidecar runs re-renders either. See DESIGN_CATALOGS.md's reference-caller
+  # live bundle (shared-classpath split) — the Robolectric daemon a serve host with
+  # the Android sidecar runs re-renders either. See DESIGN_CATALOGS.md's reference-caller
   # convention.
   # ───────────────────────────────────────────────────────────────────────────
   wear-m3:
@@ -598,10 +598,13 @@ jobs:
       module: 'samples:design-catalog-wear-m3'
       cli-source: build
       # Android Robolectric daemon can re-render Wear, so carry a live bundle and
-      # split it full (each per-preview bundle keeps its re-render classpath).
+      # split it with a SHARED classpath: `classes/app.jar` is published once into
+      # `bundle/res` and each per-preview manifest carries a hash-verified
+      # `externalClasspath`, so the live re-render lane survives without repeating the
+      # carriage once per preview (the growth #4211 measured on m3-catalog).
       publish-live-bundle: true
       split-per-preview: true
-      split-mode: full
+      split-mode: full-shared-classpath
     secrets:
       buildfetch_ro_token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
 
@@ -619,12 +622,14 @@ jobs:
       cli-source: build
       # Remote Compose is an Android/Robolectric catalog, so the same Android
       # daemon that re-renders wear-m3 (on a serve host carrying the Android
-      # sidecar) drives it — carry a live bundle and split it full so each
-      # per-preview bundle keeps its re-render classpath, and the viewer's declared
-      # Remote Compose knobs re-render live via the `rc.<name>=` override.
+      # sidecar) drives it — carry a live bundle and split it with a SHARED classpath
+      # (app.jar once in `bundle/res`, each manifest carrying a hash-verified
+      # `externalClasspath`), so the viewer's declared Remote Compose knobs still
+      # re-render live via the `rc.<name>=` override while the delivery branch stops
+      # growing with the preview count (#4211).
       publish-live-bundle: true
       split-per-preview: true
-      split-mode: full
+      split-mode: full-shared-classpath
       # The embedded (Robolectric) and cmp-jvm (Compose Desktop / Skiko) rc-compare lanes used to be
       # spelled out here; they now default to true in the reusable workflow, so every catalog that
       # ships `ir/<id>.rc` gets them — the rationale (a divergence is only attributable when the same

--- a/scripts/design-artifacts/package-lock.json
+++ b/scripts/design-artifacts/package-lock.json
@@ -8,9 +8,9 @@
       "name": "design-artifacts-driver",
       "version": "0.0.0",
       "dependencies": {
-        "@design-parity/adapter-figma": "^0.1.52",
-        "@design-parity/candidate": "^0.1.52",
-        "@design-parity/catalog-export": "^0.1.52",
+        "@design-parity/adapter-figma": "^0.1.53",
+        "@design-parity/candidate": "^0.1.53",
+        "@design-parity/catalog-export": "^0.1.53",
         "fflate": "^0.8.2",
         "pixelmatch": "^7.0.0",
         "playwright": "^1.49.0",
@@ -21,37 +21,37 @@
       }
     },
     "node_modules/@design-parity/adapter-figma": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.52.tgz",
-      "integrity": "sha512-yOTH9eY8t3P5IfjN6k1ic6+A63caUydJ0cK81gg0dBUYVDzlIAaQZd2U/TySbF8iQlIwJ/AecMxgkaMXjlOU8g==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/@design-parity/adapter-figma/-/adapter-figma-0.1.53.tgz",
+      "integrity": "sha512-idtcpNPTyWPVp/0CmtYs17VcpQ7OwCryg4TG+9fNyRX+AC0wILvHpULLJGQM4Kq3QhfoUD1G/ejWVhWzH6aA/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.52"
+        "@design-parity/core": "^0.1.53"
       }
     },
     "node_modules/@design-parity/candidate": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.52.tgz",
-      "integrity": "sha512-D4F1XNhMSFwccS4qbNG54ASClvByXv53HrTZsUWiZWF2xqfxM6hfY/dfZnqYioalWsNMOCCnh5Bkx8IxSKAbsA==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/@design-parity/candidate/-/candidate-0.1.53.tgz",
+      "integrity": "sha512-+tninhO4o0i+tOP8WR/GLrgTRw21PdM4YwpI+IckmsBoVb1I2mR7l7rYpqjhWRPMKEr4SnElyAQ7rrnZ/qQNSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.52",
+        "@design-parity/core": "^0.1.53",
         "fflate": "0.8.3"
       }
     },
     "node_modules/@design-parity/catalog-export": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.52.tgz",
-      "integrity": "sha512-hrcezomfCoolDWQjLdV41hEfYWefyYerCENjMhpY1xaR6jPVa3DsNkYaaErOW/9Irh2BOUiE+npDRyiqeZAgXg==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/@design-parity/catalog-export/-/catalog-export-0.1.53.tgz",
+      "integrity": "sha512-KndvtZBm7GL6Xqf6BNmznJpvnMYEAikWQYEADQt+N4Ka3P6I3uJ5DqgrZ3EsO3JrzyylaeJuRA/O66KETcvItw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@design-parity/core": "^0.1.52"
+        "@design-parity/core": "^0.1.53"
       }
     },
     "node_modules/@design-parity/core": {
-      "version": "0.1.52",
-      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.52.tgz",
-      "integrity": "sha512-l7qVmqNStyM41/2/opiKJP6Doyj1dWxLJ2ev4rOoDVpa6hryNDsLbFUbZA7mC01PETb1qbaMRnsFPBKL+3wDDQ==",
+      "version": "0.1.53",
+      "resolved": "https://registry.npmjs.org/@design-parity/core/-/core-0.1.53.tgz",
+      "integrity": "sha512-C4+QJeCAdHKLHAiPj/wbbv5yuWfFeEuYtPQsuY+4lKa8QPJ7wvZvh0RvifQSvmF+VLzWXtkrYfT6hjG5WFan6g==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.20.0"

--- a/scripts/design-artifacts/package.json
+++ b/scripts/design-artifacts/package.json
@@ -11,9 +11,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@design-parity/adapter-figma": "^0.1.52",
-    "@design-parity/candidate": "^0.1.52",
-    "@design-parity/catalog-export": "^0.1.52",
+    "@design-parity/adapter-figma": "^0.1.53",
+    "@design-parity/candidate": "^0.1.53",
+    "@design-parity/catalog-export": "^0.1.53",
     "fflate": "^0.8.2",
     "pixelmatch": "^7.0.0",
     "playwright": "^1.49.0",


### PR DESCRIPTION
## Summary

Two things, both in the design-artifacts lane:

1. **`wear-m3` and `remote-m3` move from `split-mode: full` to `full-shared-classpath`.** They were the last two reference callers still taking the self-contained split. A `full` split copies `classes/app.jar` into every per-preview bundle, so the delivery branch is a function of the **preview count**, not of the backend — and because any catalog edit rewrites `app.jar`, each publish re-writes all N copies and lays down a fresh git delta chain (#4211, the growth that took m3-catalog to a 2.52 GiB clone). `full-shared-classpath` publishes `app.jar` once into `bundle/res/<sha256>` and records a hash-verified `externalClasspath` in each split manifest instead.

   The live lane is unchanged: a trusted serve host fetches and verifies the pooled JAR once, restores it into a cached copy of each requested bundle, and starts the Robolectric daemon from that self-contained copy. What it gives up is offline execution of a bare per-preview download, which is documented in `docs/portable-bundles.md` ("Shared per-preview classpath") and is not how these two catalogs are consumed.

   The repo's own `generate` job (compose-m3 and friends) already splits `full-shared-classpath`; this brings the two reusable-workflow callers in line, so nothing in this repo publishes a repeated carriage any more.

2. **The export driver moves to design-parity 0.1.53** (`@design-parity/adapter-figma`, `candidate`, `catalog-export`), the current release — `scripts/design-artifacts/package.json` was at `^0.1.52` with the lock resolved to 0.1.52.

This is the upstream half of a coordinated bump; the eleven consumer repos get compose-ai-tools 1.21.0 and the same shared-classpath split mode in their own PRs.

## Test plan

- `npm install --package-lock-only` in `scripts/design-artifacts/` refreshed the lock to the 0.1.53 tree (`adapter-figma`, `candidate`, `catalog-export`, `core` all resolve to 0.1.53).
- Both edited workflow files parse as YAML.
- `--shared-classpath-out` has been in the CLI since 0.19.58 (#3641), so neither caller needs a CLI floor raise; both build the CLI from source (`cli-source: build`).
- No renderer, plugin or CLI code changed, so there is no rendered output to diff — this is workflow/publish plumbing. The actual effect (pooled `bundle/res` + `externalClasspath` in each split manifest) shows up on the next `design-artifacts/wear-m3` and `design-artifacts/remote-m3` regeneration, which this workflow's push-to-`main` trigger fires on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnmjyjLcncon6w4YXSma75)_