### PR TITLE
feat(serve): say whether the catalog blob cache actually survives a restart

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -805,9 +805,9 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       preferred != null && (preferred.isDirectory || preferred.mkdirs()) && preferred.canWrite()
     ) {
       System.err.println(
-        "serve: catalog blob cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB)"
+        "serve: catalog blob cache at $preferred (durable, cap ${maxBytes / (1024 * 1024)} MB)"
       )
-      CatalogBlobPool(preferred, maxBytes = maxBytes)
+      CatalogBlobPool(preferred, maxBytes = maxBytes, durable = true)
     } else {
       if (preferred != null) {
         System.err.println("serve: catalog blob cache $preferred is not writable; using a temp dir")
@@ -816,7 +816,14 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         java.nio.file.Files.createTempDirectory("serve-catalog-blobs").toFile().also {
           it.deleteOnExit()
         }
-      CatalogBlobPool(temp, maxBytes = maxBytes)
+      System.err.println(
+        "serve: catalog blob cache is a temp dir — it will not survive a restart. " +
+          "Set --catalog-cache-dir (SERVE_CATALOG_CACHE_DIR) to a mounted volume to keep it."
+      )
+      // Not durable, and `/status.json` says so: a temp pool fills and serves within-process hits
+      // exactly like a real one, so without the flag a box that never configured a directory looks
+      // identical to a box whose cache is working.
+      CatalogBlobPool(temp, maxBytes = maxBytes, durable = false)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -22,6 +22,24 @@ data class CatalogBlobPoolSnapshot(
   val evicted: Long,
   /** Blobs dropped because their bytes did not hash back to their name. */
   val corrupt: Long,
+  /**
+   * Whether this pool's directory outlives the process (`--catalog-cache-dir`), or is the temp-dir
+   * fallback that is discarded with the container.
+   *
+   * The field that separates a cache from a decoration. Everything else here looks the same either
+   * way — a temp pool fills, serves within-process hits, and reports climbing writes — right up
+   * until the container is recreated and none of it is there. `false` on a deployed box means the
+   * bytes are being paid for and thrown away.
+   */
+  val durable: Boolean = false,
+  /**
+   * Blobs already on disk when this process opened the pool.
+   *
+   * The only direct evidence that anything survived the last restart, and therefore the number to
+   * read after a roll: `0` on a [durable] pool that should have found a warm volume is the failure,
+   * and it is invisible in every other field.
+   */
+  val adopted: Int = 0,
   val lastFailure: String? = null,
 )
 
@@ -90,6 +108,15 @@ class CatalogBlobPool(
   private val maxBytes: Long = DEFAULT_MAX_BYTES,
   /** How recently a blob must have been touched to be spared by [sweep]. See **Concurrency**. */
   private val graceMillis: Long = DEFAULT_SWEEP_GRACE_MILLIS,
+  /**
+   * Whether [root] outlives this process — an operator-configured directory rather than the
+   * temp-dir fallback.
+   *
+   * Reported rather than inferred, because the two are indistinguishable from the inside: a pool in
+   * `/tmp` fills, serves within-process hits and reports healthy-looking counters right up until
+   * the container is recreated and every byte of it is gone. Only the caller knows which it built.
+   */
+  private val durable: Boolean = false,
   private val clock: () -> Long = System::currentTimeMillis,
 ) {
   private val hits = AtomicLong()
@@ -126,6 +153,18 @@ class CatalogBlobPool(
 
   private val contentDir = File(root, CONTENT_DIR)
   private val keysDir = File(root, KEYS_DIR)
+
+  /**
+   * Blobs already present when this process opened the pool — the only direct evidence that
+   * anything survived the last restart.
+   *
+   * One census at construction, which is also what seeds the published occupancy so `/status.json`
+   * is right from the first poll rather than from the first sweep. `0` on a durable pool after a
+   * roll that should have found a warm volume is the failure this number exists to make visible;
+   * without it a cache that is quietly starting over every time looks exactly like one that is
+   * working, since both report climbing writes.
+   */
+  private val adopted: Int = census().blobs
 
   /**
    * The blob whose sha256 is [sha256], fetching it once when absent, or null when it cannot be had.
@@ -335,6 +374,8 @@ class CatalogBlobPool(
       blobs = knownBlobs.get(),
       bytes = knownBytes.get(),
       maxBytes = maxBytes,
+      durable = durable,
+      adopted = adopted,
       hits = hits.get(),
       misses = misses.get(),
       writes = writes.get(),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -364,6 +364,42 @@ class CatalogBlobPoolTest {
   }
 
   @Test
+  fun `a pool reports whether it is durable and what it adopted`() {
+    // The two numbers that separate a working cache from a decoration. Everything else looks the
+    // same either way: a temp pool fills, serves within-process hits and reports climbing writes,
+    // right up until the container is recreated and none of it is there.
+    val root = root()
+    val first = CatalogBlobPool(root, durable = true)
+    assertFalse(CatalogBlobPool(root()).snapshot().durable, "a temp-dir pool says so")
+    assertTrue(first.snapshot().durable)
+    assertEquals(0, first.snapshot().adopted, "nothing was here before this process")
+
+    first.write("https://raw.githubusercontent.com/o/r/$COMMIT/images/a.png", "png".toByteArray())
+
+    // A restart over the same volume: what it finds is what survived.
+    val reopened = CatalogBlobPool(root, durable = true)
+    assertEquals(1, reopened.snapshot().adopted, "the blob the previous process left")
+    assertEquals(0, first.snapshot().adopted, "adopted is fixed at open, not a running total")
+  }
+
+  @Test
+  fun `occupancy is right from the first poll, before any sweep`() {
+    // The census at construction seeds the published occupancy too, so a freshly opened pool over a
+    // warm volume does not report an empty cache until its first sweep.
+    val root = root()
+    CatalogBlobPool(root)
+      .write(
+        "https://raw.githubusercontent.com/o/r/$COMMIT/images/a.png",
+        "png".toByteArray(),
+      )
+
+    val snapshot = CatalogBlobPool(root).snapshot()
+
+    assertEquals(1, snapshot.blobs)
+    assertTrue(snapshot.bytes > 0)
+  }
+
+  @Test
   fun `sweep reclaims oldest-first down to the cap`() {
     val now = AtomicLong(1_000_000L)
     val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2637,6 +2637,19 @@ tier; they are not two views of one number, and reading them as one would make a
 look inconsistent. What says the feature is working is either of them climbing while
 `branchFetch.attempted` flattens across a restart.
 
+Read **`durable`** and **`adopted`** first, because they are the two that separate a working cache
+from a decoration. Everything else on this row looks the same either way: a temp-dir pool fills,
+serves within-process hits and reports climbing writes, right up until the container is recreated
+and none of it is there. `durable: false` on a deployed box means the bytes are being paid for and
+thrown away — set `SERVE_CATALOG_CACHE_DIR` to a mounted volume. `adopted` is what was already on
+disk when the process opened the pool, so `0` after a roll that should have found a warm volume is
+the failure, and it is invisible in every other field.
+
+That distinction is not hypothetical. The image's compose file defaults `SERVE_CATALOG_CACHE_DIR` to
+the `/catalog-cache` volume, but an already-deployed box keeps its own copy of that file: the
+auto-update path rolls the **image**, never the compose. A server can therefore take every release
+of this feature and still be running the cache in `/tmp`.
+
 `corrupt` above zero says a volume is losing bytes, since every blob is named by its own digest and
 re-verified on read. `blobs`/`bytes` against `maxBytes` says whether the sweeper is keeping up —
 both are published by the last sweep rather than censused per request, so they lag a write by at


### PR DESCRIPTION
Driven by a measurement rather than by the plan. I read `preview.coo.ee/status.json` to decide whether phase 3 was worth building, and found a more pressing gap.

## What the live box says

Running **1.23.0** (phases 1–2), 23 catalogs, 1.3 h uptime:

```
branchFetch: attempted=16233  cached=300  ok=15387  notFound=846  throttled=0
themeCache:  null
catalogCache: (not in this release)
```

300 of 16,533 reads answered from cache — 1.8%. That number on its own is not alarming: most reads are first-time lazy asset fetches, and the pool's value is *across* processes, not within one. What is alarming is that **nothing in `/status.json` says whether that pool is a mounted volume or `/tmp`**, and the two are indistinguishable from the outside. A temp pool fills, serves within-process hits, and reports climbing writes — right up until the container is recreated and none of it is there.

So I cannot tell, from the box, whether the feature is working or inert. Neither can an operator. That is precisely the question phase 4's status row was meant to answer ("tell a working cache from write amplification") and doesn't.

## Why a deployment can land in that state without doing anything wrong

The image's compose file defaults `SERVE_CATALOG_CACHE_DIR` to the `/catalog-cache` volume — but an already-deployed box keeps **its own copy** of that file, and the auto-update path (`rollout` / Watchtower) rolls the **image**, never the compose. A server can therefore take every release of this feature and still be caching into `/tmp`. The same is visibly true of the theme cache on that box today: `themeCache: null`, i.e. never switched on.

## The change

- **`durable`** — whether the root is an operator-configured directory or the temp fallback. Reported rather than inferred, because only the caller knows which it built.
- **`adopted`** — blobs already on disk when this process opened the pool, from one census at construction. The only direct evidence anything survived the last restart: `0` on a `durable` pool after a roll that should have found a warm volume is the failure, and it is invisible in every other field. (This mirrors `themeCache.adopted`, which exists for exactly this reason.)
- The construction census also **seeds the published occupancy**, so `/status.json` is right from the first poll rather than from the first sweep — closing a caveat I introduced in #4352.
- The temp-dir fallback now **says so on stderr at boot**, naming the flag to set.

## Test plan

- `./gradlew ktfmtFormatAll` then `:cli:test ktfmtCheckAll` — **2,754 tests**, 1 failure, and it is **not mine**: see below.
- New `CatalogBlobPoolTest` cases — a temp-dir pool reports `durable=false` and a configured one `true`; `adopted` is 0 for a fresh volume, 1 for a pool reopened over one the previous process wrote to, and stays fixed at open rather than tracking later writes; occupancy is correct from the first poll before any sweep.

## Pre-existing failure on main

`ServeWebFixtureTest > serve web fixtures are in sync with ServeWeb` fails on **clean `main` at `af67516`** — I stashed my changes and ran it on an untouched tree to confirm before assuming. The drift is `serve-design-page.html` (a page swatch: `not implemented` → `override variant`), consistent with the design-node clipping changes in #4338/#4343 landing without regenerating the goldens. My branch touches no design pages.

The fix is a mechanical `UPDATE_SERVE_WEB_FIXTURES=true` regeneration. I have deliberately **not** folded it into this PR — regenerating someone else's golden inside an unrelated diff hides the drift rather than recording it. Happy to send it as its own one-commit PR; say the word.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_