### PR TITLE
fix(pseudolocale): stop the wrap leaking out, and stop it swallowing the fallback

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -363,6 +363,9 @@ class RenderEngine(
     val previousContext = Thread.currentThread().contextClassLoader
     Thread.currentThread().contextClassLoader = classLoader
 
+    // Drop any pseudolocalised string items a previous render left in CMP's process-wide cache
+    // before this one composes; a no-op unless this render is leaving pseudolocale mode.
+    guardPseudolocaleStringCache(spec.localeTag)
     val localeProviders = localeProviders(spec.localeTag)
     val themeFallbackCapture =
       if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
@@ -1935,6 +1938,42 @@ class RenderEngine(
           as ProvidableCompositionLocal<LocaleList>
       }
         .getOrNull()
+    }
+
+    /**
+     * Whether the *previous* render in this JVM composed under a pseudolocale, so
+     * [guardPseudolocaleStringCache] knows when the process-wide CMP string cache is holding
+     * transformed values. One daemon renders sequentially, and the flag is only ever read and
+     * written on the render path, so a plain `@Volatile` boolean is enough.
+     */
+    @Volatile private var lastRenderWasPseudolocale: Boolean = false
+
+    /**
+     * Clear Compose Resources' process-wide `stringItemsCache` when a render *leaves* pseudolocale
+     * mode. Returns true when it cleared, for the tests that pin the state machine.
+     *
+     * CMP caches a string item under `path/offset-size` with the value the **first** reader
+     * returned, so a cached value outlives the reader that produced it. `PseudolocaleOverride
+     * ExtensionDesktop` already clears on entry (a pseudo render must not be served plain strings
+     * cached earlier); this is the other edge: after a pseudo render the cache holds *transformed*
+     * values, and the next ordinary render would be handed accented / bidi text for a locale it
+     * never asked for. Only the renderer sees both renders, so the flag lives here.
+     *
+     * Deliberately does nothing while pseudolocale renders repeat back to back — the around
+     * composable's entry clear covers a mode switch between `en-XA` and `ar-XB` — and nothing at
+     * all in the ordinary case where no pseudolocale render has happened yet, so a daemon that
+     * never renders one keeps its warm cache.
+     */
+    internal fun guardPseudolocaleStringCache(localeTag: String?): Boolean {
+      val isPseudolocale =
+        ee.schimke.composeai.data.pseudolocale.Pseudolocale.fromTag(localeTag) != null
+      if (isPseudolocale) {
+        lastRenderWasPseudolocale = true
+        return false
+      }
+      if (!lastRenderWasPseudolocale) return false
+      lastRenderWasPseudolocale = false
+      return PseudolocaleResourceCache.clearStringResourcesCacheBestEffort()
     }
 
     /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLocaleTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineLocaleTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import java.util.Locale
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -36,6 +37,45 @@ class RenderEngineLocaleTest {
     assertNull(RenderEngine.effectiveLocaleTag(null))
     assertNull(RenderEngine.effectiveLocaleTag(""))
     assertNull(RenderEngine.effectiveLocaleTag("   "))
+  }
+
+  /**
+   * The other edge of the pseudolocale string cache (#4371 review). CMP's process-wide
+   * `stringItemsCache` stores whatever the *first* reader returned for a key, so after a pseudo
+   * render it holds accented / bidi text; the next ordinary render would be served that text for a
+   * locale it never asked for, without its own reader ever running. The around-composable only
+   * clears on entry, so the renderer closes the exit — but only when a render actually leaves
+   * pseudolocale mode, so a daemon that never renders one keeps its warm cache.
+   *
+   * Asserts the state machine rather than the reflective clear itself (that has its own coverage in
+   * `PseudolocaleResourceCacheTest`), and tolerates a `false` return from a CMP version drift where
+   * the reflective shim can't find the cache — the transition, not the shim, is what this pins.
+   */
+  @Test
+  fun pseudolocaleStringCacheIsClearedOnTheWayOutOfPseudolocaleMode() {
+    // Baseline: no pseudolocale render has happened, so an ordinary render clears nothing.
+    RenderEngine.guardPseudolocaleStringCache(null)
+    assertFalse(
+      "an ordinary render with no pseudolocale history must not touch the cache",
+      RenderEngine.guardPseudolocaleStringCache("de"),
+    )
+
+    // Entering, and staying in, pseudolocale mode is the around-composable's job, not this one's.
+    assertFalse(RenderEngine.guardPseudolocaleStringCache("en-XA"))
+    assertFalse(
+      "a pseudolocale-to-pseudolocale switch is the entry clear's job",
+      RenderEngine.guardPseudolocaleStringCache("ar-XB"),
+    )
+
+    // Leaving it is: the first ordinary render afterwards clears, and only that one.
+    assertTrue(
+      "the render after a pseudolocale one must drop the transformed string items",
+      RenderEngine.guardPseudolocaleStringCache(null),
+    )
+    assertFalse(
+      "and the cache must then be left alone until the next pseudolocale render",
+      RenderEngine.guardPseudolocaleStringCache(null),
+    )
   }
 
   @Test

