### PR TITLE
fix(parity): stop the issue-index producer refusing locators its own writer emits

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -516,18 +516,18 @@ tasks.withType<Test>().configureEach {
     .files(usagePsiJars)
     .withPropertyName("libUsagePsiJars")
     .withNormalizer(ClasspathNormalizer::class)
-  // The shared wire fixtures under `scripts/design-artifacts/fixtures/`, which `ServeIssueReportTest`
-  // and `ServeParityIssuesStoreTest` read straight off disk rather than through the test classpath.
-  // Undeclared, Gradle cannot know that editing one changes what those tests assert — so the exact
-  // change they exist to catch, an edit to a wire contract shared with the JavaScript producer,
-  // could be served UP-TO-DATE or from the build cache without the assertions ever running. That
-  // would leave the fixture looking like enforcement while enforcing nothing.
+  // The shared wire fixtures under `scripts/design-artifacts/fixtures/`, which
+  // `ServeIssueReportTest` and `ServeParityIssuesStoreTest` read straight off disk rather than
+  // through the test classpath. Undeclared, Gradle cannot know that editing one changes what those
+  // tests assert — so the exact change they exist to catch, an edit to a wire contract shared with
+  // the JavaScript producer, could be served UP-TO-DATE or from the build cache without the
+  // assertions ever running. That would leave the fixture looking like enforcement while enforcing
+  // nothing.
   inputs
     .files(
-      layout.projectDirectory
-        .dir("../scripts/design-artifacts/fixtures")
-        .asFileTree
-        .matching { include("*.json") }
+      layout.projectDirectory.dir("../scripts/design-artifacts/fixtures").asFileTree.matching {
+        include("*.json")
+      }
     )
     .withPropertyName("sharedWireFixtures")
     .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -516,6 +516,21 @@ tasks.withType<Test>().configureEach {
     .files(usagePsiJars)
     .withPropertyName("libUsagePsiJars")
     .withNormalizer(ClasspathNormalizer::class)
+  // The shared wire fixtures under `scripts/design-artifacts/fixtures/`, which `ServeIssueReportTest`
+  // and `ServeParityIssuesStoreTest` read straight off disk rather than through the test classpath.
+  // Undeclared, Gradle cannot know that editing one changes what those tests assert — so the exact
+  // change they exist to catch, an edit to a wire contract shared with the JavaScript producer,
+  // could be served UP-TO-DATE or from the build cache without the assertions ever running. That
+  // would leave the fixture looking like enforcement while enforcing nothing.
+  inputs
+    .files(
+      layout.projectDirectory
+        .dir("../scripts/design-artifacts/fixtures")
+        .asFileTree
+        .matching { include("*.json") }
+    )
+    .withPropertyName("sharedWireFixtures")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   jvmArgumentProviders.add(
     CommandLineArgumentProvider {
       listOf(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -1,10 +1,16 @@
 package ee.schimke.composeai.cli.serve
 
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class ServeIssueReportTest {
 
@@ -289,5 +295,45 @@ class ServeIssueReportTest {
       )
     val body = ServeIssueReport.body(tokenBearing)
     assertFalse(body.contains("token="), body)
+  }
+
+  @Test
+  fun `the writer emits the shared locator fixture byte for byte`() {
+    // The other half of `compose-parity-locator/v1`. This side asserts the bytes the writer puts in
+    // an issue body; scripts/design-artifacts/parity-issues.test.mjs asserts the producer parses
+    // those same bytes back. Without one file both read, each engine only ever tests itself — which
+    // is how the producer came to reject an omitted `revision`, an empty `variant`, and an override
+    // map ordered by code point, none of which the writer can be talked out of emitting.
+    val fixture =
+      Json.parseToJsonElement(
+          File("../scripts/design-artifacts/fixtures/parity-locators.json").readText()
+        )
+        .jsonObject
+    assertEquals(ServeIssueReport.LOCATOR_FENCE, fixture["schema"]?.jsonPrimitive?.contentOrNull)
+    val written =
+      fixture["cases"]!!.jsonArray.map { it.jsonObject }.filter { it.containsKey("writer") }
+    // A fixture that silently stopped carrying writer cases would pass every assertion below.
+    assertEquals(4, written.size, "the fixture must keep exercising the writer")
+    for (case in written) {
+      val name = case["name"]!!.jsonPrimitive.content
+      val writer = case["writer"]!!.jsonObject
+      val locator =
+        ServeIssueReport.Locator(
+          repository = writer["repository"]!!.jsonPrimitive.content,
+          system = writer["system"]!!.jsonPrimitive.content,
+          componentId = writer["componentId"]!!.jsonPrimitive.content,
+          previewId = writer["previewId"]!!.jsonPrimitive.content,
+          referenceId = writer["referenceId"]!!.jsonPrimitive.content,
+          variant = writer["variant"]!!.jsonPrimitive.content,
+          overrides =
+            writer["overrides"]!!.jsonObject.entries.associate {
+              it.key to it.value.jsonPrimitive.content
+            },
+          revision = writer["revision"]?.jsonPrimitive?.contentOrNull,
+        )
+      val block = case["block"]!!.jsonPrimitive.content
+      assertEquals(block, ServeIssueReport.locatorBlock(locator), name)
+      assertEquals(locator, ServeIssueReport.locatorFromBody(block), name)
+    }
   }
 }

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -226,7 +226,10 @@ already has a trust boundary with tests:
   issue — which would send a real, damaged report down the silent path and let the run go green
   without it. The opener is matched separately and anchored to a line, so a body that merely names
   the fence in prose still counts as absent, while an unterminated one — and a good block trailed by
-  a dangling opener — is reported.
+  a dangling opener — is reported. Both patterns tolerate the **one to three leading spaces**
+  CommonMark allows, because a block pasted inside a list item renders as an ordinary fence on
+  GitHub and a column-zero-only pattern would read a plainly visible locator as absent. Four spaces
+  is an indented code block, not a fence, so the marker is literal text and there is no locator.
 
 ### Where the regeneration workflow lives
 

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -221,6 +221,12 @@ already has a trust boundary with tests:
   the emitter red on a healthy repository, which is a good reason for a catalog never to adopt it.
   The one absent-locator case still worth a warning is an issue carrying an `area:` or `parity:`
   label: that is a parity report filed without its identity, and a human has to go add the block.
+  **"Absent" means no opening fence, not no complete fence.** A block whose closing ``` was deleted
+  matches the full-fence pattern zero times and is otherwise indistinguishable from an ordinary
+  issue — which would send a real, damaged report down the silent path and let the run go green
+  without it. The opener is matched separately and anchored to a line, so a body that merely names
+  the fence in prose still counts as absent, while an unterminated one — and a good block trailed by
+  a dangling opener — is reported.
 
 ### Where the regeneration workflow lives
 

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -162,6 +162,36 @@ so they cannot disagree.
 renderer,comparison}` and `parity:{regression,known-difference,verification-needed}`. No label per
 component — component identity lives in the locator block.
 
+### Which fields may be blank, and which may be absent
+
+Three rules that look like validator trivia and are not: each one is a shape the **writer**
+(`ServeIssueReport.locatorBlock`) can legitimately emit, and each was refused by the **producer**
+(`parseLocator`) — which drops the whole issue from the index, so the report the reporter filed is
+simply not there.
+
+- **`revision` is optional.** It comes from the session's delivery provenance, and a session that
+  has none — a developer's local `compose-preview serve` over a bundle directory, or a live daemon —
+  omits the line. That is the session a developer reports *from*. The index carries no revision
+  column either, so requiring it never bought anything.
+- **`variant` is always present and may be empty.** `ServeIssueReport.variantFor` returns `""` for a
+  preview id carrying no `__` axes. "No axes" is a fact about the preview, not a mangled body. Every
+  *other* field must be non-blank: an emptied `system` or `preview` means the block no longer names
+  one component, and that is a mangled body.
+- **`overrides` keys sort by Unicode code point, not by UTF-16 code unit.** The distinction is
+  invisible until a key is astral-plane: JavaScript's default `Array.prototype.sort` orders
+  surrogates (`D800`–`DFFF`) below `E000`–`FFFF`, so a canonical block written by
+  `ServeIssueReport.canonicalOverrides` came back re-serialised in a different order and was refused
+  as "not canonical" — a cross-engine disagreement manufactured by the validator itself, on a body
+  nobody had touched.
+
+**The fixture is the enforcement, not this list.**
+[`scripts/design-artifacts/fixtures/parity-locators.json`](../../scripts/design-artifacts/fixtures/parity-locators.json)
+carries each shape once and is read by *both* engines: `ServeIssueReportTest` asserts the writer
+emits those exact bytes, and `parity-issues.test.mjs` asserts the producer parses them back. Cases
+with no `writer` key are shapes no writer emits and the producer must keep refusing. Without one
+file both sides read, each engine only ever tests itself against itself — which is precisely how all
+three rules above came to be broken while every test in both languages passed.
+
 ---
 
 ## 3. The published issue index (`parity/issues.json`)
@@ -185,6 +215,12 @@ already has a trust boundary with tests:
 - **Failure posture** fail-soft. A missing file, a wrong schema token, a malformed record: drop that
   record or the whole index and serve the catalog normally. Issue badges are an enhancement; they
   must never cost a catalog its grid.
+- **An absent locator is not a failure.** A repository is mostly ordinary issues — a dependency
+  dashboard, a docs nit — and none of them carry a locator block. The producer skips those silently
+  and reserves its non-zero exit for a locator that is *present and broken*. Conflating the two made
+  the emitter red on a healthy repository, which is a good reason for a catalog never to adopt it.
+  The one absent-locator case still worth a warning is an issue carrying an `area:` or `parity:`
+  label: that is a parity report filed without its identity, and a human has to go add the block.
 
 ### Where the regeneration workflow lives
 

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -53,6 +53,31 @@ Not a batch; context for what exists.
   projection; published-catalog `tags/index.json`), one host API `ServeHost.tagIndexForPreview`.
 - The theme annotation layer, reachable on the focused comparison, with visible legend ordinals.
 
+### …and not yet switched on
+
+Batches 01 and 02 are merged, and until a catalog *calls* them nothing they built is reachable:
+
+- `parity-issues-reusable.yml` had **no callers**. No catalog repo carried a workflow invoking it,
+  so `parity/issues.json` was never generated — the m3-catalog delivery branch's `parity/` directory
+  held `activity.json` alone. The reader and every UI surface were serving the empty path in
+  production while their tests passed.
+- **No issue carries a locator block**, so even with the workflow adopted the index would have been
+  empty. m3-catalog's dozen genuine known differences (#40, #41, #42, #85–#95, …) are labelled
+  `invalid` + `upstream` — a taxonomy that predates this epic and that the producer does not read.
+
+Two defects found while switching it on, both fixed: the producer refused three shapes the writer
+legitimately emits (see
+[the locator contract](../COMPONENT_PARITY_WORKFLOW.md#which-fields-may-be-blank-and-which-may-be-absent)),
+and it counted every ordinary issue's absent locator as a failure, so its exit code was non-zero on
+any healthy repository.
+
+What remains before the pilot reports anything: **backfill locator blocks and `area:` / `parity:`
+labels onto the real known differences**. Their ids have to come from the published catalog, not be
+guessed — a plausible wrong `previewId` produces an index that looks right and joins to nothing.
+Worth doing before batch 04 freezes an acceptance schema, because those dozen issues are the
+population the schema is for, and most of them are whole-component geometry and token differences
+rather than the single-element colour delta the design's worked example is built around.
+
 ## Conventions every batch inherits
 
 - **Fail-soft on anything read from a catalog.** A catalog is third-party data. Malformed, wrong

--- a/scripts/design-artifacts/emit-parity-issues.mjs
+++ b/scripts/design-artifacts/emit-parity-issues.mjs
@@ -20,10 +20,21 @@ for (const repo of repos) {
   const pages = JSON.parse(raw);
   issues.push(...pages.flat().filter((issue) => !issue.pull_request));
 }
+// A repository is mostly ordinary issues, and none of them carry a locator block. Only a *broken*
+// locator fails the run; an absent one is skipped, and is worth a warning only when the issue is
+// labelled as parity work — that combination is a report filed without its identity, which is the
+// one case a human needs to go fix.
 let failures = 0;
-const index = buildIssueIndex(issues, { onError: (issue, error) => { failures++; console.error(`::warning::parity-issues: #${issue?.number ?? "?"}: ${error}`); } });
+let skipped = 0;
+const index = buildIssueIndex(issues, {
+  onError: (issue, error) => { failures++; console.error(`::warning::parity-issues: #${issue?.number ?? "?"}: ${error}`); },
+  onSkip: (issue, { labelled }) => {
+    skipped++;
+    if (labelled) console.error(`::warning::parity-issues: #${issue?.number ?? "?"}: labelled as parity work but carries no locator block`);
+  },
+});
 const target = join(out, "parity", "issues.json");
 mkdirSync(dirname(target), { recursive: true });
 writeFileSync(target, JSON.stringify(index, null, 2) + "\n");
-console.log(`parity-issues: wrote ${index.issues.length} row(s) to ${target}; ${failures} issue(s) rejected`);
+console.log(`parity-issues: wrote ${index.issues.length} row(s) to ${target}; ${skipped} issue(s) carry no locator; ${failures} issue(s) rejected`);
 if (failures) process.exitCode = 1;

--- a/scripts/design-artifacts/fixtures/parity-locators.json
+++ b/scripts/design-artifacts/fixtures/parity-locators.json
@@ -1,0 +1,152 @@
+{
+  "$comment": "Shared wire fixture for the compose-parity-locator/v1 block. Two engines read it: cli ServeIssueReportTest, which asserts ServeIssueReport.locatorBlock emits `block` byte for byte from `writer`, and scripts/design-artifacts/parity-issues.test.mjs, which asserts parseLocator(block) yields `parse`. Neither side can move the contract without failing the other's test. Cases with no `writer` are shapes no writer emits and the producer must refuse.",
+  "schema": "compose-parity-locator/v1",
+  "cases": [
+    {
+      "name": "full",
+      "why": "Every field a delivery-branch-backed comparison can name, with override values that exercise quoting and non-ASCII.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {
+          "fontScale": "1.5",
+          "knob.label": "Send;now=x",
+          "knob.quote": "a=\"b\"",
+          "knob.text": "日本語"
+        },
+        "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {\"fontScale\":\"1.5\",\"knob.label\":\"Send;now=x\",\"knob.quote\":\"a=\\\"b\\\"\",\"knob.text\":\"日本語\"}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {
+            "fontScale": "1.5",
+            "knob.label": "Send;now=x",
+            "knob.quote": "a=\"b\"",
+            "knob.text": "日本語"
+          },
+          "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+        }
+      }
+    },
+    {
+      "name": "no-revision",
+      "why": "A local `compose-preview serve` over a bundle directory has no delivery provenance, so the writer omits the line. This is the session a developer reports from.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {},
+        "revision": null
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {},
+          "revision": null
+        }
+      }
+    },
+    {
+      "name": "empty-variant",
+      "why": "`ServeIssueReport.variantFor` returns \"\" for a preview id carrying no `__` axes. No axes is a fact about the preview, not a mangled body.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton",
+        "previewId": "IconButton",
+        "referenceId": "iconbutton-figma",
+        "variant": "",
+        "overrides": {},
+        "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton\npreview: IconButton\nreference: iconbutton-figma\nvariant: \noverrides: {}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton",
+          "previewId": "IconButton",
+          "referenceId": "iconbutton-figma",
+          "variant": "",
+          "overrides": {},
+          "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+        }
+      }
+    },
+    {
+      "name": "astral-override-keys",
+      "why": "U+FF01 sorts BELOW U+1F600 by code point and ABOVE it by UTF-16 code unit, so this block is canonical to the writer and non-canonical to a `.sort()` that compares code units.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {
+          "！b": "1",
+          "😀a": "2"
+        },
+        "revision": null
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {\"！b\":\"1\",\"😀a\":\"2\"}\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {
+            "！b": "1",
+            "😀a": "2"
+          },
+          "revision": null
+        }
+      }
+    },
+    {
+      "name": "non-canonical-overrides",
+      "why": "Hand-reordered override keys. No writer emits this, and it must stay refused — the canonical form is what makes two bodies for the same variant compare equal.",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {\"knob.label\":\"Send;now=x\",\"fontScale\":\"1.5\"}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "overrides are not canonical JSON"
+      }
+    },
+    {
+      "name": "blank-identity-field",
+      "why": "An emptied identity field is a mangled body: the locator no longer names one component.",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: \ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "empty locator field(s): system"
+      }
+    }
+  ]
+}

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -8,6 +8,43 @@ const FENCE = /```compose-parity-locator\/v1\s*\n([\s\S]*?)\n```/g;
 const AREA = new Set(["spec", "component", "preview", "renderer", "comparison"]);
 const PARITY = new Set(["regression", "known-difference", "verification-needed"]);
 
