### PR TITLE
feat(cli): let a project name its preview server

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -340,6 +340,7 @@ class DoctorCommand(
     // Cheap, disk-only, and independent of the Gradle model — so it runs first and still reports
     // when the model query below fails. A wrong pin is one of the reasons a query fails.
     checkVersionPin(projectDir)
+    checkPreviewServer(projectDir)
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
     val model =
       try {
@@ -610,6 +611,42 @@ class DoctorCommand(
    *   A `-SNAPSHOT` on either side stays `ok`: a local snapshot build driving a pinned project is a
    *   deliberate development flow, not a misconfiguration.
    */
+  /**
+   * Report the project's **preview server** — the host `share-preview` uploads rendered evidence to
+   * when the project names one (see [resolveProjectServeUrl]).
+   *
+   * Reported because it changes what a command does without appearing on its command line: a
+   * project with this set makes `share-preview` upload by default where it would otherwise create a
+   * gist, and "why did my render end up on a website" should be answerable by `doctor` rather than
+   * by reading the source. Never an error — not naming a host is the normal state.
+   */
+  private fun checkPreviewServer(projectDir: File) {
+    val configured = resolveProjectServeUrl(projectDir, args, fileSystem = fileSystem)
+    addCheck(
+      DoctorCheck(
+        id = "project.preview-server",
+        category = "project",
+        status = "ok",
+        message =
+          if (configured == null) "no preview server configured"
+          else "share-preview uploads to ${configured.url}",
+        detail =
+          if (configured == null) {
+            "Set $SERVE_URL_PROPERTY in gradle.properties to point share-preview at a " +
+              "`compose-preview serve --accept-images` host, so rendered evidence gets an " +
+              "embeddable URL without `gh` or push rights. Uploading needs a GitHub token with " +
+              "access to that host's configured repository; the token is never read from a file " +
+              "you commit."
+          } else {
+            "Source: ${configured.source.display}. This is what `share-preview` uses unless " +
+              "--mechanism says otherwise. An uploaded image is readable by anyone holding its " +
+              "link, so a project whose renders shouldn't leave the building should not name a " +
+              "public host here."
+          },
+      )
+    )
+  }
+
   private fun checkVersionPin(projectDir: File) {
     val pin = resolveVersionPin(projectDir, args, fileSystem = fileSystem)
     if (pin == null) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -622,27 +622,66 @@ class DoctorCommand(
    */
   private fun checkPreviewServer(projectDir: File) {
     val configured = resolveProjectServeUrl(projectDir, args, fileSystem = fileSystem)
+    if (configured == null) {
+      addCheck(
+        DoctorCheck(
+          id = "project.preview-server",
+          category = "project",
+          status = "ok",
+          message = "no preview server configured",
+          detail =
+            "Set $SERVE_URL_PROPERTY in gradle.properties to point share-preview at a " +
+              "`compose-preview serve --accept-images` host, so rendered evidence gets an " +
+              "embeddable URL without `gh` or push rights. Uploading needs a GitHub token with " +
+              "access to that host's configured repository; the token is never read from a file " +
+              "you commit.",
+        )
+      )
+      return
+    }
+    // The same validation the upload performs, so `doctor` can't hand out a clean bill of health
+    // for a configuration the command will refuse — which is precisely the configuration it exists
+    // to diagnose.
+    ServeImageUploader.rejectUnsafeUrl(configured.url)?.let { refusal ->
+      addCheck(
+        DoctorCheck(
+          id = "project.preview-server",
+          category = "project",
+          status = "error",
+          message = "preview server URL is unusable: ${configured.url}",
+          detail = "Source: ${configured.source.display}. $refusal",
+        )
+      )
+      return
+    }
+    val trust = confirmProjectServeHost(configured, fileSystem = fileSystem)
+    if (trust is ServeUrlTrust.NeedsConfirmation) {
+      addCheck(
+        DoctorCheck(
+          id = "project.preview-server",
+          category = "project",
+          // A warning, not an error: nothing is broken, and refusing to act on an unconfirmed
+          // host is the safe behaviour working as designed. The operator just isn't getting the
+          // upload they may be expecting.
+          status = "warning",
+          message =
+            "this project names ${configured.url}, unconfirmed — share-preview won't use it",
+          detail = trust.how,
+        )
+      )
+      return
+    }
     addCheck(
       DoctorCheck(
         id = "project.preview-server",
         category = "project",
         status = "ok",
-        message =
-          if (configured == null) "no preview server configured"
-          else "share-preview uploads to ${configured.url}",
+        message = "share-preview uploads to ${configured.url}",
         detail =
-          if (configured == null) {
-            "Set $SERVE_URL_PROPERTY in gradle.properties to point share-preview at a " +
-              "`compose-preview serve --accept-images` host, so rendered evidence gets an " +
-              "embeddable URL without `gh` or push rights. Uploading needs a GitHub token with " +
-              "access to that host's configured repository; the token is never read from a file " +
-              "you commit."
-          } else {
-            "Source: ${configured.source.display}. This is what `share-preview` uses unless " +
-              "--mechanism says otherwise. An uploaded image is readable by anyone holding its " +
-              "link, so a project whose renders shouldn't leave the building should not name a " +
-              "public host here."
-          },
+          "Source: ${configured.source.display}. This is what `share-preview` uses unless " +
+            "--mechanism says otherwise. An uploaded image is readable by anyone holding its " +
+            "link, so a project whose renders shouldn't leave the building should not name a " +
+            "public host here.",
       )
     )
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -648,13 +648,17 @@ class DoctorCommand(
           id = "project.preview-server",
           category = "project",
           status = "error",
-          message = "preview server URL is unusable: ${configured.url}",
+          // Redacted: a URL is refused *because* it carries credentials, and this message is where
+          // that URL would otherwise reach a terminal, a CI log and --json output.
+          message =
+            "preview server URL is unusable: ${ServeImageUploader.redactedUrl(configured.url)}",
           detail = "Source: ${configured.source.display}. $refusal",
         )
       )
       return
     }
-    val trust = confirmProjectServeHost(configured, fileSystem = fileSystem)
+    val trust =
+      confirmProjectServeHost(configured, projectRoot = projectDir, fileSystem = fileSystem)
     if (trust is ServeUrlTrust.NeedsConfirmation) {
       addCheck(
         DoctorCheck(
@@ -665,7 +669,8 @@ class DoctorCommand(
           // upload they may be expecting.
           status = "warning",
           message =
-            "this project names ${configured.url}, unconfirmed — share-preview won't use it",
+            "this project names ${ServeImageUploader.redactedUrl(configured.url)}, unconfirmed " +
+              "— share-preview won't use it",
           detail = trust.how,
         )
       )
@@ -676,7 +681,7 @@ class DoctorCommand(
         id = "project.preview-server",
         category = "project",
         status = "ok",
-        message = "share-preview uploads to ${configured.url}",
+        message = "share-preview uploads to ${ServeImageUploader.redactedUrl(configured.url)}",
         detail =
           "Source: ${configured.source.display}. This is what `share-preview` uses unless " +
             "--mechanism says otherwise. An uploaded image is readable by anyone holding its " +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
@@ -24,6 +24,14 @@ import okio.FileSystem
  * Nothing found → null, and `share-preview` behaves exactly as it did before: gist when `gh` is
  * signed in, else a capture-branch push.
  *
+ * # A checkout supplies the value, never the trust
+ *
+ * Source 3 is a file **any pull request can edit**, so it is resolved here but not acted on until
+ * [confirmProjectServeHost] finds the host confirmed from outside the checkout. Without that, a
+ * branch could name an attacker's host and a maintainer reviewing that branch — checking it out and
+ * running the ordinary `share-preview` — would send their GitHub token to it. That is the entire
+ * reason this file has a trust function and not just a getter.
+ *
  * # What is deliberately *not* here
  *
  * **No credential of any kind.** Not the GitHub token the upload authenticates with, and not the
@@ -50,7 +58,105 @@ internal enum class ServeUrlSource(val display: String) {
 }
 
 /** A preview-server URL that was actually found, plus which source supplied it. */
-internal data class ResolvedServeUrl(val url: String, val source: ServeUrlSource)
+internal data class ResolvedServeUrl(val url: String, val source: ServeUrlSource) {
+  /**
+   * Whether this URL was named by something **outside the checkout**, and may therefore be sent a
+   * credential without further confirmation. See [confirmProjectServeHost] for why that distinction
+   * is the whole security model here.
+   */
+  val isOutsideCheckout: Boolean
+    get() = source != ServeUrlSource.GRADLE_PROPERTIES
+}
+
+/** What a caller may do with a resolved URL. */
+internal sealed interface ServeUrlTrust {
+  /** Confirmed: send to it. */
+  data class Trusted(val resolved: ResolvedServeUrl) : ServeUrlTrust
+
+  /**
+   * The **project** names this host and nothing outside the checkout confirms it. [how] is the
+   * operator-facing explanation of what would confirm it; it is safe to print.
+   */
+  data class NeedsConfirmation(val resolved: ResolvedServeUrl, val how: String) : ServeUrlTrust
+}
+
+/** Environment allowlist of hosts a checkout-named preview server may use. */
+internal const val SERVE_HOSTS_ENV = "COMPOSE_PREVIEW_SERVE_HOSTS"
+
+/**
+ * Decide whether [resolved] may be sent a GitHub credential.
+ *
+ * **A checkout may supply the value; it may never supply the trust.** `gradle.properties` is a file
+ * any pull request can edit, and checking a branch out to look at it is the normal way to review
+ * one — so a project-sourced host that took effect on its own would mean that opening someone's PR
+ * and running the ordinary `share-preview` command hands them a repository-scoped token. TLS proves
+ * nothing about that: an attacker's host has a certificate too. This is the same class as a
+ * malicious `.vscode/settings.json` or a `Makefile` that runs on open, and it gets the same answer:
+ * configuration from inside the tree is data, and the decision to *act* on it comes from outside.
+ *
+ * Anything outside the checkout is already an act of consent and passes straight through:
+ * `--serve-url` (typed for this run) and `$COMPOSE_PREVIEW_SERVE_URL` (set by the environment that
+ * built the sandbox). A `gradle.properties` value is confirmed by any of:
+ * - `$COMPOSE_PREVIEW_SERVE_HOSTS` — a comma-separated host allowlist, which is how an org's CI
+ *   image or agent sandbox says "these hosts are ours" once, for every repo it will ever check out;
+ * - `$COMPOSE_PREVIEW_SERVE_URL` naming the same host;
+ * - the **user-level** `gradle.properties` (`$GRADLE_USER_HOME` or `~/.gradle`) naming the same
+ *   host — a developer's own machine config, which no checkout can write.
+ *
+ * Comparison is on the **host** alone, exactly, so `preview.coo.ee.evil.example` does not pass as
+ * `preview.coo.ee`. Port and path are not compared: whoever operates a host operates its ports.
+ */
+internal fun confirmProjectServeHost(
+  resolved: ResolvedServeUrl,
+  env: (String) -> String? = System::getenv,
+  userHome: String? = System.getProperty("user.home"),
+  fileSystem: FileSystem = SystemFileSystem,
+): ServeUrlTrust {
+  if (resolved.isOutsideCheckout) return ServeUrlTrust.Trusted(resolved)
+  val host = hostOf(resolved.url) ?: return needsConfirmation(resolved)
+  val allowed = buildSet {
+    env(SERVE_HOSTS_ENV)?.split(',')?.forEach { entry ->
+      entry.trim().lowercase().takeIf { it.isNotEmpty() }?.let(::add)
+    }
+    env(SERVE_URL_ENV)?.let { hostOf(it)?.let(::add) }
+    userGradlePropertiesServeUrl(env, userHome, fileSystem)?.let { hostOf(it)?.let(::add) }
+  }
+  return if (host in allowed) ServeUrlTrust.Trusted(resolved) else needsConfirmation(resolved)
+}
+
+private fun needsConfirmation(resolved: ResolvedServeUrl): ServeUrlTrust.NeedsConfirmation {
+  val host = hostOf(resolved.url) ?: resolved.url
+  return ServeUrlTrust.NeedsConfirmation(
+    resolved,
+    "This project's $SERVE_URL_PROPERTY names $host, but nothing outside the checkout confirms " +
+      "it — and gradle.properties is a file any branch can change, so acting on it unconfirmed " +
+      "would let a pull request redirect your GitHub token. Confirm the host once, from outside " +
+      "the repo:" +
+      "\n  export $SERVE_HOSTS_ENV=$host        (this machine / CI image trusts that host)" +
+      "\n  or pass --serve-url ${resolved.url}  (just this run)",
+  )
+}
+
+/**
+ * `composePreview.serveUrl` from the **user-level** `gradle.properties` — `$GRADLE_USER_HOME`, else
+ * `~/.gradle`. Outside every checkout by construction, which is what makes it a confirmation.
+ */
+private fun userGradlePropertiesServeUrl(
+  env: (String) -> String?,
+  userHome: String?,
+  fileSystem: FileSystem,
+): String? {
+  val gradleHome =
+    env("GRADLE_USER_HOME")?.let(::File) ?: userHome?.let { File(it, ".gradle") } ?: return null
+  return readGradleProperty(gradleHome, SERVE_URL_PROPERTY, fileSystem)?.normalizedUrl()
+}
+
+/** Lowercased host of [url], or null when it isn't a URL with one. */
+internal fun hostOf(url: String): String? = runCatching {
+  java.net.URI(url.trim()).host?.lowercase()
+}
+  .getOrNull()
+  ?.takeIf { it.isNotEmpty() }
 
 /**
  * Resolves the project's preview server, or null when nothing names one.
@@ -59,6 +165,9 @@ internal data class ResolvedServeUrl(val url: String, val source: ServeUrlSource
  * isn't in a project — the flag and environment sources still apply, which is what lets a bare
  * directory of PNGs be uploaded from anywhere. Every disk read is failure-tolerant for the same
  * reason the pin's is: an unreadable `gradle.properties` must be no worse than an absent one.
+ *
+ * Resolution says *what* was named, never whether it may be used — [confirmProjectServeHost] owns
+ * that, so no caller can accidentally act on a checkout-supplied host by skipping a boolean.
  */
 internal fun resolveProjectServeUrl(
   projectRoot: File?,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
@@ -101,13 +101,16 @@ internal const val SERVE_HOSTS_ENV = "COMPOSE_PREVIEW_SERVE_HOSTS"
  *   image or agent sandbox says "these hosts are ours" once, for every repo it will ever check out;
  * - `$COMPOSE_PREVIEW_SERVE_URL` naming the same host;
  * - the **user-level** `gradle.properties` (`$GRADLE_USER_HOME` or `~/.gradle`) naming the same
- *   host — a developer's own machine config, which no checkout can write.
+ *   host — a developer's own machine config, which no checkout can write. Unless it can:
+ *   `GRADLE_USER_HOME=$PWD/.gradle` is a real CI cache layout, so a gradle home resolving inside
+ *   the project root is ignored rather than believed.
  *
  * Comparison is on the **host** alone, exactly, so `preview.coo.ee.evil.example` does not pass as
  * `preview.coo.ee`. Port and path are not compared: whoever operates a host operates its ports.
  */
 internal fun confirmProjectServeHost(
   resolved: ResolvedServeUrl,
+  projectRoot: File? = null,
   env: (String) -> String? = System::getenv,
   userHome: String? = System.getProperty("user.home"),
   fileSystem: FileSystem = SystemFileSystem,
@@ -119,7 +122,9 @@ internal fun confirmProjectServeHost(
       entry.trim().lowercase().takeIf { it.isNotEmpty() }?.let(::add)
     }
     env(SERVE_URL_ENV)?.let { hostOf(it)?.let(::add) }
-    userGradlePropertiesServeUrl(env, userHome, fileSystem)?.let { hostOf(it)?.let(::add) }
+    userGradlePropertiesServeUrl(env, userHome, projectRoot, fileSystem)?.let {
+      hostOf(it)?.let(::add)
+    }
   }
   return if (host in allowed) ServeUrlTrust.Trusted(resolved) else needsConfirmation(resolved)
 }
@@ -133,7 +138,7 @@ private fun needsConfirmation(resolved: ResolvedServeUrl): ServeUrlTrust.NeedsCo
       "would let a pull request redirect your GitHub token. Confirm the host once, from outside " +
       "the repo:" +
       "\n  export $SERVE_HOSTS_ENV=$host        (this machine / CI image trusts that host)" +
-      "\n  or pass --serve-url ${resolved.url}  (just this run)",
+      "\n  or pass --serve-url ${ServeImageUploader.redactedUrl(resolved.url)}  (just this run)",
   )
 }
 
@@ -144,12 +149,35 @@ private fun needsConfirmation(resolved: ResolvedServeUrl): ServeUrlTrust.NeedsCo
 private fun userGradlePropertiesServeUrl(
   env: (String) -> String?,
   userHome: String?,
+  projectRoot: File?,
   fileSystem: FileSystem,
 ): String? {
   val gradleHome =
     env("GRADLE_USER_HOME")?.let(::File) ?: userHome?.let { File(it, ".gradle") } ?: return null
+  // `GRADLE_USER_HOME=$PWD/.gradle` is a real CI cache layout, and under it a branch that commits
+  // both `gradle.properties` and `.gradle/gradle.properties` would be confirming itself — the
+  // checkout supplying its own trust, which is the one thing this mechanism exists to prevent.
+  // Compared canonically, so a symlink out of the tree and back in cannot launder it.
+  if (projectRoot != null && gradleHome.isInside(projectRoot)) return null
   return readGradleProperty(gradleHome, SERVE_URL_PROPERTY, fileSystem)?.normalizedUrl()
 }
+
+/** Whether this path is [parent] or sits beneath it, with symlinks resolved on both sides. */
+private fun File.isInside(parent: File): Boolean {
+  val here = canonicalOrAbsolute().path
+  val root = parent.canonicalOrAbsolute().path
+  return here == root || here.startsWith(root + File.separator)
+}
+
+/**
+ * The canonical path, falling back to the absolute one. Canonicalisation touches the filesystem and
+ * can fail (a missing directory, a permission error); "couldn't canonicalise" must not become
+ * "isn't inside the checkout", so the fallback still catches the plain `$PWD/.gradle` case.
+ */
+private fun File.canonicalOrAbsolute(): File = runCatching {
+  canonicalFile
+}
+  .getOrElse { absoluteFile }
 
 /** Lowercased host of [url], or null when it isn't a URL with one. */
 internal fun hostOf(url: String): String? = runCatching {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import okio.FileSystem
+
+/**
+ * The **project's preview server** — one place a repository names the `compose-preview serve` host
+ * its tooling should use, so nobody has to pass it per invocation.
+ *
+ * Same shape and the same reasoning as the version pin ([resolveVersionPin]): a fact about the
+ * *project* belongs in the project, committed, where every entrypoint and every contributor reads
+ * the same value. An agent that clones the repo and runs `share-preview` then reaches the team's
+ * host without being told about it — which is the difference between a mechanism that exists and a
+ * mechanism that gets used.
+ *
+ * # Sources, in precedence order
+ * 1. `--serve-url <url>` on the invocation — a per-run override, nothing is read from disk.
+ * 2. `COMPOSE_PREVIEW_SERVE_URL` in the environment — the CI / container override, and how a
+ *    sandbox that provisions its own host announces it.
+ * 3. `gradle.properties` → `composePreview.serveUrl` — the canonical project setting, in the same
+ *    namespace as `composePreview.version` and the plugin's other knobs.
+ *
+ * Nothing found → null, and `share-preview` behaves exactly as it did before: gist when `gh` is
+ * signed in, else a capture-branch push.
+ *
+ * # What is deliberately *not* here
+ *
+ * **No credential of any kind.** Not the GitHub token the upload authenticates with, and not the
+ * host's own browse token. `gradle.properties` is a committed file; a secret in it is a secret in
+ * the repository's history, and offering the key at all would invite exactly that. The URL is the
+ * only part of this configuration that is safe to commit — the credential comes from the
+ * environment or a protected file ([AgentGithubToken]), per run, per caller.
+ *
+ * Committing a URL is still a decision with consequences, which is why it is a deliberate act
+ * rather than a default: it makes uploading the *default* path for everyone working in the repo,
+ * and an upload publishes an image to anyone holding the link. A project whose renders shouldn't
+ * leave the building should not name a public host here.
+ */
+internal const val SERVE_URL_PROPERTY = "composePreview.serveUrl"
+
+/** Environment override, read after `--serve-url` and before anything on disk. */
+internal const val SERVE_URL_ENV = "COMPOSE_PREVIEW_SERVE_URL"
+
+/** Where a resolved preview-server URL came from. Ordered by precedence — first match wins. */
+internal enum class ServeUrlSource(val display: String) {
+  FLAG("--serve-url"),
+  ENV(SERVE_URL_ENV),
+  GRADLE_PROPERTIES("gradle.properties ($SERVE_URL_PROPERTY)"),
+}
+
+/** A preview-server URL that was actually found, plus which source supplied it. */
+internal data class ResolvedServeUrl(val url: String, val source: ServeUrlSource)
+
+/**
+ * Resolves the project's preview server, or null when nothing names one.
+ *
+ * [projectRoot] is the Gradle root (the directory holding `gradlew`); pass null when the caller
+ * isn't in a project — the flag and environment sources still apply, which is what lets a bare
+ * directory of PNGs be uploaded from anywhere. Every disk read is failure-tolerant for the same
+ * reason the pin's is: an unreadable `gradle.properties` must be no worse than an absent one.
+ */
+internal fun resolveProjectServeUrl(
+  projectRoot: File?,
+  args: List<String> = emptyList(),
+  env: (String) -> String? = System::getenv,
+  fileSystem: FileSystem = SystemFileSystem,
+): ResolvedServeUrl? {
+  args.flagValue("--serve-url")?.normalizedUrl()?.let {
+    return ResolvedServeUrl(it, ServeUrlSource.FLAG)
+  }
+  env(SERVE_URL_ENV)?.normalizedUrl()?.let {
+    return ResolvedServeUrl(it, ServeUrlSource.ENV)
+  }
+  if (projectRoot == null) return null
+  readGradleProperty(projectRoot, SERVE_URL_PROPERTY, fileSystem)?.normalizedUrl()?.let {
+    return ResolvedServeUrl(it, ServeUrlSource.GRADLE_PROPERTIES)
+  }
+  return null
+}
+
+/**
+ * Trims and drops a trailing slash, so `https://host/` and `https://host` are one value. Blank is
+ * treated as absent — an empty `composePreview.serveUrl=` line must not configure a host of "".
+ *
+ * Nothing here validates the URL: whether it is somewhere a credential may be sent is
+ * [ServeImageUploader.rejectUnsafeUrl]'s decision, made at the point of use so the answer is the
+ * same however the URL arrived.
+ */
+private fun String.normalizedUrl(): String? = trim().trimEnd('/').takeIf { it.isNotEmpty() }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
@@ -96,7 +96,9 @@ class SharePreviewCommand(
    * that reviewing somebody's branch and running the ordinary `share-preview` sends them a
    * repository-scoped GitHub token.
    */
-  private val serveTrust: ServeUrlTrust? = resolvedServeUrl?.let { confirmProjectServeHost(it) }
+  private val serveTrust: ServeUrlTrust? = resolvedServeUrl?.let {
+    confirmProjectServeHost(it, projectRoot = findGradleProjectRoot())
+  }
 
   private val serveUrl: String?
     get() = (serveTrust as? ServeUrlTrust.Trusted)?.resolved?.url

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
@@ -22,13 +22,15 @@ import okio.Path.Companion.toPath
  * directory of PNGs → a shared capture branch) into a single surface that picks the right mechanism
  * for the environment it runs in:
  *
- * - **Permissions pick the mechanism.** A configured serve host (`--serve-url`, or
- *   `$COMPOSE_PREVIEW_SERVE_URL`) wins, because naming one is a deliberate act and it is the
- *   mechanism that works where the others can't. Otherwise: when the GitHub CLI is installed *and*
- *   authenticated, the default is a **gist** — isolated, doesn't touch the project repo. When it
- *   isn't (e.g. Claude Code's hosted web sessions, which have no `gh` and no token but do have an
- *   authenticated git remote), it falls back to pushing a **branch** through that remote.
- *   `--mechanism` forces one.
+ * - **Permissions pick the mechanism.** A configured serve host wins — `--serve-url`,
+ *   `$COMPOSE_PREVIEW_SERVE_URL`, or the project's own `composePreview.serveUrl`
+ *   ([resolveProjectServeUrl]) — because naming one is a deliberate act and it is the mechanism
+ *   that works where the others can't. A repository that names its preview server therefore gets
+ *   this mechanism by default, for everyone working in it. Otherwise: when the GitHub CLI is
+ *   installed *and* authenticated, the default is a **gist** — isolated, doesn't touch the project
+ *   repo. When it isn't (e.g. Claude Code's hosted web sessions, which have no `gh` and no token
+ *   but do have an authenticated git remote), it falls back to pushing a **branch** through that
+ *   remote. `--mechanism` forces one.
  * - **The current branch picks the target.** For the branch mechanism the destination capture
  *   branch is derived from the branch you're on (`compose-preview/share/<branch>`), so each
  *   feature/PR branch's snapshots stay separate; mainline/release branches are refused. `--branch`
@@ -73,14 +75,21 @@ class SharePreviewCommand(
   private val customMessage: String? = args.flagValue("--message")
   private val allowNonPreviewBranch = "--allow-non-preview-branch" in args
   /**
-   * The serve host to upload to (`--serve-url`, else `$COMPOSE_PREVIEW_SERVE_URL`). Its presence is
-   * also the opt-in: configuring a host is a deliberate act, so `auto` prefers it, and without one
-   * the serve mechanism does not exist.
+   * The serve host to upload to: `--serve-url`, `$COMPOSE_PREVIEW_SERVE_URL`, or the project's own
+   * `composePreview.serveUrl` ([resolveProjectServeUrl]). Its presence is also the opt-in —
+   * configuring a host is a deliberate act, so `auto` prefers it, and without one the serve
+   * mechanism does not exist.
+   *
+   * Reading it from the project is what makes this the **default** in a repository that has one: an
+   * agent that clones and runs `share-preview` reaches the team's host without being told it
+   * exists, which is the difference between a mechanism that shipped and one that gets used.
    */
-  private val serveUrl: String? =
-    (args.flagValue("--serve-url") ?: System.getenv("COMPOSE_PREVIEW_SERVE_URL"))?.trim()?.takeIf {
-      it.isNotEmpty()
-    }
+  private val resolvedServeUrl: ResolvedServeUrl? =
+    resolveProjectServeUrl(findGradleProjectRoot(), args)
+
+  private val serveUrl: String?
+    get() = resolvedServeUrl?.url
+
   /** The host's own browse token, for a serve box that isn't `--public`. */
   private val serveHostToken: String? =
     (args.flagValue("--serve-token") ?: System.getenv("COMPOSE_PREVIEW_SERVE_TOKEN"))
@@ -319,6 +328,7 @@ class SharePreviewCommand(
         markdown = rewritten,
         expiresIn = expiresIn,
         credentialSource = credential.source,
+        serveUrlSource = resolvedServeUrl?.source?.display,
       )
     )
   }
@@ -1004,6 +1014,12 @@ internal data class SharePreviewResponse(
    * credentials was actually used.
    */
   val credentialSource: String? = null,
+  /**
+   * Which source named the host (`--serve-url`, the environment variable, or the project's
+   * `gradle.properties`) — the same "say where this came from" the version pin's `doctor` check
+   * reports, and for the same reason: a default nobody typed has to be traceable.
+   */
+  val serveUrlSource: String? = null,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
@@ -87,8 +87,19 @@ class SharePreviewCommand(
   private val resolvedServeUrl: ResolvedServeUrl? =
     resolveProjectServeUrl(findGradleProjectRoot(), args)
 
+  /**
+   * Whether the resolved host may actually be sent a credential ([confirmProjectServeHost]). Null
+   * when nothing named a host at all.
+   *
+   * A project-named host that nothing outside the checkout confirms is deliberately **not** usable:
+   * `gradle.properties` is a file any pull request can edit, so acting on it unchecked would mean
+   * that reviewing somebody's branch and running the ordinary `share-preview` sends them a
+   * repository-scoped GitHub token.
+   */
+  private val serveTrust: ServeUrlTrust? = resolvedServeUrl?.let { confirmProjectServeHost(it) }
+
   private val serveUrl: String?
-    get() = resolvedServeUrl?.url
+    get() = (serveTrust as? ServeUrlTrust.Trusted)?.resolved?.url
 
   /** The host's own browse token, for a serve box that isn't `--public`. */
   private val serveHostToken: String? =
@@ -130,6 +141,17 @@ class SharePreviewCommand(
 
     val first = File(positional[0])
     val mode = if (positional.size == 1 && first.isDirectory) Mode.BULK else Mode.REPORT
+
+    // An unconfirmed project host never silently selects the upload mechanism. Say so once, on
+    // stderr, so the fallback to gist/branch isn't mysterious — and so the operator learns the one
+    // command that would confirm it.
+    (serveTrust as? ServeUrlTrust.NeedsConfirmation)?.let {
+      if (forcedMechanism == Mechanism.SERVE) {
+        System.err.println(it.how)
+        exitProcess(64)
+      }
+      System.err.println("compose-preview: not using this project's preview server. ${it.how}")
+    }
 
     val mechanism =
       when (

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -137,6 +137,25 @@ internal class ServeImageUploader(
     private val LOOPBACK = setOf("127.0.0.1", "localhost", "::1", "[::1]")
 
     /**
+     * [url] with any `user:password@` stripped, for printing.
+     *
+     * Every message that names a destination goes through this. A URL carrying credentials is
+     * refused rather than used, but *refusing* it is exactly when its text gets printed to a
+     * terminal, a CI log and `--json` output — so the refusal must not be the thing that publishes
+     * the secret. Unparseable input is redacted by shape rather than trusted.
+     */
+    fun redactedUrl(url: String): String {
+      val uri = runCatching { URI(url.trim()) }.getOrNull()
+      if (uri?.userInfo == null) {
+        // Not parseable as a URI (so the check above proves nothing): strip anything that looks
+        // like userinfo in an authority, which is the only place a secret can hide in a URL.
+        return url.replace(Regex("""(?<=://)[^/@\s]*@"""), "***@")
+      }
+      val port = if (uri.port >= 0) ":${uri.port}" else ""
+      return "${uri.scheme}://***@${uri.host}$port${uri.rawPath.orEmpty()}"
+    }
+
+    /**
      * Whether [url] is somewhere a GitHub credential may be sent, or the reason it isn't. Null when
      * the URL is acceptable.
      */
@@ -145,20 +164,21 @@ internal class ServeImageUploader(
         try {
           URI(url)
         } catch (e: Exception) {
-          return "invalid --serve-url '$url': ${e.message ?: "not a URL"}"
+          return "invalid --serve-url '${redactedUrl(url)}': ${e.message ?: "not a URL"}"
         }
       val scheme = uri.scheme?.lowercase()
       val host = uri.host?.lowercase()
       if (scheme == null || host.isNullOrBlank()) {
-        return "invalid --serve-url '$url': expected something like https://preview.example.com"
+        return "invalid --serve-url '${redactedUrl(url)}': expected something like " +
+          "https://preview.example.com"
       }
       if (uri.userInfo != null) {
         return "refusing --serve-url with credentials in it: they leak into every log that " +
           "records the destination. Pass the host alone."
       }
       if (scheme != "https" && !(scheme == "http" && host in LOOPBACK)) {
-        return "refusing to send a GitHub token to '$url' over $scheme — use https:// " +
-          "(http:// is allowed only for a loopback host)."
+        return "refusing to send a GitHub token to '${redactedUrl(url)}' over $scheme — use " +
+          "https:// (http:// is allowed only for a loopback host)."
       }
       return null
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
@@ -146,6 +146,21 @@ private fun String.normalizedPin(): String? = trim().removePrefix("v").takeIf { 
 internal fun readGradlePropertiesPin(
   projectRoot: File,
   fileSystem: FileSystem = SystemFileSystem,
+): String? = readGradleProperty(projectRoot, VERSION_PIN_PROPERTY, fileSystem)?.normalizedPin()
+
+/**
+ * One `composePreview.*` value out of [projectRoot]`/gradle.properties`, trimmed, or null when the
+ * file, the parse, or the key is missing. The raw value — a caller that needs it normalised (the
+ * version pin strips a leading `v`) does that itself, since no other property wants it.
+ *
+ * Extracted from [readGradlePropertiesPin] when the preview-server URL became the second thing read
+ * this way ([resolveProjectServeUrl]): both want the same failure-tolerant read of the same file,
+ * and two copies would be two places to get properties-file escaping wrong.
+ */
+internal fun readGradleProperty(
+  projectRoot: File,
+  key: String,
+  fileSystem: FileSystem = SystemFileSystem,
 ): String? {
   val file = File(projectRoot, "gradle.properties")
   val text =
@@ -155,7 +170,7 @@ internal fun readGradlePropertiesPin(
     .getOrElse {
       return null
     }
-  return props.getProperty(VERSION_PIN_PROPERTY)?.normalizedPin()
+  return props.getProperty(key)?.trim()?.takeIf { it.isNotEmpty() }
 }
 
 /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
@@ -4,6 +4,7 @@ import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 
@@ -86,6 +87,84 @@ class ProjectPreviewServerTest {
   fun `an unreadable properties file is no worse than an absent one`() {
     // Nothing written at all: the read fails and resolution falls through rather than throwing.
     assertNull(resolveProjectServeUrl(root, env = { null }, fileSystem = fs))
+  }
+
+  // ---- a checkout supplies the value, never the trust ---------------------------------------
+
+  @Test
+  fun `a host named only by the checkout is not usable`() {
+    // The attack this gate exists for: a pull request adds the property, a maintainer checks the
+    // branch out to look at it, and the ordinary share-preview run would otherwise send their
+    // GitHub token to whoever wrote that line.
+    writeProperties("$SERVE_URL_PROPERTY=https://attacker.example\n")
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val trust = confirmProjectServeHost(resolved, env = { null }, userHome = null, fileSystem = fs)
+    val needs = trust as ServeUrlTrust.NeedsConfirmation
+    assertTrue(needs.how.contains("attacker.example"), needs.how)
+    assertTrue(needs.how.contains(SERVE_HOSTS_ENV), needs.how)
+  }
+
+  @Test
+  fun `the environment allowlist confirms a checkout-named host`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee\n")
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val env = { name: String ->
+      if (name == SERVE_HOSTS_ENV) "shots.example, preview.coo.ee" else null
+    }
+    assertTrue(
+      confirmProjectServeHost(resolved, env, userHome = null, fileSystem = fs)
+        is ServeUrlTrust.Trusted
+    )
+  }
+
+  @Test
+  fun `a lookalike host does not pass as the confirmed one`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee.evil.example\n")
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val env = { name: String -> if (name == SERVE_HOSTS_ENV) "preview.coo.ee" else null }
+    assertTrue(
+      confirmProjectServeHost(resolved, env, userHome = null, fileSystem = fs)
+        is ServeUrlTrust.NeedsConfirmation
+    )
+  }
+
+  @Test
+  fun `the user's own gradle properties confirms a host, since no checkout can write it`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee\n")
+    val userHome = "/home/dev"
+    val userProps = "$userHome/.gradle/gradle.properties".toPath()
+    fs.createDirectories(userProps.parent!!)
+    fs.write(userProps) { writeUtf8("$SERVE_URL_PROPERTY=https://preview.coo.ee\n") }
+
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    assertTrue(
+      confirmProjectServeHost(resolved, env = { null }, userHome = userHome, fileSystem = fs)
+        is ServeUrlTrust.Trusted
+    )
+  }
+
+  @Test
+  fun `anything from outside the checkout is already consent`() {
+    // Typed for this run, or set by whoever built the sandbox: both are acts by the person whose
+    // credential it is, so neither needs a second confirmation.
+    val flag =
+      resolveProjectServeUrl(
+        root,
+        args = listOf("--serve-url", "https://anywhere.example"),
+        env = { null },
+        fileSystem = fs,
+      )!!
+    assertTrue(
+      confirmProjectServeHost(flag, env = { null }, userHome = null, fileSystem = fs)
+        is ServeUrlTrust.Trusted
+    )
+
+    val fromEnv =
+      resolveProjectServeUrl(root, env = { "https://anywhere.example" }, fileSystem = fs)!!
+    assertTrue(
+      confirmProjectServeHost(fromEnv, env = { null }, userHome = null, fileSystem = fs)
+        is ServeUrlTrust.Trusted
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+
+/**
+ * The project's preview server, and its precedence. Same shape as the version pin's tests, because
+ * it is the same contract: a fact about the project, overridable per run, and never worse broken
+ * than absent.
+ */
+class ProjectPreviewServerTest {
+
+  private val fs = FakeFileSystem()
+
+  private val root = File("/project")
+
+  private fun writeProperties(text: String) {
+    val path = "/project/gradle.properties".toPath()
+    fs.createDirectories(path.parent!!)
+    fs.write(path) { writeUtf8(text) }
+  }
+
+  @Test
+  fun `a project that names a server configures share-preview without a flag`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee\n")
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)
+    assertEquals("https://preview.coo.ee", resolved?.url)
+    assertEquals(ServeUrlSource.GRADLE_PROPERTIES, resolved?.source)
+  }
+
+  @Test
+  fun `the flag beats the environment, which beats the project`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://from-the-project\n")
+    assertEquals(
+      "https://from-the-flag",
+      resolveProjectServeUrl(
+          root,
+          args = listOf("--serve-url", "https://from-the-flag"),
+          env = { "https://from-the-env" },
+          fileSystem = fs,
+        )
+        ?.url,
+    )
+    assertEquals(
+      "https://from-the-env",
+      resolveProjectServeUrl(root, env = { "https://from-the-env" }, fileSystem = fs)?.url,
+    )
+    assertEquals(
+      "https://from-the-project",
+      resolveProjectServeUrl(root, env = { null }, fileSystem = fs)?.url,
+    )
+  }
+
+  @Test
+  fun `a trailing slash is not a different host`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee/\n")
+    assertEquals(
+      "https://preview.coo.ee",
+      resolveProjectServeUrl(root, env = { null }, fileSystem = fs)?.url,
+    )
+  }
+
+  @Test
+  fun `an empty or absent setting configures nothing`() {
+    writeProperties("$SERVE_URL_PROPERTY=\n")
+    assertNull(resolveProjectServeUrl(root, env = { null }, fileSystem = fs))
+
+    writeProperties("composePreview.version=1.2.3\n")
+    assertNull(resolveProjectServeUrl(root, env = { null }, fileSystem = fs))
+  }
+
+  @Test
+  fun `no project is not an error, and the overrides still apply`() {
+    assertNull(resolveProjectServeUrl(null, env = { null }, fileSystem = fs))
+    assertEquals(
+      "https://from-the-env",
+      resolveProjectServeUrl(null, env = { "https://from-the-env" }, fileSystem = fs)?.url,
+    )
+  }
+
+  @Test
+  fun `an unreadable properties file is no worse than an absent one`() {
+    // Nothing written at all: the read fails and resolution falls through rather than throwing.
+    assertNull(resolveProjectServeUrl(root, env = { null }, fileSystem = fs))
+  }
+
+  @Test
+  fun `a server setting does not disturb the version pin beside it`() {
+    writeProperties(
+      """
+      composePreview.version=1.2.3
+      $SERVE_URL_PROPERTY=https://preview.coo.ee
+      """
+        .trimIndent()
+    )
+    assertEquals("1.2.3", readGradlePropertiesPin(root, fs))
+    assertEquals(
+      "https://preview.coo.ee",
+      resolveProjectServeUrl(root, env = { null }, fileSystem = fs)?.url,
+    )
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
@@ -98,7 +98,14 @@ class ProjectPreviewServerTest {
     // GitHub token to whoever wrote that line.
     writeProperties("$SERVE_URL_PROPERTY=https://attacker.example\n")
     val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
-    val trust = confirmProjectServeHost(resolved, env = { null }, userHome = null, fileSystem = fs)
+    val trust =
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = { null },
+        userHome = null,
+        fileSystem = fs,
+      )
     val needs = trust as ServeUrlTrust.NeedsConfirmation
     assertTrue(needs.how.contains("attacker.example"), needs.how)
     assertTrue(needs.how.contains(SERVE_HOSTS_ENV), needs.how)
@@ -112,7 +119,13 @@ class ProjectPreviewServerTest {
       if (name == SERVE_HOSTS_ENV) "shots.example, preview.coo.ee" else null
     }
     assertTrue(
-      confirmProjectServeHost(resolved, env, userHome = null, fileSystem = fs)
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = env,
+        userHome = null,
+        fileSystem = fs,
+      )
         is ServeUrlTrust.Trusted
     )
   }
@@ -123,7 +136,13 @@ class ProjectPreviewServerTest {
     val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
     val env = { name: String -> if (name == SERVE_HOSTS_ENV) "preview.coo.ee" else null }
     assertTrue(
-      confirmProjectServeHost(resolved, env, userHome = null, fileSystem = fs)
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = env,
+        userHome = null,
+        fileSystem = fs,
+      )
         is ServeUrlTrust.NeedsConfirmation
     )
   }
@@ -138,7 +157,13 @@ class ProjectPreviewServerTest {
 
     val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
     assertTrue(
-      confirmProjectServeHost(resolved, env = { null }, userHome = userHome, fileSystem = fs)
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = { null },
+        userHome = userHome,
+        fileSystem = fs,
+      )
         is ServeUrlTrust.Trusted
     )
   }
@@ -155,16 +180,89 @@ class ProjectPreviewServerTest {
         fileSystem = fs,
       )!!
     assertTrue(
-      confirmProjectServeHost(flag, env = { null }, userHome = null, fileSystem = fs)
+      confirmProjectServeHost(
+        flag,
+        projectRoot = root,
+        env = { null },
+        userHome = null,
+        fileSystem = fs,
+      )
         is ServeUrlTrust.Trusted
     )
 
     val fromEnv =
       resolveProjectServeUrl(root, env = { "https://anywhere.example" }, fileSystem = fs)!!
     assertTrue(
-      confirmProjectServeHost(fromEnv, env = { null }, userHome = null, fileSystem = fs)
+      confirmProjectServeHost(
+        fromEnv,
+        projectRoot = root,
+        env = { null },
+        userHome = null,
+        fileSystem = fs,
+      )
         is ServeUrlTrust.Trusted
     )
+  }
+
+  @Test
+  fun `a gradle user home inside the checkout cannot confirm its own host`() {
+    // `GRADLE_USER_HOME=$PWD/.gradle` is a real CI cache layout. Under it a branch that commits
+    // both files would be confirming itself, which is the whole thing the gate prevents.
+    writeProperties("$SERVE_URL_PROPERTY=https://attacker.example\n")
+    val inCheckout = "/project/.gradle/gradle.properties".toPath()
+    fs.createDirectories(inCheckout.parent!!)
+    fs.write(inCheckout) { writeUtf8("$SERVE_URL_PROPERTY=https://attacker.example\n") }
+
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val env = { name: String -> if (name == "GRADLE_USER_HOME") "/project/.gradle" else null }
+    assertTrue(
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = env,
+        userHome = null,
+        fileSystem = fs,
+      )
+        is ServeUrlTrust.NeedsConfirmation,
+      "a confirmation file inside the checkout is not a confirmation",
+    )
+  }
+
+  @Test
+  fun `a gradle user home outside the checkout still confirms`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee\n")
+    val outside = "/opt/ci-cache/gradle/gradle.properties".toPath()
+    fs.createDirectories(outside.parent!!)
+    fs.write(outside) { writeUtf8("$SERVE_URL_PROPERTY=https://preview.coo.ee\n") }
+
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val env = { name: String -> if (name == "GRADLE_USER_HOME") "/opt/ci-cache/gradle" else null }
+    assertTrue(
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = env,
+        userHome = null,
+        fileSystem = fs,
+      )
+        is ServeUrlTrust.Trusted
+    )
+  }
+
+  @Test
+  fun `a refusal never echoes credentials that were in the url`() {
+    writeProperties("$SERVE_URL_PROPERTY=https://user:hunter2@attacker.example\n")
+    val resolved = resolveProjectServeUrl(root, env = { null }, fileSystem = fs)!!
+    val needs =
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = root,
+        env = { null },
+        userHome = null,
+        fileSystem = fs,
+      )
+        as ServeUrlTrust.NeedsConfirmation
+    assertTrue("hunter2" !in needs.how, needs.how)
   }
 
   @Test

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2503,8 +2503,24 @@ compose-preview share-preview report.md before.png after.png \
   --mechanism serve --serve-url https://preview.coo.ee
 ```
 
-A configured `--serve-url` (or `$COMPOSE_PREVIEW_SERVE_URL`) also wins the `auto` choice, so a
-correctly-configured agent environment picks this lane without asking for it. The client refuses to
+**A project can name its own preview server**, and then this is simply what `share-preview` does —
+no flag, no environment variable, for everyone working in the repo:
+
+```properties
+# gradle.properties
+composePreview.serveUrl=https://preview.coo.ee
+```
+
+Precedence is the version pin's: `--serve-url` → `$COMPOSE_PREVIEW_SERVE_URL` →
+`gradle.properties`. `compose-preview doctor` reports which one is in effect
+(`project.preview-server`), because a setting that changes where your renders go without appearing
+on the command line should be answerable by `doctor` rather than by reading source. Only the **URL**
+is project configuration: no credential is ever read from a committed file — the GitHub token comes
+from the environment or a protected file, per run.
+
+Naming a host is therefore a deliberate act with a consequence worth stating: it makes uploading the
+default path for every contributor and agent in that repo, and an uploaded image is readable by
+anyone holding its link. The client refuses to
 send the credential over plaintext to anything but a loopback host, refuses a URL with credentials
 in it, and never follows a redirect while carrying it.
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2514,13 +2514,30 @@ composePreview.serveUrl=https://preview.coo.ee
 Precedence is the version pin's: `--serve-url` → `$COMPOSE_PREVIEW_SERVE_URL` →
 `gradle.properties`. `compose-preview doctor` reports which one is in effect
 (`project.preview-server`), because a setting that changes where your renders go without appearing
-on the command line should be answerable by `doctor` rather than by reading source. Only the **URL**
-is project configuration: no credential is ever read from a committed file — the GitHub token comes
-from the environment or a protected file, per run.
+on the command line should be answerable by `doctor` rather than by reading source.
 
-Naming a host is therefore a deliberate act with a consequence worth stating: it makes uploading the
-default path for every contributor and agent in that repo, and an uploaded image is readable by
-anyone holding its link. The client refuses to
+**A checkout supplies the value, never the trust.** `gradle.properties` is a file *any pull request
+can edit*, and checking a branch out to look at it is how you review one — so a project-named host
+that took effect on its own would mean that opening somebody's PR and running the ordinary
+`share-preview` hands them your GitHub token. HTTPS proves nothing here: an attacker's host has a
+certificate too. So a host named by the project is used only once something **outside** the checkout
+confirms it:
+
+```bash
+export COMPOSE_PREVIEW_SERVE_HOSTS=preview.coo.ee   # this machine / CI image trusts that host
+```
+
+or `$COMPOSE_PREVIEW_SERVE_URL` naming it, or your **user-level** `~/.gradle/gradle.properties`
+(which no checkout can write), or `--serve-url` typed for the run. Unconfirmed, `share-preview` falls
+back to gist/branch and says why; `doctor` reports it as a warning. Confirmation matches on the host
+exactly, so `preview.coo.ee.evil.example` is not `preview.coo.ee`.
+
+Only the **URL** is project configuration: no credential is ever read from a committed file — the
+GitHub token comes from the environment or a protected file, per run.
+
+Naming a host is therefore a deliberate act with a consequence worth stating: for everyone who has
+confirmed that host, it makes uploading the default path, and an uploaded image is readable by anyone
+holding its link. The client refuses to
 send the credential over plaintext to anything but a loopback host, refuses a URL with credentials
 in it, and never follows a redirect while carrying it.
 


### PR DESCRIPTION
A repository can name its preview server once, and `share-preview` uploads there instead of making a gist:

```properties
# gradle.properties
composePreview.serveUrl=https://preview.coo.ee
```

## ⚠️ Read the second commit first

**As originally written, this PR was a credential-exfiltration primitive.** `gradle.properties` is a file any pull request can edit. A branch could add `composePreview.serveUrl=https://attacker.example`, and a maintainer who checks that branch out to look at it — the normal way to review a UI change in this repo — and runs the ordinary `share-preview` would send `$GITHUB_TOKEN` to the attacker's host as a bearer credential. TLS proves nothing: an attacker's host has a certificate.

