### PR TITLE
fix(serve): stop the image lane's two budgets sharing a bucket

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1901,6 +1901,18 @@ class ServeHttpServer(
       ?.let {
         return "gh:$it"
       }
+    return clientAddressKey()
+  }
+
+  /**
+   * Who to charge **by address**, ignoring any signed-in identity — the key for work that happens
+   * before this request has an identity to charge, or that is deliberately metered per address.
+   *
+   * Separate from [rateLimitKey] because a lane that charges a caller twice — once before it knows
+   * who they are and once after — must not land both charges in the same bucket. It would halve the
+   * budget an operator configured, and at `--image-rate-limit 1` refuse every request.
+   */
+  private fun RoutingContext.clientAddressKey(): String {
     val forwarded =
       if (!trustForwardedFor) null
       else
@@ -2162,8 +2174,11 @@ class ServeHttpServer(
     // of this host's outbound requests and one of its threads per guess — and neither the
     // fingerprint cache (every value is new) nor the per-login budget below (never reached) bounds
     // that. This is the only budget an anonymous caller is ever charged against.
-    val verifyPermit = acquireImagePermit(rateLimitKey()) ?: return
-    val login =
+    // Address-only, never [rateLimitKey]: that one prefers a signed-in cookie login, which on a
+    // GitHub-auth host can be the same string the post-verification charge below uses — the two
+    // budgets would then share one bucket and halve what the operator configured.
+    val verifyPermit = acquireImagePermit(clientAddressKey()) ?: return
+    val identity =
       try {
         authorizeImageUpload(auth)
       } finally {
@@ -2171,9 +2186,11 @@ class ServeHttpServer(
         // it exists to bound *verification*, and the accepted upload below has its own budget.
         verifyPermit.release()
       } ?: return
-    // Per-caller budget, keyed by the *verified* login rather than by client address: the address
-    // of an agent in CI is shared or ephemeral, and the identity is the thing we actually know.
-    val permit = acquireImagePermit("gh:$login") ?: return
+    // Per-caller budget, charged to the *verified* identity rather than to the client address: the
+    // address of an agent in CI is shared or ephemeral, and the identity is the thing we actually
+    // know. The key comes from the gate, not from the login — see [Identity.Ok.budgetKey].
+    val permit = acquireImagePermit(identity.budgetKey) ?: return
+    val login = identity.login
     try {
       val name = call.request.queryParameters["name"]
       // Cap the body as it streams in — receiving it whole first would let a client OOM the server
@@ -2259,15 +2276,17 @@ class ServeHttpServer(
   }
 
   /**
-   * The verified GitHub login behind this upload, or null once the refusal has been written. Split
-   * out so the route reads as "who is this, then do the work" and the two refusal shapes (no
-   * credential vs. not good enough) stay in one place.
+   * The verified identity behind this upload, or null once the refusal has been written. Split out
+   * so the route reads as "who is this, then do the work" and the two refusal shapes (no credential
+   * vs. not good enough) stay in one place.
    */
-  private suspend fun RoutingContext.authorizeImageUpload(auth: ServeImageUploadAuth): String? {
+  private suspend fun RoutingContext.authorizeImageUpload(
+    auth: ServeImageUploadAuth
+  ): ServeImageUploadAuth.Identity.Ok? {
     val header = call.request.headers[HttpHeaders.Authorization]
     val bearer = header?.takeIf { it.startsWith("Bearer ", ignoreCase = true) }?.substring(7)
     return when (val identity = auth.identify(bearer)) {
-      is ServeImageUploadAuth.Identity.Ok -> identity.login
+      is ServeImageUploadAuth.Identity.Ok -> identity
       is ServeImageUploadAuth.Identity.Missing -> {
         call.response.headers.append(
           HttpHeaders.WWWAuthenticate,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuth.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuth.kt
@@ -49,8 +49,16 @@ interface ServeImageUploadAuth {
   fun identify(bearerToken: String?): Identity
 
   sealed interface Identity {
-    /** Verified: [login] has access to [repository]. */
-    data class Ok(val login: String) : Identity
+    /**
+     * Verified: [login] has access to [repository].
+     *
+     * [budgetKey] is who to charge for the upload, which is **not** always [login]. Every verified
+     * installation token shares one placeholder login (there is no user behind one), so keying a
+     * budget on that would put every GitHub App with write access to the gating repo in a single
+     * bucket — one app's batch would 429 another's. The key is therefore the credential's own
+     * fingerprint for those, and the login for a real user.
+     */
+    data class Ok(val login: String, val budgetKey: String = "gh:$login") : Identity
 
     /** No credential presented at all — answered `401`, with how to present one. */
     data object Missing : Identity
@@ -82,7 +90,13 @@ class GithubTokenUploadAuth(
   override val repository: String,
   /** When non-empty, only these logins may upload, whatever GitHub says about repo access. */
   private val allowedUsers: Set<String> = emptySet(),
-  private val verifier: GitHubOAuthVerifier = GitHubOAuthVerifier(),
+  /**
+   * The GitHub round-trip, as a function so a test can stand in for it: identity + repo access for
+   * a presented credential. Defaults to the real [GitHubOAuthVerifier], whose rule the playground
+   * already shares.
+   */
+  private val verifier: (String, String, Set<String>) -> Result<GitHubOAuthUser> =
+    GitHubOAuthVerifier()::verifyAccessToken,
   private val clock: () -> Long = System::currentTimeMillis,
 ) : ServeImageUploadAuth {
 
@@ -107,7 +121,7 @@ class GithubTokenUploadAuth(
       cache.entries.removeIf { it.value.expiresAtMillis <= now }
       if (cache.size >= MAX_CACHED_TOKENS) cache.clear()
     }
-    val identity = verify(token)
+    val identity = verify(token, key)
     val ttl =
       if (identity is ServeImageUploadAuth.Identity.Ok) POSITIVE_TTL_SECONDS
       else NEGATIVE_TTL_SECONDS
@@ -115,9 +129,9 @@ class GithubTokenUploadAuth(
     return identity
   }
 
-  private fun verify(token: String): ServeImageUploadAuth.Identity {
+  private fun verify(token: String, fingerprint: String): ServeImageUploadAuth.Identity {
     val user =
-      verifier.verifyAccessToken(token, repository, allowedUsers).getOrElse { error ->
+      verifier(token, repository, allowedUsers).getOrElse { error ->
         // The message is GitHub's or ours about GitHub — a status code, a "not allowed" — and never
         // contains the credential, which is the only thing that must not travel back out.
         return ServeImageUploadAuth.Identity.Refused(
@@ -133,7 +147,13 @@ class GithubTokenUploadAuth(
             "Uploading preview images is limited to that repository's collaborators.",
       )
     }
-    return ServeImageUploadAuth.Identity.Ok(user.login)
+    // An installation has no login to charge, so it is charged as the credential it presented.
+    // A GitHub Actions token rotates hourly, so its bucket rotates with it — which is the right
+    // granularity anyway: one workflow run, one budget.
+    val budgetKey =
+      if (user.login == GitHubOAuthVerifier.INSTALLATION_LOGIN) "app:${fingerprint.take(16)}"
+      else "gh:${user.login}"
+    return ServeImageUploadAuth.Identity.Ok(user.login, budgetKey)
   }
 
   /** SHA-256, hex — a stable cache key that is not the credential it stands for. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageUploadAuthTest.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the gate charges an upload to, which is not always who it says uploaded.
+ *
+ * The verification *rules* live in [GitHubOAuthVerifier] and need GitHub to exercise; what is
+ * pinned here is the part that is this lane's own decision — that two GitHub App installations,
+ * which necessarily share one placeholder login, do not share one rate-limit bucket.
+ */
+class ServeImageUploadAuthTest {
+
+  private fun auth(users: Map<String, GitHubOAuthUser>) =
+    GithubTokenUploadAuth(
+      repository = "yschimke/compose-ai-tools",
+      verifier = { token, _, _ ->
+        users[token]?.let { Result.success(it) }
+          ?: Result.failure(IllegalStateException("user lookup failed: 401"))
+      },
+    )
+
+  @Test
+  fun `a user is charged to their login`() {
+    val gate = auth(mapOf("t" to GitHubOAuthUser("octocat", repositoryAccess = true)))
+    val ok = gate.identify("t") as ServeImageUploadAuth.Identity.Ok
+    assertEquals("octocat", ok.login)
+    assertEquals("gh:octocat", ok.budgetKey)
+  }
+
+  @Test
+  fun `two app installations share a login but not a budget`() {
+    val installation = GitHubOAuthUser(GitHubOAuthVerifier.INSTALLATION_LOGIN, true)
+    val gate = auth(mapOf("app-one" to installation, "app-two" to installation))
+    val first = gate.identify("app-one") as ServeImageUploadAuth.Identity.Ok
+    val second = gate.identify("app-two") as ServeImageUploadAuth.Identity.Ok
+    assertEquals(first.login, second.login, "there is no user behind either")
+    assertNotEquals(
+      first.budgetKey,
+      second.budgetKey,
+      "one app exhausting its budget must not 429 another",
+    )
+    // The key stands for the credential, and must not be the credential.
+    assertTrue(first.budgetKey.startsWith("app:"), first.budgetKey)
+    assertTrue("app-one" !in first.budgetKey, first.budgetKey)
+  }
+
+  @Test
+  fun `an unverifiable credential is refused, and a missing one is not the same thing`() {
+    val gate = auth(emptyMap())
+    assertEquals(ServeImageUploadAuth.Identity.Missing, gate.identify(null))
+    assertEquals(ServeImageUploadAuth.Identity.Missing, gate.identify("   "))
+    val refused = gate.identify("bad") as ServeImageUploadAuth.Identity.Refused
+    assertEquals(401, refused.status)
+    assertTrue("bad" !in refused.reason, "the credential must never travel back out")
+  }
+
+  @Test
+  fun `an account without repository access is a distinct refusal`() {
+    val gate = auth(mapOf("t" to GitHubOAuthUser("stranger", repositoryAccess = false)))
+    val refused = gate.identify("t") as ServeImageUploadAuth.Identity.Refused
+    assertEquals(403, refused.status)
+    assertTrue(refused.reason.contains("stranger"), refused.reason)
+  }
+}


### PR DESCRIPTION
Follow-up to #4368, which merged while these were being written. Two findings from its review, both in the metering added there.

### The two budgets could land in one bucket

The pre-verification charge used `rateLimitKey()`, which prefers a signed-in cookie login over the client address. On a GitHub-auth host where that login is the same string as the bearer identity, both charges hit the same bucket — halving the budget the operator configured, and refusing *every* upload at `--image-rate-limit 1`.

It now uses a new `clientAddressKey()`, which is what "keyed by address" was always meant to mean. `rateLimitKey()` delegates to it for its own fallback, so nothing else changes.

### Every app installation shared one bucket

A verified installation token is attributed to `[app-installation]` because there is no user behind one — but keying the per-caller budget on that put every GitHub App with write access to the gating repo into a single bucket and a single concurrency slot, so one app's batch would `429` another's.

The gate now hands the route a **budget key** alongside the login: the login for a real user, the credential's own fingerprint for an installation. An Actions token rotates hourly, so its bucket rotates with it — which is the right granularity anyway: one workflow run, one budget. The key is derived from the fingerprint, never the credential itself.

To test that without reaching GitHub, `GithubTokenUploadAuth`'s verifier is now injected as a function rather than a class.

### New tests

`ServeImageUploadAuthTest` (4): a user is charged to their login; two installations share a login but not a budget (and the key is not the credential); a missing credential is `Missing` where an unverifiable one is a `401` whose reason never contains the token; no repo access is a distinct `403`.

## Test plan

- `:cli:test --tests '*ServeImage*'` green (24 across the four image-lane classes).
- `:cli:test --tests '*Serve*'` green on this base — including `ServeWebFixtureTest`, which was failing on `main` earlier today and no longer is.
- Same limitation as before: the sandbox's egress proxy rewrites GitHub API auth, so neither token path can be exercised live from this container.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wm56KASJ2s6kiHn82J1y2v)_