### PR TITLE
fix(serve): keep the catalog blob cache's ceiling true once requests fill it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -821,6 +821,35 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
   }
 
   /**
+   * Periodic enforcement of the catalog blob cache's ceiling.
+   *
+   * The publication-time sweeps below were sufficient while **every** writer sat on the load path:
+   * a blob only ever arrived as part of a load, and a load is a publication. Caching request-path
+   * reads ends that invariant — a lazily-fetched baked PNG or an `?at=<sha>` history read admits a
+   * blob with no publication anywhere near it — so a box whose catalogs are not currently being
+   * republished could admit indefinitely, with nothing enforcing `--catalog-cache-max-bytes` until
+   * its next restart. On a public server holding a couple of dozen catalogs across twenty
+   * addressable revisions each, that is a volume filling quietly.
+   *
+   * A plain daemon ticker rather than a check on the write path: enforcement is a directory census,
+   * and the request path is exactly where that must not happen. [sweepCatalogBlobs]'s own rate
+   * limit then makes a tick that lands soon after a publication's sweep free.
+   */
+  private fun startCatalogBlobSweeper(): AutoCloseable {
+    val exec =
+      java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+        Thread(r, "serve-catalog-blob-sweep").apply { isDaemon = true }
+      }
+    exec.scheduleWithFixedDelay(
+      { runCatching { sweepCatalogBlobs() } },
+      CATALOG_BLOB_SWEEP_INTERVAL_MILLIS,
+      CATALOG_BLOB_SWEEP_INTERVAL_MILLIS,
+      java.util.concurrent.TimeUnit.MILLISECONDS,
+    )
+    return AutoCloseable { exec.shutdownNow() }
+  }
+
+  /**
    * Rate limiter for [sweepCatalogBlobs] — see there for why it is not a per-call-site decision.
    */
   private val lastCatalogBlobSweep = java.util.concurrent.atomic.AtomicLong()
@@ -1375,6 +1404,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           worktrees,
           catalogWorktrees.takeIf { it !== worktrees },
           catalogPerPreviewPoolsCloseable,
+          catalogReg?.let { startCatalogBlobSweeper() },
         ),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
@@ -1573,7 +1603,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       mdnsModuleLabel = null,
       mdnsPreviewIds = null,
       closeables =
