### PR TITLE
fix(serve): correct four defects in the `uses:` filter

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewUsageIndex.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PreviewUsageIndex.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import java.util.concurrent.ConcurrentHashMap
+
 /**
  * Which functions each preview's own declaration **calls**, so the landing grid's filter can answer
  * "show me the previews that call `SwipeToReveal`".
@@ -84,7 +86,19 @@ class PreviewUsageIndex(
 
   private class Entry(val index: Index, val signature: Int, val builtAtMillis: Long)
 
-  private val cache = HashMap<String, Entry>()
+  private val cache = ConcurrentHashMap<String, Entry>()
+
+  /**
+   * One lock per catalog, so a build never blocks a search of a DIFFERENT catalog.
+   *
+   * The obvious `@Synchronized` on [match] was wrong in a way worth recording: building an index is
+   * up to [maxFiles] network reads, and holding one process-wide monitor across them meant a single
+   * cold catalog could park every other `uses:` request behind it — on a host whose request threads
+   * are shared with the routes that serve renders. Per-catalog locks keep the one property actually
+   * wanted (two concurrent searches of the same cold catalog do one build, not two) and drop the
+   * one that was accidental.
+   */
+  private val locks = ConcurrentHashMap<String, Any>()
 
   /**
    * The previews among [previewIds] whose declaration calls something matching [token].
@@ -94,7 +108,6 @@ class PreviewUsageIndex(
    * half-remembered names; an exact-match operator would need the reader to already know the
    * answer.
    */
