### PR TITLE
fix(samples): stop the Studio-parity gate skipping itself green

### DIFF
--- a/docs/STUDIO_PARITY.md
+++ b/docs/STUDIO_PARITY.md
@@ -36,6 +36,23 @@ nothing without that marker and the task fails with "did not discover any tests"
 The `-P` flag is required in both cases: it materialises the `screenshotTest` source set. Without
 it the fixtures don't compile into the build and the test skips itself.
 
+## The gate cannot skip itself silently
+
+That skip is the one thing capable of retiring this gate without anyone noticing, so it is not left
+to inference. "Our renders are missing" reads identically whether the source set was never
+materialised (fine — nothing to compare) or the flag was dropped from CI and a render produced
+nothing (not fine — we have stopped checking against Studio). The Layoutlib references are
+committed, so their presence proves nothing either way.
+
+The build therefore states which case it is: `studioParity.required` is set from the same
+`screenshotTestEnabled` property that materialises the source set. With it true, absent renders are
+a **failure**; with it false, the test skips as before. A single fixture that stops rendering was
+already a failure (`our renderer produced no PNG`) — this covers the wholesale case, which is the
+one that short-circuits the test before that check runs.
+
+Verified both ways rather than reasoned about: with the fixtures' PNGs moved aside and the flag on,
+the gate fails at the assertion; with the flag off, it still skips.
+
 ## Why sizes are pinned instead of compared loosely
 
 Text rasterises differently in Layoutlib (native Skia + platform fonts) than under our Robolectric

--- a/samples/android-screenshot-test/build.gradle.kts
+++ b/samples/android-screenshot-test/build.gradle.kts
@@ -71,6 +71,19 @@ tasks
   .matching { it.name == "testDebugUnitTest" }
   .configureEach { dependsOn("composePreviewRenderAll") }
 
+// Tell `StudioParityTest` whether its gate is SUPPOSED to run. Without this it can only see that
+// our Parity renders are missing, which is the correct state when the screenshotTest source set was
+// never materialised and a broken build when it was — indistinguishable from inside the test,
+// because the Layoutlib references are committed either way. Left to guess it assumed the benign
+// case and skipped green, so dropping the `-P` flag from CI (or a render that quietly produced
+// nothing) would have retired the Studio-parity gate without failing anything.
+//
+// `withType<Test>` rather than the `matching` block above, which configures a generic `Task` and so
+// cannot reach `systemProperty`.
+tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
+  systemProperty("studioParity.required", screenshotTestEnabled)
+}
+
 dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.truth)

--- a/samples/android-screenshot-test/src/test/kotlin/com/example/sampleandroidscreenshot/StudioParityTest.kt
+++ b/samples/android-screenshot-test/src/test/kotlin/com/example/sampleandroidscreenshot/StudioParityTest.kt
@@ -80,10 +80,25 @@ class StudioParityTest {
   fun `our renders match Android Studio's Layoutlib output, or diverge only in known ways`() {
     val references = collectReferences()
     val ours = collectOurRenders()
-    // The screenshotTest source set only exists under
-    // `-Pandroid.experimental.enableScreenshotTest=true`, so without it there is nothing of ours to
-    // compare and the gate is not applicable.
-    assumeTrue("no Studio-parity renders in $rendersDir", ours.keys.any { it.startsWith("Parity") })
+    // Whether this gate is APPLICABLE, or BROKEN. The two look identical from in here — our Parity
+    // renders are missing either way, and the Layoutlib references are committed so their presence
+    // proves nothing — so the build says which it is (`studioParity.required`, set from the same
+    // property that materialises the source set).
+    //
+    // Getting this wrong in the safe-looking direction is what makes it worth the plumbing: a
+    // bare `assumeTrue` retires the whole Studio-parity gate the moment the `-P` flag is dropped
+    // from CI or `composePreviewRenderAll` quietly renders none of these fixtures. The suite stays
+    // green, the checks stay ticked, and nothing is comparing us to Studio any more.
+    // Only the wholesale case needs deciding here. A fixture that individually stopped rendering is
+    // already a failure below ("our renderer produced no PNG"); it is ALL of them going missing
+    // that short-circuits the test, because that is indistinguishable from the source set never
+    // having existed.
+    val renderedOurs = ours.keys.any { it.startsWith("Parity") }
+    if (System.getProperty("studioParity.required") == "true") {
+      assertThat(renderedOurs).isTrue()
+    } else {
+      assumeTrue("no Studio-parity renders in $rendersDir", renderedOurs)
+    }
     assertThat(references.keys).isNotEmpty()
 
     reportDir.mkdirs()


### PR DESCRIPTION
`StudioParityTest` is the check that holds us to what Android Studio shows — it diffs `composePreviewRenderAll`'s output (the path a user actually gets) against references rendered by **Layoutlib**, the engine Studio's preview pane draws through. It guarded itself like this:

```kotlin
assumeTrue("no Studio-parity renders in $rendersDir", ours.keys.any { it.startsWith("Parity") })
```

## Why that is the one guard worth hardening

"Our Parity renders are missing" reads identically in two very different situations:

- the `screenshotTest` source set was never materialised — **fine**, there is genuinely nothing of ours to compare;
- `-Pandroid.experimental.enableScreenshotTest=true` was dropped from CI, or `composePreviewRenderAll` quietly rendered none of these fixtures — **not fine**, we have stopped checking ourselves against Studio.

The Layoutlib references are committed, so their presence distinguishes nothing. The test assumed the benign case, which means the gate could be retired entirely while the suite stayed green and the checks stayed ticked. Every other failure mode here is loud; this one is silent, and it is the one that matters most, because the whole point is that people running the plugin against their own project keep getting what Studio shows.

## The fix

The build states which case it is. `studioParity.required` is set from the same `screenshotTestEnabled` property that materialises the source set, so:

- **required and absent** → failure;
- **not required** → skip, exactly as before.

Deliberately only the wholesale case. A *single* fixture that stops rendering was already a failure (`"$name: our renderer produced no PNG"`); it is all of them going missing that short-circuits the test before that check ever runs.

The system property is set via `tasks.withType<Test>()` rather than the existing `matching { it.name == … }` block, which configures a generic `Task` and so cannot reach `systemProperty`.

## Test plan

Verified in both directions rather than reasoned about:

| | |
|---|---|
| flag on, renders present | `BUILD SUCCESSFUL` — gate runs and passes, 11 fixtures |
| flag on, `Parity*.png` moved aside | `FAILED` at `StudioParityTest.kt:98` — previously this skipped green |
| flag off | still skips, no failure |

`ktfmtCheckMain` / `ktfmtCheckTest` clean. `docs/STUDIO_PARITY.md` records the guarantee, since that doc is where someone goes to decide whether to trust this.

Text-only: no rendered output changes — this is a test guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b

---
_Generated by [Claude Code](https://claude.ai/code/session_011pNZkQkWiGChd3GUUbfg2b)_