The design assumed whoever configures the repo is whoever runs the command. On a branch or fork checkout those are different people, and that is exactly the case this feature makes convenient. Caught in review before merge; the PR was converted to draft (which cleared auto-merge) while it was fixed.

**A checkout may supply the value; it may never supply the trust.** Anything from outside the checkout is already consent and passes straight through — `--serve-url` typed for the run, `$COMPOSE_PREVIEW_SERVE_URL` set by whoever built the sandbox. A `gradle.properties` host is used only when confirmed by one of:

- `$COMPOSE_PREVIEW_SERVE_HOSTS` — a host allowlist, so a CI image or agent sandbox says "these hosts are ours" once, for every repo it will ever check out;
- `$COMPOSE_PREVIEW_SERVE_URL` naming the same host;
- the **user-level** `~/.gradle/gradle.properties`, which no checkout can write.

Host comparison is exact, so `preview.coo.ee.evil.example` is not `preview.coo.ee`. Unconfirmed, auto mode does not select serve and says why; a forced `--mechanism serve` refuses rather than uploading:

```
$ compose-preview share-preview report.md before.png after.png     # branch names attacker.example
compose-preview: not using this project's preview server. This project's composePreview.serveUrl
names attacker.example, but nothing outside the checkout confirms it — and gradle.properties is a
file any branch can change, so acting on it unconfirmed would let a pull request redirect your
GitHub token. Confirm the host once, from outside the repo:
  export COMPOSE_PREVIEW_SERVE_HOSTS=attacker.example        (this machine / CI image trusts that host)
  or pass --serve-url https://attacker.example  (just this run)
```

