### PR TITLE
fix(serve): carry a preview's ground and device frame into published catalogs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -433,6 +433,7 @@ class ServeBundleHost(
       .sorted()
       .map { id ->
         val meta = variantMeta[id]
+        val previewParams = previewParamsById[id]?.asPreviewParamsMeta() ?: meta?.previewParams
         ServePreview(
           id = id,
           label = id,
@@ -491,13 +492,21 @@ class ServeBundleHost(
           sourceFile = sourceFilesById[id],
           sourceModule = meta?.sourceModule,
           bodyLine = bodyLinesById[id],
-          uiMode = previewParamsById[id]?.uiMode ?: 0,
-          showBackground = previewParamsById[id]?.showBackground == true,
-          backgroundColor = previewParamsById[id]?.backgroundColor ?: 0L,
+          // The `@Preview` ground and device frame, from whichever source this session actually
+          // has. An uploaded bundle carries a root `previews.json` and answers directly; a
+          // published CATALOG does not stage one, and its metadata rides on
+          // `previews/variants.json` instead. Without the second source every catalog preview
+          // arrived with the annotation defaults, so `PreviewBackdrop` fell back to the catalog's
+          // declared stage for all of them and the device clip never resolved — on the ordinary
+          // read-only path, which is how a published catalog is normally read.
+          //
+          // The bundle wins where both exist: it is this render's own manifest, while the catalog
+          // record was written by an export that may predate the bundle in front of us.
+          uiMode = previewParams?.uiMode ?: 0,
+          showBackground = previewParams?.showBackground == true,
+          backgroundColor = previewParams?.backgroundColor ?: 0L,
           deviceFrame =
-            previewParamsById[id]?.let {
-              ServeDeviceFrame.from(it.device, it.widthDp, it.heightDp)
-            },
+            previewParams?.let { ServeDeviceFrame.from(it.device, it.widthDp, it.heightDp) },
         )
       }
       .toList()
@@ -1311,6 +1320,25 @@ class ServeBundleHost(
     }
   }
 }
+
+/**
+ * A bundle manifest's `@Preview` params in the shape a catalog publishes them.
+ *
+ * The two sources describe the same annotation and are reduced to one type here rather than being
+ * read separately at the call site, so "which fields does a ground need?" is answered once. Only
+ * the fields a browse surface consults before opening a daemon cross over — the rest of
+ * `PreviewParams` (locale, font scale, density) belongs to the render, not to how it is presented.
+ */
+private fun ee.schimke.composeai.cli.PreviewParams.asPreviewParamsMeta():
+  ServeCatalogStore.PreviewParamsMeta =
+  ServeCatalogStore.PreviewParamsMeta(
+    uiMode = uiMode,
+    showBackground = showBackground,
+    backgroundColor = backgroundColor,
+    device = device,
+    widthDp = widthDp,
+    heightDp = heightDp,
+  )
 
 @Serializable
 private data class BundleRenderError(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -573,6 +573,11 @@ class ServeCatalogStore(
               sourceModule = planned.componentSourceModule,
               bodyLine = planned.componentBodyLine,
               caption = planned.componentCaption,
+              // The ground and the frame this render was captured with. Straight through from the
+              // catalog's own image record — the export lifted them off the bundle's
+              // `previews.json`, which is the only place they exist and which a published catalog
+              // does not stage.
+              previewParams = image.previewParams,
             )
         }
         count++
