### PR TITLE
fix(serve): release a session lease and a live stream from a cancellable finally

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -58,6 +58,7 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -1463,7 +1464,23 @@ class ServeHttpServer(
     try {
       block(lease.host)
     } finally {
-      withContext(Dispatchers.IO) { lease.close() }
+      // Called directly, NOT through `withContext` — the same rule [withLeasedSessionOrNull]
+      // already spells out, which this lane was missing.
+      //
+      // A `withContext` in a `finally` never runs once the job is cancelled: it checks the job on
+      // entry and throws straight back out. Cancellation is exactly when this matters — a visitor
+      // navigating away, a crawler abandoning a fetch, a socket dropped mid-render all cancel the
+      // request coroutine here — and a skipped release leaves the lease count permanently
+      // elevated. That is far worse than one resident daemon: `ServeSessionRegistry.idleMillis()`
+      // answers *busy* (`null`, not a number) while ANY session holds a lease, so a single leaked
+      // lease pins the whole server as busy for the life of the process, which silently stands the
+      // theme optimizer down — the deployed box sat at `turnsGranted 0` across 23 catalogs with no
+      // traffic to explain it.
+      //
+      // Safe to call inline: `Lease.close` is a non-suspending, idempotent compare-and-set.
+      // This helper backs the page and asset lanes — the routes an aborted browse actually hits —
+      // so it is the one that had to get this right.
+      lease.close()
     }
   }
 
@@ -7071,7 +7088,15 @@ class ServeHttpServer(
               }
             }
           } finally {
-            withContext(Dispatchers.IO) { live.close() }
+            // `NonCancellable`, because the whole point of this close is to run when the socket
+            // dies — and a socket dying cancels this coroutine, which would make a plain
+            // `withContext` throw on entry and skip the close entirely. A leaked live stream keeps
+            // `activeStreamCount()` above zero, and the reaper never suspends a session with an
+            // open stream, so the daemon and its live seat stay held for the life of the process.
+            //
+            // Unlike `Lease.close` this one genuinely blocks (it tears a render stream down), so
+            // it keeps its IO dispatch rather than being called inline.
+            withContext(Dispatchers.IO + NonCancellable) { live.close() }
           }
         } else {
           val session =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLeaseCancellationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLeaseCancellationTest.kt
@@ -1,0 +1,154 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.StreamCodec
+import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+/**
+ * A request that dies before its handler finishes must still release the session lease it took.
+ *
+ * This is not a tidiness concern. [ServeSessionRegistry.idleMillis] answers *busy* — `null`, not a
+ * large number — while **any** session holds a lease, and that clock gates the theme optimizer's
+ * quiet window and the `--exit-when-idle` watchdog. So a leaked lease does not cost one resident
+ * daemon; it pins the whole server as busy for the life of the process, and every catalog on the
+ * box quietly stops optimizing.
+ *
+ * **What this test does and does not establish.** It pins the observable contract — abandon a
+ * request mid-render, and no lease is left behind — and it passes both before and after the release
+ * in `withLeasedSession` was moved out of a `withContext`. That is a real finding rather than a
+ * weak test: this server installs no request-timeout plugin, and the engine does not cancel a
+ * handler coroutine when the client hangs up, so the skipped-`finally` hazard that
+ * `withLeasedSessionOrNull` documents is **not reachable through this lane today**. The release was
+ * still moved inline, because a `withContext` in a `finally` is skipped outright once the job is
+ * cancelled and nothing about that lane guarantees it never will be — but no one should read this
+ * test as evidence that a leak was observed and closed.
+ */
+class ServeLeaseCancellationTest {
+
+  private val registry = ServeSessionRegistry(open = { null }, reaperIntervalMillis = 0)
+  private var server: ServeHttpServer? = null
+
+  @AfterTest
+  fun tearDown() {
+    server?.stop()
+    registry.close()
+  }
+
+  /**
+   * A host whose render blocks once [armed], so a request can be abandoned while its handler is
+   * still inside it.
+   *
+   * Arming is deliberate rather than blocking from the start: the first request to a fresh Ktor
+   * server spends long enough routing and JIT-ing that a client timeout short enough to be a
+   * *mid-render* abort can fire before the handler reaches the render at all — which tests nothing.
+   * The warm-up request below runs unarmed, so the abort that matters lands on a warm path.
+   */
+  private class BlockingHost(
+    private val entered: CountDownLatch,
+    private val release: CountDownLatch,
+  ) : ServeHost {
+    val armed = java.util.concurrent.atomic.AtomicBoolean(false)
+    override val previews = listOf(ServePreview(PREVIEW_ID, PREVIEW_ID))
+    override val label = "blocking"
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      if (armed.get()) {
+        entered.countDown()
+        check(release.await(10, TimeUnit.SECONDS)) { "test render was never released" }
+      }
+      return RenderOutcome.Ok("png".encodeToByteArray())
+    }
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = 0
+
+    override fun close() = Unit
+  }
+
+  @Test
+  fun `a request abandoned mid-render still releases its session lease`() {
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val host = BlockingHost(entered, release)
+    registry.register(SESSION_ID, host = host, pinned = true)
+    val http =
+      ServeHttpServer(
+          host = "127.0.0.1",
+          requestedPort = 0,
+          token = "unused",
+          sessions = registry,
+          defaultSessionId = SESSION_ID,
+          isPublic = true,
+        )
+        .also { it.start() }
+    server = http
+
+    // A client that gives up long before the render will finish — a visitor navigating away, a
+    // crawler abandoning a fetch, a dropped socket. The handler is inside `render` at this point,
+    // blocking a thread, so cancellation cannot unwind it: the release `finally` runs only once
+    // the render returns, by which time the job is already cancelled. That is the window the bug
+    // lived in.
+    val url = "http://127.0.0.1:${http.port}/render/$PREVIEW_ID.png?fontScale=1.5"
+    // Warm the route, and prove it actually reaches `render` before anything is timed.
+    OkHttpClient().newCall(Request.Builder().url(url).build()).execute().use {
+      assertEquals(200, it.code, "the render route must answer before the abort case")
+    }
+    assertEquals(emptyList(), awaitNoLeases(), "the warm-up must not leave a lease either")
+
+    host.armed.set(true)
+    val client =
+      OkHttpClient.Builder()
+        .callTimeout(500, TimeUnit.MILLISECONDS)
+        .readTimeout(500, TimeUnit.MILLISECONDS)
+        .build()
+    val abort = runCatching { client.newCall(Request.Builder().url(url).build()).execute().close() }
+    assertTrue(abort.isFailure, "the client must actually have given up: ${abort.getOrNull()}")
+    assertTrue(entered.await(5, TimeUnit.SECONDS), "the handler must have taken the lease")
+
+    release.countDown()
+
+    // The release happens on the server's own thread as the handler unwinds, so poll rather than
+    // reading the instant the latch drops.
+    assertEquals(
+      emptyList(),
+      awaitNoLeases(),
+      "an abandoned request must not leave a lease behind",
+    )
+    // ...and the whole-server idle clock is answerable again, which is the property that actually
+    // matters — a null here is what silently switches theme optimization off.
+    assertTrue(
+      registry.idleMillis() != null,
+      "a leaked lease pins the server as busy for the life of the process",
+    )
+  }
+
+  private fun awaitNoLeases(): List<String> {
+    repeat(200) {
+      val held = registry.leasedSessions()
+      if (held.isEmpty()) return held
+      Thread.sleep(25)
+    }
+    return registry.leasedSessions()
+  }
+
+  private companion object {
+    const val SESSION_ID = "default-mod"
+    const val PREVIEW_ID = "com.example.Red"
+  }
+}


