### PR TITLE
fix(serve): source captions from the publish that owns the render

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -755,6 +755,7 @@ class ServeBundleHost(
       id = previewId,
       label = previewId,
       componentId = paths.labels[previewId],
+      caption = paths.captions[previewId],
       theme = paths.themes[previewId],
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -420,14 +420,22 @@ class ServeCatalogStore(
     // per render — so they name a componentId and nothing else. This lets those rows borrow the
     // caption of the component they belong to instead of being the only cards that can't say what
     // they are.
-    val captionByComponentId: Map<String?, String?> =
-      catalog.components
-        .mapNotNull { c ->
-          val id = c.componentId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-          val caption = c.caption?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-          id to caption
-        }
-        .toMap()
+    // A WHOLLY deferred component never reaches `components[]` at all, and the export writes its
+    // caption onto the deferred record instead — so the lookup reads both, components first. That
+    // also covers its deferred *variant* records, which carry no caption of their own and are
+    // meant to inherit the entry's.
+    val captionByComponentId: Map<String?, String?> = buildMap {
+      catalog.deferred.forEach { d ->
+        val id = d.componentId?.takeIf { it.isNotBlank() } ?: return@forEach
+        val caption = d.caption?.takeIf { it.isNotBlank() } ?: return@forEach
+        putIfAbsent(id, caption)
+      }
+      catalog.components.forEach { c ->
+        val id = c.componentId?.takeIf { it.isNotBlank() } ?: return@forEach
+        val caption = c.caption?.takeIf { it.isNotBlank() } ?: return@forEach
+        put(id, caption)
+      }
+    }
     val plannedImages =
       catalog.components.flatMap { component ->
         // The component's section/group tag every one of its previews (a component maps to one
@@ -602,7 +610,9 @@ class ServeCatalogStore(
           // A live-only record carries no caption of its own — the export writes one per COMPONENT
           // — so take the caption of the component it belongs to. Without this a component whose
           // only render is live is the one card on the sheet that cannot say what it is.
-          caption = captionByComponentId[record.componentId?.takeIf { it.isNotBlank() }],
+          caption =
+            record.caption?.takeIf { it.isNotBlank() }
+              ?: captionByComponentId[record.componentId?.takeIf { it.isNotBlank() }],
         )
     }
 
@@ -2201,6 +2211,14 @@ class ServeCatalogStore(
     val componentId: String? = null,
     val section: String? = null,
     val group: String? = null,
+    /**
+     * The authored caption, written straight onto the record for a **wholly** deferred component:
+     * such a component short-circuits before it is ever added to `components[]`
+     * (`generate-design-catalog.mjs`), so this is the only copy of it in the manifest. Its deferred
+     * *variant* records carry none — they inherit the entry's, which is why the caption lookup
+     * folds these records in.
+     */
+    val caption: String? = null,
     val state: String? = null,
     val theme: String? = null,
     val props: JsonObject? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5697,6 +5697,12 @@ class ServeHttpServer(
           pinnedPreview != null ->
             currentPreview?.copy(
               componentId = pinnedPreview.componentId ?: currentPreview.componentId,
+              // The caption takes NO tip fallback, unlike the fields around it. Those are enriched
+              // from the tip because `catalog.json` does not carry them; the caption it does carry,
+              // so that revision's answer is authoritative including its silence. Falling back
+              // would print today's sentence on a historical page and, for a caption that has since
+              // been rewritten, describe the render on screen in words its publish never used.
+              caption = pinnedPreview.caption,
               theme = pinnedPreview.theme ?: currentPreview.theme,
             ) ?: pinnedPreview
           revisionAnswers -> null

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifest.kt
@@ -59,6 +59,8 @@ class ServePinnedManifest(
      * nothing to say about an id it no longer contains.
      */
     val labels: Map<String, String> = emptyMap(),
+    /** Preview id → the caption that revision published for it. See [CatalogEntries.captions]. */
+    val captions: Map<String, String> = emptyMap(),
     /** Preview id → the baked light/dark theme recorded by that revision's image entry. */
     val themes: Map<String, String> = emptyMap(),
     /** Whether `catalog.json` was fetched and parsed at this commit. */
@@ -103,6 +105,7 @@ class ServePinnedManifest(
           renders = catalog?.paths.orEmpty(),
           references = references.orEmpty(),
           labels = catalog?.labels.orEmpty(),
+          captions = catalog?.captions.orEmpty(),
           themes = catalog?.themes.orEmpty(),
           catalogRead = catalog != null,
           referencesRead = references != null,
@@ -158,6 +161,8 @@ class ServePinnedManifest(
       val paths: Map<String, String>,
       /** Preview id → the component that declared it, where the catalog names one. */
       val labels: Map<String, String>,
+      /** Preview id → the caption that component authored, where the catalog carries one. */
+      val captions: Map<String, String>,
       /** Preview id → the explicit baked theme on the winning image entry. */
       val themes: Map<String, String>,
     )
@@ -168,11 +173,17 @@ class ServePinnedManifest(
           .getOrNull() ?: return null
       val paths = LinkedHashMap<String, String>()
       val labels = LinkedHashMap<String, String>()
+      val captions = LinkedHashMap<String, String>()
       val themes = LinkedHashMap<String, String>()
       for (component in components) {
         val obj = runCatching { component.jsonObject }.getOrNull() ?: continue
         val componentId = runCatching {
           obj["componentId"]?.jsonPrimitive?.content
+        }
+          .getOrNull()
+          ?.takeIf { it.isNotBlank() }
+        val caption = runCatching {
+          obj["caption"]?.jsonPrimitive?.content
         }
           .getOrNull()
           ?.takeIf { it.isNotBlank() }
@@ -199,6 +210,10 @@ class ServePinnedManifest(
           // component behind, and the page attributes one component's render to another. Whichever
           // declaration owns the pixels owns the name, even when that name is nothing.
           if (componentId != null) labels[id] = componentId else labels.remove(id)
+          // The caption follows the winning path for the same reason the label does: it describes
+          // the component that owns these pixels, so a collision resolved towards an uncaptioned
+          // entry must not leave the loser's sentence behind explaining someone else's render.
+          if (caption != null) captions[id] = caption else captions.remove(id)
           val theme = runCatching {
             image.jsonObject["theme"]?.jsonPrimitive?.content
           }
@@ -207,7 +222,7 @@ class ServePinnedManifest(
           if (theme != null) themes[id] = theme else themes.remove(id)
         }
       }
-      return CatalogEntries(paths, labels, themes)
+      return CatalogEntries(paths, labels, captions, themes)
     }
 
     /** `references/index.json` → reference id → the canonical raster's path on the branch. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedManifestTest.kt
@@ -45,6 +45,46 @@ class ServePinnedManifestTest {
   }
 
   @Test
+  fun `a revision's captions are read from its own catalog`() {
+    // The caption is `catalog.json` data, so a pinned page must print the sentence THAT publish
+    // carried — not the tip's, which may since have been rewritten to describe the component
+    // differently than the render on screen. Absence is an answer too: a component that authored
+    // no caption then gets none now.
+    val entries =
+      ServePinnedManifest.parseCatalog(
+        """
+        {"schema":"design-parity-catalog/v1","components":[
+          {"componentId":"Button/Loading","caption":"The kit's loading pattern.",
+           "images":[{"path":"images/button-loading/ideal.png"}]},
+          {"componentId":"Card","images":[{"path":"images/card/ideal.png"}]}]}
+        """
+          .trimIndent()
+      )!!
+
+    assertEquals("The kit's loading pattern.", entries.captions["button-loading__ideal"])
+    assertNull(entries.captions["card__ideal"])
+  }
+
+  @Test
+  fun `a caption follows the winning path, exactly as its label does`() {
+    // Two declarations flattening to one route id: the entry that owns the pixels owns the words.
+    // A caption left behind by the loser would explain someone else's render.
+    val entries =
+      ServePinnedManifest.parseCatalog(
+        """
+        {"schema":"design-parity-catalog/v1","components":[
+          {"componentId":"Old","caption":"The one that lost.",
+           "images":[{"path":"images/shared/ideal.png"}]},
+          {"componentId":"New","images":[{"path":"images/shared/ideal.png"}]}]}
+        """
+          .trimIndent()
+      )!!
+
+    assertEquals("New", entries.labels["shared__ideal"])
+    assertNull(entries.captions["shared__ideal"])
+  }
+
+  @Test
   fun `references key by their declared id, whatever path they carry`() {
     val paths =
       ServePinnedManifest.parseReferences(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebBreakpointFoldTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebBreakpointFoldTest.kt
@@ -459,6 +459,32 @@ class ServeWebBreakpointFoldTest {
   }
 
   @Test
+  fun `a live-only preview carries its component's caption`() {
+    // A wholly-deferred component never reaches `components[]`, so its caption exists only on the
+    // deferred record — the component-map lookup alone would leave exactly the live-only cards
+    // (which have no baked pixels to explain them either) unable to say what they are.
+    val liveOnly =
+      ServePreview(
+        id = "livedialog__ideal__default__192dp",
+        label = "livedialog__ideal__default__192dp",
+        componentId = "LiveDialog",
+        state = "default",
+        size = "192dp",
+        section = "Containment",
+        catalogOrder = 0,
+        caption = "Rendered on demand, and it says so.",
+      )
+
+    val html =
+      ServeWeb.viewerPage(liveOnly, token = "t", basePath = "/wear", siblings = listOf(liveOnly))
+
+    assertTrue(
+      html.contains("<p class=\"cp-preview-caption\">Rendered on demand, and it says so.</p>"),
+      "a live-only preview prints its caption like any other",
+    )
+  }
+
+  @Test
   fun `a catalog that declares no sizes keeps a card per render`() {
     // The same fan-out as above with the metadata a pre-breakpoint export never wrote. Folding on
     // the id alone would make these renders unreachable — there would be no switcher to reach them


### PR DESCRIPTION
## Summary

Follow-up to [#4357](https://github.com/yschimke/compose-ai-tools/pull/4357), which merged before its review landed. Two of the three findings were real, and both are the same class of bug: a caption sourced from the wrong place.

**A wholly deferred component lost its caption entirely.** When `priority: "deferred"` applies to a whole component, the export short-circuits before adding it to `components[]` and writes the authored caption straight onto the `deferred[]` record instead ([`generate-design-catalog.mjs:527`](https://github.com/yschimke/compose-ai-tools/blob/main/scripts/design-artifacts/generate-design-catalog.mjs#L527)). `Deferred` never deserialized that field and the lookup read only `components[]`, so the caption was dropped — and live-only cards, which have no baked pixels either, are exactly the ones that most need explaining. Now deserialized, and deferred entries fold into the caption map so the entry's deferred *variant* records (which carry none of their own) inherit it.

**A pinned page printed the tip's caption.** `?rev=<commit>` builds its preview from `currentPreview` and replaced only the component id and theme, so a historical render was captioned with today's sentence — and for a caption since rewritten, described the pixels on screen in words that publish never used. The caption is `catalog.json` data, unlike the fields deliberately enriched from the tip around it, so `ServePinnedManifest` now carries it and that revision's answer is authoritative **including its silence** (no tip fallback). It follows the winning path exactly as the label does, so a route-id collision can't leave the loser's sentence explaining someone else's render.

## Not fixed here

The third finding — a component whose *every* render failed is published in `failures[]` and omitted from `components[]`, so its diagnostic page stays captionless. There is no serve-side source to read: the failure records carry no caption and the component is simply absent. Fixing it means publishing the caption on the failure record in the exporter, which is a change to a different pipeline and belongs in its own PR. Happy to do that next if you want it.

## Test plan

- `./gradlew :cli:test --tests '*serve*'` — green, with three new cases:
  - `a live-only preview carries its component's caption` (`ServeWebBreakpointFoldTest`)
  - `a revision's captions are read from its own catalog` (`ServePinnedManifestTest`)
  - `a caption follows the winning path, exactly as its label does` (`ServePinnedManifestTest`)
- `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — clean.

No visual evidence: both paths change *which* caption string is selected, not how the line is drawn — the markup and CSS #4357 added are untouched, and all committed page fixtures render byte-identically (`ServeWebFixtureTest` reports no drift). The caption line itself is already covered visually by the `serve-viewer-breakpoints` fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxWvuxmyGrW8vwEnSqago1)_