### PR TITLE
fix(design-artifacts): score the publish-time report on two grounds

### DIFF
--- a/docs/design/evidence/dual-ground-scoring/README.md
+++ b/docs/design/evidence/dual-ground-scoring/README.md
@@ -100,9 +100,23 @@ Two passes instead of one, over a plane capped at `MAX_SIDE = 192` — so under 
 # ["#ffffff", "#000000"], taking the minimum across grounds.
 ```
 
-## Known limit
+## The publish-time report had it too, and now doesn't
 
-`scripts/design-artifacts/render-compare-html.mjs` carries its **own** inline copy of `grayFromDraw`,
-also compositing on `#ffffff`, for the publish-time PNG↔figma-svg report. It has the same flaw and is
-not fixed here — unifying the two scorer implementations is its own change. Until then that lane's
-numbers keep the old behaviour.
+`scripts/design-artifacts/render-compare-html.mjs` carries its **own** scorer for the publish-time
+PNG↔figma-svg report, and it is not a copy of this one — it is SSIM, computed inside the generated
+page. Different arithmetic, identical failure: two planes a white ground flattened are the same
+uniform field, so SSIM answers `1.0` and the row reports a perfect match.
+
+Measured by extracting that page's own `grayFromDraw` / `blur` / `ssim` and running them in
+Chromium over the same Wear renders:
+
+| Pair | Before | After |
+| --- | --- | --- |
+| `TextMaxLinesTruncated` vs `IconSticker` — both white ink | **100.0** | 53.1 |
+| `TextMaxLinesTruncated` vs `FilledButton` | 84.7 | 34.0 |
+| `FilledButton` vs itself — identity guard | 100.0 | 100.0 |
+
+Same headline as the serve lane, and the same reassurance: identity still scores 100, so taking the
+worse of two grounds adds no noise-driven pessimism. That lane now carries the grounds and the
+opacity gate too — its own copy, because it runs inside the report page rather than importing from
+`cli/serve-web`, but under the same rule.

--- a/scripts/design-artifacts/render-compare-html.mjs
+++ b/scripts/design-artifacts/render-compare-html.mjs
@@ -286,27 +286,41 @@ const SCORER = String.raw`
     return m ? { tx: parseInt(m[1], 10), ty: parseInt(m[2], 10) } : { tx: 0, ty: 0 };
   }
 
-  // Draw into a tw×th canvas over white via the caller's draw(ctx) and return the
-  // grayscale (luma over white) plane as a Float32Array.
-  function grayFromDraw(draw, tw, th) {
+  // The grounds a comparison is scored on, worst result winning. One opaque ground is not a
+  // neutral choice: it ANNIHILATES ink that matches it, and two planes flattened to the same
+  // uniform field are identical — so SSIM answers 1.0 and the row reports a perfect match for a
+  // pair that shares nothing but the colour of its ink. A dark-first system draws light ink onto a
+  // transparent sticker, which is exactly that case. White and black together make it structural:
+  // a pixel can only vanish on both when its alpha is zero on both sides, which is the one case
+  // where "no evidence" is the honest answer. Same rule as the serve scorer's COMPARISON_GROUNDS.
+  const GROUNDS = ["#ffffff", "#000000"];
+
+  // Draw into a tw×th canvas over the given ground via the caller's draw(ctx), returning the
+  // grayscale plane as a Float32Array. The canvas is filled edge to edge before drawing, so every
+  // pixel read back is opaque and the luma is the composited colour outright.
+  function grayFromDraw(draw, tw, th, ground) {
     const c = document.createElement("canvas");
     c.width = tw; c.height = th;
     const ctx = c.getContext("2d", { willReadFrequently: true });
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = "high";
-    ctx.fillStyle = "#ffffff";
+    ctx.fillStyle = ground;
     ctx.fillRect(0, 0, tw, th);
     draw(ctx);
     const { data } = ctx.getImageData(0, 0, tw, th);
     const g = new Float32Array(tw * th);
     for (let i = 0; i < tw * th; i++) {
-      const a = data[i * 4 + 3] / 255;
-      const r = data[i * 4] * a + 255 * (1 - a);
-      const gr = data[i * 4 + 1] * a + 255 * (1 - a);
-      const b = data[i * 4 + 2] * a + 255 * (1 - a);
-      g[i] = 0.299 * r + 0.587 * gr + 0.114 * b;
+      g[i] = 0.299 * data[i * 4] + 0.587 * data[i * 4 + 1] + 0.114 * data[i * 4 + 2];
     }
     return g;
+  }
+
+  // Whether two planes are the same picture. The tolerance is for a nearly-opaque pixel: alpha 254
+  // lets a sliver of ground through and moves a luminance by well under one unit.
+  function samePlane(a, b) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (Math.abs(a[i] - b[i]) > 1) return false;
+    return true;
   }
 
   // Separable 3-tap [1,2,1]/4 blur — a light Gaussian that, together with the
@@ -451,7 +465,7 @@ const SCORER = String.raw`
       const tw = Math.max(1, Math.round(rw * scale));
       const th = Math.max(1, Math.round(rh * scale));
       // PNG: drawn 1:1 into the canvas (only the shared downscale applied).
