### PR TITLE
fix(serve): bound the optimizer pressure gate's recovery hold

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -16,6 +16,7 @@ import ee.schimke.composeai.cli.serve.LiveSeatLimiter
 import ee.schimke.composeai.cli.serve.MutableTrustStore
 import ee.schimke.composeai.cli.serve.OptimizerHostCoordinator
 import ee.schimke.composeai.cli.serve.OptimizerPressureGate
+import ee.schimke.composeai.cli.serve.OptimizerPressureThresholds
 import ee.schimke.composeai.cli.serve.PlaygroundAndroidRenderService
 import ee.schimke.composeai.cli.serve.PlaygroundAndroidSessionOpener
 import ee.schimke.composeai.cli.serve.PlaygroundBtaCompiler
@@ -894,7 +895,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             lanes = ServeBackgroundWork.DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
           )
         } ?: OptimizerHostCoordinator.NONE,
-      pressureGate = OptimizerPressureGate(sample = pressureSampler::sample),
+      pressureGate =
+        OptimizerPressureGate(
+          sample = pressureSampler::sample,
+          thresholds = OptimizerPressureThresholds.fromSystemProperties(),
+        ),
     )
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -26,7 +26,77 @@ data class OptimizerPressureThresholds(
   val resumeMemoryAvailableFraction: Double = 0.25,
   val resumeQuietMillis: Long = 30_000L,
   val sampleIntervalMillis: Long = 2_000L,
-)
+  /**
+   * Longest the gate may withhold admission while **no** reading is over a stop threshold.
+   *
+   * The gap between a stop and its resume side is a dead band, and a host can sit in one
+   * indefinitely: memory available 18% is neither `<= 0.15` (so nothing re-trips, and the reason
+   * degrades to the bare "host recovering") nor `>= 0.25` (so [OptimizerPressureGate] never starts
+   * counting [resumeQuietMillis]). Observed in production as a gate held for eight hours while the
+   * host sat at 2% CPU, with theme optimization stalled at 0.35% of its entries.
+   *
+   * Hysteresis exists to delay resumption, not to prevent it, so cap the hold. The stop thresholds
+   * are the real danger line; once the reading is back on their safe side, a bounded duty cycle —
+   * admit, possibly trip again, wait again — is the correct failure mode for best-effort work,
+   * where a permanent latch is not.
+   */
+  val maxRecoveryMillis: Long = 10 * 60_000L,
+) {
+  companion object {
+    /**
+     * Thresholds overridden by `composeai.serve.optimizer*` system properties.
+     *
+     * Deployments differ in what "constrained" means — a box whose steady state is 18% available
+     * memory (17 resident render daemons will do that) has a resume threshold set *below* its own
+     * baseline, so the gate is guaranteed to latch on the first transient dip. That is a property
+     * of the host, not of the code, and it needs to be settable without a rebuild.
+     */
+    fun fromSystemProperties(): OptimizerPressureThresholds {
+      val defaults = OptimizerPressureThresholds()
+      return OptimizerPressureThresholds(
+        stopLoadPerCpu = fraction("optimizerStopLoadPerCpu") ?: defaults.stopLoadPerCpu,
+        resumeLoadPerCpu = fraction("optimizerResumeLoadPerCpu") ?: defaults.resumeLoadPerCpu,
+        stopCpuUtilization = fraction("optimizerStopCpuUtilization") ?: defaults.stopCpuUtilization,
+        resumeCpuUtilization =
+          fraction("optimizerResumeCpuUtilization") ?: defaults.resumeCpuUtilization,
+        stopMemoryAvailableFraction =
+          fraction("optimizerStopMemoryAvailableFraction") ?: defaults.stopMemoryAvailableFraction,
+        resumeMemoryAvailableFraction =
+          fraction("optimizerResumeMemoryAvailableFraction")
+            ?: defaults.resumeMemoryAvailableFraction,
+        resumeQuietMillis = millis("optimizerResumeQuietMillis") ?: defaults.resumeQuietMillis,
+        sampleIntervalMillis =
+          millis("optimizerSampleIntervalMillis") ?: defaults.sampleIntervalMillis,
+        maxRecoveryMillis = millis("optimizerMaxRecoveryMillis") ?: defaults.maxRecoveryMillis,
+      )
+    }
+
+    /** A ratio in `0.0..1.0`; anything outside that is a typo, so ignore it rather than obey it. */
+    private fun fraction(name: String): Double? =
+      System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf { it in 0.0..1.0 }
+
+    /** Zero is meaningful (sample every call, never hold), so only negatives are rejected. */
+    private fun millis(name: String): Long? =
+      System.getProperty("composeai.serve.$name")?.toLongOrNull()?.takeIf { it >= 0L }
+  }
+}
+
+/** The individual readings [OptimizerPressureGate] can trip on, so resumption can be per-signal. */
+private enum class PressureSignal {
+  LOAD,
+  CPU,
+  MEMORY;
+
+  /** Whether this signal is back on the safe side of its **resume** threshold. */
+  fun recovered(sample: HostResourceSample, thresholds: OptimizerPressureThresholds): Boolean =
+    when (this) {
+      LOAD -> sample.loadPerCpu?.let { it <= thresholds.resumeLoadPerCpu } != false
+      CPU -> sample.cpuUtilization?.let { it <= thresholds.resumeCpuUtilization } != false
+      MEMORY ->
+        sample.memoryAvailableFraction?.let { it >= thresholds.resumeMemoryAvailableFraction } !=
+          false
+    }
+}
 
 /** Host-pressure state published on `/status.json` with the optimizer admission counters. */
 @Serializable
