### PR TITLE
feat(annotations): let an override cell declare the kit's whole assignment

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -113,9 +113,14 @@ package ee.schimke.composeai.preview
  *
  * A declaration is **authoritative** downstream: a resolver that honours it stops guessing for that
  * knob, so a misspelt axis resolves to nothing rather than falling back to a translation that would
- * make the typo indistinguishable from a correct declaration. It applies to a cell seeding exactly
- * ONE knob — with several there is nothing to say which of them the axis names, and the design-map
- * projection reports the declaration rather than picking one.
+ * make the typo indistinguishable from a correct declaration. The pair applies to a cell seeding
+ * exactly ONE knob — with several there is nothing to say which of them the axis names, and the
+ * design-map projection reports the declaration rather than picking one.
+ *
+ * A cell that turns several knobs at once declares the kit's whole assignment with [kitProps]
+ * instead. Kits couple their axes — turning `Icon` on can drag `Icon size` and `Alignment` with it
+ * — so the cell that lands on a node the kit actually drew is often a multi-knob one, and it is
+ * [kitProps] that lets it say so. See there.
  */
 @Repeatable
 @Retention(AnnotationRetention.BINARY)
@@ -154,6 +159,48 @@ annotation class OverrideVariant(
   val kitAxis: String = "",
   /** Design-kit value this cell maps to; empty keeps downstream value matching. */
   val kitValue: String = "",
+  /**
+   * The design kit's **whole** assignment for this cell, one `"Axis=Value"` per entry — for a cell
+   * that turns more than one knob, which [kitAxis] / [kitValue] cannot describe.
+   *
+   * ```
+   * @OverrideVariant(
+   *   name = "icon-large",
+   *   booleans = ["icon=true"],
+   *   strings = ["iconSize=lrg-32", "alignment=left"],
+   *   kitProps = ["Icon=Yes", "Icon size=Lrg 32", "Alignment=Left"],
+   * )
+   * ```
+   *
+   * ## Why a cell needs this
+   *
+   * A kit's axes are often **coupled**: the Wear kit's `Button` set has no `Icon=Yes, Icon
+   * size=n/a, Alignment=Center` node, because turning `Icon` on drags `Icon size` and `Alignment`
+   * with it. A cell that names one axis therefore resolves to nothing — it asks for a node between
+   * the cells the kit actually drew — and a cell that seeds the three knobs it takes to land on a
+   * real node has, with [kitAxis] alone, no way to say which of them the axis names. It is reported
+   * and dropped rather than guessed at, since guessing pins the wrong axis and resolves to a
+   * confidently wrong node.
+   *
+   * ## What it declares
+   *
+   * The **kit's** vector, not the code's. Each entry is matched exactly (up to case and
+   * punctuation) against the set's own property names and values, so a name the kit does not
+   * publish resolves to nothing rather than to something adjacent — the same authoritative posture
+   * [kitAxis] already has, for the same reason. Values with `=` in them keep everything after the
+   * first `=`, so `"Style=Variant (Highlighted)"` needs no escaping.
+   *
+   * This says nothing about how the render was produced. The knob seeds above still decide the
+   * pixels; `kitProps` decides only what the render is compared *against*. Keeping the two separate
+   * is deliberate: it is what lets a catalog draw a one-line button by default and still compare
+   * that component against the kit's two-line cell, rather than editing the default until the diff
+   * goes green.
+   *
+   * Mutually exclusive with [kitAxis] / [kitValue] on one annotation — two spellings of one fact,
+   * with no rule for which wins, is exactly the ambiguity this removes. Declaring both is a
+   * discovery warning and the cell keeps `kitProps`.
+   */
+  val kitProps: Array<String> = [],
 )
 
 /** Harness-driven state for an addressable [OverrideVariant]. */

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -311,6 +311,32 @@ function foldSeeds(catalog) {
 function cellSeeds(overrides, catalog) {
   if (!overrides) return { seeds: [], unattached: [] };
 
+  // A cell that declares the kit's WHOLE assignment compares against that assignment, and the knob
+  // seeds do not enter resolution at all.
+  //
+  // Not a merge, and the reason is that a resolver has to place EVERY seed it is given: one extra
+  // knob seed that aliases to nothing kills the whole cell, so carrying both vectors would make a
+  // fully-declared cell fail for the sake of information the declaration already supersedes. The
+  // knobs still say how the render was produced — that is the renderer's business and it is
+  // recorded on the preview — while `kitProps` says what it is compared against. Keeping those two
+  // apart is what lets a catalog hold a better default than the kit and still compare honestly.
+  //
+  // Each entry is emitted as its own seed carrying both halves of the declaration, which is the
+  // shape a resolver already reads per seed. The `key` is the kit's own axis name rather than a
+  // knob key: there is no knob to name here, and inventing one would be a third spelling of a fact
+  // that already has two.
+  if (overrides.kitProps?.length) {
+    return {
+      seeds: overrides.kitProps.map((p) => ({
+        key: p.key,
+        raw: p.value,
+        kitAxis: p.key,
+        kitValue: p.value,
+      })),
+      unattached: [],
+    };
+  }
+
   const seeds = overrides.props?.length
     ? overrides.props.map((p) => ({ key: p.key, raw: p.value }))
     : (overrides.seeds ?? []).map((s) => ({ key: s.key, raw: s.raw }));

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -439,6 +439,60 @@ test("variantSeeds carries a cell's declared kit axis and value onto its seed", 
   );
 });
 
