### PR TITLE
fix(serve): keep a request-scoped lease busy for its whole life

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
@@ -148,8 +148,8 @@ public data class PageNode(
    * `false` is for the kit's own internals: the base parts each published set is assembled from
    * (`Base / SelectionControl / Switch`, `Base / Loading Icon`), which a consumer of the kit never
    * places and no catalog owes an implementation. They are the same kind of thing as [isPrivate],
-   * reached by a different convention — the Material 3 Expressive Wear kit states them by a `Base /`
-   * name prefix rather than by Figma's leading dot — and `kit-sets.json` in the catalog repos
+   * reached by a different convention — the Material 3 Expressive Wear kit states them by a `Base
+   * /` name prefix rather than by Figma's leading dot — and `kit-sets.json` in the catalog repos
    * already excludes both from the kit walk. Counting them made a Buttons sheet report 24 missing
    * components that nothing could ever clear.
    *

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
@@ -177,10 +177,22 @@ class DesignPagesCoverageTest {
   fun `the kit's own base parts are not components we owe`() {
     val subject =
       page(
-        node("1:1", "Base / SelectionControl / Switch", 2, PageNodeLink.UNLINKED,
-          type = "COMPONENT_SET", inventory = false),
-        node("1:2", "Selected=Yes", 3, PageNodeLink.UNLINKED, type = "COMPONENT",
-          inventory = false),
+        node(
+          "1:1",
+          "Base / SelectionControl / Switch",
+          2,
+          PageNodeLink.UNLINKED,
+          type = "COMPONENT_SET",
+          inventory = false,
+        ),
+        node(
+          "1:2",
+          "Selected=Yes",
+          3,
+          PageNodeLink.UNLINKED,
+          type = "COMPONENT",
+          inventory = false,
+        ),
         node("1:3", "Toggle+Selection-Buttons", 2, PageNodeLink.UNLINKED, type = "COMPONENT_SET"),
         node("1:4", "Type=Switch", 3, PageNodeLink.MANIFEST, type = "COMPONENT"),
         node("1:5", "Type=Custom - Task", 3, PageNodeLink.UNLINKED, type = "COMPONENT"),
@@ -223,8 +235,7 @@ class DesignPagesCoverageTest {
   /** A manifest published before either field existed counts exactly what it counted before. */
   @Test
   fun `both flags default to counted`() {
-    val subject =
-      page(node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST, type = "COMPONENT"))
+    val subject = page(node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST, type = "COMPONENT"))
 
     assertEquals(1, subject.coverageTotal)
     assertEquals(true, subject.inventory)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -7186,7 +7186,11 @@ class ServeHttpServer(
       // Lease (not just acquire) the tenant for the socket's whole life: a fallback-lane socket
       // opens
       // no stream, so without a lease the reaper could close its host mid-connection.
-      val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId) }
+      //
+      // `connection = true`: this is the one hold that outlives any unit of work, so it is the one
+      // that has to earn its "busy" from activity rather than from being open (#4312). Every other
+      // caller takes the default request-scoped lease, which counts as busy until it is released.
+      val lease = withContext(Dispatchers.IO) { sessions.lease(sessionId, connection = true) }
       if (lease == null) {
         close(CloseReason(CloseReason.Codes.CANNOT_ACCEPT, "no such session"))
         return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -85,11 +85,22 @@ class ServeSessionRegistry(
      */
     val forked: Boolean,
     @Volatile var lastAccess: Long,
-    /** Open long-lived holders (e.g. WebSocket connections) keeping this session resident. */
-    @Volatile var leases: Int = 0,
     /**
-     * Wall-clock of the last thing a *leaseholder* actually did — the lease being taken, a client
-     * message arriving on its socket ([Lease.touch]), or any acquire/lease of this session.
+     * Open **request-scoped** holders: a lease taken for the duration of one HTTP request
+     * (`withLeasedSession`). These count as busy for their whole life, however long that is — a
+     * cold `/render` or a `/bundle.zip` legitimately runs for minutes, and the quiet gate exists to
+     * keep background work off exactly that.
+     */
+    @Volatile var requestLeases: Int = 0,
+    /**
+     * Open **connection** holders: a viewer WebSocket, held for the socket's whole life. These keep
+     * the session resident unconditionally but only count as busy while [lastLeaseActivity] is
+     * recent — see [idleMillis] and issue #4312.
+     */
+    @Volatile var connectionLeases: Int = 0,
+    /**
+     * Wall-clock of the last thing a *leaseholder* actually did — a lease being taken, a client
+     * message arriving on its socket ([Lease.touch]), or any acquire of this session.
      *
      * Separate from [lastAccess], which answers "may this session's daemon be suspended?" and is
      * deliberately generous. This one answers "is someone being served right now?" against the much
@@ -111,7 +122,11 @@ class ServeSessionRegistry(
      * Closing under the lock used to serialise this implicitly.
      */
     @Volatile var closing: Boolean = false,
-  )
+  ) {
+    /** Every open holder, of either kind — the residency question. */
+    val leases: Int
+      get() = requestLeases + connectionLeases
+  }
 
   /**
    * A read-only snapshot of one **currently-resident** session (its host is live right now), for
@@ -142,24 +157,40 @@ class ServeSessionRegistry(
     private val released = AtomicBoolean(false)
 
     /**
+     * Serialises [touch] against [close], so "a no-op once released" is a guarantee rather than a
+     * likelihood.
+     *
+     * An `AtomicBoolean` read alone makes [touch] a check-then-act: it can see the lease open, be
+     * overtaken by a `close()` that releases the hold, and only then write its timestamps — marking
+     * a session busy on behalf of a holder that has already left, and (with a second connection
+     * lease on the same session) restarting that one's quiet window from a stale instant.
+     *
+     * A private monitor rather than the registry's own lock: [touch] is on the socket's per-message
+     * path, and the registry lock is held across a session *build* in `entryFor`, so borrowing it
+     * here would park a message loop behind an unrelated tenant's Gradle work. Lock ordering is
+     * one-way — this monitor is taken before the registry lock (via `onRelease`) and never the
+     * other way round — so the pair cannot deadlock.
+     */
+    private val gate = Any()
+
+    /**
      * Report that the holder is *doing* something — a client message on its socket, say — as
      * opposed to merely still being connected.
      *
-     * Holding a lease is what keeps the session resident; calling this is what keeps it counting as
-     * **busy** on the whole-server idle clock (see [idleMillis]). A long-lived connection that
-     * never touches goes quiet on that clock while staying resident, which is the point: an open
-     * browser tab nobody is looking at should not stand the theme optimizer down for hours.
+     * Holding a lease is what keeps the session resident; calling this is what keeps a **connection
+     * lease** counting as busy on the whole-server idle clock (see [idleMillis]). A long-lived
+     * connection that never touches goes quiet on that clock while staying resident, which is the
+     * point: an open browser tab nobody is looking at should not stand the theme optimizer down for
+     * hours. Request-scoped leases count as busy regardless and need not call this.
      *
-     * Cheap and lock-free by design — it is on the per-message path. It writes volatile timestamps
-     * that no invariant spans, so a reader can only ever see an older or newer instant, never an
-     * inconsistent pair. A no-op once the lease is [close]d.
+     * A no-op once the lease is [close]d.
      */
     fun touch() {
-      if (!released.get()) onTouch()
+      synchronized(gate) { if (!released.get()) onTouch() }
     }
 
     override fun close() {
-      if (released.compareAndSet(false, true)) onRelease()
+      synchronized(gate) { if (released.compareAndSet(false, true)) onRelease() }
     }
   }
 
@@ -369,19 +400,30 @@ class ServeSessionRegistry(
    * Acquire [sessionId] and hold it resident for the returned [Lease]'s lifetime, so a long-lived
    * connection — including a WebSocket on the snapshot fallback lane that opens no stream — isn't
    * suspended mid-connection. Returns `null` when the session can't be created/opened.
+   *
+   * [connection] picks which of the two questions this hold answers on the idle clock, and the
+   * default is the conservative one:
+   * - **false (default), a request-scoped hold.** `withLeasedSession` wraps ordinary HTTP work in
+   *   one of these, and that work is not always short — a cold `/render` is 30-70s and a
+   *   `/bundle.zip` longer still. It counts as busy for its whole life, because keeping background
+   *   work off a foreground render is precisely what the quiet gate is for.
+   * - **true, a connection hold.** A viewer WebSocket, which lives as long as the tab does. It
+   *   keeps the session resident unconditionally, but counts as busy only while its holder is
+   *   actually doing something ([Lease.touch]) — see [idleMillis] and issue #4312.
    */
-  fun lease(sessionId: String): Lease? = lock.withLock {
+  fun lease(sessionId: String, connection: Boolean = false): Lease? = lock.withLock {
     check(!closed) { "ServeSessionRegistry is closed" }
     val entry = entryFor(sessionId) ?: return null
     entry.lastAccess = clock()
     entry.lastLeaseActivity = clock()
     lastActivity = clock()
     val host = liveHost(entry) ?: return null
-    entry.leases++
+    if (connection) entry.connectionLeases++ else entry.requestLeases++
     Lease(
       host,
       onTouch = {
-        // No lock: see [Lease.touch]. Three independent volatile writes, on the per-message path.
+        // No registry lock here — see [Lease.gate] for why, and for what serialises this against
+        // the release below. Three independent volatile writes, on the per-message path.
         val now = clock()
         entry.lastLeaseActivity = now
         entry.lastAccess = now
@@ -389,7 +431,7 @@ class ServeSessionRegistry(
       },
     ) {
       lock.withLock {
-        entry.leases--
+        if (connection) entry.connectionLeases-- else entry.requestLeases--
         entry.lastAccess = clock() // start the idle clock fresh once the holder leaves
         entry.lastLeaseActivity = clock()
         lastActivity = clock()
@@ -436,18 +478,24 @@ class ServeSessionRegistry(
    * Idle counts from the last acquire/lease/release/[Lease.touch]; with nothing happening it grows
    * unbounded. Drives the theme optimizer's quiet gate.
    *
-   * **A lease answers busy only while its holder is still doing something** (issue #4312). This
-   * used to be `any { leases > 0 }`, and a viewer WebSocket holds a lease for the socket's whole
-   * life — so one browser tab left open on a catalog pinned the clock at *busy* indefinitely,
-   * whether or not anyone was looking at it. Everything gated on the clock then stopped: measured
-   * on the public box, a single idle tab held the optimizer's gate shut for eight consecutive
-   * minutes with zero renders, after which only the ceiling (#4288) let work through, at a trickle.
+   * **A connection lease answers busy only while its holder is still doing something**
+   * (issue #4312). This used to be `any { leases > 0 }`, and a viewer WebSocket holds a lease for
+   * the socket's whole life — so one browser tab left open on a catalog pinned the clock at *busy*
+   * indefinitely, whether or not anyone was looking at it. Everything gated on the clock then
+   * stopped: measured on the public box, a single idle tab held the optimizer's gate shut for eight
+   * consecutive minutes with zero renders, after which only the ceiling (#4288) let work through,
+   * at a trickle.
    *
    * Residency and busyness are two questions, and `leases > 0` answered both with one number. A
    * lease still keeps its session resident unconditionally — the reaper must never close a live
-   * socket's host mid-connection — but it stops *suppressing this clock* once the holder has been
-   * quiet for [leaseBusyMillis]. Interrupting an optimizer pass costs a returning visitor at most
-   * one render (`OPTIMIZER_YIELD_MILLIS`), so the trade is heavily one-sided.
+   * socket's host mid-connection — but a **connection** lease stops *suppressing this clock* once
+   * its holder has been quiet for [leaseBusyMillis]. Interrupting an optimizer pass costs a
+   * returning visitor at most one render (`OPTIMIZER_YIELD_MILLIS`), so the trade is one-sided.
+   *
+   * A **request-scoped** lease is never aged out, however long it runs. `withLeasedSession` wraps
+   * ordinary HTTP work in one, and that work is not always quick — a cold `/render` is 30-70s, a
+   * `/bundle.zip` longer — so ageing those out would let background work start against exactly the
+   * foreground render this gate exists to protect. See [lease].
    *
    * Use [connectionIdleMillis] where a live connection must count regardless of activity.
    */
@@ -467,9 +515,12 @@ class ServeSessionRegistry(
     if (sessions.values.any { it.leases > 0 }) null else now - lastActivity
   }
 
-  /** Whether this entry's lease is recent enough to answer *busy*. See [idleMillis]. */
+  /**
+   * Whether this entry has a holder that answers *busy*: any request-scoped lease, or a connection
+   * lease whose holder has been active recently enough. See [idleMillis].
+   */
   private fun Entry.isBusy(now: Long): Boolean =
-    leases > 0 && now - lastLeaseActivity < leaseBusyMillis
+    requestLeases > 0 || (connectionLeases > 0 && now - lastLeaseActivity < leaseBusyMillis)
 
   /**
    * Session ids holding at least one open lease, sorted — i.e. exactly the set keeping a session

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -581,7 +581,7 @@ class ServeSessionRegistryTest {
         clock = clock::get,
       )
       .use { reg ->
-        val lease = assertNotNull(reg.lease("a"))
+        val lease = assertNotNull(reg.lease("a", connection = true))
 
         clock.set(29_999)
         assertNull(reg.idleMillis(), "still busy inside the window — a visitor may be mid-browse")
@@ -610,6 +610,65 @@ class ServeSessionRegistryTest {
   }
 
   /**
+   * The ageing rule is for *connection* holds only.
+   *
+   * `withLeasedSession` wraps ordinary HTTP work in a lease too, and that work is not always short
+   * — a cold `/render` is 30-70s and a `/bundle.zip` longer. Ageing one of those out would report
+   * the box as quiet while it is still rendering, and let background work start against exactly the
+   * foreground request the quiet gate exists to protect.
+   */
+  @Test
+  fun `a request-scoped lease stays busy however long the request runs`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        reaperIntervalMillis = 0,
+        leaseBusyMillis = 30_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val lease = assertNotNull(reg.lease("a")) // the default: a request-scoped hold
+
+        clock.set(10 * 60_000) // ten minutes into a cold render, and it never touched
+        assertNull(reg.idleMillis(), "a request in flight is busy until it is done, not for 30s")
+        assertEquals(listOf("a"), reg.busyLeasedSessions())
+
+        lease.close()
+        clock.set(10 * 60_000 + 5_000)
+        assertEquals(5_000L, reg.idleMillis(), "and the clock starts from its release")
+      }
+  }
+
+  /**
+   * A connection lease going quiet must not un-busy a request that is running alongside it — the
+   * two counts are tracked separately, not collapsed into one.
+   */
+  @Test
+  fun `a quiet connection lease does not mask a concurrent request lease`() {
+    val clock = AtomicLong(0)
+    ServeSessionRegistry(
+        open = Opener(),
+        factory = CountingFactory(),
+        reaperIntervalMillis = 0,
+        leaseBusyMillis = 30_000,
+        clock = clock::get,
+      )
+      .use { reg ->
+        val socket = assertNotNull(reg.lease("a", connection = true))
+        val request = assertNotNull(reg.lease("a"))
+
+        clock.set(120_000)
+        assertNull(reg.idleMillis(), "the request is still in flight")
+
+        request.close()
+        clock.set(180_000)
+        assertEquals(60_000L, reg.idleMillis(), "once it lands, the quiet socket does not hold on")
+        socket.close()
+      }
+  }
+
+  /**
    * `touch` is called from the socket's message loop, which outlives the lease's `finally` on a
    * cancelled request. Touching a released lease must not resurrect it as busy.
    */
@@ -624,7 +683,7 @@ class ServeSessionRegistryTest {
         clock = clock::get,
       )
       .use { reg ->
-        val lease = assertNotNull(reg.lease("a"))
+        val lease = assertNotNull(reg.lease("a", connection = true))
         lease.close()
         clock.set(60_000)
         lease.touch()

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -806,13 +806,20 @@ open lease **and its holder is still doing something**.
 That last qualifier is the fix for #4312. A viewer WebSocket holds a lease for the socket's whole
 life, and the clock used to read any held lease as busy, so a single browser tab left open on a
 catalog pinned it at *busy* indefinitely whether or not anyone was looking — measured on the public
-box, eight consecutive minutes with a lease held, one active stream and zero renders. A lease now
-stops suppressing the clock once its holder has been quiet for 30s
-(`ServeSessionRegistry.DEFAULT_LEASE_BUSY_MILLIS`, deliberately below the gate's own 60s window),
-while still keeping the session resident so the reaper cannot close a live socket's host
-mid-connection. Activity means the lease being taken, a client message arriving on its socket, or
-any request for that session. Interrupting a pass costs a returning visitor at most one render
-(`OPTIMIZER_YIELD_MILLIS`), which is why the trade is one-sided.
+box, eight consecutive minutes with a lease held, one active stream and zero renders. Leases now
+come in two kinds:
+
+- A **connection** lease (the viewer WebSocket) keeps its session resident unconditionally — the
+  reaper must never close a live socket's host mid-connection — but stops suppressing the idle clock
+  once its holder has been quiet for 30s (`ServeSessionRegistry.DEFAULT_LEASE_BUSY_MILLIS`,
+  deliberately below the gate's own 60s window). Activity means the lease being taken, a client
+  message arriving on its socket, or any request for that session. Interrupting a pass costs a
+  returning visitor at most one render (`OPTIMIZER_YIELD_MILLIS`), which is why the trade is
+  one-sided.
+- A **request-scoped** lease (`withLeasedSession`, the default) counts as busy until it is released,
+  however long that takes. A cold `/render` is 30-70s and a `/bundle.zip` can be longer, and keeping
+  background work off exactly those is what the gate is for — ageing them out would report the box
+  as quiet while it is still rendering for someone.
 
 `--exit-when-idle` deliberately keeps the strict rule (`connectionIdleMillis()`): standing a
 background pass down under an idle tab costs that tab one render, while shutting the process down


### PR DESCRIPTION
Follow-up to #4326 (issue #4312), addressing the two review findings on that PR. It merged before these could be pushed, so they land as a separate change rather than stacked on merged history.

## P1 — a request lease must not age out

#4326 applied the 30s quiet window to **every** lease. But `withLeasedSession` wraps ordinary HTTP work in a lease too, and that work is not always short — a cold `/render` is 30–70s and a `/bundle.zip` can be longer. Such a request would have reported the box as *quiet* while it was still rendering, letting the theme optimiser start against exactly the foreground work the quiet gate exists to protect. The gate would have gone from "never opens" to "opens at the wrong moment".

Leases are now two kinds, counted separately on the entry:

- **Request-scoped** (`lease(id)`, the default) — busy until released, however long that takes.
- **Connection** (`lease(id, connection = true)`) — taken *only* by the viewer WebSocket, the one hold that outlives any unit of work. Keeps its session resident unconditionally; counts as busy only while its holder is active (`Lease.touch()`).

Residency is unchanged: `Entry.leases` is now the sum of both, so `suspendIdle`, `reclaimIdleForked`, `connectionIdleMillis` and the `/status` per-daemon count all behave exactly as before.

## P2 — `touch` serialised against `close`

`if (!released.get()) onTouch()` was a check-then-act: a `touch` could observe the lease open, be overtaken by a `close`, and only then write its timestamps — marking a session busy for a holder that had already left, and (with a second connection lease on the same session) restarting *that* holder's quiet window from a stale instant.

Both now take a private monitor, so "a no-op once released" is a guarantee rather than a likelihood. Deliberately **not** the registry's own lock: `touch` sits on the socket's per-message path, and that lock is held across a session *build* in `entryFor`, so borrowing it would park a message loop behind an unrelated tenant's Gradle work. Lock ordering is one-way — the monitor is taken before the registry lock via `onRelease`, never the reverse — so the pair cannot deadlock.

The guarantee here is structural (one monitor shared by both paths); I have not added a race test, since a probabilistic one would be flaky and would not raise confidence above what the mutual exclusion already gives.

## Test plan

- `./gradlew :cli:test` — green, on current `main` (`f8a8fd3`).
- New in `ServeSessionRegistryTest`:
  - `a request-scoped lease stays busy however long the request runs` — ten minutes into a cold render with no `touch`, `idleMillis()` is still `null`; the clock starts from the release. This is the P1 regression.
  - `a quiet connection lease does not mask a concurrent request lease` — a socket that has gone quiet must not un-busy a request running alongside it; the two counts are tracked separately, not collapsed.
  - The existing #4312 tests now take `connection = true`, which is what the WebSocket handler passes.
- `./gradlew :cli:ktfmtCheck` — clean.

## One unrelated hunk

`api/preview-data-api` is unformatted on `main` as of `f8a8fd3`, and the repo-wide `ktfmt` pre-commit hook blocks *any* commit until it is fixed. This carries the two-file `ktfmtFormat` output for it — mechanical, no behaviour change, and separable if you would rather it landed on its own.

No visual surface is touched, so this PR is text-only by the repo's visual-evidence rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZ6HSNrXfKfvjzAR68dY3u)_