### PR TITLE
fix(serve): accept installation tokens and meter image-lane verification

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -721,7 +721,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
 
   /** Uploads per minute per GitHub account (`--image-rate-limit`); `0` disables the budget. */
   private val imageRateLimit: Int =
-    args.flagValue("--image-rate-limit")?.toIntOrNull() ?: DEFAULT_IMAGE_RATE_LIMIT
+    args.flagValue("--image-rate-limit")?.toIntOrNull()?.takeIf { it >= 0 }
+      ?: DEFAULT_IMAGE_RATE_LIMIT
 
   /**
    * The parsed `--catalogs-file`, or the empty config when none is set / it can't be read. A
@@ -1633,6 +1634,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         !imageLaneConfigured &&
         adminToken == null
     ) {
+      // An `--accept-images` that couldn't be configured is why we may be here at all, and the
+      // generic line below would tell the operator that flag wasn't set — which they know is false.
+      // Name the missing argument first, before the message that reads as if nothing was asked for.
+      if (acceptImages) System.err.println(IMAGE_LANE_NO_REPO)
       System.err.println(
         "serve: nothing to serve — no --bundle / --bundles / --catalogs registered a session, and " +
           "none of --accept-bundles / --accept-docs / --accept-images / --admin-token is set."
@@ -1782,10 +1787,7 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     if (!acceptImages) return null
     val repository = imageUploadRepository
     if (repository.isNullOrBlank()) {
-      System.err.println(
-        "serve: --accept-images needs a repository to check uploader access against. Pass " +
-          "--image-upload-repo <owner/repo> (or configure --github-auth-repo). Image lane disabled."
-      )
+      System.err.println(IMAGE_LANE_NO_REPO)
       return null
     }
     System.err.println(
@@ -4612,6 +4614,17 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
      * runaway loop is paced rather than allowed to churn the store. 0 turns the budget off.
      */
     const val DEFAULT_IMAGE_RATE_LIMIT = 60