+test("kitProps declares a whole kit assignment for a cell that turns several knobs", () => {
+  // The Wear kit's `Button` set has no `Icon=Yes, Icon size=n/a, Alignment=Center` node — turning
+  // Icon on drags the other two with it — so the cell that lands on a real node seeds three knobs,
+  // and a single kitAxis has no way to say which one it names.
+  assert.deepEqual(
+    variantSeeds(
+      overrideVariant("Button/Filled", "icon-large", {
+        seeds: [
+          { key: "icon", raw: "true" },
+          { key: "iconSize", raw: "lrg-32" },
+          { key: "alignment", raw: "left" },
+        ],
+        kitProps: [
+          { key: "Icon", value: "Yes" },
+          { key: "Icon size", value: "Lrg 32" },
+          { key: "Alignment", value: "Left" },
+        ],
+      }),
+    ),
+    [
+      { key: "Icon", raw: "Yes", kitAxis: "Icon", kitValue: "Yes" },
+      { key: "Icon size", raw: "Lrg 32", kitAxis: "Icon size", kitValue: "Lrg 32" },
+      { key: "Alignment", raw: "Left", kitAxis: "Alignment", kitValue: "Left" },
+    ],
+  );
+});
+
+test("kitProps REPLACES the knob seeds rather than joining them", () => {
+  // Load-bearing, not tidiness: a resolver has to place every seed it is given, so one knob seed
+  // that aliases to nothing would kill a cell whose declaration is complete and correct.
+  const seeds = variantSeeds(
+    overrideVariant("Button/Filled", "left", {
+      seeds: [{ key: "alignment", raw: "left" }],
+      kitProps: [{ key: "Alignment", value: "Left" }],
+    }),
+  );
+  assert.deepEqual(seeds, [
+    { key: "Alignment", raw: "Left", kitAxis: "Alignment", kitValue: "Left" },
+  ]);
+  assert.equal(
+    seeds.some((s) => s.key === "alignment"),
+    false,
+  );
+});
+
+test("a cell with no kitProps is untouched — every variant written before the field", () => {
+  assert.deepEqual(
+    variantSeeds(
+      overrideVariant("Switch", "off", { seeds: [{ key: "checked", raw: "false" }] }),
+    ),
+    [{ key: "checked", raw: "false" }],
+  );
+});
+
 test("variantSeeds carries a CatalogVariant's declaration onto its prop", () => {
   assert.deepEqual(
     variantSeeds(

--- a/docs/design/KIT_VARIANT_CELLS.md
+++ b/docs/design/KIT_VARIANT_CELLS.md
@@ -154,44 +154,80 @@ exactly what it resolves today.
 The 556 unmodelled cells need a knob before they need a cell, and the top of that list says what
 kind of work it is:
 
-| Slot | Cells it unlocks | What it is in Compose |
-| --- | --- | --- |
-| `Alignment` / `Icon` / `Icon size` on `Button` | 40 | `icon` slot + `ButtonDefaults` icon size + content alignment |
-| `Type = Custom - Task` on `Toggle+Selection-Buttons` | 8 | the `toggleControl` slot |
-| Secondary label | across `Button`, `Toggle+Selection-Buttons`, `Card` | `secondaryLabel` parameter |
-| `Segments` / `Type = Top Gap \| Bottom Gap` on the progress indicators | 264 | real API surface, its own investigation |
+| Slot | Cells it unlocks | What it is in Compose | Status |
+| --- | --- | --- | --- |
+| `Alignment` / `Icon` / `Icon size` on `Button` | 40 | `icon` slot + `ButtonDefaults` icon size + content alignment | open |
+| `Segments` / `Type = Top Gap \| Bottom Gap` on the progress indicators | 264 | real API surface, its own investigation | open |
+| `Type = Custom - Task` on `Toggle+Selection-Buttons` | 8 | the `toggleControl` slot | **deliberately refused** — see below |
+| Secondary label | 4, on `Button-ImageBackground` only | `secondaryLabel` parameter | **already done** |
 
-Adding a `secondaryLabel` knob raises the question the sheet makes obvious: **the kit draws two
-lines and we draw one, and one line is the better default.** That is not a conflict, because a
-cell and a default are different renders of the same composable:
+> **Correction.** An earlier revision of this table claimed a secondary-label slot "across `Button`,
+> `Toggle+Selection-Buttons`, `Card`". That is wrong, and the mistake is worth keeping visible
+> because it is the exact class of error this document exists to remove — a slot inferred from what
+> the sheet *draws* rather than read from what the kit *states*.
+>
+> Across the whole Wear kit, **exactly one set declares a `Secondary label` variant property:
+> `Button-ImageBackground`** — and `ImageBackgroundButton` already implements it, as a cell, with
+> the seeded-knob pattern below. `Button` declares `Style / Icon / Icon size / Alignment /
+> Disabled`; `Toggle+Selection-Buttons` declares `Type / Selected / Split (2 tap targets) /
+> Disabled`; `Card` declares `Style / Layout type / Content type / Interactive`. None of them has a
+> secondary-label axis.
+>
+> The kit does *draw* two lines in some `Toggle+Selection-Buttons` cells and one line in others,
+> without a property separating them — a specimen sheet varying its own content, not a component
+> property. So a `secondaryLabel` knob on those components would render something real and resolve
+> to **nothing**: there is no kit node for a cell the kit never stated. It would close no red.
+> Adding one is a *comparison aid*, and should be argued for on that basis rather than as coverage.
+
+Where a slot IS stated, the pattern is a seeded knob, and `ImageBackgroundButton` is the worked
+example already in the tree:
 
 ```kotlin
-@CatalogComponent(id = "Button/Filled", …)
-@OverrideVariant(name = "secondary", strings = ["secondaryLabel=Secondary"],
-                 kitProps = ["Label 2=Yes"])
+@CatalogComponent(id = "Button/ImageBackground", …)
+@OverrideVariant(
+  name = "secondary-label",
+  booleans = ["secondary=true"],
+  kitAxis = "Secondary label",
+  kitValue = "Yes",
+)
 @Composable
-fun FilledButton() = Sticker {
+fun ImageBackgroundButton() = Sticker {
   Button(
-    label = { Text(kitCopy("label", KitCopy.PRIMARY_LABEL)) },
-    secondaryLabel = previewOverrideString("secondaryLabel", "")
-      .takeIf(String::isNotEmpty)?.let { { Text(it) } },
+    label = { Text(c.label) },
+    secondaryLabel =
+      if (previewOverrideBoolean("secondary", false)) {
+        { Text(kitCopy("secondaryLabel", KitCopy.SECONDARY_LABEL)) }
+      } else null,
     …
   )
 }
 ```
 
-The base capture is unchanged — one line, the catalog's own recommendation, still what the browse
-grid and the README show. The kit's two-line cell is compared against the cell that seeds the
-secondary label. **Comparison happens against the cell that matches the kit; the default stays what
-we would tell someone to write.** Writing that down matters because the alternative — changing the
-default to make the diff go green — is the failure mode this whole surface exists to catch, and it
-is one edit away at all times.
+The base capture stays one line — the catalog's own recommendation, and what the browse grid and
+the README show. The kit's two-line cell is compared against the cell that seeds the secondary
+label. **Comparison happens against the cell that matches the kit; the default stays what we would
+tell someone to write.** Writing that down matters because the alternative — changing the default
+to make the diff go green — is the failure mode this whole surface exists to catch, and it is one
+edit away at all times. (`LoadingButton` is the case where the two agree: `Button-Loading`'s base
+cell has two lines, so the sticker fills the slot unconditionally and says so in a comment.)
 
 Where the catalog deliberately draws something the kit does not, `noReference` /
 `--allow-stated-absence` already carries the reason. The inverse — the kit draws a cell we
 deliberately will not — wants the same treatment rather than a permanent red outline: a stated,
-reasoned absence, reported apart from a gap. (`Custom - Task` already has such a reason written in
-`SelectionButtons.kt`; it just has nowhere structured to live.)
+reasoned absence, reported apart from a gap.
+
+`Type = Custom - Task` is that case, and the reason is already written, in `SelectionButtons.kt`:
+
+> `Custom - Task` is the kit showing that the control slot is swappable rather than a fourth
+> component, and Compose expresses it as the `toggleControl` slot on the same functions. It stays
+> out of the inventory until a sticker can draw it without inventing a control the kit does not
+> publish.
+
+That is a decision, not a gap, and this document should not have listed it as work. Implementing it
+means choosing a glyph the kit never published and then comparing our invention against the kit's —
+a diff whose result means nothing. The eight cells stay red until either the kit publishes the
+control or step 8 gives the refusal somewhere structured to live, at which point they stop being
+counted as missing rather than starting to be drawn.
 
 ---
 
@@ -284,11 +320,17 @@ Each step is a PR against an existing surface; each is useful on its own.
 | 4 | Sidecar carries them; resolver matches a full assignment (§2c) | `@yschimke/compose-design-map`, `@design-parity/kit-index` |
 | 5 | Adopt `@PreviewAxis` on `Toggle+Selection-Buttons`' three siblings — 12 → 24 of 32 (§2b, §5) | `wear-m3-catalog` |
 | 6 | Variant table on the comparison page, scored client-side (§6) | `ServeWeb`, `format-compare.js` |
-| 7 | `secondaryLabel` and `toggleControl` knobs, cells declared against them (§3) | `wear-m3-catalog` |
+| 7 | ~~`secondaryLabel` and `toggleControl` knobs~~ — **withdrawn**, see §3's correction: the one set that states a secondary-label axis already has it, and `Custom - Task` is a stated refusal | — |
 | 8 | Stated, reasoned refusal of a kit cell, reported apart from a gap (§3) | map schema + page view |
+| 9 | `Alignment` / `Icon` / `Icon size` knobs on the five `Button` styles — 40 cells, and the largest real slot gap on the sheet (§3) | `wear-m3-catalog` |
 
-Steps 1, 2 and 5 are independent of the upstream packages and can land first; 5 shows the
-mechanism working end to end on one set before the annotation work generalises it.
+Steps 1 and 2 have **landed** ([#4335](https://github.com/yschimke/compose-ai-tools/pull/4335) with
+[wear-m3-catalog#47](https://github.com/yschimke/wear-m3-catalog/pull/47), and
+[#4351](https://github.com/yschimke/compose-ai-tools/pull/4351)); step 1 shipped in v1.23.0.
+
+Of what is left, only **9** is independent of the upstream packages — 5 needs 3 and 4 to resolve,
+and 6 is worth having only once there are cells to put in the table. 5 remains the best first use
+of the annotation work, because it shows the mechanism end to end on one set before it generalises.
 
 ## 8. What this does not settle
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1134,6 +1134,16 @@ data class OverrideVariantSpec(
   val kitAxis: String? = null,
   /** Explicit design-kit value for this cell; null keeps downstream value matching. */
   val kitValue: String? = null,
+  /**
+   * The design kit's **whole** assignment for this cell, for a cell that turns more than one knob —
+   * `@OverrideVariant.kitProps`, already split into pairs.
+   *
+   * Empty for every cell that declares none, which is the [kitAxis] / [kitValue] form and every
+   * cell written before the field existed. Non-empty **replaces** the seed vector downstream: a
+   * declaring cell is compared against the assignment it names, not against whatever its knob keys
+   * happen to alias to. See the annotation for why the two are kept apart.
+   */
+  val kitProps: List<CatalogVariantProp> = emptyList(),
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1209,12 +1209,23 @@ object PreviewDiscovery {
   /** Reads a `String[]` annotation parameter (ClassGraph yields an `Object[]`) as a list. */
   private fun annStringArray(ann: AnnotationInfo, param: String): List<String> {
     val raw = runCatching { ann.parameterValues.getValue(param) }.getOrNull() ?: return emptyList()
-    return when (raw) {
+    return stringArrayValue(raw)
+  }
+
+  /**
+   * The strings in an annotation array parameter's already-read value.
+   *
+   * Split out of [annStringArray] because the `@OverrideVariant` walk holds the parameter list
+   * rather than the `AnnotationInfo` — it reads several arrays off one annotation — and two
+   * spellings of "what counts as a string array here" would drift on exactly the shape ClassGraph
+   * hands back for an empty one.
+   */
+  private fun stringArrayValue(raw: Any?): List<String> =
+    when (raw) {
       is Array<*> -> raw.filterIsInstance<String>()
       is Iterable<*> -> raw.filterIsInstance<String>()
       else -> emptyList()
     }
-  }
 
   /** Splits a `@CatalogVariant.props` `"key=value"` pair; `null` when malformed (no key). */
   private fun parseCatalogProp(raw: String): CatalogVariantProp? {
@@ -2264,14 +2275,36 @@ object PreviewDiscovery {
           ?.let { runCatching { OverrideVariantInteraction.valueOf(it) }.getOrNull() }
       if (seeds.isEmpty() && interaction == null) continue
       val interactionIndex = ((pv.getValue("interactionIndex") as? Int) ?: 0).coerceAtLeast(0)
+      val kitAxis = (pv.getValue("kitAxis") as? String)?.takeIf { it.isNotBlank() }
+      val kitValue = (pv.getValue("kitValue") as? String)?.takeIf { it.isNotBlank() }
+      // `"Axis=Value"`, same split as `@CatalogVariant(props = …)` — first `=` wins, so a kit value
+      // that contains one (`Style=Variant (Highlighted)`) needs no escaping.
+      // `runCatching`, unlike its sibling reads above: a catalog compiled against a
+      // preview-annotations older than this field has no `kitProps` parameter at all, and
+      // `getValue` throws for one that is absent rather than returning its default. Discovery must
+      // keep working against an older annotations jar — that is the ordinary state of a consumer
+      // repo between releases.
+      val kitProps =
+        stringArrayValue(runCatching { pv.getValue("kitProps") }.getOrNull())
+          .mapNotNull(::parseCatalogProp)
+      // Two spellings of one fact with no rule for which wins is the ambiguity `kitProps` exists to
+      // remove, so it is not resolved silently: the plural form is kept (it is the only one that
+      // can describe a multi-knob cell at all) and the singular is reported as ignored.
+      if (kitProps.isNotEmpty() && (kitAxis != null || kitValue != null)) {
+        warnings.add(
+          "composePreview: '$owner' variant '$name' declares both kitProps and kitAxis/kitValue — " +
+            "keeping kitProps and ignoring the singular pair. Declare one or the other."
+        )
+      }
       val spec =
         OverrideVariantSpec(
           name = name,
           seeds = seeds,
           interaction = interaction,
           interactionIndex = interactionIndex,
-          kitAxis = (pv.getValue("kitAxis") as? String)?.takeIf { it.isNotBlank() },
-          kitValue = (pv.getValue("kitValue") as? String)?.takeIf { it.isNotBlank() },
+          kitAxis = kitAxis.takeIf { kitProps.isEmpty() },
+          kitValue = kitValue.takeIf { kitProps.isEmpty() },
+          kitProps = kitProps,
         )
       val existing = specs.putIfAbsent(name, spec)
       // Only a *conflicting* duplicate is worth a warning. The same annotation reached twice — once

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -153,6 +153,66 @@ class PreviewDataTest {
   }
 
   @Test
+  fun `a whole kit assignment round-trips through the preview manifest`() {
+    // The coupled-axis case: the Wear kit's `Button` set has no
+    // `Icon=Yes, Icon size=n/a, Alignment=Center` node, so the cell that lands on a real one turns
+    // three knobs — and one kitAxis has no way to say which of them it names.
+    val preview =
+      PreviewInfo(
+        id = "test.Button_VARIANT_icon-large",
+        functionName = "FilledButton",
+        className = "test.ButtonsKt",
+        catalog = CatalogEntry(role = CatalogRole.COMPONENT, componentId = "Button/Filled"),
+        overrides =
+          OverrideVariantSpec(
+            name = "icon-large",
+            seeds =
+              listOf(
+                OverrideSeed(key = "icon", kind = OverrideSeedKind.BOOLEAN, raw = "true"),
+                OverrideSeed(key = "iconSize", kind = OverrideSeedKind.STRING, raw = "lrg-32"),
+                OverrideSeed(key = "alignment", kind = OverrideSeedKind.STRING, raw = "left"),
+              ),
+            kitProps =
+              listOf(
+                CatalogVariantProp("Icon", "Yes"),
+                CatalogVariantProp("Icon size", "Lrg 32"),
+                CatalogVariantProp("Alignment", "Left"),
+              ),
+          ),
+      )
+    val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews.single().overrides?.kitProps?.map { it.key to it.value })
+      .containsExactly("Icon" to "Yes", "Icon size" to "Lrg 32", "Alignment" to "Left")
+    // The knob seeds stay: they say how the render was produced, which is the renderer's business.
+    // `kitProps` says only what it is compared against.
+    assertThat(decoded.previews.single().overrides?.seeds).hasSize(3)
+  }
+
+  @Test
+  fun `a cell that declares no kit assignment carries an empty one`() {
+    val preview =
+      PreviewInfo(
+        id = "test.Switch_VARIANT_off",
+        functionName = "SwitchOn",
+        className = "test.CatalogKt",
+        overrides =
+          OverrideVariantSpec(
+            name = "off",
+            seeds =
+              listOf(OverrideSeed(key = "checked", kind = OverrideSeedKind.BOOLEAN, raw = "false")),
+          ),
+      )
+    val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews.single().overrides?.kitProps).isEmpty()
+  }
+
+  @Test
   fun `motionPreview round-trips through preview manifest and defaults to null`() {
     // The design-artifacts export reads this off `previews.json` to decide which function's
     // recordings publish on a component. A rename or a dropped field here does not fail anything —


### PR DESCRIPTION
## Summary

Step 3 of [`KIT_VARIANT_CELLS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/KIT_VARIANT_CELLS.md) §2a — and, per the experiment below, the **only** step the Button-axes work was actually blocked on.

Design kits couple their axes. The Wear kit's `Button` set has no `Icon=Yes, Icon size=n/a, Alignment=Center` node — turning `Icon` on drags `Icon size` and `Alignment` with it — so a cell that names one axis asks for a node between the ones the kit drew. Five of wear-m3-catalog's cells fail exactly that way today. The cell that lands on a real node has to seed three knobs, and `kitAxis`/`kitValue` cannot say which of them the axis names: the projection reports the declaration and drops it rather than guessing.

```kotlin
@OverrideVariant(
  name = "icon-large",
  booleans = ["icon=true"],
  strings = ["iconSize=lrg-32", "alignment=left"],
  kitProps = ["Icon=Yes", "Icon size=Lrg 32", "Alignment=Left"],
)
```

## The experiment that scoped this

Before writing anything I fabricated cells into wear-m3-catalog's committed sidecar and ran the **released** `@design-parity/kit-index@0.1.53` against its committed `figma-kit-index.json`:

| Cell | Declares | Result |
| --- | --- | --- |
| `left` | `Alignment=Left` | ✅ resolved |
| `declared-icon` | `Icon=Yes`, `Icon size=26 (Default)`, `Alignment=Left` | ✅ resolved |
| `declared-icon-32` | same, `Icon size=Lrg 32` | ✅ resolved |
| `declared-icon-disabled` | four axes at once | ✅ resolved |
| `undeclared-icon` | the same three axes, **no** declarations | ❌ `no counterpart for icon=true, iconSize=26` |
| `icon` (today's cell) | `Icon=Yes` alone | ❌ `no counterpart` |

So the resolver **already** walks a multi-seed vector and matches a full assignment; §2c of the design doc was wrong to say it resolves a delta from the base. **Step 4 — the `@design-parity/kit-index` change — is not needed at all**, which takes an external dependency off the plan. The alias tables can't carry a coupled cell on their own, but explicit per-seed declarations resolve it today.

## What changed

- **`@OverrideVariant.kitProps`** — `Array<String>` of `"Axis=Value"`, first `=` wins so `"Style=Variant (Highlighted)"` needs no escaping.
- **Discovery** reads it into `OverrideVariantSpec.kitProps`. The read is `runCatching`, unlike its siblings: a catalog compiled against an older `preview-annotations` has no such parameter, and ClassGraph's `getValue` throws for one that is absent rather than returning its default. Being able to discover an older consumer is the ordinary state between releases.
- Declaring `kitProps` **and** `kitAxis`/`kitValue` on one annotation warns and keeps `kitProps` — two spellings of one fact with no rule for which wins is the ambiguity this removes, so it isn't resolved silently.
- **The sidecar emits one declared seed per entry, replacing the knob vector.** Load-bearing, not tidiness: a resolver has to place every seed it is given, so one knob seed that aliases to nothing would kill a cell whose declaration is complete and correct.

The knob seeds still say *how* the render was produced — that's the renderer's business and it stays on the preview. `kitProps` says only what it is compared *against*. Keeping those apart is what lets a catalog hold a better default than the kit (a one-line button) and still compare honestly against the kit's cell, rather than editing the default until the diff goes green.

## Test plan

- `node --test` in `design-map/` — 59 pass, three new: a three-axis cell emits three declared seeds; `kitProps` replaces rather than joins the knob seeds; a cell without it is untouched.
- `./gradlew -p gradle-plugin :preview-discovery:test` — passes, with two new round-trip cases (a whole assignment survives the manifest; a cell that declares none carries an empty list).
- `./gradlew ktfmtCheckAll` — clean. (The `gradle-plugin` composite's own `ktfmtCheck` flags nine files including `PreviewDiscovery.kt`, but it does so on `main` too — that task isn't the CI gate.)

Not yet wired up in a catalog: wear-m3-catalog reaches this code through the published `@yschimke/compose-design-map` (pinned at 1.20.0 in its `scripts/design-map.sh`), so the 40 Button cells need a release of that package first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRkE766A84qYYyvZKj3Dzp)_