### PR TITLE
fix(serve): seed only the axes a baked-fallback render actually kept

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4417,29 +4417,47 @@ class ServeHttpServer(
    * pixels never had — the same contradiction, drawn the other way round, and worse for being on a
    * *disabled* control the visitor cannot correct.
    *
-   * Two such pages, both of which answer with bytes that ignored the override on purpose:
-   * - a **pinned revision** (`?at=<sha>`), whose image is the historical baked artifact —
-   *   `pinnedRenderQuerySuffix` strips every render override from its URL for exactly this reason;
-   * - an accepted **baked fallback** (`?fallback=baked`) on a preview with no lane that could have
-   *   applied one — `respondDroppedOverrides` returns the published snapshot and names what it
-   *   dropped. "No lane" is all three: neither serve-side render path, and no in-browser Wasm app
-   *   ([wasmSrc]) that would mount the component with the override itself.
+   * A **pinned revision** (`?at=<sha>`) drops every seed: its image is the historical baked
+   * artifact, and `pinnedRenderQuerySuffix` strips every render override from that URL for exactly
+   * this reason.
    *
-   * A daemon-backed page keeps its seeds: there the override reaches the renderer, so the control
-   * and the pixels agree by doing the ordinary thing.
+   * Otherwise only an accepted **baked fallback** (`?fallback=baked`) can answer with pixels that
+   * ignored an override — `respondDroppedOverrides` returns them and names what it dropped — and
+   * *which* seeds to withhold there is a question about **axes**, not about the host. Two ways an
+   * axis fails to reach the pixels, and a page can be in either:
+   * - the session has no lane that could apply one at all: neither serve-side render path, and no
+   *   in-browser Wasm app ([wasmSrc]) that would mount the component with the override itself;
+   * - the preview is **replayed** from a captured Remote Compose document rather than recomposed,
+   *   so a `knob.*` (and a string `rc.*`) has no composition to reach, even though the host renders
+   *   perfectly well. [CatalogLiveRouting.irReplayDroppedOverrideNames] is the authority on that
+   *   set, and asking it — rather than a host-wide capability — is what keeps this guard and the
+   *   render lane's own refusal ([droppedOverridesFor]) answering the same question.
+   *
+   * Everything the render can honour still seeds, including on those pages: withholding an axis the
+   * pixels DID apply would recreate the disagreement pointing the other way.
    */
   private fun RoutingContext.seedableOverrideParams(
     renderHost: ServeHost,
-    previewId: String,
+    preview: ServePreview,
     sessionId: String,
     pinnedRevision: String?,
     wasmSrc: String?,
   ): Map<String, String> {
     if (pinnedRevision != null) return emptyMap()
+    val params = requestOverrideParams(sessionId)
+    if (params.isEmpty() || !acceptsBakedFallback()) return params
     val overrideCanReachThePixels =
-      renderHost.canApplyOverrides || renderHost.canRenderOverridesFor(previewId) || wasmSrc != null
-    if (!overrideCanReachThePixels && acceptsBakedFallback()) return emptyMap()
-    return requestOverrideParams(sessionId)
+      renderHost.canApplyOverrides ||
+        renderHost.canRenderOverridesFor(preview.id) ||
+        wasmSrc != null
+    if (!overrideCanReachThePixels) return emptyMap()
+    if (!isReplayedPreview(renderHost, preview.id)) return params
+    val parsed =
+      ServeOverrides.parse(params, ServeOverrides.declaredKnobKinds(preview)) as? OverrideParse.Ok
+        ?: return params
+    val dropped =
+      CatalogLiveRouting.irReplayDroppedOverrideNames(preview.id, parsed.overrides).toSet()
+    return if (dropped.isEmpty()) params else params.filterKeys { it !in dropped }
   }
 
   private fun RoutingContext.requestOverrideParams(sessionId: String): Map<String, String> =
@@ -6323,13 +6341,7 @@ class ServeHttpServer(
           // case seeding is the very disagreement the parameter exists to remove, pointed the other
           // way. See `seedableOverrideParams`.
           requestOverrides =
-            seedableOverrideParams(
-              renderHost,
-              preview.id,
-              sessionId,
-              revisions.pinned,
-              wasmSrc,
-            ),
+            seedableOverrideParams(renderHost, preview, sessionId, revisions.pinned, wasmSrc),
           // Per-preview: a catalog advertises SVG globally as soon as it carries a `figma/` dir,
           // but
           // a preview whose slug has no baked `figma/<slug>.svg` still 404s the `.svg` lane, so

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplayLaneTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplayLaneTest.kt
@@ -61,8 +61,25 @@ class ServeThemeReplayLaneTest {
     val replayedId = "$name-replayed"
     val liveId = "$name-live"
 
+    /**
+     * One declared bool knob per preview, so a page has a control to read. `true` by default, so a
+     * link asking for `false` is visible in the markup exactly when it was seeded.
+     */
+    private val enabledKnob =
+      listOf(
+        ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration(
+          key = "enabled",
+          type = "bool",
+          label = "enabled",
+          default = ee.schimke.composeai.data.overrides.PreviewOverrideValue.BooleanValue(true),
+        )
+      )
+
     override val previews =
-      listOf(ServePreview(replayedId, "Replayed"), ServePreview(liveId, "Live"))
+      listOf(
+        ServePreview(replayedId, "Replayed", overrides = enabledKnob),
+        ServePreview(liveId, "Live", overrides = enabledKnob),
+      )
     override val label = name
     override val canRenderOverrides = true
 
@@ -128,6 +145,38 @@ class ServeThemeReplayLaneTest {
       }
 
   private fun themeOption(theme: ServeTheme) = "\"theme:${theme.providerFqn}\""
+
+  /** The knob row for [key] on a fetched page, so an assertion reads one control. */
+  private fun knobRow(page: String, key: String): String =
+    page.lineSequence().first { it.contains("""data-knob-key="$key"""") }
+
+  /**
+   * A deep link seeds the viewer's controls only with the axes this page's image could be carrying,
+   * and on a replayed preview a `knob.*` is not one of them.
+   *
+   * `?fallback=baked` makes `respondDroppedOverrides` answer with pixels that ignored what it could
+   * not apply. A replayed preview has no composition for a named knob to reach — that is what
+   * `CatalogLiveRouting.irReplayDroppedOverrideNames` names — even though this host renders every
+   * other axis perfectly well, so a host-wide "can this session apply overrides?" reads `true` and
+   * would have seeded a control the pixels never saw.
+   *
+   * The recomposing twin is the control case: same host, same link, and there the render DOES apply
+   * it, so withholding the seed would be the same disagreement pointing the other way.
+   */
+  @Test
+  fun `a baked fallback seeds the axes its render kept, and withholds the ones replay drops`() {
+    val replayed = get("/mixed/p/${mixed.replayedId}?knob.enabled=false&fallback=baked")
+    assertTrue(
+      knobRow(replayed, "enabled").contains(" checked"),
+      "a replayed preview seeded a knob its render dropped",
+    )
+
+    val live = get("/mixed/p/${mixed.liveId}?knob.enabled=false&fallback=baked")
+    assertFalse(
+      knobRow(live, "enabled").contains(" checked"),
+      "a recomposing preview withheld a knob its render applied",
+    )
+  }
 
   // ---------------------------------------------------------------------------------------------
   // The socket lanes.


### PR DESCRIPTION
Follow-up to #4398 — raised in review there, but that PR auto-merged before this could join it.

## The gap

#4398 withheld the request's knob seeds on an accepted `?fallback=baked` when the session had no lane that could apply an override. The granularity was wrong: whether an override reaches the pixels is a question about the **axis**, not about the host.

An IR-replayed Remote Compose preview proves it. `canApplyOverrides` is `true` and the daemon renders every other axis perfectly well — but a `knob.*` (and a string `rc.*`) has no composition to reach, which is exactly what `CatalogLiveRouting.irReplayDroppedOverrideNames` names. So:

```
/p/<replayed-id>?knob.enabled=false&fallback=baked
  → render: published pixels, X-Compose-Preview-Dropped-Overrides: knob.enabled
  → control: unchecked          ← claims a value the pixels never had
```

## The fix

`seedableOverrideParams` now asks that predicate — the same one the render lane's own refusal (`droppedOverridesFor`) asks — and withholds exactly the named axes. Everything the render *did* honour still seeds, on those pages too: withholding more would recreate the disagreement pointing the other way.

That also makes the guard read as one rule rather than two special cases: a page seeds a control from the request exactly when the picture beside it could be carrying that axis.

## Test plan

- `ServeThemeReplayLaneTest` already stands up the one fixture that can show this — a host carrying both a replayed and a recomposing preview. Its previews gain a declared bool knob so there is a control to read, and `a baked fallback seeds the axes its render kept, and withholds the ones replay drops` asserts both halves: the replayed one keeps its declaration, the recomposing twin takes the seed.
- Negative check: dropping the replay branch fails that case and nothing else.
- `./gradlew :cli:test --tests "ee.schimke.composeai.cli.serve.*"` and `ktfmtCheck` — green.

Text-only evidence is correct here: the change is which query params reach a control's rendered attributes, and no `@Preview` or fixture page draws it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvUA1ogfsLK5wmCxAgah8r)_