### PR TITLE
fix(design-artifacts): say when a pinned driver ignores reference-backdrop

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -210,6 +210,12 @@ on:
           and the row reports the missing ground instead of the component. Applied only to stickers
           whose alpha channel is the whole frame or the inscribed device disc; a transparent
           component sticker is left alone and counted in the step's summary.
+
+          Needs a driver that carries the flag. An EXTERNAL caller runs the release-pinned driver
+          from design-artifacts-driver-pin.txt, not this repo's main, so this input takes effect
+          only once a release has moved that pin past the commit adding it (compose-ai-tools' own
+          catalogs get it immediately). Setting it against an older driver publishes unchanged
+          references and says so with a warning rather than failing the catalog's render.
         required: false
         type: string
         default: ''
@@ -1529,9 +1535,29 @@ jobs:
             echo "::warning title=Chromium install failed::HTML design references will be skipped and references will publish without a match score."
             tail -n 40 "$install_log" >&2
           fi
+          # An unknown flag is INERT here, not an error: the emitter reads argv by name, so a driver
+          # older than a flag ignores it and the run goes green having done exactly nothing the
+          # caller asked for. That matters more than usual for `reference-backdrop`, because an
+          # EXTERNAL caller does not execute this repo's `main` — it executes the release-pinned
+          # driver in design-artifacts-driver-pin.txt, so a freshly merged flag reaches it only
+          # after the next release moves the pin. wear-m3-catalog#43 hit exactly that: the input was
+          # set, the step was green, and the references published unchanged.
+          #
+          # So say so, out loud, rather than leaving it to be inferred from a missing log line.
+          # A warning and not a failure: the references published are byte-for-byte what this
+          # catalog would have published with no input at all — stale against the caller's intent,
+          # never wrong — and a reference lane must not cost a catalog its render.
+          emitter=compose-ai-tools/scripts/design-artifacts/emit-design-references.mjs
+          if [ -n "$REFERENCE_BACKDROP" ] && ! grep -q 'reference-backdrop' "$emitter"; then
+            echo "::warning title=Driver too old for reference-backdrop::This run's export driver \
+          predates the --reference-backdrop flag, so '$REFERENCE_BACKDROP' was ignored and the \
+          references published exactly as they would have with no backdrop. External callers run \
+          the driver pinned in compose-ai-tools/.github/design-artifacts-driver-pin.txt; it reaches \
+          them when the next release moves that pin."
+          fi
           # `--spec` must be the caller's configured path, not the emitter's root default:
           # this repo's own catalogs live at samples/design-catalog-*/catalog.spec.json.
-          node compose-ai-tools/scripts/design-artifacts/emit-design-references.mjs \
+          node "$emitter" \
             --out "$GITHUB_WORKSPACE/out" \
             --repo "$GITHUB_WORKSPACE" \
             --spec "$INPUT_SPEC" \

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1507,6 +1507,16 @@ the missing ground rather than the component.
 publishes each reference on that ground. Empty is the default and changes nothing, which is right
 wherever the kit's own cells already carry a background.
 
+**It reaches an external caller only when the driver pin moves.** The emitter reads argv by name, so
+a driver that predates a flag ignores it and the run goes green having done nothing — and an
+external caller executes the release-pinned commit in
+[`design-artifacts-driver-pin.txt`](../.github/design-artifacts-driver-pin.txt), not `main`.
+wear-m3-catalog set the input the same day the flag merged, and its publish step ran the 1.21.0
+driver: green run, unchanged references, no `backdrop …` line in the log. The step now checks the
+emitter it is about to run and warns when the two disagree, rather than leaving the silence to be
+read as success. compose-ai-tools' own catalogs run the driver from the commit under test, so a flag
+merged to `main` applies to them at once.
+
 The colour is **declared** and the shape is **recognised**. Only the catalog knows what its previews
 asked for, and a colour read off the sticker would be read off the very image the reference is about
 to be compared with — so the caller names it (`reference-backdrop: '#000000'` for a dark-first Wear


### PR DESCRIPTION
Follow-up to #4297, closing the hole that PR opened.

The emitter reads argv by name, so a flag the driver does not know is **inert rather than an error**. The run goes green having done exactly nothing the caller asked for.

That is not theoretical. An external caller does not execute this repo's `main` — it executes the release-pinned commit in [`design-artifacts-driver-pin.txt`](https://github.com/yschimke/compose-ai-tools/blob/main/.github/design-artifacts-driver-pin.txt) — so a freshly merged flag reaches it only once a release moves the pin.

wear-m3-catalog set `reference-backdrop: '#000000'` the same day the flag merged. Its publish step ran the **1.21.0** driver (`c5cd378`), which predates the flag:

- workflow run: ✅ success
- `REFERENCE_BACKDROP: #000000` in the step env, `--reference-backdrop "$REFERENCE_BACKDROP"` on the command line
- references published: **unchanged**
- the only evidence of the problem: a log line that was *absent*

```
design-references: scored 186 of 186 published reference(s)
design-references: published 186/186 reference(s) to references/ — 49/49 primary, …
```

No `backdrop … laid under N device-mask` line, because `BACKDROP` was never parsed. A missing line is not a signal anybody reads.

## The change

The step greps the emitter it is about to run and warns when the two disagree, naming the pin and when the input will start working.

A **warning, not a failure**, and deliberately: what published is byte-for-byte what this catalog would have published with no input at all — stale against intent, never wrong — and the step's stated posture is that a reference lane must never cost a catalog its render. (Contrast `render-shards`, which *does* `::error::` and exit, because a wrong shard config produces a wrong bundle.)

## Test plan

Exercised against both real drivers rather than a mock — the old emitter is `git show c5cd378:…`, the new one `git show origin/main:…`:

| driver | input | result |
|---|---|---|
| 1.21.0 (`c5cd378`, predates the flag) | `#000000` | **warning emitted** |
| 1.21.0 | unset | silent |
| current `main` (carries the flag) | `#000000` | silent |

So it fires exactly on the case that just happened, and costs nothing to any caller that does not set the input.

- `yaml.safe_load` on the workflow, and `bash -n` on the extracted `run:` block.
- Input description and `docs/public-preview-server.md` now state the pin dependency — the part that made this invisible in the first place.

## What this does not do

It does not hand-bump the driver pin. The pin exists so the privileged workflow executes an immutable, release-blessed commit, and it is maintained by `refresh-driver-pin.sh` after a release. `reference-backdrop` starts working for wear-m3-catalog when the next release moves it past `c3273b8`; until then its run will now say so out loud instead of looking like it worked.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wx4PdYHyT19r7r7L6PdGT)_