@@ -2408,6 +2413,12 @@ class ServeCatalogStore(
      * daemon is ever opened.
      */
     val fixedTheme: Boolean = false,
+    /**
+     * This render's `@Preview` ground and device frame, lifted from the bundle's `previews.json` at
+     * export time. See [PreviewParamsMeta] for why a published catalog cannot recover them
+     * otherwise.
+     */
+    val previewParams: PreviewParamsMeta? = null,
   )
 
   /**
@@ -2436,6 +2447,42 @@ class ServeCatalogStore(
     val kind: String? = null,
     val caption: String? = null,
     val extension: String = ".apng",
+  )
+
+  /**
+   * The `@Preview` parameters a browse surface needs BEFORE any daemon is opened — what ground the
+   * render sits on, and what device frame it was captured in.
+   *
+   * These live in a bundle's root `previews.json`, which a **published catalog does not stage**: it
+   * carries per-preview metadata on `previews/variants.json` instead. So on the ordinary read-only
+   * serving path — a published catalog with no trusted live daemon — every preview arrived with the
+   * annotation defaults, and `PreviewBackdrop` fell back to the catalog's declared stage for all of
+   * them. That is the per-preview half of the backdrop being silently inert exactly where a
+   * published catalog is read, and it took the device clip down with it once
+   * [ServeDeviceFrame][ee.schimke.composeai.cli.serve.ServeDeviceFrame] arrived: a round Wear
+   * comparison was drawn on a square stage there and nowhere else.
+   *
+   * Carried as ONE nested record rather than five loose fields so the two halves cannot be wired up
+   * separately and drift — the ground and the frame are the same question about the same render,
+   * asked of the same annotation.
+   *
+   * Every field defaults, so a catalog published before this existed reads back as `null` and keeps
+   * exactly its old behaviour rather than failing to parse.
+   */
+  @Serializable
+  data class PreviewParamsMeta(
+    /** `@Preview(uiMode = …)`, for the viewer's Day/Night default. */
+    val uiMode: Int = 0,
+    /** `@Preview(showBackground = …)`. */
+    val showBackground: Boolean = false,
+    /** `@Preview(backgroundColor = …)`; `0` is the annotation's own "unset". */
+    val backgroundColor: Long = 0L,
+    /** The raw `@Preview(device = …)` string; the shape is resolved from it, never from the dp. */
+    val device: String? = null,
+    /** `@Preview(widthDp = …)`, when the annotation states one. */
+    val widthDp: Int? = null,
+    /** `@Preview(heightDp = …)`, when the annotation states one. */
+    val heightDp: Int? = null,
   )
 
   @Serializable
