### PR TITLE
feat(deploy): turn on agent grants wherever there is someone to approve them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,6 +1243,13 @@ jobs:
       # kept the public host's playground pinned to one catalog with the Android modes off.
       - name: Run deploy compose env-passthrough tests
         run: ./deploy/image/test-compose-env-passthrough.sh
+      # The agent-grant lane derives its own default (on where SERVE_GITHUB_AUTH_* gives it a human
+      # to approve against, off otherwise), because both flat answers are wrong in opposite
+      # directions: `1` fails startup on every box with no OAuth app, `0` ships the feature dead on
+      # the box it was built for. A derivation has no output of its own, so getting it wrong either
+      # breaks unrelated deployments on their next roll or quietly disables the lane — both silent.
+      - name: Run deploy agent-grant default tests
+        run: ./deploy/image/test-agent-grants-default.sh
       # The version-control config overlay is opt-in, so nothing exercises it on the way to a
       # release — a wrong source path or mount target is found on a box, after a restart, serving a
       # stale catalog set. Every failure mode is silent: a missing source makes Docker create an

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
@@ -27,6 +27,17 @@ import kotlinx.serialization.json.Json
  * Expired entries are dropped on read rather than swept on a schedule: this is a CLI, it runs and
  * exits, and a stale row costs nothing until someone asks about it.
  */
