### PR TITLE
perf(daemon): back the live frame loop off while nothing is moving

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -254,6 +254,12 @@ class JsonRpcServer(
   private val interactiveBurstIntervalMs: Long = INTERACTIVE_BURST_INTERVAL_MS,
   private val interactiveBurstMs: Long = INTERACTIVE_BURST_MS,
   /**
+   * The idle backoff, injectable so tests can drive the curve in milliseconds rather than the tens
+   * of seconds the shipped values need. See [interactiveIdleCadenceMs].
+   */
+  private val interactiveIdleMaxIntervalMs: Long = INTERACTIVE_IDLE_MAX_INTERVAL_MS,
+  private val interactiveQuiescentAfter: Int = INTERACTIVE_QUIESCENT_AFTER,
+  /**
    * Stage-2 in-process compile. When non-null, `compileSources` requests dispatch through this
    * service; on `Ok` we swap the user classloader the same way `fileChanged({kind:source})` does.
    * When null (fake-mode harness scenarios, integration tests that don't opt in, daemons whose
@@ -498,6 +504,17 @@ class JsonRpcServer(
    * component that does not animate costs renders but almost no wire.
    */
   private val interactiveBurstUntilMs = ConcurrentHashMap<String, Long>()
+
+  /**
+   * Consecutive renders of a preview that came back byte-identical — the quiescence signal
+   * [interactiveIdleCadenceMs] backs the live frame loop off on.
+   *
+   * Keyed by previewId, alongside [lastFrameHashes] and updated from the same comparison, because
+   * that is where the hash is already computed and because two streams watching one preview are
+   * watching the same composition settle. Reset by any changed frame, by any input (via
+   * [startInteractiveBurst]), and when a stream starts.
+   */
+  private val interactiveIdleRun = ConcurrentHashMap<String, Int>()
 
   /**
    * Per-stream wake channel for the frame loop, so an input that starts a burst does not wait out
@@ -1339,6 +1356,10 @@ class JsonRpcServer(
     val frameHash = hashFrameBytes(result.pngPath)
     val isUnchanged =
       frameHash != null && lastFrameHashes[previewId] == frameHash && firstRenderFinishedSeen.get()
+    // Feed the idle backoff's quiescence signal from the comparison that already happened. Tracked
+    // for every render, not just interactive ones: an unchanged render is an unchanged render.
+    if (isUnchanged) interactiveIdleRun.merge(previewId, 1, Int::plus)
+    else interactiveIdleRun.remove(previewId)
     val outboundFinished = if (isUnchanged) finished.copy(unchanged = true) else finished
     sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), outboundFinished))
     // Live-frame streaming (`composestream/1`). The streaming layer is a *consumer* of the
@@ -2630,6 +2651,9 @@ class JsonRpcServer(
     // Per-preview wipe (not per-stream): two streams targeting the same preview both want a
     // fresh first frame, and the dedup state is shared by design.
     lastFrameHashes.remove(params.previewId)
+    // …and the idle run with it, so a fresh stream opens at the base cadence rather than inheriting
+    // the backoff a previous viewer of this preview left behind.
+    interactiveIdleRun.remove(params.previewId)
     if (session != null) {
       interactiveSessions[streamId] = session
       startInteractiveFrameLoop(streamId, params.previewId, session)
@@ -2887,6 +2911,9 @@ class JsonRpcServer(
     // line 1910 — without it, a stream that re-attaches to an already-rendered preview would
     // see an `unchanged` heartbeat as its first frame.
     lastFrameHashes.remove(params.previewId)
+    // …and the idle run with it, so a fresh stream opens at the base cadence rather than inheriting
+    // the backoff a previous viewer of this preview left behind.
+    interactiveIdleRun.remove(params.previewId)
     sendResponse(
       req.id,
       encode(
@@ -3011,16 +3038,52 @@ class JsonRpcServer(
 
   /**
    * How long the frame loop for [streamId] should wait before its next render — the burst cadence
-   * while an input is still settling, the idle cadence otherwise. See [interactiveBurstUntilMs].
+   * while an input is still settling, then the idle cadence, then progressively slower while
+   * nothing on the preview is moving. See [interactiveBurstUntilMs] and [interactiveIdleRun].
    */
   private fun interactiveFrameCadenceMs(streamId: String): Long {
-    val until = interactiveBurstUntilMs[streamId] ?: return interactiveFrameIntervalMs
-    if (System.currentTimeMillis() >= until) {
+    val until = interactiveBurstUntilMs[streamId]
+    if (until != null) {
+      if (System.currentTimeMillis() < until) {
+        return minOf(interactiveBurstIntervalMs, interactiveFrameIntervalMs)
+      }
       // Expired: drop the entry so the map does not accumulate one per stream that ever saw input.
       interactiveBurstUntilMs.remove(streamId, until)
-      return interactiveFrameIntervalMs
     }
-    return minOf(interactiveBurstIntervalMs, interactiveFrameIntervalMs)
+    return interactiveIdleCadenceMs(interactiveTargets[streamId]?.previewId)
+  }
+
+  /**
+   * The idle cadence for [previewId] — [interactiveFrameIntervalMs], doubling for every further
+   * byte-identical frame past [interactiveQuiescentAfter], capped at
+   * [interactiveIdleMaxIntervalMs].
+   *
+   * A held session that nobody is touching still has to be *polled*: nothing tells the daemon that
+   * an animation has started, so the only way to find out is to render and compare. That is why the
+   * loop cannot simply stop. But polling a resting preview four times a second, for as long as its
+   * socket stays open, is most of what a live viewer costs on a public server — and because every
+   * render refreshes the held session's `lastUsedAtMs`, it also meant the idle lease could never
+   * reclaim the sandbox from a viewer who had wandered off. An idle viewer now settles to roughly
+   * one render every two seconds instead of four a second.
+   *
+   * The quiescence signal is free: the daemon already SHA-256s every frame for
+   * `renderFinished.unchanged`, and [interactiveIdleRun] counts the run length off that same
+   * comparison. Nothing here delays a *response* — an input calls [startInteractiveBurst], which
+   * clears the run and wakes the parked loop, so a click during a two-second idle wait is answered
+   * at the burst cadence rather than waiting it out.
+   *
+   * [interactiveQuiescentAfter] frames of grace before backing off at all, because one unchanged
+   * frame is ordinary inside an animation — a tween's flat leading edge, a `delay()` that has not
+   * elapsed — and reacting to a single one would stutter the cadence for the rest of the motion.
+   */
+  internal fun interactiveIdleCadenceMs(previewId: String?): Long {
+    if (interactiveFrameIntervalMs <= 0L) return interactiveFrameIntervalMs
+    val run = previewId?.let { interactiveIdleRun[it] } ?: 0
+    if (run < interactiveQuiescentAfter) return interactiveFrameIntervalMs
+    // Double per quiescent frame past the grace window. The shift is bounded well below Long
+    // overflow by the coerce, which the cap below would enforce anyway.
+    val steps = (run - interactiveQuiescentAfter + 1).coerceAtMost(16)
+    return (interactiveFrameIntervalMs shl steps).coerceAtMost(interactiveIdleMaxIntervalMs)
   }
 
   /**
@@ -3030,6 +3093,9 @@ class JsonRpcServer(
    * visible, so the animation only reaches the client if the frames after it are sampled too.
    */
   private fun startInteractiveBurst(streamId: String) {
+    // Whatever the burst does, an input is the one reliable signal that this preview is no longer
+    // resting — so clear the idle run first, unconditionally.
+    interactiveTargets[streamId]?.previewId?.let(interactiveIdleRun::remove)
     if (interactiveFrameIntervalMs <= 0L || interactiveBurstMs <= 0L) return
     interactiveBurstUntilMs[streamId] = System.currentTimeMillis() + interactiveBurstMs
     interactiveFrameWakes[streamId]?.offer(Unit)
@@ -4008,6 +4074,7 @@ class JsonRpcServer(
     interactiveFrameLoops.clear()
     interactiveFrameWakes.clear()
     interactiveBurstUntilMs.clear()
+    interactiveIdleRun.clear()
     frameLoops.forEach { it.interrupt() }
     // v2 phase 3 — drop any pending coalesced inputs and in-flight claims. The render workers
     // they refer to may still be running; they observe the cleared sessions map on their post-
@@ -4315,6 +4382,27 @@ class JsonRpcServer(
      * next tap.
      */
     const val INTERACTIVE_BURST_MS: Long = 600L
+
+    /**
+     * Ceiling on the idle backoff — how rarely a resting live preview is re-rendered.
+     *
+     * Two seconds takes an idle viewer from four renders a second to roughly one every two, which
+     * on a public server is most of what an unattended live session costs. It is also short enough
+     * that the preview is never meaningfully stale: an input wakes the loop immediately rather than
+     * waiting this out, so the only thing a longer gap delays is an animation that started with
+     * nobody touching it.
+     */
+    const val INTERACTIVE_IDLE_MAX_INTERVAL_MS: Long = 2_000L
+
+    /**
+     * Byte-identical frames tolerated before the idle backoff starts.
+     *
+     * One unchanged frame mid-animation is ordinary — a tween's flat leading edge, a `delay()` that
+     * has not elapsed — and treating it as quiescence would stutter the cadence for the rest of the
+     * motion. Three at the idle cadence is ~750ms of nothing moving, which is well past the burst
+     * window any input opens.
+     */
+    const val INTERACTIVE_QUIESCENT_AFTER: Int = 3
 
     /** RECORDING.md — minimum legal `recording/start.fps`. */
     const val MIN_RECORDING_FPS: Int = 1

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveIdleCadenceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveIdleCadenceTest.kt
@@ -1,0 +1,138 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The live frame loop's idle backoff.
+ *
+ * A held session that nobody is touching still has to be polled — nothing tells the daemon an
+ * animation has started, so the only way to find out is to render and compare. The loop therefore
+ * cannot stop. But polling a resting preview four times a second for as long as its socket stays
+ * open is most of what an unattended live viewer costs on a public server, and because every render
+ * refreshes the held session's `lastUsedAtMs`, it also kept the idle lease from ever reclaiming the
+ * sandbox from a visitor who had wandered off.
+ *
+ * These drive [JsonRpcServer.interactiveIdleCadenceMs] directly. It is a pure function of the
+ * byte-identical-frame run length — which is the point of deriving quiescence from the hash the
+ * daemon already computes for `renderFinished.unchanged` — so the policy is testable without a
+ * daemon, a sandbox, or a wall clock.
+ *
+ * The burst cadence an input opens is a separate mechanism and is unaffected; see
+ * `InteractiveInputBurstTest`.
+ */
+class InteractiveIdleCadenceTest {
+
+  /** Never asked to render anything — these tests only exercise the cadence policy. */
+  private object InertHost : RenderHost {
+    override fun start() = Unit
+
+    override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult =
+      error("InertHost renders nothing")
+
+    override fun shutdown(timeoutMs: Long) = Unit
+  }
+
+  private fun server(
+    idleMax: Long = 2_000L,
+    quiescentAfter: Int = 3,
+    intervalMs: Long = JsonRpcServer.INTERACTIVE_FRAME_INTERVAL_MS,
+  ): JsonRpcServer =
+    JsonRpcServer(
+      input = java.io.ByteArrayInputStream(ByteArray(0)),
+      output = java.io.ByteArrayOutputStream(),
+      host = InertHost,
+      daemonVersion = "test",
+      onExit = {},
+      interactiveFrameIntervalMs = intervalMs,
+      interactiveIdleMaxIntervalMs = idleMax,
+      interactiveQuiescentAfter = quiescentAfter,
+    )
+
+  /** Drive the policy at a given run length without a daemon: the run is keyed by previewId. */
+  private fun JsonRpcServer.cadenceAtRun(run: Int): Long {
+    val field = JsonRpcServer::class.java.getDeclaredField("interactiveIdleRun")
+    field.isAccessible = true
+    @Suppress("UNCHECKED_CAST")
+    val map = field.get(this) as java.util.concurrent.ConcurrentHashMap<String, Int>
+    if (run <= 0) map.remove(PREVIEW) else map[PREVIEW] = run
+    return interactiveIdleCadenceMs(PREVIEW)
+  }
+
+  @Test
+  fun `a preview with pixels still moving keeps the base cadence`() {
+    val s = server()
+    assertEquals(250L, s.cadenceAtRun(0))
+    assertEquals(250L, s.cadenceAtRun(1))
+    assertEquals(250L, s.cadenceAtRun(2))
+  }
+
+  @Test
+  fun `a single unchanged frame mid-animation does not slow the loop down`() {
+    // The grace window is the whole point of `quiescentAfter`. One byte-identical frame is ordinary
+    // inside an animation, and backing off on it would stutter the cadence for the rest of it.
+    val s = server(quiescentAfter = 3)
+    assertEquals(250L, s.cadenceAtRun(2))
+    assertTrue(s.cadenceAtRun(3) > 250L)
+  }
+
+  @Test
+  fun `backs off geometrically once the preview is quiescent`() {
+    val s = server()
+    assertEquals(500L, s.cadenceAtRun(3))
+    assertEquals(1_000L, s.cadenceAtRun(4))
+    assertEquals(2_000L, s.cadenceAtRun(5))
+  }
+
+  @Test
+  fun `the backoff is capped, and stays capped however long the session idles`() {
+    // The cap is what stops "poll less often" decaying into "never" — the loop is the only thing
+    // that can notice an animation starting on a preview nobody is touching.
+    val s = server(idleMax = 4_000L)
+    assertEquals(4_000L, s.cadenceAtRun(6))
+    assertEquals(4_000L, s.cadenceAtRun(50))
+    assertEquals(4_000L, s.cadenceAtRun(10_000))
+    assertEquals(4_000L, s.cadenceAtRun(Int.MAX_VALUE))
+  }
+
+  @Test
+  fun `an unknown preview gets the base cadence rather than an accidental backoff`() {
+    val s = server()
+    assertEquals(250L, s.interactiveIdleCadenceMs(null))
+    assertEquals(250L, s.interactiveIdleCadenceMs("never-rendered"))
+  }
+
+  @Test
+  fun `a disabled loop stays disabled rather than picking up an idle cadence`() {
+    // `interactiveFrameIntervalMs <= 0` is how callers switch the loop off entirely
+    // (InteractiveCoalescingTest does this to measure input coalescing in isolation).
+    val s = server(intervalMs = 0L)
+    assertEquals(0L, s.cadenceAtRun(0))
+    assertEquals(0L, s.cadenceAtRun(10))
+  }
+
+  @Test
+  fun `an idle viewer costs a fraction of what the flat cadence did`() {
+    // The headline number, computed rather than timed: renders issued over a minute of a live
+    // preview nobody is interacting with.
+    val s = server()
+    var elapsed = 0L
+    var renders = 0
+    var run = 0
+    while (elapsed < 60_000L) {
+      renders++
+      elapsed += s.cadenceAtRun(run)
+      run++ // every frame of a resting preview is byte-identical
+    }
+    val flat = (60_000L / JsonRpcServer.INTERACTIVE_FRAME_INTERVAL_MS).toInt()
+    assertTrue(
+      "an idle minute should cost far fewer than the flat cadence's $flat renders, got $renders",
+      renders * 5 < flat,
+    )
+  }
+
+  private companion object {
+    private const val PREVIEW = "com.example.Resting"
+  }
+}

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -425,6 +425,40 @@ is still rendering, so a slow host simply renders as fast as it can, and
 pixel-identical into `unchanged` heartbeats — a burst over a component
 that does not animate costs renders, not wire.
 
+## 9.7.2 The idle cadence backs off while nothing moves
+
+The other end of the same loop. A resting preview cannot simply stop
+being rendered: nothing tells the daemon that an animation has started,
+so the only way to notice is to render and compare. But polling it at
+`INTERACTIVE_FRAME_INTERVAL_MS` for as long as its socket stays open is
+most of what an unattended live viewer costs on a public server — and
+because every render refreshes the held session's `lastUsedAtMs`, it also
+meant the idle lease could never reclaim the sandbox from a visitor who
+had wandered off. The session outlived the attention.
+
+So the idle cadence is not flat. Past `INTERACTIVE_QUIESCENT_AFTER` (3)
+consecutive byte-identical frames it doubles per frame, capped at
+`INTERACTIVE_IDLE_MAX_INTERVAL_MS` (2s): 250 → 500 → 1000 → 2000. An
+idle viewer settles to roughly one render every two seconds instead of
+four a second.
+
+The quiescence signal costs nothing. The daemon already SHA-256s every
+frame to set `renderFinished.unchanged`; `interactiveIdleRun` counts the
+run length off that same comparison, keyed by previewId alongside
+`lastFrameHashes` so two streams watching one preview share the
+observation.
+
+Three frames of grace before backing off at all, because one unchanged
+frame is ordinary *inside* an animation — a tween's flat leading edge, a
+`delay()` that has not elapsed — and reacting to a single one would
+stutter the cadence for the rest of the motion.
+
+**Nothing here delays a response.** `startInteractiveBurst` clears the
+run and wakes the parked loop, so a click arriving two seconds deep into
+a backoff is answered at the burst cadence, not after the wait. The only
+thing a longer gap can delay is an animation that starts with nobody
+touching the preview.
+
 ## 9.8 The `localeTag` scope is a process-wide reader/writer gate
 
 Applying `localeTag` means moving the **process-global** JVM default


### PR DESCRIPTION
Refs #4283 — the half of it that #4274 did not already cover.

#4274 fixed the loop's behaviour *after an input*: a 16 ms burst for 600 ms, so press feedback gets sampled instead of falling between two frames. This is the other end — what the loop does when nobody is touching the preview at all.

## What's wrong

Outside a burst the loop runs at a flat `INTERACTIVE_FRAME_INTERVAL_MS` (250 ms) forever. A resting preview genuinely cannot stop being rendered — nothing tells the daemon an animation has started, so the only way to notice is to render and compare — but four Robolectric captures a second, for as long as a socket stays open, is most of what an unattended live viewer costs on a public server.

It has a second effect that is easy to miss: every render refreshes the held session's `lastUsedAtMs`, so `AndroidInteractiveSession`'s idle lease **can never fire while a socket is open**. A visitor who opened a live preview and wandered off pinned a sandbox indefinitely. The session outlived the attention.

## The change

Past `INTERACTIVE_QUIESCENT_AFTER` (3) consecutive byte-identical frames, the idle cadence doubles per frame, capped at `INTERACTIVE_IDLE_MAX_INTERVAL_MS` (2 s):

```
250 → 250 → 250 → 500 → 1000 → 2000 → 2000 …
```

An idle viewer settles to roughly one render every two seconds instead of four a second — a bit over 10× fewer renders across a quiet minute.

Three points worth calling out:

- **The signal is free.** The daemon already SHA-256s every frame to set `renderFinished.unchanged`. `interactiveIdleRun` counts the run length off that same comparison, keyed by previewId alongside `lastFrameHashes` so two streams watching one preview share the observation rather than each re-deriving it.
- **Three frames of grace, not zero.** One unchanged frame is ordinary *inside* an animation — a tween's flat leading edge, a `delay()` that has not elapsed — and reacting to a single one would stutter the cadence for the rest of the motion.
- **Nothing here delays a response.** `startInteractiveBurst` clears the run and wakes the parked loop, so a click arriving two seconds deep into a backoff is answered at the burst cadence, not after the wait. The only thing a longer gap can delay is an animation that starts with nobody touching the preview. The burst mechanism is otherwise untouched.

## Test plan

- `:daemon:core` `InteractiveIdleCadenceTest` — new, 7 cases: base cadence while pixels move, the grace window, the geometric curve, the cap holding at `Int.MAX_VALUE`, unknown-preview safety, the disabled-loop escape hatch (`interactiveFrameIntervalMs <= 0`, which `InteractiveCoalescingTest` relies on), and the renders-per-idle-minute figure.
- `:daemon:core` full suite: **563 tests, 0 failures** — including `InteractiveInputBurstTest`, so #4274's burst still behaves.
- `docs/daemon/INTERACTIVE.md` § 9.7.2 documents it beside § 9.7.1's burst.

No visual evidence: this changes *when* frames are produced, not what any frame looks like. The pixels of every frame are unchanged, which is exactly the property the backoff keys off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
