### PR TITLE
fix(serve): close the admin holes and the census cost in the cache surface

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1423,7 +1423,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
             it.seedInitialHeads(loaded)
-            it.start()
+            // The poller is what the interval switches off; the manual route stays either way.
+            if (catalogRefreshSeconds > 0) it.start()
           }
         }
       },
@@ -1622,7 +1623,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         catalogReg?.loader?.start { loaded ->
           catalogRefresher?.let {
             it.seedInitialHeads(loaded)
-            it.start()
+            // The poller is what the interval switches off; the manual route stays either way.
+            if (catalogRefreshSeconds > 0) it.start()
           }
         }
       },
@@ -3410,7 +3412,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // Also built for an admin-enabled server with no configured catalogs: the entries are read from
     // the tracker per pass, so a catalog published at runtime starts being polled without a
     // restart.
-    if (catalogRefreshSeconds <= 0 || !needsCatalogMachinery) return null
+    // Deliberately NOT gated on the poll interval. `--catalog-refresh-interval 0` turns the
+    // background poller off, which is a statement about cadence, not about whether an operator may
+    // ask. Returning null here also took away `POST /<system>/refresh` — so a box that had opted
+    // out of polling could clear its blob cache and then have no way to force the re-read the
+    // clear was the first half of. The interval decides only whether [start] is called; see the
+    // `onStarted` hooks.
+    if (!needsCatalogMachinery) return null
     // Read from the tracker per pass, not from the startup refs: a catalog published through the
     // admin API must start being polled without a restart (and a retired one must stop).
     val entries = {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -98,6 +98,18 @@ class CatalogBlobPool(
   private val writeFailures = AtomicLong()
   private val evicted = AtomicLong()
   private val corrupt = AtomicLong()
+  /**
+   * Occupancy as of the last census, advanced by each write and reclaim in between.
+   *
+   * Published rather than measured, for the reason [maxBytes] is enforced by [sweep] rather than at
+   * write time: a census is a directory listing plus a `length()` per file, and `/status.json` is
+   * polled. Reading it there would put an O(blobs) filesystem walk on a monitoring request and make
+   * the cost grow with exactly the thing the cache is trying to grow. [ThemeCacheStore] publishes
+   * its own the same way. The cost is that these lag a write by at most one sweep interval, which
+   * is the right trade for a number nobody reads to the byte.
+   */
+  private val knownBlobs = java.util.concurrent.atomic.AtomicInteger()
+  private val knownBytes = AtomicLong()
   @Volatile private var lastFailure: String? = null
   private val tempSequence = AtomicLong()
 
@@ -253,12 +265,23 @@ class CatalogBlobPool(
    * this is bandwidth, not correctness.
    */
   fun clear(): CatalogBlobPoolSnapshot {
-    for (dir in listOf(contentDir, keysDir)) {
-      for (file in dir.listFiles()?.filter { it.isFile }.orEmpty()) {
-        if (runCatching { file.delete() }.getOrDefault(false)) evicted.increment()
-      }
+    // Only the blobs count as evictions. A pointer is not a blob, and deduplication means many of
+    // them can name one — counting both would let a clear report far more reclaimed than existed,
+    // in the very metric an operator reads to check the clear did what they asked.
+    for (blob in contentDir.listFiles()?.filter { it.isFile }.orEmpty()) {
+      if (runCatching { blob.delete() }.getOrDefault(false)) evicted.increment()
     }
-    return snapshot()
+    for (pointer in keysDir.listFiles()?.filter { it.isFile }.orEmpty()) {
+      runCatching { pointer.delete() }
+    }
+    // Scratch too. A process killed mid-produce leaves a bundle-sized file under `tmp/`, which no
+    // census counts and no read will ever want — so without this an operator could clear the cache,
+    // be told it holds nothing, and still find the volume full. A live writer losing its scratch
+    // file fails that one produce and returns null, which every caller already treats as a miss.
+    for (scratch in File(root, TEMP_DIR).listFiles()?.filter { it.isFile }.orEmpty()) {
+      runCatching { scratch.delete() }
+    }
+    return census()
   }
 
   /**
@@ -286,14 +309,31 @@ class CatalogBlobPool(
     for (pointer in keysDir.listFiles()?.filter { it.isFile }.orEmpty()) {
       if (resolve(pointer, verify = false) == null) runCatching { pointer.delete() }
     }
+    // Abandoned scratch, on the same reasoning as [clear] — but bounded by the grace window rather
+    // than unconditional, because this runs on a timer while writers are live and a scratch file
+    // younger than that may be one of theirs. Anything older belonged to a process that is gone.
+    for (scratch in File(root, TEMP_DIR).listFiles()?.filter { it.isFile }.orEmpty()) {
+      if (now - scratch.lastModified() >= graceMillis) runCatching { scratch.delete() }
+    }
+    return census()
+  }
+
+  /**
+   * Re-measure occupancy from the filesystem and publish it. Only ever called from the paths that
+   * are already walking the directory — see [knownBlobs].
+   */
+  private fun census(): CatalogBlobPoolSnapshot {
+    val blobs = contentDir.listFiles()?.filter { it.isFile }.orEmpty()
+    knownBlobs.set(blobs.size)
+    knownBytes.set(blobs.sumOf { it.length() })
     return snapshot()
   }
 
+  /** Counters and the last published occupancy. Cheap enough for a polled status endpoint. */
   fun snapshot(): CatalogBlobPoolSnapshot {
-    val blobs = contentDir.listFiles()?.filter { it.isFile }.orEmpty()
     return CatalogBlobPoolSnapshot(
-      blobs = blobs.size,
-      bytes = blobs.sumOf { it.length() },
+      blobs = knownBlobs.get(),
+      bytes = knownBytes.get(),
       maxBytes = maxBytes,
       hits = hits.get(),
       misses = misses.get(),
@@ -336,7 +376,11 @@ class CatalogBlobPool(
   private fun dropCorrupt(blob: File, why: String) {
     corrupt.increment()
     recordFailure("discarded ${blob.name.take(12)}… on $why mismatch")
-    runCatching { blob.delete() }
+    val size = runCatching { blob.length() }.getOrDefault(0L)
+    if (runCatching { blob.delete() }.getOrDefault(false)) {
+      knownBlobs.updateAndGet { (it - 1).coerceAtLeast(0) }
+      knownBytes.updateAndGet { (it - size).coerceAtLeast(0L) }
+    }
   }
 
   /**
@@ -412,6 +456,9 @@ class CatalogBlobPool(
       return null
     }
     writes.increment()
+    // Advance the published occupancy so a write is visible before the next sweep re-measures.
+    knownBlobs.incrementAndGet()
+    knownBytes.addAndGet(runCatching { blob.length() }.getOrDefault(0L))
     // Stamped from the same clock every hit reads, so "least recently used" is one notion rather
     // than a mix of the pool's clock and whatever mtime the move happened to preserve.
     stamp(blob)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -479,6 +479,16 @@ class ServeHttpServer(
   /** As [adminEnabled], for the `/admin/sites` routes. Same token, separately supplied admin. */
   private val siteAdminEnabled: Boolean = siteAdmin != null && !adminToken.isNullOrBlank()
 
+  /**
+   * As [adminEnabled], for `DELETE /admin/catalog-cache`.
+   *
+   * Paired with the token like every sibling rather than registered on the handle alone: discarding
+   * the cache is destructive-ish (it costs a re-fetch, not data), and a box whose operator never
+   * configured a credential must not expose it at all.
+   */
+  private val catalogCacheAdminEnabled: Boolean =
+    catalogCacheClear != null && !adminToken.isNullOrBlank()
+
   private val server: EmbeddedServer<*, *> =
     embeddedServer(CIO, host = host, port = port) {
       install(WebSockets)
@@ -957,10 +967,10 @@ class ServeHttpServer(
         // cost of using this unnecessarily is bandwidth. Responds with what the pool holds
         // afterwards, which is the same shape `/status.json` reports, so an operator can see it
         // took.
-        if (catalogCacheClear != null) {
+        if (catalogCacheAdminEnabled) {
           delete("/admin/catalog-cache") {
             if (rejectBadAdminToken()) return@delete
-            val after = withContext(Dispatchers.IO) { catalogCacheClear.invoke() }
+            val after = withContext(Dispatchers.IO) { catalogCacheClear!!.invoke() }
             call.response.headers.append(HttpHeaders.CacheControl, "no-store")
             call.respondText(
               Json.encodeToString(CatalogBlobPoolSnapshot.serializer(), after),
@@ -1392,7 +1402,17 @@ class ServeHttpServer(
     // also means there is otherwise no way to say "read it again anyway", which is exactly what an
     // operator wants after clearing the blob cache, or when they simply want the published bytes
     // re-read rather than reasoned about.
+    // Gated by the ADMIN token, not the browse token this handler opens with. On a `--public` box
+    // the browse gate authorizes everyone, and an ordinary refresh is safe to hand out because it
+    // short-circuits on an unchanged head — a repeated call costs one `git ls-remote`. Forcing
+    // removes that short-circuit, so an anonymous caller could drive a full re-stage (and, with a
+    // cold pool, a bundle re-download) in a loop. Refused the way the admin surface refuses
+    // everything, which also means a box with no configured admin token cannot be forced at all.
     val force = call.request.queryParameters["force"] == "1"
+    if (force && rejectBadAdminToken()) {
+      catalogRefreshesInFlight.remove(system)
+      return
+    }
     val result =
       try {
         withContext(Dispatchers.IO) { refresh(system, force) }
@@ -3094,7 +3114,16 @@ class ServeHttpServer(
    */
   private suspend fun RoutingContext.rejectBadAdminToken(): Boolean {
     val provided = call.request.queryParameters["token"] ?: call.request.headers[ADMIN_TOKEN_HEADER]
-    if (ServeUrls.tokensMatch(adminToken.orEmpty(), provided)) return false
+    // An unconfigured token is not a token everyone matches. `tokensMatch` compares bytes, so a
+    // blank expected value is satisfied by `?token=` — which would turn "the operator never set a
+    // credential" into "no credential is required", the exact inversion the `*Enabled` flags below
+    // exist to prevent. They gate registration; this gates the check, so a route that forgets to
+    // pair itself with one still fails closed rather than open.
+    if (adminToken.isNullOrBlank()) {
+      call.respondText("not found", status = HttpStatusCode.NotFound)
+      return true
+    }
+    if (ServeUrls.tokensMatch(adminToken, provided)) return false
     call.respondText("not found", status = HttpStatusCode.NotFound)
     return true
   }
@@ -7934,11 +7963,17 @@ private data class StatusResponse(
    * The catalog blob cache ([CatalogBlobPoolSnapshot]), or null on a server that publishes no
    * catalogs.
    *
-   * The pair to watch is `cached` on `branchFetch` against this row's `hits`: they count the same
-   * event from the two ends, and both climbing while `branchFetch.attempted` flattens across a
-   * restart is the whole feature working. `blobs`/`bytes` against `maxBytes` says whether the
-   * sweeper is keeping up; `corrupt` above zero says a volume is losing bytes, since every blob is
-   * named by its own digest and re-verified on read.
+   * `hits` here is the **aggregate** across all three lanes the pool serves — small assets, the
+   * executable bundles, and the content-addressed resource pool — while `branchFetch.cached` counts
+   * only the small-asset subset. So `hits` is normally the larger of the two and the gap is the
+   * executable tier; they are not the same number, and reading them as one would make a healthy
+   * warm start look inconsistent. What says the feature is working is either of them climbing while
+   * `branchFetch.attempted` flattens across a restart.
+   *
+   * `blobs`/`bytes` against `maxBytes` says whether the sweeper is keeping up — both are published
+   * by the last sweep rather than censused per request, so they lag a write by at most one sweep
+   * interval. `corrupt` above zero says a volume is losing bytes, since every blob is named by its
+   * own digest and re-verified on read.
    */
   val catalogCache: CatalogBlobPoolSnapshot? = null,
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -291,6 +291,79 @@ class CatalogBlobPoolTest {
   }
 
   @Test
+  fun `occupancy is published by the last census, not measured per read`() {
+    // /status.json is polled, so a snapshot must not walk the pool. Proven by changing the
+    // filesystem behind the pool's back: a reported count that did not move is a reported count
+    // that was not measured, and the next sweep is what corrects it.
+    val pool = CatalogBlobPool(root(), graceMillis = 0)
+    val bytes = "a baked png".toByteArray()
+    pool.write("https://raw.githubusercontent.com/o/r/$COMMIT/images/a.png", bytes)
+    assertEquals(1, pool.snapshot().blobs, "a write advances the published census")
+
+    assertTrue(pool.contentFile(sha(bytes)).delete())
+
+    assertEquals(1, pool.snapshot().blobs, "still reporting what it last measured")
+    assertEquals(0, pool.sweep().blobs, "the sweep is what re-measures")
+    assertEquals(0, pool.snapshot().blobs)
+  }
+
+  @Test
+  fun `clearing counts blobs as evicted and not the pointers naming them`() {
+    // Deduplication means many keys can name one blob. Counting pointers too would let a clear
+    // report more reclaimed than ever existed, in the metric an operator reads to check it worked.
+    val pool = CatalogBlobPool(root())
+    val bytes = "one shared asset".toByteArray()
+    pool.write("https://raw.githubusercontent.com/o/r/${"a".repeat(40)}/images/a.png", bytes)
+    pool.write("https://raw.githubusercontent.com/o/r/${"b".repeat(40)}/images/a.png", bytes)
+    pool.write("https://raw.githubusercontent.com/o/r/${"c".repeat(40)}/images/a.png", bytes)
+    assertEquals(1, pool.snapshot().blobs, "three keys, one deduplicated blob")
+
+    val after = pool.clear()
+
+    assertEquals(0, after.blobs)
+    assertEquals(0, after.bytes)
+    assertEquals(1, after.evicted, "one blob went, not three")
+  }
+
+  @Test
+  fun `clearing reclaims abandoned scratch files too`() {
+    // A process killed mid-produce leaves a bundle-sized file under tmp/ that no census counts and
+    // no read will ever want. Without this an operator could clear the cache, be told it holds
+    // nothing, and still find the volume full.
+    val root = root()
+    val pool = CatalogBlobPool(root)
+    pool.write("https://raw.githubusercontent.com/o/r/$COMMIT/images/a.png", "real".toByteArray())
+    val scratch =
+      File(root, CatalogBlobPool.TEMP_DIR).let {
+        it.mkdirs()
+        File(it, "produce-deadproc-1").apply { writeBytes(ByteArray(4096)) }
+      }
+
+    pool.clear()
+
+    assertFalse(scratch.exists(), "an abandoned scratch file is not left behind by a clear")
+  }
+
+  @Test
+  fun `sweeping reclaims scratch older than the grace window and spares the rest`() {
+    // Same reasoning as the clear, but bounded: this runs on a timer while writers are live, so a
+    // scratch file younger than the grace window may be one of theirs.
+    val now = AtomicLong(1_000_000L)
+    val root = root()
+    val pool = CatalogBlobPool(root, graceMillis = 60_000, clock = { now.get() })
+    val tmp = File(root, CatalogBlobPool.TEMP_DIR).apply { mkdirs() }
+    val stale = File(tmp, "produce-old-1").apply { writeBytes(ByteArray(16)) }
+    val live = File(tmp, "produce-new-1").apply { writeBytes(ByteArray(16)) }
+    assertTrue(stale.setLastModified(now.get() - 120_000))
+    assertTrue(live.setLastModified(now.get()))
+
+    pool.sweep()
+
+    assertFalse(stale.exists(), "scratch from a process that is gone")
+    assertTrue(live.exists(), "scratch a live writer may still be filling")
+  }
+
+  @Test
   fun `sweep reclaims oldest-first down to the cap`() {
     val now = AtomicLong(1_000_000L)
     val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -32,6 +32,8 @@ class ServeAdminRoutingTest {
 
   private val adminToken = "admin-secret"
 
+  private val refreshes = mutableListOf<String>()
+
   /** A real pool, so the cache-clearing route is exercised against actual blobs on disk. */
   private val blobPool =
     CatalogBlobPool(Files.createTempDirectory("admin-blobs").toFile().also { it.deleteOnExit() })
@@ -140,6 +142,10 @@ class ServeAdminRoutingTest {
         themeOptimizerAdmin = optimizerWork,
         catalogCacheStats = { blobPool.snapshot() },
         catalogCacheClear = { blobPool.clear() },
+        catalogRefresh = { system, force ->
+          refreshes += if (force) "$system!force" else system
+          CatalogRefreshResult.CURRENT
+        },
         adminToken = adminToken,
         wasmCatalogs = wasmCatalogs,
       )
@@ -192,6 +198,23 @@ class ServeAdminRoutingTest {
     assertEquals(404, send("/admin/catalogs", token = "wrong").first)
     assertEquals(404, send("/admin/catalogs", method = "POST", body = "{}", token = null).first)
     assertEquals(200, send("/admin/catalogs").first)
+  }
+
+  @Test
+  fun `forcing a refresh needs the admin token, and without it does no work`() {
+    // The counterpart to the public-server refusal: with the credential the operator configured,
+    // `?force=1` reaches the refresher; without it the request is refused the way every other
+    // admin action is, and nothing is reloaded.
+    assertEquals(404, send("/compose-m3/refresh?force=1", method = "POST", token = null).first)
+    assertEquals(404, send("/compose-m3/refresh?force=1", method = "POST", token = "wrong").first)
+    assertTrue(refreshes.isEmpty(), "a refused force must do no remote work: $refreshes")
+
+    assertEquals(200, send("/compose-m3/refresh?force=1", method = "POST").first)
+    assertEquals(listOf("compose-m3!force"), refreshes)
+
+    // An ordinary refresh stays open to any browser on this public box.
+    assertEquals(200, send("/compose-m3/refresh", method = "POST", token = null).first)
+    assertEquals(listOf("compose-m3!force", "compose-m3"), refreshes)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -619,18 +619,20 @@ class ServeHttpRoutingTest {
   }
 
   @Test
-  fun `catalog refresh carries the force flag through to the refresher`() {
-    // The ordinary check short-circuits on an unchanged branch head, which is what makes polling
-    // cheap. `?force=1` is the only way to say "read it again anyway" — what an operator wants
-    // after discarding the blob cache.
-    assertEquals(200 to "{\"status\":\"current\"}", post("/compose-m3/refresh?force=1"))
-    assertEquals(200 to "{\"status\":\"current\"}", post("/refresh?session=compose-m3&force=1"))
-    // Anything other than an explicit 1 is an ordinary refresh, so a stray query cannot force one.
+  fun `forcing a refresh is refused on a public server with no admin token`() {
+    // This server is `--public` with no admin token, so the browse gate authorizes everyone. An
+    // ordinary refresh is safe to hand out — it short-circuits on an unchanged head — but forcing
+    // removes that short-circuit, so an anonymous caller could drive a full re-stage in a loop.
+    // A box that configured no admin credential cannot be forced at all, rather than being
+    // forceable
+    // by everyone.
+    assertEquals(404, post("/compose-m3/refresh?force=1").first)
+    assertEquals(404, post("/refresh?session=compose-m3&force=1").first)
+    assertTrue(refreshes.isEmpty(), "a refused force must do no remote work: $refreshes")
+
+    // Anything other than an explicit 1 is an ordinary refresh, which stays open.
     assertEquals(200 to "{\"status\":\"current\"}", post("/compose-m3/refresh?force=0"))
-    assertEquals(
-      listOf("compose-m3!force", "compose-m3!force", "compose-m3"),
-      refreshes,
-    )
+    assertEquals(listOf("compose-m3"), refreshes)
   }
 
   @Test

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2600,9 +2600,16 @@ hits into them would make a warming cache look like a quietening branch. `cached
 Two operator affordances, deliberately separate because they answer different questions:
 
 ```
-DELETE /admin/catalog-cache          # discard every cached byte (admin token)
+DELETE /admin/catalog-cache          # discard every cached byte
 POST   /<system>/refresh?force=1     # re-read this catalog even if its branch has not moved
 ```
+
+**Both need the admin token**, including `?force=1` on a box that is otherwise open for browsing. An
+ordinary refresh is safe to hand to any visitor because it short-circuits on an unchanged head — a
+repeated call costs one `git ls-remote` — but forcing removes that short-circuit, so an anonymous
+caller could drive a full re-stage (and, with a cold pool, a bundle re-download) in a loop. A server
+with no `--admin-token` configured therefore has neither affordance at all, rather than having them
+open to everyone.
 
 `DELETE /admin/catalog-cache` is **whole-pool, not per catalog**, and that is not a shortcut. Blobs
 are named by their own digest and shared between systems on purpose — a font fetched for one catalog
@@ -2614,18 +2621,27 @@ bandwidth. It responds with the pool's state afterwards, in the same shape `/sta
 `?force=1` exists because the ordinary refresh short-circuits on an unchanged branch head — the
 thing that makes polling cheap, and right almost always, but it leaves no way to say *read it again
 anyway*. Together the two are the full "prove it from the branch" sequence: clear the pool, then
-force a refresh.
+force a refresh. The manual route is available even with `--catalog-refresh-interval 0`: that flag
+turns the background *poller* off, which is a statement about cadence rather than about whether an
+operator may ask.
 
 #### Reading whether it is working
 
 `/status.json` gains a whole-box **`catalogCache`** row: `blobs`, `bytes` against `maxBytes`, `hits`,
 `misses`, `writes`, `evicted`, `corrupt`.
 
-The pair to watch is `branchFetch.cached` against `catalogCache.hits` — they count the same event
-from the two ends — and both against `branchFetch.attempted`. Hits climbing while `attempted`
-flattens across a restart is the feature working. `corrupt` above zero says a volume is losing
-bytes, since every blob is named by its own digest and re-verified on read. `blobs`/`bytes` against
-`maxBytes` says whether the sweeper is keeping up.
+`hits` is the **aggregate** across all three lanes the pool serves — small assets, the executable
+bundles, and the content-addressed resource pool — while `branchFetch.cached` counts only the
+small-asset subset. So `hits` is normally the larger, and the gap between them is the executable
+tier; they are not two views of one number, and reading them as one would make a healthy warm start
+look inconsistent. What says the feature is working is either of them climbing while
+`branchFetch.attempted` flattens across a restart.
+
+`corrupt` above zero says a volume is losing bytes, since every blob is named by its own digest and
+re-verified on read. `blobs`/`bytes` against `maxBytes` says whether the sweeper is keeping up —
+both are published by the last sweep rather than censused per request, so they lag a write by at
+most one sweep interval; `/status.json` is polled, and an occupancy walk there would grow with
+exactly the thing the cache exists to grow.
 
 What this does **not** yet do is let a restart serve a catalog before it has talked to the branch.
 The manifests are read from the pool now rather than the network, but the per-system directory is


### PR DESCRIPTION
The seven review findings on #4339, which merged while these were in progress — so they land here. All were verified against the code before acting; the first two were exploitable, and I'd rather state that plainly than fold them into a tidy list.

## Two unauthenticated holes

**An unconfigured admin token was a token everyone matched.** `ServeUrls.tokensMatch` compares bytes, so a blank expected value is satisfied by `?token=`. Every other admin surface is safe only because it pairs its handle with `!adminToken.isNullOrBlank()` — the comment above `adminEnabled` says as much: *"who never set a token gets no admin surface, not an open one."* I registered `DELETE /admin/catalog-cache` on the handle alone, so on a box with no `--admin-token` an anonymous caller could wipe the whole cache.

Fixed twice over: the route now carries the pairing like its siblings, **and** `rejectBadAdminToken` itself fails closed on a blank expected token, so a future route that forgets the pairing is refused rather than opened.

**`?force=1` ran behind the browse token**, which a `--public` box hands to every visitor. An ordinary refresh is safe to hand out precisely because it short-circuits on an unchanged head — a repeated call costs one `git ls-remote`. Forcing removes that short-circuit, so an anonymous caller could drive a full re-stage (and, with a cold pool, a bundle re-download) in a loop. It now requires the admin token, which also means a box with no token configured cannot be forced at all.

## A cost I put on the monitoring path

`snapshot()` listed every content file and read every `length()` — on `/status.json`, which is polled, growing with exactly the thing the cache exists to grow. `ThemeCacheStore` deliberately avoids this, and phase 1's own `maxBytes` KDoc says writes must not block on a byte census; I then put one on the status path anyway. Occupancy is now published by the last census and advanced by each write and reclaim.

## Three correctness/leak fixes

- **`clear()` counted pointer files as evicted blobs.** Deduplication means many keys name one blob, so a clear could report far more reclaimed than ever existed — in the metric an operator reads to check it worked.
- **`clear()` left abandoned scratch behind.** A process killed mid-produce leaves a bundle-sized file under `tmp/` that no census counts, so an operator could clear the cache, be told it holds nothing, and still find the volume full. Clear now reclaims scratch unconditionally; sweep reclaims only scratch older than the grace window, since a younger one may belong to a live writer.
- **Manual refresh depended on the poll interval.** `--catalog-refresh-interval 0` made `buildCatalogRefresher` return null, which took away `POST /<system>/refresh` entirely — so a box that opted out of polling could clear its cache and then have no way to force the re-read the clear was the first half of. The interval now decides only whether the poller is `start()`ed.

## A documentation claim that was false

I wrote that `branchFetch.cached` and `catalogCache.hits` "count the same event from the two ends". They don't: pool hits aggregate the small-asset, executable-bundle and resource lanes, while `cached` counts only the small-asset subset. `hits` is normally larger and the gap is the executable tier — an operator following my guidance would have diagnosed a healthy warm start as inconsistent. Corrected in the KDoc and the server docs.

## Test plan

- `./gradlew :cli:test ktfmtCheckAll` — **2,744 tests, 0 failures**, BUILD SUCCESSFUL.
- **`CatalogBlobPoolTest`** (4 new) — occupancy is published not measured (proven by deleting a blob behind the pool's back: the count doesn't move until a sweep re-measures); a clear counts one deduplicated blob rather than its three pointers; a clear reclaims abandoned scratch; a sweep reclaims scratch older than the grace window and spares younger.
- **`ServeAdminRoutingTest`** (1 new, plus the clear tests) — `?force=1` reaches the refresher with the token and 404s without it or with a wrong one, doing no work; an ordinary refresh stays open on the same public box.
- **`ServeHttpRoutingTest`** (rewritten) — on a public server with **no** admin token, `?force=1` is refused through both route forms and does no remote work, while `?force=0` stays an ordinary open refresh.

No visual evidence: gating, telemetry and docs — nothing renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_