+/**
+ * No safe place to keep credentials could be determined. Carries the remedy, because the only thing
+ * the user can do about it is name a location.
+ */
+internal class NoCredentialHomeException :
+  IllegalStateException(
+    "no user config directory could be determined (XDG_CONFIG_HOME, HOME and user.home are all " +
+      "unset), and credentials will not be written to the working directory. Set " +
+      "COMPOSE_PREVIEW_AGENT_ACCESS_FILE to a path you control."
+  )
+
 internal open class AgentAccessStore(
   private val file: File = defaultFile(),
   private val clock: () -> Long = System::currentTimeMillis,
@@ -342,10 +353,23 @@ internal open class AgentAccessStore(
 
     /**
      * `$COMPOSE_PREVIEW_AGENT_ACCESS_FILE`, else `$XDG_CONFIG_HOME/compose-preview/…`, else
-     * `~/.config/compose-preview/…`. The override exists for CI and for tests; the XDG path is
-     * where a user would look for it.
+     * `$HOME/.config/…`, else the JVM's `user.home`. The override exists for CI and for tests; the
+     * XDG path is where a user would look for it.
+     *
+     * Throws [NoCredentialHomeException] when none of those yields a location, rather than falling
+     * back to the working directory — see the body.
      */
-    fun defaultFile(env: (String) -> String? = System::getenv): File {
+    fun defaultFile(
+      /**
+       * Injected so a test can simulate a JVM with no `user.home`, which it otherwise always has.
+       *
+       * Deliberately **before** [env] rather than appended: several call sites pass the environment
+       * as a trailing lambda, and a new last parameter silently rebinds those to this one instead —
+       * they still compile, and they quietly test the wrong thing.
+       */
+      prop: (String) -> String? = System::getProperty,
+      env: (String) -> String? = System::getenv,
+    ): File {
       env("COMPOSE_PREVIEW_AGENT_ACCESS_FILE")
         ?.takeIf { it.isNotBlank() }
         ?.let {
@@ -353,7 +377,18 @@ internal open class AgentAccessStore(
         }
       val configHome =
         env("XDG_CONFIG_HOME")?.takeIf { it.isNotBlank() }
-          ?: (env("HOME")?.takeIf { it.isNotBlank() }?.let { "$it/.config" } ?: ".")
+          ?: env("HOME")?.takeIf { it.isNotBlank() }?.let { "$it/.config" }
+          // The JVM's own view of the user's home, which on Linux comes from the passwd entry
+          // rather than the environment — so it survives the minimal `env -i` service context that
+          // has neither variable set.
+          ?: prop("user.home")?.takeIf { it.isNotBlank() && it != "?" }?.let { "$it/.config" }
+          // …and if there is genuinely nowhere, REFUSE. The old fallback was `.`, which wrote
+          // bearer tokens and device secrets into whatever directory the command happened to run
+          // in — for an agent that is a checkout, so the credentials land somewhere that gets
+          // archived by CI or committed by the next `git add -A`. Worse, the target directory
+          // would then be attacker-influenced by anything that can add a `compose-preview/` path
+          // to the tree. Better to store nothing and say so.
+          ?: throw NoCredentialHomeException()
       return File("$configHome/compose-preview/agent-access.json")
     }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
@@ -375,27 +375,35 @@ internal open class AgentAccessStore(
         ?.let {
           return File(it)
         }
+      // ONE rule, applied to every candidate: a home must be an absolute path.
+      //
+      // This leak has now been reachable three times by three different routes — the original `.`
+      // fallback, then a relative `user.home`, then a relative `XDG_CONFIG_HOME`/`HOME` — because
+      // each fix was applied to the branch that was pointed at rather than to the question. The
+      // question is the same every time: is this a real home, or does it resolve under whatever
+      // directory the command happens to be run from? For an agent that directory is a checkout,
+      // so the credentials land somewhere CI archives or the next `git add -A` commits, and the
+      // target becomes influenceable by anything that can add a `compose-preview/` path to the
+      // tree. Anything that fails the question is treated as absent.
       val configHome =
-        env("XDG_CONFIG_HOME")?.takeIf { it.isNotBlank() }
-          ?: env("HOME")?.takeIf { it.isNotBlank() }?.let { "$it/.config" }
+        absoluteHome(env("XDG_CONFIG_HOME"))
+          ?: absoluteHome(env("HOME"))?.let { "$it/.config" }
           // The JVM's own view of the user's home, which on Linux comes from the passwd entry
           // rather than the environment — so it survives the minimal `env -i` service context that
           // has neither variable set.
-          // Absolute only. `-Duser.home=.` resolves to `./.config/…` — straight back under the
-          // working directory, which is the exact outcome this whole path exists to prevent. A
-          // relative home is not a home; treat it as absent and let the refusal below fire.
-          ?: prop("user.home")
-            ?.takeIf { it.isNotBlank() && it != "?" && File(it).isAbsolute }
-            ?.let { "$it/.config" }
-          // …and if there is genuinely nowhere, REFUSE. The old fallback was `.`, which wrote
-          // bearer tokens and device secrets into whatever directory the command happened to run
-          // in — for an agent that is a checkout, so the credentials land somewhere that gets
-          // archived by CI or committed by the next `git add -A`. Worse, the target directory
-          // would then be attacker-influenced by anything that can add a `compose-preview/` path
-          // to the tree. Better to store nothing and say so.
+          ?: absoluteHome(prop("user.home"))?.let { "$it/.config" }
+          // …and if there is genuinely nowhere, REFUSE rather than inventing one.
           ?: throw NoCredentialHomeException()
       return File("$configHome/compose-preview/agent-access.json")
     }
+
+    /**
+     * [candidate] if it is a usable absolute path, else null — the single test every
+     * credential-home candidate goes through. `?` is JVM shorthand for "unknown", and a relative
+     * path is not a home however it was supplied.
+     */
+    private fun absoluteHome(candidate: String?): String? =
+      candidate?.trim()?.takeIf { it.isNotEmpty() && it != "?" && File(it).isAbsolute }
 
     /**
      * `scheme://host[:port]`, lowercased, default ports dropped, path and query discarded.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
@@ -353,8 +353,8 @@ internal open class AgentAccessStore(
 
     /**
      * `$COMPOSE_PREVIEW_AGENT_ACCESS_FILE`, else `$XDG_CONFIG_HOME/compose-preview/…`, else
-     * `$HOME/.config/…`, else the JVM's `user.home`. The override exists for CI and for tests; the
-     * XDG path is where a user would look for it.
+     * `$HOME/.config/…`, else the JVM's `user.home` **when that is an absolute path**. The override
+     * exists for CI and for tests; the XDG path is where a user would look for it.
      *
      * Throws [NoCredentialHomeException] when none of those yields a location, rather than falling
      * back to the working directory — see the body.
@@ -381,7 +381,12 @@ internal open class AgentAccessStore(
           // The JVM's own view of the user's home, which on Linux comes from the passwd entry
           // rather than the environment — so it survives the minimal `env -i` service context that
           // has neither variable set.
-          ?: prop("user.home")?.takeIf { it.isNotBlank() && it != "?" }?.let { "$it/.config" }
+          // Absolute only. `-Duser.home=.` resolves to `./.config/…` — straight back under the
+          // working directory, which is the exact outcome this whole path exists to prevent. A
+          // relative home is not a home; treat it as absent and let the refusal below fire.
+          ?: prop("user.home")
+            ?.takeIf { it.isNotBlank() && it != "?" && File(it).isAbsolute }
+            ?.let { "$it/.config" }
           // …and if there is genuinely nowhere, REFUSE. The old fallback was `.`, which wrote
           // bearer tokens and device secrets into whatever directory the command happened to run
           // in — for an agent that is a checkout, so the credentials land somewhere that gets

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -35,8 +35,22 @@ internal class AuthCommand(
    * behaviour against a real server without reaching for the caller's actual credential file —
    * production always gets the default.
    */
-  private val store: AgentAccessStore = AgentAccessStore(),
+  injectedStore: AgentAccessStore? = null,
 ) {
+
+  /**
+   * Opened lazily so a machine with nowhere safe to keep credentials fails with one clear sentence
+   * instead of a stack trace out of a constructor default — and only when a subcommand actually
+   * needs the store, so `auth --help` still works there.
+   */
+  private val store: AgentAccessStore by lazy {
+    injectedStore
+      ?: try {
+        AgentAccessStore()
+      } catch (e: NoCredentialHomeException) {
+        fail(e.message ?: "no user config directory could be determined")
+      }
+  }
 
   private val json: Boolean = "--json" in args
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -36,6 +36,13 @@ internal class AuthCommand(
    * production always gets the default.
    */
   injectedStore: AgentAccessStore? = null,
+  /**
+   * How the default store is opened when none was injected. A seam, because the one behaviour worth
+   * pinning here is what happens when this **throws** — `auth request --json` must still print the
+   * device secret rather than exiting, and a test cannot make a real machine forget where its home
+   * directory is.
+   */
+  private val openStore: () -> AgentAccessStore = { AgentAccessStore() },
 ) {
 
   /**
@@ -44,13 +51,29 @@ internal class AuthCommand(
    * needs the store, so `auth --help` still works there.
    */
   private val store: AgentAccessStore by lazy {
+    optionalStore ?: fail(storeFailure ?: "no user config directory could be determined")
+  }
+
+  /**
+   * The store, or null when this machine has nowhere safe to keep credentials.
+   *
+   * Separate from [store] because **one path legitimately does not need it**: `auth request --json`
+   * prints the device secret, which is the whole point of that mode — the caller polls for itself.
+   * Failing there would open a request on the server and then exit before printing the secret that
+   * could redeem it, leaving the human with an approval link that mints a credential nobody can
+   * ever collect. Every other path needs somewhere to write and says so through [store].
+   */
+  private val optionalStore: AgentAccessStore? by lazy {
     injectedStore
       ?: try {
-        AgentAccessStore()
+        openStore()
       } catch (e: NoCredentialHomeException) {
-        fail(e.message ?: "no user config directory could be determined")
+        storeFailure = e.message
+        null
       }
   }
+
+  private var storeFailure: String? = null
 
   private val json: Boolean = "--json" in args
 
@@ -138,8 +161,10 @@ internal class AuthCommand(
     // device secret is the only thing that can redeem the approval, so a `--no-wait` that printed
     // "re-run auth status" without persisting it was telling the user to do something impossible —
     // and a wait interrupted by Ctrl-C would have thrown the request away just as completely.
+    // `optionalStore` rather than `store`: with `--json` the device secret is printed, so a machine
+    // with nowhere to write can still drive the flow. Handled below.
     val remembered =
-      store.savePending(
+      optionalStore?.savePending(
         AgentAccessStore.Pending(
           origin = client.origin,
           requestId = opened.requestId,
@@ -155,7 +180,7 @@ internal class AuthCommand(
     // never prints the token, by design. Waiting would mean asking a person to approve access that
     // is guaranteed to be lost. `--json` is exempt: it prints the device secret, so its caller can
     // poll for itself and needs no store at all.
-    if (!remembered && !json) {
+    if (remembered != true && !json) {
       fail(
         "opened the request, but could not save it locally (see the warning above) — so nothing " +
           "could collect the token once it was approved. Fix the credential file's directory and " +
@@ -221,9 +246,9 @@ internal class AuthCommand(
     // grant with nothing left to redeem it.
     // The waiting path replaces this origin's entry too, and had no superseded handling at all —
     // the previous round only taught the `--no-wait` collector to do this.
-    handOverSuperseded(store, client, client.origin, outcome.token.orEmpty())
+    optionalStore?.let { handOverSuperseded(it, client, client.origin, outcome.token.orEmpty()) }
     val saved =
-      store.save(
+      optionalStore?.save(
         AgentAccessStore.Entry(
           origin = client.origin,
           token = outcome.token.orEmpty(),
@@ -233,7 +258,7 @@ internal class AuthCommand(
           expiresAtMillis = System.currentTimeMillis() + (outcome.expiresInSeconds ?: 0) * 1000,
         )
       )
-    if (saved) store.forgetPendingRequest(opened.requestId)
+    if (saved == true) optionalStore?.forgetPendingRequest(opened.requestId)
     if (json) {
       printJson(
         GrantedJson.serializer(),
@@ -242,7 +267,7 @@ internal class AuthCommand(
           scopes = outcome.scopes,
           approvedBy = outcome.approvedBy.orEmpty(),
           expiresInSeconds = outcome.expiresInSeconds ?: 0,
-          stored = saved,
+          stored = saved == true,
         ),
       )
       return
@@ -255,7 +280,7 @@ internal class AuthCommand(
         "."
     )
     println(
-      if (saved)
+      if (saved == true)
         "Saved for ${client.origin}. Other compose-preview commands against this server will use " +
           "it automatically; `compose-preview auth token` prints it for anything else."
       else

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -268,6 +268,8 @@ internal class AuthCommand(
           approvedBy = outcome.approvedBy.orEmpty(),
           expiresInSeconds = outcome.expiresInSeconds ?: 0,
           stored = saved == true,
+          // See [GrantedJson.token]: handed back only when nothing else can retrieve it.
+          token = if (saved == true) null else outcome.token,
         ),
       )
       return
@@ -759,6 +761,16 @@ internal class AuthCommand(
     val approvedBy: String,
     val expiresInSeconds: Long,
     val stored: Boolean,
+    /**
+     * The bearer — present **only when it could not be stored**, and otherwise omitted.
+     *
+     * Normally this response deliberately withholds it: the grant is on disk and `auth token`
+     * prints it for anything that needs the string, so putting it here would spread a credential
+     * through logs for no gain. When there is nowhere to store it, that reasoning inverts — the
+     * caller waited for a grant that is live on the server, and withholding it means they waited
+     * for nothing while the credential stays minted until it expires.
+     */
+    val token: String? = null,
   )
 
   @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -151,6 +151,21 @@ internal class AuthCommand(
         else fail("unrecognised --ttl '$ttlRaw' — try 45m, 2h, or a number of seconds", code = 64)
     val label = args.flagValue("--label")?.trim().orEmpty().ifEmpty { defaultLabel() }
 
+    // Establish that we can KEEP the result before asking the server for one.
+    //
+    // The abort for "nowhere to store credentials" used to fire after the request was opened, which
+    // left an uncollectable request sitting in the server's bounded pending map for its full ten
+    // minutes — and a caller retrying the way anyone would could exhaust the slots for everyone
+    // else. `--json` is exempt because it genuinely does not need a store: it prints the device
+    // secret, so its caller can poll for itself.
+    if (!json && optionalStore == null) {
+      fail(
+        storeFailure
+          ?: "no user config directory could be determined, and credentials will not be written " +
+            "to the working directory."
+      )
+    }
+
     val opened =
       when (val r = client.open(label = label, scope = scope, ttlSeconds = ttl)) {
         is AgentAccessClient.Result.Ok -> r.value
@@ -176,10 +191,10 @@ internal class AuthCommand(
         )
       )
 
-    // Nothing was persisted, so nothing later can redeem an approval — and the human-readable path
-    // never prints the token, by design. Waiting would mean asking a person to approve access that
-    // is guaranteed to be lost. `--json` is exempt: it prints the device secret, so its caller can
-    // poll for itself and needs no store at all.
+    // A store that EXISTS but could not be written to — checked after the fact, because unlike the
+    // missing-home case above it is not knowable until the write is attempted. Same conclusion:
+    // waiting would mean asking a person to approve access that is guaranteed to be lost, and the
+    // human-readable path never prints the token.
     if (remembered != true && !json) {
       fail(
         "opened the request, but could not save it locally (see the warning above) — so nothing " +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -59,7 +59,18 @@ fun main(args: Array<String>) {
             "(ignored)"
         )
       }
-      COMMANDS.getValue(route.command).invoke(route.args)
+      try {
+        COMMANDS.getValue(route.command).invoke(route.args)
+      } catch (e: NoCredentialHomeException) {
+        // Handled here rather than in each caller. `AuthCommand` is not the only thing that opens
+        // the grant store — `share-preview --mechanism serve` reaches for it whenever no explicit
+        // token was given — so catching it there alone turned a deliberate refusal, whose whole
+        // point is a message naming the remedy, into an uncaught stack trace on the second
+        // consumer. One boundary means the next consumer inherits the right behaviour instead of
+        // reintroducing the bug.
+        System.err.println("compose-preview: ${e.message}")
+        exitProcess(1)
+      }
     }
     is CliRouter.Route.GroupUsage -> {
       printGroupUsage(route.group)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -704,8 +704,16 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * Kotlin here; opting into it is a typed decision.
    */
   private val agentGrantMaxScope: ServeAgentGrantScope =
-    ServeAgentGrantScope.parseHighest(args.flagValue("--agent-grant-scopes"))
-      ?: ServeAgentGrantScope.DEFAULT_MAX
+    args.flagValue("--agent-grant-scopes")?.let {
+      // The worst of this family to default silently: `--agent-grant-scopes preivew` is an operator
+      // narrowing the box to read-only, and the default it would fall back to is `preview,live`. A
+      // typo would have *widened* what every grant on the host may do, which is the opposite of the
+      // intent that made them type the flag.
+      ServeAgentGrantScope.parseHighest(it)
+        ?: throw IllegalArgumentException(
+          "--agent-grant-scopes '$it' is not a scope list — use preview, live, or playground"
+        )
+    } ?: ServeAgentGrantScope.DEFAULT_MAX
 
   /**
    * Longest grant this box will mint (`--agent-grant-max-ttl`, e.g. `2h`/`90m`/`3600`). Clamped to
@@ -730,8 +738,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
 
   /** How many grants may be live at once (`--agent-grant-max-active`). */
   private val agentGrantMaxActive: Int =
-    args.flagValue("--agent-grant-max-active")?.toIntOrNull()?.takeIf { it > 0 }
-      ?: ServeAgentGrantStore.DEFAULT_MAX_ACTIVE_GRANTS
+    args.flagValue("--agent-grant-max-active")?.let {
+      it.toIntOrNull()?.takeIf { n -> n > 0 }
+        ?: throw IllegalArgumentException(
+          "--agent-grant-max-active '$it' is not a positive whole number"
+        )
+    } ?: ServeAgentGrantStore.DEFAULT_MAX_ACTIVE_GRANTS
 
   /**
    * Per-address budget on the two ungated grant routes (`--agent-grant-rate-limit`, requests per
@@ -740,8 +752,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
    * map.
    */
   private val agentGrantRateLimit: Int =
-    args.flagValue("--agent-grant-rate-limit")?.toIntOrNull()?.takeIf { it >= 0 }
-      ?: DEFAULT_AGENT_GRANT_RATE_LIMIT
+    args.flagValue("--agent-grant-rate-limit")?.let {
+      it.toIntOrNull()?.takeIf { n -> n >= 0 }
+        ?: throw IllegalArgumentException(
+          "--agent-grant-rate-limit '$it' is not a whole number of requests per minute (0 disables)"
+        )
+    } ?: DEFAULT_AGENT_GRANT_RATE_LIMIT
 
   /**
    * Image ingestion (`--accept-images`): enable `POST /images` so an **agent preparing a pull

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
@@ -184,12 +184,18 @@ class ServeAgentGrantStore(
     val now = clock()
     purge(now)
     if (requests.size >= maxPendingRequests) {
-      // Shed only what is genuinely finished with: a denial, or an approval whose token has been
-      // collected. An approved-but-uncollected request still owes its owner a credential, and a
-      // pending one still owes a human a decision — dropping either loses work someone is waiting
-      // on, which is worse than refusing this new ask.
+      // Shed only what is genuinely finished with: a denial, or an approval whose GRANT is gone
+      // (expired or revoked). A pending request still owes a human a decision, and an approved one
+      // still owes its owner a credential — dropping either loses work someone is waiting on, which
+      // is worse than refusing this new ask.
+      //
+      // Deliberately NOT keyed on `collected`. That flag means a poll *built* a response, not that
+      // the agent received one; a response lost in flight has to be retriable. `purge` learned this
+      // and this path did not, so a full map plus one dropped packet still stranded a live grant —
+      // and filling the map is something an anonymous caller can attempt. Same rule, both places.
       requests.entries.removeIf { (_, r) ->
-        r.state == Request.State.DENIED || (r.state == Request.State.APPROVED && r.collected)
+        r.state == Request.State.DENIED ||
+          (r.state == Request.State.APPROVED && grantIsGone(r, now))
       }
       if (requests.size >= maxPendingRequests) return null
     }
@@ -495,17 +501,37 @@ class ServeAgentGrantStore(
      * request. Neither is theoretical: the log line is emitted at approval time, on the operator's
      * console, from text the requester chose.
      *
-     * Every C0/C1 control (and DEL) becomes a space, runs collapse, and the result is trimmed and
-     * capped. The HTML page escapes this same value again on its own account — this is not a
-     * substitute for that, it is the half that protects the terminal rather than the browser.
+     * Every C0/C1 control (and DEL), plus every Unicode **format** character — see
+     * [isInvisibleFormat], which is what stops a bidi override from rewriting what the approval
+     * page appears to say — becomes a space; runs collapse, and the result is trimmed and capped.
+     * The HTML page escapes this same value again on its own account: escaping is not a substitute
+     * for this, because the characters that matter here survive it untouched.
      */
     fun sanitizeLabel(raw: String): String =
       raw
-        .map { if (it.isISOControl() || it == '\u007f') ' ' else it }
+        .map { if (it.isISOControl() || it == '\u007f' || it.isInvisibleFormat()) ' ' else it }
         .joinToString("")
         .replace(Regex("\\s+"), " ")
         .trim()
         .take(MAX_LABEL_CHARS)
+
+    /**
+     * Unicode's **format** category (Cf): the characters that render as nothing but change how
+     * everything around them is laid out.
+     *
+     * Stripping C0/C1 was not enough, and the gap mattered most on the one page whose entire job is
+     * honest display. A requester chooses their own label, and `U+202E RIGHT-TO-LEFT OVERRIDE`
+     * survives both an `isISOControl` filter and HTML escaping — so a label could visually reverse
+     * the text after it and rewrite what the approval page appears to say, including the scope and
+     * lifetime the human is agreeing to. The same trick reorders the audit line in the operator's
+     * console. The isolates (`U+2066`–`U+2069`) and the zero-width joiners do the same job more
+     * quietly.
+     *
+     * Cf is exactly that set — overrides, embeddings, isolates, marks, zero-widths, the BOM — and
+     * nothing a purpose string legitimately needs, so the whole category goes.
+     */
+    private fun Char.isInvisibleFormat(): Boolean =
+      Character.getType(this) == Character.FORMAT.toInt()
 
     /** The bearer's prefix — greppable, and unmistakable for the operator's `--token`. */
     const val TOKEN_PREFIX = "cpat_"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
@@ -155,8 +155,9 @@ class ServeAgentGrantStore(
   // ---------------------------------------------------------------- requests
 
   /**
-   * Open a request. Returns null when the box is already tracking [maxPendingRequests] live ones
-   * and none can be purged — a refusal, rather than growing a map an anonymous caller controls.
+   * Open a request. Returns null when the box is already tracking [maxPendingRequests] **pending**
+   * ones and none can be purged — a refusal, rather than growing a map an anonymous caller
+   * controls.
    */
   fun openRequest(
     label: String,
@@ -183,21 +184,31 @@ class ServeAgentGrantStore(
   ): Request? {
     val now = clock()
     purge(now)
-    if (requests.size >= maxPendingRequests) {
-      // Shed only what is genuinely finished with: a denial, or an approval whose GRANT is gone
-      // (expired or revoked). A pending request still owes a human a decision, and an approved one
-      // still owes its owner a credential — dropping either loses work someone is waiting on, which
-      // is worse than refusing this new ask.
-      //
-      // Deliberately NOT keyed on `collected`. That flag means a poll *built* a response, not that
-      // the agent received one; a response lost in flight has to be retriable. `purge` learned this
-      // and this path did not, so a full map plus one dropped packet still stranded a live grant —
-      // and filling the map is something an anonymous caller can attempt. Same rule, both places.
+    // The cap counts **pending** requests, not every row in the map.
+    //
+    // These are two different populations with two different reasons to be bounded. Pending
+    // requests are what an anonymous caller can create at will, so they need a ceiling — that is
+    // what this number is for. A retained approval is not that: it exists only while its grant is
+    // alive, and grants are already bounded by [maxActiveGrants]. Counting both against one number
+    // made the two caps fight: retention (correctly) stopped shedding live approvals, so with
+    // `--agent-grant-max-active` above this cap, enough approvals could fill the map and every
+    // further request was refused — an operator who asked for 100 concurrent grants could never get
+    // past 32, with no way to tell why. Bounding each population by its own limit keeps total
+    // memory bounded (pending + active) and lets the configured numbers mean what they say.
+    val pending = requests.values.count { it.state == Request.State.PENDING }
+    if (pending >= maxPendingRequests) {
+      // Sweep what is genuinely finished with before refusing: a denial, or an approval whose grant
+      // is gone. Neither owes anyone anything. (A pending request still owes a human a decision and
+      // an approved-with-live-grant one still owes its owner a credential, so neither is touched —
+      // and note `collected` is deliberately not consulted: it means a poll *built* a response, not
+      // that the agent received one, and a lost response has to stay retriable.)
       requests.entries.removeIf { (_, r) ->
         r.state == Request.State.DENIED ||
           (r.state == Request.State.APPROVED && grantIsGone(r, now))
       }
-      if (requests.size >= maxPendingRequests) return null
+      if (requests.values.count { it.state == Request.State.PENDING } >= maxPendingRequests) {
+        return null
+      }
     }
     val request =
       Request(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
@@ -184,32 +184,31 @@ class ServeAgentGrantStore(
   ): Request? {
     val now = clock()
     purge(now)
-    // The cap counts **pending** requests, not every row in the map.
+    // The cap counts what an anonymous caller can CREATE: rows that are pending, plus rows they got
+    // denied. What it does not count is a retained approval, which exists only while its grant does
+    // and is therefore already bounded by [maxActiveGrants].
     //
-    // These are two different populations with two different reasons to be bounded. Pending
-    // requests are what an anonymous caller can create at will, so they need a ceiling — that is
-    // what this number is for. A retained approval is not that: it exists only while its grant is
-    // alive, and grants are already bounded by [maxActiveGrants]. Counting both against one number
-    // made the two caps fight: retention (correctly) stopped shedding live approvals, so with
-    // `--agent-grant-max-active` above this cap, enough approvals could fill the map and every
-    // further request was refused — an operator who asked for 100 concurrent grants could never get
-    // past 32, with no way to tell why. Bounding each population by its own limit keeps total
-    // memory bounded (pending + active) and lets the configured numbers mean what they say.
-    val pending = requests.values.count { it.state == Request.State.PENDING }
-    if (pending >= maxPendingRequests) {
-      // Sweep what is genuinely finished with before refusing: a denial, or an approval whose grant
-      // is gone. Neither owes anyone anything. (A pending request still owes a human a decision and
-      // an approved-with-live-grant one still owes its owner a credential, so neither is touched —
-      // and note `collected` is deliberately not consulted: it means a poll *built* a response, not
-      // that the agent received one, and a lost response has to stay retriable.)
-      requests.entries.removeIf { (_, r) ->
-        r.state == Request.State.DENIED ||
-          (r.state == Request.State.APPROVED && grantIsGone(r, now))
+    // Getting this split wrong has now failed in both directions, which is why it is spelled out.
+    // Counting every row against one number made the two caps fight: retention (correctly) stopped
+    // shedding live approvals, so an operator who set `--agent-grant-max-active` above this cap
+    // could never reach it. Counting only *pending* rows then leaked the other way — a denial sits
+    // in the map until its own deadline, so an attacker could submit a batch, have an operator deny
+    // it, and submit another, growing an anonymously-controlled map without bound while the pending
+    // count stayed comfortably under the cap.
+    //
+    // A denial has to be kept (the agent must be able to learn it was denied rather than being told
+    // `unknown`), so it is kept AND charged. That is the honest accounting: the attacker caused the
+    // row, the operator's decision does not hand them a free one, and the row still expires on its
+    // own deadline. Total map size is bounded by maxPendingRequests + maxActiveGrants.
+    //
+    // Rows nobody is owed anything for — an approval whose grant has expired or been revoked — are
+    // reclaimed FIRST, unconditionally, so they can never be what pushes a legitimate caller over.
+    requests.entries.removeIf { (_, r) -> r.state == Request.State.APPROVED && grantIsGone(r, now) }
+    val charged =
+      requests.values.count {
+        it.state == Request.State.PENDING || it.state == Request.State.DENIED
       }
-      if (requests.values.count { it.state == Request.State.PENDING } >= maxPendingRequests) {
-        return null
-      }
-    }
+    if (charged >= maxPendingRequests) return null
     val request =
       Request(
         id = mintId(),

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessClientIntegrationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessClientIntegrationTest.kt
@@ -245,4 +245,38 @@ class AgentAccessClientIntegrationTest {
   fun `a URL carrying credentials is refused`() {
     assertFailsWith<IllegalArgumentException> { AgentAccessClient("https://u:p@preview.coo.ee") }
   }
+
+  @Test
+  fun `a json request still prints its secret with nowhere to store credentials`() {
+    // `--json` prints the device secret precisely so the caller can poll for itself. Failing on a
+    // missing credential store would open a request on the server and then exit BEFORE printing the
+    // one thing that could redeem it — leaving a human with an approval link that mints a
+    // credential nobody can ever collect. The storeless fallback the refusal message recommends has
+    // to actually work.
+    val out = java.io.ByteArrayOutputStream()
+    val original = System.out
+    try {
+      System.setOut(java.io.PrintStream(out, true))
+      AuthCommand(
+          listOf(
+            "request",
+            "--server",
+            client().origin,
+            "--json",
+            "--no-wait",
+            "--scope",
+            "preview",
+          ),
+          injectedStore = null,
+          openStore = { throw NoCredentialHomeException() },
+        )
+        .run()
+    } finally {
+      System.setOut(original)
+    }
+    val line = out.toString().trim().lines().last()
+    assertTrue(line.startsWith("{"), "expected a JSON line, got: $line")
+    assertTrue(line.contains("deviceSecret"), "the secret must be printed: $line")
+    assertTrue(line.contains("approveUrl"), "the approval link must be printed: $line")
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
@@ -4,6 +4,7 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -231,6 +232,29 @@ class AgentAccessStoreTest {
     val kept = store().pendingFor("https://preview.coo.ee")
     assertNotNull(kept, "the device secret must survive the approval window")
     assertTrue(kept.windowClosed(now), "…while still reporting the window as closed")
+  }
+
+  @Test
+  fun `credentials are never written to the working directory`() {
+    // The old fallback was `.`, so on a minimal service environment with neither XDG_CONFIG_HOME
+    // nor HOME an agent wrote bearer tokens into whatever directory it ran in — for an agent that
+    // is a checkout, which gets archived by CI or swept up by the next `git add -A`.
+    val err =
+      assertFailsWith<NoCredentialHomeException> {
+        AgentAccessStore.defaultFile(prop = { null }, env = { null })
+      }
+    assertTrue(err.message!!.contains("COMPOSE_PREVIEW_AGENT_ACCESS_FILE"), "names the remedy")
+  }
+
+  @Test
+  fun `the explicit override still wins with no home at all`() {
+    val chosen =
+      AgentAccessStore.defaultFile(
+        env = { name ->
+          if (name == "COMPOSE_PREVIEW_AGENT_ACCESS_FILE") "/tmp/x/creds.json" else null
+        }
+      )
+    assertEquals(File("/tmp/x/creds.json"), chosen)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
@@ -247,15 +247,40 @@ class AgentAccessStoreTest {
   }
 
   @Test
-  fun `a relative user home is not a home`() {
-    // `-Duser.home=.` resolved to `./.config/…` — straight back under the working directory, the
-    // exact outcome the refusal exists to prevent, reached by a different route.
-    assertFailsWith<NoCredentialHomeException> {
-      AgentAccessStore.defaultFile(prop = { "." }, env = { null })
+  fun `no relative path is ever a home, whichever variable supplies it`() {
+    // This leak was reachable three times by three routes — the original `.` fallback, a relative
+    // `user.home`, then a relative `XDG_CONFIG_HOME`/`HOME` — because each fix was applied to the
+    // branch that was pointed at. One rule now covers every candidate, and this covers all of them
+    // so a fourth route cannot open quietly.
+    for (relative in listOf(".", "relative/path", "./x", "")) {
+      assertFailsWith<NoCredentialHomeException>("user.home=$relative") {
+        AgentAccessStore.defaultFile(prop = { relative }, env = { null })
+      }
+      assertFailsWith<NoCredentialHomeException>("XDG_CONFIG_HOME=$relative") {
+        AgentAccessStore.defaultFile(
+          prop = { null },
+          env = { n -> if (n == "XDG_CONFIG_HOME") relative else null },
+        )
+      }
+      assertFailsWith<NoCredentialHomeException>("HOME=$relative") {
+        AgentAccessStore.defaultFile(
+          prop = { null },
+          env = { n -> if (n == "HOME") relative else null },
+        )
+      }
     }
-    assertFailsWith<NoCredentialHomeException> {
-      AgentAccessStore.defaultFile(prop = { "relative/path" }, env = { null })
-    }
+  }
+
+  @Test
+  fun `a relative variable falls through to an absolute one rather than winning`() {
+    // A relative XDG_CONFIG_HOME must not shadow a perfectly good HOME.
+    assertEquals(
+      File("/home/u/.config/compose-preview/agent-access.json"),
+      AgentAccessStore.defaultFile(
+        prop = { null },
+        env = { n -> mapOf("XDG_CONFIG_HOME" to ".", "HOME" to "/home/u")[n] },
+      ),
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessStoreTest.kt
@@ -247,6 +247,27 @@ class AgentAccessStoreTest {
   }
 
   @Test
+  fun `a relative user home is not a home`() {
+    // `-Duser.home=.` resolved to `./.config/…` — straight back under the working directory, the
+    // exact outcome the refusal exists to prevent, reached by a different route.
+    assertFailsWith<NoCredentialHomeException> {
+      AgentAccessStore.defaultFile(prop = { "." }, env = { null })
+    }
+    assertFailsWith<NoCredentialHomeException> {
+      AgentAccessStore.defaultFile(prop = { "relative/path" }, env = { null })
+    }
+  }
+
+  @Test
+  fun `an absolute platform home is used when the environment has neither variable`() {
+    // A minimal service context often has no HOME while the JVM still knows the passwd entry.
+    assertEquals(
+      File("/home/svc/.config/compose-preview/agent-access.json"),
+      AgentAccessStore.defaultFile(prop = { "/home/svc" }, env = { null }),
+    )
+  }
+
+  @Test
   fun `the explicit override still wins with no home at all`() {
     val chosen =
       AgentAccessStore.defaultFile(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
@@ -228,11 +228,19 @@ class ServeAgentGrantStoreTest {
   }
 
   @Test
-  fun `a resolved request makes room for a new one`() {
+  fun `a denial does not make room for a new one`() {
+    // Inverted deliberately. This used to assert that denying freed capacity, which is exactly the
+    // vector that made the map unbounded: an operator working through hostile requests would hand
+    // the sender a fresh slot with every click. A denial is kept (its owner must be able to learn
+    // it was denied) and charged to whoever caused it; only its own expiry frees the space.
     val store = store(maxPendingRequests = 2)
     val first = store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600)!!
     store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
     store.deny(first.id, "@yuri")
+    assertNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    // The denial is still readable by its owner while it holds that slot.
+    assertTrue(store.poll(first.id, first.deviceSecret) is ServeAgentGrantStore.Poll.Denied)
+    now += (store.requestTtlSeconds + 5) * 1000
     assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
   }
 
@@ -464,6 +472,44 @@ class ServeAgentGrantStoreTest {
   }
 
   @Test
+  fun `denying a batch does not hand the attacker a fresh batch`() {
+    // A denial stays in the map so the agent can learn it was denied rather than being told
+    // `unknown` — so if denials were not charged against the cap, an operator working through
+    // hostile requests would free capacity with every click: submit a batch, get it denied, submit
+    // another, forever, in an anonymously-controlled map that was supposed to be bounded.
+    val store = store(maxPendingRequests = 3)
+    val first =
+      (1..3).mapNotNull {
+        store.openRequest("spam-$it", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600)
+      }
+    assertEquals(3, first.size)
+    // The operator denies every one of them.
+    for (r in first) assertTrue(store.deny(r.id, "@yuri"))
+    // The attacker immediately tries again, and gets nowhere.
+    assertNull(
+      store.openRequest("spam-again", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600),
+      "a denied row must still be charged to whoever created it",
+    )
+    // …and the denials remain visible to their owners in the meantime.
+    assertTrue(store.poll(first[0].id, first[0].deviceSecret) is ServeAgentGrantStore.Poll.Denied)
+    // Only the passage of time frees the capacity.
+    now += (store.requestTtlSeconds + 5) * 1000
+    assertNotNull(store.openRequest("later", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600))
+  }
+
+  @Test
+  fun `a dead approval never blocks a legitimate caller`() {
+    // Rows nobody is owed anything for are reclaimed before the count, so they can never be what
+    // pushes someone over the cap.
+    val store = store(maxPendingRequests = 2)
+    val done = store.ask(ttl = 60)
+    store.approve(done.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
+    now += 61_000 // the grant is gone; the row owes nobody anything
+    assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600))
+  }
+
+  @Test
   fun `the pending cap still bounds what an anonymous caller can create`() {
     val store = store(maxPendingRequests = 2)
     assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
@@ -485,15 +531,6 @@ class ServeAgentGrantStoreTest {
     store.approve(done.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
     assertTrue(store.poll(done.id, done.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
     now += 61_000 // its grant is gone, so the record owes nobody anything
-    store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
-    assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
-  }
-
-  @Test
-  fun `a denial is shed to make room`() {
-    val store = store(maxPendingRequests = 2)
-    val denied = store.ask()
-    assertTrue(store.deny(denied.id, "@yuri"))
     store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
     assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
@@ -287,15 +287,19 @@ class ServeAgentGrantStoreTest {
 
   @Test
   fun `overflow never strands a token the agent has not collected yet`() {
+    // This used to assert the *mechanism* — that a new ask was refused rather than evicting the
+    // uncollected approval. The mechanism changed (an approval no longer spends the pending budget
+    // at all, so there is nothing to refuse), but the guarantee it was protecting has not, so the
+    // test now states that instead: fill the pending budget and the uncollected token still
+    // arrives.
     val store = store(maxPendingRequests = 2)
     val approved = store.ask()
     store.approve(approved.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
-    store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
-    // The map is full and the only resolved entry is an approval nobody has polled for yet, so the
-    // new ask is refused rather than deleting a live credential its owner can never fetch again.
-    assertNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    // Saturate the pending budget, then keep asking — every one of these is refused or admitted on
+    // its own merits, and none of them may cost the approval above its credential.
+    repeat(6) { store.openRequest("filler-$it", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600) }
     val polled = store.poll(approved.id, approved.deviceSecret)
-    assertTrue(polled is ServeAgentGrantStore.Poll.Approved)
+    assertTrue(polled is ServeAgentGrantStore.Poll.Approved, "got $polled")
   }
 
   @Test
@@ -429,6 +433,45 @@ class ServeAgentGrantStoreTest {
     now += (store.requestTtlSeconds + 5) * 1000
     // The grant expired too, so the record owes nobody anything and goes.
     assertNull(store.request(request.id))
+  }
+
+  @Test
+  fun `retained approvals do not consume the pending-request budget`() {
+    // Two populations, two reasons to be bounded. Pending requests are what an anonymous caller can
+    // create at will; a retained approval exists only while its grant does, and grants have their
+    // own cap. Counting both against one number made the caps fight: an operator asking for more
+    // concurrent grants than the request cap could never get them, with nothing to explain why.
+    val store = store(maxPendingRequests = 2, maxActiveGrants = 8)
+    // Fill the map with approvals whose grants are all live.
+    val approved =
+      (1..5).map { i ->
+        val r = store.ask(ttl = 3600)
+        store.approve(r.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+        r
+      }
+    // …and a fresh request still gets in, because none of those is pending.
+    assertNotNull(
+      store.openRequest("new", "ip", ServeAgentGrantScope.PREVIEW, 600),
+      "retained approvals must not spend the pending budget",
+    )
+    // Every one of those grants is still collectable.
+    for (r in approved) {
+      assertTrue(
+        store.poll(r.id, r.deviceSecret) is ServeAgentGrantStore.Poll.Approved,
+        "a live grant was shed to admit a new request",
+      )
+    }
+  }
+
+  @Test
+  fun `the pending cap still bounds what an anonymous caller can create`() {
+    val store = store(maxPendingRequests = 2)
+    assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNull(
+      store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600),
+      "a third pending request must be refused",
+    )
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -360,6 +361,41 @@ class ServeAgentGrantStoreTest {
   }
 
   @Test
+  fun `a label cannot reorder what the approval page says`() {
+    // U+202E RIGHT-TO-LEFT OVERRIDE survives an isISOControl filter AND HTML escaping, so a
+    // requester could reverse the rendering of everything after their label — on the one page whose
+    // whole job is to state accurately what is being agreed to, and in the operator's audit line.
+    val nasty = "fix \u202Ednarg lla tnarg\u202C \u2066issue\u2069 \u200Bnow\uFEFF"
+    val clean = ServeAgentGrantStore.sanitizeLabel(nasty)
+    for (c in clean) {
+      assertNotEquals(
+        Character.FORMAT.toInt(),
+        Character.getType(c),
+        "a format character survived: U+%04X".format(c.code),
+      )
+    }
+    assertTrue(clean.startsWith("fix "), "the readable text survives: '$clean'")
+  }
+
+  @Test
+  fun `overflow never sheds an approval whose grant is still live`() {
+    // `collected` means a poll BUILT a response, not that the agent got one. Shedding on it meant a
+    // full map plus one dropped packet stranded a live grant — and filling the map is something an
+    // anonymous caller can attempt.
+    val store = store(maxPendingRequests = 2)
+    val mine = store.ask(ttl = 3600)
+    store.approve(mine.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+    assertTrue(store.poll(mine.id, mine.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
+    // …that response is lost. Now an anonymous caller tries to fill the map. `openRequest` rather
+    // than the `!!` helper: being REFUSED is the correct outcome here, not an error.
+    repeat(4) { store.openRequest("spam", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600) }
+    assertTrue(
+      store.poll(mine.id, mine.deviceSecret) is ServeAgentGrantStore.Poll.Approved,
+      "a live grant was shed to admit an anonymous request",
+    )
+  }
+
+  @Test
   fun `a lost token response can be collected again`() {
     // `collected` marks that a poll BUILT a response, not that the agent received one. Treating it
     // as a deletion trigger meant a response lost in flight left the retry told `unknown` while the
@@ -396,13 +432,25 @@ class ServeAgentGrantStoreTest {
   }
 
   @Test
-  fun `a collected request is shed to make room`() {
+  fun `a finished request is shed to make room`() {
+    // This used to assert that a *collected* request was shed. That was wrong for the same reason
+    // the purge was: `collected` means a poll built a response, not that the agent received one, so
+    // shedding on it stranded a live grant whenever a response was lost. What may be shed is a
+    // request that is genuinely finished with — here, one whose grant has since expired.
     val store = store(maxPendingRequests = 2)
-    val collected = store.ask()
-    store.approve(collected.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
-    assertTrue(
-      store.poll(collected.id, collected.deviceSecret) is ServeAgentGrantStore.Poll.Approved
-    )
+    val done = store.ask(ttl = 60)
+    store.approve(done.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
+    assertTrue(store.poll(done.id, done.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
+    now += 61_000 // its grant is gone, so the record owes nobody anything
+    store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
+    assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+  }
+
+  @Test
+  fun `a denial is shed to make room`() {
+    val store = store(maxPendingRequests = 2)
+    val denied = store.ask()
+    assertTrue(store.deny(denied.id, "@yuri"))
     store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
     assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
   }

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -221,6 +221,9 @@ services:
       # SERVE_IMAGE_UPLOAD_REPO (which falls back to SERVE_GITHUB_AUTH_REPO), and the lane refuses
       # to start without one. Off unless asked for.
       SERVE_ACCEPT_IMAGES: "${SERVE_ACCEPT_IMAGES:-}"
+      # Empty means "let the entrypoint decide": on when SERVE_GITHUB_AUTH_* gives it a human to
+      # approve against, off otherwise (the lane refuses to start with no approver, so a flat
+      # default of 1 would break every box without an OAuth app). `0` opts out explicitly.
       SERVE_AGENT_GRANTS: "${SERVE_AGENT_GRANTS:-}"
       SERVE_AGENT_GRANT_SCOPES: "${SERVE_AGENT_GRANT_SCOPES:-}"
       SERVE_AGENT_GRANT_MAX_TTL: "${SERVE_AGENT_GRANT_MAX_TTL:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -371,6 +371,23 @@ fi
 # GitHub user here (SERVE_GITHUB_AUTH_* is what supplies the identity), so on the open profile the
 # lane refuses to start without it rather than letting anonymous visitors mint credentials.
 # Off unless asked for. See docs/design/AGENT_ACCESS_GRANTS.md.
+# Unset means "on where it can work": the lane needs a human identity to approve against, which is
+# exactly what SERVE_GITHUB_AUTH_* supplies, and on the open profile the server refuses to start
+# without one rather than letting anonymous visitors mint credentials. So defaulting it to a flat
+# `1` would take out every public box that has no OAuth app configured — while defaulting it off
+# leaves the feature switched off on the one box it was built for. Deriving it from the approver's
+# presence turns it on precisely where it is safe and useful, and an operator can still force either
+# answer explicitly (`SERVE_AGENT_GRANTS=0` to opt out with auth configured, `=1` to insist without
+# it and get the server's own refusal, which is the honest failure).
+if [[ -z "${SERVE_AGENT_GRANTS:-}" ]]; then
+  if [[ -n "${SERVE_GITHUB_AUTH_CLIENT_ID:-}" && -n "${SERVE_GITHUB_AUTH_CLIENT_SECRET:-}" &&
+    -n "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}" ]]; then
+    SERVE_AGENT_GRANTS=1
+  else
+    SERVE_AGENT_GRANTS=0
+  fi
+fi
+
 if [[ "${SERVE_AGENT_GRANTS:-}" == "1" || "${SERVE_AGENT_GRANTS:-}" == "true" ]]; then
   args+=(--agent-grants)
   [[ -n "${SERVE_AGENT_GRANT_SCOPES:-}" ]] &&

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -380,8 +380,18 @@ fi
 # answer explicitly (`SERVE_AGENT_GRANTS=0` to opt out with auth configured, `=1` to insist without
 # it and get the server's own refusal, which is the honest failure).
 if [[ -z "${SERVE_AGENT_GRANTS:-}" ]]; then
+  # There are exactly TWO ways to be an approver, and the server names both: a signed-in GitHub
+  # visitor, or the holder of `--token` on a box that is not `--public`. Keying only on the first
+  # left the lane switched off on every private token-gated deployment — a configuration
+  # `buildAgentGrantStore` explicitly supports, and whose own refusal message recommends ("drop
+  # --public (the --token holder then approves)").
   if [[ -n "${SERVE_GITHUB_AUTH_CLIENT_ID:-}" && -n "${SERVE_GITHUB_AUTH_CLIENT_SECRET:-}" &&
     -n "${SERVE_GITHUB_AUTH_COOKIE_SECRET:-}" ]]; then
+    SERVE_AGENT_GRANTS=1
+  elif [[ "${SERVE_PUBLIC:-}" != "1" && "${SERVE_PUBLIC:-}" != "true" &&
+    -n "${SERVE_TOKEN:-}" ]]; then
+    # Token-gated: the operator token IS the approver identity. Mirrors the posture test above,
+    # which treats anything but 1/true as private and requires SERVE_TOKEN.
     SERVE_AGENT_GRANTS=1
   else
     SERVE_AGENT_GRANTS=0

--- a/deploy/image/test-agent-grants-default.sh
+++ b/deploy/image/test-agent-grants-default.sh
@@ -31,7 +31,14 @@ expect() {
   local want="$1" desc="$2"
   shift 2
   local got
-  got="$(env "$@" bash -c "set -euo pipefail; ${gate}; echo \"\${SERVE_AGENT_GRANTS}\"")"
+  # `env -i` — an EMPTY environment, not merely the assignments layered on top of this shell's.
+  # A runner or operator shell that already exports SERVE_GITHUB_AUTH_* would otherwise leak those
+  # into the "no auth" and "partial auth" cases, which would then be exercising full auth and
+  # passing for the wrong reason. Reproduce the old behaviour with:
+  #   SERVE_GITHUB_AUTH_CLIENT_ID=x SERVE_GITHUB_AUTH_CLIENT_SECRET=x \
+  #     SERVE_GITHUB_AUTH_COOKIE_SECRET=x ./deploy/image/test-agent-grants-default.sh
+  # PATH is restored because bash needs it; nothing else is.
+  got="$(env -i PATH="${PATH}" "$@" bash -c "set -euo pipefail; ${gate}; echo \"\${SERVE_AGENT_GRANTS:-}\"")"
   if [[ "${got}" != "${want}" ]]; then
     echo "FAIL: ${desc}: expected SERVE_AGENT_GRANTS=${want}, got '${got}'" >&2
     exit 1
@@ -51,6 +58,12 @@ expect 0 "unset + no GitHub auth => off"
 expect 0 "unset + partial GitHub auth (no cookie secret) => off" \
   SERVE_GITHUB_AUTH_CLIENT_ID=id SERVE_GITHUB_AUTH_CLIENT_SECRET=secret
 expect 0 "unset + only a client id => off" SERVE_GITHUB_AUTH_CLIENT_ID=id
+
+# The other way to be an approver: a token-gated box, where the operator token is the identity.
+expect 1 "unset + private with a token => on" SERVE_PUBLIC=0 SERVE_TOKEN=t
+expect 1 "unset + private (SERVE_PUBLIC absent) with a token => on" SERVE_TOKEN=t
+expect 0 "unset + public with a token but no auth => off" SERVE_PUBLIC=1 SERVE_TOKEN=t
+expect 0 "unset + private with no token => off" SERVE_PUBLIC=0
 
 # An explicit answer always wins, in both directions — including "insist without an approver",
 # which is meant to reach the server's own refusal rather than being silently downgraded here.

--- a/deploy/image/test-agent-grants-default.sh
+++ b/deploy/image/test-agent-grants-default.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Guard: the agent-access-grant lane turns itself on exactly where it can work.
+#
+# Why this needs a test rather than a comment. The lane mints credentials, so it needs a human
+# identity to approve against — SERVE_GITHUB_AUTH_* — and on the open profile the server REFUSES TO
+# START without one rather than letting anonymous visitors mint them. That makes both obvious
+# defaults wrong in opposite directions: a flat `1` takes out every public box with no OAuth app
+# configured, and a flat `0` leaves the feature switched off on the box it was built for.
+#
+# So the entrypoint derives it, and a derivation is exactly the kind of shell that rots silently: it
+# has no output of its own, and getting it wrong either breaks unrelated deployments on their next
+# roll or quietly ships a dead feature. Both failures are invisible until someone goes looking.
+#
+# Runs the real gate out of entrypoint.sh rather than a copy, so the two cannot drift.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+
+# The derivation block, lifted verbatim from the entrypoint by its sentinel comment so this test
+# exercises the shipped logic. Extracted rather than sourced because entrypoint.sh runs a server.
+gate="$(awk '/^# Unset means "on where it can work"/,/^fi$/' "${entrypoint}")"
+[[ -n "${gate}" ]] || {
+  echo "FAIL: could not find the SERVE_AGENT_GRANTS derivation in ${entrypoint}" >&2
+  echo "      (did the leading comment change? this test locates it by that line)" >&2
+  exit 1
+}
+
+# $1 = expected value, $2… = environment assignments
+expect() {
+  local want="$1" desc="$2"
+  shift 2
+  local got
+  got="$(env "$@" bash -c "set -euo pipefail; ${gate}; echo \"\${SERVE_AGENT_GRANTS}\"")"
+  if [[ "${got}" != "${want}" ]]; then
+    echo "FAIL: ${desc}: expected SERVE_AGENT_GRANTS=${want}, got '${got}'" >&2
+    exit 1
+  fi
+  echo "  ok: ${desc} -> ${got}"
+}
+
+auth=(
+  SERVE_GITHUB_AUTH_CLIENT_ID=id
+  SERVE_GITHUB_AUTH_CLIENT_SECRET=secret
+  SERVE_GITHUB_AUTH_COOKIE_SECRET=cookie
+)
+
+echo "==> SERVE_AGENT_GRANTS derivation"
+expect 1 "unset + full GitHub auth => on" "${auth[@]}"
+expect 0 "unset + no GitHub auth => off"
+expect 0 "unset + partial GitHub auth (no cookie secret) => off" \
+  SERVE_GITHUB_AUTH_CLIENT_ID=id SERVE_GITHUB_AUTH_CLIENT_SECRET=secret
+expect 0 "unset + only a client id => off" SERVE_GITHUB_AUTH_CLIENT_ID=id
+
+# An explicit answer always wins, in both directions — including "insist without an approver",
+# which is meant to reach the server's own refusal rather than being silently downgraded here.
+expect 0 "explicit 0 with auth configured => stays off" SERVE_AGENT_GRANTS=0 "${auth[@]}"
+expect 1 "explicit 1 without auth => stays on (server refuses, honestly)" SERVE_AGENT_GRANTS=1
+expect true "explicit 'true' is passed through untouched" SERVE_AGENT_GRANTS=true
+
+echo "PASS: the lane enables itself only where an approver exists"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2795,15 +2795,28 @@ On the deployed image the lane **enables itself where it can work**: leave `SERV
 unset and it comes on whenever this box has an approver — which, matching the server's own rule, is
 either of:
 
-- **`SERVE_GITHUB_AUTH_CLIENT_ID` / `_CLIENT_SECRET` / `_COOKIE_SECRET` all set** — any signed-in
-  GitHub user approves; or
-- **a token-gated box** (`SERVE_PUBLIC` not `1`, with `SERVE_TOKEN` set) — the operator token
-  holder approves.
+- **`SERVE_GITHUB_AUTH_CLIENT_ID` / `_CLIENT_SECRET` / `_COOKIE_SECRET` all set**, or
+- **a token-gated box** — `SERVE_PUBLIC` not `1`, with `SERVE_TOKEN` set.
 
 Only a `--public` box with no GitHub auth has neither, and there the server refuses the lane
 outright rather than letting anonymous visitors mint credentials. Neither flat default was right —
 a hardcoded `1` would fail startup on exactly that configuration, and a hardcoded `0` shipped the
 feature switched off on the box it was built for.
+
+**What *approving* then requires is a separate question, and the two conditions stack rather than
+substituting for each other.** Reaching the approval page needs, in order:
+
+| Box | To approve you need |
+|---|---|
+| public + GitHub auth | a signed-in GitHub account |
+| private, no GitHub auth | the browse token (`SERVE_TOKEN`) |
+| **private + GitHub auth** | **both — the browse token *and* a signed-in account** |
+
+The last row is the one to be deliberate about. The server's own front door comes first and a GitHub
+session is not a substitute for it: without that rule, any account the (by default empty)
+`--github-auth-users` allowlist accepts could open a request and approve it into a server whose
+browse token they never had. In practice the token arrives for free — `/status` is where the waiting
+requests are listed, and the page you already have open carries it in its links.
 
 Set it explicitly to override in either direction: `SERVE_AGENT_GRANTS=0` opts out on a box that
 *does* have GitHub auth, and `=1` insists on a box that doesn't — which reaches the server's own

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2791,9 +2791,21 @@ a signed-in account. A session alone is not enough — otherwise any account you
 grant into a server whose browse token they never had. In practice this is the `/status` route: the
 page you already have open carries the token, and each waiting request has a **Review →** link.
 
-On the deployed image set `SERVE_AGENT_GRANTS=1` (optional `SERVE_AGENT_GRANT_SCOPES`,
-`SERVE_AGENT_GRANT_MAX_TTL`, `SERVE_AGENT_GRANT_MAX_ACTIVE`, `SERVE_AGENT_GRANT_RATE_LIMIT`); it's
-off by default. The design, and why each control is where it is, is in
+On the deployed image the lane **enables itself where it can work**: leave `SERVE_AGENT_GRANTS`
+unset and it comes on exactly when `SERVE_GITHUB_AUTH_CLIENT_ID` / `_CLIENT_SECRET` /
+`_COOKIE_SECRET` are all set, because that is what supplies the human identity a grant is approved
+against. Neither flat default was right — a hardcoded `1` would fail startup on every public box
+with no OAuth app configured (the server refuses the lane rather than letting anonymous visitors
+mint credentials), and a hardcoded `0` shipped it switched off on the box it was built for.
+
+Set it explicitly to override in either direction: `SERVE_AGENT_GRANTS=0` opts out on a box that
+*does* have GitHub auth, and `=1` insists on a box that doesn't — which reaches the server's own
+refusal, deliberately, rather than being quietly downgraded to off. Optional knobs:
+`SERVE_AGENT_GRANT_SCOPES`, `SERVE_AGENT_GRANT_MAX_TTL`, `SERVE_AGENT_GRANT_MAX_ACTIVE`,
+`SERVE_AGENT_GRANT_RATE_LIMIT` — each rejects a malformed value at startup rather than silently
+falling back to its default. The derivation is pinned by
+[`deploy/image/test-agent-grants-default.sh`](../deploy/image/test-agent-grants-default.sh). The
+design, and why each control is where it is, is in
 [docs/design/AGENT_ACCESS_GRANTS.md](design/AGENT_ACCESS_GRANTS.md).
 
 ## Deploying `preview.coo.ee`

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2792,11 +2792,18 @@ grant into a server whose browse token they never had. In practice this is the `
 page you already have open carries the token, and each waiting request has a **Review →** link.
 
 On the deployed image the lane **enables itself where it can work**: leave `SERVE_AGENT_GRANTS`
-unset and it comes on exactly when `SERVE_GITHUB_AUTH_CLIENT_ID` / `_CLIENT_SECRET` /
-`_COOKIE_SECRET` are all set, because that is what supplies the human identity a grant is approved
-against. Neither flat default was right — a hardcoded `1` would fail startup on every public box
-with no OAuth app configured (the server refuses the lane rather than letting anonymous visitors
-mint credentials), and a hardcoded `0` shipped it switched off on the box it was built for.
+unset and it comes on whenever this box has an approver — which, matching the server's own rule, is
+either of:
+
+- **`SERVE_GITHUB_AUTH_CLIENT_ID` / `_CLIENT_SECRET` / `_COOKIE_SECRET` all set** — any signed-in
+  GitHub user approves; or
+- **a token-gated box** (`SERVE_PUBLIC` not `1`, with `SERVE_TOKEN` set) — the operator token
+  holder approves.
+
+Only a `--public` box with no GitHub auth has neither, and there the server refuses the lane
+outright rather than letting anonymous visitors mint credentials. Neither flat default was right —
+a hardcoded `1` would fail startup on exactly that configuration, and a hardcoded `0` shipped the
+feature switched off on the box it was built for.
 
 Set it explicitly to override in either direction: `SERVE_AGENT_GRANTS=0` opts out on a box that
 *does* have GitHub auth, and `=1` insists on a box that doesn't — which reaches the server's own


### PR DESCRIPTION
Follow-up to #4394, which merged while a further review round was in flight. Three things: switching the lane on for real, the findings that arrived too late for that PR, and the findings this branch's own fixes then attracted.

## Turning it on

#4394 shipped `--agent-grants` **off everywhere**, including on `preview.coo.ee` — the box it was built for. Enabling it needs care, because neither flat default is right, in opposite directions:

- Hardcoding `SERVE_AGENT_GRANTS=1` in the compose file **takes out every public box with no OAuth app configured**, on its next roll. The lane mints credentials, so it needs a human identity to approve against, and on the open profile the server deliberately refuses to start without one.
- Hardcoding `0` is what we have now: a feature nobody can use without first reading the deploy docs.

So the entrypoint derives it. Unset means **on where it can work** — on when this box has an approver, which (matching the server's own rule) is either all three `SERVE_GITHUB_AUTH_*` secrets, **or** a token-gated box (`SERVE_PUBLIC` not `1`, with `SERVE_TOKEN` set), where the operator token holder approves. Only a `--public` box with no GitHub auth has neither, and there the server refuses the lane outright. An explicit value still wins both ways: `0` opts out, and `1` insists on a box that can't and reaches the server's own refusal — the honest failure rather than a silent downgrade.

`preview.coo.ee` already sets those three secrets, so it picks the lane up on its next roll with no `.env` edit. **Set `SERVE_AGENT_GRANTS=0` before merging if you'd rather it waited.**

What *enables* the lane and what *approving* requires are different questions, and the docs now say so with a table: on a private box that also configures OAuth you need **both** the browse token and a signed-in account, because the server checks its front door first and a session is not a substitute for it.

## Why the derivation gets a test

`deploy/image/test-agent-grants-default.sh` extracts the real gate out of `entrypoint.sh` by its leading comment and runs it, so the test and the shipped logic can't drift. It's wired into CI beside the other deploy guards.

A derivation earns a test rather than a comment for the same reason the env-passthrough guard exists: it has no output of its own. Get it wrong and you either break unrelated deployments on their next roll, or quietly ship a dead feature — both invisible until someone goes looking. That is exactly how `SERVE_PLAYGROUND` spent its whole life inert on the prebuilt image.

## The findings that missed the merge

`bc168f1` merged at 22:40; two review rounds landed at 22:36 and after, so these are bugs on `main` rather than review comments.

**A label could reorder what the approval page appears to say.** `sanitizeLabel` stripped C0/C1 and DEL. `U+202E RIGHT-TO-LEFT OVERRIDE` is neither and survives HTML escaping untouched — so a requester, who picks their own label, could reverse the rendering of the text after it and change what the human appears to be agreeing to, **including the scope and lifetime**. The whole Unicode format category (Cf) now goes: exactly the set that renders as nothing while changing everything around it.

**Credentials could land in a checkout.** With no `XDG_CONFIG_HOME` and no `HOME`, the store fell back to `.` — bearer tokens in whatever directory the command ran in, which for an agent is a checkout.

**A malformed grant flag silently became its default — on all three.** The review named `--agent-grant-max-active`; an earlier round had fixed the same thing for `--agent-grant-max-ttl` and I hadn't swept for siblings. Sweeping found a third and worst: `--agent-grant-scopes preivew` is an operator narrowing the box to read-only, and the silent default is `preview,live` — a typo that **widens** what every grant may do. All three now refuse a present-but-invalid value at startup.

## What this branch's own fixes then attracted

Listed separately because that is what they are — each is a consequence of an earlier fix in this same PR, and two of them were the *same bug reached through its own mitigation*:

- **The working-directory leak was reachable three times.** The original `.` fallback, then a relative `user.home`, then a relative `XDG_CONFIG_HOME`/`HOME`. Each fix went to the branch that was pointed at rather than the question underneath. There is now one `absoluteHome` check every candidate passes through, with that history recorded next to it.
- **`auth request --json` died on the machine it exists for.** That mode prints the device secret so the caller can poll without local storage — which is what the no-credential-home refusal recommends. The refusal fired *before* printing, so it opened a server-side request and exited, leaving an approvable link nothing could redeem. Strictly worse than the stack trace it replaced. It also had to learn to hand back the token when it could not store it, rather than reporting `stored: false` and nothing else.
- **Two caps were fighting, then one leaked.** Retention correctly stopped shedding live approvals, so counting every row against the pending cap meant `--agent-grant-max-active` above it could never be reached. Counting only *pending* rows then let denials accumulate unbounded — an operator denying a hostile batch freed a slot with every click. The cap now charges what an anonymous caller can create (pending **and** denied) and excludes retained approvals, which their own limit already bounds.
- **The refusal reached only one of its two callers.** `share-preview --mechanism serve` opens the same store; handled at `Main`'s dispatch boundary now, so the next consumer inherits it. And it fired after the request was opened, leaving an uncollectable row holding a slot in the very map above — so it now runs before.
- **The gate test didn't control its own inputs**, so an ambient `SERVE_GITHUB_AUTH_*` turned its negative cases positive. `env -i` now, verified against the reviewer's reproduction.

## Test plan

- `test-agent-grants-default.sh` — 11 cases: full auth on, no/partial auth off, private+token on, private-by-default+token on, public+token off, private-without-token off, and explicit `0`/`1`/`true` winning in each direction.
- `test-compose-env-passthrough.sh` still passes — the variable stays forwarded.
- New CLI tests for: the no-home refusal naming its remedy, relative paths rejected from **all three** sources, a relative value falling through to an absolute one, the explicit override winning, a two-character credential filename, a bidi-laden label leaving no format character behind, a live grant surviving an anonymous attempt to fill the request map, denials still charged so denying a batch admits no new one, retained approvals not spending the pending budget, and `request --json` printing its secret with the store constructor throwing.
- **Three were verified against the unfixed code** — the storeless JSON test, the gate-isolation fix, and the concurrency ordering — because a test that passes either way is not evidence. The concurrency one is documented in its body as a smoke test rather than the guarantee, since the guarantee is a lock.
- Full `:cli:test` green (**2964**, 0 failures).

**Seven tests across this feature were rewritten rather than added.** Six pinned mechanism instead of promise. The seventh — `a resolved request makes room for a new one` — asserted that denying frees capacity, which *was* the unbounded-growth vector: the suite was defending the bug. Called out because a suite full of mechanism assertions makes every later refactor look like a regression, and because a green tick obtained by removing a test is worth nothing.

Text-only change to a deploy default, a sanitizer, and a credential path — no rendered surface, so no visual evidence. The consent pages this configures are unchanged and already in the fixture set from #4394.