### PR TITLE
fix(backdrop): a transparent explicit colour is not a showBackground sheet

### DIFF
--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewBackdrop.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewBackdrop.kt
@@ -162,14 +162,22 @@ public object PreviewBackdrop {
     fallback: Boolean = false,
   ): Backdrop =
     when {
-      // Nonzero AND actually opaque enough to sit behind something. `0` is the annotation's own
-      // "unset", but a nonzero-yet-fully-transparent value like `0x00FFFFFF` is not a ground
-      // either — publishing it would hand a consumer `#FFFFFF00` to composite onto, which paints
-      // nothing while claiming the preview answered, so a dark catalog's transparent artwork would
-      // lose its stage. Same rule the captured-theme rungs below apply, for the same reason.
+      // An explicit colour SETTLES the annotation's two background knobs, exactly as it does in
+      // `PreviewBackground.resolveArgb`: the renderer fills with it and never consults
+      // `showBackground`. So it settles this too, in one of two ways.
+      //
+      // Opaque enough to sit behind something — a real ground, and the highest evidence there is.
       backgroundColor != 0L && !isTransparentArgb(backgroundColor) ->
         Backdrop(hexArgb(backgroundColor.toInt()), Source.PREVIEW_BACKGROUND_COLOR)
-      showBackground ->
+      // Stated but fully transparent (`0x00FFFFFF`): the render's pixels ARE transparent, so there
+      // is no ground here — and crucially no `showBackground` sheet either, because the renderer
+      // never painted one. Falling to that rung would publish a white sheet over transparent
+      // pixels and, being marked preview-explicit, would pin a dark-first catalog's render to
+      // white for good. Skip to the rungs that can still answer honestly.
+      //
+      // `0` is the annotation's own "unset" and is NOT this case — it leaves `showBackground` to
+      // speak, which is the ordinary path.
+      backgroundColor == 0L && showBackground ->
         Backdrop(
           hexArgb(if (night) PreviewBackground.NIGHT_ARGB else PreviewBackground.DAY_ARGB),
           Source.PREVIEW_SHOW_BACKGROUND,

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewBackdropTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewBackdropTest.kt
@@ -80,6 +80,21 @@ class PreviewBackdropTest {
   }
 
   @Test
+  fun `a transparent explicit colour does not revive the showBackground sheet`() {
+    // The renderer fills with the explicit colour and never consults `showBackground`, so the
+    // pixels are transparent. Publishing the white sheet here would describe a render that never
+    // happened — and mark it preview-explicit, pinning a dark catalog to white permanently.
+    val backdrop =
+      PreviewBackdrop.resolve(
+        showBackground = true,
+        backgroundColor = 0x00FFFFFFL,
+        catalogSurface = PreviewBackdrop.CatalogSurface.DARK,
+      )
+    assertEquals(PreviewBackdrop.Source.CATALOG_SURFACE, backdrop.source)
+    assertTrue(backdrop.isDark)
+  }
+
+  @Test
   fun `a barely-opaque explicit colour still counts`() {
     // Only *fully* transparent falls through — a low-alpha wash is still the author stating one.
     val backdrop = PreviewBackdrop.resolve(backgroundColor = 0x01FFFFFFL)


### PR DESCRIPTION
Follow-up to #4375, from a review finding on its final commit that arrived after it merged.

## The bug

`PreviewBackground.resolveArgb` lets an explicit `backgroundColor` settle the annotation's two background knobs outright — the renderer fills with that colour and never consults `showBackground`.

`PreviewBackdrop` only honoured half of that. #4375 taught it to skip a fully transparent explicit colour (correctly — `#FFFFFF00` is not a ground anyone can composite onto), but it then fell through to the `showBackground` rung and published a **white sheet for a render whose pixels are transparent**.

That is worse than a cosmetic slip, because the sheet is marked preview-explicit: the daemon's `render/deviceBackground` caches it, and `withCatalogDefault` treats it as the preview speaking for itself. A dark-first catalog's transparent render would sit on white permanently, with the variant and catalog rungs never consulted — the exact failure wear-m3-catalog#56 was about, reachable through a different door.

## The fix

An explicit colour now settles it in one of two ways, matching the renderer:

- opaque enough to sit behind something → a real ground, highest evidence
- stated but fully transparent → **no evidence at all**, and no `showBackground` sheet either, because the renderer never painted one

Only an unset `0` — the annotation's own default — leaves `showBackground` to speak, which is the ordinary path and is unchanged.

## Test plan

- `:data-render-core:test` — 1 new test pinning the combination: `showBackground = true` with `backgroundColor = 0x00FFFFFF` in a dark-first catalog resolves to `catalog.surface`, not the white sheet. The neighbouring transparent-colour and barely-opaque tests still pass, so the three cases are pinned together.
- `:data-render-connector:test` and `:cli:test` green
- `ktfmtCheckAll` clean

Text-only: this changes which rung answers, not how any surface draws. The pages' rendering is unchanged and already covered by #4375's fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b

---
_Generated by [Claude Code](https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b)_