### PR TITLE
fix(deploy): restate caddy's CMD so the container starts at all

### DIFF
--- a/deploy/image/caddy-entrypoint.sh
+++ b/deploy/image/caddy-entrypoint.sh
@@ -42,4 +42,14 @@ else
   echo "caddy: no top-level site hostnames (none in ${CATALOGS_FILE}, none in SITE_DOMAINS)" >&2
 fi
 
+# Belt and braces for the failure that took the box down: if the arguments are missing — a
+# Dockerfile that declares ENTRYPOINT without restating CMD, a compose file that sets `entrypoint:`
+# and forgets `command:` — `exec caddy` with none prints usage and exits, and a caddy container that
+# exits takes ports 80/443 with it. Every hostname on the box goes dark, not just the sites. Default
+# to what caddy:2 would have run rather than letting a config slip become an outage.
+if [ "$#" -eq 0 ]; then
+  echo "caddy: no arguments given (dropped CMD?) — defaulting to the standard config" >&2
+  set -- run --config /etc/caddy/Caddyfile --adapter caddyfile
+fi
+
 exec caddy "$@"

--- a/deploy/image/caddy.Dockerfile
+++ b/deploy/image/caddy.Dockerfile
@@ -24,7 +24,12 @@ COPY Caddyfile /etc/caddy/Caddyfile
 COPY site-domains.sh /usr/local/bin/site-domains.sh
 COPY caddy-entrypoint.sh /usr/local/bin/caddy-entrypoint.sh
 RUN chmod +x /usr/local/bin/site-domains.sh /usr/local/bin/caddy-entrypoint.sh
-# CMD is inherited from caddy:2 (`run --config /etc/caddy/Caddyfile --adapter caddyfile`) and passed
-# through by the entrypoint's `exec caddy "$@"`, so this changes what Caddy is *told*, never how it
-# is run.
+# ENTRYPOINT + CMD, and the CMD is NOT optional: Docker **resets an inherited CMD to empty** when a
+# Dockerfile declares ENTRYPOINT, so `caddy:2`'s own `run --config … --adapter caddyfile` does not
+# survive the line below. Without this, the entrypoint's `exec caddy "$@"` runs `caddy` with no
+# arguments — which prints usage and exits, so the container dies and takes ports 80/443 with it.
+# That is the whole box offline, not a degraded site: it is what happened when this image first
+# shipped without the CMD. Restated verbatim from caddy:2 so the entrypoint passes it straight
+# through and changes what Caddy is *told*, never how it is run.
 ENTRYPOINT ["/usr/local/bin/caddy-entrypoint.sh"]
+CMD ["run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/deploy/image/test-site-domains.sh
+++ b/deploy/image/test-site-domains.sh
@@ -138,6 +138,29 @@ check "the caddy command line is passed through" \
   "ARGS=[run --config /etc/caddy/Caddyfile --adapter caddyfile]" \
   "$(entry_of '{"catalogs":[]}' | sed -n 2p)"
 
+# An entrypoint that is handed nothing must still start Caddy. `exec caddy` with no arguments
+# prints usage and exits; a caddy container that exits releases ports 80/443, so EVERY hostname on
+# the box goes dark, not just the sites. This is the shape of the outage the missing CMD caused.
+check "no arguments still starts Caddy with the standard config" \
+  "ARGS=[run --config /etc/caddy/Caddyfile --adapter caddyfile]" \
+  "$(printf '%s' '{"catalogs":[]}' > "${work}/catalogs.json"
+     PATH="${work}/bin:${PATH}" CATALOGS_FILE="${work}/catalogs.json" SITE_DOMAINS="" \
+       sh "${entrypoint}" 2>/dev/null | sed -n 2p)"
+
+# …and the image must not rely on that fallback: Docker RESETS an inherited CMD to empty when a
+# Dockerfile declares ENTRYPOINT, so caddy:2's own command line does not survive our ENTRYPOINT
+# line. Shipping the pair without a CMD is what took the box offline; this pins that they stay
+# together.
+dockerfile="${here}/caddy.Dockerfile"
+if grep -q '^ENTRYPOINT' "${dockerfile}"; then
+  if grep -q '^CMD' "${dockerfile}"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: caddy.Dockerfile declares ENTRYPOINT without a CMD — Docker resets the inherited one to empty, so Caddy would start with no arguments and exit." >&2
+  fi
+fi
+
 # --- the real deployment config ----------------------------------------------------------------
 # The committed file is the one input that must never surprise this. Its hostnames are what the box
 # routes, so a scan that disagrees with the file is a site that silently doesn't come up.


### PR DESCRIPTION
**Outage fix for #4301.** `preview.coo.ee` is down — every hostname, not just the top-level sites.

## What broke

`caddy.Dockerfile` gained an `ENTRYPOINT` with no `CMD`. **Docker resets an inherited `CMD` to empty when a Dockerfile declares `ENTRYPOINT`**, so `caddy:2`'s own `run --config /etc/caddy/Caddyfile --adapter caddyfile` did not survive that line — the comment I wrote there claimed the opposite. The entrypoint's `exec caddy "$@"` therefore ran `caddy` with no arguments, which prints usage and exits. A caddy container that exits releases ports 80/443, so the edge disappeared entirely.

```
$ curl -s -o /dev/null -w '%{http_code}\n' https://preview.coo.ee/healthz
000
```

## Fix

Two changes, because either alone would have prevented it:

- **`caddy.Dockerfile` restates the CMD** verbatim beside the `ENTRYPOINT`.
- **The entrypoint defaults to that command line when handed no arguments**, so the same mistake from a different direction — a compose file that sets `entrypoint:` and forgets `command:`, which clears the image CMD the same way — degrades to the standard config instead of taking the edge down.

## Immediate mitigation on the box

If this needs to come back before the image publishes and Watchtower pulls, pin the previous caddy image in `.env` and recreate:

```bash
CADDY_IMAGE_TAG=<sha before the #4301 build>   # in deploy/image/.env
docker compose up -d caddy
```

That image predates the entrypoint entirely, so it starts as it always did.

## Test plan

- `deploy/image/test-site-domains.sh` — 20 checks (was 18), two new:
  - an entrypoint invoked with **no arguments** must still start Caddy with the standard config;
  - `caddy.Dockerfile` must declare a `CMD` whenever it declares an `ENTRYPOINT`.
- Verified the guard actually catches the regression: with the `CMD` line removed the suite fails with `1 check(s) failed, 19 passed` and names the reason; restored, `OK: 20 site-domain check(s) passed.`

## Why the existing test missed it

The "the caddy command line is passed through" check invoked the entrypoint with the arguments spelled out — which is precisely what the image stopped doing. It tested the script and never the image's contract with it. Both new checks close that gap from opposite ends.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CokUnR3SPMa2gTng2DZ5oP)_