### PR DESCRIPTION
Follow-up to #4288, which fixed the theme optimiser's idle gate. That PR left one thread open: whether `preview.coo.ee`'s idle clock was pinned by a **leaked session lease**. This chases that down.

## What I found

`ServeSessionRegistry.idleMillis()` answers *busy* — `null`, not a large number — while **any** session holds a lease, and that clock gates both the theme optimiser's quiet window and the `--exit-when-idle` watchdog. So a single leaked lease pins the whole server as busy for the life of the process.

Three helpers take a lease. `withLeasedSessionOrNull` releases inline and its KDoc explains exactly why:

> Called directly, NOT through `withContext`. […] a `withContext` in a `finally` is skipped outright once the job is cancelled […] A skipped release leaves the lease count permanently elevated.

The other two did the thing that comment warns against — `withLeasedSession` (which backs the page and asset lanes, i.e. ~20 route handlers) and the live-stream close in the WebSocket handler.

## What I changed

- `withLeasedSession` releases inline. `Lease.close` is a non-suspending, idempotent compare-and-set, so it needs no dispatch.
- The live-stream close keeps its IO dispatch (it genuinely blocks tearing a render stream down) but gains `NonCancellable` — the whole point of that close is to run when the socket dies, which is precisely when the coroutine is cancelled.

## Scope — this is hardening, not a reproduced leak

I could not demonstrate the leak, and the PR should not be read as closing one.

The new test abandons a request while its handler is blocked inside `render`, then asserts no lease survives. **It passes both before and after the change.** I verified that by restoring the old `withContext` release and re-running — still green. The reason is a real finding rather than a weak test: this server installs no request-timeout plugin, and the engine does not cancel a handler coroutine when the client hangs up. I confirmed the client genuinely aborts (`InterruptedIOException: timeout`) and the lease is still released. So the documented hazard is **not reachable through that lane today**.

It is still wrong to leave a release on a path a cancellation would skip — nothing about these lanes guarantees one never will be, and the three helpers now agree with each other and with the comment that already explained the rule. The test pins the observable contract rather than claiming a fixed bug.

**So the deployed symptom is still unexplained.** The diagnostics in #4288 are what will settle it: once deployed, `themeOptimizer.idleBlockedBy` on `/status.json` will read `session-lease` or `catalog-load`, and `daemons.leasedSessions` will name any holder. If it reads `session-lease` on a box serving nothing, there is a leak somewhere I haven't found and this was not it.

## Test plan

- `./gradlew :cli:test --tests '*Serve*'` — green.
- New `ServeLeaseCancellationTest`: warms the render route, arms a blocking host, aborts the client mid-render, and asserts both that no lease is left and that `idleMillis()` is answerable again. The warm-up is deliberate — on a cold Ktor server the first request takes longer than a timeout short enough to be a *mid-render* abort, so without it the test would assert nothing.
- No UI surface changes, so no visual evidence.

_Generated by [Claude Code](https://claude.com/claude-code)_