@@ -2497,6 +2544,11 @@ class ServeCatalogStore(
     val bodyLine: Int? = null,
     /** Failure shown by the landing card instead of requesting a missing PNG. */
     val renderFailure: CatalogRenderFailure? = null,
+    /**
+     * This preview's `@Preview` ground and device frame, so the read-only catalog path can resolve
+     * a per-preview backdrop and device clip without a live daemon. See [PreviewParamsMeta].
+     */
+    val previewParams: PreviewParamsMeta? = null,
   )
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBakedCatalogPreviewParamsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBakedCatalogPreviewParamsTest.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.cli.serve
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The read-only catalog path resolving a per-preview ground and device frame.
+ *
+ * This is the path a **published catalog is normally served on**: `ServeCatalogStore` stages
+ * `previews/variants.json` and no root `previews.json`, and there is no trusted live daemon whose
+ * twin could supply the missing params. Everything a preview says about itself in `@Preview` was
+ * therefore lost here — `showBackground` / `backgroundColor` came back as the annotation defaults,
+ * so `PreviewBackdrop` fell back to the catalog's declared stage for every card, and once the
+ * device clip arrived it never resolved at all, drawing round Wear comparisons on a square stage on
+ * this path and nowhere else.
+ *
+ * The fixtures below are deliberately shaped like the production manifest — a staging directory
+ * with baked PNGs and a `variants.json`, no `previews.json` anywhere — because a test that handed
+ * the host a bundle manifest would pass without the feature under test existing.
+ */
+class ServeBakedCatalogPreviewParamsTest {
+
+  private fun png(): ByteArray =
+    ByteArrayOutputStream()
+      .also { ImageIO.write(BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB), "png", it) }
+      .toByteArray()
+
+  /** A published catalog staged the way the store writes it: baked pixels + `variants.json`. */
+  private fun bakedCatalog(variantsJson: String): ServeBundleHost {
+    val dir = Files.createTempDirectory("baked-catalog").toFile().also { it.deleteOnExit() }
+    File(dir, "previews").mkdirs()
+    File(dir, "previews/timetext.png").writeBytes(png())
+    File(dir, "previews/sticker.png").writeBytes(png())
+    File(dir, "previews/variants.json").writeText(variantsJson)
+    return ServeBundleHost(dir, label = "wear-m3", title = "Wear M3")
+  }
+
+  private fun previewOf(host: ServeBundleHost, id: String): ServePreview =
+    host.previews.first { it.id == id }
+
+  @Test
+  fun `a baked catalog preview keeps the ground and frame its annotation stated`() {
+    val host =
+      bakedCatalog(
+        """
+        {"timetext":{"componentId":"Template/TimeText",
+          "previewParams":{"uiMode":32,"showBackground":true,"backgroundColor":4278190080,
+            "device":"id:wearos_large_round","widthDp":227,"heightDp":227}}}
+        """
+          .trimIndent()
+      )
+    val preview = previewOf(host, "timetext")
+    assertTrue(preview.showBackground, "showBackground survives the catalog round trip")
+    assertEquals(0xFF000000L, preview.backgroundColor)
+    assertEquals(32, preview.uiMode)
+    assertEquals(ServeDeviceFrame(227.0, 227.0, isRound = true), preview.deviceFrame)
+  }
+
+  @Test
+  fun `the stated ground reaches the comparison stage, rather than the catalog's default`() {
+    // The point of the whole change, asserted where a reader would see it. `PreviewBackdrop` would
+    // otherwise answer from `declaredSurface` — the catalog's dark plate `#1C1B1F` — for a preview
+    // that explicitly named opaque black, and the stage would be the wrong colour on every card.
+    val host =
+      bakedCatalog(
+        """
+        {"timetext":{"previewParams":{"showBackground":true,"backgroundColor":4278190080,
+          "device":"id:wearos_large_round","widthDp":227,"heightDp":227}}}
+        """
+          .trimIndent()
+      )
+    val preview = previewOf(host, "timetext")
+    val backdrop = ServeWeb.backdropFor(preview, darkFirst = true)
+    assertEquals("#FF000000", backdrop.color)
+    assertEquals(PreviewBackdropSourceOfTest, backdrop.source.wire)
+    // …and the shape with it, which is what made this visible: a round device on a square stage.
+    assertEquals("circle(50% at 50% 50%)", ServeWeb.stageClipFor(preview))
+  }
+
+  @Test
+  fun `a catalog published before this existed keeps exactly its old behaviour`() {
+    // Every field defaults and the record is absent, so an older delivery branch must still parse
+    // and must not gain an invented ground or a clip. This is the state of every published catalog
+    // until `design-artifacts.yml` regenerates it, so it is the common case for a while.
+    val host =
+      bakedCatalog("""{"sticker":{"componentId":"Button/Filled","section":"Components"}}""")
+    val preview = previewOf(host, "sticker")
+    assertEquals(false, preview.showBackground)
+    assertEquals(0L, preview.backgroundColor)
+    assertEquals(0, preview.uiMode)
+    assertNull(preview.deviceFrame)
+    assertNull(ServeWeb.stageClipFor(preview))
+  }
+
+  @Test
+  fun `a preview with no variant entry at all is unaffected`() {
+    // `sticker` is staged as pixels but named by no manifest entry — a flat catalog's ordinary
+    // shape. It must not throw and must not acquire params from its neighbour.
+    val host = bakedCatalog("""{"timetext":{"previewParams":{"device":"id:wearos_large_round"}}}""")
+    assertNull(previewOf(host, "sticker").deviceFrame)
+    assertTrue(previewOf(host, "timetext").deviceFrame?.isRound == true)
+  }
+
+  private companion object {
+    /** `PreviewBackdrop.Source.PREVIEW_BACKGROUND_COLOR`'s wire form. */
+    const val PreviewBackdropSourceOfTest = "preview.backgroundColor"
+  }
+}

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -20,6 +20,36 @@ function sidecarDeclarations(bundle, previewId, suffix) {
   }
 }
 