-      const ga = blur(grayFromDraw((ctx) => ctx.drawImage(png, 0, 0, rw * scale, rh * scale), tw, th), tw, th);
+      const drawPng = (ctx) => ctx.drawImage(png, 0, 0, rw * scale, rh * scale);
       // SVG: drawn at its native px size but offset by (-tx, -ty) so its content origin
       // lands at (0,0) and the export's transparent padding is cropped — the same align
       // the daemon's FigmaSvgFidelity does before scoring. No independent scaling: SVG px
@@ -459,16 +473,26 @@ const SCORER = String.raw`
       // rather than being hidden by a fit-to-box rescale.
       const { tx, ty } = translateOf(rawSvg);
       const sw = svg.naturalWidth || svg.width, sh = svg.naturalHeight || svg.height;
-      const gb = blur(
-        grayFromDraw(
-          (ctx) => ctx.drawImage(svg, -tx * scale, -ty * scale, sw * scale, sh * scale),
-          tw,
-          th,
-        ),
-        tw,
-        th,
-      );
-      const pct = Math.max(0, Math.min(100, ssim(ga, gb, tw, th) * 100));
+      const drawSvg = (ctx) => ctx.drawImage(svg, -tx * scale, -ty * scale, sw * scale, sh * scale);
+      // Every ground rasterised BEFORE any is scored, then the worst kept. The gate below is why
+      // both are rasterised rather than scored one at a time: an opaque frame composites
+      // identically onto every ground, so equal planes are how opacity is detected, for free.
+      const planes = GROUNDS.map((ground) => ({
+        a: blur(grayFromDraw(drawPng, tw, th, ground), tw, th),
+        b: blur(grayFromDraw(drawSvg, tw, th, ground), tw, th),
+      }));
+      // A second ground only means something when there is alpha for it to show through. On a
+      // MIXED pair — an opaque Figma export against a render with a transparent surround — nothing
+      // about the export moves between grounds while all of the render's surround does, so the
+      // black pass would report a difference that lives in the grounds rather than in the artwork,
+      // and the minimum would take it.
+      const varies = (side) => planes.some((p) => !samePlane(p[side], planes[0][side]));
+      const scored = varies("a") && varies("b") ? planes : [planes[0]];
+      let worst = 100;
+      for (const p of scored) {
+        worst = Math.min(worst, Math.max(0, Math.min(100, ssim(p.a, p.b, tw, th) * 100)));
+      }
+      const pct = worst;
       // A newer control change may have started while this row was awaiting its fetch /
       // decode. Everything above only read; from here down mutates the row, so bail now
       // if superseded — otherwise a stale pass could overwrite the current one's image

--- a/scripts/design-artifacts/render-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-compare-html.test.mjs
@@ -310,3 +310,30 @@ test("a superseded scoring pass bails before mutating the row", () => {
   assert.match(html, /await scoreRow\(tr, mySeq\)/);
   assert.match(html, /if \(seq !== runSeq\) return null/);
 });
+
+test("a row is scored on two grounds, worst result winning", () => {
+  // One opaque ground annihilates ink that matches it, and two planes flattened to the same
+  // uniform field are IDENTICAL — so SSIM answers 1.0 and the row reports a perfect match for a
+  // pair sharing nothing but the colour of its ink. A dark-first system draws light ink onto a
+  // transparent sticker, which is exactly that case. Same rule the serve scorer applies through
+  // COMPARISON_GROUNDS; this lane carries its own copy because it runs inside the report page.
+  const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
+  assert.match(html, /const GROUNDS = \["#ffffff", "#000000"\]/);
+  // The ground is a parameter, not a constant baked into the rasteriser.
+  assert.match(html, /function grayFromDraw\(draw, tw, th, ground\)/);
+  assert.match(html, /ctx\.fillStyle = ground/);
+  // Every ground rasterised before any is scored, then the minimum kept.
+  assert.match(html, /const planes = GROUNDS\.map\(/);
+  assert.match(html, /worst = Math\.min\(worst, Math\.max\(0, Math\.min\(100, ssim\(/);
+});
+
+test("the extra ground is gated on both sides actually showing one", () => {
+  // A MIXED pair — an opaque Figma export against a render with a transparent surround — moves on
+  // one side only, so the black pass would measure the grounds rather than the artwork and the
+  // minimum would take it. Equal planes are how opacity is detected, which is why every ground is
+  // rasterised up front rather than scored one at a time.
+  const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
+  assert.match(html, /function samePlane\(a, b\)/);
+  assert.match(html, /const varies = \(side\) =>/);
+  assert.match(html, /varies\("a"\) && varies\("b"\) \? planes : \[planes\[0\]\]/);
+});


### PR DESCRIPTION
Closes the "Known limit" #4396 wrote down: the publish-time PNG↔figma-svg report was the last lane still compositing onto a single white ground.

## Same failure, different arithmetic

It is **not** a copy of the serve scorer. `render-compare-html.mjs` computes **SSIM** inside the generated report page. But one opaque ground annihilates ink that matches it either way, and two planes flattened to the same uniform field are *identical* — so SSIM answers `1.0` and the row reports a perfect match for a pair sharing nothing but the colour of its ink.

A dark-first system draws light ink onto a transparent sticker, which is exactly that case, so this hit the Wear catalogs hardest — the ones the report exists to check.

## Measured

Not asserted from the serve lane's numbers: I extracted **this page's own** `grayFromDraw` / `blur` / `ssim` and ran them in Chromium over the `design-catalog-wear-m3` renders. `before` is one ground (`#ffffff`), `after` the worse of two.