@@ -42,9 +112,13 @@ data class OptimizerPressureSnapshot(
 /**
  * Hysteretic host-resource gate for best-effort optimization.
  *
- * A high reading stops admission immediately. Resumption requires every available reading to be on
- * the safe side for [OptimizerPressureThresholds.resumeQuietMillis], so a render finishing does not
- * instantly admit another cold daemon while the host is still recovering.
+ * A high reading stops admission immediately. Resumption requires every reading that tripped the
+ * hold to be back on its resume side for [OptimizerPressureThresholds.resumeQuietMillis], so a
+ * render finishing does not instantly admit another cold daemon while the host is still recovering.
+ *
+ * Because the stop and resume sides differ, a reading can settle between them and satisfy neither.
+ * [OptimizerPressureThresholds.maxRecoveryMillis] bounds how long that costs: hysteresis delays
+ * resumption, and this is what stops it preventing resumption outright.
  */
 class OptimizerPressureGate(
   private val sample: () -> HostResourceSample?,
@@ -56,48 +130,68 @@ class OptimizerPressureGate(
   private var nextSampleAt = Long.MIN_VALUE
   private var safeSince = Long.MIN_VALUE
 
+  /** Signals that tripped this hold; only these have to recover to clear it. Empty when open. */
+  private var trippedBy = emptySet<PressureSignal>()
+
+  /** When the current hold last saw every stop threshold clear — the [maxRecoveryMillis] anchor. */
+  private var recoveringSince = Long.MIN_VALUE
+
   fun snapshot(): OptimizerPressureSnapshot =
     synchronized(lock) {
       val now = clock()
       if (now < nextSampleAt) return@synchronized cached
       nextSampleAt = now + thresholds.sampleIntervalMillis.coerceAtLeast(0L)
       val current = runCatching(sample).getOrNull() ?: return@synchronized cached
-      val reasons = buildList {
+      val tripped = buildList {
         current.loadPerCpu
           ?.takeIf { it >= thresholds.stopLoadPerCpu }
-          ?.let { add("load ${formatRatio(it)} per CPU") }
+          ?.let { add(PressureSignal.LOAD to "load ${formatRatio(it)} per CPU") }
         current.cpuUtilization
           ?.takeIf { it >= thresholds.stopCpuUtilization }
-          ?.let { add("CPU ${formatPercent(it)}") }
+          ?.let { add(PressureSignal.CPU to "CPU ${formatPercent(it)}") }
         current.memoryAvailableFraction
           ?.takeIf { it <= thresholds.stopMemoryAvailableFraction }
-          ?.let { add("memory available ${formatPercent(it)}") }
+          ?.let { add(PressureSignal.MEMORY to "memory available ${formatPercent(it)}") }
       }
-      val safe =
-        current.loadPerCpu?.let { it <= thresholds.resumeLoadPerCpu } != false &&
-          current.cpuUtilization?.let { it <= thresholds.resumeCpuUtilization } != false &&
-          current.memoryAvailableFraction?.let { it >= thresholds.resumeMemoryAvailableFraction } !=
-            false
+      // Only what actually stopped us has to come back: a hold taken for memory should not also
+      // wait on a CPU reading that never crossed its own stop threshold.
+      val safe = trippedBy.all { it.recovered(current, thresholds) }
       val constrained =
-        if (reasons.isNotEmpty()) {
+        if (tripped.isNotEmpty()) {
+          trippedBy = trippedBy + tripped.map { it.first }
           safeSince = Long.MIN_VALUE
+          recoveringSince = Long.MIN_VALUE
           true
         } else if (!cached.constrained) {
           false
-        } else if (!safe) {
-          safeSince = Long.MIN_VALUE
-          true
         } else {
-          if (safeSince == Long.MIN_VALUE) safeSince = now
-          now - safeSince < thresholds.resumeQuietMillis
+          // Nothing is over a stop threshold any more, so the hold is now bounded either way:
+          // it ends when the resume side is held for `resumeQuietMillis`, or when the dead band
+          // between the two sides has withheld admission for `maxRecoveryMillis`.
+          if (recoveringSince == Long.MIN_VALUE) recoveringSince = now
+          val recoveryExhausted = now - recoveringSince >= thresholds.maxRecoveryMillis
+          val quiet =
+            if (!safe) {
+              safeSince = Long.MIN_VALUE
+              false
+            } else {
+              if (safeSince == Long.MIN_VALUE) safeSince = now
+              now - safeSince >= thresholds.resumeQuietMillis
+            }
+          !quiet && !recoveryExhausted
         }
+      if (!constrained) {
+        trippedBy = emptySet()
+        safeSince = Long.MIN_VALUE
+        recoveringSince = Long.MIN_VALUE
+      }
       cached =
         OptimizerPressureSnapshot(
           constrained = constrained,
           reason =
             when {
-              reasons.isNotEmpty() -> reasons.joinToString(", ")
-              constrained -> "host recovering"
+              tripped.isNotEmpty() -> tripped.joinToString(", ") { it.second }
+              constrained -> recoveringReason(current)
               else -> null
             },
           loadPerCpu = current.loadPerCpu,
@@ -107,6 +201,36 @@ class OptimizerPressureGate(
         )
       cached
     }
+
+  /**
+   * Why a hold with no reading over a stop threshold is still held.
+   *
+   * The bare "host recovering" this replaces was actively misleading during the eight-hour stall
+   * [OptimizerPressureThresholds.maxRecoveryMillis] documents: it reads as "nearly there" whether
+   * the gate is counting down its quiet window or parked in a dead band it cannot leave. Naming the
+   * signal and the bar it has to clear makes the two distinguishable from `/status.json` alone.
+   */
+  private fun recoveringReason(sample: HostResourceSample): String {
+    val waiting =
+      trippedBy
+        .filterNot { it.recovered(sample, thresholds) }
+        .sorted()
+        .map { signal ->
+          when (signal) {
+            PressureSignal.LOAD ->
+              "load per CPU ${formatRatio(sample.loadPerCpu ?: 0.0)}" +
+                " above resume ${formatRatio(thresholds.resumeLoadPerCpu)}"
+            PressureSignal.CPU ->
+              "CPU ${formatPercent(sample.cpuUtilization ?: 0.0)}" +
+                " above resume ${formatPercent(thresholds.resumeCpuUtilization)}"
+            PressureSignal.MEMORY ->
+              "memory available ${formatPercent(sample.memoryAvailableFraction ?: 0.0)}" +
+                " below resume ${formatPercent(thresholds.resumeMemoryAvailableFraction)}"
+          }
+        }
+    return if (waiting.isEmpty()) "host recovering"
+    else "host recovering: ${waiting.joinToString(", ")}"
+  }
 
   private fun formatRatio(value: Double): String = "%.2f".format(java.util.Locale.ROOT, value)
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -68,6 +68,136 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `a reading parked in the dead band cannot hold the gate forever`() {
+    // The production stall: memory settles at 18% available, which is neither at-or-below the 15%
+    // stop side (so nothing re-trips) nor at-or-above the 25% resume side (so the quiet window
+    // never starts). Before maxRecoveryMillis this held admission for eight hours.
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.02, cpuUtilization = 0.02, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 1_000,
+            sampleIntervalMillis = 0,
+            maxRecoveryMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.10)
+    assertTrue(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.18)
+    now = 1_000
+    assertTrue(gate.snapshot().constrained, "the dead band must still hold the gate at first")
+    val reason = gate.snapshot().reason.orEmpty()
+    assertTrue(reason.contains("18%"), "reason should name the reading: $reason")
+    assertTrue(reason.contains("25%"), "reason should name the bar it must clear: $reason")
+
+    now = 10_999
+    assertTrue(gate.snapshot().constrained)
+    now = 11_000
+    assertFalse(gate.snapshot().constrained, "the hold must expire once no stop threshold is met")
+  }
+
+  @Test
+  fun `a dead band hold does not expire while a stop threshold is still met`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.02, cpuUtilization = 0.02, memoryAvailableFraction = 0.10)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 1_000,
+            sampleIntervalMillis = 0,
+            maxRecoveryMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    // Still under the stop threshold well past maxRecoveryMillis: the cap must not admit into a
+    // host that is genuinely out of memory.
+    now = 60_000
+    assertTrue(gate.snapshot().constrained)
+    assertTrue(gate.snapshot().reason.orEmpty().contains("memory available 10%"))
+
+    sample = sample.copy(memoryAvailableFraction = 0.30)
+    now = 60_001
+    assertTrue(gate.snapshot().constrained, "recovery is still gated on the quiet window")
+    now = 61_001
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `only the signal that tripped the hold has to recover`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.2, cpuUtilization = 0.2, memoryAvailableFraction = 0.8)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(resumeQuietMillis = 1_000, sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertFalse(gate.snapshot().constrained)
+
+    sample = sample.copy(memoryAvailableFraction = 0.10)
+    assertTrue(gate.snapshot().constrained)
+
+    // Memory is back above its resume side. CPU sits between its resume (0.70) and stop (0.85)
+    // thresholds — uncomfortable, but it never stopped anything, so it must not block resumption.
+    sample = sample.copy(memoryAvailableFraction = 0.40, cpuUtilization = 0.75)
+    now = 1
+    assertTrue(gate.snapshot().constrained, "one safe sample must not flap the optimizer back on")
+    now = 1_001
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
+  fun `thresholds fall back to defaults when system properties are absent or unparseable`() {
+    val key = "composeai.serve.optimizerStopMemoryAvailableFraction"
+    val quiet = "composeai.serve.optimizerResumeQuietMillis"
+    val previous = System.getProperty(key)
+    val previousQuiet = System.getProperty(quiet)
+    try {
+      System.clearProperty(key)
+      System.clearProperty(quiet)
+      assertEquals(
+        OptimizerPressureThresholds(),
+        OptimizerPressureThresholds.fromSystemProperties(),
+      )
+
+      System.setProperty(key, "0.35")
+      System.setProperty(quiet, "5000")
+      val tuned = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(0.35, tuned.stopMemoryAvailableFraction)
+      assertEquals(5_000L, tuned.resumeQuietMillis)
+
+      // A ratio outside 0..1 and a negative duration are typos, not instructions.
+      System.setProperty(key, "35")
+      System.setProperty(quiet, "-1")
+      val rejected = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(
+        OptimizerPressureThresholds().stopMemoryAvailableFraction,
+        rejected.stopMemoryAvailableFraction,
+      )
+      assertEquals(OptimizerPressureThresholds().resumeQuietMillis, rejected.resumeQuietMillis)
+    } finally {
+      if (previous == null) System.clearProperty(key) else System.setProperty(key, previous)
+      if (previousQuiet == null) System.clearProperty(quiet)
+      else System.setProperty(quiet, previousQuiet)
+    }
+  }
+
+  @Test
   fun `load and memory independently constrain optimization`() {
     var sample =
       HostResourceSample(loadPerCpu = 0.9, cpuUtilization = 0.1, memoryAvailableFraction = 0.8)

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -883,6 +883,29 @@ keep a shut gate from turning the feature off:
   broken idle clock. The ceiling does **not** override a pause, the pressure gate, or catalog
   loading; a daemon start starved during loading is recorded as `livebundle-unavailable` and
   degrades that catalog to baked PNGs for the whole process, which is much worse than a cold cache.
+- **The host-pressure gate stops on one reading and resumes on another, and the gap between them is
+  bounded.** Load, CPU and available memory each have a stop side (`0.85`, `0.85`, `0.15`) and a
+  resume side (`0.60`, `0.70`, `0.25`); crossing a stop side halts admission at once, and only the
+  signals that actually tripped have to return to their resume side, held for 30s, before it opens
+  again. A reading can settle *between* the two — memory available 18% is neither at-or-below `0.15`
+  nor at-or-above `0.25` — and hysteresis alone has no answer to that: nothing re-trips, so the
+  reason degrades to a bare `host recovering`, and the quiet window never starts counting. Measured
+  on the public box as a gate held for eight hours at 2% CPU with theme optimization stuck at 0.35%
+  of its entries. So a hold during which **no** reading is over a stop threshold expires after
+  `-Dcomposeai.serve.optimizerMaxRecoveryMillis` (10 minutes). Hysteresis is meant to delay
+  resumption, not prevent it, and a bounded duty cycle — admit, maybe trip again, wait again — is
+  the right failure mode for best-effort work where a permanent latch is not. A reading still on
+  the wrong side of a *stop* threshold is untouched by the cap and holds the gate as long as it
+  lasts.
+- **The thresholds themselves are tunable**, because what counts as constrained is a property of
+  the host: `-Dcomposeai.serve.optimizerStopMemoryAvailableFraction`,
+  `…optimizerResumeMemoryAvailableFraction`, and the matching `…StopLoadPerCpu` /
+  `…ResumeLoadPerCpu` / `…StopCpuUtilization` / `…ResumeCpuUtilization`, plus
+  `…optimizerResumeQuietMillis` and `…optimizerSampleIntervalMillis`. Ratios outside `0.0..1.0` and
+  negative durations are ignored as typos. Worth setting when the box's *steady state* sits below a
+  resume threshold — 17 resident render daemons hold enough memory to park the public box near 18%
+  available, which puts the default `0.25` resume bar under the baseline and makes a permanent
+  latch on the first transient dip the expected outcome rather than a surprise.
 
 The grid is serial by default. Selecting an app-declared theme asks the server for a fixed,
 60-second page lease; at most one page server-wide receives a burst, clamped to five workers and


### PR DESCRIPTION
## The bug

`OptimizerPressureGate` has separate stop and resume thresholds, so a reading can settle **between** them and satisfy neither side. When that happens the gate never reopens.

Walking `snapshot()` with the public box's live numbers (memory available `0.1835`, stop `0.15`, resume `0.25`):

- `reasons` is **empty** — `0.1835` is not `<= 0.15`, so nothing re-trips. This is why the status reason degrades to the bare `"host recovering"` instead of naming a signal.
- `safe` is **false** — `0.1835` is not `>= 0.25`.
- Control lands in `else if (!safe) { safeSince = Long.MIN_VALUE; true }`, which resets the quiet-window anchor on *every* sample.

So `resumeQuietMillis` never starts counting, and the hold is permanent. Only a restart or an unrelated memory drop clears it.

## Observed impact

From `preview.coo.ee/status.json`, 8h 25m into the process:

| | |
|---|---|
| Theme entries cached | **65 / 18,604 (0.35%)** across 18 catalogs |
| Admissions / refusals | 25 / 97 (**80% refused**) |
| Aggregate wait | 2.3h, of which **100% gate wait** (`permitWaitMillis` was 0 everywhere — lanes were never the constraint) |
| Host at the time | **2.3% CPU**, load **0.02 per CPU** |
| Never admitted once | `m3-catalog` (0/10,456, `turnsGranted: 0`), `remote-m3` (0/255) |

The host was essentially idle. Nothing was over a stop threshold. The gate was closed anyway.

## Changes

**1. Cap the hold when nothing is over a stop threshold.** New `maxRecoveryMillis` (10 min). Hysteresis exists to *delay* resumption, not to prevent it — the stop thresholds are the real danger line, and once a reading is back on their safe side a bounded duty cycle (admit → maybe trip again → wait again) is the correct failure mode for best-effort background work. A permanent latch is not. A reading still past a *stop* threshold is untouched by the cap and holds the gate exactly as before.

**2. Only the signals that tripped a hold have to recover.** Previously `safe` required *every* reading to be on its resume side, so a hold taken for memory also waited on a CPU reading that had never crossed its own stop threshold. Tracked per-signal now.

**3. Thresholds are tunable** via `composeai.serve.optimizer*` system properties, matching the existing `themeOptimizationIdleMillis` / `themeOptimizerSliceMillis` knobs. Previously `OptimizerPressureThresholds` was constructed with pure defaults at `ServeCommand.kt:897` and reachable from no flag or property at all.

This last one matters beyond convenience: with 17 resident render daemons the box's *steady state* is ~18% available memory, which puts the default `0.25` resume bar **below its own baseline**. On that host, latching permanently on the first transient dip isn't an edge case — it's the expected outcome, and it needs to be correctable without a rebuild.

Also: the `"host recovering"` reason now names the signal and the bar it must clear (`host recovering: memory available 18% below resume 25%`), so a gate counting down its quiet window and a gate stuck in a dead band are distinguishable from `/status.json` alone. That ambiguity is what made this take a while to spot.

## Test plan

`./gradlew :cli:test` — full suite green. `HostOptimizerAdmissionTest` is 12/12, the 8 pre-existing tests unchanged:

- `a reading parked in the dead band cannot hold the gate forever` — reproduces the incident (drop to 10%, settle at 18%), asserts the hold persists at first and then expires at `maxRecoveryMillis`, and that the reason names both `18%` and `25%`.
- `a dead band hold does not expire while a stop threshold is still met` — the cap must not admit into a host genuinely out of memory; still held at 6× `maxRecoveryMillis`, then resumes only via the normal quiet window.
- `only the signal that tripped the hold has to recover` — memory recovers while CPU sits at 0.75 (between its resume 0.70 and stop 0.85); resumption is not blocked.
- `thresholds fall back to defaults when system properties are absent or unparseable` — including ratios outside `0.0..1.0` and negative durations, which are ignored as typos rather than obeyed.

`./gradlew ktfmtFormatAll` clean. Non-visual change (server admission logic), so no render evidence applies.

## Not covered here

Two separate findings from the same investigation, both out of scope for this PR:

- The 60s idle gate (`themeOptimizationIdleMillis`) is rarely satisfied — `serverIdleMillis` was **1430** against a 60,000 threshold. That is already tunable, so it needs an ops change, not a code change.
- `meshcore-mobile`'s render lane is fatally disabled on a `RemoteDocumentPlayer` `NoSuchMethodError` — catalog published with compose-ai-tools 1.15.0 against a server running 1.29.0. Needs a republish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWf2xFKRgddNfKUP3yaC49)_