### PR TITLE
feat(serve): keep fetched catalog bytes across reloads and restarts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -136,6 +136,8 @@ internal object CliFlagValidation {
             "--bundles",
             "--catalog-branch-prefix",
             "--catalog-feed-cache",
+            "--catalog-cache-dir",
+            "--catalog-cache-max-bytes",
             "--theme-cache-dir",
             "--theme-cache-max-bytes",
             "--theme-optimizer-coordination-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -107,6 +107,8 @@ internal object CliFlags {
       "--catalog-max-images",
       "--catalog-feed-idle-timeout",
       "--catalog-feed-cache",
+      "--catalog-cache-dir",
+      "--catalog-cache-max-bytes",
       "--theme-cache-dir",
       "--theme-cache-max-bytes",
       "--theme-optimizer-coordination-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.cli.serve.BundleVerifier
+import ee.schimke.composeai.cli.serve.CatalogBlobPool
 import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.CatalogRefreshResult
 import ee.schimke.composeai.cli.serve.CatalogThemeCache
@@ -774,6 +775,83 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         } ?: OptimizerHostCoordinator.NONE,
       pressureGate = OptimizerPressureGate(sample = pressureSampler::sample),
     )
+  }
+
+  /**
+   * Durable, content-addressed home for the heavy bytes a catalog load fetches — the executable
+   * `liveBundle`, its per-preview splits, and the externalised resource pool ([CatalogBlobPool]).
+   *
+   * **Unlike the theme cache, unset is not off.** A temp-directory pool is exactly what this server
+   * has always had — it is shared across systems and reloads and simply dies with the process — so
+   * falling back to one costs nothing that was not already being paid. What `none` buys is the
+   * ability to say "do not keep these bytes anywhere durable"; what a directory buys is that a
+   * rolled container stops re-downloading ~100 MB per live catalog.
+   *
+   * **There is deliberately no derived default.** The feed and theme caches land beside
+   * `catalogs.json`, which on the prebuilt image is the configuration volume — fine for a few MB of
+   * feed XML, wrong for a pool that may hold several GB of executable bundles. So an unset flag
+   * means the temp-dir pool this always had, a path means that path, and `none` forces the temp dir
+   * back (which is how a deployment overrides an environment default without unsetting it).
+   */
+  private val catalogBlobPool: CatalogBlobPool by lazy {
+    val requested = args.flagValue("--catalog-cache-dir")?.takeIf { it.isNotBlank() }
+    val maxBytes =
+      args.flagValue("--catalog-cache-max-bytes")?.toLongOrNull()?.takeIf { it > 0 }
+        ?: CatalogBlobPool.DEFAULT_MAX_BYTES
+    val preferred = requested?.takeIf { it != "none" }?.let(::File)
+    if (
+      preferred != null && (preferred.isDirectory || preferred.mkdirs()) && preferred.canWrite()
+    ) {
+      System.err.println(
+        "serve: catalog blob cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB)"
+      )
+      CatalogBlobPool(preferred, maxBytes = maxBytes)
+    } else {
+      if (preferred != null) {
+        System.err.println("serve: catalog blob cache $preferred is not writable; using a temp dir")
+      }
+      val temp =
+        java.nio.file.Files.createTempDirectory("serve-catalog-blobs").toFile().also {
+          it.deleteOnExit()
+        }
+      CatalogBlobPool(temp, maxBytes = maxBytes)
+    }
+  }
+
+  /**
+   * Rate limiter for [sweepCatalogBlobs] — see there for why it is not a per-call-site decision.
+   */
+  private val lastCatalogBlobSweep = java.util.concurrent.atomic.AtomicLong()
+
+  /**
+   * Reclaim pooled blobs no longer worth their disk.
+   *
+   * Eviction is always safe here — the worst a reclaimed blob costs is the fetch that produces it
+   * again — so unlike [sweepThemeCache] this needs to know nothing about which catalogs are live.
+   * What it does need is to run after a **refresh** and not only after the startup pass: a box that
+   * regenerates several times a day would otherwise accumulate every superseded revision's bundles
+   * for the life of the process, which is exactly the disk this is supposed to bound.
+   *
+   * That makes it callable from every publication site, so the cost is bounded here rather than by
+   * each caller remembering to: a sweep is a directory census, the grace window means a sweep
+   * minutes after the last one is a near-certain no-op, and 23 catalogs publishing in sequence at
+   * boot would otherwise run 23 of them. [force] is for the end of the startup pass, which reports
+   * what the boot actually found — the one number that says whether the cache is working.
+   */
+  private fun sweepCatalogBlobs(force: Boolean = false) {
+    val now = System.currentTimeMillis()
+    val previous = lastCatalogBlobSweep.get()
+    if (!force && now - previous < CATALOG_BLOB_SWEEP_INTERVAL_MILLIS) return
+    if (!lastCatalogBlobSweep.compareAndSet(previous, now)) return
+    val snapshot = runCatching { catalogBlobPool.sweep() }.getOrNull() ?: return
+    // Otherwise silent: a periodic line saying nothing happened is noise, and the counters belong
+    // on /status rather than in the log.
+    if (force || snapshot.evicted > 0) {
+      System.err.println(
+        "serve: catalog blob cache — ${snapshot.blobs} blob(s), ${snapshot.bytes / (1024 * 1024)} MB, " +
+          "${snapshot.hits} hit(s), ${snapshot.misses} miss(es), ${snapshot.evicted} reclaimed"
+      )
+    }
   }
 
   /**
@@ -3078,6 +3156,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           // work is free to start; leaving it claimed would park the optimizer forever.
           backgroundWork.initialCatalogLoadFinished()
           sweepThemeCache()
+          sweepCatalogBlobs(force = true)
           if (!closed.get()) onComplete(loaded)
         }
       }
@@ -3123,6 +3202,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         repo = catalogRepo,
         branchPrefix = catalogBranchPrefix,
         maxImages = catalogMaxImages,
+        blobs = catalogBlobPool,
         serverSideRenderEnabled = allowRenderTrusted,
         registerWasm = { system, wasmDir ->
           // A local `--wasm-dir` is the operator's explicit override, so a published app never
@@ -3426,6 +3506,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // keeps
     // a failed `openHost` from deleting the cache of the host still serving.
     sweepThemeCache()
+    sweepCatalogBlobs()
     return true
   }
 
@@ -3690,6 +3771,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // needs its own post-publication sweep — without it a deployment of only source-backed catalogs
     // never reclaims a superseded generation, whatever the cap says.
     sweepThemeCache()
+    sweepCatalogBlobs()
     System.err.println(
       "serve: catalog $system → LIVE server-render from ${source.module}@${source.ref} " +
         "(?session=$system)"
@@ -4213,6 +4295,21 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         --catalog-feed-cache <dir>
                           Durable shallow-Git + generated-XML cache for catalog feeds. Defaults to a
                           catalog-feeds directory beside --catalogs-file, or a temp dir in local mode.
+        --catalog-cache-dir <dir>|none
+                          Durable, content-addressed store for the heavy bytes a catalog fetches —
+                          the executable liveBundle, its per-preview splits and the externalised
+                          resource pool — so a reload or a restart re-reads them instead of pulling
+                          ~100 MB per live catalog again. Unset (and `none`) keeps the temp-dir pool
+                          this always had, which dies with the process; there is no derived default,
+                          because the obvious one is the config volume. Only bytes addressed by a
+                          commit-pinned URL are cached, so a load that could not resolve its
+                          delivery commit populates nothing.
+        --catalog-cache-max-bytes <n>
+                          Ceiling for that store (default
+                          ${CatalogBlobPool.DEFAULT_MAX_BYTES / (1024L * 1024 * 1024)} GB).
+                          Reclaimed oldest-first after the startup pass and after each later
+                          catalog publication; blobs newer than an hour are spared so the replicas
+                          that overlap during a rolling update cannot evict each other's.
         --theme-cache-dir <dir>|none
                           Durable store for warmed theme renders, so background warming survives a
                           restart and a catalog refresh. `none` disables it. Defaults to a
@@ -4261,6 +4358,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
      */
     const val DEFAULT_CATALOG_REFRESH_SECONDS = 600L
     const val DEFAULT_CATALOG_FEED_IDLE_SECONDS = 7L * 24 * 60 * 60