+/**
+ * The subset of a preview's `@Preview` params that decides how it is PRESENTED — the ground behind
+ * it and the device frame around it — or null when it states none of them.
+ *
+ * Deliberately not the whole params record: locale, font scale and density describe how the render
+ * was produced and are already baked into the pixels, so republishing them would grow every
+ * catalog for no reader. These six are the ones a browse surface has to know *before* it opens
+ * anything, because they decide what it paints behind the image and what shape it clips it to.
+ *
+ * Omitting an all-defaults record keeps the catalog quiet for the ordinary preview: a component
+ * sticker states no device and no background, and a `previewParams: {}` on every image would be
+ * pure noise. Kotlin reads a missing record back as null and keeps its existing behaviour.
+ */
+function presentationParams(params) {
+  if (!params) return null;
+  const out = {};
+  if (params.uiMode) out.uiMode = params.uiMode;
+  if (params.showBackground === true) out.showBackground = true;
+  if (params.backgroundColor) out.backgroundColor = params.backgroundColor;
+  if (typeof params.device === "string" && params.device.trim() !== "") out.device = params.device;
+  // The dp ride along ONLY with a device, because that is the only thing they qualify: the frame
+  // resolver applies them both-axes-or-neither against a named device, and on their own they say
+  // nothing a consumer of this record can use.
+  if (out.device) {
+    if (Number.isFinite(params.widthDp)) out.widthDp = params.widthDp;
+    if (Number.isFinite(params.heightDp)) out.heightDp = params.heightDp;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 /** Metadata that must be visible on the browse surface before a preview daemon is opened. */
 export function declarationsByPreviewId(bundles) {
   const out = new Map();
@@ -36,12 +66,21 @@ export function declarationsByPreviewId(bundles) {
       // this card under a theme override, and it has to know that from catalog.json alone —
       // deciding it lazily would mean the specimen re-themes until its daemon happens to be opened.
       const fixedTheme = preview.fixedTheme === true;
+      // What ground this render sits on and what device frame it was captured in. These live ONLY
+      // in the bundle's root `previews.json`, which a published catalog does not stage — it carries
+      // per-preview metadata on `previews/variants.json` instead. Without lifting them here, every
+      // preview on the read-only serving path arrives with the annotation defaults, so the
+      // per-preview backdrop falls back to the catalog's declared stage for all of them and the
+      // device clip never resolves: a round Wear comparison is drawn on a square stage there and
+      // nowhere else.
+      const previewParams = presentationParams(preview.params);
       if (
         overrides.length > 0 ||
         remoteComposeKnobs.length > 0 ||
         supportsFocus ||
         supportsGestures ||
-        fixedTheme
+        fixedTheme ||
+        previewParams
       ) {
         out.set(preview.id, {
           ...(overrides.length > 0 ? { overrides } : {}),
@@ -49,6 +88,7 @@ export function declarationsByPreviewId(bundles) {
           ...(supportsFocus ? { supportsFocus: true } : {}),
           ...(supportsGestures ? { supportsGestures: true } : {}),
           ...(fixedTheme ? { fixedTheme: true } : {}),
+          ...(previewParams ? { previewParams } : {}),
         });
       }
     }

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -140,3 +140,64 @@ test("ignores missing and malformed sidecars", () => {
 
   assert.deepEqual([...declarationsByPreviewId(bundle)], []);
 });
+
+test("lifts the ground and device frame a browse surface needs before opening anything", () => {
+  // A published catalog stages `previews/variants.json` and NOT a root `previews.json`, so these
+  // are unrecoverable downstream unless the export writes them. Without them the read-only serving
+  // path resolves every preview's ground from the catalog's declared stage and never resolves a
+  // device clip at all — a round Wear comparison is drawn on a square stage there and nowhere else.
+  const bundle = {
+    previews: [
+      {
+        id: "TimeText_Large_Round",
+        params: {
+          device: "id:wearos_large_round",
+          widthDp: 227,
+          heightDp: 227,
+          showBackground: true,
+          backgroundColor: 4278190080,
+          uiMode: 32,
+          // Produced-the-render params, deliberately NOT republished: they are already baked into
+          // the pixels and say nothing about how the image should be presented.
+          density: 2.0,
+          fontScale: 1.0,
+          locale: "en-GB",
+        },
+      },
+    ],
+    entries: {},
+  };
+
+  assert.deepEqual(declarationsByPreviewId(bundle).get("TimeText_Large_Round"), {
+    previewParams: {
+      uiMode: 32,
+      showBackground: true,
+      backgroundColor: 4278190080,
+      device: "id:wearos_large_round",
+      widthDp: 227,
+      heightDp: 227,
+    },
+  });
+});
+
+test("records nothing for a preview that states no ground and no device", () => {
+  // The ordinary component sticker. A `previewParams: {}` on every image would grow every catalog
+  // for no reader, and Kotlin reads a missing record back as null — its existing behaviour.
+  const bundle = {
+    previews: [{ id: "FilledButton", params: { density: 2.0, fontScale: 1.0 } }],
+    entries: {},
+  };
+  assert.equal(declarationsByPreviewId(bundle).get("FilledButton"), undefined);
+});
+
+test("drops dp that name no device, because nothing downstream can use them", () => {
+  // The frame resolver applies annotation dp against a NAMED device, both axes or neither. On their
+  // own they qualify nothing, so republishing them would be bytes a reader must then ignore.
+  const bundle = {
+    previews: [{ id: "Sized", params: { widthDp: 320, heightDp: 480, showBackground: true } }],
+    entries: {},
+  };
+  assert.deepEqual(declarationsByPreviewId(bundle).get("Sized"), {
+    previewParams: { showBackground: true },
+  });
+});


### PR DESCRIPTION
Follow-up to #4402, closing the gap its review found ([#4402 review](https://github.com/yschimke/compose-ai-tools/pull/4402#discussion_r3827663010)).

## The read-only path lost everything a preview said about itself

`ServeCatalogStore` stages `previews/variants.json` and **no root `previews.json`** — that manifest belongs to an uploaded bundle. On the ordinary read-only path (a published catalog, no trusted live daemon) there is also no daemon twin to supply the difference, so `previewParamsById` is empty and every preview arrived with the annotation defaults.

Two consequences, one long-standing and one new:

- **The backdrop's per-preview half was inert.** `PreviewBackdrop` fell back to the catalog's declared stage for every card, so a preview stating `@Preview(backgroundColor = 0xFF000000)` was drawn on the catalog's `#1C1B1F` plate instead of its own black. This predates #4402 and is documented on `ServeCatalogLiveHost`.
- **The device clip never resolved at all.** Round Wear comparisons were drawn on a square stage on this path and nowhere else — the exact fault #4402 fixed, still present where a published catalog is normally read.

They are the same missing data, so they're fixed together rather than the device being bolted on alone.

## The change

The export already holds the bundle's `previews.json` in memory. `catalog-preview-declarations.mjs` — which already lifts `supportsFocus` / `fixedTheme` for exactly this reason — now also lifts the params that decide how a render is **presented**, and they ride through `Image` → `VariantMeta` → `ServeBundleHost`.

`ServeBundleHost` prefers the bundle manifest where one exists (it is this render's own, while the catalog record was written by an export that may predate the bundle in front of us) and falls back to the catalog record otherwise.

**One nested record, not six loose fields.** The ground and the frame are the same question about the same annotation, and splitting them is how they'd get wired up separately and drift.

**Only presentation params cross over.** `uiMode`, `showBackground`, `backgroundColor`, `device`, `widthDp`, `heightDp`. Locale, font scale and density describe how the render was *produced* and are already baked into the pixels; republishing them would grow every catalog for no reader. The dp ride along only with a device, because the frame resolver applies them both-axes-or-neither against a named device and on their own they qualify nothing.

## Compatibility, both directions

- Every field defaults and the record is omitted when a preview states none of them, so the ordinary component sticker adds no bytes.
- A catalog published **before** this reads back as `null` and keeps precisely its current behaviour — no invented ground, no clip. That is every delivery branch until `design-artifacts.yml` regenerates it, so it is the common case for a while.
- The catalog parser is `ignoreUnknownKeys = true`, so an **older** CLI reading a **newer** catalog is unaffected.

`scripts/validate-report-schemas.mjs` covers `schema/**` and the harness fixtures, not the published catalog, so there is no schema file to update.

## Test plan

- `ServeBakedCatalogPreviewParamsTest` — 4 new, driving a staging directory shaped like the production manifest (baked PNGs + `variants.json`, no `previews.json` anywhere), because a test handed a bundle manifest would pass without this feature existing. Covers the round trip, the resolved backdrop *and* clip reaching the comparison stage, an older catalog keeping its old behaviour, and a preview with no variant entry.
- `catalog-preview-declarations.test.mjs` — 3 new, covering the lift, the all-defaults preview recording nothing, and dp being dropped when they name no device.
- `:cli:test` green; `ktfmtCheckMain` / `ktfmtCheckTest` clean.
- `scripts/design-artifacts` `npm test`: 799 pass / 7 fail — the same 7 fail on a clean tree (Chromium- and network-dependent suites in this container), verified by stashing the change and re-running.

Text-only body: this is data-product plumbing. What a reader ends up seeing is the clipped round stage already captured by the committed `serve-reference-compare-round-device` fixture from #4402 — this change is what makes a *published* catalog reach it, and the Kotlin test asserts the exact stage colour (`#FF000000`) and clip (`circle(50% at 50% 50%)`) that fixture shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b

---
_Generated by [Claude Code](https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b)_