## The feature itself

Built as a sibling of the version pin, which is this repo's existing answer to "one place a project names a thing every entrypoint honours": same precedence shape (`--serve-url` → env → `gradle.properties`), same `composePreview.*` namespace, same failure tolerance, and the two now share one `readGradleProperty` instead of two copies of the same properties-file handling.

`doctor` gains `project.preview-server`, beside the pin — reporting the URL, **which source supplied it**, and now the same `rejectUnsafeUrl` validation the upload performs (an unusable URL is an `error`, an unconfirmed host a `warning`). It previously reported `ok` for configurations the command would refuse, which is a clean bill of health for precisely what the check exists to diagnose.

Only the URL is project configuration. No credential is read from a committed file — the GitHub token still comes from the environment or a protected file, per run, per caller.

## Test plan

- Full `:cli:test` green.
- `ProjectPreviewServerTest` (12), including the attack itself: `a host named only by the checkout is not usable`, `a lookalike host does not pass as the confirmed one`, `the environment allowlist confirms a checkout-named host`, `the user's own gradle properties confirms a host, since no checkout can write it`, `anything from outside the checkout is already consent`.
- Live against the built CLI, all three states: a branch-named host is refused with the explanation above; the same host with `COMPOSE_PREVIEW_SERVE_HOSTS` set uploads (reaching a real `serve --accept-images` host, which then refused on GitHub access as expected in this sandbox); `doctor` warns with the confirmation instructions.
- One unrelated CI failure on the previous head — `ServeCatalogStoreTest > live bundles use the larger dedicated download envelope`, a `ConcurrentModificationException` in a test this diff doesn't touch, which passes locally on the same commit. The push re-runs it.

Not done here, deliberately: this repo's own `gradle.properties` still names no host, so nothing changes for contributors until someone adds the line.