### PR TITLE
feat(deploy): serve wear-m3-catalog on wear.preview.coo.ee

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -79,7 +79,8 @@ what it takes to stand one up is three things, in two places.
 place, and an `AAAA` added later is inherited for free:
 
 ```
-m3.preview.coo.ee.  CNAME  preview.coo.ee.
+m3.preview.coo.ee.    CNAME  preview.coo.ee.
+wear.preview.coo.ee.  CNAME  preview.coo.ee.
 ```
 
 An `A` record straight to the host IP works identically; it is just a second copy of the IP to keep
@@ -89,8 +90,10 @@ which follows the alias without caring that it is one.
 **2. `.env` on the box** — **both** variables, because they configure different processes:
 
 ```bash
-SERVE_SITES=m3.preview.coo.ee=m3-catalog   # the app: which catalog this Host means
-SITE_DOMAINS=m3.preview.coo.ee             # Caddy: match the name AND get a cert for it
+# the app: which catalog each Host means
+SERVE_SITES=m3.preview.coo.ee=m3-catalog,wear.preview.coo.ee=wear-m3-catalog
+# Caddy: match the names AND get a cert for each
+SITE_DOMAINS=m3.preview.coo.ee wear.preview.coo.ee
 ```
 
 Multiple sites are comma-separated in `SERVE_SITES`, space- or comma-separated in `SITE_DOMAINS`.
@@ -108,6 +111,7 @@ docker compose up -d          # preview picks up SERVE_SITES, caddy picks up SIT
 curl -sI https://m3.preview.coo.ee/ | head -1                            # 200 — catalog landing at /
 curl -sI https://m3.preview.coo.ee/m3-catalog/p/button-filled | head -1  # 308 → /p/button-filled
 curl -sI https://m3.preview.coo.ee/wear-m3/ | head -1                    # 404 — neighbours unreachable
+curl -sI https://wear.preview.coo.ee/ | head -1                          # 200 — the Wear catalog's landing
 ```
 
 Sites are read **at startup**, so this is a restart either way; the additive `/admin/catalogs`

--- a/deploy/preview.coo.ee/catalogs.json
+++ b/deploy/preview.coo.ee/catalogs.json
@@ -204,6 +204,10 @@
     {
       "host": "m3.preview.coo.ee",
       "system": "m3-catalog"
+    },
+    {
+      "host": "wear.preview.coo.ee",
+      "system": "wear-m3-catalog"
     }
   ]
 }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -76,18 +76,26 @@
 ## Top-level sites: one catalog on a hostname of its own
 
 A published catalog can additionally be served on **its own hostname**, where it presents as the
-only thing on the server. `m3.preview.coo.ee` serves what `preview.coo.ee/m3-catalog/` serves:
+only thing on the server. `m3.preview.coo.ee` serves what `preview.coo.ee/m3-catalog/` serves, and
+`wear.preview.coo.ee` serves what `preview.coo.ee/wear-m3-catalog/` serves — the deployment's two
+reference design systems, one hostname each:
 
 ```
---sites m3.preview.coo.ee=m3-catalog,wear.preview.coo.ee=wear-m3
+--sites m3.preview.coo.ee=m3-catalog,wear.preview.coo.ee=wear-m3-catalog
 ```
 
 or, durably, beside the catalog set in `catalogs.json` (the form the deployment uses):
 
 ```json
 {
-  "catalogs": [{ "system": "m3-catalog", "repo": "yschimke/m3-catalog" }],
-  "sites": [{ "host": "m3.preview.coo.ee", "system": "m3-catalog" }]
+  "catalogs": [
+    { "system": "m3-catalog", "repo": "yschimke/m3-catalog" },
+    { "system": "wear-m3-catalog", "repo": "yschimke/wear-m3-catalog" }
+  ],
+  "sites": [
+    { "host": "m3.preview.coo.ee", "system": "m3-catalog" },
+    { "host": "wear.preview.coo.ee", "system": "wear-m3-catalog" }
+  ]
 }
 ```
 


### PR DESCRIPTION
Gives the Wear reference design system a hostname of its own, the way `m3.preview.coo.ee` already serves `m3-catalog`. `wear.preview.coo.ee` lands on `wear-m3-catalog` at `/`, keeps links inside the domain (`/p/<id>`, no `?session=`, no "← All design systems"), scopes `/status` + `/sitemap.xml` to that one catalog, `308`s `/wear-m3-catalog/…` to the rooted spelling, and `404`s the neighbours — including the `/wear-m3/` harness catalog, which is a different system and stays reachable only on the front-door host.

A site adds no catalog, no daemon and no render: same sessions, same baked pixels as `preview.coo.ee/wear-m3-catalog/`.

## Changes

- **`deploy/preview.coo.ee/catalogs.json`** — one `sites` entry, `wear.preview.coo.ee` → `wear-m3-catalog`.
- **`docs/public-preview-server.md`** — the `--sites` and `catalogs.json` examples now name the two real sites instead of a hypothetical `wear-m3` one.
- **`deploy/image/README.md`** — the DNS, `SERVE_SITES` and `SITE_DOMAINS` steps show both hostnames, so the comma/space-separated multi-site form has a concrete example, plus a smoke `curl` for the new landing.

Already in place, no change needed: `yschimke/wear-m3-catalog` is trusted in `producers.json` beside the catalogs file, `wear-m3-catalog` is a published `listed: true` catalog, and `SERVE_GITHUB_AUTH_COOKIE_DOMAIN=preview.coo.ee` already covers any host under it — so sign-in works on the new name without a second OAuth app.

## Operator steps to deliver it

`sites` is read at startup and the additive `/admin/catalogs` reconcile is blind to it, so merging this does **not** by itself stand the site up. On the box:

1. **DNS** — `wear.preview.coo.ee. CNAME preview.coo.ee.`, resolving before the restart so Caddy can answer the HTTP-01 challenge.
2. **`.env`** — add the name to both `SERVE_SITES` (app: which catalog this Host means) and `SITE_DOMAINS` (Caddy: match the name and get a cert for it). On the `docker-compose.deploy-config.yml` overlay or the `deploy/vps` profile, where this file is bind-mounted, `git pull` covers the app half and only `SITE_DOMAINS` is needed.
3. **`docker compose up -d`** — a recreate, not `rollout.sh`; sites are startup config.

## Test plan

- `python3 -c "import json; json.load(...)"` on the edited `catalogs.json` — parses; `sites` reads as the two expected entries.
- Checked against `ServeCatalogsConfig.problems()`: the host normalizes, is unique, and names a system the catalog list serves — the three conditions that would otherwise drop the entry at startup.
- `bash deploy/image/test-deploy-config-mount.sh` → `OK: 2 deploy-config mount(s) check out.`
- Behaviour itself is unchanged code, already covered by `ServeTopLevelSiteTest` / `ServeGithubSiteAuthTest`.

No visual evidence: this is deployment config plus docs. The new hostname serves the existing `wear-m3-catalog` pages byte-for-byte — the only rendered difference from `preview.coo.ee/wear-m3-catalog/` is the header losing its "← All design systems" button, which is existing site behaviour verified by `ServeTopLevelSiteTest` rather than anything this diff draws. Post-deploy it is visible at `https://wear.preview.coo.ee/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CokUnR3SPMa2gTng2DZ5oP)_