### PR TITLE
fix(serve): stop an idle browser tab pinning the server's idle clock

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2902,7 +2902,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     }
     exec.scheduleWithFixedDelay(
       {
-        val idle = registry.idleMillis()
+        // The STRICT clock, not the one the theme optimizer reads: an open socket keeps the process
+        // up however quiet its holder has gone. Standing a background pass down under an idle tab
+        // costs that tab one render when it comes back; exiting under it drops their connection.
+        val idle = registry.connectionIdleMillis()
         if (idle != null && idle >= timeoutMillis) {
           System.err.println(
             "serve: idle ${idle / 1000}s (--exit-when-idle=${idleExitSeconds}s) — shutting down."

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -523,7 +523,8 @@ data class ThemeOptimizerAdmissionSnapshot(
   val serverIdleMillis: Long? = null,
   /**
    * Why [serverIdleMillis] is null, when it is: [IDLE_BLOCKED_BY_SESSION_LEASE] (a session holds an
-   * open lease — `daemons.leasedSessions` names it) or [IDLE_BLOCKED_BY_CATALOG_LOAD] (catalogs are
+   * open lease *and is actively using it* — `daemons.busyLeasedSessions` names it, against
+   * `daemons.leasedSessions` for every holder) or [IDLE_BLOCKED_BY_CATALOG_LOAD] (catalogs are
    * still being fetched). Null when the clock is running, or before any catalog host has asked for
    * one.
    *

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -1021,11 +1021,18 @@ class ServeCatalogLiveHost(
    * interruption, grant one anyway.
    *
    * **A gate that can close permanently is indistinguishable from the feature being off**, and this
-   * one can: the quiet window is measured from `ServeSessionRegistry.idleMillis()`, which answers
-   * *busy* outright — not a large number, but `null` — while any session holds an open lease. One
-   * long-lived WebSocket, or one lease leaked by a request cancelled mid-flight, and no amount of
-   * waiting will ever satisfy the window. The deployed server sat in exactly that state for its
+   * one could: the quiet window is measured from `ServeSessionRegistry.idleMillis()`, which used to
+   * answer *busy* outright — not a large number, but `null` — while any session held an open lease.
+   * One long-lived WebSocket, or one lease leaked by a request cancelled mid-flight, and no amount
+   * of waiting would ever satisfy the window. The deployed server sat in exactly that state for its
    * whole uptime: 23 catalogs, `turnsGranted 0`, 1 of 17,914 entries cached.
+   *
+   * That clock has since been relaxed (#4312): a lease stops suppressing it once its holder has
+   * been quiet, so the ordinary idle-tab case now opens the gate on its own and this ceiling should
+   * fire far less often. It stays because it is a backstop against the *class* of failure, not
+   * against that one instance — a leaked lease still counts as busy for its quiet window, and any
+   * future clock input can jam the same way. `turnsForced` climbing on a box with no visitors is
+   * the signal that something is jamming it again.
    *
    * The grant is deliberately small and self-limiting — one preview, then back to the gate (see
    * [optimizerTurnForced]) — so a genuinely busy box pays one preview per ceiling period per

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1510,11 +1510,11 @@ class ServeHttpServer(
       // entry and throws straight back out. Cancellation is exactly when this matters — a visitor
       // navigating away, a crawler abandoning a fetch, a socket dropped mid-render all cancel the
       // request coroutine here — and a skipped release leaves the lease count permanently
-      // elevated. That is far worse than one resident daemon: `ServeSessionRegistry.idleMillis()`
-      // answers *busy* (`null`, not a number) while ANY session holds a lease, so a single leaked
-      // lease pins the whole server as busy for the life of the process, which silently stands the
-      // theme optimizer down — the deployed box sat at `turnsGranted 0` across 23 catalogs with no
-      // traffic to explain it.
+      // elevated. That is far worse than one resident daemon: a leaked lease keeps its session
+      // resident for the life of the process, so its daemon is never suspended and the
+      // `--exit-when-idle` watchdog (`connectionIdleMillis`) never fires. Since #4312 it no longer
+      // also pins the theme optimizer's clock — a lease stops counting as busy once its holder goes
+      // quiet — but that relaxation is a floor under the damage, not a licence to leak one.
       //
       // Safe to call inline: `Lease.close` is a non-suspending, idempotent compare-and-set.
       // This helper backs the page and asset lanes — the routes an aborted browse actually hits —
@@ -4449,11 +4449,22 @@ class ServeHttpServer(
       if (onlySystem == null) themeOptimizerStats?.invoke() else null
 
     /**
-     * Sessions holding an open lease — the reason the server-wide idle clock can read *busy* on a
-     * box serving nothing. Scoped like `knownSessions`: a top-level site names only its own.
+     * Sessions holding an open lease — what keeps a session resident. Scoped like `knownSessions`:
+     * a top-level site names only its own.
      */
     val leasedSessions: List<String> =
       sessions.leasedSessions().let { held ->
+        if (onlySystem == null) held else held.filter { it == onlySystem }
+      }
+
+    /**
+     * The subset of [leasedSessions] whose holder has been active recently — the ones actually
+     * making the server-wide idle clock read *busy* (#4312). Published beside the full list because
+     * the difference is the diagnosis: leases held with none of them busy is an idle tab keeping a
+     * daemon warm, which is fine; a busy one is someone genuinely being served.
+     */
+    val busyLeasedSessions: List<String> =
+      sessions.busyLeasedSessions().let { held ->
         if (onlySystem == null) held else held.filter { it == onlySystem }
       }
     val openRenderBreakerCount: Int = running.count { it.renderStats?.breaker?.open == true }
@@ -4492,8 +4503,11 @@ class ServeHttpServer(
             val why =
               when (admission.idleBlockedBy) {
                 ServeBackgroundWork.IDLE_BLOCKED_BY_SESSION_LEASE ->
-                  if (leasedSessions.isEmpty()) "session lease held"
-                  else "session lease held by ${leasedSessions.joinToString(", ")}"
+                  // The *busy* holders, not every leaseholder: since #4312 an idle tab's lease
+                  // keeps its session resident without shutting this gate, so naming it here would
+                  // blame the one connection that is not the reason.
+                  if (busyLeasedSessions.isEmpty()) "session lease held"
+                  else "session lease held by ${busyLeasedSessions.joinToString(", ")}"
                 ServeBackgroundWork.IDLE_BLOCKED_BY_CATALOG_LOAD -> "catalogs loading"
                 else -> "server busy"
               }
@@ -4537,6 +4551,7 @@ class ServeHttpServer(
             liveSeatRefusals = liveSeats.refusalCount(),
             liveSeatRefusalsUnverified = liveSeats.unverifiedRefusalCount(),
             leasedSessions = leasedSessions,
+            busyLeasedSessions = busyLeasedSessions,
           ),
         config =
           ConfigDto(
@@ -7205,6 +7220,10 @@ class ServeHttpServer(
             for (frame in incoming) {
               if (frame is Frame.Text) {
                 val text = frame.readText()
+                // The lease keeps the session resident for the socket's whole life; THIS is what
+                // says someone is using it (#4312). Without it an open-but-untouched tab reads as
+                // "being served" forever and holds the theme optimizer's quiet gate shut.
+                lease.touch()
                 withContext(Dispatchers.IO) { live.onClientMessage(text) }
               }
             }
@@ -7234,6 +7253,7 @@ class ServeHttpServer(
           for (frame in incoming) {
             if (frame is Frame.Text) {
               val text = frame.readText()
+              lease.touch() // see the live lane above
               withContext(Dispatchers.IO) { session.onClientMessage(text) }
             }
           }
@@ -7974,12 +7994,18 @@ private data class DaemonSummaryDto(
   /**
    * Sessions holding an open lease — see [ServeSessionRegistry.leasedSessions].
    *
-   * Non-empty means the server-wide idle clock reads *busy* whatever the render counters say, which
-   * is the state that silently stands the theme optimizer down. Normally this is short-lived (a
-   * WebSocket, an in-flight asset fetch); an entry that persists across polls on a box serving no
-   * traffic is a leaked lease.
+   * Non-empty means those sessions are held resident: their daemons will not be suspended and the
+   * `--exit-when-idle` watchdog will not fire. Normally short-lived (a WebSocket, an in-flight
+   * asset fetch); an entry that persists across polls on a box serving no traffic is either an open
+   * browser tab or a leaked lease, and [busyLeasedSessions] tells those two apart.
    */
   val leasedSessions: List<String> = emptyList(),
+  /**
+   * The holders among [leasedSessions] that have been active recently — see
+   * [ServeSessionRegistry.busyLeasedSessions]. Non-empty is what makes the server-wide idle clock
+   * read *busy*, which is the state that stands the theme optimizer down.
+   */
+  val busyLeasedSessions: List<String> = emptyList(),
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -60,6 +60,12 @@ class ServeSessionRegistry(
    * Non-positive falls back to [idleTimeoutMillis], preserving the old behaviour.
    */
   private val daemonIdleMillis: Long = DEFAULT_DAEMON_IDLE_MILLIS,
+  /**
+   * How recently a leaseholder must have shown activity for its lease to keep answering *busy* on
+   * the whole-server idle clock ([idleMillis]). See [DEFAULT_LEASE_BUSY_MILLIS] for why residency
+   * and busyness are asked as two questions rather than one.
+   */
+  private val leaseBusyMillis: Long = DEFAULT_LEASE_BUSY_MILLIS,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : AutoCloseable {
 
@@ -81,6 +87,15 @@ class ServeSessionRegistry(
     @Volatile var lastAccess: Long,
     /** Open long-lived holders (e.g. WebSocket connections) keeping this session resident. */
     @Volatile var leases: Int = 0,
+    /**
+     * Wall-clock of the last thing a *leaseholder* actually did — the lease being taken, a client
+     * message arriving on its socket ([Lease.touch]), or any acquire/lease of this session.
+     *
+     * Separate from [lastAccess], which answers "may this session's daemon be suspended?" and is
+     * deliberately generous. This one answers "is someone being served right now?" against the much
+     * shorter [leaseBusyMillis], and only [idleMillis] reads it.
+     */
+    @Volatile var lastLeaseActivity: Long = lastAccess,
     /**
      * Wall-clock when [host] last transitioned suspended→resident (null while suspended). The basis
      * for the "up for" figure the `/status` page shows per running daemon; reset each time the
@@ -118,9 +133,30 @@ class ServeSessionRegistry(
   )
 
   /** A live hold on a session that keeps it from being suspended until [close] (idempotent). */
-  class Lease internal constructor(val host: ServeHost, private val onRelease: () -> Unit) :
-    AutoCloseable {
+  class Lease
+  internal constructor(
+    val host: ServeHost,
+    private val onTouch: () -> Unit = {},
+    private val onRelease: () -> Unit,
+  ) : AutoCloseable {
     private val released = AtomicBoolean(false)
+
+    /**
+     * Report that the holder is *doing* something — a client message on its socket, say — as
+     * opposed to merely still being connected.
+     *
+     * Holding a lease is what keeps the session resident; calling this is what keeps it counting as
+     * **busy** on the whole-server idle clock (see [idleMillis]). A long-lived connection that
+     * never touches goes quiet on that clock while staying resident, which is the point: an open
+     * browser tab nobody is looking at should not stand the theme optimizer down for hours.
+     *
+     * Cheap and lock-free by design — it is on the per-message path. It writes volatile timestamps
+     * that no invariant spans, so a reader can only ever see an older or newer instant, never an
+     * inconsistent pair. A no-op once the lease is [close]d.
+     */
+    fun touch() {
+      if (!released.get()) onTouch()
+    }
 
     override fun close() {
       if (released.compareAndSet(false, true)) onRelease()
@@ -198,8 +234,9 @@ class ServeSessionRegistry(
     this.snapshots = snapshots
   }
 
-  // Wall-clock of the most recent acquire/lease/release across all sessions — the basis for the
-  // server-level idle check ([idleMillis]) that the ephemeral exit-when-idle watchdog reads.
+  // Wall-clock of the most recent acquire/lease/touch/release across all sessions — the basis for
+  // the server-level idle checks ([idleMillis], [connectionIdleMillis]) that the theme optimizer's
+  // quiet gate and the ephemeral exit-when-idle watchdog read.
   @Volatile private var lastActivity: Long = clock()
 
   // A daemon reaper suspends idle sessions. Disabled (null) when either knob is non-positive —
@@ -323,6 +360,7 @@ class ServeSessionRegistry(
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
+    entry.lastLeaseActivity = clock()
     lastActivity = clock()
     liveHost(entry)
   }
@@ -336,13 +374,24 @@ class ServeSessionRegistry(
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
+    entry.lastLeaseActivity = clock()
     lastActivity = clock()
     val host = liveHost(entry) ?: return null
     entry.leases++
-    Lease(host) {
+    Lease(
+      host,
+      onTouch = {
+        // No lock: see [Lease.touch]. Three independent volatile writes, on the per-message path.
+        val now = clock()
+        entry.lastLeaseActivity = now
+        entry.lastAccess = now
+        lastActivity = now
+      },
+    ) {
       lock.withLock {
         entry.leases--
         entry.lastAccess = clock() // start the idle clock fresh once the holder leaves
+        entry.lastLeaseActivity = clock()
         lastActivity = clock()
       }
     }
@@ -383,28 +432,74 @@ class ServeSessionRegistry(
   }
 
   /**
-   * Milliseconds the *whole server* has been idle, or `null` when it's busy (any session has an
-   * open lease — e.g. a live WebSocket). Idle counts from the last acquire/lease/release; with no
-   * leases and no requests it grows unbounded. Drives the ephemeral "exit when idle" watchdog.
+   * Milliseconds the *whole server* has been idle, or `null` when someone is actually being served.
+   * Idle counts from the last acquire/lease/release/[Lease.touch]; with nothing happening it grows
+   * unbounded. Drives the theme optimizer's quiet gate.
+   *
+   * **A lease answers busy only while its holder is still doing something** (issue #4312). This
+   * used to be `any { leases > 0 }`, and a viewer WebSocket holds a lease for the socket's whole
+   * life — so one browser tab left open on a catalog pinned the clock at *busy* indefinitely,
+   * whether or not anyone was looking at it. Everything gated on the clock then stopped: measured
+   * on the public box, a single idle tab held the optimizer's gate shut for eight consecutive
+   * minutes with zero renders, after which only the ceiling (#4288) let work through, at a trickle.
+   *
+   * Residency and busyness are two questions, and `leases > 0` answered both with one number. A
+   * lease still keeps its session resident unconditionally — the reaper must never close a live
+   * socket's host mid-connection — but it stops *suppressing this clock* once the holder has been
+   * quiet for [leaseBusyMillis]. Interrupting an optimizer pass costs a returning visitor at most
+   * one render (`OPTIMIZER_YIELD_MILLIS`), so the trade is heavily one-sided.
+   *
+   * Use [connectionIdleMillis] where a live connection must count regardless of activity.
    */
   fun idleMillis(now: Long = clock()): Long? = lock.withLock {
-    if (sessions.values.any { it.leases > 0 }) null else now - lastActivity
+    if (sessions.values.any { it.isBusy(now) }) null else now - lastActivity
   }
 
   /**
-   * Session ids holding at least one open lease, sorted — i.e. exactly the set that makes
-   * [idleMillis] answer `null`.
+   * [idleMillis] under the strict rule: **any** open lease answers busy, however quiet its holder.
+   *
+   * The `--exit-when-idle` watchdog reads this one rather than the relaxed clock. Standing an
+   * optimizer pass down under an idle tab costs that tab one render when it comes back; tearing the
+   * process down under it drops a live socket, so the two want different definitions of busy even
+   * though both are asking "is anyone here?".
+   */
+  fun connectionIdleMillis(now: Long = clock()): Long? = lock.withLock {
+    if (sessions.values.any { it.leases > 0 }) null else now - lastActivity
+  }
+
+  /** Whether this entry's lease is recent enough to answer *busy*. See [idleMillis]. */
+  private fun Entry.isBusy(now: Long): Boolean =
+    leases > 0 && now - lastLeaseActivity < leaseBusyMillis
+
+  /**
+   * Session ids holding at least one open lease, sorted — i.e. exactly the set keeping a session
+   * resident, and exactly the set that makes [connectionIdleMillis] answer `null`.
    *
    * Published on `/status.json` because a busy answer with nothing to attribute it to is not
    * diagnosable from outside the process, and everything downstream of the idle clock (the theme
    * optimizer's quiet gate, the `--exit-when-idle` watchdog) then looks broken for no visible
    * reason. A lease is released in a `finally`, but a request cancelled mid-flight can still leak
-   * one — see `withLeasedSessionOrNull` — and a single leaked lease pins the whole server as busy
-   * for the life of the process. This names the holder so that failure is a one-line read rather
-   * than an inference.
+   * one — see `withLeasedSessionOrNull` — and a leaked lease keeps a session resident for the life
+   * of the process. This names the holder so that failure is a one-line read rather than an
+   * inference.
+   *
+   * Since #4312 this is a *superset* of what shuts the optimizer's gate: see [busyLeasedSessions]
+   * for the holders that are also currently counting as busy.
    */
   fun leasedSessions(): List<String> = lock.withLock {
     sessions.entries.filter { it.value.leases > 0 }.map { it.key }.sorted()
+  }
+
+  /**
+   * The subset of [leasedSessions] whose holder has been active within [leaseBusyMillis] — i.e.
+   * exactly the set that makes [idleMillis] answer `null`.
+   *
+   * The two lists are published side by side so the interesting state is readable rather than
+   * inferred: `leasedSessions` non-empty with this one empty is the idle-tab case, a session held
+   * resident for a connection nobody is using.
+   */
+  fun busyLeasedSessions(now: Long = clock()): List<String> = lock.withLock {
+    sessions.entries.filter { it.value.isBusy(now) }.map { it.key }.sorted()
   }
 
   /**
@@ -654,5 +749,23 @@ class ServeSessionRegistry(
      * different windows.
      */
     const val DEFAULT_DAEMON_IDLE_MILLIS = 60 * 1000L
+
+    /**
+     * Default quiet window before an open lease stops answering *busy* on [idleMillis] — thirty
+     * seconds, against the ten minutes a whole session gets before suspension.
+     *
+     * The two windows price different mistakes. Suspending a session under a visitor costs them a
+     * daemon rebuild, so that one is generous. Letting a background pass start under a visitor
+     * costs them one render — the optimizer yields as soon as a request lands
+     * (`OPTIMIZER_YIELD_MILLIS`) — so this one can afford to be short, and has to be: it must sit
+     * **below** the optimizer's 60s cold-entry window (`themeOptimizationIdleMillis`), or a lease
+     * that only stops counting as busy after the gate's own window would still be the binding
+     * constraint and the gate would never open under a held lease.
+     *
+     * It also sits well below the page's presence heartbeat ([ServeWeb.PRESENCE_INTERVAL_SECONDS],
+     * 240s), so an open tab's own keepalive can't keep the lease permanently "active" — the
+     * heartbeat re-arms the clock every four minutes and it runs freely in between.
+     */
+    const val DEFAULT_LEASE_BUSY_MILLIS = 30 * 1000L
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -545,7 +545,12 @@ class ServeSessionRegistryTest {
         val b = assertNotNull(reg.lease("b"))
         val a = assertNotNull(reg.lease("a"))
         assertEquals(listOf("a", "b"), reg.leasedSessions(), "sorted, so a diff is stable")
-        assertNull(reg.idleMillis(), "and these are precisely why the clock reads busy")
+        assertEquals(
+          listOf("a", "b"),
+          reg.busyLeasedSessions(),
+          "and while the holders are fresh they are also the busy set",
+        )
+        assertNull(reg.idleMillis(), "which is precisely why the clock reads busy")
 
         a.close()
         assertEquals(listOf("b"), reg.leasedSessions())
@@ -554,6 +559,99 @@ class ServeSessionRegistryTest {
         assertEquals(emptyList(), reg.leasedSessions())
         assertNotNull(reg.idleMillis(), "the clock runs again once the last lease is released")
       }
+  }
+
+  /**
+   * The regression this whole change exists for (#4312).
+   *
+   * A viewer WebSocket holds a lease for the socket's whole life, and `leases > 0` used to mean
+   * *busy* outright — so one browser tab left open on a catalog pinned the server's idle clock at
+   * null indefinitely, whether or not anyone was looking at it. Measured on the public box: eight
+   * consecutive minutes with a lease held, `activeStreams 1` and zero renders, after which only the
+   * ceiling let any work through.
+   */
+  @Test
+  fun `a lease stops suppressing the idle clock once its holder goes quiet`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        reaperIntervalMillis = 0,
+        leaseBusyMillis = 30_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("a"))
+
+        clock.set(29_999)
+        assertNull(reg.idleMillis(), "still busy inside the window — a visitor may be mid-browse")
+
+        clock.set(30_000)
+        assertEquals(
+          30_000L,
+          reg.idleMillis(),
+          "quiet for the window: the clock runs again with the socket still open",
+        )
+        assertNull(
+          reg.connectionIdleMillis(),
+          "but the connection is still live, so exit-when-idle must not fire",
+        )
+        assertEquals(listOf("a"), reg.leasedSessions(), "and the session is still held resident")
+        assertEquals(emptyList(), reg.busyLeasedSessions(), "just not by anyone doing anything")
+
+        // A client message on the socket is what real use looks like from here.
+        clock.set(45_000)
+        lease.touch()
+        assertNull(reg.idleMillis(), "activity re-arms it without needing a new lease")
+
+        clock.set(80_000)
+        assertEquals(35_000L, reg.idleMillis(), "and it counts from that activity, not the lease")
+      }
+  }
+
+  /**
+   * `touch` is called from the socket's message loop, which outlives the lease's `finally` on a
+   * cancelled request. Touching a released lease must not resurrect it as busy.
+   */
+  @Test
+  fun `touching a closed lease does nothing`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        reaperIntervalMillis = 0,
+        leaseBusyMillis = 30_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("a"))
+        lease.close()
+        clock.set(60_000)
+        lease.touch()
+        assertEquals(60_000L, reg.idleMillis(), "still counted from the release, not the touch")
+        assertEquals(emptyList(), reg.leasedSessions())
+      }
+  }
+
+  /**
+   * The busy window has to sit **below** the optimizer's cold-entry window, or a held lease that
+   * only goes quiet after the gate's own window is still the binding constraint and the gate never
+   * opens under one — which is the bug, restated with a different number.
+   *
+   * It also has to sit below the page's presence heartbeat, or an open tab's own keepalive keeps
+   * the lease permanently "active" and nothing changes.
+   */
+  @Test
+  fun `the lease busy window fits inside the optimizer gate and the presence heartbeat`() {
+    assertTrue(
+      ServeSessionRegistry.DEFAULT_LEASE_BUSY_MILLIS <
+        ServeCatalogLiveHost.themeOptimizationIdleMillisDefault(),
+      "a lease must go quiet before the gate's own window elapses",
+    )
+    assertTrue(
+      ServeSessionRegistry.DEFAULT_LEASE_BUSY_MILLIS < ServeWeb.PRESENCE_INTERVAL_SECONDS * 1_000L,
+      "or the heartbeat alone would keep every open tab busy forever",
+    )
   }
 
   /**

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -800,17 +800,34 @@ When enabled, it yields twice over — both learned from `preview.coo.ee`:
 **When it isn't running, `/status` says which gate is holding it.** A pass must clear a quiet gate
 before it starts: the whole server has to have been untouched for
 `-Dcomposeai.serve.themeOptimizationIdleMillis` (60s by default). That gate reads
-`ServeSessionRegistry.idleMillis()`, which answers *busy* — not a number — while any session holds
-an open lease, so one long-lived WebSocket, or one lease leaked by a request cancelled mid-flight,
-stands the optimizer down for as long as it is held. The per-catalog `themeOptimization` rows cannot
+`ServeSessionRegistry.idleMillis()`, which answers *busy* — not a number — while a session holds an
+open lease **and its holder is still doing something**.
+
+That last qualifier is the fix for #4312. A viewer WebSocket holds a lease for the socket's whole
+life, and the clock used to read any held lease as busy, so a single browser tab left open on a
+catalog pinned it at *busy* indefinitely whether or not anyone was looking — measured on the public
+box, eight consecutive minutes with a lease held, one active stream and zero renders. A lease now
+stops suppressing the clock once its holder has been quiet for 30s
+(`ServeSessionRegistry.DEFAULT_LEASE_BUSY_MILLIS`, deliberately below the gate's own 60s window),
+while still keeping the session resident so the reaper cannot close a live socket's host
+mid-connection. Activity means the lease being taken, a client message arriving on its socket, or
+any request for that session. Interrupting a pass costs a returning visitor at most one render
+(`OPTIMIZER_YIELD_MILLIS`), which is why the trade is one-sided.
+
+`--exit-when-idle` deliberately keeps the strict rule (`connectionIdleMillis()`): standing a
+background pass down under an idle tab costs that tab one render, while shutting the process down
+under it drops a live connection. A *leaked* lease therefore still holds the watchdog open and keeps
+its session resident, even though it no longer stands the optimizer down for the life of the
+process. The per-catalog `themeOptimization` rows cannot
 show this: they say `paused` whether the box is being politely quiet or the gate will never open
 again. Read `themeOptimizer` on `/status.json` instead:
 
 - `serverIdleMillis` — the gate's input, or `null` for busy — against `idleThresholdMillis`, the
   quiet it must reach. The `/status` page prints the same comparison as **Theme optimiser gate**.
-- `idleBlockedBy` — why it reads busy: `session-lease` (a lease is held; `daemons.leasedSessions`
-  names the holders) or `catalog-load` (catalogs are still being fetched, which is the gate working
-  as designed).
+- `idleBlockedBy` — why it reads busy: `session-lease` (a lease is held *and active*;
+  `daemons.busyLeasedSessions` names those holders, against `daemons.leasedSessions` for every
+  session held resident — leases listed with none of them busy is an idle tab, not a stuck gate) or
+  `catalog-load` (catalogs are still being fetched, which is the gate working as designed).
 - Per catalog, `gateWaitMillis` accrues *while* a pass waits, not only once it is let through — so a
   gate that has never opened shows a climbing wait beside `turnsGranted: 0`, rather than the zeros
   that also describe a catalog with nothing left to do.


### PR DESCRIPTION
Fixes #4312.

## The mismatch

`ServeSessionRegistry.idleMillis()` answered *busy* — `null`, not a large number — while **any** session held a lease, and a viewer WebSocket holds one for the socket's whole life. So a single browser tab left open on a catalog pinned the whole server as busy indefinitely, whether or not anyone was looking at it. Everything gated on that clock then stopped: the theme optimiser's quiet gate never opened, and only the #4288 ceiling let work through, at a trickle (~5 entries/min against 17,992 targets ≈ 60 hours).

`leases > 0` was answering two different questions with one number:

- **Residency** — may the reaper close this session's host? No, never under a live socket.
- **Busyness** — is someone actually being served right now? A tab that hasn't asked for a frame in minutes isn't.

## The change

A lease still keeps its session resident unconditionally. It now stops *suppressing the idle clock* once its holder has been quiet for `DEFAULT_LEASE_BUSY_MILLIS` (30s).

- **What counts as activity**: the lease being taken, any acquire/lease of that session, and a client message arriving on its socket — `Lease.touch()`, wired into both WebSocket lanes (live and snapshot). Lock-free volatile writes, since it sits on the per-message path.
- **The window**: 30s, deliberately **below** the optimiser's 60s cold-entry window (or the lease would still be the binding constraint and the gate would never open under one) and well below the page's 240s presence heartbeat (or a tab's own keepalive would keep it permanently "active"). Both relationships are asserted in a test rather than restated in prose.
- **`--exit-when-idle` keeps the strict rule**, via a new `connectionIdleMillis()`: standing a background pass down under an idle tab costs that tab one render (`OPTIMIZER_YIELD_MILLIS`), while exiting under it drops a live connection. The two want different definitions of busy.
- A leaked lease still holds the watchdog open and keeps its session resident — this relaxation is a floor under that damage, not a licence to leak one. The ceiling stays as a backstop against the class of failure; `turnsForced` climbing on a box with no visitors is the signal something is jamming the clock again.

## Diagnostics

`/status.json` gains `daemons.busyLeasedSessions` beside `daemons.leasedSessions`, and the **Theme optimiser gate** row names the *busy* holders. The difference is the diagnosis: leases listed with none of them busy is an idle tab keeping a daemon warm (fine); a busy one is someone genuinely being served. Previously those two states were indistinguishable from a stuck gate.

`docs/public-preview-server.md` is updated to describe the relaxed clock, the strict watchdog clock, and the new field.

## Test plan

- `./gradlew :cli:test` — green (full CLI suite).
- New in `ServeSessionRegistryTest`, all on a fake clock:
  - `a lease stops suppressing the idle clock once its holder goes quiet` — the regression itself: busy at 29,999ms, running at 30,000ms with the socket still open; `connectionIdleMillis()` still `null`; `leasedSessions` still names the holder while `busyLeasedSessions` is empty; `touch()` re-arms it and the clock then counts from the touch.
  - `touching a closed lease does nothing` — `touch` is called from a message loop that outlives the lease's `finally` on a cancelled request.
  - `the lease busy window fits inside the optimizer gate and the presence heartbeat` — the two ordering constraints above.
- `./gradlew :cli:ktfmtCheck` — clean.

No visual surface is touched (idle-clock semantics, a status JSON field, and the status page's gate text), so this PR is text-only by the repo's visual-evidence rule.

## Verification on the box

Per the issue: with a tab still open, `themeOptimizer.serverIdleMillis` should read a number rather than `null`, `idleBlockedBy` should clear, `turnsForced` should stay flat (turns granted normally rather than by the ceiling), and `cached` should climb at render speed rather than the ceiling's trickle. `daemons.leasedSessions` will still name the tab's session — now beside an empty `busyLeasedSessions`, which is the state that says "held resident, nobody using it".

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ6HSNrXfKfvjzAR68dY3u)_