### PR TITLE
feat(serve): answer commit-pinned catalog asset reads from the blob pool

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -39,6 +39,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
   private val lock = Any()
 
   private var attempted = 0L
+  private var cached = 0L
   private var ok = 0L
   private var notFound = 0L
   private var throttled = 0L
@@ -47,6 +48,18 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
   private var lastThrottleAtEpochMillis: Long? = null
   private var lastFailureAtEpochMillis: Long? = null
   private var lastFailureReason: String? = null
+
+  /**
+   * One read the [CatalogBlobPool] answered, so no request was made.
+   *
+   * Deliberately **not** an [BranchFetch.Ok] and not counted in [attempted]: those describe what
+   * happened between this server and the branch host, and folding a cache hit into them would make
+   * the cache invisible in exactly the numbers that exist to show what the branch is doing to us —
+   * a throttle rate computed over hits plus reads understates itself as the cache warms. Kept
+   * beside them because the interesting comparison is `cached` against `attempted`: that ratio is
+   * the requests this box stopped making.
+   */
+  fun recordCached(): Unit = synchronized(lock) { cached++ }
 
   /** One completed read, however it ended. */
   fun record(outcome: BranchFetch): Unit =
@@ -71,9 +84,10 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
   /** A snapshot for `/status.json`, or null when nothing has been read yet. */
   fun snapshot(): BranchFetchSnapshot? =
     synchronized(lock) {
-      if (attempted == 0L) return null
+      if (attempted == 0L && cached == 0L) return null
       BranchFetchSnapshot(
         attempted = attempted,
+        cached = cached,
         ok = ok,
         notFound = notFound,
         throttled = throttled,
@@ -102,6 +116,14 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
 @Serializable
 data class BranchFetchSnapshot(
   val attempted: Long,
+  /**
+   * Reads the catalog blob cache answered — requests this server did **not** make.
+   *
+   * Excluded from [attempted] on purpose (see `BranchFetchStats.recordCached`), so every other
+   * field here keeps describing the branch host alone. Climbing while [attempted] flattens across
+   * restarts is what a working cache looks like.
+   */
+  val cached: Long = 0,
   val ok: Long,
   /** Reads the branch answered as genuinely absent. Expected, not a fault. */
   val notFound: Long,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -202,6 +202,35 @@ class CatalogBlobPool(
     resolve(File(keysDir, sha256Hex(key.toByteArray())), verify = false) != null
 
   /**
+   * The bytes cached under [key], or null when there is no verified entry.
+   *
+   * The read half of the small-asset lane, split from [keyed] because that one is built around
+   * *producing* the blob under a lock — right for a 100 MB bundle a grid of daemons would otherwise
+   * fetch twenty times over, wrong for a baked PNG on the request path, where a miss should return
+   * immediately so the caller can go to the branch and report **why** it failed rather than have
+   * that answer collapsed into a null.
+   */
+  fun read(key: String): ByteArray? {
+    val blob = resolve(File(keysDir, sha256Hex(key.toByteArray()))) ?: return null
+    hits.increment()
+    return runCatching { blob.readBytes() }.getOrNull()
+  }
+
+  /**
+   * Cache [bytes] under [key]. Best-effort — a full or read-only disk simply leaves the next read a
+   * miss.
+   *
+   * [key] must be an immutable address; see **The rule callers must keep**.
+   */
+  fun write(key: String, bytes: ByteArray) {
+    misses.increment()
+    val sha = sha256Hex(bytes)
+    val blob = File(contentDir, sha)
+    if (!blob.isFile && store(bytes, sha) == null) return
+    writeAtomically(File(keysDir, sha256Hex(key.toByteArray())), sha.toByteArray())
+  }
+
+  /**
    * Reclaim blobs until the pool is under [maxBytes], oldest-touched first, sparing anything
    * younger than [graceMillis]; then drop pointers whose blob is gone.
    *
@@ -279,9 +308,32 @@ class CatalogBlobPool(
     runCatching { blob.delete() }
   }
 
-  /** Keeps a blob that is still being read out of the sweeper's reach. Best-effort. */
-  private fun touch(blob: File) {
+  /**
+   * Put a newly published blob on this pool's clock. Best-effort.
+   *
+   * Unconditional, unlike [touch]: a blob arrives carrying whatever mtime the filesystem gave the
+   * scratch file it was moved from, which is wall-clock time and therefore says nothing about when
+   * *this* pool saw it. Stamping on write is what makes every subsequent comparison — the sweeper's
+   * ordering, [touch]'s staleness check — read one clock instead of two.
+   */
+  private fun stamp(blob: File) {
     runCatching { blob.setLastModified(clock()) }
+  }
+
+  /**
+   * Keeps a blob that is still being read out of the sweeper's reach. Best-effort.
+   *
+   * Skipped when the recorded time is already recent. Once the small-asset lane reads through this
+   * pool, a touch on every hit is a filesystem metadata write on the **request path** — one per
+   * baked PNG a visitor's grid paints — bought to refine an ordering the sweeper only consults
+   * against an hour-wide grace window. Re-stamping at most once per [TOUCH_INTERVAL_MILLIS] keeps
+   * "least recently used" meaningful at the resolution anything actually uses it.
+   */
+  private fun touch(blob: File) {
+    val now = clock()
+    val recorded = runCatching { blob.lastModified() }.getOrDefault(0L)
+    if (now - recorded in 0 until TOUCH_INTERVAL_MILLIS) return
+    runCatching { blob.setLastModified(now) }
   }
 
   private fun store(bytes: ByteArray, sha: String): File? {
@@ -308,7 +360,7 @@ class CatalogBlobPool(
     // has no loser worth reporting: drop the duplicate and read what is already published.
     if (blob.isFile) {
       scratch.delete()
-      touch(blob)
+      stamp(blob)
       return blob
     }
     val moved = runCatching {
@@ -329,9 +381,9 @@ class CatalogBlobPool(
       return null
     }
     writes.increment()
-    // Stamped from the same clock every hit stamps, so "least recently used" is one notion rather
+    // Stamped from the same clock every hit reads, so "least recently used" is one notion rather
     // than a mix of the pool's clock and whatever mtime the move happened to preserve.
-    touch(blob)
+    stamp(blob)
     return blob
   }
 
@@ -391,6 +443,12 @@ class CatalogBlobPool(
 
     /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
     const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
+
+    /**
+     * How stale a blob's recorded time must be before a hit re-stamps it — see [touch]. Well under
+     * the sweep grace window, so a blob being read regularly can never age into eviction.
+     */
+    const val TOUCH_INTERVAL_MILLIS: Long = 5L * 60 * 1000
 
     const val MAX_REASON_CHARS: Int = 200
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRevision.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRevision.kt
@@ -88,6 +88,43 @@ object ServeCatalogRevision {
     return "https://raw.githubusercontent.com/$r/$c/$encoded"
   }
 
+  /**
+   * Whether [url] addresses **one immutable commit** on the delivery-branch host, rather than a
+   * moving branch ref.
+   *
+   * This is the admission rule for caching a fetched asset ([CatalogBlobPool]), and it lives here
+   * because this object already owns the question of what counts as a commit — [COMMIT] is the same
+   * regex a request-supplied `?at=` pin is validated against. A second spelling of "is this a sha"
+   * elsewhere is how the two would eventually disagree, and a disagreement in the permissive
+   * direction caches a branch ref, which is precisely the moving target the cache must never key
+   * on.
+   *
+   * Deliberately shaped as "recognise the exact URL form we build" rather than "parse any URL":
+   * everything cacheable is assembled by [assetUrl] or by the store's `base + path`, both of which
+   * are `https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path…>`. Anything that does not
+   * match that shape — a different host, a short ref, a missing path — is simply not cached, which
+   * costs a re-fetch and never a wrong answer.
+   */
+  fun isCommitPinned(url: String): Boolean {
+    val rest = url.removePrefix(RAW_HOST_PREFIX)
+    if (rest.length == url.length) return false
+    val segments = rest.split('/')
+    // owner, repo, ref, and at least one NON-EMPTY path segment — a URL with nothing after the ref
+    // (with or without a trailing slash) addresses no asset, so there is nothing to cache under it
+    // either.
+    if (segments.size < 4 || segments.drop(3).all { it.isEmpty() }) return false
+    // The full 40 hex characters, not the 7–40 a visitor may type: every URL this server builds
+    // for itself carries a resolved head, and accepting an abbreviation here would let two
+    // spellings of one commit occupy two cache entries.
+    return segments[2].length == FULL_COMMIT_LENGTH && COMMIT.matches(segments[2])
+  }
+
+  /** The host and scheme every delivery-branch read goes through. */
+  private const val RAW_HOST_PREFIX = "https://raw.githubusercontent.com/"
+
+  /** A resolved commit sha, in full. */
+  private const val FULL_COMMIT_LENGTH = 40
+
   /** A branch path is pinnable when it is a relative, traversal-free path to a PNG. */
   fun normalizePath(path: String?): String? {
     val p = path?.trim()?.takeIf { it.isNotEmpty() } ?: return null

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2734,8 +2734,41 @@ class ServeCatalogStore(
     networkProbe(url).also(branchFetchStats::record) is BranchFetch.Ok
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
-  private fun fetchCatalogAsset(url: String): ByteArray? =
-    if (fetch != null) fetch.invoke(url) else branchRead(url, MAX_FETCH_BYTES).bytesOrNull
+  private fun fetchCatalogAsset(url: String): ByteArray? = cachedBranchRead(url).bytesOrNull
+
+  /**
+   * Every small-asset read, with the [blobs] pool in front of the transport: baked PNGs, motion
+   * captures, figma vectors, design references and pages, and the `?at=<sha>` permalink reads that
+   * resolve out of an older commit.
+   *
+   * Admission is decided by the URL, through [ServeCatalogRevision.isCommitPinned] — the one place
+   * that owns what a commit is. That is the right seam here rather than a flag threaded from the
+   * load, because these reads do **not** all come from the current load's `base`: a pinned request
+   * addresses a commit the load never resolved, and it is exactly as immutable. What the rule
+   * refuses is the un-pinned fallback, where `base` is the branch ref.
+   *
+   * Only [BranchFetch.Ok] is stored. A `NotFound` is a statement about one revision that a caller
+   * may already cache permanently in its own terms ([ServeBundleHost.fetchPinnedAssetOutcome]), and
+   * a throttle or a transport failure is a statement about *now* — caching either would turn a bad
+   * minute into a permanent answer.
+   *
+   * The pool sits **outside** the injected [fetch] seam, exactly as the executable-bundle lane's
+   * does, so a stubbed transport exercises the same caching a real one gets. Putting it on the
+   * network side instead would leave the whole behaviour untested by the 48 tests that inject a
+   * fetcher, which is how the two paths would drift.
+   */
+  private fun cachedBranchRead(url: String): BranchFetch {
+    val read = {
+      if (fetch != null) fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
+      else branchRead(url, MAX_FETCH_BYTES)
+    }
+    if (!ServeCatalogRevision.isCommitPinned(url)) return read()
+    blobs.read(url)?.let {
+      branchFetchStats.recordCached()
+      return BranchFetch.Ok(it)
+    }
+    return read().also { if (it is BranchFetch.Ok) blobs.write(url, it.bytes) }
+  }
 
   /**
    * [fetchCatalogAsset], keeping the reason a failure failed.
@@ -2745,12 +2778,7 @@ class ServeCatalogStore(
    * [BranchFetch.NotFound], which is what those tests mean by it; only the real network path
    * distinguishes a throttle, and only the real network path can.
    */
-  private fun fetchCatalogAssetOutcome(url: String): BranchFetch =
-    if (fetch != null) {
-      fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
-    } else {
-      branchRead(url, MAX_FETCH_BYTES)
-    }
+  private fun fetchCatalogAssetOutcome(url: String): BranchFetch = cachedBranchRead(url)
 
   /**
    * Fetch [urls] **concurrently**, returning `url → bytes` for the ones that came back. A URL that

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -209,6 +209,65 @@ class CatalogBlobPoolTest {
   }
 
   @Test
+  fun `written bytes are read back by key and a stranger key is a miss`() {
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button/ideal.png"
+    val bytes = "a baked png".toByteArray()
+
+    assertNull(pool.read(url), "nothing was written yet")
+    pool.write(url, bytes)
+
+    assertContentEquals(bytes, assertNotNull(pool.read(url)))
+    assertNull(pool.read("https://raw.githubusercontent.com/o/r/$COMMIT/images/other.png"))
+  }
+
+  @Test
+  fun `a read whose blob was corrupted on disk is a miss, not wrong bytes`() {
+    // Same guarantee the produce-once lane gets, on the lane that answers request-path reads: the
+    // blob's name is its digest, so bytes that no longer hash to it are dropped rather than served.
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button/ideal.png"
+    val bytes = "a baked png".toByteArray()
+    pool.write(url, bytes)
+    pool.contentFile(sha(bytes)).writeBytes("tampered".toByteArray())
+
+    assertNull(pool.read(url))
+    assertEquals(1, pool.snapshot().corrupt)
+  }
+
+  @Test
+  fun `a written blob survives into a pool reopened over the same root`() {
+    val root = root()
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button/ideal.png"
+    val bytes = "carried over".toByteArray()
+    CatalogBlobPool(root).write(url, bytes)
+
+    assertContentEquals(bytes, assertNotNull(CatalogBlobPool(root).read(url)))
+  }
+
+  @Test
+  fun `a hit does not re-stamp a blob that was already touched recently`() {
+    // Once the small-asset lane reads through this pool, a touch per hit is a metadata write on the
+    // request path. Re-stamping is throttled to a resolution the sweeper's hour-wide grace window
+    // cannot tell the difference at.
+    val now = AtomicLong(1_000_000L)
+    val pool = CatalogBlobPool(root(), clock = { now.get() })
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button/ideal.png"
+    val bytes = "a baked png".toByteArray()
+    pool.write(url, bytes)
+    val blob = pool.contentFile(sha(bytes))
+    val stamped = blob.lastModified()
+
+    now.addAndGet(CatalogBlobPool.TOUCH_INTERVAL_MILLIS / 2)
+    assertNotNull(pool.read(url))
+    assertEquals(stamped, blob.lastModified(), "a recent blob is not re-stamped")
+
+    now.addAndGet(CatalogBlobPool.TOUCH_INTERVAL_MILLIS)
+    assertNotNull(pool.read(url))
+    assertEquals(now.get(), blob.lastModified(), "once it is stale enough, the hit refreshes it")
+  }
+
+  @Test
   fun `sweep reclaims oldest-first down to the cap`() {
     val now = AtomicLong(1_000_000L)
     val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRevisionTest.kt
@@ -2,9 +2,55 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ServeCatalogRevisionTest {
+
+  @Test
+  fun `a full-sha raw URL is commit-pinned`() {
+    assertTrue(
+      ServeCatalogRevision.isCommitPinned(
+        "https://raw.githubusercontent.com/o/r/${"a".repeat(40)}/images/button/ideal.png"
+      )
+    )
+  }
+
+  @Test
+  fun `a branch ref is not commit-pinned`() {
+    // The admission rule the asset cache depends on. `design-artifacts/<system>` is a branch whose
+    // name contains a slash, so the ref position reads as `design-artifacts` — not a sha, and not
+    // cacheable, which is the whole point: a branch ref moves.
+    assertFalse(
+      ServeCatalogRevision.isCommitPinned(
+        "https://raw.githubusercontent.com/o/r/design-artifacts/compose-m3/catalog.json"
+      )
+    )
+    assertFalse(
+      ServeCatalogRevision.isCommitPinned("https://raw.githubusercontent.com/o/r/main/x.png")
+    )
+  }
+
+  @Test
+  fun `an abbreviated sha is not commit-pinned`() {
+    // A visitor may type a 7-character pin and `normalize` accepts it, but every URL this server
+    // builds for itself carries a resolved head. Admitting both spellings would file one commit's
+    // bytes under two cache keys.
+    assertFalse(
+      ServeCatalogRevision.isCommitPinned("https://raw.githubusercontent.com/o/r/abc1234/x.png")
+    )
+  }
+
+  @Test
+  fun `only the delivery-branch host and a real asset path are commit-pinned`() {
+    val sha = "b".repeat(40)
+    // Another host that happens to carry a sha-shaped segment is not this cache's business.
+    assertFalse(ServeCatalogRevision.isCommitPinned("https://example.com/o/r/$sha/x.png"))
+    // A URL naming no asset under the ref addresses nothing worth caching.
+    assertFalse(ServeCatalogRevision.isCommitPinned("https://raw.githubusercontent.com/o/r/$sha"))
+    assertFalse(ServeCatalogRevision.isCommitPinned("https://raw.githubusercontent.com/o/r/$sha/"))
+  }
 
   @Test
   fun `a pin must be a sha, never a ref`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1852,6 +1852,108 @@ class ServeCatalogStoreTest {
   // ------------------------------------------------------------------------------------------
 
   /** A one-entry commit feed, so a load resolves a delivery commit and pins its reads to it. */
+  // ------------------------------------------------------------------------------------------
+  // The asset cache: small commit-pinned reads answered from the pool.
+  // ------------------------------------------------------------------------------------------
+
+  @Test
+  fun `a pinned load reads its manifests from the pool on the next load`() {
+    // Every asset a load reads is addressed through the delivery commit it resolved first, so the
+    // bytes at that URL are immutable and a second load of the same revision need not ask again.
+    // A branch that HAS moved names a different commit, so its URLs miss and are fetched — the
+    // freshness rule needs no cache logic of its own.
+    val reads = java.util.concurrent.atomic.AtomicLong()
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Button/Filled","images":[
+          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url ==
+          ServeCatalogRevision.commitsFeedUrl(
+            "yschimke/compose-ai-tools",
+            "design-artifacts/compose-m3",
+          ) -> feed(COMMIT).encodeToByteArray()
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> {
+          reads.incrementAndGet()
+          json.toByteArray()
+        }
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranch },
+        fetch = fetch,
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertEquals(1, reads.get())
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(1, reads.get(), "the same revision's manifest must not be re-fetched")
+    // Not an exact count: a load also samples a baked image to prove the branch can serve one, and
+    // that read is pinned and cached too. What matters is that the pool answered rather than the
+    // branch, which the manifest count above states precisely.
+    assertTrue(assertNotNull(store.branchFetchStats.snapshot()).cached > 0)
+  }
+
+  @Test
+  fun `an un-pinned load reads its manifests from the branch every time`() {
+    // No feed ⇒ no delivery commit ⇒ the base is the branch ref, which is a moving target. Caching
+    // under it would answer a regenerated branch with last week's bytes.
+    val reads = java.util.concurrent.atomic.AtomicLong()
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Button/Filled","images":[
+          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> {
+          reads.incrementAndGet()
+          json.toByteArray()
+        }
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranch },
+        fetch = fetch,
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(2, reads.get())
+    assertNull(store.branchFetchStats.snapshot()?.cached?.takeIf { it > 0 })
+  }
+
+  @Test
+  fun `a missing asset is not remembered as missing`() {
+    // Only Ok is stored. A NotFound is a statement about one revision that callers cache in their
+    // own terms, and a throttle is a statement about now — caching either would turn a bad minute
+    // into a permanent answer.
+    val pool = CatalogBlobPool(tempRoot())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/late.png"
+    assertFalse(pool.holds(url))
+    // Nothing was written for a failed read, so the next attempt is free to succeed.
+    pool.write(url, "arrived later".toByteArray())
+    assertContentEquals("arrived later".toByteArray(), assertNotNull(pool.read(url)))
+  }
+
   private fun feed(commit: String): String =
     """
     <feed><entry>

--- a/docs/design/CATALOG_CONTENT_CACHE.md
+++ b/docs/design/CATALOG_CONTENT_CACHE.md
@@ -260,7 +260,7 @@ Each ships independently and is provable on its own.
 | # | Change | Wins | Risk |
 | --- | --- | --- | --- |
 | **1 — landed** | `--catalog-cache-dir` + `--catalog-cache-max-bytes`; `.res-cache` and the executable bundles + splits moved into a content-addressed [`CatalogBlobPool`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt) | The largest byte win (100 MB-class bundles), and it survives *reloads* as well as restarts | Low — the sha verification already existed; only the path changed |
-| **2** | Asset cache for commit-pinned reads, behind `fetchCatalogAsset`; `cached` counter | Lazy PNGs, motion, references, and the `?at=` lane stop re-fetching | Low — one funnel, one admission rule |
+| **2 — landed** | Asset cache for commit-pinned reads, behind `fetchCatalogAsset`; `cached` counter on `branchFetch` | Manifests, lazy PNGs, motion, references, and the `?at=` lane stop re-fetching | Low — one funnel, one admission rule |
 | **3** | Generation snapshots + `current` pointer; adopt-then-converge boot; seed the refresher's head | The restart win: catalogs serve before any network | Medium — the adoption checks are where the care goes |
 | **4** | `?flush=1`, `DELETE /admin/catalog-cache[/<system>]`, `catalogCache` status block | Operability, and the ability to tell a working cache from write amplification | Low |
 | **5** | Background audit: adopted-commit reachability from the Atom feed, plus a sampled byte comparison | Catches disk corruption and rewritten history | Low — reports, never gates |
@@ -289,6 +289,24 @@ Also worth recording, because it is the number phase 3 has to beat: with the poo
 still pays is the *manifests* — one Atom feed, one `catalog.json`, one preview index and the
 reference/page indexes per catalog — plus re-assembling each per-system staging directory. The
 executable tier, which was the bulk, is now read locally.
+
+### What phase 2 shipped, and what it leaves for phase 3
+
+Phase 2 took the manifests off that list too: every commit-pinned read now goes through the pool, so
+a boot on an unchanged revision reads `catalog.json`, the preview and reference indexes, and every
+baked asset a visitor touches from disk. One departure from the sketch above, in the same
+ship-less-surface direction: the admission rule is decided **from the URL**
+(`ServeCatalogRevision.isCommitPinned`) rather than threaded from the load as a flag. That looked
+like re-deriving a fact we already had, and for the executable lane it would have been — but these
+reads do not all come from the load's own base. A `?at=<sha>` request addresses a commit the load
+never resolved and is exactly as immutable, so the URL genuinely is where the answer lives, and the
+rule sits beside the regex that already validates a visitor's pin.
+
+What is left for phase 3 is therefore **narrower than when this plan was written**, which sharpens
+the open question rather than settling it: the remaining boot cost is resolving each branch head
+(one `git ls-remote` per catalog) and re-assembling each per-system staging directory from bytes
+that are already local. Generation snapshots would remove the second; nothing removes the first,
+because that is the freshness check itself. Measure before building.
 
 ## What this deliberately does not do
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2527,10 +2527,33 @@ times a day accumulating each superseded revision's bundles for the life of the 
 limit keeps a burst of publications to one census. Eviction is always safe: the worst a reclaimed
 blob costs is the fetch that produces it again.
 
-What this does **not** yet do is let a restart serve a catalog before it has talked to the branch —
-the manifests are still fetched and the per-system directory still re-assembled on the boot path.
-That is the next step, and whether it is worth the complexity is a question for what this one
-measures; see [the plan](design/CATALOG_CONTENT_CACHE.md).
+#### The small assets ride the same pool
+
+The same rule extends past the executable tier to everything else a load reads by URL: the
+`catalog.json` itself, the preview and reference indexes, the lazily-fetched baked PNGs, motion
+captures, figma vectors and design pages — and, for free, the `?at=<sha>` permalink lane, which is
+the same shape of read against an older commit.
+
+Admission is decided by the URL rather than by a flag carried from the load, because these reads do
+not all come from the current load's base: a pinned request addresses a commit the load never
+resolved, and it is exactly as immutable. `ServeCatalogRevision.isCommitPinned` is what decides, so
+the rule lives beside the regex a visitor-supplied `?at=` pin is validated against rather than in a
+second spelling that could drift.
+
+Only a successful read is stored. A `404` is a statement about one revision that callers already
+cache in their own terms, and a throttle or a timeout is a statement about *now* — caching either
+would turn a bad minute into a permanent answer.
+
+`/status.json`'s `branchFetch` row gains a **`cached`** counter beside `attempted`, deliberately
+outside it: the other fields describe what is happening between this server and GitHub, and folding
+hits into them would make a warming cache look like a quietening branch. `cached` climbing while
+`attempted` flattens across restarts is what working looks like.
+
+What this does **not** yet do is let a restart serve a catalog before it has talked to the branch.
+The manifests are read from the pool now rather than the network, but the per-system directory is
+still re-assembled on the boot path and the branch head is still resolved before anything serves.
+That is the next step, and whether it is worth the complexity is a question for what these two
+measure; see [the plan](design/CATALOG_CONTENT_CACHE.md).
 
 ### The catalog set is config, not image content
 


### PR DESCRIPTION
Phase 2 of [the catalog content cache plan](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/CATALOG_CONTENT_CACHE.md). Phase 1 was #4303.

## The change

Phase 1 pooled the executable tier — the `liveBundle`, its per-preview splits, the externalised resources. This extends the same pool to everything else a load reads by URL: `catalog.json`, the preview and reference indexes, the lazily-fetched baked PNGs, motion captures, figma vectors and design pages — and, for free, the `?at=<sha>` permalink lane, which is the same shape of read against an older commit.

Both bulk lanes (`fetchCatalogAssetsToFiles`, `fetchCatalogAssets`) already funnel through `fetchCatalogAsset`, so they inherit it without changes.

## Admission is decided from the URL, and that's a deliberate reversal

Phase 1 threaded a `pinned` flag down from the load and I said explicitly that deriving it from the URL would be re-deriving a fact we already had. That reasoning holds for the executable lane, where every read comes from the load's own `base` — but it does **not** hold here: a `?at=<sha>` request addresses a commit the load never resolved and is exactly as immutable. For these reads the URL genuinely is where the answer lives.

So the rule is `ServeCatalogRevision.isCommitPinned`, sitting beside the `COMMIT` regex that already validates a visitor-supplied pin — one spelling of "is this a commit" rather than two that could drift, and a drift in the permissive direction would cache a *branch ref*, which is the one thing this must never key on. It requires the **full 40 characters** (not the 7–40 a visitor may type) so one commit cannot occupy two cache entries under two spellings.

Only `BranchFetch.Ok` is stored. A `NotFound` is a statement about one revision that callers already cache in their own terms (`ServeBundleHost.fetchPinnedAssetOutcome`); a throttle or a transport failure is a statement about *now*. Caching either would turn a bad minute into a permanent answer.

The pool sits **outside** the injected `fetch` seam, exactly as the bundle lane's does — otherwise the 48 tests that inject a fetcher would exercise none of this and the two paths would drift.

## Observability

`branchFetch` gains a **`cached`** counter, deliberately excluded from `attempted`: the other fields describe what is happening between this server and GitHub, and folding hits into them would make a warming cache look like a quietening branch — a throttle rate computed over hits-plus-reads understates itself. `cached` climbing while `attempted` flattens across restarts is what working looks like.

## Two follow-on fixes in the pool

- **Writes now stamp from the pool's own clock** (`stamp`, unconditional) while hits re-stamp only once the recording is stale (`touch`, throttled to 5 min). A published blob otherwise carries whatever mtime the scratch file had, so the sweeper's ordering was comparing two different clocks. My first cut throttled both and broke `sweep reclaims oldest-first` — caught by running the full suite.
- The touch throttle exists because, now that reads are on the request path, a stamp per hit is a filesystem metadata write per baked PNG a visitor's grid paints, bought to refine an ordering only ever consulted against an hour-wide grace window.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — **2,673 tests, 0 failures**, BUILD SUCCESSFUL.
- `deploy/image/test-compose-env-passthrough.sh` — passes.
- **`ServeCatalogRevisionTest`** (4 new) — a full-sha raw URL is pinned; a branch ref is not (including `design-artifacts/<system>`, whose slash puts a non-sha in the ref position); an abbreviated sha is not; another host, and a URL naming no asset under the ref (with or without a trailing slash), are not.
- **`CatalogBlobPoolTest`** (4 new) — write/read round-trip and a stranger key missing; a blob corrupted on disk reads as a miss rather than wrong bytes; a written blob survives into a pool reopened over the same root; a hit does not re-stamp a recently-touched blob but does once it is stale.
- **`ServeCatalogStoreTest`** (3 new) — a pinned load reads its manifest from the pool on the next load; **an un-pinned load reads from the branch every time**; a failed read is not remembered as missing.

Four of my own tests failed on the first full run (the stamp/touch bug above, a trailing-slash URL admitted as pinned, and one over-precise count assertion). All fixed; the trailing-slash one was a real admission-rule hole.

No visual evidence: fetch-path plumbing, telemetry and docs — nothing renders.

## What's left for phase 3

Narrower than when the plan was written, which sharpens the open question rather than settling it. With both phases warm, a boot still pays: one `git ls-remote` per catalog to resolve the head, plus re-assembling each per-system staging directory from bytes that are now local. Generation snapshots would remove the second; nothing removes the first, because that *is* the freshness check. The plan says measure before building, and that still stands.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_