### PR TITLE
style(design-pages): reformat with ktfmt

### DIFF
--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/designpages/DesignPages.kt
@@ -148,8 +148,8 @@ public data class PageNode(
    * `false` is for the kit's own internals: the base parts each published set is assembled from
    * (`Base / SelectionControl / Switch`, `Base / Loading Icon`), which a consumer of the kit never
    * places and no catalog owes an implementation. They are the same kind of thing as [isPrivate],
-   * reached by a different convention — the Material 3 Expressive Wear kit states them by a `Base /`
-   * name prefix rather than by Figma's leading dot — and `kit-sets.json` in the catalog repos
+   * reached by a different convention — the Material 3 Expressive Wear kit states them by a `Base
+   * /` name prefix rather than by Figma's leading dot — and `kit-sets.json` in the catalog repos
    * already excludes both from the kit walk. Counting them made a Buttons sheet report 24 missing
    * components that nothing could ever clear.
    *

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/designpages/DesignPagesCoverageTest.kt
@@ -177,10 +177,22 @@ class DesignPagesCoverageTest {
   fun `the kit's own base parts are not components we owe`() {
     val subject =
       page(
-        node("1:1", "Base / SelectionControl / Switch", 2, PageNodeLink.UNLINKED,
-          type = "COMPONENT_SET", inventory = false),
-        node("1:2", "Selected=Yes", 3, PageNodeLink.UNLINKED, type = "COMPONENT",
-          inventory = false),
+        node(
+          "1:1",
+          "Base / SelectionControl / Switch",
+          2,
+          PageNodeLink.UNLINKED,
+          type = "COMPONENT_SET",
+          inventory = false,
+        ),
+        node(
+          "1:2",
+          "Selected=Yes",
+          3,
+          PageNodeLink.UNLINKED,
+          type = "COMPONENT",
+          inventory = false,
+        ),
         node("1:3", "Toggle+Selection-Buttons", 2, PageNodeLink.UNLINKED, type = "COMPONENT_SET"),
         node("1:4", "Type=Switch", 3, PageNodeLink.MANIFEST, type = "COMPONENT"),
         node("1:5", "Type=Custom - Task", 3, PageNodeLink.UNLINKED, type = "COMPONENT"),
@@ -223,8 +235,7 @@ class DesignPagesCoverageTest {
   /** A manifest published before either field existed counts exactly what it counted before. */
   @Test
   fun `both flags default to counted`() {
-    val subject =
-      page(node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST, type = "COMPONENT"))
+    val subject = page(node("1:1", "Shape=Circle", 3, PageNodeLink.MANIFEST, type = "COMPONENT"))
 
     assertEquals(1, subject.coverageTotal)
     assertEquals(true, subject.inventory)


### PR DESCRIPTION
## Summary

[#4335](https://github.com/yschimke/compose-ai-tools/pull/4335) landed with `DesignPages.kt` and `DesignPagesCoverageTest.kt` unformatted, so the `ktfmt (Google style)` gate is red on `main` and on every branch cut from it (e.g. [#4336](https://github.com/yschimke/compose-ai-tools/pull/4336), where the failure has nothing to do with the diff).

This is pure `./gradlew :preview-data-api:ktfmtFormatMain :preview-data-api:ktfmtFormatTest` output — a KDoc rewrap and two call-site reflows. No behaviour change.

## Test plan

- `./gradlew :preview-data-api:ktfmtCheckMain :preview-data-api:ktfmtCheckTest` — clean (fails on `main`).
- `./gradlew :preview-data-api:test` — green.

Non-visual change, so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxWvuxmyGrW8vwEnSqago1)_