--- a/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourceCache.kt
+++ b/data/pseudolocale/connector-desktop/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourceCache.kt
@@ -27,11 +27,19 @@ package ee.schimke.composeai.daemon
  * JVM between modes"). We never crash a render over a reflective miss; we just degrade to the
  * documented behaviour.
  *
+ * **Both edges of a pseudolocale render need this**, which is why the shim is public rather than
+ * internal to this module. The around-composable clears on *entry*, so a pseudo render never reads
+ * plain strings a previous render cached. The reverse leak is just as real: a pseudo render leaves
+ * the cache holding *transformed* values, and the next ordinary render is served those without ever
+ * consulting its own reader — a preview browsed right after an `?localeTag=en-XA` one would show
+ * accented text at no locale at all. `RenderEngine.guardPseudolocaleStringCache` closes that edge
+ * from the renderer, which is the only place that sees both renders.
+ *
  * **Not a long-term solution.** Tracked at compose-ai-tools#1360 finding #3 — the right fix is for
  * CMP to expose a per-renderer cache scope, at which point this whole shim goes away. Until then,
  * this reflective workaround eliminates the silent no-op the issue calls out.
  */
-internal object PseudolocaleResourceCache {
+object PseudolocaleResourceCache {
 
   /**
    * Class name of the Kotlin top-level file that holds the cache. Held as a literal string so the

--- a/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
+++ b/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.res.Resources
+import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import ee.schimke.composeai.data.pseudolocale.Pseudolocale
@@ -25,6 +26,16 @@ import ee.schimke.composeai.data.pseudolocale.Pseudolocalizer
  * naturally — the template is pseudolocalised once, then `String.format` substitutes args into it.
  * Placeholders like `%1$s` survive the transform unchanged, see `Pseudolocalizer`.
  *
+ * **Every accessor delegates to the wrapped [base] instance, never to `super`.** The base class is
+ * constructed over the same `AssetManager` / `DisplayMetrics` / `Configuration`, so `super`
+ * resolves the same table and looks equivalent — but only for a [base] that *is* the raw table. The
+ * live daemon stacks resource wrappers (`PlaceholderFallbackResources` for a detached bundle whose
+ * packed table is absent or stale, the `resources/used` recorder), and `super` steps straight over
+ * whatever this instance was installed on top of. That turned a missing resource inside a
+ * pseudolocale render into the hard `NotFoundException` abort the fallback exists to prevent, so a
+ * preview that rendered fine at `en` failed at `en-XA`. `PlaceholderFallbackResources` documents
+ * the same rule from the other side; the two must keep composing in either order.
+ *
  * **Span preservation.** `Resources.getText(int)` returns `CharSequence`, which is a `Spanned`
  * (`SpannedString`) when the resource is styled — `<b>`, `<i>`, `<a>`, custom `<annotation>` tags
  * all surface as `Object`-typed spans on a single underlying string. A naive
@@ -35,18 +46,44 @@ import ee.schimke.composeai.data.pseudolocale.Pseudolocalizer
  * take the cheaper `transform` fast path with no `SpannableStringBuilder` allocation.
  */
 @Suppress("DEPRECATION")
-internal class PseudolocaleResources(base: Resources, private val mode: Pseudolocale) :
+internal class PseudolocaleResources(private val base: Resources, private val mode: Pseudolocale) :
   Resources(base.assets, base.displayMetrics, base.configuration) {
 
-  override fun getText(id: Int): CharSequence = pseudolocalise(super.getText(id))
+  override fun getText(id: Int): CharSequence = pseudolocalise(base.getText(id))
 
   override fun getText(id: Int, def: CharSequence): CharSequence {
-    val raw = super.getText(id, def)
+    val raw = base.getText(id, def)
     return if (raw === def) def else pseudolocalise(raw)
   }
 
   override fun getQuantityText(id: Int, quantity: Int): CharSequence =
-    pseudolocalise(super.getQuantityText(id, quantity))
+    pseudolocalise(base.getQuantityText(id, quantity))
+
+  // Value resources pass through untouched — there is nothing to pseudolocalise about a colour or
+  // a dimension — but they are still forwarded to [base] rather than left to `super`, for the
+  // reason spelled out in the class KDoc: `super` resolves against the raw table and would step
+  // over whatever wrapper we were installed on top of. `PlaceholderFallbackResources` is that
+  // wrapper on the live daemon, so leaving these to `super` turned a missing drawable into a hard
+  // `NotFoundException` render abort in exactly the pseudolocale renders this class serves.
+  override fun getColor(id: Int): Int = base.getColor(id)
+
+  override fun getColor(id: Int, theme: Theme?): Int = base.getColor(id, theme)
+
+  override fun getDimension(id: Int): Float = base.getDimension(id)
+
+  override fun getDimensionPixelOffset(id: Int): Int = base.getDimensionPixelOffset(id)
+
+  override fun getDimensionPixelSize(id: Int): Int = base.getDimensionPixelSize(id)
+
+  override fun getDrawable(id: Int): Drawable = base.getDrawable(id)
+
+  override fun getDrawable(id: Int, theme: Theme?): Drawable = base.getDrawable(id, theme)
+
+  override fun getDrawableForDensity(id: Int, density: Int): Drawable? =
+    base.getDrawableForDensity(id, density)
+
+  override fun getDrawableForDensity(id: Int, density: Int, theme: Theme?): Drawable? =
+    base.getDrawableForDensity(id, density, theme)
 
   private fun pseudolocalise(raw: CharSequence): CharSequence {
     if (raw !is Spanned) return Pseudolocalizer.transform(raw.toString(), mode)

--- a/data/pseudolocale/connector/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourcesDelegationTest.kt
+++ b/data/pseudolocale/connector/src/test/kotlin/ee/schimke/composeai/daemon/PseudolocaleResourcesDelegationTest.kt
@@ -1,0 +1,101 @@
+package ee.schimke.composeai.daemon
+
+import android.content.res.Resources
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import ee.schimke.composeai.data.pseudolocale.Pseudolocale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * [PseudolocaleResources] must resolve **through the `Resources` instance it wraps**, not through
+ * `super`.
+ *
+ * The live daemon stacks resource wrappers, and `PlaceholderFallbackResources` — which turns a
+ * missing id into a visible placeholder instead of a `NotFoundException` that aborts the whole
+ * render — is one of them. Because this class extends `Resources` over the wrapped instance's
+ * `AssetManager`, a `super.getText(id)` reads the raw table directly and steps over that fallback:
+ * a preview that renders fine at `en` dies at `en-XA`, which is the opposite of what a debugging
+ * aid should do. The same applies to the value families the fallback guards (colour, dimension,
+ * drawable), which this class passes through untransformed but must still delegate.
+ *
+ * Sibling of `:daemon:android`'s `PlaceholderFallbackResourcesTest.fallback delegates through a
+ * wrapped Resources implementation before substituting`, which pins the rule from the other side.
+ * The two wrappers have to compose in either order.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PseudolocaleResourcesDelegationTest {
+
+  private val base: Resources by lazy { RuntimeEnvironment.getApplication().resources }
+
+  /** An id no table resolves — what an absent / stale packed resource table hands the renderer. */
+  private val missingId = 0x7f0f0000
+
+  private val handledText = "Battery low"
+  private val handledColor = 0xFF123456.toInt()
+
+  /**
+   * Stands in for `PlaceholderFallbackResources`: answers [missingId] itself and forwards every
+   * other lookup to the real table. Declared here rather than depending on `:daemon:android` (the
+   * dependency runs the other way), which is also the point — the contract is "delegate to the
+   * wrapped instance", not "know about that one class".
+   */
+  private fun fallback(): Resources =
+    object : Resources(base.assets, base.displayMetrics, base.configuration) {
+      override fun getText(id: Int): CharSequence =
+        if (id == missingId) handledText else base.getText(id)
+
+      override fun getColor(id: Int, theme: Theme?): Int =
+        if (id == missingId) handledColor else base.getColor(id, theme)
+
+      override fun getDimension(id: Int): Float =
+        if (id == missingId) 42f else base.getDimension(id)
+
+      override fun getDrawableForDensity(id: Int, density: Int, theme: Theme?): Drawable? =
+        if (id == missingId) ColorDrawable(handledColor)
+        else base.getDrawableForDensity(id, density, theme)
+    }
+
+  @Test
+  fun `a string the wrapped Resources handles is pseudolocalised, not re-resolved`() {
+    val pseudo = PseudolocaleResources(fallback(), Pseudolocale.ACCENT)
+    val text = pseudo.getText(missingId).toString()
+    // Delegation gives us the wrapper's answer; the transform then runs over it. Through `super`
+    // this id resolves nowhere and throws instead.
+    assertTrue("expected the wrapped value, pseudolocalised; got '$text'", text.contains("ļöŵ"))
+  }
+
+  @Test
+  fun `getString funnels through the delegating getText too`() {
+    // `getString(int)` is `getText(int).toString()`, so it inherits both the delegation and the
+    // transform — no separate override, same as the class has always relied on.
+    val pseudo = PseudolocaleResources(fallback(), Pseudolocale.ACCENT)
+    assertTrue(pseudo.getString(missingId).contains("ļöŵ"))
+  }
+
+  @Test
+  fun `value resources the wrapped Resources handles come back untransformed but delegated`() {
+    val pseudo = PseudolocaleResources(fallback(), Pseudolocale.BIDI)
+    assertEquals(handledColor, pseudo.getColor(missingId, null))
+    assertEquals(42f, pseudo.getDimension(missingId), 0f)
+    val drawable = pseudo.getDrawableForDensity(missingId, 160, null)
+    assertTrue("expected the wrapper's drawable, got $drawable", drawable is ColorDrawable)
+    assertEquals(handledColor, (drawable as ColorDrawable).color)
+  }
+
+  @Test
+  fun `an ordinary lookup still resolves against the real table`() {
+    // Delegation must not change the plain case: wrapping the app's own Resources resolves every
+    // present id exactly as before, transform included.
+    val pseudo = PseudolocaleResources(base, Pseudolocale.ACCENT)
+    val ok = pseudo.getString(android.R.string.ok)
+    assertTrue("framework string must still resolve, pseudolocalised; got '$ok'", ok != "OK")
+    assertTrue(ok.startsWith("["))
+  }
+}


### PR DESCRIPTION
Follow-up to #4382 (merged), which activated the pseudolocale wrap on the daemon render lanes. The review on that PR flagged two P1 hazards in the paths it made reachable — both real, both verified, both fixed here. Refs #4371.

Text-only change: neither fix alters the pixels of a correct render. They stop a *previous* render from corrupting the next one, and stop a render aborting outright.

## 1. The desktop string cache leaked forward

Compose Resources keys its process-wide `stringItemsCache` by `path/offset-size` and stores whatever the **first** reader returned, so a cached value outlives the reader that produced it. `PseudolocaleOverrideExtensionDesktop` clears on *entry*, which stops a pseudo render being served plain strings a previous render cached. The reverse was open: after a pseudo render the cache holds *transformed* values, so the next ordinary render was handed accented / bidi text for a locale it never asked for, its own reader never consulted — a preview browsed right after an `?localeTag=en-XA` one.

Only the renderer sees both renders, so `RenderEngine.guardPseudolocaleStringCache` closes that edge there. It clears exactly when a render **leaves** pseudolocale mode: a pseudo→pseudo switch stays the entry clear's job, and a daemon that never renders a pseudolocale keeps its warm cache untouched. `PseudolocaleResourceCache` becomes public for that call, with the two-edge rationale in its KDoc.

## 2. The Android wrapper stepped over the wrapper below it

`PseudolocaleResources` resolved through `super` — the raw table it constructs itself over — rather than through the `Resources` instance it wraps. Equivalent for a raw base, wrong for a stacked one, and the live daemon stacks: with `PlaceholderFallbackResources` underneath (a detached bundle whose packed table is absent or stale), a missing id skipped the fallback and threw `NotFoundException`, aborting a render that succeeded at `en`. A debugging aid that kills the render it was asked to annotate is the worst version of this bug.

Every accessor now delegates to the wrapped instance — including the colour / dimension / drawable families this class passes through untransformed, which the fallback also guards, so a missing *drawable* under `en-XA` degrades to the placeholder like it does at any other locale. `PlaceholderFallbackResources` already documents the same rule from its side; the two now compose in either order.

## Test plan

- New `PseudolocaleResourcesDelegationTest` (Robolectric, `:data-pseudolocale-connector`) — wraps a `Resources` that handles an otherwise-unresolvable id and asserts the string comes back *pseudolocalised, not re-resolved*, that `getString` inherits it, that the value families delegate, and that an ordinary lookup against the real table is unchanged. Verified to fail on the `super` version (2 of 4 cases red).
- New `RenderEngineLocaleTest.pseudolocaleStringCacheIsClearedOnTheWayOutOfPseudolocaleMode` — pins the clear-on-exit state machine, including the two cases that must *not* clear.
- Suites green locally: `:daemon:core:test`, `:daemon:desktop:test`, `:daemon:android:testDebugUnitTest`, both pseudolocale connectors. `./gradlew ktfmtFormat` applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F5tkZMg9vXuNCqxxy2eMnW)_