### PR TITLE
fix(ci): pin the Gradle wrapper to 9.7.0 until the 9.7.1 regression is fixed

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -167,6 +167,13 @@
         "@types/vscode"
       ],
       "enabled": false
+    },
+    {
+      "description": "Gradle wrapper: hold at 9.7.0. Under 9.7.1 a second build invocation in one session leaves `:samples:cmp`'s Kotlin output with zero .class files, so `composePreviewDiscover` writes an assets-only manifest and `composePreviewRender` then fails with 'matched no previews' — the `interactive-e-g` shard of VS Code Extension E2E went red the moment 9.7.1 landed (#4318) and stayed red across unrelated commits. Measured with three dispatched five-shard runs: 9.7.1 fails, both pins reverted passes, and wrapper-only-reverted ALSO passes — which is why `org.gradle:gradle-tooling-api` is deliberately NOT pinned here (it is on 9.7.1 and innocent; the refresh path shells out to gradlew rather than driving the tooling API). This cap is temporary and #4364 tracks removing it — close that issue by deleting this rule, and dispatch the e2e on the branch before merging, since a push run can be cancelled by the next merge and prove nothing.",
+      "matchManagers": [
+        "gradle-wrapper"
+      ],
+      "allowedVersions": "<=9.7.0"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -169,11 +169,12 @@
       "enabled": false
     },
     {
-      "description": "Gradle wrapper: hold at 9.7.0. Under 9.7.1 a second build invocation in one session leaves `:samples:cmp`'s Kotlin output with zero .class files, so `composePreviewDiscover` writes an assets-only manifest and `composePreviewRender` then fails with 'matched no previews' — the `interactive-e-g` shard of VS Code Extension E2E went red the moment 9.7.1 landed (#4318) and stayed red across unrelated commits. Measured with three dispatched five-shard runs: 9.7.1 fails, both pins reverted passes, and wrapper-only-reverted ALSO passes — which is why `org.gradle:gradle-tooling-api` is deliberately NOT pinned here (it is on 9.7.1 and innocent; the refresh path shells out to gradlew rather than driving the tooling API). This cap is temporary and #4364 tracks removing it — close that issue by deleting this rule, and dispatch the e2e on the branch before merging, since a push run can be cancelled by the next merge and prove nothing.",
+      "description": "Gradle wrapper: hold at 9.7.0. Under 9.7.1 a second build invocation in one session leaves `:samples:cmp`'s Kotlin output with zero .class files, so `composePreviewDiscover` writes an assets-only manifest and `composePreviewRender` then fails with 'matched no previews' — the `interactive-e-g` shard of VS Code Extension E2E went red the moment 9.7.1 landed (#4318) and stayed red across unrelated commits. Measured with three dispatched five-shard runs: 9.7.1 fails, both pins reverted passes, and wrapper-only-reverted ALSO passes — which is why `org.gradle:gradle-tooling-api` is deliberately NOT pinned here (it is on 9.7.1 and innocent; the refresh path shells out to gradlew rather than driving the tooling API). Written as an exact-version REGEX rather than a `<=9.7.0` range: the `gradle-wrapper` manager resolves through the `gradle` versioning module, which does not support npm-style ranges, so a comparison constraint is not applied and the pin would silently let 9.7.1 straight back in. Same shape as the `slf4j-nop` exact pin above. Pinning to exactly 9.7.0 also holds back 9.7.2+, which is deliberate — every later release is equally unverified against this regression, and nothing should move without an e2e run. This cap is temporary and #4364 tracks removing it — close that issue by deleting this rule, and dispatch the e2e on the branch before merging, since a push run can be cancelled by the next merge and prove nothing.",
       "matchManagers": [
         "gradle-wrapper"
       ],
-      "allowedVersions": "<=9.7.0"
+      "matchCurrentValue": "/^9\\.7\\.0$/",
+      "allowedVersions": "/^9\\.7\\.0$/"
     }
   ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Refs #4364, which tracks removing this pin.

The `interactive-e-g` shard of `VS Code Extension E2E` has been red on `main` since #4318 landed, and stayed red across unrelated commits.

## The failure

```
Execution failed for task ':samples:cmp:composePreviewRender'
> composePreviewRender --preview matched no previews for '…'.
  Manifest contains 0 code preview(s) and 3 asset preview(s)
     lottie/spin.json
     svg/badge.svg
     svg/star.svg
[refresh] done — 0 visible previews in Previews.kt, module has 3
```

Under 9.7.1 a second build invocation in one session leaves `:samples:cmp`'s Kotlin output with **zero `.class` files**. `composePreviewDiscover` then finds no code previews, writes an assets-only manifest and exits `BUILD SUCCESSFUL` — so the render task is the first thing to complain, pointing at a manifest that looks legitimately empty. The cause is a long way from the symptom, which is why this took a bisect rather than a read.

Reproduced locally, independent of CI: delete the class output, run discovery, and it writes exactly `0 code previews + 3 asset previews` and succeeds. Ruled out along the way — discovery is healthy on a good tree (71 previews), the exact failing Gradle command passes, and the source edit the e2e makes compiles and renders fine (7 previews). It is a build-state problem, not a code problem.

## The measurement

Three `workflow_dispatch` runs of the full five-shard e2e. Dispatched rather than pushed on purpose: the concurrency group cancels push runs on the next merge, which is why the push history reads as noise.

| Arm | wrapper | gradle-tooling-api | Result |
|---|---|---|---|
| `main` (control) | 9.7.1 | 9.7.1 | [failure](https://github.com/yschimke/compose-ai-tools/actions/runs/32360920853) |
| both reverted | 9.7.0 | 9.7.0 | [success](https://github.com/yschimke/compose-ai-tools/actions/runs/32360913963) |
| wrapper only | 9.7.0 | **9.7.1** | [success](https://github.com/yschimke/compose-ai-tools/actions/runs/32362124710) |

The third arm is what scopes the change: the wrapper alone accounts for it, so **`org.gradle:gradle-tooling-api` stays on 9.7.1** rather than being reverted along with it. That matches how the path actually runs — a refresh shells out to `gradlew` rather than driving the tooling API.

## The change

- `gradle/wrapper/gradle-wrapper.properties` back to 9.7.0.
- A `gradle-wrapper` cap in `.github/renovate.json` so 9.7.1 does not come straight back, following the same shape as the existing per-dependency pins (`material-kolor`, `compottie`, `slf4j-nop`) — the rule carries its own rationale and names #4364 as the exit.

## What this costs

Holding the repo on 9.7.0 to keep one e2e shard green is a real trade, and worth stating rather than burying: this is the immediate stop-the-bleeding fix, not the end state. #4364 carries the follow-up — establish what in 9.7.1 empties the compile output, confirm it upstream or work around it in the plugin, then drop the rule.

## Worth fixing regardless

`PreviewDiscovery` already detects this exact state — `emptyCompiledOutputs`, added for #3600 — and only **warns**. That is why a broken build surfaced as "matched no previews" and as a panel reporting "0 visible previews in Previews.kt" rather than naming the empty compile output. Out of scope here, noted on #4364.

## Test plan

- `./gradlew --version` → Gradle 9.7.0; `:samples:cmp:composePreviewDiscover` green with a 71-preview manifest on the pinned wrapper.
- `.github/renovate.json` parses; 16 `packageRules`, the new one last.
- The wrapper-only arm above **is** the test for this diff: same one-line change, full five-shard e2e, green.
- Before merging, dispatch `vscode-extension-e2e.yml` on this branch and confirm `interactive-e-g` — a push run can be cancelled by the next merge and prove nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDVrHkAyguUgnUx4VxqZrS)_