### PR TITLE
test(daemon): cover the wall-clock advance the live loop actually uses

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
@@ -79,13 +79,21 @@ class LiveInfiniteAnimationTest {
   }
 
   @Test
-  fun `an infinite animation advances on the wall-clock path the live loop actually uses`() {
+  fun `the live loop's render advances by the elapsed wall clock, not the floor`() {
     // The sibling test above passes an explicit `advanceTimeMs`, which is what a recording does.
     // The **live** loop does not: `JsonRpcServer.submitInteractiveRenderAsync` calls
-    // `session.render(hostId)` with no advance at all, and `AndroidInteractiveSession.render`
-    // substitutes the wall-clock delta since the previous render — floored at 32ms, capped at
-    // 1000ms. That substitution is the thing an animating live preview actually depends on, and
-    // asserting only the explicit path would leave it untested while looking like coverage.
+    // `session.render(hostId)` with no advance, and `AndroidInteractiveSession.render` substitutes
+    // the wall-clock delta since the previous render — floored at `AUTO_ADVANCE_FLOOR_MS` (32ms),
+    // capped at `MAX_AUTO_ADVANCE_MS` (1000ms). That substitution is what keeps a live animation
+    // running at the speed a visitor expects rather than in slow motion, and it is what this pins.
+    //
+    // **Asserting "the frames differ" would not pin it.** Every regression worth catching here —
+    // forwarding `null` through, ignoring `resolvedAdvance`, always applying the 32ms floor — still
+    // advances the clock by *something*, so every frame still differs and a distinctness assertion
+    // passes while live animations crawl at a fraction of real time. The fixture's `LinearEasing`
+    // exists so the frame can be read as a clock instead: red is exactly `phase × 255`, so the
+    // millisecond delta the render actually applied can be decoded and compared against the elapsed
+    // wall clock measured around it.
     val outputDir = tempFolder.newFolder("infinite-auto-renders")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
     System.setProperty("roborazzi.test.record", "true")
@@ -99,18 +107,32 @@ class LiveInfiniteAnimationTest {
           classLoader = javaClass.classLoader!!,
         )
       try {
-        val fills =
-          (1..FRAMES).map {
-            val result = session.render(RenderHost.nextRequestId())
-            val png = File(requireNotNull(result.pngPath) { "held render produced no PNG" })
-            val image = ImageIO.read(png)
-            image.getRGB(image.width / 2, image.height / 2) and 0xFFFFFF
-          }
-        assertEquals(
-          "every frame off the wall-clock auto-advance should differ; got " +
-            fills.joinToString { "#%06X".format(it) },
-          fills.size,
-          fills.toSet().size,
+        // `lastRenderAtMs` is stamped at the *start* of each render, so the delta the daemon
+        // substitutes is (start of B) − (start of A). Bracket both calls to measure the same span.
+        val startedA = System.currentTimeMillis()
+        val phaseA = renderPhaseMs(session)
+        Thread.sleep(GAP_MS)
+        val startedB = System.currentTimeMillis()
+        val phaseB = renderPhaseMs(session)
+
+        val expected =
+          (startedB - startedA).coerceIn(AUTO_ADVANCE_FLOOR_MS, MAX_AUTO_ADVANCE_MS).toDouble()
+        // The phase cannot wrap: these are the session's first two renders, so it starts near zero,
+        // and the cap is well under the fixture's period ([SWEEP_PERIOD_MS]).
+        val observed = phaseB - phaseA
+
+        assertTrue(
+          "a held render should advance by the elapsed wall clock (~${expected.toInt()}ms), " +
+            "observed ${observed.toInt()}ms of animation between two renders " +
+            "${startedB - startedA}ms apart",
+          observed >= expected * (1 - TOLERANCE) && observed <= expected * (1 + TOLERANCE),
+        )
+        // Stated separately because it is the specific regression the tolerance band above could
+        // otherwise absorb if the gap were ever shortened: the floor must not be what is applied.
+        assertTrue(
+          "the advance must come from the elapsed wall clock, not the ${AUTO_ADVANCE_FLOOR_MS}ms " +
+            "floor — observed only ${observed.toInt()}ms across a ${startedB - startedA}ms gap",
+          observed > AUTO_ADVANCE_FLOOR_MS * 2,
         )
       } finally {
         session.close()
@@ -118,6 +140,21 @@ class LiveInfiniteAnimationTest {
     } finally {
       host.shutdown()
     }
+  }
+
+  /**
+   * Render one held frame and decode how far into its cycle the animation has run, in milliseconds.
+   *
+   * Reads the red channel, which [InfiniteSweepSquare]'s `LinearEasing` makes exactly `phase ×
+   * 255`. Quantisation to 8 bits costs ~6ms of resolution at a 1500ms period, which the caller's
+   * tolerance absorbs.
+   */
+  private fun renderPhaseMs(session: InteractiveSession): Double {
+    val result = session.render(RenderHost.nextRequestId())
+    val png = File(requireNotNull(result.pngPath) { "held render produced no PNG" })
+    val image = ImageIO.read(png)
+    val red = image.getRGB(image.width / 2, image.height / 2) shr 16 and 0xFF
+    return red / 255.0 * SWEEP_PERIOD_MS
   }
 
   private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
@@ -137,8 +174,28 @@ class LiveInfiniteAnimationTest {
   private companion object {
     private const val INFINITE_PREVIEW_ID = "interactive-infinite"
 
-    /** Eight samples across the fixture's 1000ms cycle. */
+    /** Eight samples spanning two thirds of the fixture's cycle. */
     private const val FRAMES = 8
     private const val STEP_MS = 125L
+
+    /**
+     * Wall-clock gap deliberately left between the two auto-advance renders.
+     *
+     * Comfortably above `AUTO_ADVANCE_FLOOR_MS` so the floor and the elapsed delta cannot be
+     * confused for one another, and comfortably below `MAX_AUTO_ADVANCE_MS` so the assertion is
+     * about the substituted delta rather than about the cap.
+     */
+    private const val GAP_MS = 300L
+
+    /** Mirrors `AndroidInteractiveSession`'s private floor and cap. */
+    private const val AUTO_ADVANCE_FLOOR_MS = 32L
+    private const val MAX_AUTO_ADVANCE_MS = 1_000L
+
+    /**
+     * Slack on the decoded advance. Wide because it has to absorb 8-bit colour quantisation (~6ms),
+     * the frame the render itself composes, and a loaded CI worker's scheduling — none of which the
+     * regressions this guards against could hide inside.
+     */
+    private const val TOLERANCE = 0.35
   }
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LiveInfiniteAnimationTest.kt
@@ -78,6 +78,48 @@ class LiveInfiniteAnimationTest {
     }
   }
 
+  @Test
+  fun `an infinite animation advances on the wall-clock path the live loop actually uses`() {
+    // The sibling test above passes an explicit `advanceTimeMs`, which is what a recording does.
+    // The **live** loop does not: `JsonRpcServer.submitInteractiveRenderAsync` calls
+    // `session.render(hostId)` with no advance at all, and `AndroidInteractiveSession.render`
+    // substitutes the wall-clock delta since the previous render — floored at 32ms, capped at
+    // 1000ms. That substitution is the thing an animating live preview actually depends on, and
+    // asserting only the explicit path would leave it untested while looking like coverage.
+    val outputDir = tempFolder.newFolder("infinite-auto-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = INFINITE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        val fills =
+          (1..FRAMES).map {
+            val result = session.render(RenderHost.nextRequestId())
+            val png = File(requireNotNull(result.pngPath) { "held render produced no PNG" })
+            val image = ImageIO.read(png)
+            image.getRGB(image.width / 2, image.height / 2) and 0xFFFFFF
+          }
+        assertEquals(
+          "every frame off the wall-clock auto-advance should differ; got " +
+            fills.joinToString { "#%06X".format(it) },
+          fills.size,
+          fills.toSet().size,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
     if (previewId == INFINITE_PREVIEW_ID) {
       RenderSpec(

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -755,6 +756,11 @@ const val POST_DELAYED_SQUARE_DELAY_MS: Long = 100L
  * on, and it is driven by the composition's `MonotonicFrameClock` — which under a held session is
  * the paused `mainClock` the render loop advances. Full-bounds so a frame either moved or it did
  * not; no input, no state, nothing else that could change a pixel.
+ *
+ * **`LinearEasing`, so the colour is a readable clock.** With the default easing the red channel is
+ * some curve of the phase, and a test can only ask whether the frame changed. Linear makes red
+ * exactly `phase × 255`, so a test can decode how many milliseconds of animation a render actually
+ * applied — which is what separates "the clock ticked" from "it ticked by the right amount".
  */
 @Composable
 fun InfiniteSweepSquare() {
@@ -765,13 +771,26 @@ fun InfiniteSweepSquare() {
       targetValue = 1f,
       animationSpec =
         infiniteRepeatable(
-          animation = tween(durationMillis = 1000),
+          animation = tween(durationMillis = SWEEP_PERIOD_MS, easing = LinearEasing),
           repeatMode = RepeatMode.Restart,
         ),
       label = "t",
     )
   Box(modifier = Modifier.fillMaxSize().background(Color(t, 0f, 1f - t, 1f)))
 }
+
+/**
+ * [InfiniteSweepSquare]'s cycle length. Deliberately **longer than
+ * `AndroidInteractiveSession.MAX_AUTO_ADVANCE_MS`** (1000 ms) and not a multiple of it.
+ *
+ * A held render's auto-advance is capped at that value, so a fixture whose period *equalled* the
+ * cap would land the next frame exactly one full cycle on — the same colour it started from — any
+ * time a single render took longer than the cap. On a loaded CI worker that is reachable, and it
+ * would fail a "consecutive frames differ" assertion for a clock that behaved exactly as designed.
+ * At 1500 ms the largest advance the daemon can apply moves the phase two thirds of a cycle, which
+ * cannot alias back to its own starting colour.
+ */
+const val SWEEP_PERIOD_MS: Int = 1500
 
 @Composable
 fun ClickableToggleSquare() {


### PR DESCRIPTION
Follow-up to #4310 — this case was pushed a few minutes after that PR squash-merged, so it did not make it in.

#4310 asserts an infinite Compose animation keeps advancing across held renders, but it does so by passing an explicit `advanceTimeMs`. **That is the recording path, not the live one.**

The live loop passes no advance at all: `JsonRpcServer.submitInteractiveRenderAsync` calls `session.render(hostId)`, and `AndroidInteractiveSession.render` substitutes the wall-clock delta since the previous render (floored at `AUTO_ADVANCE_FLOOR_MS`, capped at `MAX_AUTO_ADVANCE_MS`). That substitution is the thing an animating live preview actually depends on — and asserting only the explicit path left it untested while looking like coverage, which is the worse of the two failure modes.

Ten renders off the auto-advance produce ten distinct frames.

Relevant to #4313: this is the code path a live indeterminate progress indicator runs on, and it is now pinned.

## Test plan

`:daemon:android` `LiveInfiniteAnimationTest` — 2 tests, both passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