+/**
+ * Every key the writer always emits. `revision` is deliberately absent: `ServeIssueReport.locator`
+ * fills it from the session's delivery provenance, and a session that has none — a developer's
+ * local `compose-preview serve` over a bundle directory, or a live daemon — omits the line
+ * entirely. Requiring it here rejected the whole locator, so an issue filed from exactly the
+ * session a developer reports from never reached the index. The index carries no revision column
+ * either, so requiring it bought nothing even when it was there.
+ */
+const REQUIRED_FIELDS = ["repository", "system", "component", "preview", "reference", "variant", "overrides"];
+
+/**
+ * The subset whose value may not be blank. `variant` is the exception and the reason this list is
+ * separate from [REQUIRED_FIELDS]: `ServeIssueReport.variantFor` returns "" for a preview id that
+ * carries no `__` axes, and "no axes" is a fact about the preview, not a mangled body.
+ */
+const NON_EMPTY_FIELDS = ["repository", "system", "component", "preview", "reference", "overrides"];
+
+/**
+ * Order override keys the way the Kotlin writer does — by Unicode **code point**.
+ *
+ * JavaScript's default `Array.prototype.sort` compares UTF-16 **code units**, which puts every
+ * astral-plane key (surrogates `D800`–`DFFF`) below `E000`–`FFFF` instead of above it. So a
+ * canonical block written by `ServeIssueReport.canonicalOverrides` and re-serialised here came back
+ * in a different order and was refused as "not canonical" — a cross-engine disagreement produced by
+ * the validator rather than by the body. The existing round-trip test did not catch it because its
+ * one astral key sorts identically under both orders.
+ */
+function compareCodePoints(a, b) {
+  const left = [...a];
+  const right = [...b];
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    const delta = left[i].codePointAt(0) - right[i].codePointAt(0);
+    if (delta !== 0) return delta;
+  }
+  return left.length - right.length;
+}
+
 export function canonicalIssueUrl(value) {
   const match = /^https:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/issues\/([1-9][0-9]*)\/?$/i.exec(String(value ?? "").trim());
   if (!match) return null;
@@ -16,10 +53,17 @@ export function canonicalIssueUrl(value) {
   return { repository, number: Number(match[3]), url: `https://github.com/${repository}/issues/${Number(match[3])}` };
 }
 
+/**
+ * The one error that means "this is not a parity report" rather than "this parity report is
+ * broken". Every repository is mostly ordinary issues — a dependency dashboard, a docs nit — and
+ * none of them carry a locator. Conflating the two makes the producer fail on a healthy repo.
+ */
+export const NO_LOCATOR = "missing locator block";
+
 /** Parse exactly one visible locator fence. A malformed or duplicate block is an explicit error. */
 export function parseLocator(body) {
   const matches = [...String(body ?? "").matchAll(FENCE)];
-  if (matches.length !== 1) return { ok: false, error: matches.length ? "multiple locator blocks" : "missing locator block" };
+  if (matches.length !== 1) return { ok: false, error: matches.length ? "multiple locator blocks" : NO_LOCATOR };
   const fields = Object.create(null);
   for (const line of matches[0][1].split(/\r?\n/)) {
     const colon = line.indexOf(":");
@@ -29,16 +73,20 @@ export function parseLocator(body) {
     if (Object.hasOwn(fields, key)) return { ok: false, error: `duplicate locator field: ${key}` };
     fields[key] = value;
   }
-  const required = ["repository", "system", "component", "preview", "reference", "variant", "overrides", "revision"];
-  const missing = required.filter((key) => !Object.hasOwn(fields, key) || fields[key] === "");
+  // Split three ways rather than one, because the writer can legitimately emit an empty `variant`
+  // and no `revision` at all, and treating either as "missing" drops the whole issue.
+  const missing = REQUIRED_FIELDS.filter((key) => !Object.hasOwn(fields, key));
   if (missing.length) return { ok: false, error: `missing locator field(s): ${missing.join(", ")}` };
+  const blank = NON_EMPTY_FIELDS.filter((key) => fields[key] === "");
+  if (blank.length) return { ok: false, error: `empty locator field(s): ${blank.join(", ")}` };
+  if (Object.hasOwn(fields, "revision") && fields.revision === "") return { ok: false, error: "empty locator field(s): revision" };
   if (!REPO.test(fields.repository)) return { ok: false, error: "invalid repository" };
   let overrides;
   try { overrides = JSON.parse(fields.overrides); } catch { return { ok: false, error: "invalid overrides JSON" }; }
   if (!overrides || Array.isArray(overrides) || typeof overrides !== "object") return { ok: false, error: "overrides must be an object" };
-  const canonicalOverrides = Object.fromEntries(Object.keys(overrides).sort().map((key) => [key, overrides[key]]));
+  const canonicalOverrides = Object.fromEntries(Object.keys(overrides).sort(compareCodePoints).map((key) => [key, overrides[key]]));
   if (JSON.stringify(canonicalOverrides) !== fields.overrides) return { ok: false, error: "overrides are not canonical JSON" };
-  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, revision: fields.revision } };
+  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
 }
 
 function labelValue(labels, prefix, allowed) {
@@ -46,13 +94,25 @@ function labelValue(labels, prefix, allowed) {
   return values.map((label) => label.toLowerCase()).find((label) => label.startsWith(prefix) && allowed.has(label.slice(prefix.length)))?.slice(prefix.length) ?? null;
 }
 
-/** Build an index and report mangled locator blocks instead of silently losing them. */
-export function buildIssueIndex(issues, { generatedAt = new Date().toISOString(), onError = () => {} } = {}) {
+/**
+ * Build an index and report mangled locator blocks instead of silently losing them.
+ *
+ * An issue with **no** locator block at all goes to `onSkip`, not `onError`: it is an ordinary
+ * issue, and a repository is mostly those. `onSkip` is told whether the issue carries an `area:` or
+ * `parity:` label, because an issue classified as parity work with no locator is a report filed
+ * without its identity — worth saying out loud, unlike the dependency dashboard.
+ */
+export function buildIssueIndex(issues, { generatedAt = new Date().toISOString(), onError = () => {}, onSkip = () => {} } = {}) {
   const byIdentity = new Map();
   for (const issue of issues ?? []) {
     const identity = canonicalIssueUrl(issue?.html_url ?? issue?.url);
     if (!identity) { onError(issue, "invalid issue URL"); continue; }
     const parsed = parseLocator(issue?.body);
+    if (!parsed.ok && parsed.error === NO_LOCATOR) {
+      const labelled = Boolean(labelValue(issue?.labels, "area:", AREA) ?? labelValue(issue?.labels, "parity:", PARITY));
+      onSkip(issue, { labelled });
+      continue;
+    }
     if (!parsed.ok) { onError(issue, parsed.error); continue; }
     if (parsed.locator.repository !== identity.repository) { onError(issue, "locator repository does not match issue URL"); continue; }
     const row = {

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -5,6 +5,14 @@ export const LOCATOR_FENCE = "compose-parity-locator/v1";
 
 const REPO = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
 const FENCE = /```compose-parity-locator\/v1\s*\n([\s\S]*?)\n```/g;
+/**
+ * Just the opening line of a fence, so a locator that FAILS to close can be told apart from one
+ * that was never there. [FENCE] needs both delimiters, so a body whose closing ``` was deleted
+ * matches zero times and looks identical to an ordinary issue — which would send a real,
+ * damaged parity report down the silent-skip path in [buildIssueIndex]. Anchored to a line so a
+ * body merely *mentioning* the fence name in prose is not mistaken for one.
+ */
+const FENCE_OPEN = /^```compose-parity-locator\/v1[^\S\n]*$/gm;
 const AREA = new Set(["spec", "component", "preview", "renderer", "comparison"]);
 const PARITY = new Set(["regression", "known-difference", "verification-needed"]);
 
@@ -62,8 +70,13 @@ export const NO_LOCATOR = "missing locator block";
 
 /** Parse exactly one visible locator fence. A malformed or duplicate block is an explicit error. */
 export function parseLocator(body) {
-  const matches = [...String(body ?? "").matchAll(FENCE)];
-  if (matches.length !== 1) return { ok: false, error: matches.length ? "multiple locator blocks" : NO_LOCATOR };
+  const text = String(body ?? "");
+  const matches = [...text.matchAll(FENCE)];
+  // Count openers too: one that never closed is invisible to [FENCE], and a body carrying a good
+  // block plus a dangling opener is ambiguous about which frame it describes.
+  const openers = [...text.matchAll(FENCE_OPEN)].length;
+  if (matches.length > 1 || openers > 1) return { ok: false, error: "multiple locator blocks" };
+  if (matches.length === 0) return { ok: false, error: openers ? "unterminated locator block" : NO_LOCATOR };
   const fields = Object.create(null);
   for (const line of matches[0][1].split(/\r?\n/)) {
     const colon = line.indexOf(":");

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -4,7 +4,13 @@ export const ISSUES_SCHEMA = "compose-preview-issues/v1";
 export const LOCATOR_FENCE = "compose-parity-locator/v1";
 
 const REPO = /^[A-Za-z0-9_.-]{1,100}\/[A-Za-z0-9_.-]{1,100}$/;
-const FENCE = /```compose-parity-locator\/v1\s*\n([\s\S]*?)\n```/g;
+/**
+ * Both delimiters, anchored to a line and tolerating the one to three leading spaces CommonMark
+ * allows — a block indented inside a list item renders as an ordinary fence on GitHub, so a
+ * column-zero-only pattern reads a perfectly visible locator as absent. Content lines keep their
+ * indentation; the field parser already trims each key and value.
+ */
+const FENCE = /^ {0,3}```compose-parity-locator\/v1\s*\n([\s\S]*?)\n {0,3}```/gm;
 /**
  * Just the opening line of a fence, so a locator that FAILS to close can be told apart from one
  * that was never there. [FENCE] needs both delimiters, so a body whose closing ``` was deleted
@@ -12,7 +18,7 @@ const FENCE = /```compose-parity-locator\/v1\s*\n([\s\S]*?)\n```/g;
  * damaged parity report down the silent-skip path in [buildIssueIndex]. Anchored to a line so a
  * body merely *mentioning* the fence name in prose is not mistaken for one.
  */
-const FENCE_OPEN = /^```compose-parity-locator\/v1[^\S\n]*$/gm;
+const FENCE_OPEN = /^ {0,3}```compose-parity-locator\/v1[^\S\n]*$/gm;
 const AREA = new Set(["spec", "component", "preview", "renderer", "comparison"]);
 const PARITY = new Set(["regression", "known-difference", "verification-needed"]);
 

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -101,3 +101,18 @@ test("a locator that fails to close is broken, not absent", () => {
   // And a good block followed by a dangling opener is ambiguous, not usable.
   assert.equal(parseLocator(shared.cases[0].block + "\n```compose-parity-locator/v1\nrepository: a/b\n").error, "multiple locator blocks");
 });
+
+test("a fence indented the way CommonMark allows is still a locator", () => {
+  // One to three leading spaces renders as an ordinary fenced block on GitHub — pasting the report
+  // inside a list item is enough to produce it — so a column-zero-only pattern reads a locator the
+  // reporter can plainly see as absent, and skips it.
+  const indent = (block, n) => block.split("\n").map((line) => (line ? " ".repeat(n) + line : line)).join("\n");
+  const good = shared.cases.find((shape) => shape.name === "full");
+  for (const n of [1, 2, 3]) {
+    assert.deepEqual(parseLocator(indent(good.block, n)), good.parse, `indented by ${n}`);
+  }
+  // Four is an indented code block, not a fence: the marker is literal text, so there is no locator.
+  assert.equal(parseLocator(indent(good.block, 4)).error, NO_LOCATOR);
+  // An indented block that fails to close is still broken rather than absent.
+  assert.equal(parseLocator("  ```compose-parity-locator/v1\n  repository: a/b\n").error, "unterminated locator block");
+});

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -82,3 +82,22 @@ test("an ordinary issue is skipped, not rejected", () => {
   assert.deepEqual(skips, [["Dependency Dashboard", false], ["Filed without its identity", true]]);
   assert.equal(parseLocator("nothing").error, NO_LOCATOR);
 });
+
+test("a locator that fails to close is broken, not absent", () => {
+  // The skip path exists for issues that are not parity reports. A fence whose closing ``` was
+  // deleted matches the full-fence regex zero times and would otherwise look exactly like one —
+  // sending a real, damaged report down the silent path and letting the run go green without it.
+  const errors = [];
+  const skips = [];
+  const truncated = shared.cases[0].block.replace(/\n```\n$/, "\n");
+  buildIssueIndex(
+    [{ html_url: "https://github.com/yschimke/m3-catalog/issues/40", title: "Glyph colour", body: truncated, state: "open" }],
+    { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error), onSkip: () => skips.push(true) },
+  );
+  assert.deepEqual(errors, ["unterminated locator block"]);
+  assert.deepEqual(skips, [], "a broken locator must never be skipped");
+  // A body that merely names the fence in prose still carries no locator.
+  assert.equal(parseLocator("I pasted a compose-parity-locator/v1 block once.").error, NO_LOCATOR);
+  // And a good block followed by a dangling opener is ambiguous, not usable.
+  assert.equal(parseLocator(shared.cases[0].block + "\n```compose-parity-locator/v1\nrepository: a/b\n").error, "multiple locator blocks");
+});

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildIssueIndex, canonicalIssueUrl, parseLocator } from "./parity-issues.mjs";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { NO_LOCATOR, buildIssueIndex, canonicalIssueUrl, parseLocator } from "./parity-issues.mjs";
 
 const body = `Difference details.\n\n\`\`\`compose-parity-locator/v1
 repository: yschimke/m3-catalog
@@ -34,4 +36,49 @@ test("buildIssueIndex canonicalises URLs, labels, and preserves closed rows", ()
 test("canonicalIssueUrl rejects non-GitHub and mismatched shapes", () => {
   assert.equal(canonicalIssueUrl("javascript:alert(1)"), null);
   assert.equal(canonicalIssueUrl("https://github.com/o/r/pull/2"), null);
+});
+
+// The half of the contract this file owns. The other half — that `ServeIssueReport.locatorBlock`
+// emits these exact bytes — is asserted by ServeIssueReportTest against the same file, which is the
+// only thing stopping a Kotlin writer and a JavaScript producer from drifting apart on a contract
+// neither of them can see the other half of. See the fixture's own $comment.
+const shared = JSON.parse(
+  readFileSync(fileURLToPath(new URL("./fixtures/parity-locators.json", import.meta.url)), "utf8"),
+);
+
+for (const shape of shared.cases) {
+  test(`shared locator fixture: ${shape.name}`, () => {
+    assert.deepEqual(parseLocator(shape.block), shape.parse, shape.why);
+  });
+}
+
+test("an indexed issue survives a locator that names no revision", () => {
+  // The writer omits `revision` whenever the session has no delivery provenance — a developer's
+  // local serve, or a live daemon. Requiring it dropped exactly those reports.
+  const local = shared.cases.find((shape) => shape.name === "no-revision");
+  const index = buildIssueIndex(
+    [{ html_url: "https://github.com/yschimke/m3-catalog/issues/40", title: "Glyph colour", body: local.block, state: "open" }],
+    { generatedAt: "2026-08-15T10:00:00Z" },
+  );
+  assert.equal(index.issues.length, 1);
+  assert.equal(index.issues[0].component, "IconButton/Tonal");
+});
+
+test("an ordinary issue is skipped, not rejected", () => {
+  // Every repository is mostly issues that are not parity reports. Counting each of them as a
+  // failure made the producer red on a healthy repo, which is why no catalog could adopt it.
+  const errors = [];
+  const skips = [];
+  const index = buildIssueIndex(
+    [
+      { html_url: "https://github.com/yschimke/m3-catalog/issues/71", title: "Dependency Dashboard", body: "no locator here", state: "open" },
+      { html_url: "https://github.com/yschimke/m3-catalog/issues/72", title: "Filed without its identity", body: "no locator here", state: "open", labels: [{ name: "parity:known-difference" }] },
+    ],
+    { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error), onSkip: (issue, info) => skips.push([issue.title, info.labelled]) },
+  );
+  assert.deepEqual(index.issues, []);
+  assert.deepEqual(errors, [], "an absent locator is not an error");
+  // …but a parity-labelled issue with no locator is a mis-filed report, and says so.
+  assert.deepEqual(skips, [["Dependency Dashboard", false], ["Filed without its identity", true]]);
+  assert.equal(parseLocator("nothing").error, NO_LOCATOR);
 });


### PR DESCRIPTION
## Summary

`compose-parity-locator/v1` has two implementations — the Kotlin writer in `ServeIssueReport` and the JavaScript producer in `parity-issues.mjs` — and, until this PR, nothing that both of them read. Each tested itself against itself, and three disagreements passed review:

| Shape the writer emits | What the producer did |
| --- | --- |
| No `revision` line — `ServeIssueReport.locator` fills it from delivery provenance, and a local `compose-preview serve` or a live daemon has none | `missing locator field(s): revision` |
| `variant: ` — `variantFor` returns `""` for a preview id carrying no `__` axes | `missing locator field(s): variant` |
| Override keys sorted by Unicode **code point** (`canonicalOverrides`) | Re-serialised with `Array.prototype.sort` (UTF-16 **code units**) and refused as `overrides are not canonical JSON` for any astral-plane key |

Each one rejects the **whole locator**, so `buildIssueIndex` drops the issue: the report is filed, and is then silently absent from every surface #3806 built to show it. The first row is the ordinary developer path — reporting from a local serve.

Separately, `emit-parity-issues.mjs` set a non-zero exit for every issue whose locator was *absent*. A repository is mostly ordinary issues and none of them carry a locator block, so the emitter was red on any healthy repo. That is now split: an absent locator is skipped, a **present and broken** one still fails the run, and an `area:`/`parity:`-labelled issue with no locator warns — that one is a report filed without its identity.

## The fix that matters is the fixture

`scripts/design-artifacts/fixtures/parity-locators.json` carries each shape once and is read by **both** engines: `ServeIssueReportTest` asserts `locatorBlock` emits those exact bytes, `parity-issues.test.mjs` asserts `parseLocator` parses them back. Cases with no `writer` key are shapes no writer emits and the producer must keep refusing. Batch 01 planned this shared fixture and it never landed; without it, neither side can see the half of the contract it does not own.

## Context

Found while trying to switch Phase 1 on. `parity-issues-reusable.yml` has had **no callers** since it merged — `parity/issues.json` has never been generated for any catalog, and the m3-catalog delivery branch's `parity/` directory holds `activity.json` alone. yschimke/m3-catalog#170 adds the caller. Docs updated in `COMPONENT_PARITY_WORKFLOW.md` §2/§3 and the batch README.

Refs #3680, #3804, #3805.

## Test plan

- `node --test scripts/design-artifacts/parity-issues.test.mjs` — 12 pass. Confirmed the six new fixture cases and the skip-vs-reject test **fail** against the unpatched producer (`git stash` of `parity-issues.mjs`: 6 failures, then a whole-file failure once `NO_LOCATOR` is imported).
- `./gradlew :cli:test --tests "…ServeIssueReportTest"` — BUILD SUCCESSFUL; the new `the writer emits the shared locator fixture byte for byte` case is in the XML report, proving the fixture bytes match the writer exactly rather than being hand-copied approximations.
- `./gradlew :cli:ktfmtFormat` clean.

Not a visual change — producer/validator plumbing and a wire fixture, no rendered surface touched.