+
+    /**
+     * Floor between catalog-blob sweeps. Comfortably shorter than the pool's own grace window (so a
+     * sweep is never the thing that delays a reclaim) and long enough that a burst of catalog
+     * publications runs one census rather than one each.
+     */
+    const val CATALOG_BLOB_SWEEP_INTERVAL_MILLIS = 5L * 60 * 1000
 
     /**
      * Compiles per minute per caller. Sized for a person using the editor, not for a script: a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -1,0 +1,424 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.Serializable
+
+/** What the pool holds and what its reads did — `/status.json` → `catalogCache`. */
+@Serializable
+data class CatalogBlobPoolSnapshot(
+  val blobs: Int,
+  val bytes: Long,
+  val maxBytes: Long,
+  /** Reads answered from disk — the requests this pool did not make. */
+  val hits: Long,
+  /** Reads that had to produce the blob. */
+  val misses: Long,
+  val writes: Long,
+  val writeFailures: Long,
+  /** Blobs reclaimed by [CatalogBlobPool.sweep]. */
+  val evicted: Long,
+  /** Blobs dropped because their bytes did not hash back to their name. */
+  val corrupt: Long,
+  val lastFailure: String? = null,
+)
+
+/**
+ * Content-addressed home for the heavy bytes a catalog load fetches — the executable `liveBundle`,
+ * its per-preview splits, and the externalised resource pool.
+ *
+ * ### What this exists to stop
+ *
+ * `ServeCommand.registerCatalogs` roots the catalog store at a `createTempDirectory`, so everything
+ * a catalog fetched is discarded when the container is recreated — which on the prebuilt image is
+ * what every rolled release performs. Worse, it is not only restarts: [ServeCatalogStore.load]
+ * finishes by deleting the live per-system directory before renaming staging over it, so **every
+ * reload throws the previous generation away too**, including a 100 MB-class bundle the new
+ * revision may not have changed at all. Only the old `.res-cache` survived a reload, and only
+ * because it sat above that directory.
+ *
+ * Pointing [ServeCommand] at a durable root makes the pool outlive both events. It is deliberately
+ * the whole of the change: nothing here decides *what* to cache or *when* a catalog is stale — that
+ * is the caller's business, and the rule the caller must keep is stated below.
+ *
+ * ### The rule callers must keep
+ *
+ * **Only bytes with an immutable address may be [keyed] here.** A catalog load resolves its
+ * delivery commit first and pins every subsequent URL to it
+ * (`raw.githubusercontent.com/<repo>/<commit>/…`), so those reads are immutable by construction and
+ * a cached answer can only ever be *the* answer. The un-pinned fallback — a load whose revision
+ * feed could not be read, which addresses the branch ref instead — is mutable, and must not reach
+ * this pool at all. One rule, no TTLs, nothing to revalidate.
+ *
+ * [contentAddressed] carries no such caveat: its key *is* the digest a trusted manifest declared,
+ * so it is safe wherever that manifest is.
+ *
+ * ### Layout, and why there is only one blob space
+ *
+ * ```
+ * <root>/content/<sha256-of-bytes>     the blobs themselves
+ * <root>/keys/<sha256-of-key>          a pointer: the content sha its key resolves to
+ * ```
+ *
+ * Both addressing modes land in the same `content/` space, so a bundle fetched by URL and the same
+ * bundle declared by sha are one file. More importantly it makes **every blob self-verifying**: the
+ * file name is the digest, so a read hashes the bytes and compares, and a truncated or corrupted
+ * entry can never be handed to a classloader. A sidecar recording the digest beside the blob would
+ * have needed the pair to stay consistent across two writers and a kill; a name cannot go out of
+ * step with itself.
+ *
+ * The pointer file is the only mutable thing here, and it is a single small atomic write whose
+ * every possible value names a self-verifying blob — so two replicas racing on it cannot produce a
+ * wrong read, at worst a re-produced one.
+ *
+ * ### Concurrency
+ *
+ * The prebuilt image's rolling update boots a new replica alongside the running one and both mount
+ * this volume. Writes are therefore staged per-writer and moved into place atomically, reads verify
+ * before trusting, and [sweep] spares anything younger than [graceMillis] so a booting replica
+ * cannot reclaim the bytes the outgoing one is still serving from.
+ */
+class CatalogBlobPool(
+  private val root: File,
+  /**
+   * Ceiling for the whole pool, enforced by [sweep] rather than at write time — a load must not
+   * block on a byte census, and a pool that refused to grow between sweeps would stop caching
+   * exactly when it was busiest.
+   */
+  private val maxBytes: Long = DEFAULT_MAX_BYTES,
+  /** How recently a blob must have been touched to be spared by [sweep]. See **Concurrency**. */
+  private val graceMillis: Long = DEFAULT_SWEEP_GRACE_MILLIS,
+  private val clock: () -> Long = System::currentTimeMillis,
+) {
+  private val hits = AtomicLong()
+  private val misses = AtomicLong()
+  private val writes = AtomicLong()
+  private val writeFailures = AtomicLong()
+  private val evicted = AtomicLong()
+  private val corrupt = AtomicLong()
+  @Volatile private var lastFailure: String? = null
+  private val tempSequence = AtomicLong()
+
+  /** Distinguishes this process's in-flight writes from a concurrently deployed replica's. */
+  private val writerId: String =
+    ProcessHandle.current().pid().toString(36) + "-" + System.identityHashCode(this).toString(36)
+
+  /**
+   * Serialises production per key within this process, so a grid opening twenty per-preview daemons
+   * at once produces each blob once instead of once per caller. Cross-process races are left to the
+   * atomic move — they are rare, and the loser's work is simply discarded.
+   */
+  private val keyLocks = ConcurrentHashMap<String, Any>()
+
+  private val contentDir = File(root, CONTENT_DIR)
+  private val keysDir = File(root, KEYS_DIR)
+
+  /**
+   * The blob whose sha256 is [sha256], fetching it once when absent, or null when it cannot be had.
+   *
+   * The key is the digest, so a hit is trusted only after its bytes hash back to it: a same-length
+   * but corrupt entry (a partial write, a disk fault) is re-fetched rather than silently put on a
+   * classpath. [size] is checked first purely because it is free.
+   *
+   * Null rather than an exception throughout — the pool is an optimisation, and a box with a
+   * read-only or full disk must load catalogs exactly as it did before this existed.
+   */
+  fun contentAddressed(sha256: String, size: Long, fetch: () -> ByteArray?): File? {
+    val sha = sha256.takeIf(::isSha) ?: return null
+    val blob = File(contentDir, sha)
+    readVerified(blob, sha, size)?.let {
+      hits.increment()
+      return it
+    }
+    misses.increment()
+    return synchronized(keyLocks.computeIfAbsent(sha) { Any() }) {
+      // Double-checked: a caller that queued behind another's fetch reads what it just landed —
+      // and is counted as the hit it is, so contention does not quietly depress the hit rate these
+      // counters exist to report.
+      readVerified(blob, sha, size)?.also { hits.increment() }
+        ?: run {
+          val bytes = runCatching(fetch).getOrNull() ?: return@run null
+          if (sha256Hex(bytes) != sha) {
+            recordFailure("declared sha256 $sha does not match the bytes fetched for it")
+            return@run null
+          }
+          store(bytes, sha)
+        }
+    }
+  }
+
+  /**
+   * The blob [key] resolves to, producing it once with [produce] when absent, or null when it
+   * cannot be had.
+   *
+   * [key] must be an **immutable** address — see **The rule callers must keep**. [produce] is
+   * handed a scratch file to write and returns whether it wrote one; whatever it left there is
+   * hashed, stored under its digest, and the key repointed at it. So a producer that is not
+   * byte-reproducible (a repack that stamps a timestamp) costs at most a duplicate blob, never a
+   * wrong read.
+   */
+  fun keyed(key: String, produce: (dest: File) -> Boolean): File? {
+    val pointer = File(keysDir, sha256Hex(key.toByteArray()))
+    resolve(pointer)?.let {
+      hits.increment()
+      return it
+    }
+    misses.increment()
+    return synchronized(keyLocks.computeIfAbsent(key) { Any() }) {
+      resolve(pointer)?.also { hits.increment() }
+        ?: run {
+          val scratch = temp("produce") ?: return@run null
+          val produced = runCatching { produce(scratch) }.getOrDefault(false) && scratch.isFile
+          if (!produced) {
+            scratch.delete()
+            return@run null
+          }
+          val sha = sha256Hex(scratch)
+          if (sha == null) {
+            scratch.delete()
+            recordFailure("could not digest the blob produced for a key")
+            return@run null
+          }
+          val blob = adopt(scratch, sha) ?: return@run null
+          // Written last, and only once the blob it names is in place — a pointer is only ever
+          // read back through [resolve], which re-verifies, so a stale one degrades to a miss.
+          writeAtomically(pointer, sha.toByteArray())
+          blob
+        }
+    }
+  }
+
+  /**
+   * Whether [key] already resolves to a blob that is present, **without** verifying its bytes.
+   *
+   * For an availability probe that must not download: the caller asking is deciding whether a lane
+   * exists at all, and hashing a multi-megabyte bundle to answer would defeat the point of asking
+   * cheaply. A `true` that a later [keyed] read then rejects as corrupt costs one re-produce, which
+   * is the same thing a `true` from a network probe costs.
+   */
+  fun holds(key: String): Boolean =
+    resolve(File(keysDir, sha256Hex(key.toByteArray())), verify = false) != null
+
+  /**
+   * Reclaim blobs until the pool is under [maxBytes], oldest-touched first, sparing anything
+   * younger than [graceMillis]; then drop pointers whose blob is gone.
+   *
+   * Eviction is always safe — the worst a reclaimed blob costs is the fetch that produces it again
+   * — which is what lets this run without knowing anything about which catalogs are live. Run it
+   * once the catalog pass has finished, where the byte census is worth paying for.
+   */
+  fun sweep(): CatalogBlobPoolSnapshot {
+    val now = clock()
+    val blobs =
+      contentDir.listFiles()?.filter { it.isFile }.orEmpty().sortedBy { it.lastModified() }
+    var total = blobs.sumOf { it.length() }
+    for (blob in blobs) {
+      if (total <= maxBytes) break
+      if (now - blob.lastModified() < graceMillis) continue
+      val size = blob.length()
+      if (runCatching { blob.delete() }.getOrDefault(false)) {
+        total -= size
+        evicted.increment()
+      }
+    }
+    for (pointer in keysDir.listFiles()?.filter { it.isFile }.orEmpty()) {
+      if (resolve(pointer, verify = false) == null) runCatching { pointer.delete() }
+    }
+    return snapshot()
+  }
+
+  fun snapshot(): CatalogBlobPoolSnapshot {
+    val blobs = contentDir.listFiles()?.filter { it.isFile }.orEmpty()
+    return CatalogBlobPoolSnapshot(
+      blobs = blobs.size,
+      bytes = blobs.sumOf { it.length() },
+      maxBytes = maxBytes,
+      hits = hits.get(),
+      misses = misses.get(),
+      writes = writes.get(),
+      writeFailures = writeFailures.get(),
+      evicted = evicted.get(),
+      corrupt = corrupt.get(),
+      lastFailure = lastFailure,
+    )
+  }
+
+  /** The file a blob with this digest occupies, whether or not it exists. Visible for tests. */
+  fun contentFile(sha256: String): File = File(contentDir, sha256)
+
+  // ---------------------------------------------------------------------------------------------
+
+  /** [blob] if it exists and hashes back to [sha], else null — dropping it when it does not. */
+  private fun readVerified(blob: File, sha: String, size: Long = -1): File? {
+    if (!blob.isFile) return null
+    if (size >= 0 && blob.length() != size) {
+      dropCorrupt(blob, "size")
+      return null
+    }
+    if (sha256Hex(blob) != sha) {
+      dropCorrupt(blob, "digest")
+      return null
+    }
+    touch(blob)
+    return blob
+  }
+
+  /** The blob [pointer] names, verified unless the caller only wants to know it is still there. */
+  private fun resolve(pointer: File, verify: Boolean = true): File? {
+    val sha = runCatching { pointer.readText().trim() }.getOrNull()?.takeIf(::isSha) ?: return null
+    val blob = File(contentDir, sha)
+    if (!verify) return blob.takeIf { it.isFile }
+    return readVerified(blob, sha)
+  }
+
+  private fun dropCorrupt(blob: File, why: String) {
+    corrupt.increment()
+    recordFailure("discarded ${blob.name.take(12)}… on $why mismatch")
+    runCatching { blob.delete() }
+  }
+
+  /** Keeps a blob that is still being read out of the sweeper's reach. Best-effort. */
+  private fun touch(blob: File) {
+    runCatching { blob.setLastModified(clock()) }
+  }
+
+  private fun store(bytes: ByteArray, sha: String): File? {
+    val scratch = temp("store") ?: return null
+    return runCatching { scratch.writeBytes(bytes) }
+      .fold(
+        onSuccess = { adopt(scratch, sha) },
+        onFailure = {
+          scratch.delete()
+          recordFailure("could not stage a blob: ${it.message}")
+          null
+        },
+      )
+  }
+
+  /** Move [scratch] into `content/<sha>`, or drop it when another writer got there first. */
+  private fun adopt(scratch: File, sha: String): File? {
+    val blob = File(contentDir, sha)
+    if (!ensureDir(contentDir)) {
+      scratch.delete()
+      return null
+    }
+    // A blob already there is by definition these bytes — the name is their digest — so the race
+    // has no loser worth reporting: drop the duplicate and read what is already published.
+    if (blob.isFile) {
+      scratch.delete()
+      touch(blob)
+      return blob
+    }
+    val moved = runCatching {
+      java.nio.file.Files.move(
+        scratch.toPath(),
+        blob.toPath(),
+        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+      )
+      true
+    }
+      .getOrElse { runCatching { scratch.renameTo(blob) }.getOrDefault(false) }
+    if (!moved) {
+      scratch.delete()
+      // Another writer landing the identical bytes first is a success, not a failure.
+      if (blob.isFile) return blob
+      writeFailures.increment()
+      recordFailure("could not publish a blob into $contentDir")
+      return null
+    }
+    writes.increment()
+    // Stamped from the same clock every hit stamps, so "least recently used" is one notion rather
+    // than a mix of the pool's clock and whatever mtime the move happened to preserve.
+    touch(blob)
+    return blob
+  }
+
+  private fun writeAtomically(target: File, bytes: ByteArray) {
+    if (!ensureDir(target.parentFile)) return
+    val scratch = temp("pointer") ?: return
+    runCatching {
+      scratch.writeBytes(bytes)
+      java.nio.file.Files.move(
+        scratch.toPath(),
+        target.toPath(),
+        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+      )
+    }
+      .onFailure {
+        scratch.delete()
+        recordFailure("could not write a key pointer: ${it.message}")
+      }
+  }
+
+  /** A scratch file in the pool's own temp dir, so every publish is a same-filesystem move. */
+  private fun temp(what: String): File? {
+    val dir = File(root, TEMP_DIR)
+    if (!ensureDir(dir)) return null
+    return File(dir, "$what-$writerId-${tempSequence.incrementAndGet()}")
+  }
+
+  private fun ensureDir(dir: File?): Boolean {
+    if (dir == null) return false
+    if (dir.isDirectory) return true
+    if (runCatching { dir.mkdirs() }.getOrDefault(false) || dir.isDirectory) return true
+    writeFailures.increment()
+    recordFailure("could not create $dir")
+    return false
+  }
+
+  private fun recordFailure(reason: String) {
+    lastFailure = reason.take(MAX_REASON_CHARS)
+  }
+
+  private fun AtomicLong.increment() {
+    incrementAndGet()
+  }
+
+  companion object {
+    const val CONTENT_DIR: String = "content"
+    const val KEYS_DIR: String = "keys"
+    const val TEMP_DIR: String = "tmp"
+
+    /**
+     * Ceiling for the whole pool. Sized for a box publishing a couple of dozen catalogs: the
+     * executable bundles are the bulk and run to ~100 MB each, and a catalog keeps its previous
+     * revision's bundle until the sweeper reclaims it.
+     */
+    const val DEFAULT_MAX_BYTES: Long = 8L * 1024 * 1024 * 1024
+
+    /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
+    const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
+
+    const val MAX_REASON_CHARS: Int = 200
+
+    private const val BUFFER_BYTES = 1 shl 16
+
+    private fun isSha(value: String): Boolean =
+      value.length == 64 && value.all { it in '0'..'9' || it in 'a'..'f' }
+
+    fun sha256Hex(bytes: ByteArray): String =
+      MessageDigest.getInstance("SHA-256").digest(bytes).hex()
+
+    /**
+     * Streamed rather than `readBytes()` — these blobs run to 100 MB and are hashed on every read.
+     */
+    fun sha256Hex(file: File): String? = runCatching {
+      val digest = MessageDigest.getInstance("SHA-256")
+      file.inputStream().use { input ->
+        val buffer = ByteArray(BUFFER_BYTES)
+        while (true) {
+          val read = input.read(buffer)
+          if (read < 0) break
+          digest.update(buffer, 0, read)
+        }
+      }
+      digest.digest().hex()
+    }
+      .getOrNull()
+
+    private fun ByteArray.hex(): String = joinToString("") { "%02x".format(it) }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
-import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -170,6 +169,17 @@ class ServeCatalogStore(
     { _, _, _, _ ->
       false
     },
+  /**
+   * Durable, content-addressed home for the heavy bytes this store fetches — the executable
+   * `liveBundle`, its per-preview splits, and the externalised resource pool. See
+   * [CatalogBlobPool].
+   *
+   * Defaults to a pool rooted under [root], which is exactly the behaviour that existed before it
+   * was configurable: shared across systems and reloads, discarded with the process. `serve
+   * --catalog-cache-dir` supplies a durable root instead, and that is the whole of the difference —
+   * nothing below asks which kind it was given.
+   */
+  private val blobs: CatalogBlobPool = CatalogBlobPool(File(root, BLOB_CACHE_DIR)),
 ) {
 
   /** A catalog's buildable source — where to check out + build to re-render it live. */
@@ -344,6 +354,10 @@ class ServeCatalogStore(
     val base =
       deliveryCommit?.let { "https://raw.githubusercontent.com/$repo/$it/" }
         ?: "https://raw.githubusercontent.com/$repo/$branch/"
+    // Whether [base] names one immutable tree, and therefore whether the heavy executable bundles
+    // this load fetches may be cached by URL. See [CatalogBlobPool] — an un-pinned base is the
+    // branch ref, which is a moving target and must not populate a cache keyed on it.
+    val pinned = deliveryCommit != null
 
     val catalogBytes =
       try {
@@ -882,7 +896,7 @@ class ServeCatalogStore(
               nonEmptyPrefixes.none(daemonId::startsWith)
             }
           }
-          val bundleFile = fetchLiveBundle(descriptor, base, dir, safe)
+          val bundleFile = fetchLiveBundle(descriptor, base, dir, safe, pinned)
           if (bundleFile == null) {
             prepared.clear()
             liveBundleFallback =
@@ -917,12 +931,12 @@ class ServeCatalogStore(
                 PerPreviewBundleAccess(
                   available = { daemonId ->
                     safeStems[daemonId]?.let { stem ->
-                      perPreviewBundleAvailable(stem, descriptor, base, dir)
+                      perPreviewBundleAvailable(stem, descriptor, base, dir, pinned)
                     } ?: false
                   },
                   fetch = { daemonId ->
                     safeStems[daemonId]?.let { stem ->
-                      fetchPerPreviewBundle(stem, descriptor, base, dir, safe, resources)
+                      fetchPerPreviewBundle(stem, descriptor, base, dir, safe, resources, pinned)
                     }
                   },
                 ),
@@ -961,7 +975,7 @@ class ServeCatalogStore(
     // A multi-module declaration is atomic: never silently start only its primary legacy bundle.
     val liveBundle = if (multiLiveBundle) null else catalog.liveBundle
     if (verdict is BundleVerifier.Verdict.Trusted && liveBundle != null) {
-      val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe)
+      val bundleFile = fetchLiveBundle(liveBundle, base, dir, safe, pinned)
       if (bundleFile == null) {
         liveBundleFallback =
           ServeDegradation.liveBundleUnavailable(
@@ -1007,12 +1021,12 @@ class ServeCatalogStore(
               PerPreviewBundleAccess(
                 available = { daemonId ->
                   safeStems[daemonId]?.let { stem ->
-                    perPreviewBundleAvailable(stem, liveBundle, base, dir)
+                    perPreviewBundleAvailable(stem, liveBundle, base, dir, pinned)
                   } ?: false
                 },
                 fetch = { daemonId ->
                   safeStems[daemonId]?.let { stem ->
-                    fetchPerPreviewBundle(stem, liveBundle, base, dir, safe, res.dir)
+                    fetchPerPreviewBundle(stem, liveBundle, base, dir, safe, res.dir, pinned)
                   }
                 },
               )
@@ -1166,22 +1180,49 @@ class ServeCatalogStore(
   /**
    * Fetch a catalog's `liveBundle` (`{path, file}`) — the executable preview bundle
    * (`<system>-bundle.png`) `design-artifacts.yml` carries alongside the baked PNGs — from
-   * `<base><path>/<file>` into `<dir>/$LIVE_BUNDLE_DIR/<file>`. Fail-closed like [fetchWasmApp]: an
-   * invalid/escaping file entry or a fetch miss aborts and returns null, so the caller falls back
-   * to the Gradle `source` build (or, failing that, the static host). The file list is a single
-   * entry from the trusted catalog itself, not client input.
+   * `<base><path>/<file>`. Fail-closed like [fetchWasmApp]: an invalid/escaping file entry or a
+   * fetch miss aborts and returns null, so the caller falls back to the Gradle `source` build (or,
+   * failing that, the static host). The file list is a single entry from the trusted catalog
+   * itself, not client input.
+   *
+   * [pinned] says the load resolved a delivery commit, so [base] names one immutable tree. That is
+   * the whole of what decides whether the ~100 MB download may be cached: a pinned URL identifies
+   * exactly these bytes forever, so the bundle goes into the [blobs] pool and a reload — or, given
+   * `--catalog-cache-dir`, a restart — re-reads it instead of pulling it again. An un-pinned load
+   * (its revision feed could not be read, so [base] is the branch ref) addresses a moving target
+   * and stages into `<dir>/$LIVE_BUNDLE_DIR/<file>` exactly as this did before the pool existed.
    */
   private fun fetchLiveBundle(
     liveBundle: LiveBundle,
     base: String,
     dir: File,
     system: String,
+    pinned: Boolean,
   ): File? {
     val name = liveBundle.file.trim('/')
     if (name.isEmpty() || ".." in name.split("/")) {
       System.err.println("serve: $system liveBundle has an invalid file entry — skipping")
       return null
     }
+    val prefix = liveBundle.path.trim('/')
+    val url = if (prefix.isEmpty()) "$base$name" else "$base$prefix/$name"
+
+    if (pinned) {
+      val blob =
+        blobs.keyed(url) { dest ->
+          val bytes = runCatching { fetchExecutableBundle(url) }.getOrNull()
+          if (bytes == null) false
+          else {
+            dest.writeBytes(bytes)
+            true
+          }
+        }
+      if (blob == null) {
+        System.err.println("serve: $system liveBundle fetch failed ($url) — skipping")
+      }
+      return blob
+    }
+
     val bundleDir = File(dir, LIVE_BUNDLE_DIR)
     val bundleRoot = bundleDir.canonicalFile.toPath()
     val target = File(bundleDir, name)
@@ -1189,8 +1230,6 @@ class ServeCatalogStore(
       System.err.println("serve: $system liveBundle escaping entry '$name' — skipping")
       return null
     }
-    val prefix = liveBundle.path.trim('/')
-    val url = if (prefix.isEmpty()) "$base$name" else "$base$prefix/$name"
     val bytes = runCatching { fetchExecutableBundle(url) }.getOrNull()
     if (bytes == null) {
       System.err.println("serve: $system liveBundle fetch failed ($url) — skipping")
@@ -1310,8 +1349,14 @@ class ServeCatalogStore(
    * monolithic bundle into these (one re-renderable sticker per preview) beside it. Fail-closed
    * like [fetchLiveBundle]: an escaping [stem] or a fetch miss returns null and the caller simply
    * falls back to the monolithic daemon for that id (so a branch that ships no per-preview bundles
-   * still serves live from the monolith). Cached on disk: a second request for the same stem
-   * re-uses the already-fetched file rather than re-downloading.
+   * still serves live from the monolith).
+   *
+   * **What is cached is the HYDRATED bundle, not the thin download.** Hydration resolves the
+   * classpath entries the thin bundle declares *by sha256*, so its output is a deterministic
+   * function of this one URL — which means that when [pinned] holds, the finished bundle can be
+   * keyed on that URL in the [blobs] pool and a later reload (or restart, given
+   * `--catalog-cache-dir`) skips both the download and the repack. An un-pinned load keeps the
+   * per-system staging this used before the pool existed.
    *
    * [stem] is the route-safe filename `bundle split` wrote the bundle under (a sanitised bundle
    * preview descriptor id), pre-resolved by [uniquePerPreviewStems] so it's unambiguous — the URL
@@ -1324,7 +1369,16 @@ class ServeCatalogStore(
     dir: File,
     system: String,
     externalResourcesDir: File?,
+    pinned: Boolean,
   ): File? {
+    val url = perPreviewBundleUrl(stem, liveBundle, base)
+    val prefix = liveBundle.path.trim('/')
+    val hydrate = { dest: File ->
+      hydratePerPreviewBundle(url, dest, base, prefix, system, stem, externalResourcesDir)
+    }
+
+    if (pinned) return blobs.keyed(url) { dest -> hydrate(dest) }
+
     val previewsDir = File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR)
     val previewsRoot = previewsDir.canonicalFile.toPath()
     val target = File(previewsDir, "$stem.png")
@@ -1337,24 +1391,42 @@ class ServeCatalogStore(
       if (isCompleteExecutableBundle(target)) return target
       target.delete()
     }
-    val prefix = liveBundle.path.trim('/')
-    val url = perPreviewBundleUrl(stem, liveBundle, base)
+    target.parentFile?.mkdirs()
+    return target.takeIf { hydrate(it) }
+  }
+
+  /**
+   * Download one per-preview split bundle and repack it into [dest] with its externalised classpath
+   * and resources folded back in, reporting whether [dest] now holds a usable bundle.
+   *
+   * Boolean rather than `File?` because it is written to be handed a destination the caller chose —
+   * the pool's scratch file on a pinned load, the staged per-system path otherwise — and the two
+   * must not drift into separate hydration paths.
+   */
+  private fun hydratePerPreviewBundle(
+    url: String,
+    dest: File,
+    base: String,
+    prefix: String,
+    system: String,
+    stem: String,
+    externalResourcesDir: File?,
+  ): Boolean {
     val bytes = runCatching { fetchExecutableBundle(url) }.getOrNull()
     if (bytes == null) {
       // Expected when the branch ships no per-preview bundle for this id (older catalog, view-only
       // tier); the caller falls back to the monolithic daemon. Quiet — not an error.
-      return null
+      return false
     }
-    target.parentFile?.mkdirs()
     val thin =
-      java.nio.file.Files.createTempFile(previewsDir.toPath(), "$stem.", ".shared.png").toFile()
+      java.nio.file.Files.createTempFile(dest.parentFile.toPath(), "$stem.", ".shared.png").toFile()
     val hydrated =
       try {
         thin.writeBytes(bytes)
         runCatching {
           BundleClasspathHydration.hydrate(
             source = thin,
-            output = target,
+            output = dest,
             resolveClasspath = { entry -> fetchExternalClasspathBlob(entry, base, prefix, system) },
             resolveResource = { entry ->
               readMaterializedExternalResource(entry, externalResourcesDir)
@@ -1370,11 +1442,12 @@ class ServeCatalogStore(
       } finally {
         thin.delete()
       }
-    if (hydrated != null && !isCompleteExecutableBundle(hydrated)) {
+    if (hydrated == null) return false
+    if (!isCompleteExecutableBundle(hydrated)) {
       hydrated.delete()
-      return null
+      return false
     }
-    return hydrated
+    return true
   }
 
   /** Check publication without downloading and hydrating the potentially 100 MB bundle. */
@@ -1383,11 +1456,15 @@ class ServeCatalogStore(
     liveBundle: LiveBundle,
     base: String,
     dir: File,
+    pinned: Boolean,
   ): Boolean {
+    val url = perPreviewBundleUrl(stem, liveBundle, base)
+    // Deliberately unverified — see [CatalogBlobPool.holds]. Hashing a multi-megabyte bundle to
+    // answer "does this lane exist" would cost more than the network probe it replaces.
+    if (pinned && blobs.holds(url)) return true
     val cached = File(File(File(dir, LIVE_BUNDLE_DIR), PER_PREVIEW_DIR), "$stem.png")
     if (cached.isFile && cached.length() > 0 && isCompleteExecutableBundle(cached)) return true
-    return runCatching { branchProbe(perPreviewBundleUrl(stem, liveBundle, base)) }
-      .getOrDefault(false)
+    return runCatching { branchProbe(url) }.getOrDefault(false)
   }
 
   private fun perPreviewBundleUrl(stem: String, liveBundle: LiveBundle, base: String): String {
@@ -1438,19 +1515,23 @@ class ServeCatalogStore(
       System.err.println("serve: $system external classpath declaration is invalid — skipping")
       return null
     }
-    val cached = File(File(root, RES_CACHE_DIR).apply { mkdirs() }, sha)
-    val cachedBytes = cached.takeIf { it.isFile && it.length() == entry.size }?.readBytes()
-    if (cachedBytes != null && sha256Hex(cachedBytes) == sha) return cachedBytes
-
     val prefix = bundlePathPrefix.trim('/')
     val url = if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
-    val bytes = runCatching { fetchExecutableBundle(url) }.getOrNull() ?: return null
-    if (bytes.size.toLong() != entry.size || sha256Hex(bytes) != sha) {
-      System.err.println("serve: $system external classpath verification failed ($url)")
+    // Content-addressed: the pool returns a hit only once its bytes hash back to the digest the
+    // manifest declared, so a truncated or corrupt entry is refetched rather than put on a
+    // classpath. Being keyed by that digest rather than by a URL is also what makes it safe on an
+    // un-pinned load — there is no moving address involved.
+    val blob =
+      blobs.contentAddressed(sha, entry.size) {
+        runCatching { fetchExecutableBundle(url) }
+          .getOrNull()
+          ?.takeIf { it.size.toLong() == entry.size }
+      }
+    if (blob == null) {
+      System.err.println("serve: $system external classpath could not be fetched ($url)")
       return null
     }
-    cached.writeBytes(bytes)
-    return bytes
+    return runCatching { blob.readBytes() }.getOrNull()
   }
 
   /** Filesystem/route-safe stem for a per-preview id (mirrors `bundle split`'s sanitiser). */
@@ -1502,7 +1583,6 @@ class ServeCatalogStore(
         ?: emptyList()
     if (resources.isEmpty()) return ResRehydrate.Ready(null)
 
-    val cacheDir = File(root, RES_CACHE_DIR).apply { mkdirs() }
     val materialized = File(dir, RES_MATERIALIZED_DIR)
     val matRoot = materialized.canonicalFile.toPath()
     val prefix = bundlePathPrefix.trim('/')
@@ -1515,36 +1595,20 @@ class ServeCatalogStore(
         )
         return ResRehydrate.Unavailable
       }
-      // Content-addressed cache: fetch once, reuse across systems + reloads. The cache key IS the
-      // sha256, so a hit is only trusted after its bytes hash back to that key — a same-length but
-      // corrupt entry (partial write, disk fault) must be refetched, not silently put on the
-      // classpath. Verifying on read is cheap (fonts are small, reloads infrequent) and is the
-      // whole
-      // point of a content-addressed store.
-      val cached = File(cacheDir, sha)
-      val cacheValid =
-        cached.isFile &&
-          cached.length() == res.size &&
-          runCatching { sha256Hex(cached.readBytes()) == sha }.getOrDefault(false)
-      if (!cacheValid) {
-        cached.delete()
-        val url =
-          if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
-        val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull()
-        if (bytes == null) {
-          System.err.println(
-            "serve: $system external resource fetch failed ($url) — skipping live bundle"
-          )
-          return ResRehydrate.Unavailable
-        }
-        if (sha256Hex(bytes) != sha) {
-          System.err.println(
-            "serve: $system external resource sha256 mismatch ($url) — skipping live bundle"
-          )
-          return ResRehydrate.Unavailable
-        }
-        cached.parentFile?.mkdirs()
-        cached.writeBytes(bytes)
+      // Content-addressed cache: fetch once, reuse across systems, reloads and — given a durable
+      // `--catalog-cache-dir` — restarts. The cache key IS the sha256, so a hit is only trusted
+      // after its bytes hash back to that key: a same-length but corrupt entry (partial write,
+      // disk fault) is refetched, not silently put on the classpath.
+      val url =
+        if (prefix.isEmpty()) "$base$RES_POOL_DIR/$sha" else "$base$prefix/$RES_POOL_DIR/$sha"
+      val cached =
+        blobs.contentAddressed(sha, res.size) { runCatching { fetchCatalogAsset(url) }.getOrNull() }
+      if (cached == null) {
+        System.err.println(
+          "serve: $system external resource could not be fetched or verified ($url) — " +
+            "skipping live bundle"
+        )
+        return ResRehydrate.Unavailable
       }
       // Materialize at the recorded classpath path (path-contained — reject traversal/absolute).
       if (res.path.isBlank() || res.path.startsWith("/") || ".." in res.path.split("/")) {
@@ -2436,20 +2500,16 @@ class ServeCatalogStore(
     const val RES_POOL_DIR = "res"
 
     /**
-     * Shared, content-addressed on-disk cache for externalized resources, under the store root
-     * (`<root>/.res-cache/<sha>`). Shared across systems + reloads so a font fetched for one
-     * catalog is reused by the next.
+     * Default root for the [CatalogBlobPool] — under the store root, so a store given no durable
+     * pool behaves as it always did: shared across systems and reloads, discarded with the process.
+     * `serve --catalog-cache-dir` roots the pool on a volume instead.
      */
-    const val RES_CACHE_DIR = ".res-cache"
+    const val BLOB_CACHE_DIR = ".blobs"
 
     /**
      * Per-system subdir the rehydrated resources are materialized into at their classpath paths.
      */
     const val RES_MATERIALIZED_DIR = "bundle-res"
-
-    /** Lowercase-hex SHA-256 of [bytes] — the content-address a rehydrated resource is keyed by. */
-    private fun sha256Hex(bytes: ByteArray): String =
-      MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
 
     /**
      * The single-path-segment preview id for a catalog image path. The serve routes (`/p/{name}`,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -1,0 +1,297 @@
+package ee.schimke.composeai.cli.serve
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [CatalogBlobPool] — the content-addressed store that lets a catalog's heavy bytes
+ * (the executable `liveBundle`, its per-preview splits, the externalised resource pool) outlive
+ * both a reload and, given a durable root, the process.
+ *
+ * The load-bearing properties are that a hit is only ever returned once its bytes hash back to the
+ * name it is filed under, and that a pool reopened over the same directory reads what the previous
+ * one wrote. Everything else here guards those two.
+ */
+class CatalogBlobPoolTest {
+
+  private fun root(): File =
+    Files.createTempDirectory("blob-pool").toFile().also { it.deleteOnExit() }
+
+  private fun sha(bytes: ByteArray) = CatalogBlobPool.sha256Hex(bytes)
+
+  @Test
+  fun `a content-addressed blob is fetched once and served from disk after that`() {
+    val pool = CatalogBlobPool(root())
+    val bytes = "a font".toByteArray()
+    val fetches = AtomicLong()
+    val fetch = {
+      fetches.incrementAndGet()
+      bytes
+    }
+
+    val first = assertNotNull(pool.contentAddressed(sha(bytes), bytes.size.toLong(), fetch))
+    val second = assertNotNull(pool.contentAddressed(sha(bytes), bytes.size.toLong(), fetch))
+
+    assertContentEquals(bytes, first.readBytes())
+    assertEquals(first, second)
+    assertEquals(1, fetches.get(), "the second read must not go back to the branch")
+    assertEquals(1, pool.snapshot().hits)
+    assertEquals(1, pool.snapshot().misses)
+  }
+
+  @Test
+  fun `bytes that do not hash to the declared digest are refused`() {
+    // Fail-closed: the declared sha256 is the only thing that makes a fetched classpath entry safe
+    // to hand to a classloader, so bytes that do not match it are not merely uncached — they are
+    // not returned at all.
+    val pool = CatalogBlobPool(root())
+    val declared = sha("what the manifest declared".toByteArray())
+
+    val blob = pool.contentAddressed(declared, 5) { "other".toByteArray() }
+
+    assertNull(blob)
+    assertFalse(pool.contentFile(declared).exists())
+  }
+
+  @Test
+  fun `a corrupt cached entry is refetched rather than trusted by size`() {
+    // The whole point of a content-addressed store: a same-length but wrong-content entry (a
+    // partial write, a disk fault) must never be served. Verifying on read is what catches it.
+    val root = root()
+    val pool = CatalogBlobPool(root)
+    val bytes = ByteArray(64) { 7 }
+    val digest = sha(bytes)
+    pool.contentFile(digest).apply {
+      parentFile.mkdirs()
+      writeBytes(ByteArray(64) { 0 })
+    }
+    val fetches = AtomicLong()
+
+    val blob =
+      assertNotNull(
+        pool.contentAddressed(digest, 64) {
+          fetches.incrementAndGet()
+          bytes
+        }
+      )
+
+    assertContentEquals(bytes, blob.readBytes())
+    assertEquals(1, fetches.get())
+    assertEquals(1, pool.snapshot().corrupt)
+  }
+
+  @Test
+  fun `a keyed blob is produced once and read back by key`() {
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/bundle/app-bundle.png"
+    val produced = AtomicLong()
+    val produce = { dest: File ->
+      produced.incrementAndGet()
+      dest.writeBytes("bundle bytes".toByteArray())
+      true
+    }
+
+    val first = assertNotNull(pool.keyed(url, produce))
+    val second = assertNotNull(pool.keyed(url, produce))
+
+    assertEquals(first, second)
+    assertContentEquals("bundle bytes".toByteArray(), second.readBytes())
+    assertEquals(1, produced.get())
+  }
+
+  @Test
+  fun `a keyed blob written by one pool is read by the next over the same root`() {
+    // The restart case, stated directly: a rolled container is a new process over the same volume,
+    // and the point of the whole feature is that it does not pull the bundle again.
+    val root = root()
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/bundle/app-bundle.png"
+    val bytes = "carried over".toByteArray()
+    assertNotNull(
+      CatalogBlobPool(root).keyed(url) { dest ->
+        dest.writeBytes(bytes)
+        true
+      }
+    )
+
+    val reopened = CatalogBlobPool(root)
+    val produced = AtomicLong()
+    val blob =
+      assertNotNull(
+        reopened.keyed(url) { dest ->
+          produced.incrementAndGet()
+          dest.writeBytes(bytes)
+          true
+        }
+      )
+
+    assertContentEquals(bytes, blob.readBytes())
+    assertEquals(0, produced.get(), "a restarted process must read, not re-produce")
+    assertEquals(1, reopened.snapshot().hits)
+  }
+
+  @Test
+  fun `a producer that fails leaves nothing behind and does not poison the key`() {
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/bundle/missing.png"
+
+    assertNull(pool.keyed(url) { false })
+    assertFalse(pool.holds(url))
+
+    // The next attempt is free to succeed — a miss is not remembered, which is what makes a
+    // transient branch blip self-heal.
+    val blob =
+      assertNotNull(
+        pool.keyed(url) { dest ->
+          dest.writeBytes("landed".toByteArray())
+          true
+        }
+      )
+    assertContentEquals("landed".toByteArray(), blob.readBytes())
+    assertTrue(pool.holds(url))
+  }
+
+  @Test
+  fun `a pointer whose blob was reclaimed re-produces instead of returning a missing file`() {
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/bundle/app-bundle.png"
+    val bytes = "bundle".toByteArray()
+    assertNotNull(
+      pool.keyed(url) { dest ->
+        dest.writeBytes(bytes)
+        true
+      }
+    )
+    assertTrue(pool.contentFile(sha(bytes)).delete())
+
+    assertFalse(pool.holds(url))
+    val produced = AtomicLong()
+    val blob =
+      assertNotNull(
+        pool.keyed(url) { dest ->
+          produced.incrementAndGet()
+          dest.writeBytes(bytes)
+          true
+        }
+      )
+
+    assertEquals(1, produced.get())
+    assertContentEquals(bytes, blob.readBytes())
+  }
+
+  @Test
+  fun `both addressing modes share one blob space`() {
+    // A bundle fetched by URL and the same bytes declared by sha are one file, because the name is
+    // the digest either way. Two spaces would double the disk for no gain.
+    val pool = CatalogBlobPool(root())
+    val bytes = "shared".toByteArray()
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/bundle/app-bundle.png"
+    val keyed =
+      assertNotNull(
+        pool.keyed(url) { dest ->
+          dest.writeBytes(bytes)
+          true
+        }
+      )
+
+    val addressed =
+      assertNotNull(pool.contentAddressed(sha(bytes), bytes.size.toLong()) { error("no fetch") })
+
+    assertEquals(keyed, addressed)
+    assertEquals(1, pool.snapshot().blobs)
+  }
+
+  @Test
+  fun `sweep reclaims oldest-first down to the cap`() {
+    val now = AtomicLong(1_000_000L)
+    val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })
+    val blobs =
+      (1..4).map { i ->
+        now.addAndGet(1_000)
+        assertNotNull(
+          pool.keyed("https://raw.githubusercontent.com/o/r/$COMMIT/b$i.png") { dest ->
+            dest.writeBytes(ByteArray(100) { i.toByte() })
+            true
+          }
+        )
+      }
+
+    now.addAndGet(1_000)
+    val snapshot = pool.sweep()
+
+    assertEquals(200, snapshot.bytes)
+    assertEquals(2, snapshot.blobs)
+    assertEquals(2, snapshot.evicted)
+    assertFalse(blobs[0].exists(), "the oldest blob goes first")
+    assertFalse(blobs[1].exists())
+    assertTrue(blobs[2].exists())
+    assertTrue(blobs[3].exists())
+  }
+
+  @Test
+  fun `sweep spares blobs younger than the grace window`() {
+    // The overlapping-replica case: a booting replica shares this volume with the one still
+    // serving, and knows nothing about what it just wrote. Without the window it would reclaim it.
+    val now = AtomicLong(1_000_000L)
+    val pool = CatalogBlobPool(root(), maxBytes = 10, graceMillis = 60_000, clock = { now.get() })
+    val blob =
+      assertNotNull(
+        pool.keyed("https://raw.githubusercontent.com/o/r/$COMMIT/fresh.png") { dest ->
+          dest.writeBytes(ByteArray(100))
+          true
+        }
+      )
+
+    val snapshot = pool.sweep()
+
+    assertTrue(blob.exists(), "a blob the outgoing replica may still be reading must survive")
+    assertEquals(0, snapshot.evicted)
+    assertEquals(100, snapshot.bytes, "over the cap, and reported rather than acted on")
+  }
+
+  @Test
+  fun `sweep drops pointers whose blob is gone`() {
+    val root = root()
+    val pool = CatalogBlobPool(root, graceMillis = 0)
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/b.png"
+    val bytes = "gone soon".toByteArray()
+    assertNotNull(
+      pool.keyed(url) { dest ->
+        dest.writeBytes(bytes)
+        true
+      }
+    )
+    assertTrue(pool.contentFile(sha(bytes)).delete())
+
+    pool.sweep()
+
+    val pointers = File(root, CatalogBlobPool.KEYS_DIR).listFiles()?.filter { it.isFile }.orEmpty()
+    assertTrue(pointers.isEmpty(), "a pointer to nothing is not worth keeping")
+  }
+
+  @Test
+  fun `an unwritable root degrades to no caching rather than failing the load`() {
+    // Persistence is an optimisation. A box with a read-only or full disk must load catalogs
+    // exactly as it did before this existed, which means every call here answers null or refetches
+    // — never throws.
+    val root = File(root(), "nested").apply { writeText("not a directory") }
+    val pool = CatalogBlobPool(root)
+    val bytes = "x".toByteArray()
+
+    assertNull(pool.contentAddressed(sha(bytes), bytes.size.toLong()) { bytes })
+    assertNull(pool.keyed("https://raw.githubusercontent.com/o/r/$COMMIT/b.png") { true })
+    assertFalse(pool.holds("https://raw.githubusercontent.com/o/r/$COMMIT/b.png"))
+    assertNotNull(pool.snapshot().lastFailure)
+  }
+
+  private companion object {
+    const val COMMIT = "0123456789abcdef0123456789abcdef01234567"
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -30,6 +30,16 @@ class ServeCatalogStoreTest {
   private fun tempRoot(): File =
     Files.createTempDirectory("catalog").toFile().also { it.deleteOnExit() }
 
+  /**
+   * Where a store rooted at [root] holds the blob whose sha256 is [sha] — the default
+   * [CatalogBlobPool] location, which is the store root plus its own subdirectory.
+   */
+  private fun blobFile(root: File, sha: String): File =
+    File(File(root, ServeCatalogStore.BLOB_CACHE_DIR), "${CatalogBlobPool.CONTENT_DIR}/$sha")
+
+  /** A plausible delivery-branch head, so a stubbed feed pins a load to one immutable tree. */
+  private val COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
   private val registered = LinkedHashMap<String, ServeBundleHost>()
   private val registeredWasm = LinkedHashMap<String, File>()
 
@@ -1645,8 +1655,8 @@ class ServeCatalogStoreTest {
     val materializedFont = File(dir, "fonts/Roboto-Regular.ttf")
     assertTrue(materializedFont.isFile, "font materialized at its classpath path")
     assertEquals(font.toList(), materializedFont.readBytes().toList())
-    // It was cached content-addressed under the shared cache dir.
-    assertTrue(File(root, "${ServeCatalogStore.RES_CACHE_DIR}/$sha").isFile)
+    // It was cached content-addressed in the shared blob pool.
+    assertTrue(blobFile(root, sha).isFile)
   }
 
   @Test
@@ -1803,9 +1813,9 @@ class ServeCatalogStoreTest {
         branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*"))
       )
     val root = tempRoot()
-    // Pre-seed the shared cache with a same-size but WRONG-content entry.
+    // Pre-seed the shared blob pool with a same-size but WRONG-content entry.
     val cacheFile =
-      File(root, "${ServeCatalogStore.RES_CACHE_DIR}/$sha").apply {
+      blobFile(root, sha).apply {
         parentFile.mkdirs()
         writeBytes(ByteArray(2048) { 0 })
       }
@@ -1837,6 +1847,138 @@ class ServeCatalogStoreTest {
     }
 
   /** Build a minimal desktop-bundle polyglot (PNG cover + zip) with the given bundle.json. */
+  // ------------------------------------------------------------------------------------------
+  // The blob pool: what a reload and a restart no longer have to re-download.
+  // ------------------------------------------------------------------------------------------
+
+  /** A one-entry commit feed, so a load resolves a delivery commit and pins its reads to it. */
+  private fun feed(commit: String): String =
+    """
+    <feed><entry>
+      <id>tag:github.com,2008:Grit::Commit/$commit</id>
+      <updated>2026-08-19T09:42:57Z</updated>
+    </entry></feed>
+    """
+      .trimIndent()
+
+  private val liveBundleCatalogJson =
+    """
+    {"schema":"design-parity-catalog/v1","system":"compose-m3",
+     "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+     "components":[{"componentId":"Button/Filled","images":[
+       {"path":"images/button-filled/ideal__default__dark.png","theme":"dark","previewId":"FilledButton_Dark"}]}]}
+    """
+      .trimIndent()
+
+  private val trustedBranch =
+    TrustStore(branches = listOf(TrustedBranch("yschimke/compose-ai-tools", "design-artifacts/*")))
+
+  private val liveBundleBytes: ByteArray by lazy {
+    polyglotBundle(
+      """{"schemaVersion":8,"backend":"desktop","previewIds":["FilledButton_Dark"],
+         "coverPreviewId":"FilledButton_Dark","classpath":[{"kind":"module","path":"classes/app.jar"}],
+         "modulePath":":app","producedBy":"test"}"""
+    )
+  }
+
+  /**
+   * A branch that resolves one commit and serves the catalog + its liveBundle, counting every read
+   * of the bundle itself. Reads are answered under both the pinned and the branch-name base so the
+   * same stub drives a pinned and an un-pinned load.
+   */
+  private fun liveBundleBranch(
+    commit: String,
+    bundleReads: java.util.concurrent.atomic.AtomicLong,
+    serveFeed: Boolean = true,
+  ): (String) -> ByteArray? = { url ->
+    when {
+      url ==
+        ServeCatalogRevision.commitsFeedUrl(
+          "yschimke/compose-ai-tools",
+          "design-artifacts/compose-m3",
+        ) -> if (serveFeed) feed(commit).encodeToByteArray() else null
+      url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> liveBundleCatalogJson.toByteArray()
+      url.endsWith("bundle/compose-m3-bundle.png") -> {
+        bundleReads.incrementAndGet()
+        liveBundleBytes
+      }
+      url.contains("bundle/previews/") -> null
+      url.endsWith(".png") -> png()
+      else -> null
+    }
+  }
+
+  @Test
+  fun `a pinned load caches the liveBundle so a reload does not download it again`() {
+    // The reload half of the problem: `load` deletes the per-system directory before swapping
+    // staging over it, so before the pool every regeneration re-pulled a ~100 MB bundle the new
+    // revision may not have changed. A commit-pinned URL names one immutable object, so the second
+    // load reads the pooled copy.
+    val reads = java.util.concurrent.atomic.AtomicLong()
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranch },
+        fetch = liveBundleBranch(COMMIT, reads),
+        buildTrustedBundle = { _, _, _, _, _, _ -> true },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertEquals(1, reads.get())
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(1, reads.get(), "a reload must read the pooled bundle, not the branch")
+  }
+
+  @Test
+  fun `a pool shared with a fresh store carries the liveBundle across a restart`() {
+    // The restart half: a rolled container is a new process over the same volume. Two stores with
+    // separate roots and one durable pool is exactly that arrangement.
+    val pool = CatalogBlobPool(tempRoot())
+    val reads = java.util.concurrent.atomic.AtomicLong()
+    fun store() =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranch },
+        fetch = liveBundleBranch(COMMIT, reads),
+        buildTrustedBundle = { _, _, _, _, _, _ -> true },
+        blobs = pool,
+      )
+
+    assertTrue(store().load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertEquals(1, reads.get())
+    assertTrue(store().load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(1, reads.get(), "a restarted server must read the pooled bundle")
+    assertTrue(pool.snapshot().hits >= 1)
+  }
+
+  @Test
+  fun `an un-pinned load caches nothing`() {
+    // The rule the pool depends on: without a resolved delivery commit the base is the branch ref,
+    // which is a moving target. Caching under it would let a regenerated branch be answered with
+    // the bytes it published last week, so an un-pinned load stages exactly as it always did.
+    val pool = CatalogBlobPool(tempRoot())
+    val reads = java.util.concurrent.atomic.AtomicLong()
+    fun store() =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranch },
+        fetch = liveBundleBranch(COMMIT, reads, serveFeed = false),
+        buildTrustedBundle = { _, _, _, _, _, _ -> true },
+        blobs = pool,
+      )
+
+    assertTrue(store().load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(store().load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(2, reads.get(), "each un-pinned load must re-read the branch")
+    assertEquals(0, pool.snapshot().blobs, "nothing addressed by a branch ref may be pooled")
+  }
+
   private fun polyglotBundle(
     manifest: String,
     extra: Map<String, ByteArray> = emptyMap(),

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -192,6 +192,19 @@ services:
       # first-release posture is opt-in.
       SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-none}"
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
+      # The heavy bytes a catalog FETCHES (as opposed to the pixels it renders): each live
+      # catalog's executable liveBundle — ~100 MB — its per-preview split bundles, and the
+      # externalised font/resource pool. Held content-addressed, so a rolled replica reads them
+      # off this volume instead of re-downloading them from raw.githubusercontent.com, and a
+      # delivery-branch regeneration re-fetches only what actually moved.
+      #
+      # Defaulted ON here, unlike the theme cache above, because unset is not the same trade: the
+      # server has always kept these in a temp dir, so pointing them at a volume only changes how
+      # long they live. Nothing mutable is cached — only bytes addressed by a commit-pinned URL,
+      # which name one immutable object forever. Set SERVE_CATALOG_CACHE_DIR=none in .env to keep
+      # the temp-dir behaviour.
+      SERVE_CATALOG_CACHE_DIR: "${SERVE_CATALOG_CACHE_DIR:-/catalog-cache}"
+      SERVE_CATALOG_CACHE_MAX_BYTES: "${SERVE_CATALOG_CACHE_MAX_BYTES:-}"
       # Bundle-upload lane (POST a locally-built bundle and browse it here). Off unless asked for.
       SERVE_ACCEPT_BUNDLES: "${SERVE_ACCEPT_BUNDLES:-}"
       SERVE_ACCEPT_BUNDLES_FROM: "${SERVE_ACCEPT_BUNDLES_FROM:-}"
@@ -234,6 +247,12 @@ services:
       # cache. Mounted unconditionally so turning the cache on is a one-line .env change
       # (SERVE_THEME_CACHE_DIR=/theme-cache); while it stays `none` the volume is simply empty.
       - preview_theme_cache:/theme-cache
+      # Fetched catalog bytes, on a volume of their OWN for the same reason the theme cache got
+      # one: preview_config holds the catalog set and the trust store and must not be crowded out
+      # by an up-to-8-GB blob pool. Two replicas mount this at once during a rolling update, which
+      # the pool is built for — writes are content-addressed and its sweeper spares anything young
+      # enough to belong to the outgoing replica.
+      - preview_catalog_cache:/catalog-cache
     # To also pin your OWN producers, mount a trust store over the baked one and keep
     # SERVE_TRUST_STORE pointing at it:
     #   - ./producers.json:/trust/producers.json:ro
@@ -382,6 +401,8 @@ services:
 
 volumes:
   preview_theme_cache:
+  # The executable bundles, split bundles and externalised resources each live catalog fetches.
+  preview_catalog_cache:
   # Runtime download caches for `preview` (resolved live-bundle dep jars + fonts), kept across
   # image rolls so a freshly-rolled replica reuses them instead of re-downloading. See the
   # `preview` service's volumes block for why the baked android-all / ~/.m2 are excluded.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -383,5 +383,13 @@ fi
 [[ -n "${SERVE_THEME_CACHE_MAX_BYTES:-}" ]] &&
   args+=(--theme-cache-max-bytes "${SERVE_THEME_CACHE_MAX_BYTES}")
 
+# The heavy bytes a catalog fetches — its executable liveBundle, the per-preview splits and the
+# externalised resource pool — kept on a volume so a rolled replica reads them instead of pulling
+# ~100 MB per live catalog again. Unlike the theme cache, unset is NOT off: the server falls back
+# to a temp-dir pool, which is what it always had. Only commit-pinned reads are cached.
+[[ -n "${SERVE_CATALOG_CACHE_DIR:-}" ]] && args+=(--catalog-cache-dir "${SERVE_CATALOG_CACHE_DIR}")
+[[ -n "${SERVE_CATALOG_CACHE_MAX_BYTES:-}" ]] &&
+  args+=(--catalog-cache-max-bytes "${SERVE_CATALOG_CACHE_MAX_BYTES}")
+
 echo "entrypoint: compose-preview serve on 0.0.0.0:${PORT}" >&2
 exec compose-preview "${args[@]}"

--- a/docs/design/CATALOG_CONTENT_CACHE.md
+++ b/docs/design/CATALOG_CONTENT_CACHE.md
@@ -259,14 +259,36 @@ Each ships independently and is provable on its own.
 
 | # | Change | Wins | Risk |
 | --- | --- | --- | --- |
-| **1** | `--catalog-cache-dir`; move `.res-cache` and the executable bundles + splits into `<root>/blobs/` | The largest byte win (100 MB-class bundles), and it survives *reloads* as well as restarts | Low — the sha verification already exists; only the path changes |
+| **1 — landed** | `--catalog-cache-dir` + `--catalog-cache-max-bytes`; `.res-cache` and the executable bundles + splits moved into a content-addressed [`CatalogBlobPool`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt) | The largest byte win (100 MB-class bundles), and it survives *reloads* as well as restarts | Low — the sha verification already existed; only the path changed |
 | **2** | Asset cache for commit-pinned reads, behind `fetchCatalogAsset`; `cached` counter | Lazy PNGs, motion, references, and the `?at=` lane stop re-fetching | Low — one funnel, one admission rule |
 | **3** | Generation snapshots + `current` pointer; adopt-then-converge boot; seed the refresher's head | The restart win: catalogs serve before any network | Medium — the adoption checks are where the care goes |
-| **4** | `?flush=1`, `DELETE /admin/catalog-cache[/<system>]`, `catalogCache` status block, sweeper + grace window | Operability, and the ability to tell a working cache from write amplification | Low |
+| **4** | `?flush=1`, `DELETE /admin/catalog-cache[/<system>]`, `catalogCache` status block | Operability, and the ability to tell a working cache from write amplification | Low |
 | **5** | Background audit: adopted-commit reachability from the Atom feed, plus a sampled byte comparison | Catches disk corruption and rewritten history | Low — reports, never gates |
 
 Phases 1–2 are worth doing regardless of whether 3 lands: they are pure subtraction from the fetch
 path with no new correctness surface. Phase 3 is where the headline number is.
+
+### What phase 1 shipped, and where it differs from this plan
+
+Two deliberate departures, both in the direction of shipping less surface rather than more:
+
+- **The sweeper came with phase 1, not phase 4.** It was planned late because it reads like
+  operability, but an opt-in durable cache with no ceiling is a "you turned this on and it filled
+  your disk" waiting to happen — and it turned out to be ~30 lines here rather than the careful
+  live-set reasoning `ThemeCacheStore.sweep` needs, because evicting a pooled blob is *always* safe:
+  the worst it costs is the fetch that produces it again. The grace window came with it, for the
+  overlapping replicas a rolling update creates.
+- **There is no derived default.** The plan said "mirroring `--theme-cache-dir`'s conventions
+  exactly", and the theme and feed caches both default to a directory beside `catalogs.json` — which
+  on the prebuilt image is the *configuration* volume. That is fine for a few MB of feed XML and
+  wrong for several GB of executable bundles, and the theme cache already had to introduce a `none`
+  sentinel to defend against exactly that. So this one has no derived location at all: unset means
+  the temp-dir pool the server always had, a path means that path, `none` forces the temp dir back.
+
+Also worth recording, because it is the number phase 3 has to beat: with the pool warm, what a boot
+still pays is the *manifests* — one Atom feed, one `catalog.json`, one preview index and the
+reference/page indexes per catalog — plus re-assembling each per-system staging directory. The
+executable tier, which was the bulk, is now read locally.
 
 ## What this deliberately does not do
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2362,6 +2362,65 @@ signed-in GitHub user to use live previews; playground still requires access to
 for both surfaces. The allowlist only ever **restricts** — naming a login does not grant it
 playground access, which always comes from the repo check above.
 
+### Fetched catalog bytes outlive the container (`--catalog-cache-dir`)
+
+`serve --catalogs` fetches each system's delivery branch into a directory the server creates with
+`createTempDirectory`, so everything a catalog pulled is discarded when the container is recreated —
+which on this image is what every rolled release performs. It is not only restarts: a catalog load
+deletes the live per-system directory before renaming its staging over it, so **each reload throws
+the previous generation away too**, including bytes the new revision never changed.
+
+For most of what a catalog fetches that costs little, because the baked PNGs are already lazy — a
+grid fills them through the ordinary request path. The exception is the executable tier: each live
+catalog's `liveBundle` runs to ~100 MB, its per-preview split bundles are fetched and repacked one
+per edited preview, and the externalised font/resource pool is fetched beside them. On a box
+publishing a couple of dozen catalogs that is the same download on every roll and every
+regeneration.
+
+`--catalog-cache-dir <dir>` puts those bytes in a content-addressed pool that outlives both events:
+
+```
+SERVE_CATALOG_CACHE_DIR=/catalog-cache   # the prebuilt image's default; `none` for a temp dir
+```
+
+**Unlike `--theme-cache-dir`, unset is not off.** A temp-directory pool is what this server has
+always had, so falling back to one costs nothing that was not already being paid; what a durable
+directory buys is that the bytes survive the container, and what `none` buys is the ability to say
+they should not. The image mounts a dedicated `preview_catalog_cache` volume for it, kept away from
+`preview_config` for the same reason the theme cache is.
+
+#### What makes reuse safe here
+
+A load does not read a branch. It resolves the delivery commit from the branch's Atom feed first and
+pins every subsequent URL to it (`raw.githubusercontent.com/<repo>/<commit>/…`), so those reads are
+**immutable by construction** — a cached answer can only ever be *the* answer. That is a stronger
+position than the theme cache, which caches derived pixels and therefore needs a fingerprint of
+everything that produced them plus a sample verification for whatever the fingerprint missed. Here
+there is nothing to approximate, so there is no fingerprint, no TTL and nothing to revalidate.
+
+Two rules carry it:
+
+- **Only commit-pinned reads are pooled.** A load whose revision feed could not be read falls back
+  to addressing the branch ref, which is a moving target; those reads stage exactly as they did
+  before the pool existed and populate nothing.
+- **Every blob is self-verifying.** A blob's file name *is* the sha256 of its bytes, so a read
+  hashes and compares before returning, and a truncated or corrupted entry is re-produced rather
+  than handed to a classloader. The externalised resources were already checked this way against
+  the digest their manifest declares; the pool extends the same rule to everything it holds.
+
+The pool is swept after the startup pass and after each later catalog publication — oldest-touched
+first, down to `--catalog-cache-max-bytes` (8 GB by default), sparing anything written in the last
+hour so the two replicas that overlap during a rolling update cannot reclaim each other's bytes.
+Sweeping on every publication and not only at boot is what stops a box that regenerates several
+times a day accumulating each superseded revision's bundles for the life of the process; a rate
+limit keeps a burst of publications to one census. Eviction is always safe: the worst a reclaimed
+blob costs is the fetch that produces it again.
+
+What this does **not** yet do is let a restart serve a catalog before it has talked to the branch —
+the manifests are still fetched and the per-system directory still re-assembled on the boot path.
+That is the next step, and whether it is worth the complexity is a question for what this one
+measures; see [the plan](design/CATALOG_CONTENT_CACHE.md).
+
 ### The catalog set is config, not image content
 
 **Which catalogs a box publishes lives in a `catalogs.json` outside the image**, on the mounted


### PR DESCRIPTION
Phase 1 of [the catalog content cache plan](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/CATALOG_CONTENT_CACHE.md) (#4291).

## The problem

`serve --catalogs` roots its catalog store at a `createTempDirectory` (`ServeCommand.kt:3099`), so everything a catalog fetched dies with the container — which on the prebuilt image is what every rolled release performs.

It is **not only restarts**. `ServeCatalogStore.load` ends with `dir.deleteRecursively()` before renaming staging over it (`ServeCatalogStore.kt:678`), so every *reload* discarded the previous generation too — including a ~100 MB `liveBundle` the new revision may not have changed at all. Only `.res-cache` survived a reload, and only because it sat above that directory. `preview.coo.ee` runs 23 catalogs and regenerates several times a day.

## The change

A new `CatalogBlobPool` — a content-addressed store for the heavy bytes:

- the executable `liveBundle`;
- its **per-preview split bundles**, cached *hydrated* rather than as the thin download: hydration resolves the classpath entries the thin bundle declares by sha256, so its output is a deterministic function of the one URL, and a cache hit skips both the download and the repack;
- the externalised font/resource pool, which `.res-cache` already held content-addressed — this just moves it somewhere that can outlive the process.

`--catalog-cache-dir <dir>` roots the pool on a volume. **Unset keeps the temp-dir pool the server always had**, so nothing changes for a deployment that does not opt in, and there is deliberately no derived default — the obvious one (beside `catalogs.json`) is the config volume, which is the footgun `--theme-cache-dir` had to grow a `none` sentinel to defend against. The prebuilt image mounts a dedicated `preview_catalog_cache` volume and turns it on.

## Why reuse is safe here without a fingerprint

A load does not read a branch: it resolves the delivery commit from the Atom feed and pins every subsequent URL to it, so those addresses are **immutable by construction**. Unlike the theme cache — which caches derived pixels and therefore needs `ThemeCacheFingerprint` plus a sample verification for whatever the fingerprint missed — there is nothing to approximate. Two rules carry it:

1. **Only commit-pinned reads are pooled.** A load whose revision feed could not be read addresses the branch ref, which is a moving target; that path stages exactly as it did before and populates nothing.
2. **Every blob is filed under the sha256 of its own bytes.** A read hashes and compares before returning, so a truncated or corrupt entry is re-produced rather than handed to a classloader. That also means both addressing modes (declared-digest and pinned-URL) share one blob space, with a small pointer file mapping key → digest whose every possible value names a self-verifying blob.

Swept oldest-first down to `--catalog-cache-max-bytes` (8 GB default) after the startup pass and after each later publication, sparing blobs younger than an hour so the two replicas that overlap during a `docker-rollout` cannot evict each other's. Eviction is always safe — the worst a reclaimed blob costs is the fetch that produces it again — so unlike the theme cache's sweeper this needs no notion of a live set.

## Test plan

All green locally:

- **`CatalogBlobPoolTest`** (new, 11 cases) — fetch-once-then-read; bytes that do not hash to the declared digest are refused; a same-size-but-corrupt entry is refetched rather than trusted by size; a pool reopened over the same root reads what the previous one wrote (**the restart case, stated directly**); a failed producer poisons nothing; a pointer whose blob was reclaimed re-produces; both addressing modes share one blob space; sweep evicts oldest-first to the cap, spares the grace window, and drops orphaned pointers; an unwritable root degrades to no caching rather than throwing.
- **`ServeCatalogStoreTest`** (3 new cases) — a pinned load caches the `liveBundle` so a reload does not download it again; a pool shared with a fresh store carries it across a restart; **an un-pinned load caches nothing**.
- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.*"` — **1,918 tests, 0 failures**.
- `./gradlew :cli:compileKotlin ktfmtCheckAll` — BUILD SUCCESSFUL.
- `deploy/image/test-compose-env-passthrough.sh` — passes with the two new `SERVE_CATALOG_CACHE_*` knobs (55 variables checked); `test-deploy-config-mount.sh` and `test-env-migrations.sh` also pass.

One bug found and fixed during review of my own diff: a nested `run { }` in `keyed` captured the `return@run` label, which the compiler caught as a nullability mismatch rather than silently mis-scoping.

No visual evidence: this change renders nothing — it is fetch-path plumbing, build wiring and docs.

## Follow-ups

Phase 2 (asset cache for the lazily-fetched PNGs and the `?at=` lane) and phase 3 (generation snapshots + adopt-then-converge boot) are unchanged in the plan. The doc now records what a boot still pays with this pool warm — the manifests plus re-assembling each staging directory — since that is the number phase 3 has to beat, and the plan already says phase 3's value is a hypothesis to measure rather than assume.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_