-        listOfNotNull(catalogReg?.loader, catalogRefresher, catalogPerPreviewPoolsCloseable),
+        listOfNotNull(
+          catalogReg?.loader,
+          catalogRefresher,
+          catalogPerPreviewPoolsCloseable,
+          catalogReg?.let { startCatalogBlobSweeper() },
+        ),
       catalogLoads = catalogReg?.loads,
       catalogStore = catalogReg?.store,
       catalogRefresh = catalogRefresher?.let { refresher -> refresher::refresh },

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -226,7 +226,16 @@ class CatalogBlobPool(
     misses.increment()
     val sha = sha256Hex(bytes)
     val blob = File(contentDir, sha)
-    if (!blob.isFile && store(bytes, sha) == null) return
+    if (blob.isFile) {
+      // Already held under some other key — the overwhelmingly common case on a republish, where a
+      // regenerated catalog carries mostly byte-identical assets at a NEW commit, so every
+      // unchanged asset's fresh URL dedupes onto the blob that is already here. Stamping it is
+      // what makes that a refresh rather than a silent ageing: without it the blob keeps the time
+      // it was first written, and the next sweep can evict precisely the assets that are current.
+      stamp(blob)
+    } else if (store(bytes, sha) == null) {
+      return
+    }
     writeAtomically(File(keysDir, sha256Hex(key.toByteArray())), sha.toByteArray())
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -268,6 +268,29 @@ class CatalogBlobPoolTest {
   }
 
   @Test
+  fun `re-keying bytes that are already held refreshes them against the sweeper`() {
+    // The republish case, and the common one: a regenerated catalog carries mostly byte-identical
+    // assets at a NEW commit, so every unchanged asset's fresh URL dedupes onto the blob already
+    // here. Without a stamp that blob keeps the time it was FIRST written, and the next sweep
+    // evicts precisely the assets that are current.
+    val now = AtomicLong(1_000_000L)
+    val pool = CatalogBlobPool(root(), maxBytes = 0, graceMillis = 60_000, clock = { now.get() })
+    val bytes = "an unchanged asset".toByteArray()
+    val old = "https://raw.githubusercontent.com/o/r/${"a".repeat(40)}/images/button.png"
+    val fresh = "https://raw.githubusercontent.com/o/r/${"b".repeat(40)}/images/button.png"
+    pool.write(old, bytes)
+
+    // Long enough that the blob's original stamp is outside the grace window…
+    now.addAndGet(120_000)
+    // …then the same bytes are admitted under the new revision's URL.
+    pool.write(fresh, bytes)
+    val snapshot = pool.sweep()
+
+    assertEquals(0, snapshot.evicted, "a blob just re-admitted under a new key is not stale")
+    assertContentEquals(bytes, assertNotNull(pool.read(fresh)))
+  }
+
+  @Test
   fun `sweep reclaims oldest-first down to the cap`() {
     val now = AtomicLong(1_000_000L)
     val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2537,9 +2537,13 @@ Two rules carry it:
   than handed to a classloader. The externalised resources were already checked this way against
   the digest their manifest declares; the pool extends the same rule to everything it holds.
 
-The pool is swept after the startup pass and after each later catalog publication — oldest-touched
-first, down to `--catalog-cache-max-bytes` (8 GB by default), sparing anything written in the last
-hour so the two replicas that overlap during a rolling update cannot reclaim each other's bytes.
+The pool is swept after the startup pass, after each later catalog publication, and on a periodic
+daemon tick — oldest-touched first, down to `--catalog-cache-max-bytes` (8 GB by default), sparing
+anything written in the last hour so the two replicas that overlap during a rolling update cannot
+reclaim each other's bytes. The tick is what keeps the ceiling true once **request-path** reads
+populate the pool: publication-time sweeps covered every writer only while every writer sat on the
+load path, and a lazily-fetched preview or an `?at=<sha>` history read admits a blob with no
+publication anywhere near it. Enforcement is a directory census, so it stays off the request path.
 Sweeping on every publication and not only at boot is what stops a box that regenerates several
 times a day accumulating each superseded revision's bundles for the life of the process; a rate
 limit keeps a burst of publications to one census. Eviction is always safe: the worst a reclaimed


### PR DESCRIPTION
Follow-up to #4316, which merged while I was preparing these. Both defects are review findings on that PR that I confirmed against the code; both are now on `main`, so they land here instead.

They share a root cause: **caching request-path reads ended the invariant the sweeper was built on** — that every writer sits on the load path. Phase 1 (#4303) was safe because a blob could only arrive as part of a load, and a load is a publication.

## 1 — Enforcement never ran between publications

`sweepCatalogBlobs` was called only after the startup pass and after each catalog publication. A lazily-fetched baked PNG or an `?at=<sha>` history read now admits a blob with no publication anywhere near it, so a box whose catalogs are not currently being republished could admit indefinitely with **nothing enforcing `--catalog-cache-max-bytes` until its next restart**. On a public server holding a couple of dozen catalogs across ~20 addressable revisions each, that is a volume filling quietly.

Adds a daemon ticker, registered in the server's `closeables` at both serve paths so it shuts down with everything else. The existing 5-minute rate limit on `sweepCatalogBlobs` makes a tick that lands soon after a publication's sweep free.

Deliberately **not** a check on the write path: enforcement is a directory census, and the request path is exactly where that must not happen.

## 2 — A deduplicated blob was never stamped

`write` skipped `store` entirely when the blob already existed, so nothing refreshed its timestamp. That is the *common* case on a republish — a regenerated catalog carries mostly byte-identical assets at a new commit, so every unchanged asset's fresh URL resolves onto the blob already held. Without a stamp it keeps the time it was **first** written, and the next sweep evicts precisely the assets that are current. Filed P2; in practice it defeats the cache on the most frequent path there is.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — **2,682 tests, 0 failures**, BUILD SUCCESSFUL.
- New `CatalogBlobPoolTest` case, `re-keying bytes that are already held refreshes them against the sweeper`: writes bytes under one commit's URL, advances the clock past the grace window, re-admits the same bytes under a *second* commit's URL, and asserts the sweep evicts nothing and the blob is still readable under the new key. It fails on the pre-fix `write`.
- The ticker is wiring rather than logic — it calls the already-tested, already-rate-limited `sweepCatalogBlobs`. Its value is the call site existing at all, which the diff shows directly; I did not add a timing test for a 5-minute scheduler.

No visual evidence: sweeper wiring, a one-line stamp fix and docs — nothing renders.

## Credit

Both were found by the Codex review bot on #4316. I verified each against the code before acting rather than taking the badges at face value — and the P2 is worse than its badge, for the reason above.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_