### PR TITLE
fix(serve): correct five page-shape holes in the KDoc link resolver

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ApiDocLinks.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ApiDocLinks.kt
@@ -11,8 +11,9 @@ package ee.schimke.composeai.cli.serve
  * in `ee.schimke.wearm3catalog` — and nothing about that name says the component on screen is
  * `androidx.wear.compose.material3.Button`. The *usage snippet* does: [PlaygroundSourceCleaner] has
  * already reduced the sticker to the plain Compose a reader would write, and pruned its imports to
- * exactly what that code touches. So the snippet's imports **are** the API surface of the render,
- * with no join table to maintain and nothing for a catalog to declare.
+ * exactly what that code touches. So the snippet's imports — plus the APIs the cleaner chose to
+ * write out in full ([QUALIFIED]) — **are** the API surface of the render, with no join table to
+ * maintain and nothing for a catalog to declare.
  *
  * ### The two page shapes, and why the kind has to be inferred
  *
@@ -23,6 +24,10 @@ package ee.schimke.composeai.cli.serve
  * - used as a **qualifier** (`ButtonDefaults.buttonColors()`), an **annotation** (`@Composable`),
  *   or a **type** (`: Modifier`, `<Dp>`) ⇒ the declaration page. A composable is never any of
  *   those.
+ * - outside a Compose namespace ([composableNamespace]) ⇒ the declaration page, without consulting
+ *   the call site at all. `Button(onClick = { Intent(ctx, T::class.java) })` puts a constructor
+ *   exactly where a composable call sits, and nothing in the braces alone tells a callback lambda
+ *   from a slot one — but `android.content.Intent` has no `.composable` page to be wrong about.
  * - otherwise, **called in statement position** ⇒ the composable page. "Statement position" is the
  *   discriminator that matters, and it is decided by the character before the call rather than by
  *   the start of a line: a value called for its constructor is always part of a larger expression
@@ -48,7 +53,7 @@ package ee.schimke.composeai.cli.serve
  *   name anyway.
  *
  * Measured against 244 live snippets spanning every catalog on the public preview host, every URL
- * this produces resolves (220 distinct pages, zero 404s). `ApiDocLinksTest` pins the shapes that
+ * this produces resolves (227 distinct pages, zero 404s). `ApiDocLinksTest` pins the shapes that
  * got it there, so a "simplification" that drops one of them fails rather than silently starts
  * publishing dead links.
  */
