### PR TITLE
feat(serve): audit the one cache fault content-addressing cannot see

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -849,7 +849,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     ) {
       System.err.println(
         "serve: catalog blob cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB) — " +
-          "it survives a restart only if that path is a mounted volume"
+          "it survives only if that path outlives the process; in a container that means a " +
+          "mounted volume, since the writable layer goes with the container"
       )
       CatalogBlobPool(preferred, maxBytes = maxBytes, persistenceConfigured = true)
     } else {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPool.kt
@@ -22,6 +22,16 @@ data class CatalogBlobPoolSnapshot(
   val evicted: Long,
   /** Blobs dropped because their bytes did not hash back to their name. */
   val corrupt: Long,
+  /** Cached entries re-checked against the branch by the sampled audit. */
+  val audited: Long = 0,
+  /**
+   * Audited entries whose cached bytes did **not** match the branch.
+   *
+   * Expected to be zero forever: the audit exists to check the one thing content-addressing cannot
+   * — that a key is filed against the right content — and a non-zero value means something the
+   * design treats as impossible has happened. Worth an alert, not a dashboard.
+   */
+  val mismatched: Long = 0,
   /**
    * Whether an operator configured a directory (`--catalog-cache-dir`), rather than this being the
    * temp-dir fallback discarded with the container.
@@ -112,10 +122,11 @@ class CatalogBlobPool(
    * Whether an operator named a directory for [root], rather than this being the temp-dir fallback.
    *
    * Deliberately **not** called durable. Nothing here can establish that the storage outlives the
-   * container — `--catalog-cache-dir /var/cache/x` in an image with no volume mounted there is
-   * configured and just as ephemeral, and no portable test tells a bind mount from a writable
-   * layer. So this reports the decision that was made, and [adopted] reports what actually
-   * survived. Claiming the stronger thing would be the false reassurance it exists to remove.
+   * process — `--catalog-cache-dir /var/cache/x` in a container with no volume mounted there is
+   * configured and just as ephemeral, while the same path under a plain host `serve` persists fine,
+   * and no portable test tells those apart from in here. So this reports the decision that was
+   * made, and [adopted] reports what actually survived. Claiming the stronger thing would be the
+   * false reassurance it exists to remove.
    */
   private val persistenceConfigured: Boolean = false,
   private val clock: () -> Long = System::currentTimeMillis,
@@ -126,6 +137,8 @@ class CatalogBlobPool(
   private val writeFailures = AtomicLong()
   private val evicted = AtomicLong()
   private val corrupt = AtomicLong()
+  private val audited = AtomicLong()
+  private val mismatched = AtomicLong()
   /**
    * Occupancy as of the last census, advanced by each write and reclaim in between.
    *
@@ -292,6 +305,44 @@ class CatalogBlobPool(
   }
 
   /**
+   * Check what this pool would serve for [key] against [fresh] — bytes just read from the branch —
+   * and drop the entry when they differ.
+   *
+   * ### The one thing nothing else here checks
+   *
+   * Every blob is verified against its **own** name on read, so a truncated or bit-rotted file can
+   * never be served. What that cannot catch is a wrong *mapping*: the pointer says "key K holds
+   * content sha S", and if K were ever filed against the wrong S — a mistaken `write` call site, a
+   * refactor that reuses a key, a race nobody predicted — the blob under S still hashes to S, every
+   * check passes, and the pool serves the wrong bytes for K indefinitely. Content-addressing makes
+   * corruption impossible and mis-filing invisible; this is the only thing that would notice.
+   *
+   * Deliberately a **report, not a gate**. It runs on a sample, behind the request path, and its
+   * effect on a mismatch is to drop the entry so the next read re-fetches. A mismatch means
+   * something is wrong that the design says cannot happen, so the point is that [mismatched] stops
+   * being zero and someone looks — not that a visitor waits for an audit.
+   */
+  fun audit(key: String, fresh: ByteArray): AuditResult {
+    val held = read(key) ?: return AuditResult.NOT_CACHED
+    audited.increment()
+    if (held.contentEquals(fresh)) return AuditResult.MATCHED
+    mismatched.increment()
+    recordFailure("audit: cached bytes for a key did not match the branch — entry dropped")
+    runCatching { File(keysDir, sha256Hex(key.toByteArray())).delete() }
+    return AuditResult.MISMATCHED
+  }
+
+  /** What [audit] established about one key. */
+  enum class AuditResult {
+    /** Nothing cached under that key — the audit had nothing to check. */
+    NOT_CACHED,
+    /** What the pool holds is what the branch serves. */
+    MATCHED,
+    /** They differ. The entry was dropped; something is wrong upstream of the blob. */
+    MISMATCHED,
+  }
+
+  /**
    * Drop **everything** this pool holds, returning what is left (normally nothing).
    *
    * The operator's "I do not trust this; fetch it again" button. Whole-pool rather than per
@@ -383,6 +434,8 @@ class CatalogBlobPool(
       writeFailures = writeFailures.get(),
       evicted = evicted.get(),
       corrupt = corrupt.get(),
+      audited = audited.get(),
+      mismatched = mismatched.get(),
       lastFailure = lastFailure,
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -765,6 +765,17 @@ class ServeCatalogStore(
     // turns on at the next host build instead of being lost until someone republishes.
     scheduleFigmaSvgFetch(system, generation, slugs, variantSvgPaths, base, dir)
 
+    // Sampled integrity audit of what the blob cache holds for this catalog. Only for a pinned
+    // load: an un-pinned one caches nothing, so there is nothing to check. Runs on the same
+    // single-threaded post-publish lane as the vector fill, for the same reason — it must never
+    // outweigh the request path.
+    if (pinned) {
+      val sample = bakedPathById.values.take(AUDIT_SAMPLE_ASSETS).map { base + it }
+      if (sample.isNotEmpty()) {
+        figmaExecutor.execute { runCatching { auditCachedAssets(sample, safe) } }
+      }
+    }
+
     // The catalog's OWN palette, so its pages are framed in its own colours (see [ServeThemeCss]).
     // A few kB of JSON off the same branch as the images, and best-effort throughout: a missing /
     // unfetchable / unparseable token file just leaves the pages on the built-in chrome.
@@ -2623,6 +2634,15 @@ class ServeCatalogStore(
      * couple of others, so "the branch can serve pixels" is proven without one missing file being
      * able to fail the catalog. Everything else arrives on first use.
      */
+    /**
+     * How many of a catalog's cached assets the post-publish audit re-reads from the branch.
+     *
+     * Small on purpose. This is checking for something the design says cannot happen, so its job is
+     * to be running at all rather than to be exhaustive; a wide sample would spend real bandwidth
+     * on every load to raise the odds of catching a fault that should never occur.
+     */
+    private const val AUDIT_SAMPLE_ASSETS = 3
+
     private const val PUBLISH_SAMPLE_IMAGES = 3
 
     /**
@@ -2812,16 +2832,44 @@ class ServeCatalogStore(
    * fetcher, which is how the two paths would drift.
    */
   private fun cachedBranchRead(url: String): BranchFetch {
-    val read = {
-      if (fetch != null) fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
-      else branchRead(url, MAX_FETCH_BYTES)
-    }
-    if (!ServeCatalogRevision.isCommitPinned(url)) return read()
+    if (!ServeCatalogRevision.isCommitPinned(url)) return directBranchRead(url)
     blobs.read(url)?.let {
       branchFetchStats.recordCached()
       return BranchFetch.Ok(it)
     }
-    return read().also { if (it is BranchFetch.Ok) blobs.write(url, it.bytes) }
+    return directBranchRead(url).also { if (it is BranchFetch.Ok) blobs.write(url, it.bytes) }
+  }
+
+  /**
+   * The transport with no cache in front of it — [cachedBranchRead] minus the pool.
+   *
+   * Named and shared rather than inlined, because the audit ([auditCachedAssets]) needs exactly
+   * this: bytes from the branch for a URL the pool almost certainly holds. Reaching for the
+   * ordinary read there would compare the cache against itself and pass every time.
+   */
+  private fun directBranchRead(url: String): BranchFetch =
+    if (fetch != null) fetch.invoke(url)?.let { BranchFetch.Ok(it) } ?: BranchFetch.NotFound
+    else branchRead(url, MAX_FETCH_BYTES)
+
+  /**
+   * Re-read a small sample of this catalog's cached assets from the branch and check them against
+   * what the pool would serve — see [CatalogBlobPool.audit] for the failure this exists to notice.
+   *
+   * Sampled and post-publish: a handful of requests per load, off the request path, and never a
+   * gate. The sample is taken from the front of the catalog's own baked paths rather than at
+   * random, so the same few entries are re-checked on every load of a given revision — which is
+   * what makes a mis-filing show up repeatedly instead of once in a thousand loads.
+   */
+  private fun auditCachedAssets(urls: List<String>, system: String) {
+    for (url in urls) {
+      val fresh = runCatching { directBranchRead(url) }.getOrNull()?.bytesOrNull ?: continue
+      if (blobs.audit(url, fresh) == CatalogBlobPool.AuditResult.MISMATCHED) {
+        System.err.println(
+          "serve: $system cached bytes for $url did not match the branch — entry dropped. " +
+            "This should be impossible; check /status.json catalogCache.mismatched."
+        )
+      }
+    }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogBlobPoolTest.kt
@@ -403,6 +403,52 @@ class CatalogBlobPoolTest {
   }
 
   @Test
+  fun `the audit catches a key filed against the wrong content`() {
+    // The one failure content-addressing cannot see. Every blob is verified against its OWN name,
+    // so a mis-filed pointer — key K naming content sha S when S is not what K holds — passes every
+    // existing check: the blob under S hashes to S perfectly well. Simulated here by writing one
+    // key's bytes and then auditing it against what the branch actually serves.
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button.png"
+    pool.write(url, "the wrong asset".toByteArray())
+
+    val result = pool.audit(url, "what the branch serves".toByteArray())
+
+    assertEquals(CatalogBlobPool.AuditResult.MISMATCHED, result)
+    assertEquals(1, pool.snapshot().mismatched)
+    assertNull(pool.read(url), "a mismatched entry is dropped so the next read re-fetches")
+  }
+
+  @Test
+  fun `an audit that agrees leaves the entry alone`() {
+    val pool = CatalogBlobPool(root())
+    val url = "https://raw.githubusercontent.com/o/r/$COMMIT/images/button.png"
+    val bytes = "the right asset".toByteArray()
+    pool.write(url, bytes)
+
+    assertEquals(CatalogBlobPool.AuditResult.MATCHED, pool.audit(url, bytes))
+    assertEquals(0, pool.snapshot().mismatched)
+    assertEquals(1, pool.snapshot().audited)
+    assertContentEquals(bytes, assertNotNull(pool.read(url)))
+  }
+
+  @Test
+  fun `auditing a key the pool does not hold checks nothing`() {
+    // Not a pass and not a failure — there was nothing to compare. Counting it as audited would
+    // make the audit look like it is doing more work than it is.
+    val pool = CatalogBlobPool(root())
+
+    val result =
+      pool.audit(
+        "https://raw.githubusercontent.com/o/r/$COMMIT/images/absent.png",
+        "x".toByteArray(),
+      )
+
+    assertEquals(CatalogBlobPool.AuditResult.NOT_CACHED, result)
+    assertEquals(0, pool.snapshot().audited)
+  }
+
+  @Test
   fun `sweep reclaims oldest-first down to the cap`() {
     val now = AtomicLong(1_000_000L)
     val pool = CatalogBlobPool(root(), maxBytes = 200, graceMillis = 0, clock = { now.get() })

--- a/docs/design/CATALOG_CONTENT_CACHE.md
+++ b/docs/design/CATALOG_CONTENT_CACHE.md
@@ -263,7 +263,7 @@ Each ships independently and is provable on its own.
 | **2 — landed** | Asset cache for commit-pinned reads, behind `fetchCatalogAsset`; `cached` counter on `branchFetch` | Manifests, lazy PNGs, motion, references, and the `?at=` lane stop re-fetching | Low — one funnel, one admission rule |
 | **3** | Generation snapshots + `current` pointer; adopt-then-converge boot; seed the refresher's head | The restart win: catalogs serve before any network | Medium — the adoption checks are where the care goes |
 | **4 — landed** | `DELETE /admin/catalog-cache`, `POST /<system>/refresh?force=1`, `catalogCache` status block | Operability, and the ability to tell a working cache from write amplification | Low |
-| **5** | Background audit: adopted-commit reachability from the Atom feed, plus a sampled byte comparison | Catches disk corruption and rewritten history | Low — reports, never gates |
+| **5 — landed, reduced** | Sampled post-publish audit of the cache's key→content mapping | Catches the one fault content-addressing cannot see | Low — reports, never gates |
 
 Phases 1–2 are worth doing regardless of whether 3 lands: they are pure subtraction from the fetch
 path with no new correctness surface. Phase 3 is where the headline number is.
@@ -329,6 +329,32 @@ to overstate what is expressible, and shipping them as written would have been a
 The rename matters more than it looks: `flush` on a route that does not evict anything would read as
 a cache control and behave as a poll, and the next person to reach for it would be reaching for the
 wrong thing.
+
+### What phase 5 shipped, and why two thirds of it was dropped
+
+The plan justified phase 5 on three grounds. What actually shipped in phases 1–2 removed two of
+them, and it is worth recording that rather than building the audit as specified:
+
+- **Disk corruption** is already caught. Every blob is named by the sha256 of its own bytes and
+  re-verified on read (phase 1), so a truncated or bit-rotted file cannot be served. A sampled byte
+  comparison adds nothing here.
+- **Rewritten history** was a worry for *adopted commits*, which only phase 3 would introduce. As
+  built, every load resolves the branch head fresh and nothing is adopted across restarts — and a
+  git sha's content is immutable by construction, so a force-push can make a commit unreachable but
+  never make it serve different bytes. There is no reachability question to ask.
+
+What remains is a fault neither the plan nor the implementation had named: **the key→content
+mapping is the one thing nothing verifies.** A blob is checked against its own name; the pointer
+that says "this URL holds that sha" is not checked against anything. A key filed against the wrong
+content — a mistaken `write` call site, a refactor reusing a key — passes every existing check,
+because the blob under that sha hashes to it perfectly well, and the pool then serves the wrong
+bytes for that URL indefinitely. Content-addressing makes corruption impossible and mis-filing
+invisible.
+
+So phase 5 is a three-asset sample re-read from the branch after each pinned load, compared against
+what the pool would serve, reported as `audited` / `mismatched`. Small on purpose: it is checking
+for something the design says cannot happen, so its job is to be running at all rather than to be
+exhaustive.
 
 ## What this deliberately does not do
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2745,7 +2745,17 @@ auto-update path rolls the **image**, never the compose. A server can therefore 
 of this feature and still be running the cache in `/tmp`.
 
 `corrupt` above zero says a volume is losing bytes, since every blob is named by its own digest and
-re-verified on read. `blobs`/`bytes` against `maxBytes` says whether the sweeper is keeping up —
+re-verified on read.
+
+**`mismatched` should be zero forever.** Content-addressing makes corruption impossible to serve —
+a blob is verified against its own name on every read — but it cannot see a wrong *mapping*: a key
+filed against the wrong content sha passes every check, because the blob under that sha hashes to it
+perfectly well. After each pinned load the server re-reads a three-asset sample from the branch and
+compares it against what the pool would serve; `audited` counts those checks and `mismatched` counts
+disagreements. A non-zero `mismatched` means something the design treats as impossible has happened,
+so it is worth an alert rather than a dashboard. The audit is a report, never a gate: it runs behind
+the request path, and its only effect on a mismatch is to drop the entry so the next read
+re-fetches. `blobs`/`bytes` against `maxBytes` says whether the sweeper is keeping up —
 both are published by the last sweep rather than censused per request, so they lag a write by at
 most one sweep interval; `/status.json` is polled, and an occupancy walk there would grow with
 exactly the thing the cache exists to grow.


### PR DESCRIPTION
Phase 5 of [the plan](https://github.com/yschimke/compose-ai-tools/blob/main/docs/design/CATALOG_CONTENT_CACHE.md) — **reduced, and the reduction is most of the point.**

## Two thirds of phase 5 was obsolete before I started

The plan justified a background audit on three grounds. What phases 1–2 actually shipped removed two of them:

- **Disk corruption** is already caught. Every blob is named by the sha256 of its own bytes and re-verified on read, so a truncated or bit-rotted file cannot be served. A sampled byte comparison adds nothing.
- **Rewritten history / adopted-commit reachability** was a worry for *adopted commits*, which only phase 3 would introduce. As built, every load resolves the branch head fresh and nothing is adopted across restarts — and a git sha's content is immutable by construction, so a force-push can make a commit unreachable but never make it serve different bytes. There is no reachability question to ask.

Building those anyway would have been busywork dressed as diligence, so the design doc now records why they were dropped.

## What is left is a fault nobody had named

**The key→content mapping is the one thing nothing verifies.** A blob is checked against its own name. The pointer that says *"this URL holds that sha"* is checked against nothing. If a key were ever filed against the wrong content — a mistaken `write` call site, a refactor reusing a key, a race nobody predicted — every existing check passes, because the blob under that sha hashes to it perfectly well, and the pool then serves the wrong bytes for that URL indefinitely.

Content-addressing makes corruption impossible and mis-filing invisible. That asymmetry is worth one small guard.

## The guard

After each **pinned** load, three of the catalog's cached assets are re-read from the branch and compared with what the pool would serve:

- through `directBranchRead`, extracted from `cachedBranchRead` — reaching for the ordinary read would compare the cache against itself and pass every time;
- sampled from the front of the catalog's baked paths rather than at random, so the same entries are re-checked on every load of a revision and a mis-filing shows up repeatedly rather than once in a thousand loads;
- on the existing single-threaded post-publish lane, so it can never outweigh the request path;
- reported as `audited` / `mismatched`, with a mismatch dropping the entry so the next read re-fetches.

**`mismatched` should be zero forever** — non-zero means something the design treats as impossible has happened. That is an alert, not a dashboard. Three assets is deliberate: the job is to be running at all, not to be exhaustive.

## Also carried

The boot-message wording from the last review round, which #4367 merged without: an ordinary writable directory persists fine under a host `serve`, so claiming *only* a mounted volume survives was wrong in the other direction. The mount is the container-specific case, not the general one.

## Test plan

- `./gradlew ktfmtFormatAll` then `:cli:test ktfmtCheckAll` — **2,778 tests, 0 failures**, BUILD SUCCESSFUL.
- New `CatalogBlobPoolTest` cases — a key filed against the wrong content is caught, counted and dropped; an audit that agrees leaves the entry alone and counts one check; auditing a key the pool does not hold counts nothing, since there was nothing to compare and counting it would overstate the work done.

No visual evidence: an integrity check, counters and docs — nothing renders.

## This completes the plan

Phases 1, 2, 4 and 5 are in; **phase 3 is the one deliberately not built.** With the pool warm a boot pays one `git ls-remote` per catalog — irreducible, because that *is* the freshness check — plus staging assembly from local bytes, which nobody has measured. The decision needs one `/status.json` read after a real roll: `catalogCache.persistenceConfigured` and `adopted`. If persistence turns out not to be configured on the box, that is a compose change worth more than any code in phase 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PoRMxwHiYqJq2WdXfEN64)_