### PR TITLE
test(daemon): pin that an infinite animation keeps advancing in a live session

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * An endlessly-running Compose animation keeps producing new frames in a held live session.
+ *
+ * This is the property the whole live lane rests on for the components that never come to rest — an
+ * indeterminate progress indicator, a shimmer, a `rememberInfiniteTransition` of any kind. They
+ * have no settled state to reach, so "did the frame change?" is the only evidence that the held
+ * composition's clock is moving at all, and a still frame is indistinguishable from a preview
+ * served off the baked snapshot lane. That ambiguity is what makes it worth pinning: when someone
+ * reports a live indeterminate indicator sitting motionless, the first thing to rule out is that
+ * the daemon stopped advancing it.
+ *
+ * It also guards the **idle backoff** from the far side. That backoff keys off consecutive
+ * byte-identical frames, so a preview that genuinely never stops moving must never trip it — the
+ * run has to keep resetting. An infinite animation is the strongest case: if anything here ever
+ * starts returning identical frames, the backoff would quietly throttle a preview that is still
+ * animating, and this test fails before that can ship.
+ */
+class LiveInfiniteAnimationTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `an infinite animation keeps advancing across held renders`() {
+    val outputDir = tempFolder.newFolder("infinite-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = INFINITE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        // Sample the way the live frame loop does: repeated renders, each advancing the held
+        // clock by a slice of the animation's 1000ms cycle.
+        val fills =
+          (1..FRAMES).map {
+            val result = session.render(RenderHost.nextRequestId(), advanceTimeMs = STEP_MS)
+            val png = File(requireNotNull(result.pngPath) { "held render produced no PNG" })
+            val image = ImageIO.read(png)
+            image.getRGB(image.width / 2, image.height / 2) and 0xFFFFFF
+          }
+
+        // Every frame distinct. The fixture sweeps a full-bounds colour across a 1000ms cycle and
+        // is sampled 8 times at 125ms, so any two adjacent frames are far apart — a repeat here
+        // means the clock stalled, not that the animation happened to return to the same value.
+        assertEquals(
+          "every held frame of an infinite animation should differ; got " +
+            fills.joinToString { "#%06X".format(it) },
+          fills.size,
+          fills.toSet().size,
+        )
+
+        // …and it is genuinely sweeping rather than drifting by a rounding step.
+        val spread = fills.maxOf { it shr 16 and 0xFF } - fills.minOf { it shr 16 and 0xFF }
+        assertTrue(
+          "the animation should sweep a wide range across a full cycle, saw a red spread of $spread",
+          spread > 100,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    if (previewId == INFINITE_PREVIEW_ID) {
+      RenderSpec(
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "InfiniteSweepSquare",
+        widthPx = 64,
+        heightPx = 64,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "interactive-infinite",
+      )
+    } else null
+  }
+
+  private companion object {
+    private const val INFINITE_PREVIEW_ID = "interactive-infinite"
+
+    /** Eight samples across the fixture's 1000ms cycle. */
+    private const val FRAMES = 8
+    private const val STEP_MS = 125L
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,5 +1,10 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -742,6 +747,31 @@ fun PostDelayedSquare() {
 
 /** Looper delay [PostDelayedSquare] flips on. Well under one held render's auto-advance cap. */
 const val POST_DELAYED_SQUARE_DELAY_MS: Long = 100L
+
+/**
+ * An endlessly-running Compose animation, for asking whether a held live session advances one.
+ *
+ * `rememberInfiniteTransition` is what Wear/Material indeterminate progress indicators are built
+ * on, and it is driven by the composition's `MonotonicFrameClock` — which under a held session is
+ * the paused `mainClock` the render loop advances. Full-bounds so a frame either moved or it did
+ * not; no input, no state, nothing else that could change a pixel.
+ */
+@Composable
+fun InfiniteSweepSquare() {
+  val transition = rememberInfiniteTransition(label = "sweep")
+  val t by
+    transition.animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec =
+        infiniteRepeatable(
+          animation = tween(durationMillis = 1000),
+          repeatMode = RepeatMode.Restart,
+        ),
+      label = "t",
+    )
+  Box(modifier = Modifier.fillMaxSize().background(Color(t, 0f, 1f - t, 1f)))
+}
 
 @Composable
 fun ClickableToggleSquare() {


### PR DESCRIPTION
Follow-up from a report that a live `CircularProgressIndicator` (indeterminate) was not animating on `wear.preview.coo.ee`.

Investigating that needed a fact nobody could look up: **does an endlessly-running Compose animation keep advancing inside a held live session?** There was no test for it, so the only way to answer was to write a throwaway probe. This lands the probe as a guard.

## Why this class of preview is worth its own test

Components that never come to rest — an indeterminate progress indicator, a shimmer, any `rememberInfiniteTransition` — have no settled state to reach. "Did the frame change?" is therefore the *only* evidence that the held composition's clock is moving at all. Everything else in the suite asserts a preview reaches some particular end state; nothing asserted that a preview which has no end state keeps moving.

That matters because a still frame from an infinite animation is **indistinguishable from the same preview served off the baked snapshot lane** — which is a still by design, since the static renderer pauses the clock precisely so infinite animations terminate deterministically. So "the live indicator isn't moving" is a report that could mean the daemon stalled, or could mean the viewer never left the snapshot lane. This makes the daemon half decidable on its own.

## It also guards the idle backoff from the far side

#4307 backs the frame loop off after three consecutive byte-identical frames. A preview that genuinely never stops moving must never trip that — its run has to keep resetting. An infinite animation is the strongest case available: if held renders ever start returning identical frames, the backoff would quietly throttle something that is still animating, and this test fails before that ships.

## What it found

The current held loop is fine. Eight samples across the fixture's 1000 ms cycle come back as eight distinct fills, sweeping the full range rather than drifting by a rounding step — so the clock advances and the animation is genuinely running.

Measured the cost of the stepped advance from #4293 at the same time, since a hot loop that now iterates was the obvious suspect: **4 ms for a single 16 ms step, 13 ms for a worst-case 1000 ms advance across 63 steps** — about 0.15 ms per step. Real, bounded, and nowhere near enough to stall a live session.

## Test plan

- `:daemon:android` `LiveInfiniteAnimationTest` — new; passes against the current held loop.
- New `InfiniteSweepSquare` fixture: full-bounds colour sweep on a 1000 ms `infiniteRepeatable`, no input and no state, so nothing but the animation can move a pixel.

No visual evidence: the assertion is that frames *differ over time*, which a still image cannot show. The fixture is a flat colour sweep by design — a filmstrip of it would carry less information than the eight hex fills the failure message already prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
