### PR TITLE
fix(design-pages): stop counting the kit's own internals as missing components

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
@@ -141,6 +141,27 @@ public data class PageNode(
    * attach meaning to the grouping type they understand; see [isContainer].
    */
   val type: String? = null,
+  /**
+   * Whether this node is part of the design system's **published inventory** — something a catalog
+   * could be expected to implement.
+   *
+   * `false` is for the kit's own internals: the base parts each published set is assembled from
+   * (`Base / SelectionControl / Switch`, `Base / Loading Icon`), which a consumer of the kit never
+   * places and no catalog owes an implementation. They are the same kind of thing as [isPrivate],
+   * reached by a different convention — the Material 3 Expressive Wear kit states them by a `Base /`
+   * name prefix rather than by Figma's leading dot — and `kit-sets.json` in the catalog repos
+   * already excludes both from the kit walk. Counting them made a Buttons sheet report 24 missing
+   * components that nothing could ever clear.
+   *
+   * **Stated by the producer, never inferred here**, for the same reason [container] is: the flat
+   * node list has no ancestors, so a consumer cannot tell which set a `Selected=Yes, Disabled=No`
+   * variant came out of. The importer walks the real tree and knows; see the note on [coverageGaps]
+   * about why the depth-ordering shortcut is unsound in exactly the direction that hides a gap.
+   *
+   * Defaults to `true`, so every manifest published before this field existed keeps counting
+   * exactly what it counted before.
+   */
+  val inventory: Boolean = true,
 ) {
   /**
    * A component the design file marks as **private** — Figma's leading-dot convention, used for the
@@ -205,15 +226,15 @@ public data class PageNode(
   /**
    * A concrete, public component that the page should count and highlight.
    *
-   * Three kinds of node are not one, and on a real specimen sheet they are most of it: the sheet's
-   * private furniture ([isPrivate]), the variant sets ([isContainer]), and the placements no
-   * mapping claims ([isPlacement]). Everything the page draws a mark for — the outline, the hit
-   * area, the audit row, the coverage tally — starts here, so a node excluded here is not merely
-   * uncounted: it stops being something the reader can point at, which is the right outcome for all
-   * three.
+   * Four kinds of node are not one, and on a real specimen sheet they are most of it: the sheet's
+   * private furniture ([isPrivate]), the kit's own base parts ([inventory] `= false`), the variant
+   * sets ([isContainer]), and the placements no mapping claims ([isPlacement]). Everything the page
+   * draws a mark for — the outline, the hit area, the audit row, the coverage tally — starts here,
+   * so a node excluded here is not merely uncounted: it stops being something the reader can point
+   * at, which is the right outcome for all four.
    */
   public val isComponent: Boolean
-    get() = !isPrivate && !isContainer && !(isPlacement && isUnlinked)
+    get() = inventory && !isPrivate && !isContainer && !(isPlacement && isUnlinked)
 
   /** Whether this node can be drawn by us, i.e. it names a preview we could ask for. */
   public val isRenderable: Boolean
@@ -273,10 +294,34 @@ public data class DesignPage(
   val image: PageImage,
   /** In the design file's own order, so a re-import diffs cleanly. */
   val nodes: List<PageNode> = emptyList(),
+  /**
+   * Whether this sheet is a **component inventory** — a page whose contents a catalog is measured
+   * against.
+   *
+   * `false` is the kit's icon page: 499 `COMPONENT` nodes that are an icon set, not a component
+   * inventory, and that no Compose catalog implements one-by-one. Counting them reported 499
+   * missing components — a third of the whole kit's apparent gap — and drowned every real one.
+   * `kit-sets.json` already excludes that page by name from the kit walk; this is the same
+   * exclusion, stated where the page view can read it.
+   *
+   * The page is still imported, still drawn, and still browsable — this changes what the page
+   * *claims*, not what it shows. [coverageTotal] is 0 for such a page and the view says what it is
+   * instead of scoring it.
+   *
+   * Page-level rather than a `false` on all 499 nodes because it is a fact about the sheet, and
+   * because 499 stamped nodes is a fact repeated 499 times that a re-import can get half-right.
+   */
+  val inventory: Boolean = true,
 ) {
-  /** Nodes with code behind them. */
+  /**
+   * Nodes with code behind them — the numerator of the page's coverage.
+   *
+   * Empty for a page that is not an [inventory], together with [coverageGaps] and [coverageTotal]:
+   * these three are the one fraction, and a consumer that read a numerator against a zero
+   * denominator would print `12 of 0`. Use [nodes] for an honest node query.
+   */
   public val linked: List<PageNode>
-    get() = nodes.filter { it.isComponent && !it.isUnlinked }
+    get() = if (!inventory) emptyList() else nodes.filter { it.isComponent && !it.isUnlinked }
 
   /** Nodes with no code behind them. Not the same as [coverageGaps] — see there. */
   public val unlinked: List<PageNode>
@@ -305,14 +350,18 @@ public data class DesignPage(
    * over-counting a container is visible and harmless; a gap that quietly disappears is neither.
    */
   public val coverageGaps: List<PageNode>
-    get() = nodes.filter { it.isComponent && it.isUnlinked }
+    get() = if (!inventory) emptyList() else nodes.filter { it.isComponent && it.isUnlinked }
 
   /**
    * How many components on this page a catalog could implement — the denominator behind "N of M
    * implemented", and deliberately not `nodes.size`.
+   *
+   * Zero for a page that is not an [inventory], which is how a consumer tells "this sheet is fully
+   * implemented" from "this sheet is not the kind of thing you implement": the first has a
+   * numerator, and the second has no fraction to state at all.
    */
   public val coverageTotal: Int
-    get() = linked.size + coverageGaps.size
+    get() = if (!inventory) 0 else linked.size + coverageGaps.size
 }
 
 /** A committed design-page import. */

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
@@ -19,6 +19,7 @@ class DesignPagesCoverageTest {
     link: PageNodeLink,
     container: Boolean = false,
     type: String? = null,
+    inventory: Boolean = true,
   ) =
     PageNode(
       nodeId = id,
@@ -28,9 +29,10 @@ class DesignPagesCoverageTest {
       link = link,
       container = container,
       type = type,
+      inventory = inventory,
     )
 
-  private fun page(vararg nodes: PageNode) =
+  private fun page(vararg nodes: PageNode, inventory: Boolean = true) =
     DesignPage(
       id = "shape",
       name = "Shape",
@@ -38,6 +40,7 @@ class DesignPagesCoverageTest {
       frame = PageFrame(1200.0, 800.0),
       image = PageImage(uri = "shape.svg", format = PageImage.SVG),
       nodes = nodes.toList(),
+      inventory = inventory,
     )
 
   @Test
@@ -159,5 +162,72 @@ class DesignPagesCoverageTest {
     assertEquals(listOf("Snackbar"), subject.linked.map { it.name })
     assertEquals(emptyList(), subject.coverageGaps.map { it.name })
     assertEquals(1, subject.coverageTotal)
+  }
+
+  /**
+   * The kit's own base parts. `Base / SelectionControl / Switch` and friends are what a published
+   * set is assembled FROM, not something a catalog implements, and `kit-sets.json` already excludes
+   * them from the kit walk — but the Buttons sheet counted 24 of them and reported missing work no
+   * code could ever clear.
+   *
+   * Read off the node, like every other exclusion here, because the flat list has no ancestors: a
+   * bare `Selected=Yes, Disabled=No` variant does not say which set it came out of.
+   */
+  @Test
+  fun `the kit's own base parts are not components we owe`() {
+    val subject =
+      page(
+        node("1:1", "Base / SelectionControl / Switch", 2, PageNodeLink.UNLINKED,
+          type = "COMPONENT_SET", inventory = false),
+        node("1:2", "Selected=Yes", 3, PageNodeLink.UNLINKED, type = "COMPONENT",
+          inventory = false),
+        node("1:3", "Toggle+Selection-Buttons", 2, PageNodeLink.UNLINKED, type = "COMPONENT_SET"),
+        node("1:4", "Type=Switch", 3, PageNodeLink.MANIFEST, type = "COMPONENT"),
+        node("1:5", "Type=Custom - Task", 3, PageNodeLink.UNLINKED, type = "COMPONENT"),
+      )
+
+    assertEquals(listOf("Type=Custom - Task"), subject.coverageGaps.map { it.name })
+    assertEquals(listOf("Type=Switch"), subject.linked.map { it.name })
+    assertEquals(2, subject.coverageTotal)
+    // Uncounted AND unpointable, the same outcome a private component gets: a base part is not
+    // something a reader of this sheet has any use for selecting.
+    assertEquals(
+      listOf("Type=Switch", "Type=Custom - Task"),
+      subject.nodes.filter { it.isComponent }.map { it.name },
+    )
+  }
+
+  /**
+   * A whole sheet that is not a component inventory — the kit's icon page, 499 `COMPONENT` nodes
+   * that are an icon set. It reported `0 of 499` and was a third of the entire kit's apparent gap.
+   *
+   * The page is still imported and still browsable; what changes is that it makes no claim. The
+   * numerator goes with the denominator, so no consumer can print `12 of 0`.
+   */
+  @Test
+  fun `a sheet that is not a component inventory states no fraction`() {
+    val subject =
+      page(
+        node("1:1", "Icon=Alarm", 2, PageNodeLink.MANIFEST, type = "COMPONENT"),
+        node("1:2", "Icon=Bell", 2, PageNodeLink.UNLINKED, type = "COMPONENT"),
+        inventory = false,
+      )
+
+    assertEquals(0, subject.coverageTotal)
+    assertEquals(emptyList(), subject.linked.map { it.name })
+    assertEquals(emptyList(), subject.coverageGaps.map { it.name })
+    // `nodes` stays an honest query — the sheet still draws, and still says how much is on it.
+    assertEquals(2, subject.nodes.size)
+  }
+
+  /** A manifest published before either field existed counts exactly what it counted before. */
+  @Test
+  fun `both flags default to counted`() {
+    val subject =
+      page(node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST, type = "COMPONENT"))
+
+    assertEquals(1, subject.coverageTotal)
+    assertEquals(true, subject.inventory)
+    assertEquals(true, subject.nodes.single().inventory)
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -8371,11 +8371,17 @@ $rows
         // sheet: a private component and a variant-set container are furniture, and counting them
         // reports a complete family as one short. See `DesignPage.coverageGaps`.
         val linked = page.linked.size
+        // A sheet that is not a component inventory — the kit's icon page — has no fraction to
+        // state, and stating `0 of 499` was the loudest wrong number on this index. Say what the
+        // sheet is instead; the card still opens it.
+        val count =
+          if (!page.inventory) "${page.nodes.size} nodes · not a component inventory"
+          else "$linked of ${page.coverageTotal} components implemented"
         """
         <a class="cp-page-card" href="$basePath/pages/$id$q">
           <img loading="lazy" alt="" src="$basePath/pages/$id.svg$q">
           <strong>${WebEscaping.htmlEscape(page.name)}</strong>
-          <span class="cp-page-count">$linked of ${page.coverageTotal} components implemented</span>
+          <span class="cp-page-count">${WebEscaping.htmlEscape(count)}</span>
         </a>
         """
           .trimIndent()
@@ -9016,6 +9022,10 @@ $cards
     // a private component and a variant-set container are furniture, and counting them reports a
     // complete family as one short. See `DesignPage.coverageGaps`.
     val total = page.coverageTotal
+    // See the pages index: a non-inventory sheet says what it is rather than scoring itself.
+    val coverageText =
+      if (!page.inventory) "${page.nodes.size} nodes · not a component inventory"
+      else "$linked of $total components implemented"
     val figmaLink =
       ServeFigmaSpec.url(fileKey, page.nodeId)
         ?.let {
@@ -9035,7 +9045,9 @@ $cards
     return document(
       title = "${page.name} — page",
       unfurlTitle = "$heading — ${page.name}",
-      unfurlDescription = "$linked of $total components on this page are implemented",
+      unfurlDescription =
+        if (!page.inventory) "${page.nodes.size} nodes on this page; not a component inventory"
+        else "$linked of $total components on this page are implemented",
       unfurl = unfurl,
       version = version,
       navSuffix = navSuffix,
@@ -9047,7 +9059,7 @@ $cards
         """
         <div id="cp-design-page">
           <h1 class="cp-head cp-catalog-head">${WebEscaping.htmlEscape(page.name)}${compactTrustBadge(trust)}</h1>
-          <p class="cp-sub">$linked of $total components implemented$figmaLink</p>
+          <p class="cp-sub">${WebEscaping.htmlEscape(coverageText)}$figmaLink</p>
           <div class="cp-page-controls">
             <div class="cp-page-lane" role="radiogroup" aria-label="What the sheet shows">
               <label><input type="radio" name="cp-page-lane" value="code" data-cp-page-lane checked>

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
@@ -55,6 +55,7 @@ class ServeDesignPageRoutingTest {
       File(dir, "${ServeDesignPageStore.DIRECTORY}/${ServeDesignPageStore.INDEX_FILE}")
         .writeText(pages)
       File(dir, "${ServeDesignPageStore.DIRECTORY}/shape.svg").writeText(svg)
+      File(dir, "${ServeDesignPageStore.DIRECTORY}/icons.svg").writeText(svg)
     }
     return ServeBundleHost(dir, label = label)
   }
@@ -77,7 +78,17 @@ class ServeDesignPageRoutingTest {
          {"nodeId":"1:12","name":"Shape=Gem","depth":3,
           "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:12","link":"unlinked"},
          {"nodeId":"1:9","name":".Header","depth":2,
-          "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:9","link":"unlinked"}]}]}
+          "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:9","link":"unlinked"},
+         {"nodeId":"1:20","name":"Base / Corner","depth":2,"inventory":false,
+          "ref":"figma:ocdacdEsnHipMJD3egzxKb/1:20","link":"unlinked"}]},
+      {"id":"icons","name":"Icons","nodeId":"58548:9000","inventory":false,
+       "frame":{"width":1200,"height":800},
+       "image":{"uri":"icons.svg","format":"svg"},
+       "nodes":[
+         {"nodeId":"2:1","name":"Icon=Alarm","depth":2,
+          "ref":"figma:ocdacdEsnHipMJD3egzxKb/2:1","link":"unlinked"},
+         {"nodeId":"2:2","name":"Icon=Bell","depth":2,
+          "ref":"figma:ocdacdEsnHipMJD3egzxKb/2:2","link":"unlinked"}]}]}
     """
       .trimIndent()
 
@@ -125,6 +136,28 @@ class ServeDesignPageRoutingTest {
     // missing when one was.
     assertTrue(body.contains("2 of 3 components implemented"), body)
     assertTrue(body.contains("/m3-catalog/pages/shape"))
+  }
+
+  /**
+   * The kit's own base parts and a sheet that is not a component inventory, over the wire.
+   *
+   * `Base / Corner` is a sixth node on the Shape sheet and the count does not move: a base part is
+   * what a published set is assembled from, not something a catalog owes. And the Icons sheet — 499
+   * nodes in the real kit — states what it is instead of reporting `0 of 499`, which was a third of
+   * the whole kit's apparent gap and drowned every real one.
+   */
+  @Test
+  fun `base parts and a non-inventory sheet make no coverage claim`() {
+    val (_, _, index) = get("/m3-catalog/pages")
+    assertTrue(index.contains("2 of 3 components implemented"), index)
+    assertFalse(index.contains("0 of 2 components implemented"), index)
+    assertTrue(index.contains("2 nodes · not a component inventory"), index)
+
+    val (code, _, page) = get("/m3-catalog/pages/icons")
+    assertEquals(200, code)
+    assertTrue(page.contains("2 nodes · not a component inventory"), page)
+    // Still drawn and still browsable — this changes what the sheet claims, not what it shows.
+    assertTrue(page.contains("data-node-id=\"1:1\""), page)
   }
 
   @Test

--- a/docs/design/KIT_VARIANT_CELLS.md
+++ b/docs/design/KIT_VARIANT_CELLS.md
@@ -31,7 +31,7 @@ states are out of scope:
 | `Base / …` sets (`Base / SelectionControl / Switch`, `Base / Loading Icon`, …) | 24, all on Buttons | The kit's own internals — the parts each published set is assembled from. `kit-sets.json` excludes them alongside the `.`-prefixed privates that `PageNode.isPrivate` already drops. |
 
 Correcting for both moves the whole-kit figure from a demoralising **185 / 1554 (12%)** to
-**185 / 1031 (18%)**, and the Buttons sheet from 75 / 303 to **75 / 273**. That is not the
+**185 / 1031 (18%)**, and the Buttons sheet from 75 / 303 to **75 / 279**. That is not the
 interesting change — the interesting change is that the remaining red is now *all* real.
 
 **Fix:** teach `design-pages.mjs` the same two exclusions `kit-sets.json` states, so one repo does

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -247,6 +247,16 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // Literal `true` only, in the same spirit as `confidence` above — this decodes into a
         // Kotlin Boolean, and a truthy string is a parse failure for the whole manifest.
         ...(node?.container === true ? { container: true } : {}),
+        // The kit's own base parts — `Base / SelectionControl / Switch`, `Base / Loading Icon` —
+        // which no catalog owes an implementation and which `kit-sets.json` already excludes from
+        // the kit walk. Stated by the importer, which has the real tree and therefore knows which
+        // set a bare `Selected=Yes, Disabled=No` variant came out of; this flat list does not, so
+        // nothing is inferred here.
+        //
+        // Literal `false` only, and emitted only then: the consumer defaults it to `true`, so a
+        // manifest published before the field existed counts exactly what it counted before, and a
+        // truthy string would fail the parse for every page.
+        ...(node?.inventory === false ? { inventory: false } : {}),
       });
     }
     if (unresolved > 0) {
@@ -264,6 +274,10 @@ export function planDesignPages({ manifest, spec, catalog }) {
       frame: { width: page.frame.width, height: page.frame.height },
       image: { uri: pageImageName(id), format: "svg" },
       nodes,
+      // A sheet that is not a component inventory — the kit's 499-node icon page. Same literal
+      // `false` rule as the node field: absent means `true`, which is what every page published
+      // before this field existed means.
+      ...(page?.inventory === false ? { inventory: false } : {}),
     });
   }
 

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -315,6 +315,35 @@ test("a truthy non-boolean container is dropped rather than republished", () => 
   assert.equal(node.container, undefined);
 });
 
+test("a node's inventory=false survives publishing; true is left implicit", () => {
+  // Same allowlist hazard as `container`: drop the field on the way to the delivery branch and the
+  // kit's own base parts come back as 24 components nobody implemented. `true` is the consumer's
+  // default, so emitting it would only make every manifest larger and every re-import noisier.
+  const base = { ...appBar, nodeId: "1:8", name: "Base / Loading Icon", inventory: false };
+  const kept = { ...appBar, nodeId: "1:9", name: "Button", inventory: true };
+  const plan = planDesignPages({ manifest: manifest([page([base, kept])]), spec, catalog });
+  const nodes = plan.manifest.pages[0].nodes;
+  assert.equal(nodes.find((n) => n.nodeId === "1:8").inventory, false);
+  assert.equal(nodes.find((n) => n.nodeId === "1:9").inventory, undefined);
+});
+
+test("a non-boolean inventory is dropped rather than republished", () => {
+  // It decodes into a Kotlin Boolean. Same reasoning as `container`: one bad string there fails the
+  // parse for the whole manifest and hides every page, which is worse than counting one base part.
+  const base = { ...appBar, nodeId: "1:8", name: "Base / Loading Icon", inventory: "no" };
+  const plan = planDesignPages({ manifest: manifest([page([base])]), spec, catalog });
+  assert.equal(plan.manifest.pages[0].nodes[0].inventory, undefined);
+});
+
+test("a page's inventory=false survives publishing; true is left implicit", () => {
+  const icons = page([appBar], { id: "icons", inventory: false });
+  const shapes = page([appBar], { id: "shapes", inventory: true });
+  const plan = planDesignPages({ manifest: manifest([icons, shapes]), spec, catalog });
+  const [published, other] = plan.manifest.pages;
+  assert.equal(published.inventory, false);
+  assert.equal(other.inventory, undefined);
+});
+
 test("an unsupported confidence is dropped, not republished", () => {
   // The consumer decodes this into a strict enum, so republishing an unknown value would fail the
   // parse for the WHOLE manifest — one bad string hiding every page the catalog publishes.


### PR DESCRIPTION
## Summary

Step 1 of [`docs/design/KIT_VARIANT_CELLS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/KIT_VARIANT_CELLS.md) §7. A design page's coverage line counted nodes that `kit-sets.json` **already** states are out of scope for the kit walk, so one repo held two disagreeing answers to "is this a component we owe an implementation":

| Counted as a gap | How many (Wear kit) | Why it is not one |
| --- | --- | --- |
| The `Icons` page | 499 | An icon set, not a component inventory — a third of the whole kit's apparent gap |
| The kit's `Base / …` parts | 24, all on Buttons | What each published set is assembled *from*; `Base / SelectionControl / Switch`, `Base / Loading Icon` |

On the Wear kit that moves the whole-kit figure from **185/1554 (12%) to 185/1031 (18%)** and the Buttons sheet from **75/303 to 75/279** — verified against the committed import, not estimated. Nothing that was a real gap stops being one.

## What changed

- **`PageNode.inventory`** and **`DesignPage.inventory`**, both defaulting to `true`, so every manifest published before this field counts exactly what it counted before.
- `isComponent` honours the node flag, which uncounts **and** unpoints a base part — the same outcome `isPrivate` already gets, and the right one: a base part is not something a reader of the sheet has any use for selecting.
- A non-inventory sheet states what it is (`499 nodes · not a component inventory`) instead of scoring itself, on the pages index, the page header and the unfurl. `linked`, `coverageGaps` and `coverageTotal` are gated together so no consumer can print `12 of 0`; `nodes` stays an honest query, and the sheet still draws and still browses.
- The producer republishes both fields, literal `false` only — same rule `container` follows, because these decode into Kotlin Booleans and one truthy string fails the parse for every page in the manifest.

**Nothing is inferred here.** The flat node list has no ancestors, so it cannot tell which set a bare `Selected=Yes, Disabled=No` variant came out of, and deriving it from depth ordering is the unsound shortcut `PageNode.container`'s own contract warns about — an unlisted frame between two components lets a shallower node be followed by a deeper one that is not inside it, and that misattribution runs in the direction that *hides* a gap. The importer walks the real tree and states it; the wear-m3-catalog side is a companion PR.

Also corrects one number in the design doc: the Buttons denominator is 279, not 273 — the six `Button-ImageBackground-Round` nodes I had lumped in are a real set, not a base one.

## Test plan

- `node --test scripts/design-artifacts/design-pages.test.mjs` — 23 pass, including three new: node `inventory:false` survives publishing while `true` stays implicit, a non-boolean is dropped, and the page-level flag does the same.
- `./gradlew :preview-data-api:test --tests '*DesignPagesCoverageTest*'` — passes, with new cases for base parts (uncounted and unpointable), a non-inventory sheet stating no fraction, and both flags defaulting to counted.
- `./gradlew :cli:test --tests '*ServeDesignPage*'` — passes. The routing test now serves a `Base / Corner` node and a whole non-inventory `Icons` sheet over real HTTP and asserts the count does not move, the sheet says what it is, and it still renders.

No visual evidence: the only rendered surface touched is one line of text on the pages index and page header, whose exact before/after strings are asserted in `ServeDesignPageRoutingTest` above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRkE766A84qYYyvZKj3Dzp)_