@@ -59,6 +64,9 @@ internal object ApiDocLinks {
 
   /** Most links one snippet may contribute, so a screen-sized panel stays screen-sized. */
   private const val MAX_LINKS = 24
+
+  /** What a string literal's characters become — see [blankCommentsAndStrings]. */
+  private const val STRING_FILL = '0'
 
   /**
    * Packages that publish **value types only** — no top-level composable has ever lived in them.
@@ -103,6 +111,20 @@ internal object ApiDocLinks {
     Regex("""^\s*import\s+([A-Za-z_][A-Za-z0-9_.]*)\s*(?:as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*$""")
 
   /**
+   * A platform API written out in full in the body — lower-case package segments and **one**
+   * capitalised type.
+   *
+   * One, not a chain: `androidx.compose.ui.graphics.Color.Transparent` is a member read off
+   * `Color`, and taking both capitalised segments asks the site for a nested type that does not
+   * exist. An import is the opposite case and keeps its whole chain, because an import line names
+   * the type exactly — including a genuinely nested one like `LayoutElementBuilders.Box`.
+   */
+  private val QUALIFIED =
+    Regex(
+      """(?<![A-Za-z0-9_.])((?:androidx|android)(?:\.[a-z][A-Za-z0-9_]*)+\.[A-Z][A-Za-z0-9_]*)"""
+    )
+
+  /**
    * The reference links for [snippet] — composables first, then declarations, each group in the
    * order the code first names them.
    *
@@ -115,14 +137,14 @@ internal object ApiDocLinks {
    */
   fun of(snippet: String): List<Link> {
     val body = StringBuilder()
-    val imports = mutableListOf<Pair<String, String>>()
+    val candidates = mutableListOf<Pair<String, String>>()
     for (line in snippet.lineSequence()) {
       val match = IMPORT.matchEntire(line)
       if (match != null) {
         val fqn = match.groupValues[1]
         // A star import names no symbol, and has no leaf to choose a page shape for.
         if (!fqn.endsWith(".*")) {
-          imports += match.groupValues[2].ifEmpty { fqn.substringAfterLast('.') } to fqn
+          candidates += match.groupValues[2].ifEmpty { fqn.substringAfterLast('.') } to fqn
         }
       }
       // Import and `package` lines are blanked rather than dropped so the offsets that order the
@@ -131,10 +153,20 @@ internal object ApiDocLinks {
       body.append(if (keep) line else "").append('\n')
     }
     val code = blankCommentsAndStrings(body.toString())
-    return imports
-      .mapNotNull { (name, fqn) -> linkFor(name, fqn, code) }
-      // Two imports can reach the same page (the same symbol under an alias as well as its own
-      // name); the page is what the reader opens, so it is what de-duplicates.
+    // Fully-qualified uses, which carry no import at all. Not an edge case: the cleaner's
+    // `MATERIAL3_SYSTEM_THEME` rewrite deliberately emits
+    // `androidx.compose.material3.MaterialTheme(...)` and prunes the import, so a catalog whose
+    // theme wrapper goes through it would otherwise be missing the most prominent API on the card.
+    // Here the spelling the code uses IS the qualified name, which every rule below matches on
+    // just as it matches a simple one.
+    for (match in QUALIFIED.findAll(code)) {
+      candidates += match.groupValues[1] to match.groupValues[1]
+    }
+    return candidates
+      .mapNotNull { (spelling, fqn) -> linkFor(spelling, fqn, code) }
+      // Two candidates can reach the same page — a symbol under an alias as well as its own name,
+      // or an import and a qualified use of the same thing. The page is what the reader opens, so
+      // it is what de-duplicates.
       .distinctBy { it.link.url }
       .sortedWith(compareBy({ if (it.link.composable) 0 else 1 }, { it.firstUse }))
       .take(MAX_LINKS)
@@ -144,15 +176,18 @@ internal object ApiDocLinks {
   /** A resolved link plus the offset that orders it; the offset never leaves this file. */
   private class Ranked(val link: Link, val firstUse: Int)
 
-  private fun linkFor(name: String, fqn: String, code: String): Ranked? {
+  private fun linkFor(spelling: String, fqn: String, code: String): Ranked? {
     if (!fqn.startsWith("androidx.") && !fqn.startsWith("android.")) return null
     val leaf = fqn.substringAfterLast('.')
     if (leaf.firstOrNull()?.isUpperCase() != true) return null
+    // `android.permission.BLUETOOTH_CONNECT` is a String constant, not a type. Reached only
+    // through the qualified scan, which cannot lean on an import line to tell it otherwise.
+    if (leaf.length > 1 && leaf == leaf.uppercase()) return null
     if (fqn.contains(".compose.material.icons.") || fqn.contains(".compose.material3.icons.")) {
       return null
     }
     if (Regex("""^Local[A-Z]""").containsMatchIn(leaf)) return null
-    val quoted = Regex.escape(name)
+    val quoted = Regex.escape(spelling)
     // The name written on its own — not the tail of `Icons.Filled.Add`, not part of a longer
     // identifier. An import the snippet never spells this way is not a symbol its code uses.
     val firstUse =
@@ -160,13 +195,51 @@ internal object ApiDocLinks {
     val composable =
       when {
         usedAsDeclaration(quoted, code) -> false
-        VALUE_PACKAGES.any { fqn.startsWith("$it.") } -> false
-        calledInStatementPosition(name, code) -> true
+        // Outside a Compose namespace there is no `.composable` page to be wrong about, so the
+        // call-site reading is not consulted at all: `Button(onClick = { Intent(ctx, T::class.java)
+        // })`
+        // puts a constructor exactly where a composable call sits, and no reading of the braces
+        // alone tells a callback lambda from a slot one.
+        !composableNamespace(fqn) -> false
+        calledInStatementPosition(spelling, code) -> true
         // Mentioned, but neither a type nor a call: a property, which has no page of its own.
         else -> return null
       }
-    val url = BASE + fqn.replace('.', '/') + if (composable) ".composable" else ""
-    return Ranked(Link(name = name, fqn = fqn, composable = composable, url = url), firstUse)
+    val url = BASE + referencePath(fqn) + if (composable) ".composable" else ""
+    // The name the panel shows is what the code writes — an `as` alias included, since that is
+    // the identifier the reader just met. A qualified use writes the whole path, which is not a
+    // label, so it shows its leaf instead.
+    val label = if (spelling.contains('.')) leaf else spelling
+    return Ranked(Link(name = label, fqn = fqn, composable = composable, url = url), firstUse)
+  }
+
+  /**
+   * Whether a `.composable` page could exist for [fqn] at all — the namespaces that publish
+   * composable functions, minus the [VALUE_PACKAGES] inside them.
+   *
+   * `androidx.compose.*` and `androidx.wear.compose.*` are both covered by the `.compose.` segment;
+   * Glance and TV Material are the two composable homes that do not carry it.
+   */
+  private fun composableNamespace(fqn: String): Boolean =
+    (fqn.contains(".compose.") ||
+      fqn.startsWith("androidx.glance.") ||
+      fqn.startsWith("androidx.tv.material3.")) && VALUE_PACKAGES.none { fqn.startsWith("$it.") }
+
+  /**
+   * The reference site's path for [fqn]: package segments separated by `/`, and the class chain
+   * kept dotted — `androidx/wear/protolayout/LayoutElementBuilders.Box` for a nested type, which is
+   * how the site spells one. Replacing every dot would ask for a directory that does not exist.
+   *
+   * Package segments are the leading lower-case ones, which is the naming convention every
+   * `androidx` and `android` package follows.
+   */
+  private fun referencePath(fqn: String): String {
+    val segments = fqn.split('.')
+    val firstType = segments.indexOfFirst { it.firstOrNull()?.isUpperCase() == true }
+    if (firstType < 0) return segments.joinToString("/")
+    return (segments.subList(0, firstType) +
+        segments.subList(firstType, segments.size).joinToString("."))
+      .joinToString("/")
   }
 
   /** Qualifier, annotation, or type position — three uses a composable function never has. */
@@ -178,16 +251,28 @@ internal object ApiDocLinks {
 
   /**
    * Whether [name] is called somewhere a *statement* may start: at the beginning of the code, after
-   * `{`, `}`, `)`, `;` or `->`, or as the `fun … () = Name(…)` expression body of a composable.
+   * `{`, `}`, `)`, `;` or `->`, after a line break that closed the previous statement, or as the
+   * `fun … () = Name(…)` expression body of a composable.
    *
    * The `{` case excludes the value-producing lambdas ([VALUE_LAMBDAS]) and the trailing lambda of
    * an already-parenthesised call, since neither opens a composition.
+   *
+   * The **line break** case is what makes a call after an ordinary local declaration reachable —
+   * `val enabled = true` then `Button(enabled = enabled)`, where the character before the call is
+   * the `e` of `true`. Kotlin has no statement terminator, so the line break is the only thing
+   * separating them. It counts only when the previous line *ended* an expression (an identifier, a
+   * literal, a `]`); a line ending in `=` or `,` or `(` is one argument wrapped across two lines,
+   * and treating that as a statement is exactly what put a `.composable` page on a value class.
    */
   private fun calledInStatementPosition(name: String, code: String): Boolean {
     val call = Regex("""(?<![A-Za-z0-9_.])${Regex.escape(name)}\s*[({]""")
     for (match in call.findAll(code)) {
       var j = match.range.first - 1
-      while (j >= 0 && code[j].isWhitespace()) j--
+      var crossedLineBreak = false
+      while (j >= 0 && code[j].isWhitespace()) {
+        if (code[j] == '\n') crossedLineBreak = true
+        j--
+      }
       if (j < 0) return true
       when (code[j]) {
         '}',
@@ -202,6 +287,10 @@ internal object ApiDocLinks {
           if (k >= 0 && code[k] == ')') return true
         }
         '{' -> if (ownerOfBrace(code, j) !in VALUE_LAMBDAS) return true
+        else ->
+          if (crossedLineBreak && (code[j].isLetterOrDigit() || code[j] == '_' || code[j] == ']')) {
+            return true
+          }
       }
     }
     return false
@@ -241,30 +330,47 @@ internal object ApiDocLinks {
    * Deliberately a scanner rather than a regex: `"a // b"` is a string containing what looks like a
    * comment and `// "a` is a comment containing what looks like an unterminated string. A pattern
    * that handles one gets the other wrong, and both appear in ordinary catalog source.
+   *
+   * A **raw** `"""…"""` string is consumed whole, before the single-quote case can see it. Toggling
+   * per quote instead would treat a raw string's own `"` characters as delimiters and hand back
+   * alternating slices of its contents as though they were code.
+   *
+   * A string blanks to **digits**, not spaces, while a comment blanks to spaces. The difference is
+   * that a string literal *is* an expression: `val json = "…"` ends a statement, and the next line
+   * may open a new one. Blanked to whitespace it would read as though the `=` were still hanging
+   * open, and the composable called on the following line would be lost.
    */
   private fun blankCommentsAndStrings(source: String): String {
     val out = StringBuilder(source.length)
     var i = 0
-    var inString = false
     while (i < source.length) {
       val c = source[i]
-      if (inString) {
-        if (c == '\\') {
-          out.append(' ')
-          if (i + 1 < source.length) out.append(if (source[i + 1] == '\n') '\n' else ' ')
-          i += 2
-          continue
-        }
-        if (c == '"') inString = false
-        out.append(if (c == '\n') '\n' else ' ')
-        i++
-        continue
-      }
       when {
+        c == '"' && source.startsWith("\"\"\"", i) -> {
+          val end = source.indexOf("\"\"\"", i + 3)
+          val stop = if (end < 0) source.length else end + 3
+          while (i < stop) {
+            out.append(if (source[i] == '\n') '\n' else STRING_FILL)
+            i++
+          }
+        }
         c == '"' -> {
-          inString = true
-          out.append(' ')
+          out.append(STRING_FILL)
           i++
+          while (i < source.length) {
+            if (source[i] == '\\') {
+              out.append(STRING_FILL)
+              if (i + 1 < source.length) {
+                out.append(if (source[i + 1] == '\n') '\n' else STRING_FILL)
+              }
+              i += 2
+              continue
+            }
+            val ch = source[i]
+            out.append(if (ch == '\n') '\n' else STRING_FILL)
+            i++
+            if (ch == '"') break
+          }
         }
         c == '/' && i + 1 < source.length && source[i + 1] == '/' -> {
           while (i < source.length && source[i] != '\n') {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ApiDocLinksTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ApiDocLinksTest.kt
@@ -224,6 +224,122 @@ class ApiDocLinksTest {
   }
 
   @Test
+  fun `a line break ends the statement before a composable call`() {
+    // Kotlin has no statement terminator, so the character before `Button(` is the `e` of `true`.
+    // Reading only that dropped the component the card is about — the most visible way this can
+    // be wrong, and invisible in a 404 count because a missing link 404s nothing.
+    val links =
+      urls(
+        """
+        import androidx.wear.compose.material3.Button
+
+        fun demo() {
+          val enabled = true
+          Button(onClick = {}, enabled = enabled)
+        }
+        """
+          .trimIndent()
+      )
+    assertEquals(ref("androidx/wear/compose/material3/Button.composable"), links["Button"])
+  }
+
+  @Test
+  fun `a constructor in a callback lambda is not a composable`() {
+    // `onClick = { … }` and `label = { … }` are the same shape and opposite kinds, so the braces
+    // cannot decide this. The namespace can: nothing outside Compose has a `.composable` page.
+    val links =
+      urls(
+        """
+        import android.content.Intent
+        import androidx.wear.compose.material3.Button
+
+        fun demo() {
+          Button(onClick = { Intent(context, Target::class.java) })
+        }
+        """
+          .trimIndent()
+      )
+    assertEquals(ref("android/content/Intent"), links["Intent"])
+    assertEquals(ref("androidx/wear/compose/material3/Button.composable"), links["Button"])
+  }
+
+  @Test
+  fun `a nested type keeps its dot`() {
+    val links =
+      urls(
+        """
+        import androidx.wear.protolayout.LayoutElementBuilders.Box
+
+        fun demo() {
+          val box: Box = build()
+        }
+        """
+          .trimIndent()
+      )
+    // `…/LayoutElementBuilders/Box` asks for a directory; the site spells the nested type dotted.
+    assertEquals(ref("androidx/wear/protolayout/LayoutElementBuilders.Box"), links["Box"])
+  }
+
+  @Test
+  fun `an API written out in full is linked even with no import`() {
+    // The cleaner's `MATERIAL3_SYSTEM_THEME` rewrite emits exactly this and prunes the import, so
+    // reading import lines alone missed the most prominent API on the card.
+    val links =
+      urls(
+        """
+        import androidx.compose.runtime.Composable
+
+        @Composable
+        fun FilledButton() =
+          androidx.compose.material3.MaterialTheme(
+            colorScheme = androidx.compose.material3.lightColorScheme()
+          ) {}
+        """
+          .trimIndent()
+      )
+    // Called, so the composable page — the same reading a plain `MaterialTheme { }` would get.
+    assertEquals(ref("androidx/compose/material3/MaterialTheme.composable"), links["MaterialTheme"])
+  }
+
+  @Test
+  fun `a qualified use stops at the type, and a constant is not one`() {
+    val links =
+      urls(
+        """
+        fun demo() {
+          val c = androidx.compose.ui.graphics.Color.Transparent
+          request(android.permission.BLUETOOTH_CONNECT)
+        }
+        """
+          .trimIndent()
+      )
+    // `Color.Transparent` is a member read off `Color`, not a nested type.
+    assertEquals(ref("androidx/compose/ui/graphics/Color"), links["Color"])
+    // A SCREAMING_CASE leaf is a String constant. Only the qualified scan can reach one, and an
+    // import line is not there to say otherwise.
+    assertTrue("BLUETOOTH_CONNECT" !in links)
+  }
+
+  @Test
+  fun `a raw string is blanked whole`() {
+    // Toggling per quote hands back alternating slices of a raw string as though they were code —
+    // and `Button.foo` inside one reads as a qualifier, demoting the real composable call.
+    val links =
+      urls(
+        """
+        import androidx.compose.material3.Button
+
+        fun demo() {
+          val json = ${"\"\"\""}{"kind": "Button.foo"}${"\"\"\""}
+          Button(onClick = {})
+        }
+        """
+          .trimIndent()
+      )
+    assertEquals(ref("androidx/compose/material3/Button.composable"), links["Button"])
+  }
+
+  @Test
   fun `a snippet with no platform imports contributes nothing`() {
     assertEquals(emptyList(), ApiDocLinks.of("fun demo() { println(\"hi\") }"))
   }

--- a/docs/design/USAGE_SNIPPET_CORPUS.md
+++ b/docs/design/USAGE_SNIPPET_CORPUS.md
@@ -186,7 +186,7 @@ rather than guessing. And the pages are **not** framable, so this is a list of l
 docs tab the issue asked about; the links sit under the code that names them.
 
 The measurement is the same shape as this document's: run against 244 live snippets from every
-catalog on the public host, it produced 220 distinct pages and no 404s. `ApiDocLinksTest` pins the
+catalog on the public host, it produced 227 distinct pages and no 404s. `ApiDocLinksTest` pins the
 call-site shapes that got it there — each one a page shape that was wrong before it was added.
 
 ## Running it in CI


### PR DESCRIPTION
Follow-up to #4348, which merged before these landed on it. Each item is a shape `ApiDocLinks` got wrong — the first two produce a dead link, the other three silently omit an API that is plainly on screen.

## The five

**A line break ends a statement.** Kotlin has no statement terminator, so after `val enabled = true` the character before `Button(` is the `e` of `true`, and the component the card is *about* was dropped. A crossed newline now ends the statement when the previous line ended an expression — and not when it ended in `=` or `,`, which is the wrapped argument the character rule exists to catch in the first place.

**A callback lambda is not a composition.** `onClick = { Intent(ctx, T::class.java) }` and `label = { Text("Hi") }` are the same shape and opposite kinds, so no reading of the braces alone can separate them. The namespace can: `.composable` pages exist only under Compose, so outside it the call site is not consulted at all and `android.content.Intent` gets the class page it actually has.

**A nested type keeps its dot.** `androidx.wear.protolayout.LayoutElementBuilders.Box` publishes at `…/LayoutElementBuilders.Box`; replacing every dot asked the site for a directory. Package segments (the leading lower-case ones) split on `/`, the class chain stays dotted.

**A fully-qualified use has no import to read.** The cleaner's `MATERIAL3_SYSTEM_THEME` rewrite deliberately emits `androidx.compose.material3.MaterialTheme(...)` and prunes the import, so reading import lines alone missed the most prominent API on those cards. Qualified uses are candidates too now — stopping at the first capitalised segment, so `Color.Transparent` resolves to `Color` rather than a nested type that does not exist, and skipping SCREAMING_CASE leaves, which are constants.

**A raw string is one literal.** Toggling per quote handed back alternating slices of `"""{"kind": "Button.foo"}"""` as though they were code, and the `Button.foo` inside read as a qualifier that demoted the real composable call. Related, and found by the test for it: a string now blanks to **digits** rather than spaces, because a string literal *is* an expression — blanked to whitespace it left the preceding `=` looking open and swallowed the statement after it.

## Test plan

* Re-measured exactly as #4348 was, but running the **real Kotlin** over the corpus rather than the prototype: 244 live snippets from every catalog on `preview.coo.ee`, every produced URL HEAD-checked. **227 distinct pages, zero 404s** — up from 220, and the pages gained are precisely the primary components the first two holes were dropping.
* Six new cases in `ApiDocLinksTest`, one per shape above (17 total, all green).
* `./gradlew :cli:ktfmtCheck :cli:test` — green.

No viewer, CSS, or harness change, so the Source-panel captures are unmoved; this is all inside the resolver.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQDGHVyAHJsEfaQJ5netHb)_