| Pair | Before | After |
| --- | --- | --- |
| `TextMaxLinesTruncated` vs `IconSticker` — both white ink | **100.0** | 53.1 |
| `TextMaxLinesTruncated` vs `FilledButton` | 84.7 | 34.0 |
| `FilledButton` vs itself — identity guard | 100.0 | 100.0 |

Row one is the headline, and it is the same headline the serve lane had: two different components scoring the number an image scores against itself. Row three is the reassurance — identity still scores 100, so taking the worse of two grounds adds no noise-driven pessimism.

## The opacity gate comes with it

For the reason it exists in `cli/serve-web`: on a **mixed** pair — an opaque Figma export against a render with a transparent surround — nothing about the export moves between grounds while all of the render's surround does, so the black pass would measure the grounds rather than the artwork and the minimum would take it. Every ground is rasterised before any is scored, which is also how opacity is detected: equal planes, for free.

The duplication with `cli/serve-web/src/scorer` is deliberate and unchanged by this — that code is a bundled ES module, this runs inside a self-contained report page with no bundler. Unifying them is its own change; what matters is that the **rule** no longer differs between lanes.

## Also

`grayFromDraw` composited alpha over a hardcoded `255` after already filling the canvas — dead arithmetic (the readback is opaque), and actively wrong once the ground can be black. It now reads the composited RGB directly, like the serve lane's.

## Test plan

- 2 new structural tests in `render-compare-html.test.mjs` (25 pass), matching that file's own stated convention — its header notes the scoring "runs in a browser canvas (untestable under `node --test`)", so the page is pinned structurally and the behaviour is measured separately, as above.
- `scripts/design-artifacts` `npm test`: 801 pass / 7 fail — the same 7 fail on a clean tree (Chromium- and network-dependent suites in this container), verified earlier by stashing and re-running.
- Evidence and method appended to `docs/design/evidence/dual-ground-scoring/`, replacing the "Known limit" section that pointed here.

Text-only body, on the same reasoning #4396 gave: the change is a metric, and its evidence is the score table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b

---
_Generated by [Claude Code](https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b)_