-  @Synchronized
   fun match(system: String, previewIds: List<String>, token: String): Match {
     val index = index(system, previewIds)
     val needle = token.trim().lowercase()
@@ -118,16 +131,26 @@ class PreviewUsageIndex(
    */
   private fun index(system: String, previewIds: List<String>): Index {
     val signature = previewIds.sorted().hashCode()
-    val now = clock()
-    cache[system]
-      ?.takeIf { it.signature == signature && now - it.builtAtMillis < ttlSeconds * 1000 }
-      ?.let {
-        return it.index
+    fresh(system, signature)?.let {
+      return it
+    }
+    // Re-checked inside the lock: several requests can pass the read above together, and without
+    // the second look each of them would rebuild what the first has just finished.
+    synchronized(locks.computeIfAbsent(system) { Any() }) {
+      fresh(system, signature)?.let {
+        return it
       }
-    val built = build(system, previewIds)
-    cache[system] = Entry(built, signature, now)
-    return built
+      val built = build(system, previewIds)
+      cache[system] = Entry(built, signature, clock())
+      return built
+    }
   }
+
+  /** The cached index for [system], if it is still current for [signature] and inside its TTL. */
+  private fun fresh(system: String, signature: Int): Index? =
+    cache[system]
+      ?.takeIf { it.signature == signature && clock() - it.builtAtMillis < ttlSeconds * 1000 }
+      ?.index
 
   private fun build(system: String, previewIds: List<String>): Index {
     // Grouped by file, because that is the unit of both the fetch and the parse. Previews that
@@ -164,10 +187,7 @@ class PreviewUsageIndex(
       val lines = text.lines()
       val lineStarts = lineStartOffsets(lines)
       for ((previewId, bodyLine) in previews) {
-        val bounds = PlaygroundSeedResolver.declarationLines(lines, bodyLine) ?: continue
-        val from = lineStarts[bounds.first]
-        // End-exclusive: the offset one past the last character of the declaration's last line.
-        val to = lineStarts[bounds.last] + lines[bounds.last].length
+        val (from, to) = declarationSpan(facts, lines, lineStarts, bodyLine) ?: continue
         val callees =
           facts.calls
             .asSequence()
@@ -181,6 +201,46 @@ class PreviewUsageIndex(
       }
     }
     return Index(calleesById = calleesById, available = true, truncated = truncated)
+  }
+
+  /**
+   * The character range of the declaration [bodyLine] falls in, half-open, or null when it cannot
+   * be established.
+   *
+   * **The parse is the authority, and the line scan is only a fallback.**
+   * [PlaygroundSeedResolver.declarationLines] finds a declaration's bounds from formatting — a
+   * non-blank line at column 0 preceded by a blank one — and where two top-level declarations sit
+   * with no blank line between them it deliberately over-selects, taking both. That is the safe
+   * failure for its own caller, which seeds an editor buffer and would rather hand over too much
+   * than truncate someone's code mid-expression. It is the *unsafe* failure here: a merged range
+   * gives each of those previews the other's calls, so `uses:Button` answers with a preview that
+   * never calls one — a wrong answer, delivered confidently, which is worse than no answer.
+   *
+   * So the real declaration list from the parse decides whenever it can. The line scan stays for
+   * the one case it cannot: an analyzer predating the `declarations` field, which reports none.
+   * ktfmt (Google style) guarantees the blank line, so that fallback is right about every catalog
+   * in this repository — it just cannot be right about every catalog anywhere, which is the gap the
+   * parse closes.
+   */
+  private fun declarationSpan(
+    facts: UsageSourceFacts,
+    lines: List<String>,
+    lineStarts: IntArray,
+    bodyLine: Int?,
+  ): Pair<Int, Int>? {
+    if (bodyLine == null || bodyLine < 1 || bodyLine > lines.size) return null
+    if (facts.declarations.isNotEmpty()) {
+      // The anchor is a line inside the body; any offset on that line is inside the declaration,
+      // and the line's first non-blank character avoids landing on trailing whitespace beyond it.
+      val anchorOffset =
+        lineStarts[bodyLine - 1] +
+          lines[bodyLine - 1].indexOfFirst { !it.isWhitespace() }.coerceAtLeast(0)
+      val span = facts.declarationAt(anchorOffset) ?: return null
+      return span.start to span.end
+    }
+    val bounds = PlaygroundSeedResolver.declarationLines(lines, bodyLine) ?: return null
+    // End-exclusive: the offset one past the last character of the declaration's last line.
+    return lineStarts[bounds.first] to (lineStarts[bounds.last] + lines[bounds.last].length)
   }
 
   /** One file's text, or null when it cannot be read as Kotlin source. */
@@ -237,7 +297,19 @@ class PreviewUsageIndex(
   )
 
   companion object {
-    const val DEFAULT_MAX_BYTES: Int = 512 * 1024
+    /**
+     * Deliberately the **same** cap as [PlaygroundSeedResolver.DEFAULT_MAX_BYTES], and not merely a
+     * similar number.
+     *
+     * `PlaygroundSeedResolver.httpFetch` reads `maxBytes + 1` bytes and stops. That extra byte is
+     * the whole truncation protocol: a body at or over the cap comes back one byte longer than the
+     * cap, so a reader whose own limit matches can tell "a big file" from "the start of a bigger
+     * one". Setting a *larger* limit here silently accepts that prefix as if it were the file — and
+     * a prefix still parses, so the index would answer with the calls in the first 256 KiB and
+     * report itself complete, which is exactly the confident-but-wrong answer `available` exists to
+     * prevent.
+     */
+    const val DEFAULT_MAX_BYTES: Int = PlaygroundSeedResolver.DEFAULT_MAX_BYTES
     const val DEFAULT_MAX_FILES: Int = 200
     const val DEFAULT_TTL_SECONDS: Long = 300
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5923,7 +5923,11 @@ class ServeHttpServer(
           return
         }
     val token = call.request.queryParameters["q"].orEmpty()
-    val match = index.match(system, previewIds, token)
+    // Off the request thread. A cold catalog's first `uses:` search is up to `maxFiles` network
+    // reads with the fetcher's own timeout on each, and running that inline blocks a thread Ktor
+    // also serves renders on — so a handful of uncached searches could starve routes that have
+    // nothing to do with this one.
+    val match = withContext(Dispatchers.IO) { index.match(system, previewIds, token) }
     // The answer depends on the interface-mode cookie, so it must not be cached across visitors in
     // one mode and handed to a visitor in the other — the same reason `componentBrowserMode` marks
     // the HTML it gates.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3307,6 +3307,9 @@ ${captureControlsHtml().prependIndent("          ")}
      */
     usesUrl: String = "",
   ): String {
+    // Declared before anything that branches on it — the tab predicate and the pane split below
+    // both ask whether the operator is wired.
+    val usesFilter = usesUrl.isNotEmpty()
     val hasDeclaredThemes = themeBaseJs.isNotEmpty()
     val themeLeaseUrlJs = WebEscaping.jsString(themeLeaseUrl)
     // Spliced one level in, so a page with no presence URL emits the script byte-for-byte as
@@ -3863,10 +3866,18 @@ ${captureControlsHtml().prependIndent("          ")}
           "\n      document.documentElement.classList.add(\"cp-js\");"
       else ""
     // A card is shown when it matches the search AND (while not searching) sits in the current tab.
+    // A filter spans every section; tab selection is ignored until it clears. `uses:` is a filter,
+    // so the same has to be true of it — and it is not enough to test `q`, because a query that is
+    // ONLY `uses:Foo` leaves `q` empty. Reading that as "not searching" kept every other section
+    // hidden, so matches outside the selected tab vanished and the readout counted only the cards
+    // in it. `reflectTabs`'s own `searching` was already right about this — it reads the raw input,
+    // where the operator is still present — which is why the branches opened while the cards under
+    // them stayed hidden; this line is the half that disagreed.
+    val searchingExpr = if (usesFilter) "(q !== \"\" || usesActive())" else "q !== \"\""
     val tabOkLine =
       if (hasTabs)
         "\n          var sec = c.closest(\".cp-section\");" +
-          "\n          var tabOk = q !== \"\" || !sec" +
+          "\n          var tabOk = $searchingExpr || !sec" +
           allTabCardClause +
           " || sec.getAttribute(\"data-section\") === current;"
       else ""
@@ -3951,10 +3962,17 @@ ${captureControlsHtml().prependIndent("          ")}
     // filter" under a sidebar that just found the Shape page, which is the box contradicting
     // itself. The grid belongs to the Components pane, so it is filtered when that pane is the one
     // showing and left whole otherwise.
+    // The Pages pane lists design sheets, which have no composables to call — so `uses:` is a
+    // question they cannot answer, and the pane filters on the RAW query rather than on the
+    // operator-stripped remainder. Without that, a query of only `uses:Foo` reached the pane as an
+    // empty string and showed every page while the readout above described the hidden component
+    // grid. Filtering on the raw text instead lands the pane on its own empty state, which is the
+    // truthful answer to "which of these sheets calls a Button".
+    val paneQExpr = if (usesFilter) "usesRawQuery" else "q"
     val paneSplit =
       if (!hasPanes) ""
       else
-        "\n        var paneQ = pane === \"pages\" ? q : \"\";" +
+        "\n        var paneQ = pane === \"pages\" ? $paneQExpr : \"\";" +
           "\n        if (pane === \"pages\") q = \"\";"
     val paneWiring =
       if (!hasPanes) ""
@@ -4050,7 +4068,6 @@ ${captureControlsHtml().prependIndent("          ")}
     // text filter narrows, so it has to share `apply()` and the state around it. A parallel script
     // would need its own pass over the cards and could disagree with this one about which are
     // showing — the exact failure the pane strip's comment above describes.
-    val usesFilter = usesUrl.isNotEmpty()
     val usesDecls = if (usesFilter) usesFilterScript(usesUrl) else ""
     val queryExpr =
       if (usesFilter) "var q = usesSplit(input ? input.value.trim() : \"\");"
@@ -4148,8 +4165,13 @@ ${captureControlsHtml().prependIndent("          ")}
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = ${WebEscaping.jsString(usesUrl)};
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -4159,6 +4181,9 @@ ${captureControlsHtml().prependIndent("          ")}
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -21,10 +21,30 @@ import kotlinx.serialization.json.Json
 data class UsageSourceFacts(
   @SerialName("calls") val calls: List<Call> = emptyList(),
   /**
+   * The file's top-level declarations, in source order. Empty from an analyzer predating the field,
+   * which is why every reader treats "no declarations" as "fall back", not as "an empty file".
+   */
+  @SerialName("declarations") val declarations: List<Span> = emptyList(),
+  /**
    * Set when the analyzer could not parse at all; the caller then behaves as if it had no facts.
    */
   @SerialName("error") val error: String? = null,
 ) {
+
+  /** A half-open character range into the analysed source. */
+  @Serializable
+  data class Span(@SerialName("start") val start: Int, @SerialName("end") val end: Int) {
+    operator fun contains(offset: Int): Boolean = offset in start until end
+  }
+
+  /**
+   * The top-level declaration containing [offset], or null when no parsed declaration does.
+   *
+   * Null is a real answer and not a shrug: an offset in the file header, in a blank run between
+   * declarations, or past the end of the last one belongs to no declaration, and a caller
+   * attributing calls must be able to say so rather than picking the nearest.
+   */
+  fun declarationAt(offset: Int): Span? = declarations.firstOrNull { offset in it }
 
   @Serializable
   data class Call(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewUsageIndexTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PreviewUsageIndexTest.kt
@@ -227,6 +227,58 @@ class PreviewUsageIndexTest {
     assertEquals(1, fetched.size)
   }
 
+  /**
+   * Two top-level declarations with **no blank line between them** — the case
+   * `PlaygroundSeedResolver.declarationLines` deliberately gets wrong.
+   *
+   * Its blank-line rule cannot see the second declaration start, so it returns one range covering
+   * both. That is the safe failure for seeding an editor buffer (hand over too much rather than cut
+   * code in half) and the unsafe one here: under it both previews inherit both call sets and
+   * `uses:Spacer` answers with the preview that never calls one. The parse reports real declaration
+   * spans, so attribution no longer depends on how the file is formatted.
+   */
+  @Test
+  fun `declarations with no blank line between them do not share their calls`() {
+    val packed =
+      """
+      package sections
+
+      @Composable
+      fun A() = Sticker { Spacer() }
+      @Composable
+      fun B() = Sticker { Icon() }
+      """
+        .trimIndent()
+    fun lineIn(needle: String) = packed.lines().indexOfFirst { it.contains(needle) } + 1
+    val where =
+      mapOf(
+        "A" to location(lineIn("fun A()")).copy(sourceFile = "src/main/kotlin/sections/Packed.kt"),
+        "B" to location(lineIn("fun B()")).copy(sourceFile = "src/main/kotlin/sections/Packed.kt"),
+      )
+    val index = index(locate = { _, id -> where[id] }, body = { packed.toByteArray() })
+    assertEquals(setOf("A"), index.match("m3", listOf("A", "B"), "Spacer").ids)
+    assertEquals(setOf("B"), index.match("m3", listOf("A", "B"), "Icon").ids)
+  }
+
+  /**
+   * A body over the fetcher's cap comes back as a truncated prefix plus one byte, and a prefix
+   * still parses — so accepting it would report the calls in the first 256 KiB as if they were the
+   * file's. The cap here matches the fetcher's precisely so that read is refused instead.
+   */
+  @Test
+  fun `a truncated read is refused rather than parsed as the whole file`() {
+    assertEquals(
+      PlaygroundSeedResolver.DEFAULT_MAX_BYTES,
+      PreviewUsageIndex.DEFAULT_MAX_BYTES,
+      "a larger cap here silently accepts the fetcher's truncated prefix",
+    )
+    // Exactly what `PlaygroundSeedResolver.httpFetch` hands back for an over-cap body.
+    val truncated = ByteArray(PreviewUsageIndex.DEFAULT_MAX_BYTES + 1) { ' '.code.toByte() }
+    val match = index(body = { truncated }).match("m3", ids, "Button")
+    assertTrue(match.ids.isEmpty())
+    assertTrue(log.any { it.contains("index cap") }, log.toString())
+  }
+
   /** CRLF source must not walk the call offsets out of the declaration they belong to. */
   @Test
   fun `a CRLF file indexes the same as an LF one`() {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -4182,8 +4182,14 @@ class ServeWebFixtureTest {
     // no card is filtered out by section; the per-section <h2>s that `cp-js` hides come back,
     // because the selected row no longer names the one section on screen; and a jump to a group
     // scrolls without narrowing the catalog down to that group's section.
+    // The leading conjunct is "is a filter running", and it is matched loosely on purpose: it was
+    // `q !== ""` alone until the Dev-mode `uses:` operator, and is `(q !== "" || usesActive())`
+    // since — because a query of only `uses:Foo` leaves `q` empty, and a filter has to span every
+    // section (see `ServeWeb.searchingExpr`). What this line is about is the rest of the
+    // expression, which that change does not touch: while All is the selected row, the section a
+    // card sits in must not hide it.
     assertTrue(
-      landingSections.contains("var tabOk = q !== \"\" || !sec || current === \"all\""),
+      Regex("""var tabOk = .+ \|\| !sec \|\| current === "all"""").containsMatchIn(landingSections),
       "under All a card is in the current tab whatever section holds it",
     )
     assertTrue(

--- a/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
+++ b/usage-source-psi/src/main/kotlin/ee/schimke/composeai/usagepsi/UsageSourceAnalyzer.kt
@@ -58,7 +58,8 @@ class UsageSourceAnalyzer : AutoCloseable {
   }
 
   /**
-   * [source] → a JSON object of `calls`, or `{"error":"…"}` if it could not be parsed at all.
+   * [source] → a JSON object of `calls` and `declarations`, or `{"error":"…"}` if it could not be
+   * parsed at all.
    *
    * Never throws across the reflective boundary: an exception here would surface in the caller as
    * an `InvocationTargetException` carrying a frontend-loaded class the caller cannot name. A JSON
@@ -75,6 +76,19 @@ class UsageSourceAnalyzer : AutoCloseable {
       json {
         arrayField("calls", PsiTreeUtil.findChildrenOfType(file, KtCallExpression::class.java)) {
           call(it)
+        }
+        // The file's top-level declarations, in source order. Reported for the same reason the
+        // calls are: a caller that has to say WHICH declaration a call belongs to would otherwise
+        // infer the boundaries from formatting, and the blank-line rule that is safe for seeding an
+        // editor buffer (over-select rather than truncate) is wrong here — over-selecting merges
+        // two declarations, and every call in both is then attributed to each.
+        arrayField("declarations", file.declarations) { declaration ->
+          // `textRange` starts at the declaration proper. `startOffsetSkippingComments` would skip
+          // the KDoc the other way; what is wanted is the widest honest span, so the KDoc and
+          // annotations that precede a `fun` count as part of it rather than as a gap between
+          // declarations.
+          number("start", declaration.textRange.startOffset)
+          number("end", declaration.textRange.endOffset)
         }
       }
     } catch (e: Throwable) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-breakpoints.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-breakpoints.html
@@ -182,8 +182,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/wear-m3-catalog/api/uses";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -193,6 +198,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }
@@ -303,7 +311,7 @@
       var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
       var searchOk = (q === "" || hay.indexOf(q) !== -1) && usesOk(c);
       var sec = c.closest(".cp-section");
-      var tabOk = q !== "" || !sec || current === "all" || sec.getAttribute("data-section") === current;
+      var tabOk = (q !== "" || usesActive()) || !sec || current === "all" || sec.getAttribute("data-section") === current;
       c.hidden = !(searchOk && tabOk);
       if (searchOk && tabOk) shown++;
     });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-catalog-palette.html
@@ -217,8 +217,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=wear-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -228,6 +233,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-declared-themes.html
@@ -170,8 +170,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=compose-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -181,6 +186,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-grouped.html
@@ -313,8 +313,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -324,6 +329,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }
@@ -495,7 +503,7 @@ function applyThemeChoice() {
 }
 applyThemeChoice();
         var q = usesSplit(input ? input.value.trim() : "");
-        var paneQ = pane === "pages" ? q : "";
+        var paneQ = pane === "pages" ? usesRawQuery : "";
         if (pane === "pages") q = "";
         var shown = 0;
         cards.forEach(function (c) {

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-ir-replay-themes.html
@@ -166,8 +166,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=remote-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -177,6 +182,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-live.html
@@ -166,8 +166,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=compose-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -177,6 +182,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-path.html
@@ -174,8 +174,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/meshcore-mobile/api/uses";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -185,6 +190,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-public.html
@@ -173,8 +173,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/api/uses";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -184,6 +189,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-sections.html
@@ -297,8 +297,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/meshcore-mobile/api/uses";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -308,6 +313,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }
@@ -418,7 +426,7 @@
       var hay = ((lab ? lab.textContent : "") + " " + (idn ? idn.textContent : "")).toLowerCase();
       var searchOk = (q === "" || hay.indexOf(q) !== -1) && usesOk(c);
       var sec = c.closest(".cp-section");
-      var tabOk = q !== "" || !sec || current === "all" || sec.getAttribute("data-section") === current;
+      var tabOk = (q !== "" || usesActive()) || !sec || current === "all" || sec.getAttribute("data-section") === current;
       c.hidden = !(searchOk && tabOk);
       if (searchOk && tabOk) shown++;
     });

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-site.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-site.html
@@ -175,8 +175,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/api/uses";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -186,6 +191,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-states.html
@@ -156,8 +156,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -167,6 +172,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-themed.html
@@ -168,8 +168,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=compose-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -179,6 +184,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-tree-depth.html
@@ -241,8 +241,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses?session=compose-m3";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -252,6 +257,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing-variants.html
@@ -141,8 +141,13 @@
       // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
       var usesEndpoint = "/api/uses";
       var usesToken = "";
+      var usesRawQuery = "";
       var usesCache = {};
       var usesPending = {};
+      // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+      // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+      // every such test would then read as "resting".
+      function usesActive() { return usesToken !== ""; }
       // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
       // It also notices a CHANGE of token and starts the lookup, which is why it is one function
       // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -152,6 +157,9 @@
         var found = "";
         var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
         if (found !== usesToken) { usesToken = found; usesFetch(found); }
+        // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+        // see `paneQ` in the filter script.
+        usesRawQuery = raw.trim().toLowerCase();
         return rest.trim().toLowerCase();
       }
       function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-landing.html
@@ -171,8 +171,13 @@
   // ---- `uses:<composable>` — which previews CALL a thing (Dev mode only)
   var usesEndpoint = "/api/uses?token=demo-token-fixture";
   var usesToken = "";
+  var usesRawQuery = "";
   var usesCache = {};
   var usesPending = {};
+  // Whether a `uses:` filter is running right now. Asked wherever the page would otherwise
+  // test `q !== ""` to mean "a filter is on": a query of only `uses:Foo` leaves `q` empty, and
+  // every such test would then read as "resting".
+  function usesActive() { return usesToken !== ""; }
   // Pulls `uses:<token>` out of the raw query and returns what is left for the text filter.
   // It also notices a CHANGE of token and starts the lookup, which is why it is one function
   // and not a pure split: `apply()` is the only place that reads the box, so it is the only
@@ -182,6 +187,9 @@
     var found = "";
     var rest = raw.replace(/(^|\s)uses:(\S*)/i, function (m, lead, t) { found = t; return lead; });
     if (found !== usesToken) { usesToken = found; usesFetch(found); }
+    // Kept for the Pages pane, which filters on what was TYPED rather than on the remainder —
+    // see `paneQ` in the filter script.
+    usesRawQuery = raw.trim().toLowerCase();
     return rest.trim().toLowerCase();
   }
   function usesEntry() { return usesToken ? usesCache[usesToken.toLowerCase()] : null; }

--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -3561,6 +3561,123 @@ test("contract · a tree row's jump has landed before the shutter, not during it
   expect(await page.evaluate(() => window.scrollY)).toBe(landed);
 });
 
+test("contract · a uses: filter spans every section, like any other filter", async ({
+  page,
+}) => {
+  // A filter ignores tab selection and searches the whole catalog; only a resting page is scoped
+  // to the open section. `uses:Foo` alone leaves the TEXT query empty, so a `q !== ""` test reads
+  // it as resting and keeps every other section hidden — matches outside the open tab vanish, and
+  // the readout counts only what survived. This holds the operator to the same rule the text
+  // filter has always had (#4424 review).
+  for (const [name, contentType] of SERVE_ASSETS) {
+    await page.route(`**/assets/serve/**/${name}`, (route) =>
+      route.fulfill({
+        contentType,
+        body: readFileSync(resolve(serveAssetsDir, name), "utf8"),
+      }),
+    );
+  }
+  await page.route("**/render/**", (route) =>
+    route.fulfill({ path: renderPlaceholder }),
+  );
+  await page.goto("/preview-harness/fixtures/pages/serve-landing-sections.html");
+
+  // Pick a REAL section, not the All row this catalog opens on. On `all` every card passes the tab
+  // predicate whatever the query is, so a test that skipped this step would pass with the fix
+  // reverted — it did, which is how this step earned its place.
+  const [picked, away] = await page.evaluate(() => {
+    const sections = Array.from(document.querySelectorAll(".cp-section")).filter(
+      (s) => s.querySelector("[data-uses-id]"),
+    );
+    const target = sections[sections.length - 1];
+    const other = sections.find((s) => s !== target);
+    return [
+      other.getAttribute("data-section"),
+      target.querySelector("[data-uses-id]").getAttribute("data-uses-id"),
+    ];
+  });
+  expect(picked).toBeTruthy();
+  expect(away).toBeTruthy();
+
+  // Select the section the match is NOT in, and confirm the card really is hidden first — so the
+  // assertion below is about the filter revealing it, not about it having been visible all along.
+  await page.click(`.cp-tab[data-tab="${picked}"], [data-tab="${picked}"]`);
+  await page.waitForFunction(
+    (id) => document.querySelector(`[data-uses-id="${id}"]`)?.hidden === true,
+    away,
+    { timeout: 15_000 },
+  );
+
+  await page.route("**/api/uses*", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ available: true, truncated: false, ids: [away] }),
+    }),
+  );
+  await page.fill("#cp-search", "uses:Foo");
+  await page.waitForFunction(
+    (id) => {
+      const card = document.querySelector(`[data-uses-id="${id}"]`);
+      return card && !card.hidden;
+    },
+    away,
+    { timeout: 15_000 },
+  );
+
+  // And the readout counted it, rather than counting only the open tab.
+  await expect(page.locator("#cp-uses-status")).toContainText("1 of");
+});
+
+test("contract · the Pages pane filters on what was typed, not on the remainder", async ({
+  page,
+}) => {
+  // `usesSplit` strips `uses:Foo` out of the query before the pane split runs, so a uses-only
+  // query reached the Pages pane as an EMPTY string — which that pane reads as "no filter" and
+  // answers by showing every page, while the readout above it described the hidden component grid.
+  // Design sheets have no composables to call, so the honest answer is the pane's own empty state
+  // (#4424 review).
+  for (const [name, contentType] of SERVE_ASSETS) {
+    await page.route(`**/assets/serve/**/${name}`, (route) =>
+      route.fulfill({
+        contentType,
+        body: readFileSync(resolve(serveAssetsDir, name), "utf8"),
+      }),
+    );
+  }
+  await page.route("**/render/**", (route) =>
+    route.fulfill({ path: renderPlaceholder }),
+  );
+  await page.route("**/pages/*.svg**", (route) =>
+    route.fulfill({ contentType: "image/svg+xml", body: PAGE_PLACEHOLDER }),
+  );
+  await page.route("**/api/uses*", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ available: true, truncated: false, ids: [] }),
+    }),
+  );
+  await page.goto("/preview-harness/fixtures/pages/serve-landing-grouped.html");
+
+  // Top-level page rows only — the nested section links under a branch are filtered as a unit
+  // with it, so counting both would blur what this is measuring.
+  const pageRows = () =>
+    page.evaluate(
+      () =>
+        Array.from(
+          document.querySelectorAll("#cp-pane-pages .cp-page-list > li"),
+        ).filter((r) => !r.hidden).length,
+    );
+
+  await page.click('.cp-pane-tab[data-pane="pages"]');
+  await expect.poll(pageRows).toBeGreaterThan(0);
+
+  await page.fill("#cp-search", "uses:Button");
+  // `uses:Button` is not any sheet's name, so the pane empties and says so. Before the fix the
+  // operator was stripped first, the pane filtered on "" and every row stayed.
+  await expect.poll(pageRows, { timeout: 15_000 }).toBe(0);
+  await expect(page.locator("#cp-pages-empty")).toBeVisible();
+});
+
 test("contract · the sidebar filter follows the pane it is pointed at", async ({
   page,
 }) => {


### PR DESCRIPTION
Follow-up to #4424, which merged before these fixes were pushed — so all four defects below are on `main` right now, in `5388020`.

They came out of the Codex review on that PR. I verified each against the code; none were false positives, and each fix here has a test I confirmed **fails without it**.

## Wrong answers, not rough edges

**Truncated reads were parsed as whole files.** `PlaygroundSeedResolver.httpFetch` reads `maxBytes + 1` and stops — that extra byte is the entire truncation protocol, letting a caller tell a big file from the start of a bigger one. `PreviewUsageIndex` set its own cap at twice the fetcher's, so any source file over 256 KiB arrived as a prefix, parsed cleanly, and was reported as a **complete** index. `uses:Foo` would then answer "nothing calls that" about calls it had never read. The cap is now `PlaygroundSeedResolver.DEFAULT_MAX_BYTES` itself rather than a matching literal, so the two cannot drift apart again.

**Adjacent declarations shared their calls.** `declarationLines` finds bounds from blank lines and deliberately over-selects where two top-level declarations have none between them — the safe failure when seeding an editor buffer, the unsafe one when attributing calls, because both previews then inherit both call sets. `:usage-source-psi` now reports real top-level declaration spans and those decide; the line scan remains only for an analyzer predating the field. The test is the minimal case: `fun A() { Spacer() }` immediately followed by `fun B() { Icon() }`.

**A uses-only query stopped spanning sections.** `uses:Foo` alone leaves the text query empty, and `tabOk` read that as "not searching" — so matches outside the open tab stayed hidden and the readout counted only the open one. Worth noting `reflectTabs`'s own `searching` was already right (it reads the raw input), which is why the branches opened while the cards under them did not.

**The Pages pane listed everything.** The operator was stripped before the pane split, so a uses-only query reached the pane as `""` — read as "no filter" — and every sheet stayed while the readout above described the hidden component grid. The pane now filters on the raw query and lands on its own empty state, which is the honest answer to asking a design sheet what it calls.

## And one that was only a matter of time

The index build ran up to `maxFiles` network reads behind a process-wide `@Synchronized` monitor, called inline from the handler — on threads Ktor also serves renders on. Now per-catalog locks, which keep the property that mattered (two concurrent searches of one cold catalog do a single build) and drop the one that was accidental, plus a double-checked read outside the lock and `withContext(Dispatchers.IO)` in the handler.

## Test plan

- `PreviewUsageIndexTest`: two new cases — packed declarations do not share calls, and a truncated read is refused rather than parsed. Both verified to fail on the old code.
- `pages-snapshot.spec.mjs`: two new contract tests driving a real browser — a `uses:` filter spans every section, and the Pages pane filters on what was typed. Both verified to fail on the old expressions.
- `ServeWebFixtureTest` pinned `tabOk` as a literal string; its intent is the `current === "all"` tail, which this does not touch, so that assertion is now a regex over the tail with the leading conjunct left loose.
- `:cli:test`, `:usage-source-psi:test`, `ktfmtCheckAll`, and all 160 page-harness tests green on this branch rebased onto `main`.

No visual evidence: nothing here changes what a resting page looks like. The two behavioural changes are covered by the browser contract tests above rather than by pixels, since both are about which cards are *hidden* under a filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sd9w15eKsxnedz8s4bdmY

---
_Generated by [Claude Code](https://claude.ai/code/session_016sd9w15eKsxnedz8s4bdmY)_