### PR TITLE
fix(serve): stop a shut idle gate from parking theme optimisation forever

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -71,6 +71,16 @@ data class ThemeOptimizationSnapshot(
   val turnsGranted: Int = 0,
   val turnsYielded: Int = 0,
   /**
+   * Turns the *ceiling* granted because the gate had withheld one for too long, counted inside
+   * [turnsGranted].
+   *
+   * A number climbing here says the box never looks quiet to the optimizer and the only progress it
+   * makes is the forced kind — which is a working cache and a broken gate, not a healthy server. On
+   * a box whose idle clock is pinned by a leaked session lease this is the *only* counter that
+   * would ever move.
+   */
+  val turnsForced: Int = 0,
+  /**
    * Daemons that actually rendered **concurrently** in the last batch, and the most so far.
    *
    * Deliberately not the batch's job count. The optimizer submits N jobs to an executor and the
@@ -209,6 +219,7 @@ class CatalogThemeCache(
   private val permitWaitMillis = AtomicLong(0)
   private val turnsGranted = java.util.concurrent.atomic.AtomicInteger(0)
   private val turnsYielded = java.util.concurrent.atomic.AtomicInteger(0)
+  private val turnsForced = java.util.concurrent.atomic.AtomicInteger(0)
   private val lastBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
   private val maxBatchWidth = java.util.concurrent.atomic.AtomicInteger(0)
   // Entries the OPTIMIZER produced. The rate's denominator is optimizer time, so its numerator has
@@ -224,6 +235,15 @@ class CatalogThemeCache(
   /** Traffic took the turn back. */
   fun recordTurnYielded() {
     turnsYielded.incrementAndGet()
+  }
+
+  /**
+   * The ceiling granted a turn the gate would not have. Counted in [recordTurnGranted] too, so
+   * `turnsGranted` stays the total and this is the slice of it the box never actually offered.
+   */
+  fun recordTurnForced() {
+    turnsForced.incrementAndGet()
+    turnsGranted.incrementAndGet()
   }
 
   /** Wall-clock the idle gate withheld a turn because the box looked busy. */
@@ -605,6 +625,7 @@ class CatalogThemeCache(
       permitWaitMillis = permitWait,
       turnsGranted = turnsGranted.get(),
       turnsYielded = turnsYielded.get(),
+      turnsForced = turnsForced.get(),
       lastBatchWidth = lastBatchWidth.get(),
       maxBatchWidth = maxBatchWidth.get(),
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -94,6 +94,21 @@ class ServeBackgroundWork(
   private val optimizerHostRefusals = AtomicLong()
 
   /**
+   * The clocks [idleClock] handed out, retained so [optimizerAdmissionSnapshot] can publish the
+   * value the optimizer's quiet gate actually reads.
+   *
+   * Every counter on `/status.json` described what the optimizer was doing *after* it got a turn,
+   * and none described the input that decides whether it ever gets one. A box where the gate never
+   * opens therefore reports the same all-zero row as a box with nothing left to do — which is how a
+   * server ran for hours with `turnsGranted 0` on all 23 catalogs and no page saying why.
+   * [publishedRequestIdleClock] is kept alongside the composed one so the null can be attributed: a
+   * held session lease and a catalog load are both "busy" to the gate and have nothing else in
+   * common.
+   */
+  @Volatile private var publishedIdleClock: (() -> Long?)? = null
+  @Volatile private var publishedRequestIdleClock: (() -> Long?)? = null
+
+  /**
    * True while the server is bringing catalogs up: the startup pass hasn't finished, or a refresh /
    * admin registration is fetching one right now. Background work treats this as "busy" even though
    * no visitor is waiting, because a catalog that loads slowly enough loses its live lane.
@@ -132,7 +147,15 @@ class ServeBackgroundWork(
    * clock restarts at zero when startup, refresh, or admin registration finishes. The catalog host
    * applies its quiet-window threshold to the smaller of this and request/render idleness.
    */
-  fun idleClock(idleMillis: () -> Long?): () -> Long? = {
+  fun idleClock(idleMillis: () -> Long?): () -> Long? =
+    composeIdleClock(idleMillis).also {
+      // Every catalog host asks for one and they all wrap the same registry, so last-wins is the
+      // same clock each time. Retained purely so status can read it; nothing here drives behaviour.
+      publishedRequestIdleClock = idleMillis
+      publishedIdleClock = it
+    }
+
+  private fun composeIdleClock(idleMillis: () -> Long?): () -> Long? = {
     if (catalogsLoading) {
       null
     } else {
@@ -341,6 +364,15 @@ class ServeBackgroundWork(
         unlock()
       }
     }
+    // Read the composed clock ONCE; the attribution below re-reads the request side only when it
+    // has already answered "busy", so the two can never contradict each other in the same row.
+    val serverIdle = publishedIdleClock?.invoke()
+    val idleBlockedBy =
+      when {
+        publishedIdleClock == null || serverIdle != null -> null
+        publishedRequestIdleClock?.invoke() == null -> IDLE_BLOCKED_BY_SESSION_LEASE
+        else -> IDLE_BLOCKED_BY_CATALOG_LOAD
+      }
     return ThemeOptimizerAdmissionSnapshot(
       lanes = optimizerLanes,
       running = optimizerRunning.values.sumOf(AtomicInteger::get),
@@ -360,6 +392,9 @@ class ServeBackgroundWork(
           else -> null
         },
       pressure = pressure,
+      serverIdleMillis = serverIdle,
+      idleBlockedBy = idleBlockedBy,
+      idleThresholdMillis = ServeCatalogLiveHost.themeOptimizationIdleMillisDefault(),
     )
   }
 
@@ -396,6 +431,12 @@ class ServeBackgroundWork(
 
     /** Pause reasons are bounded before they reach a status page. */
     const val MAX_PAUSE_REASON_CHARS: Int = 200
+
+    /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: a session holds an open lease. */
+    const val IDLE_BLOCKED_BY_SESSION_LEASE: String = "session-lease"
+
+    /** [ThemeOptimizerAdmissionSnapshot.idleBlockedBy]: catalogs are still loading. */
+    const val IDLE_BLOCKED_BY_CATALOG_LOAD: String = "catalog-load"
 
     /** Widest lane [renderLaneFor] will derive on its own. Beyond this, ask for it explicitly. */
     const val MAX_DERIVED_CONCURRENT_RENDERS: Int = 3
@@ -470,4 +511,27 @@ data class ThemeOptimizerAdmissionSnapshot(
   val pausedUntilEpochMillis: Long? = null,
   val pauseReason: String? = null,
   val pressure: OptimizerPressureSnapshot? = null,
+  /**
+   * The whole-server idle clock the optimizer's quiet gate reads, or null when it reads *busy*.
+   *
+   * This is the gate's input, and until it was published nothing on the page distinguished "the box
+   * is never quiet enough to start" from "there is nothing left to do": both showed a pass that had
+   * rendered nothing. Compare against [idleThresholdMillis] — a number consistently below it, or a
+   * persistent null, means no catalog will ever be granted a turn, whatever [lanes], [admissions]
+   * and [paused] say.
+   */
+  val serverIdleMillis: Long? = null,
+  /**
+   * Why [serverIdleMillis] is null, when it is: [IDLE_BLOCKED_BY_SESSION_LEASE] (a session holds an
+   * open lease — `daemons.leasedSessions` names it) or [IDLE_BLOCKED_BY_CATALOG_LOAD] (catalogs are
+   * still being fetched). Null when the clock is running, or before any catalog host has asked for
+   * one.
+   *
+   * The two have opposite fixes and are indistinguishable from the outside: a lease that outlives
+   * its request is a bug that stands the optimizer down permanently, while a catalog load is the
+   * gate working as designed.
+   */
+  val idleBlockedBy: String? = null,
+  /** Quiet [serverIdleMillis] must reach before a cold pass may start. */
+  val idleThresholdMillis: Long = 0,
 )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -125,6 +125,11 @@ class ServeCatalogLiveHost(
   private val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
   private val themeOptimizationIdleMillis: Long = themeOptimizationIdleMillisDefault(),
   /**
+   * How long the idle gate may withhold a turn before one is granted anyway — see
+   * [grantForcedTurn]. Non-positive disables the ceiling and restores the pure gate.
+   */
+  private val optimizerGateCeilingMillis: Long = optimizerGateCeilingMillisDefault(),
+  /**
    * How long one admitted pass may hold its optimizer lane before giving it back and re-queueing.
    *
    * The knob trades **rotation latency against re-warming**. A slice shorter than a cold daemon
@@ -247,6 +252,14 @@ class ServeCatalogLiveHost(
   // When the optimizer last checked for activity. Any activity newer than this happened while it
   // was rendering, and must cost it the turn even if the server looks quiet again by now.
   private val optimizerSampledAt = java.util.concurrent.atomic.AtomicLong(0)
+  /**
+   * When the gate started withholding a turn, or [Long.MIN_VALUE] while it isn't — the clock the
+   * ceiling in [grantForcedTurn] measures. Reset the moment a turn is granted, by either route, so
+   * it always reads "how long has this catalog been shut out *right now*".
+   */
+  private val optimizerGateBlockedSince = java.util.concurrent.atomic.AtomicLong(Long.MIN_VALUE)
+  /** Set while the pass is running on a turn the ceiling forced rather than the box granting. */
+  private val optimizerTurnForced = AtomicBoolean(false)
   /**
    * Next preview position for a new optimizer slice; prevents an evicted prefix monopolising it.
    */
@@ -524,12 +537,26 @@ class ServeCatalogLiveHost(
         // freshly-stamped `lastRanAt` puts it behind everyone still waiting, so the next slice goes
         // to them and this catalog resumes once they have had theirs.
         while (true) {
+          // **The gate is waited out BEFORE a lane is taken, not inside one.** Waiting inside
+          // converts "the box is busy" into "two catalogs own both lanes indefinitely": the quiet
+          // wait blocks until the server goes quiet, and on a box that never does — one held
+          // session lease is enough, since the registry's idle clock then answers busy outright —
+          // the two admitted passes park on their lanes forever while every other catalog is
+          // refused every 20s. Measured on the deployed server: 2 lanes held for the whole 3h
+          // uptime, 16 catalogs queued behind them, 8,052 refusals, `turnsGranted 0` everywhere.
+          // A pass parked at the gate holding nothing costs a sleeping thread; parked on a lane it
+          // costs every other catalog its turn.
+          if (!awaitOptimizerTurn()) {
+            catalogThemeCache.markPaused()
+            if (!awaitOptimizerResume()) return@execute
+            continue
+          }
           val outcome =
             backgroundWork.withOptimizerSlot(label, optimizerAdmissionWaitMillis) {
-              // Inside the lane and behind the idle gate, so the sample's renders are admitted on
+              // Holding the turn established above, so the sample's renders are admitted on
               // exactly the terms every other background render is. Cheap and once per host: a
               // no-op when nothing was adopted from disk.
-              if (!persistenceVerified.get() && awaitOptimizerTurn()) verifyPersistedRenders(jobs)
+              if (!persistenceVerified.get()) verifyPersistedRenders(jobs)
               if (catalogThemeCache.snapshot().fullyOptimized) PassOutcome.FINISHED
               else runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
             }
@@ -542,9 +569,12 @@ class ServeCatalogLiveHost(
             if (!awaitOptimizerResume()) return@execute
             continue
           }
-          // Anything other than a spent slice is the pass deciding it is done for now — finished,
-          // gated, paused or breakered — and re-queueing on those would spin.
-          if (outcome != PassOutcome.SLICE_SPENT) return@execute
+          // A spent slice re-queues, and so does a pass the gate took the turn back from — that
+          // one used to exit and wait for a visitor heartbeat, on the reasoning that re-queueing
+          // would spin. It no longer can: the loop's next stop is the quiet gate above, which
+          // parks until the box is actually quiet. Anything else — finished, breakered,
+          // interrupted — is the pass deciding it is done for now.
+          if (outcome != PassOutcome.SLICE_SPENT && outcome != PassOutcome.GATED) return@execute
         }
       } finally {
         optimizationActive.set(false)
@@ -625,12 +655,21 @@ class ServeCatalogLiveHost(
     }
   }
 
-  /** Why an optimizer pass returned; only [SLICE_SPENT] asks for another lane. */
+  /** Why an optimizer pass returned; [SLICE_SPENT] and [GATED] ask for another lane. */
   private enum class PassOutcome {
     /** Every target this pass could see is cached — nothing left to re-queue for. */
     FINISHED,
-    /** The idle gate, a pause, or the render breaker stopped the pass. */
+    /** The render breaker or a shutdown interrupt stopped the pass. */
     STOPPED,
+    /**
+     * Traffic took the turn back and it did not come back inside [OPTIMIZER_RESUME_WAIT_MILLIS], so
+     * the pass returned its lane rather than idling on one.
+     *
+     * Distinct from [STOPPED] because the two want opposite things from the caller: a breakered
+     * pass must not re-queue (nothing it renders can succeed), while a gated one must, or the
+     * catalog is stranded until a visitor's heartbeat happens to revive it.
+     */
+    GATED,
     /** The lane slice ran out with work remaining. */
     SLICE_SPENT,
   }
@@ -690,7 +729,7 @@ class ServeCatalogLiveHost(
       // cold daemon, which is the single most expensive thing this pass can do to a box that is
       // still loading catalogs or serving traffic — exactly what the idle gate exists to
       // prevent. Warming ahead of it let every catalog host kick off a cold start at prewarm.
-      if (!awaitOptimizerTurn()) return PassOutcome.STOPPED
+      if (!awaitOptimizerTurn()) return gateStopOutcome()
       val previewDaemonId = alias[previewId]
       // Await a cold warm ONCE per preview rather than letting each theme rediscover it. The
       // old per-job loop spent retry budget on this; here it is a precondition of the batch.
@@ -711,7 +750,7 @@ class ServeCatalogLiveHost(
         // Checked per batch, and a batch is bounded by ONE render — so a visitor arriving mid
         // batch still waits at most a render, which is the guarantee the old per-render permit
         // was expressing.
-        if (!awaitOptimizerTurn()) return PassOutcome.STOPPED
+        if (!awaitOptimizerTurn()) return gateStopOutcome()
         val batch =
           previewJobs.subList(index, minOf(index + optimizerBatchWidth(), previewJobs.size))
         index += batch.size
@@ -784,6 +823,14 @@ class ServeCatalogLiveHost(
             else -> catalogThemeCache.markFailed(job.cacheKey)
           }
         }
+      }
+      // A turn the ceiling forced buys exactly this one preview. Hand the lane back rather than
+      // carrying a turn the box never actually granted into the next one — the ceiling exists so a
+      // permanently-shut gate still makes progress, not so it stops being a gate.
+      if (optimizerTurnForced.compareAndSet(true, false)) {
+        optimizerHasTurn.set(false)
+        catalogThemeCache.markPaused()
+        return PassOutcome.SLICE_SPENT
       }
     }
     catalogThemeCache.markPassFinished(clock())
@@ -869,7 +916,8 @@ class ServeCatalogLiveHost(
     }
     if (!optimizerHasTurn.get()) {
       // The wait is charged inside [awaitQuiet], per poll — see there for why charging it here,
-      // on the way out, was the wrong place.
+      // on the way out, was the wrong place. Unbounded, deliberately: this call holds no lane, so
+      // a pass parked here costs a sleeping thread and nothing else.
       val granted = awaitServerIdle()
       if (!granted) return false
       catalogThemeCache.recordTurnGranted()
@@ -877,6 +925,10 @@ class ServeCatalogLiveHost(
       optimizerSampledAt.set(clock())
       return true
     }
+    // A forced turn is not re-examined against traffic: the ceiling granted it precisely because
+    // the box never looks quiet, so asking again would take it straight back. It lasts one preview
+    // — see where [optimizerTurnForced] is cleared.
+    if (optimizerTurnForced.get()) return true
     // Holding a turn. The question is NOT "is the server idle right this instant" — sampling that
     // misses every request that arrived *during* the render we just finished. A render can outlast
     // OPTIMIZER_YIELD_MILLIS several times over, so by the time we look, a visitor's request has
@@ -901,7 +953,12 @@ class ServeCatalogLiveHost(
     // left is "has the visitor who just interrupted me finished?". Charging the full entry window
     // per interruption is what capped throughput: at a ~50% yield rate a 60s re-entry averages
     // ~30s/entry against a sub-second render, i.e. ~97% waiting.
-    return awaitQuiet(OPTIMIZER_RESUME_MILLIS).also {
+    //
+    // **Bounded, unlike the cold entry above**, because this one waits with a lane in hand. A pass
+    // that cannot get its turn back inside [OPTIMIZER_RESUME_WAIT_MILLIS] gives the lane up and
+    // re-parks at the cold gate, where waiting is free; holding it while the box stays busy is how
+    // two catalogs came to own both lanes for three hours.
+    return awaitQuiet(OPTIMIZER_RESUME_MILLIS, maxWaitMillis = OPTIMIZER_RESUME_WAIT_MILLIS).also {
       if (it) {
         // A resume IS a grant. Counting only cold entries made yields exceed grants after any
         // interrupted pass, which reads as the gate losing turns it never handed out.
@@ -911,6 +968,17 @@ class ServeCatalogLiveHost(
       }
     }
   }
+
+  /**
+   * Why a mid-pass [awaitOptimizerTurn] returned false: a shutdown interrupt, or the gate simply
+   * not reopening in time.
+   *
+   * They differ in what the caller should do next — [PassOutcome.STOPPED] ends the worker,
+   * [PassOutcome.GATED] sends it back to the cold gate to wait without a lane — and conflating them
+   * is what left a gated catalog stranded until a visitor's heartbeat revived it.
+   */
+  private fun gateStopOutcome(): PassOutcome =
+    if (Thread.currentThread().isInterrupted) PassOutcome.STOPPED else PassOutcome.GATED
 
   private fun awaitServerIdle(): Boolean = awaitQuiet(themeOptimizationIdleMillis)
 
@@ -927,18 +995,58 @@ class ServeCatalogLiveHost(
    * Accruing as we wait makes an unopened gate visible while it is still unopened, which is the
    * only time the reading is any use.
    */
-  private fun awaitQuiet(quietMillis: Long): Boolean {
+  private fun awaitQuiet(quietMillis: Long, maxWaitMillis: Long = Long.MAX_VALUE): Boolean {
     val pollMillis = quietMillis.coerceAtMost(1_000L).coerceAtLeast(50L) / 2
+    val startedAt = clock()
+    optimizerGateBlockedSince.compareAndSet(Long.MIN_VALUE, startedAt)
     while (true) {
       if (!awaitOptimizerResume()) return false
       val idleMillis = serverIdleMillis()
-      if (idleMillis != null && idleMillis >= quietMillis) return true
+      if (idleMillis != null && idleMillis >= quietMillis) {
+        optimizerGateBlockedSince.set(Long.MIN_VALUE)
+        return true
+      }
+      if (grantForcedTurn()) return true
+      if (clock() - startedAt >= maxWaitMillis) return false
       catalogThemeCache.markPaused()
       val polledFrom = clock()
       val slept = pauseOptimization(pollMillis)
       catalogThemeCache.recordGateWait(clock() - polledFrom)
       if (!slept) return false
     }
+  }
+
+  /**
+   * The ceiling: once the gate has withheld a turn for [optimizerGateCeilingMillis] without
+   * interruption, grant one anyway.
+   *
+   * **A gate that can close permanently is indistinguishable from the feature being off**, and this
+   * one can: the quiet window is measured from `ServeSessionRegistry.idleMillis()`, which answers
+   * *busy* outright — not a large number, but `null` — while any session holds an open lease. One
+   * long-lived WebSocket, or one lease leaked by a request cancelled mid-flight, and no amount of
+   * waiting will ever satisfy the window. The deployed server sat in exactly that state for its
+   * whole uptime: 23 catalogs, `turnsGranted 0`, 1 of 17,914 entries cached.
+   *
+   * The grant is deliberately small and self-limiting — one preview, then back to the gate (see
+   * [optimizerTurnForced]) — so a genuinely busy box pays one preview per ceiling period per
+   * catalog rather than losing the politeness the gate exists for.
+   *
+   * Two things it will **not** override, because both are correct refusals rather than a stuck
+   * clock: a pause (manual or pressure), which [awaitOptimizerResume] has already blocked on above,
+   * and catalog loading — a slow daemon start there is recorded as `livebundle-unavailable` and
+   * degrades that catalog to baked PNGs for the life of the process, which is a far worse outcome
+   * than a cold theme cache.
+   */
+  private fun grantForcedTurn(): Boolean {
+    if (optimizerGateCeilingMillis <= 0 || backgroundWork.catalogsLoading) return false
+    val blockedSince = optimizerGateBlockedSince.get()
+    if (blockedSince == Long.MIN_VALUE || clock() - blockedSince < optimizerGateCeilingMillis) {
+      return false
+    }
+    optimizerGateBlockedSince.set(Long.MIN_VALUE)
+    optimizerTurnForced.set(true)
+    catalogThemeCache.recordTurnForced()
+    return true
   }
 
   /** Park an unfinished optimizer through a timed/manual pause, stopping only for shutdown. */
@@ -1661,6 +1769,32 @@ class ServeCatalogLiveHost(
      * resume could immediately re-detect the activity it just waited out and livelock.
      */
     internal const val OPTIMIZER_RESUME_MILLIS = 2_000L
+
+    /**
+     * How long a pass that has yielded will wait, **holding its lane**, for the box to go quiet
+     * again before giving the lane back.
+     *
+     * The trade is re-warming against lane occupancy. Shorter than a cold daemon start (34-68s on
+     * an Android/Robolectric lane) and a pass keeps throwing away warms it has just paid for;
+     * unbounded — which is what this was — and a box that never goes quiet has its lanes held by
+     * the first passes to take them, permanently. Thirty seconds rides out an ordinary browse
+     * without re-warming, while a box that is busy for minutes rotates its lanes instead of
+     * freezing them.
+     */
+    internal const val OPTIMIZER_RESUME_WAIT_MILLIS = 30_000L
+
+    /**
+     * Default ceiling on how long the idle gate may withhold a turn — see [grantForcedTurn] for why
+     * a gate with no ceiling is a gate that can turn the feature off.
+     *
+     * Ten minutes, and the cost of being wrong is bounded by the grant's size rather than by this
+     * number: a forced turn buys ONE preview. A 23-catalog box that never goes quiet therefore
+     * spends 23 previews per ten minutes on background work — still behind the render permit and
+     * the two-lane cap — against a cache that otherwise never fills at all.
+     */
+    internal fun optimizerGateCeilingMillisDefault(): Long =
+      System.getProperty("composeai.serve.themeOptimizationGateCeilingMillis")?.toLongOrNull()
+        ?: (10 * 60_000L)
 
     /**
      * Ceiling on prefetch batch width. Matches the replica pool's own capacity, so the batch can

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -123,8 +123,7 @@ class ServeCatalogLiveHost(
    * [ServeBackgroundWork].
    */
   private val backgroundWork: ServeBackgroundWork = ServeBackgroundWork(),
-  private val themeOptimizationIdleMillis: Long =
-    System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L,
+  private val themeOptimizationIdleMillis: Long = themeOptimizationIdleMillisDefault(),
   /**
    * How long one admitted pass may hold its optimizer lane before giving it back and re-queueing.
    *
@@ -869,9 +868,9 @@ class ServeCatalogLiveHost(
       return false
     }
     if (!optimizerHasTurn.get()) {
-      val waitedFrom = clock()
+      // The wait is charged inside [awaitQuiet], per poll — see there for why charging it here,
+      // on the way out, was the wrong place.
       val granted = awaitServerIdle()
-      catalogThemeCache.recordGateWait(clock() - waitedFrom)
       if (!granted) return false
       catalogThemeCache.recordTurnGranted()
       optimizerHasTurn.set(true)
@@ -896,7 +895,6 @@ class ServeCatalogLiveHost(
     optimizerHasTurn.set(false)
     catalogThemeCache.recordTurnYielded()
     catalogThemeCache.markPaused()
-    val resumeFrom = clock()
     // Re-enter on the SHORT window, not the full entry one. [themeOptimizationIdleMillis] answers
     // "may I start work on a box someone might be using?" — a cold-start question, asked once. Once
     // the pass has been running, the box has already proved it goes quiet, and the only question
@@ -904,7 +902,6 @@ class ServeCatalogLiveHost(
     // per interruption is what capped throughput: at a ~50% yield rate a 60s re-entry averages
     // ~30s/entry against a sub-second render, i.e. ~97% waiting.
     return awaitQuiet(OPTIMIZER_RESUME_MILLIS).also {
-      catalogThemeCache.recordGateWait(clock() - resumeFrom)
       if (it) {
         // A resume IS a grant. Counting only cold entries made yields exceed grants after any
         // interrupted pass, which reads as the gate losing turns it never handed out.
@@ -921,6 +918,14 @@ class ServeCatalogLiveHost(
    * Block until the server has been untouched for [quietMillis]. Polls at a fraction of the window
    * so a short resume window is not rounded up to a full second of dead time — a 1s poll against a
    * 1.5s window would put the floor back where it started.
+   *
+   * **The gate wait is charged here, per poll, not by the caller once this returns.** Charging on
+   * the way out means a pass still waiting has spent, as far as `/status` is concerned, no time at
+   * the gate — so the one counter that names a closed gate reads `gateWaitMillis: 0`, which is also
+   * what a pass that sailed straight through reports. A box whose gate had never opened once in
+   * three hours published an all-zero optimizer row on every catalog and looked idle by choice.
+   * Accruing as we wait makes an unopened gate visible while it is still unopened, which is the
+   * only time the reading is any use.
    */
   private fun awaitQuiet(quietMillis: Long): Boolean {
     val pollMillis = quietMillis.coerceAtMost(1_000L).coerceAtLeast(50L) / 2
@@ -929,7 +934,10 @@ class ServeCatalogLiveHost(
       val idleMillis = serverIdleMillis()
       if (idleMillis != null && idleMillis >= quietMillis) return true
       catalogThemeCache.markPaused()
-      if (!pauseOptimization(pollMillis)) return false
+      val polledFrom = clock()
+      val slept = pauseOptimization(pollMillis)
+      catalogThemeCache.recordGateWait(clock() - polledFrom)
+      if (!slept) return false
     }
   }
 
@@ -1627,6 +1635,17 @@ class ServeCatalogLiveHost(
      * next presence heartbeat.
      */
     internal const val OPTIMIZER_ADMISSION_WAIT_MILLIS = 20_000L
+
+    /**
+     * Whole-server quiet the idle gate requires before a cold pass may start.
+     *
+     * Read through a function rather than held in a `val` so the system property is still honoured
+     * when it is set after this class loads, and so [ServeBackgroundWork] can publish the same
+     * number on `/status.json` without restating the default. A gate whose threshold is invisible
+     * is one nobody can tell from a gate that is simply never reached.
+     */
+    internal fun themeOptimizationIdleMillisDefault(): Long =
+      System.getProperty("composeai.serve.themeOptimizationIdleMillis")?.toLongOrNull() ?: 60_000L
 
     /** Default lane slice — see the `optimizerSliceMillis` constructor parameter for the trade. */
     internal const val DEFAULT_OPTIMIZER_SLICE_MILLIS = 5 * 60_000L

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4248,6 +4248,23 @@ class ServeHttpServer(
     /** Live daemons (a render daemon is up), excluding pinned static baked hosts. */
     val liveDaemons: List<ServeSessionRegistry.RunningDaemon> = running.filter { it.hasLiveStream }
     val activeStreams: Int = liveDaemons.sumOf { it.activeStreams }
+
+    /**
+     * Cross-catalog optimizer admission, taken once and shared by the JSON and HTML projections so
+     * the two cannot disagree about the same instant. Whole-box only: the counters are server-wide
+     * and a single-system site has no business reading them.
+     */
+    val optimizerAdmission: ThemeOptimizerAdmissionSnapshot? =
+      if (onlySystem == null) themeOptimizerStats?.invoke() else null
+
+    /**
+     * Sessions holding an open lease — the reason the server-wide idle clock can read *busy* on a
+     * box serving nothing. Scoped like `knownSessions`: a top-level site names only its own.
+     */
+    val leasedSessions: List<String> =
+      sessions.leasedSessions().let { held ->
+        if (onlySystem == null) held else held.filter { it == onlySystem }
+      }
     val openRenderBreakerCount: Int = running.count { it.renderStats?.breaker?.open == true }
     val currentLiveRenderFailureCount: Int = running.count {
       it.renderStats?.let { stats -> stats.breaker?.open != true && stats.lastRenderFailed } == true
@@ -4263,6 +4280,37 @@ class ServeHttpServer(
 
     private fun countLabel(count: Int, singular: String): String =
       "$count $singular${if (count == 1) "" else "s"}"
+
+    /**
+     * One line saying whether the theme optimizer's quiet gate is open, and what is holding it shut
+     * when it isn't.
+     *
+     * Worth a row of its own because a shut gate is otherwise indistinguishable from an idle one:
+     * every catalog reports `theme optimization paused` either way, and the counters that would
+     * separate them are server-wide, not per-catalog. The threshold is printed beside the reading
+     * so "closed" always comes with the number it was compared against.
+     */
+    private fun optimizerGateText(admission: ThemeOptimizerAdmissionSnapshot): String {
+      val needs = "needs ${admission.idleThresholdMillis / 1000}s quiet"
+      if (admission.paused) {
+        return "paused" + (admission.pauseReason?.let { " · $it" } ?: "")
+      }
+      val idle =
+        admission.serverIdleMillis
+          ?: run {
+            val why =
+              when (admission.idleBlockedBy) {
+                ServeBackgroundWork.IDLE_BLOCKED_BY_SESSION_LEASE ->
+                  if (leasedSessions.isEmpty()) "session lease held"
+                  else "session lease held by ${leasedSessions.joinToString(", ")}"
+                ServeBackgroundWork.IDLE_BLOCKED_BY_CATALOG_LOAD -> "catalogs loading"
+                else -> "server busy"
+              }
+            return "closed · $why · $needs"
+          }
+      val open = idle >= admission.idleThresholdMillis
+      return "${if (open) "open" else "closed"} · idle ${idle / 1000}s · $needs"
+    }
 
     fun toResponse(): StatusResponse =
       StatusResponse(
@@ -4297,6 +4345,7 @@ class ServeHttpServer(
               if (liveSeats.unbounded) -1 else liveSeats.perPreviewPermitsAvailable(),
             liveSeatRefusals = liveSeats.refusalCount(),
             liveSeatRefusalsUnverified = liveSeats.unverifiedRefusalCount(),
+            leasedSessions = leasedSessions,
           ),
         config =
           ConfigDto(
@@ -4361,7 +4410,7 @@ class ServeHttpServer(
         branchFetch = if (onlySystem == null) branchFetchStats?.invoke() else null,
         // Box-wide and unattributed per system, so scoped out on a site host for the same reason
         // the branch counters are.
-        themeOptimizer = if (onlySystem == null) themeOptimizerStats?.invoke() else null,
+        themeOptimizer = optimizerAdmission,
         themeCache = if (onlySystem == null) themeCacheStats?.invoke() else null,
         renderStats =
           RenderPerfSnapshot.aggregate(
@@ -4487,6 +4536,12 @@ class ServeHttpServer(
         )
         add(ServeWeb.Stat("Live daemons running", liveDaemons.size.toString()))
         add(ServeWeb.Stat("Active streams", activeStreams.toString()))
+        // The optimizer's *input*, next to the counters that describe its output. Every per-catalog
+        // row already says "theme optimization paused"; none of them says whether that is the box
+        // choosing to be polite or a gate that will never open, and those need different fixes.
+        optimizerAdmission?.let {
+          add(ServeWeb.Stat("Theme optimiser gate", optimizerGateText(it)))
+        }
         add(
           ServeWeb.Stat(
             "Live seats",
@@ -7713,6 +7768,15 @@ private data class DaemonSummaryDto(
    * first-request demand.
    */
   val liveSeatRefusalsUnverified: Long = 0,
+  /**
+   * Sessions holding an open lease — see [ServeSessionRegistry.leasedSessions].
+   *
+   * Non-empty means the server-wide idle clock reads *busy* whatever the render counters say, which
+   * is the state that silently stands the theme optimizer down. Normally this is short-lived (a
+   * WebSocket, an in-flight asset fetch); an entry that persists across polls on a box serving no
+   * traffic is a leaked lease.
+   */
+  val leasedSessions: List<String> = emptyList(),
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -392,6 +392,22 @@ class ServeSessionRegistry(
   }
 
   /**
+   * Session ids holding at least one open lease, sorted — i.e. exactly the set that makes
+   * [idleMillis] answer `null`.
+   *
+   * Published on `/status.json` because a busy answer with nothing to attribute it to is not
+   * diagnosable from outside the process, and everything downstream of the idle clock (the theme
+   * optimizer's quiet gate, the `--exit-when-idle` watchdog) then looks broken for no visible
+   * reason. A lease is released in a `finally`, but a request cancelled mid-flight can still leak
+   * one — see `withLeasedSessionOrNull` — and a single leaked lease pins the whole server as busy
+   * for the life of the process. This names the holder so that failure is a one-line read rather
+   * than an inference.
+   */
+  fun leasedSessions(): List<String> = lock.withLock {
+    sessions.entries.filter { it.value.leases > 0 }.map { it.key }.sorted()
+  }
+
+  /**
    * Suspend (close the daemon of, keep the state of) resident sessions idle past the timeout.
    *
    * The [suspendListeners] notification and the host `close()` both run **after** the lock is

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -210,4 +210,74 @@ class ServeBackgroundWorkTest {
     release.countDown()
     holder.join(5_000)
   }
+
+  /**
+   * The gate's *input*, published so a closed gate is diagnosable from `/status.json`.
+   *
+   * A box whose optimizer never ran reported the same all-zero row as one with nothing left to do,
+   * because every counter described what a pass did after it was granted a turn and none described
+   * whether a turn was ever available. These three fields are that missing read.
+   */
+  @Test
+  fun `the admission snapshot publishes the idle clock the quiet gate reads`() {
+    var now = 100_000L
+    var requestIdle: Long? = 90_000L
+    val work = ServeBackgroundWork(clock = { now })
+    work.initialCatalogLoadFinished()
+    work.idleClock { requestIdle }
+
+    val running = work.optimizerAdmissionSnapshot()
+    assertEquals(0L, running.serverIdleMillis, "the load just finished, so the catalog clock is 0")
+    assertNull(running.idleBlockedBy)
+    assertEquals(
+      ServeCatalogLiveHost.themeOptimizationIdleMillisDefault(),
+      running.idleThresholdMillis,
+      "the threshold travels with the reading, so `closed` names what it was compared against",
+    )
+
+    now += 120_000
+    assertEquals(90_000L, work.optimizerAdmissionSnapshot().serverIdleMillis)
+  }
+
+  @Test
+  fun `a held session lease is named as the reason the idle clock reads busy`() {
+    val work = ServeBackgroundWork(clock = { 100_000L })
+    work.initialCatalogLoadFinished()
+    // Null from the registry means "a session holds an open lease" — the state that stands the
+    // optimizer down for the life of the process when the lease is leaked.
+    work.idleClock { null }
+
+    val snapshot = work.optimizerAdmissionSnapshot()
+
+    assertNull(snapshot.serverIdleMillis)
+    assertEquals(ServeBackgroundWork.IDLE_BLOCKED_BY_SESSION_LEASE, snapshot.idleBlockedBy)
+  }
+
+  @Test
+  fun `catalog loading is distinguished from a lease as the reason for a busy clock`() {
+    val work = ServeBackgroundWork(clock = { 100_000L })
+    work.idleClock { 90_000L }
+    work.expectInitialCatalogLoad()
+
+    val loading = work.optimizerAdmissionSnapshot()
+    assertNull(loading.serverIdleMillis)
+    assertEquals(
+      ServeBackgroundWork.IDLE_BLOCKED_BY_CATALOG_LOAD,
+      loading.idleBlockedBy,
+      "the two have opposite fixes: one is a bug, the other is the gate working",
+    )
+
+    work.initialCatalogLoadFinished()
+    assertNull(work.optimizerAdmissionSnapshot().idleBlockedBy)
+  }
+
+  @Test
+  fun `a server whose hosts never asked for a clock reports no idle reading at all`() {
+    val work = ServeBackgroundWork(clock = { 100_000L })
+
+    val snapshot = work.optimizerAdmissionSnapshot()
+
+    assertNull(snapshot.serverIdleMillis)
+    assertNull(snapshot.idleBlockedBy, "no clock is not the same as a clock reading busy")
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1598,6 +1598,48 @@ class ServeCatalogLiveHostTest {
   }
 
   /** Wait for the background pass to go quiet, finished or not (unlike [awaitOptimization]). */
+  /**
+   * A pass still waiting at the idle gate must report the time it is spending there.
+   *
+   * The wait used to be charged by the caller, once [awaitQuiet] returned — so a gate that had not
+   * opened yet contributed nothing, and `gateWaitMillis: 0` meant both "sailed straight through"
+   * and "has been stuck here for three hours". The deployed server published exactly that: 23
+   * catalogs, `turnsGranted 0`, and a wait counter reading zero on every one of them.
+   */
+  @Test
+  fun `time spent at a gate that has not opened is reported while it is still shut`() {
+    val backgroundWork = ServeBackgroundWork()
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        // Null is how the registry spells "a session holds a lease": permanently busy, so this
+        // gate never opens and the pass never gets a turn.
+        serverIdleMillis = { null },
+        themeOptimizationIdleMillis = 100,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+    val waited =
+      awaitOk(5_000) { composite.themeOptimizationSnapshot()?.takeIf { it.gateWaitMillis > 0 } }
+
+    assertEquals(0, waited.turnsGranted, "the gate never opened, so no turn was ever granted")
+    assertEquals(0, live.renderCalls, "and nothing was rendered")
+    assertTrue(
+      waited.waitingMillis >= waited.gateWaitMillis,
+      "the total must not contradict the part it is made of",
+    )
+    composite.close()
+  }
+
   private fun awaitPassIdle(host: ServeCatalogLiveHost) {
     repeat(200) {
       if (!host.backgroundWorkActive) return

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1219,7 +1219,15 @@ class ServeCatalogLiveHostTest {
       )
 
     composite.prewarm()
-    awaitOk(5_000) { backgroundWork.optimizerAdmissionSnapshot().takeIf { it.running == 1 } }
+    // The pass is at the quiet gate, which it now waits out holding NO lane — so what says it has
+    // started is its own worker being active, not an admission. (It used to be `running == 1`;
+    // that assertion was reading the bug where a gated pass sat on a lane the whole time.)
+    awaitOk(5_000) { composite.backgroundWorkActive.takeIf { it } }
+    assertEquals(
+      0,
+      backgroundWork.optimizerAdmissionSnapshot().running,
+      "a pass waiting for quiet must not be occupying a lane while it waits",
+    )
     backgroundWork.pauseOptimizers(60_000, "deploy")
     idleMillis.set(Long.MAX_VALUE)
     Thread.sleep(150)
@@ -1637,6 +1645,137 @@ class ServeCatalogLiveHostTest {
       waited.waitingMillis >= waited.gateWaitMillis,
       "the total must not contradict the part it is made of",
     )
+    composite.close()
+  }
+
+  /**
+   * A gated pass must not hold a lane while it waits — the failure that took the deployed server's
+   * theme cache to a standstill.
+   *
+   * Two catalogs won the two lanes at startup, blocked in the quiet wait, and never came out:
+   * `idleMillis()` answers *busy* outright while any session holds a lease, so nothing they were
+   * waiting for could ever arrive. Every other catalog was refused every 20s — 8,052 refusals, 43
+   * cumulative hours at the door — and not one of the 23 was ever granted a turn.
+   */
+  @Test
+  fun `a pass waiting on a gate that never opens leaves both lanes free for everyone else`() {
+    val backgroundWork = ServeBackgroundWork(maxConcurrentOptimizers = 1)
+    val previews = listOf(ServePreview(daemonId, daemonId))
+    fun host(idle: () -> Long?) =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live =
+          RecordingHost(previews = previews, tag = "live", declaredThemes = listOf(brandTheme)),
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = idle,
+        themeOptimizationIdleMillis = 100,
+        // The ceiling is the subject of its own test; off here so this one measures the lane.
+        optimizerGateCeilingMillis = 0,
+        backgroundWork = backgroundWork,
+      )
+
+    // Null is the registry's "a session holds an open lease": this catalog can never be granted a
+    // turn, however long it waits.
+    val blocked = host { null }
+    blocked.prewarm()
+    awaitOk(5_000) { blocked.backgroundWorkActive.takeIf { it } }
+
+    repeat(5) {
+      assertEquals(
+        0,
+        backgroundWork.optimizerAdmissionSnapshot().running,
+        "a pass that cannot be granted a turn must wait at the gate, not on the only lane",
+      )
+      Thread.sleep(50)
+    }
+
+    // ...and the single lane is still there for a catalog whose box IS quiet.
+    val quiet = host { Long.MAX_VALUE }
+    quiet.prewarm()
+    assertTrue(awaitOptimization(quiet).fullyOptimized, "the free lane must be usable")
+
+    blocked.close()
+    quiet.close()
+  }
+
+  /**
+   * The ceiling: a gate that can shut permanently is indistinguishable from the feature being off.
+   *
+   * `idleMillis()` returning null is not "very busy", it is "unanswerable" — no quiet window ever
+   * satisfies it — so without a ceiling one leaked session lease switches theme optimization off
+   * for the life of the process, silently. The forced turn is deliberately one preview wide, which
+   * this asserts by leaving the box permanently busy and still expecting the work to finish.
+   */
+  @Test
+  fun `a gate that stays shut past the ceiling still grants a turn`() {
+    val backgroundWork = ServeBackgroundWork()
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = { null },
+        themeOptimizationIdleMillis = 100,
+        optimizerGateCeilingMillis = 50,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+    val done = awaitOptimization(composite)
+
+    assertTrue(done.fullyOptimized, "the ceiling must make progress a shut gate never would")
+    assertTrue(done.turnsForced > 0, "and say so: the box never granted this turn, the ceiling did")
+    assertTrue(
+      done.turnsForced <= done.turnsGranted,
+      "forced turns are a slice of the granted total, not a separate tally",
+    )
+    composite.close()
+  }
+
+  /**
+   * The one refusal the ceiling must respect.
+   *
+   * Catalog loading reads as busy on purpose: a daemon start starved by background renders is
+   * recorded as `livebundle-unavailable` and degrades that catalog to baked PNGs for the whole
+   * process. A cold theme cache is recoverable; that is not — so the ceiling waits for loading in a
+   * way it deliberately does not wait for traffic.
+   */
+  @Test
+  fun `the ceiling does not override the catalog-loading gate`() {
+    val backgroundWork = ServeBackgroundWork()
+    backgroundWork.expectInitialCatalogLoad()
+    val live =
+      RecordingHost(
+        previews = listOf(ServePreview(daemonId, daemonId)),
+        tag = "live",
+        declaredThemes = listOf(brandTheme),
+      )
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live = live,
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        // Quiet as far as requests go — only the load is holding the gate.
+        serverIdleMillis = backgroundWork.idleClock { Long.MAX_VALUE },
+        themeOptimizationIdleMillis = 100,
+        optimizerGateCeilingMillis = 50,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+    // Comfortably past the ceiling, which would have forced a turn were traffic the only reason.
+    Thread.sleep(400)
+    assertEquals(0, live.renderCalls, "no render may start while catalogs are still loading")
+    assertEquals(0, composite.themeOptimizationSnapshot()?.turnsForced)
+
+    backgroundWork.initialCatalogLoadFinished()
+    assertTrue(awaitOptimization(composite).fullyOptimized)
     composite.close()
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -528,6 +528,35 @@ class ServeSessionRegistryTest {
   }
 
   /**
+   * A busy answer has to be attributable, or everything downstream of it looks broken for no
+   * visible reason.
+   *
+   * [ServeSessionRegistry.idleMillis] going null stands the theme optimizer down and holds the
+   * `--exit-when-idle` watchdog open, and a lease released in a `finally` can still leak when the
+   * request is cancelled mid-flight. Naming the holders turns "the box says it is busy and is
+   * serving nothing" from an inference into a one-line read on `/status.json`.
+   */
+  @Test
+  fun `leasedSessions names exactly the holders that make the server read busy`() {
+    ServeSessionRegistry(open = Opener(), factory = CountingFactory(), reaperIntervalMillis = 0)
+      .use { reg ->
+        assertEquals(emptyList(), reg.leasedSessions())
+
+        val b = assertNotNull(reg.lease("b"))
+        val a = assertNotNull(reg.lease("a"))
+        assertEquals(listOf("a", "b"), reg.leasedSessions(), "sorted, so a diff is stable")
+        assertNull(reg.idleMillis(), "and these are precisely why the clock reads busy")
+
+        a.close()
+        assertEquals(listOf("b"), reg.leasedSessions())
+
+        b.close()
+        assertEquals(emptyList(), reg.leasedSessions())
+        assertNotNull(reg.idleMillis(), "the clock runs again once the last lease is released")
+      }
+  }
+
+  /**
    * The GC is the *second* removal path, and it has to discard too.
    *
    * Every suspended session is captured, a forked revision host included, so a reclaim that removed

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.int
@@ -864,5 +865,60 @@ class ServeStatusTest {
     assertEquals(true, opt["paused"]?.jsonPrimitive?.content?.toBoolean())
     assertEquals(65_000L, opt["pausedUntilEpochMillis"]?.jsonPrimitive?.long)
     assertTrue(body.contains("traffic spike"), "the pause reason should reach the page: $body")
+  }
+
+  /**
+   * The gate's input reaches the page, in both projections.
+   *
+   * `/status.json` had every counter describing what a pass did once it was granted a turn and none
+   * describing whether a turn was available at all — so a server whose quiet gate never opened
+   * published the same row as one with nothing left to do. The HTML page carried even less: 23
+   * catalogs each saying "theme optimization paused" and nothing saying why.
+   */
+  @Test
+  fun `status explains a theme optimizer gate that is being held shut`() {
+    val bg = ServeBackgroundWork(clock = { 5_000L })
+    bg.initialCatalogLoadFinished()
+    // Null is the registry's "a session holds an open lease" — permanently busy to the gate.
+    bg.idleClock { null }
+
+    server =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = "default-mod",
+          isPublic = true,
+          themeOptimizerStats = { bg.optimizerAdmissionSnapshot() },
+        )
+        .also { it.start() }
+
+    val (code, body) = get("/status.json")
+    assertEquals(200, code)
+    val opt =
+      Json.parseToJsonElement(body).jsonObject["themeOptimizer"]?.jsonObject
+        ?: error("status.json carries no themeOptimizer: $body")
+    assertTrue(
+      opt["serverIdleMillis"] is kotlinx.serialization.json.JsonNull,
+      "a busy clock is published as null, not omitted: $body",
+    )
+    assertEquals(
+      ServeBackgroundWork.IDLE_BLOCKED_BY_SESSION_LEASE,
+      opt["idleBlockedBy"]?.jsonPrimitive?.content,
+    )
+    assertTrue(
+      (opt["idleThresholdMillis"]?.jsonPrimitive?.long ?: 0) > 0,
+      "the threshold travels with the reading: $body",
+    )
+    assertNotNull(
+      Json.parseToJsonElement(body).jsonObject["daemons"]?.jsonObject?.get("leasedSessions"),
+      "the lease holders are named beside the daemon counters: $body",
+    )
+
+    val (htmlCode, html) = get("/status")
+    assertEquals(200, htmlCode)
+    assertTrue(html.contains("Theme optimiser gate"), "the page names the gate: $html")
+    assertTrue(html.contains("closed"), "and says it is shut: $html")
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2587,6 +2587,15 @@ class ServeWebFixtureTest {
                 ),
                 ServeWeb.Stat("Live daemons running", "1"),
                 ServeWeb.Stat("Active streams", "2"),
+                // Captured in the state that used to be invisible: a quiet gate held shut by a
+                // session lease, which stands the theme optimizer down indefinitely while every
+                // per-catalog row says only "paused". The fixture keeps the awkward case — the
+                // longest of the four wordings, with a holder named — so the row's wrapping is
+                // covered rather than the tidy "open · idle 90s" one.
+                ServeWeb.Stat(
+                  "Theme optimiser gate",
+                  "closed · session lease held by compose-m3 · needs 60s quiet",
+                ),
                 ServeWeb.Stat(
                   "Live seats",
                   "3 free / 5",

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -767,6 +767,26 @@ again. Read `themeOptimizer` on `/status.json` instead:
   gate that has never opened shows a climbing wait beside `turnsGranted: 0`, rather than the zeros
   that also describe a catalog with nothing left to do.
 
+**Waiting at that gate costs nothing but a sleeping thread, and it cannot last forever.** Two rules
+keep a shut gate from turning the feature off:
+
+- **A pass waits for quiet *before* it takes an optimizer lane, never while holding one.** Waiting
+  inside a lane converts "the box is busy" into "the first two catalogs own both lanes
+  indefinitely" — which is precisely what happened: two passes held the two lanes for a whole
+  uptime, blocked on quiet that a held lease meant could never arrive, while the other 16 catalogs
+  were refused every 20s. A pass that yields mid-slice and cannot get its turn back within 30s
+  (`OPTIMIZER_RESUME_WAIT_MILLIS`) also gives its lane back and re-parks at the gate, rather than
+  idling on a lane through a busy stretch.
+- **After ten minutes shut out, a catalog is granted one preview anyway**
+  (`-Dcomposeai.serve.themeOptimizationGateCeilingMillis`, non-positive to disable). The grant is
+  one preview wide and then the pass returns to the gate, so a genuinely busy box pays one preview
+  per catalog per ceiling period instead of never filling the cache at all. Forced turns are
+  counted separately as `turnsForced` (a subset of `turnsGranted`): a figure climbing there means
+  the box never looks quiet and every bit of progress is the forced kind — a working cache and a
+  broken idle clock. The ceiling does **not** override a pause, the pressure gate, or catalog
+  loading; a daemon start starved during loading is recorded as `livebundle-unavailable` and
+  degrades that catalog to baked PNGs for the whole process, which is much worse than a cold cache.
+
 The grid is serial by default. Selecting an app-declared theme asks the server for a fixed,
 60-second page lease; at most one page server-wide receives a burst, clamped to five workers and
 the server's render-slot count. Other pages remain serial, queue completion/page exit releases the

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -749,6 +749,24 @@ When enabled, it yields twice over — both learned from `preview.coo.ee`:
   more than one background one. The permit is taken per render, so a catalog that parks for traffic
   hands it straight to the next one.
 
+**When it isn't running, `/status` says which gate is holding it.** A pass must clear a quiet gate
+before it starts: the whole server has to have been untouched for
+`-Dcomposeai.serve.themeOptimizationIdleMillis` (60s by default). That gate reads
+`ServeSessionRegistry.idleMillis()`, which answers *busy* — not a number — while any session holds
+an open lease, so one long-lived WebSocket, or one lease leaked by a request cancelled mid-flight,
+stands the optimizer down for as long as it is held. The per-catalog `themeOptimization` rows cannot
+show this: they say `paused` whether the box is being politely quiet or the gate will never open
+again. Read `themeOptimizer` on `/status.json` instead:
+
+- `serverIdleMillis` — the gate's input, or `null` for busy — against `idleThresholdMillis`, the
+  quiet it must reach. The `/status` page prints the same comparison as **Theme optimiser gate**.
+- `idleBlockedBy` — why it reads busy: `session-lease` (a lease is held; `daemons.leasedSessions`
+  names the holders) or `catalog-load` (catalogs are still being fetched, which is the gate working
+  as designed).
+- Per catalog, `gateWaitMillis` accrues *while* a pass waits, not only once it is let through — so a
+  gate that has never opened shows a climbing wait beside `turnsGranted: 0`, rather than the zeros
+  that also describe a catalog with nothing left to do.
+
 The grid is serial by default. Selecting an app-declared theme asks the server for a fixed,
 60-second page lease; at most one page server-wide receives a burst, clamped to five workers and
 the server's render-slot count. Other pages remain serial, queue completion/page exit releases the

--- a/vscode-extension/preview-harness/fixtures/pages/serve-status.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-status.html
@@ -81,6 +81,7 @@
 <div class="cp-stat"><div class="cp-stat-key">Published catalog renders</div><div class="cp-stat-val">76 rendered · 1 failed · 0 deferred</div><div class="cp-meter" role="img" aria-label="76 rendered · 1 failed · 0 deferred"><span class="cp-meter-segment cp-meter-segment--primary" style="width:98.701%" title="rendered: 76"></span><span class="cp-meter-segment cp-meter-segment--warning" style="width:1.299%" title="failed: 1"></span></div></div>
 <div class="cp-stat"><div class="cp-stat-key">Live daemons running</div><div class="cp-stat-val">1</div></div>
 <div class="cp-stat"><div class="cp-stat-key">Active streams</div><div class="cp-stat-val">2</div></div>
+<div class="cp-stat"><div class="cp-stat-key">Theme optimiser gate</div><div class="cp-stat-val">closed · session lease held by compose-m3 · needs 60s quiet</div></div>
 <div class="cp-stat"><div class="cp-stat-key">Live seats</div><div class="cp-stat-val">3 free / 5</div><div class="cp-meter" role="img" aria-label="3 free / 5"><span class="cp-meter-segment cp-meter-segment--secondary" style="width:40.000%" title="in use: 2"></span><span class="cp-meter-segment cp-meter-segment--primary" style="width:60.000%" title="free: 3"></span></div></div>
 <div class="cp-stat"><div class="cp-stat-key">Known sessions</div><div class="cp-stat-val">4</div></div>
 <div class="cp-stat"><div class="cp-stat-key">Uptime</div><div class="cp-stat-val">3d 4h</div></div>


### PR DESCRIPTION
Theme optimisation on `preview.coo.ee` had not run once since the process started, and nothing on `/status` said so, or said why.

Measured on the deployed box over ~3h uptime, stable across repeated polls:

| | |
|---|---|
| `turnsGranted`, summed over all 23 catalogs | **0** |
| `gateWaitMillis`, summed over all 23 catalogs | **0** |
| Entries cached | **1 of 17,914** (and that one came from a foreground render) |
| Optimiser admissions / refusals | 3 / 8,052 |
| `paused` / `pressure.constrained` | false / false |

## The failure

A pass must clear a quiet gate before it starts: the whole server has to have been untouched for 60s. That gate reads `ServeSessionRegistry.idleMillis()`, which answers *busy* — `null`, not a large number — while **any** session holds an open lease. One long-lived WebSocket, or one lease leaked by a request cancelled mid-flight, and no amount of waiting will ever satisfy the window.

Two properties of the gate turned that into a permanent stop:

1. **The wait happened from inside an optimiser lane.** The two passes that won lanes at startup blocked on a condition that could never arrive and held both lanes for the entire uptime. The other 16 catalogs were refused every 20s — 8,052 refusals, 43 cumulative hours at the door.
2. **The gate had no ceiling.** A gate that can shut permanently is indistinguishable from the eager pass being disabled, and nothing distinguished them.

And it was invisible. Every counter on `/status.json` described what a pass did *after* it was granted a turn; nothing described the input deciding whether it ever got one. `gateWaitMillis` made that worse — it was charged once the wait *returned*, so a pass still stuck at the gate reported **zero** time spent there, the same reading as one that sailed straight through.

## The fix

- **A pass waits at the gate holding nothing**, and takes a lane only once it has its turn. Parked at the gate it costs a sleeping thread; parked on a lane it costs every other catalog its turn.
- **A mid-slice yield waits at most 30s** (`OPTIMIZER_RESUME_WAIT_MILLIS`) for the turn to come back before giving the lane up — long enough to ride out an ordinary browse without re-paying a 34–68s cold warm, short enough that a busy box rotates its lanes instead of freezing them.
- **`PassOutcome.GATED`** separates "traffic took the turn back" from "the breaker stopped us". A gated pass re-queues; a breakered one still exits. Previously both exited and the catalog was stranded until a visitor heartbeat revived it.
- **After ten minutes shut out, a catalog gets one preview anyway** (`-Dcomposeai.serve.themeOptimizationGateCeilingMillis`, non-positive disables). One preview wide, then back to the gate, counted as `turnsForced`. It does **not** override a pause, the pressure gate, or catalog loading — a daemon start starved during loading is recorded as `livebundle-unavailable` and degrades that catalog to baked PNGs for the whole process, which is far worse than a cold cache.

## The diagnostics

Kept in the same PR because they are what says *which* of the two idle-clock candidates the box actually hit, and the fix works either way.

- `themeOptimizer.serverIdleMillis` publishes the value the gate reads (`null` = busy), `idleThresholdMillis` the quiet it must reach, and `idleBlockedBy` attributes a busy clock to `session-lease` or `catalog-load` — two states that look identical from outside and have opposite fixes.
- `daemons.leasedSessions` names the lease holders.
- The `/status` page carries the same reading as a **Theme optimiser gate** row.
- `gateWaitMillis` now accrues per poll, so an unopened gate is visible while it is still unopened.
- `turnsForced` per catalog: climbing means the box never looks quiet and all progress is the forced kind — a working cache and a broken idle clock.

## Visual evidence

`/status`, light theme — before and after. The new card sits between **Active streams** and **Live seats**.

Before:

![Status page summary before the gate row](https://raw.githubusercontent.com/yschimke/compose-ai-tools/7b2d0b93f03427b5721fefc7a11314af8f937020/renders/serve-status-gate-before.png)

After:

![Status page summary with the Theme optimiser gate card](https://raw.githubusercontent.com/yschimke/compose-ai-tools/7b2d0b93f03427b5721fefc7a11314af8f937020/renders/serve-status-gate-after.png)

Dark theme, after:

![Status page summary with the Theme optimiser gate card, dark](https://raw.githubusercontent.com/yschimke/compose-ai-tools/7b2d0b93f03427b5721fefc7a11314af8f937020/renders/serve-status-gate-after-dark.png)

The row is wired into the committed `serve-status.html` page fixture, so the harness screenshots it per theme and the visual-diff bot covers every later change to it without anyone remembering to.

## Test plan

- `./gradlew :cli:test --tests '*Serve*' --tests '*CatalogThemeCache*'` — green (1341 tests).
- New coverage for the fix: a pass that can never be granted a turn leaves the only lane free for a catalog whose box *is* quiet; a gate shut past the ceiling still finishes the work and reports `turnsForced > 0`; the ceiling does not override the catalog-loading gate.
- New coverage for the diagnostics: the admission snapshot publishes the idle clock and threshold; a held lease and a catalog load are attributed apart; a server whose hosts never asked for a clock reports no reading rather than a false "busy"; `leasedSessions` names exactly the holders that make the clock read busy; a pass at a gate that never opens reports a climbing `gateWaitMillis` beside `turnsGranted: 0`; `/status.json` and `/status` both carry the gate reading.
- One existing test updated: `a pause arriving during the quiet wait parks work until resume` asserted `running == 1` while the pass sat at the gate — it was reading the bug. It now asserts the pass is active *and* holding no lane.
- Preview harness `pages-snapshot` re-run and the `serve-status` fixture regenerated (`UPDATE_SERVE_WEB_FIXTURES=true`). Two unrelated `serve-landing-sections` specs flake locally on a `#cp-search` focus wait — they fail identically on an unmodified tree and touch no file in this PR.

_Generated by [Claude Code](https://claude.com/claude-code)_
