### PR TITLE
fix(serve): report configured persistence as a decision, not as proof

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -805,9 +805,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       preferred != null && (preferred.isDirectory || preferred.mkdirs()) && preferred.canWrite()
     ) {
       System.err.println(
-        "serve: catalog blob cache at $preferred (durable, cap ${maxBytes / (1024 * 1024)} MB)"
+        "serve: catalog blob cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB) — " +
+          "it survives a restart only if that path is a mounted volume"
       )
-      CatalogBlobPool(preferred, maxBytes = maxBytes, durable = true)
+      CatalogBlobPool(preferred, maxBytes = maxBytes, persistenceConfigured = true)
     } else {
       if (preferred != null) {
         System.err.println("serve: catalog blob cache $preferred is not writable; using a temp dir")
@@ -820,10 +821,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         "serve: catalog blob cache is a temp dir — it will not survive a restart. " +
           "Set --catalog-cache-dir (SERVE_CATALOG_CACHE_DIR) to a mounted volume to keep it."
       )
-      // Not durable, and `/status.json` says so: a temp pool fills and serves within-process hits
+      // Not configured, and `/status.json` says so: a temp pool fills and serves within-process
+      // hits
       // exactly like a real one, so without the flag a box that never configured a directory looks
       // identical to a box whose cache is working.
-      CatalogBlobPool(temp, maxBytes = maxBytes, durable = false)
+      CatalogBlobPool(temp, maxBytes = maxBytes, persistenceConfigured = false)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -23,21 +23,21 @@ data class CatalogBlobPoolSnapshot(
   /** Blobs dropped because their bytes did not hash back to their name. */
   val corrupt: Long,
   /**
-   * Whether this pool's directory outlives the process (`--catalog-cache-dir`), or is the temp-dir
-   * fallback that is discarded with the container.
+   * Whether an operator configured a directory (`--catalog-cache-dir`), rather than this being the
+   * temp-dir fallback discarded with the container.
    *
-   * The field that separates a cache from a decoration. Everything else here looks the same either
-   * way — a temp pool fills, serves within-process hits, and reports climbing writes — right up
-   * until the container is recreated and none of it is there. `false` on a deployed box means the
-   * bytes are being paid for and thrown away.
+   * `false` on a deployed box means the bytes are certainly being paid for and thrown away. `true`
+   * means only that the decision was made: a configured path inside an image with no volume mounted
+   * there is just as ephemeral, and nothing here can tell those apart. [adopted] is the evidence
+   * that the storage actually persisted.
    */
-  val durable: Boolean = false,
+  val persistenceConfigured: Boolean = false,
   /**
    * Blobs already on disk when this process opened the pool.
    *
    * The only direct evidence that anything survived the last restart, and therefore the number to
-   * read after a roll: `0` on a [durable] pool that should have found a warm volume is the failure,
-   * and it is invisible in every other field.
+   * read after a roll: `0` on a pool with [persistenceConfigured] that should have found a warm
+   * volume is the failure, and it is invisible in every other field.
    */
   val adopted: Int = 0,
   val lastFailure: String? = null,
@@ -109,14 +109,15 @@ class CatalogBlobPool(
   /** How recently a blob must have been touched to be spared by [sweep]. See **Concurrency**. */
   private val graceMillis: Long = DEFAULT_SWEEP_GRACE_MILLIS,
   /**
-   * Whether [root] outlives this process — an operator-configured directory rather than the
-   * temp-dir fallback.
+   * Whether an operator named a directory for [root], rather than this being the temp-dir fallback.
    *
-   * Reported rather than inferred, because the two are indistinguishable from the inside: a pool in
-   * `/tmp` fills, serves within-process hits and reports healthy-looking counters right up until
-   * the container is recreated and every byte of it is gone. Only the caller knows which it built.
+   * Deliberately **not** called durable. Nothing here can establish that the storage outlives the
+   * container — `--catalog-cache-dir /var/cache/x` in an image with no volume mounted there is
+   * configured and just as ephemeral, and no portable test tells a bind mount from a writable
+   * layer. So this reports the decision that was made, and [adopted] reports what actually
+   * survived. Claiming the stronger thing would be the false reassurance it exists to remove.
    */
-  private val durable: Boolean = false,
+  private val persistenceConfigured: Boolean = false,
   private val clock: () -> Long = System::currentTimeMillis,
 ) {
   private val hits = AtomicLong()
@@ -159,7 +160,7 @@ class CatalogBlobPool(
    * anything survived the last restart.
    *
    * One census at construction, which is also what seeds the published occupancy so `/status.json`
-   * is right from the first poll rather than from the first sweep. `0` on a durable pool after a
+   * is right from the first poll rather than from the first sweep. `0` on a configured pool after a
    * roll that should have found a warm volume is the failure this number exists to make visible;
    * without it a cache that is quietly starting over every time looks exactly like one that is
    * working, since both report climbing writes.
@@ -374,7 +375,7 @@ class CatalogBlobPool(
       blobs = knownBlobs.get(),
       bytes = knownBytes.get(),
       maxBytes = maxBytes,
-      durable = durable,
+      persistenceConfigured = persistenceConfigured,
       adopted = adopted,
       hits = hits.get(),
       misses = misses.get(),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -973,7 +973,11 @@ class ServeHttpServer(
             val after = withContext(Dispatchers.IO) { catalogCacheClear!!.invoke() }
             call.response.headers.append(HttpHeaders.CacheControl, "no-store")
             call.respondText(
-              Json.encodeToString(CatalogBlobPoolSnapshot.serializer(), after),
+              // JSON, not the bare companion: that one leaves `encodeDefaults` off, which silently
+              // drops exactly the fields whose default value is the alarming one — an operator
+              // clearing a temp-backed pool would get a response with no `persistenceConfigured`
+              // in it at all. Same encoder as `/status.json` so the two agree in shape.
+              JSON.encodeToString(CatalogBlobPoolSnapshot.serializer(), after),
               ContentType.Application.Json,
             )
           }
@@ -7973,6 +7977,12 @@ private data class StatusResponse(
   /**
    * The catalog blob cache ([CatalogBlobPoolSnapshot]), or null on a server that publishes no
    * catalogs.
+   *
+   * Read `persistenceConfigured` and `adopted` first — but read them for what they are. The first
+   * says only that an operator named a directory, which is not proof the storage outlives the
+   * container: `--catalog-cache-dir /var/cache/x` inside an image with no volume there is
+   * configured and just as ephemeral. `adopted` is the evidence — blobs found at open, so non-zero
+   * after a restart is the pool actually having survived one.
    *
    * `hits` here is the **aggregate** across all three lanes the pool serves — small assets, the
    * executable bundles, and the content-addressed resource pool — while `branchFetch.cached` counts

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -364,20 +364,23 @@ class CatalogBlobPoolTest {
   }
 
   @Test
-  fun `a pool reports whether it is durable and what it adopted`() {
-    // The two numbers that separate a working cache from a decoration. Everything else looks the
-    // same either way: a temp pool fills, serves within-process hits and reports climbing writes,
-    // right up until the container is recreated and none of it is there.
+  fun `a pool reports whether persistence was configured and what it adopted`() {
+    // `persistenceConfigured` reports a decision; `adopted` is the evidence. Everything else looks
+    // the same either way: a temp pool fills, serves within-process hits and reports climbing
+    // writes, right up until the container is recreated and none of it is there.
     val root = root()
-    val first = CatalogBlobPool(root, durable = true)
-    assertFalse(CatalogBlobPool(root()).snapshot().durable, "a temp-dir pool says so")
-    assertTrue(first.snapshot().durable)
+    val first = CatalogBlobPool(root, persistenceConfigured = true)
+    assertFalse(
+      CatalogBlobPool(root()).snapshot().persistenceConfigured,
+      "a temp-dir pool says so",
+    )
+    assertTrue(first.snapshot().persistenceConfigured)
     assertEquals(0, first.snapshot().adopted, "nothing was here before this process")
 
     first.write("https://raw.githubusercontent.com/o/r/$COMMIT/images/a.png", "png".toByteArray())
 
     // A restart over the same volume: what it finds is what survived.
-    val reopened = CatalogBlobPool(root, durable = true)
+    val reopened = CatalogBlobPool(root, persistenceConfigured = true)
     assertEquals(1, reopened.snapshot().adopted, "the blob the previous process left")
     assertEquals(0, first.snapshot().adopted, "adopted is fixed at open, not a running total")
   }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2637,13 +2637,19 @@ tier; they are not two views of one number, and reading them as one would make a
 look inconsistent. What says the feature is working is either of them climbing while
 `branchFetch.attempted` flattens across a restart.
 
-Read **`durable`** and **`adopted`** first, because they are the two that separate a working cache
-from a decoration. Everything else on this row looks the same either way: a temp-dir pool fills,
+Read **`persistenceConfigured`** and **`adopted`** first, and read them for what they are.
+Everything else on this row looks the same whether the cache works or not: a temp-dir pool fills,
 serves within-process hits and reports climbing writes, right up until the container is recreated
-and none of it is there. `durable: false` on a deployed box means the bytes are being paid for and
-thrown away — set `SERVE_CATALOG_CACHE_DIR` to a mounted volume. `adopted` is what was already on
-disk when the process opened the pool, so `0` after a roll that should have found a warm volume is
-the failure, and it is invisible in every other field.
+and none of it is there.
+
+`persistenceConfigured: false` means the bytes are certainly being paid for and thrown away — set
+`SERVE_CATALOG_CACHE_DIR` to a mounted volume. `true` means only that a directory was configured; it
+is **not** proof the storage persists, because a configured path inside an image with no volume
+mounted there is just as ephemeral and nothing in the server can tell those apart.
+
+`adopted` is the evidence: blobs already on disk when the process opened the pool. Non-zero after a
+restart is the cache actually having survived one, and `0` after a roll that should have found a warm
+volume is the failure — invisible in every other field.
 
 That distinction is not hypothetical. The image's compose file defaults `SERVE_CATALOG_CACHE_DIR` to
 the `/catalog-cache` volume, but an already-deployed box keeps its own copy of that file: the


### PR DESCRIPTION
Two review findings on #4362, which merged while these were in progress. Both verified against the code.

## `durable` claimed more than the server can know

I set it from "an explicit directory was named and is writable". That is satisfied by `--catalog-cache-dir /var/cache/x` inside an image with no volume mounted there — configured, and just as ephemeral as the `/tmp` fallback it was meant to distinguish. No portable test tells a bind mount from a writable layer, so the field could hand back **exactly the false reassurance it was added to remove**, which is a worse failure than not having it.

Renamed to **`persistenceConfigured`**, which is the thing actually known — a decision an operator made — with `adopted` documented as the evidence: blobs found at open, so non-zero after a restart is the pool having genuinely survived one. The boot line stops saying "durable" and names the condition instead:

```
serve: catalog blob cache at /catalog-cache (cap 8192 MB) — it survives a restart only if that path is a mounted volume
```

## The clear response dropped the alarming value

`DELETE /admin/catalog-cache` serialised with the bare `Json` companion, whose `encodeDefaults` is off, while `/status.json` uses `JSON = Json { encodeDefaults = true }`. Any field sitting at its declared default was therefore omitted from the clear response — including `persistenceConfigured: false`, the value that matters, on exactly the pools that need it said. Now uses the same encoder, so the two agree in shape.

## Test plan

- `./gradlew ktfmtFormatAll` then `:cli:test ktfmtCheckAll` — **2,753 tests, 0 failures**, BUILD SUCCESSFUL.
- Existing `CatalogBlobPoolTest` coverage updated to the new name; it already asserts a temp pool reports `false`, a configured one `true`, and that `adopted` is 0 for a fresh volume, 1 for a pool reopened over a written one, and fixed at open rather than tracking later writes.

Also worth noting: `ServeWebFixtureTest`, which was failing on clean `main` at `af67516` when I opened #4362, is green on this base (`2b11542`) — the golden drift has been regenerated in the meantime, so there is no longer a pre-existing failure to work around.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_