+
+    /**
+     * Why the image lane didn't start. One constant because two places say it: [openImageLane] when
+     * the rest of the server is coming up anyway, and the nothing-to-serve exit, whose own message
+     * would otherwise be the only thing an operator of a pure image host ever sees — and it reads
+     * as "you didn't ask for a lane" when what happened is "the lane you asked for needs one more
+     * argument".
+     */
+    const val IMAGE_LANE_NO_REPO =
+      "serve: --accept-images needs a repository to check uploader access against. Pass " +
+        "--image-upload-repo <owner/repo> (or configure --github-auth-repo). Image lane disabled."
 
     /**
      * Uploads one account may have in flight at once. One: each upload is a memory write that

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt
@@ -644,11 +644,52 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
     repository: String,
     allowedUsers: Set<String> = emptySet(),
   ): Result<GitHubOAuthUser> = runCatching {
-    val login = fetchLogin(token)
+    // Null when `/user` refuses the credential, which is the normal answer for a GitHub **App
+    // installation** token rather than a sign of a bad one — see [verifyInstallationToken].
+    val login = runCatching { fetchLogin(token) }.getOrNull()
+    if (login == null) return@runCatching verifyInstallationToken(token, repository, allowedUsers)
     if (allowedUsers.isNotEmpty() && login.lowercase() !in allowedUsers) {
       error("GitHub user $login is not allowed")
     }
     GitHubOAuthUser(login, repositoryAccess = fetchRepositoryAccess(token, repository, login))
+  }
+
+  /**
+   * The other kind of credential a CI caller actually holds: a **GitHub App installation token** —
+   * what `${'$'}{{ github.token }}` / `GITHUB_TOKEN` is inside every GitHub Actions job.
+   *
+   * There is no user behind one, so `GET /user` answers `403 Resource not accessible by
+   * integration` and the user path above can't decide anything about it. What it *can* do is read
+   * the repositories its installation covers, and `GET /repos/{owner}/{repo}` reports the
+   * installation's own `permissions` — which is the grant that matters here: a workflow token
+   * carrying `contents: write` on the gating repo was deliberately given that by the repo's own
+   * configuration.
+   *
+   * Two deliberate narrowings against the user path:
+   * - **Write, always**, public or private. The private-repo "any real grant counts" reasoning is
+   *   about a *person* somebody let in; a machine credential scoped by a workflow file is not that,
+   *   and a read-only workflow token (what a fork's pull_request run gets) must not be able to post
+   *   to the host.
+   * - **Refused outright when the operator narrowed sign-in** with `--github-auth-users`. That list
+   *   names people; an installation token is nobody on it, and silently admitting one would widen a
+   *   gate whose whole point is to be narrow.
+   *
+   * The identity returned is [INSTALLATION_LOGIN] rather than a name, because there isn't one: an
+   * installation token cannot read `GET /app` (that needs the app's JWT). The audit trail says
+   * "some app installation with write on this repo", which is exactly what was verified.
+   */
+  private fun verifyInstallationToken(
+    token: String,
+    repository: String,
+    allowedUsers: Set<String>,
+  ): GitHubOAuthUser {
+    if (allowedUsers.isNotEmpty()) {
+      error("this host admits only named GitHub users, and that is not a user credential")
+    }
+    val permissions =
+      repositoryView(token, repository)?.permissions
+        ?: error("credential is not a GitHub user, and cannot read $repository as an installation")
+    return GitHubOAuthUser(INSTALLATION_LOGIN, repositoryAccess = permissions.write())
   }
 
   private fun exchangeCode(
@@ -787,6 +828,13 @@ class GitHubOAuthVerifier(private val client: OkHttpClient = OkHttpClient()) {
      * costs nothing and survives GitHub widening the legacy field.
      */
     private val WRITE_PERMISSIONS = setOf("admin", "maintain", "write")
+
+    /**
+     * The identity a verified **installation** token is attributed to. Not a login — no user is
+     * behind one — and shaped so it can never collide with a real GitHub login, which cannot
+     * contain a bracket.
+     */
+    const val INSTALLATION_LOGIN = "[app-installation]"
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2157,22 +2157,23 @@ class ServeHttpServer(
     auth: ServeImageUploadAuth,
   ) {
     if (rejectBadToken()) return
-    val login = authorizeImageUpload(auth) ?: return
+    // **Before** the identity check, keyed by address: verifying a token is a synchronous call to
+    // GitHub, so an unauthenticated caller spraying unique invalid tokens would otherwise spend one
+    // of this host's outbound requests and one of its threads per guess — and neither the
+    // fingerprint cache (every value is new) nor the per-login budget below (never reached) bounds
+    // that. This is the only budget an anonymous caller is ever charged against.
+    val verifyPermit = acquireImagePermit(rateLimitKey()) ?: return
+    val login =
+      try {
+        authorizeImageUpload(auth)
+      } finally {
+        // Released as soon as the GitHub round-trip is done rather than at the end of the request:
+        // it exists to bound *verification*, and the accepted upload below has its own budget.
+        verifyPermit.release()
+      } ?: return
     // Per-caller budget, keyed by the *verified* login rather than by client address: the address
     // of an agent in CI is shared or ephemeral, and the identity is the thing we actually know.
-    val permit =
-      when (val decision = imageUploadLimiter?.tryAcquire(login)) {
-        is ServeRateLimiter.Decision.Throttled -> {
-          call.response.headers.append(
-            HttpHeaders.RetryAfter,
-            decision.retryAfterSeconds.toString(),
-          )
-          call.respondText(decision.reason, status = HttpStatusCode.TooManyRequests)
-          return
-        }
-        is ServeRateLimiter.Decision.Admitted -> decision
-        null -> null
-      }
+    val permit = acquireImagePermit("gh:$login") ?: return
     try {
       val name = call.request.queryParameters["name"]
       // Cap the body as it streams in — receiving it whole first would let a client OOM the server
@@ -2232,7 +2233,28 @@ class ServeHttpServer(
           call.respondText(result.reason, status = HttpStatusCode.BadRequest)
       }
     } finally {
-      permit?.release()
+      permit.release()
+    }
+  }
+
+  /**
+   * Charge one unit of image-lane work to [key], answering `429` + `Retry-After` and returning null
+   * when the caller is over budget. A non-null result MUST be released.
+   *
+   * Returns a no-op permit when the operator disabled the budget, so a call site never has to
+   * distinguish "admitted" from "unmetered".
+   */
+  private suspend fun RoutingContext.acquireImagePermit(
+    key: String
+  ): ServeRateLimiter.Decision.Admitted? {
+    val limiter = imageUploadLimiter ?: return ServeRateLimiter.Decision.Admitted {}
+    return when (val decision = limiter.tryAcquire(key)) {
+      is ServeRateLimiter.Decision.Admitted -> decision
+      is ServeRateLimiter.Decision.Throttled -> {
+        call.response.headers.append(HttpHeaders.RetryAfter, decision.retryAfterSeconds.toString())
+        call.respondText(decision.reason, status = HttpStatusCode.TooManyRequests)
+        null
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuth.kt
@@ -10,6 +10,15 @@ import java.util.concurrent.ConcurrentHashMap
  * anonymous — not even on a `--public` box, where every *browsing* surface is open. A caller must
  * present a GitHub credential that GitHub itself says has real access to the operator's repository.
  *
+ * ## What counts as a credential
+ *
+ * Both kinds a headless caller actually holds:
+ * - A **user token** — `gh auth token`, a PAT — verified as that user, against the same repo-access
+ *   rule the playground applies.
+ * - A **GitHub App installation token**, which is what `${'$'}{{ github.token }}` is inside a
+ *   GitHub Actions job. There is no user behind one, so it is verified on the installation's own
+ *   write permission on the gating repo and attributed to [GitHubOAuthVerifier.INSTALLATION_LOGIN].
+ *
  * ## Why a bearer token and not the OAuth session
  *
  * [ServeGithubAuth] already gates the playground on a signed-in GitHub account, and reusing it here

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageRoutingTest.kt
@@ -40,6 +40,9 @@ class ServeImageRoutingTest {
     override fun identify(bearerToken: String?): ServeImageUploadAuth.Identity {
       val token =
         bearerToken?.takeIf { it.isNotBlank() } ?: return ServeImageUploadAuth.Identity.Missing
+      // Stands in for the GitHub round-trip the real gate makes: what the pre-auth budget exists
+      // to bound is how often this runs at all.
+      verifications.incrementAndGet()
       collaborators[token]?.let {
         return ServeImageUploadAuth.Identity.Ok(it)
       }
@@ -55,6 +58,9 @@ class ServeImageRoutingTest {
     companion object {
       const val TOKEN = "gho_collaborator"
       const val OUTSIDER_TOKEN = "gho_outsider"
+
+      /** How many credentials have been verified, across every instance. */
+      val verifications = java.util.concurrent.atomic.AtomicInteger()
     }
   }
 
@@ -105,6 +111,26 @@ class ServeImageRoutingTest {
       .also { it.start() }
   }
 
+  /**
+   * A fourth host for the spray test, with a budget of its own. The pre-auth budget is keyed by
+   * address, so two tests sharing one limiter would be sharing one bucket — and would pass or fail
+   * on the order they happened to run in.
+   */
+  private val sprayServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = "unused-in-public",
+        sessions = ServeSessionRegistry(open = { null }),
+        defaultSessionId = "none",
+        isPublic = true,
+        imageStore = ServeImageStore(ttlSeconds = 60, clock = { now }),
+        imageUploadAuth = FakeAuth(),
+        imageUploadLimiter = ServeRateLimiter(permitsPerWindow = 1, windowSeconds = 60),
+      )
+      .also { it.start() }
+  }
+
   private val client = OkHttpClient()
 
   @AfterTest
@@ -112,6 +138,7 @@ class ServeImageRoutingTest {
     runCatching { server.stop() }
     runCatching { plainServer.stop() }
     runCatching { meteredServer.stop() }
+    runCatching { sprayServer.stop() }
     runCatching { registry.close() }
   }
 
@@ -223,6 +250,25 @@ class ServeImageRoutingTest {
       assertEquals(429, response.code)
       assertNotNull(response.header("Retry-After"))
     }
+  }
+
+  @Test
+  fun `an unauthenticated token spray is throttled before it reaches github`() {
+    // The budget an anonymous caller is charged against is taken BEFORE the identity check, keyed
+    // by address — otherwise each unique bad token buys a synchronous GitHub round-trip on this
+    // host's outbound connection, which neither the fingerprint cache nor the per-login budget can
+    // bound.
+    val attempted = FakeAuth.verifications.get()
+    upload(bearer = "gho_spray_1", port = sprayServer.port).use { assertEquals(401, it.code) }
+    upload(bearer = "gho_spray_2", port = sprayServer.port).use { response ->
+      assertEquals(429, response.code)
+      assertNotNull(response.header("Retry-After"))
+    }
+    assertEquals(
+      1,
+      FakeAuth.verifications.get() - attempted,
+      "the second spray attempt must not have reached the verifier",
+    )
   }
 
   @Test

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2499,14 +2499,24 @@ curl -sS -H "Authorization: Bearer $(gh auth token)" \
   bar is the same one the playground applies ([`GitHubOAuthVerifier`](../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeGithubAuth.kt)):
   write access on a public repo, any real grant on a private one. No access, no upload — `403`.
 - It is a **bearer token, not the OAuth cookie**, because the whole audience is headless: a CI job or
-  a cloud coding session holding a `GITHUB_TOKEN`, not a browser that can round-trip a redirect. That
-  also means the lane needs no OAuth app — a box with no `--github-auth-*` config at all can run it,
+  a cloud coding session holding a token, not a browser that can round-trip a redirect. That also
+  means the lane needs no OAuth app — a box with no `--github-auth-*` config at all can run it,
   given a repository to check against. Without a repository it **refuses to start**, loudly: a gate
   with nothing to check is not a gate.
+- **Both kinds of token a headless caller actually has** are accepted. A *user* token (`gh auth
+  token`, a PAT) is verified as that user. A *GitHub App installation* token — what
+  `${{ github.token }}` is inside every Actions job — has no user behind it, so `GET /user` refuses
+  it; it is verified instead on the installation's own **write** permission on the gating repo and
+  attributed to `[app-installation]`. Two narrowings there: write is required whether the repo is
+  public or private (a fork's read-only workflow token must not be able to post), and an
+  installation token is refused outright when `--github-auth-users` narrows sign-in, since that list
+  names people.
 - The token is used for two GitHub reads and dropped. It is never stored, logged, or echoed back; the
   verification cache is keyed by its SHA-256.
-- Per-account budget, default 60 uploads/minute (`--image-rate-limit`, `0` disables). It bounds both
-  the obvious abuse and the GitHub API calls an uncached upload costs.
+- Two budgets, both from `--image-rate-limit` (default 60/minute, `0` disables). The first is
+  charged **before** verification and keyed by client address — verifying costs a synchronous call
+  to GitHub, so a spray of unique invalid tokens must not buy one outbound request per guess. The
+  second is charged per verified account, which is what bounds a real caller across addresses.
 
 **Who may read: anyone with the link, deliberately.** This is the one asymmetry in the lane and it is
 load-bearing. GitHub renders an embedded image by fetching it through its own proxy, **anonymously**


### PR DESCRIPTION
Follow-up to #4366, which merged while these were being written. Four findings from the Codex review of that PR — two of them real holes in the gate.

### Installation tokens were refused before access was ever checked (P1)

A GitHub App **installation** token — what `${{ github.token }}` is inside every Actions job, and a credential the lane advertises — has no user behind it, so `GET /user` answers `403 Resource not accessible by integration` and verification failed there, before repository access was consulted. The primary CI caller could not use the lane at all.

It is now verified on what an installation token *can* prove: the installation's own `permissions` on the gating repo, read from `GET /repos/{owner}/{repo}`. Two deliberate narrowings against the user path:

- **Write is required whether the repo is public or private.** The "any real grant counts on a private repo" reasoning is about a person somebody let in; a workflow token scoped by a YAML file is not that, and a fork's read-only `pull_request` token must not be able to post to the host.
- **Refused outright when `--github-auth-users` narrows sign-in.** That list names people; an installation token is nobody on it.

Attributed to `[app-installation]` — not a login, because there isn't one (an installation token can't read `GET /app`), and shaped so it can never collide with a real login.

### Verification itself was unmetered (P1)

The per-login budget was only charged *after* a caller was identified, so a stream of unique invalid bearer tokens reached the synchronous GitHub call every time — one outbound request and one blocked thread per guess, and the fingerprint cache can't help when every value is new.

Uploads now take a budget keyed by **client address before verification** (released as soon as the round-trip finishes), and the per-account one after. Same `--image-rate-limit`, two key spaces. `an unauthenticated token spray is throttled before it reaches github` asserts the verifier is not reached a second time, not merely that the response is a 429.

### Two smaller ones

- A **negative** `--image-rate-limit` silently disabled the limiter, where only `0` is documented to — a typo in a deployment variable could leave the lane unmetered. Now validated like `--playground-rate-limit`.
- A pure image host started with `--accept-images` but no repository exited saying *none of the opt-in flags was set*, which the operator knows is false, and the actionable "pass `--image-upload-repo`" line never printed because the exit came first. Both sites now share one message, and it prints before the generic one.

### Two findings not taken

- **"Publish the image lane in the consumer skill."** Operator flags for running a serve host are documented in `docs/public-preview-server.md`, not in `yschimke/skills` — that's where `--accept-docs`, `--accept-bundles` and every `--playground-*` flag live, and the skill tracks the *released* CLI. This flag isn't in a release yet, so consumer-facing guidance for it belongs with that release rather than ahead of it. The agent-facing half (how to upload a render and embed it in a PR) is worth a skill section once the CLI ships it.
- **`rc-cmp-wasm-parity` "the comparison did not produce a report"** on the previous head: non-blocking, and this change touches no renderer, Compose, or wasm code.

## Test plan

- `:cli:test --tests '*ServeImage*' --tests '*CliFlag*'` green on this base (20 image-lane tests, up from 19).
- Full `:cli:test` was green on the pre-rebase tree except `ServeWebFixtureTest`'s `serve-design-page.html` golden, which also fails on a clean `origin/main` — verified by stashing.
- Not exercised end to end here: the sandbox's egress proxy rewrites GitHub API auth, so neither token path can be verified live from this container. The installation path is the documented `GET /repos` permissions read, and it shares `repositoryView` with the user path that already ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm56KASJ2s6kiHn82J1y2v)_