### PR TITLE
feat(parity): a compose-parity-locator/v1 erratum — multi-component reports and reserved selection fields

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -43,6 +43,9 @@ internal object ServeIssueReport {
 
   const val LOCATOR_FENCE: String = "compose-parity-locator/v1"
 
+  /** The only plane `v1` accepts for [Bounds]; see that type and D1. */
+  const val RENDER_PIXELS: String = "render-pixels"
+
   /** Repo bugs fall back to when a session names no source of its own — the renderer is ours. */
   const val FALLBACK_REPO: String = "yschimke/compose-ai-tools"
 
@@ -73,6 +76,13 @@ internal object ServeIssueReport {
     val referenceId: String? = null,
     /** Preview-id axes only; live controls belong exclusively to [overrides]. */
     val variant: String = "",
+    /**
+     * The selected element, when the reporter picked one. Reserved for batch 03; nothing fills it
+     * yet — see [Locator.element].
+     */
+    val element: String? = null,
+    /** The selected region, when the reporter dragged one. Reserved for batch 03; see [Bounds]. */
+    val bounds: Bounds? = null,
     /** The complete, normalised query map consumed by the render lane. */
     val overrides: Map<String, String> = emptyMap(),
     /** GitHub blob URL of the preview's source file (from [ServeUrls.githubBlobUrl]). */
@@ -123,7 +133,37 @@ internal object ServeIssueReport {
     val referenceId: String,
     val variant: String,
     val overrides: Map<String, String>,
+    /**
+     * The element a selection named, and the region it covered. **Reserved, and unwritten until
+     * batch 03 has a selector to fill them.**
+     *
+     * They exist now because batch 01 called for them before this writer, the JavaScript producer
+     * and the shared fixture froze, and that did not happen. Both parsers ignore unknown keys, so
+     * adding the selection to `v1` afterwards would have been indexed with the selection silently
+     * dropped — no strict-parser rejection to notice, no error anywhere.
+     */
+    val element: String? = null,
+    val bounds: Bounds? = null,
     val revision: String? = null,
+  )
+
+  /**
+   * A selected region **and the plane it is measured in**, which is the half a bare rectangle
+   * leaves out.
+   *
+   * Three spaces are in play and they disagree: a tag selection comes from the index in render
+   * pixels, a drag selection is in display pixels, and an acceptance wants the canonical plane. D1
+   * settles that both tag-index producers publish `render-pixels` and that the canonical-plane
+   * transform is a step of the *comparison* — a plane is a property of a comparison, the index is a
+   * property of a render — so `v1` carries only that space, and an element that never moved cannot
+   * report as moved because two ends of the wire assumed different planes.
+   */
+  data class Bounds(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val space: String = RENDER_PIXELS,
   )
 
   /**
@@ -244,6 +284,8 @@ internal object ServeIssueReport {
       referenceId = reference,
       variant = ctx.variant,
       overrides = ctx.overrides,
+      element = ctx.element?.trim()?.takeIf { it.isNotEmpty() },
+      bounds = ctx.bounds,
       revision = ctx.catalog?.trim()?.takeIf { it.isNotEmpty() },
     )
   }
@@ -275,15 +317,36 @@ internal object ServeIssueReport {
     append("reference: ${locator.referenceId}\n")
     append("variant: ${locator.variant}\n")
     append("overrides: ${canonicalOverrides(locator.overrides)}\n")
+    locator.element?.let { append("element: $it\n") }
+    locator.bounds?.let { append("bounds: ${canonicalBounds(it)}\n") }
     locator.revision?.let { append("revision: $it\n") }
     append("```\n")
   }
+
+  /**
+   * Every locator a body carries, in order.
+   *
+   * One issue may name several components — an umbrella report like m3-catalog#42's Elevated shadow
+   * level covers three — and one block can only say one of them, so the body carries one block each
+   * and the index emits a row per block. Returns empty when the body has none; a body whose blocks
+   * contradict each other (two repositories, two systems, or one component twice) is the producer's
+   * to reject, since it is the side that turns them into rows.
+   */
+  fun locatorsFromBody(body: String): List<Locator> =
+    body.split("```$LOCATOR_FENCE\n").drop(1).mapNotNull { rest ->
+      val content = rest.substringBefore("\n```", missingDelimiterValue = "")
+      content.takeIf { it.isNotEmpty() }?.let { locatorFromContent(it) }
+    }
 
   fun locatorFromBody(body: String): Locator? {
     val fenced = body.substringAfter("```$LOCATOR_FENCE\n", missingDelimiterValue = "")
     if (fenced.isEmpty()) return null
     val content = fenced.substringBefore("\n```", missingDelimiterValue = "")
     if (content.isEmpty()) return null
+    return locatorFromContent(content)
+  }
+
+  private fun locatorFromContent(content: String): Locator? {
     val fields =
       content
         .lineSequence()
@@ -303,6 +366,8 @@ internal object ServeIssueReport {
       referenceId = fields["reference"]?.takeIf { it.isNotBlank() } ?: return null,
       variant = fields["variant"] ?: return null,
       overrides = overrides,
+      element = fields["element"]?.takeIf { it.isNotBlank() },
+      bounds = fields["bounds"]?.let { runCatching { parseBounds(it) }.getOrNull() ?: return null },
       revision = fields["revision"]?.takeIf { it.isNotBlank() },
     )
   }
@@ -313,6 +378,41 @@ internal object ServeIssueReport {
       JsonObject.serializer(),
       JsonObject(sorted.associate { it.key to JsonPrimitive(it.value) }),
     )
+  }
+
+  /**
+   * Canonical bounds JSON: the same code-point key order the overrides carry, so a block is
+   * comparable byte for byte without parsing it back.
+   */
+  fun canonicalBounds(bounds: Bounds): String =
+    Json.encodeToString(
+      JsonObject.serializer(),
+      JsonObject(
+        // Code point order: height < space < width < x < y.
+        linkedMapOf(
+          "height" to JsonPrimitive(bounds.height),
+          "space" to JsonPrimitive(bounds.space),
+          "width" to JsonPrimitive(bounds.width),
+          "x" to JsonPrimitive(bounds.x),
+          "y" to JsonPrimitive(bounds.y),
+        )
+      ),
+    )
+
+  private fun parseBounds(value: String): Bounds {
+    val json = Json.parseToJsonElement(value).jsonObject
+    val space = json["space"]?.jsonPrimitive?.contentOrNull ?: error("bounds names no space")
+    // `v1` accepts only the plane both tag-index producers publish; see [Bounds] and D1.
+    require(space == RENDER_PIXELS) { "bounds space must be $RENDER_PIXELS" }
+    fun extent(key: String): Int =
+      json[key]?.jsonPrimitive?.content?.toIntOrNull()?.takeIf { it >= 0 }
+        ?: error("bounds $key must be a non-negative integer")
+    val bounds =
+      Bounds(x = extent("x"), y = extent("y"), width = extent("width"), height = extent("height"))
+    require(bounds.width >= 1 && bounds.height >= 1) { "bounds must have a positive extent" }
+    require(json.keys.size == 5) { "bounds carries unknown keys" }
+    require(canonicalBounds(bounds) == value) { "bounds are not canonical JSON" }
+    return bounds
   }
 
   private fun parseOverrides(value: String): Map<String, String> =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -336,7 +336,7 @@ internal object ServeIssueReport {
     append("reference: ${locator.referenceId}\n")
     append("variant: ${locator.variant}\n")
     append("overrides: ${canonicalOverrides(locator.overrides)}\n")
-    locator.element?.let { append("element: $it\n") }
+    locator.element?.let { append("element: ${canonicalElement(it)}\n") }
     locator.bounds?.let { append("bounds: ${canonicalBounds(it)}\n") }
     locator.revision?.let { append("revision: $it\n") }
     append("```\n")
@@ -388,7 +388,8 @@ internal object ServeIssueReport {
       referenceId = fields["reference"]?.takeIf { it.isNotBlank() } ?: return null,
       variant = fields["variant"] ?: return null,
       overrides = overrides,
-      element = fields["element"]?.takeIf { it.isNotBlank() },
+      element =
+        fields["element"]?.let { runCatching { parseElement(it) }.getOrNull() ?: return null },
       bounds = fields["bounds"]?.let { runCatching { parseBounds(it) }.getOrNull() ?: return null },
       revision = fields["revision"]?.takeIf { it.isNotBlank() },
     )
@@ -401,6 +402,18 @@ internal object ServeIssueReport {
       JsonObject(sorted.associate { it.key to JsonPrimitive(it.value) }),
     )
   }
+
+  /**
+   * `element` is written as a **JSON string**, which is what keeps a tag from becoming syntax.
+   *
+   * The block is line-oriented `key: value`, and a `testTag` is an arbitrary string: one containing
+   * a newline would not stay one field — `row\nrevision: injected` reads back as an element plus a
+   * revision nobody wrote — and one carrying a fence delimiter could end the block early and drop
+   * the whole issue from the index. Quoting also makes a tag with leading or trailing whitespace
+   * expressible, which a format whose readers trim otherwise cannot carry at all.
+   */
+  fun canonicalElement(element: String): String =
+    Json.encodeToString(JsonPrimitive.serializer(), JsonPrimitive(element))
 
   /**
    * Canonical bounds JSON: the same code-point key order the overrides carry, so a block is
@@ -420,6 +433,15 @@ internal object ServeIssueReport {
         )
       ),
     )
+
+  private fun parseElement(value: String): String {
+    val element =
+      Json.parseToJsonElement(value).jsonPrimitive.takeIf { it.isString }?.contentOrNull
+        ?: error("element must be a JSON string")
+    require(element.isNotEmpty()) { "element must not be empty" }
+    require(canonicalElement(element) == value) { "element is not canonical JSON" }
+    return element
+  }
 
   private fun parseBounds(value: String): Bounds {
     val json = Json.parseToJsonElement(value).jsonObject

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -303,7 +303,11 @@ internal object ServeIssueReport {
       referenceId = reference,
       variant = ctx.variant,
       overrides = ctx.overrides,
-      element = ctx.element?.trim()?.takeIf { it.isNotEmpty() },
+      // Verbatim, deliberately: the tag is JSON-quoted on the wire, so edge whitespace survives
+      // both parsers and the selected tag keeps its identity. A tag index treats `" glyph "` and
+      // `"glyph"` as different keys, and normalising here would point the acceptance at the wrong
+      // one — or at none. Only an *empty* tag is dropped, which both parsers refuse anyway.
+      element = ctx.element?.takeIf { it.isNotEmpty() },
       bounds = ctx.bounds,
       revision = ctx.catalog?.trim()?.takeIf { it.isNotEmpty() },
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -164,7 +164,26 @@ internal object ServeIssueReport {
     val width: Int,
     val height: Int,
     val space: String = RENDER_PIXELS,
-  )
+  ) {
+    /**
+     * The invariants both parsers enforce, checked where the rectangle is *made* rather than where
+     * it is serialised.
+     *
+     * A writer that emitted a rectangle its own producer refuses would hand the reporter a
+     * prefilled body that looks right and takes the **whole issue** out of the index when the
+     * workflow next runs — a failure with no symptom until someone wonders why the report never
+     * appeared. The reachable version of that is batch 03's drag selection, which starts in display
+     * pixels: a missed conversion is a mistake at the point of construction, and this is where it
+     * should stop.
+     */
+    init {
+      require(space == RENDER_PIXELS) { "bounds space must be $RENDER_PIXELS, was $space" }
+      require(x >= 0 && y >= 0) { "bounds origin must be non-negative, was ($x, $y)" }
+      require(width >= 1 && height >= 1) {
+        "bounds must have a positive extent, was ${width}x$height"
+      }
+    }
+  }
 
   /**
    * Which repo a preview's bug belongs to: the catalog's **source** repo (the Kotlin the preview is
@@ -353,7 +372,10 @@ internal object ServeIssueReport {
         .mapNotNull { line ->
           val separator = line.indexOf(':')
           if (separator <= 0) null
-          else line.substring(0, separator) to line.substring(separator + 1).trimStart()
+          // Trim **both** ends, as the producer does. This side trimmed only the start, so a value
+          // carrying a trailing space read one way here and another there — two engines disagreeing
+          // about what a block says, which is precisely what the shared fixture exists to stop.
+          else line.substring(0, separator).trim() to line.substring(separator + 1).trim()
         }
         .toMap()
     val overrides =
@@ -405,11 +427,11 @@ internal object ServeIssueReport {
     // `v1` accepts only the plane both tag-index producers publish; see [Bounds] and D1.
     require(space == RENDER_PIXELS) { "bounds space must be $RENDER_PIXELS" }
     fun extent(key: String): Int =
-      json[key]?.jsonPrimitive?.content?.toIntOrNull()?.takeIf { it >= 0 }
-        ?: error("bounds $key must be a non-negative integer")
+      json[key]?.jsonPrimitive?.content?.toIntOrNull() ?: error("bounds $key must be an integer")
+    // [Bounds] enforces the origin, extent and space invariants itself, so a rectangle that fails
+    // them throws here and the caller's `runCatching` turns it into a refused locator.
     val bounds =
       Bounds(x = extent("x"), y = extent("y"), width = extent("width"), height = extent("height"))
-    require(bounds.width >= 1 && bounds.height >= 1) { "bounds must have a positive extent" }
     require(json.keys.size == 5) { "bounds carries unknown keys" }
     require(canonicalBounds(bounds) == value) { "bounds are not canonical JSON" }
     return bounds

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssues.kt
@@ -64,7 +64,15 @@ object ServeParityIssuesStore {
   fun sanitize(raw: ParityIssues): ParityIssues? {
     if (raw.schema != ParityIssues.SCHEMA || raw.issues.size > MAX_ISSUES) return null
     val generatedAt = raw.generatedAt?.trim()?.takeIf(::isTimestamp)
-    val issues = raw.issues.mapNotNull(::sanitizeIssue).distinctBy { it.repository to it.number }
+    // Identity is repository + number + **component**, not repository + number. One issue may name
+    // several components — an umbrella report covering three Elevated stickers files one issue and
+    // the producer emits a row each — and deduping by issue alone collapsed those to an arbitrary
+    // one of them at load time, so the report reached one component page and silently missed the
+    // rest. Two rows that agree on all three are still a duplicate and still collapse.
+    val issues =
+      raw.issues.mapNotNull(::sanitizeIssue).distinctBy {
+        Triple(it.repository, it.number, it.component)
+      }
     if (issues.isEmpty()) return null
     return ParityIssues(generatedAt = generatedAt, issues = issues)
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -10560,8 +10560,11 @@ $cards
           groups.entries.joinToString("\n") { (component, rows) ->
             "<section class=\"cp-parity-issue-group\"><h3>${esc(component)} (${rows.size})</h3>${parityIssueRowsHtml(rows)}</section>"
           }
+        // The heading counts *components*, and `open` is rows: an umbrella issue contributes one
+        // row per component it names, so counting rows here would report three components with an
+        // open issue where one issue names three.
         val openBand =
-          "<h2 class=\"cp-status-sec\">Components with open issues (${open.size})</h2>" +
+          "<h2 class=\"cp-status-sec\">Components with open issues (${groups.size})</h2>" +
             if (open.isEmpty()) "<p class=\"cp-muted\">No open issues.</p>" else summary
         val closedBand =
           if (closed.isEmpty()) ""

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -10566,10 +10566,16 @@ $cards
         val openBand =
           "<h2 class=\"cp-status-sec\">Components with open issues (${groups.size})</h2>" +
             if (open.isEmpty()) "<p class=\"cp-muted\">No open issues.</p>" else summary
+        // The closed band is flat and its rows do not name a component, so one closed umbrella
+        // issue
+        // would otherwise render as three identical links under a count that claims three issues.
+        // The open band above needs no such collapse: it groups by component, which is exactly what
+        // distinguishes those rows from each other.
+        val closedIssues = closed.distinctBy { it.repository to it.number }
         val closedBand =
-          if (closed.isEmpty()) ""
+          if (closedIssues.isEmpty()) ""
           else
-            "<h2 class=\"cp-status-sec\">Closed issues (${closed.size})</h2>${parityIssueRowsHtml(closed)}"
+            "<h2 class=\"cp-status-sec\">Closed issues (${closedIssues.size})</h2>${parityIssueRowsHtml(closedIssues)}"
         openBand + closedBand
       }
     val issueBand =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -7,7 +7,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -313,7 +315,7 @@ class ServeIssueReportTest {
     val written =
       fixture["cases"]!!.jsonArray.map { it.jsonObject }.filter { it.containsKey("writer") }
     // A fixture that silently stopped carrying writer cases would pass every assertion below.
-    assertEquals(4, written.size, "the fixture must keep exercising the writer")
+    assertEquals(5, written.size, "the fixture must keep exercising the writer")
     for (case in written) {
       val name = case["name"]!!.jsonPrimitive.content
       val writer = case["writer"]!!.jsonObject
@@ -329,6 +331,8 @@ class ServeIssueReportTest {
             writer["overrides"]!!.jsonObject.entries.associate {
               it.key to it.value.jsonPrimitive.content
             },
+          element = writer["element"]?.jsonPrimitive?.contentOrNull,
+          bounds = writer["bounds"]?.jsonObject?.let(::boundsOf),
           revision = writer["revision"]?.jsonPrimitive?.contentOrNull,
         )
       val block = case["block"]!!.jsonPrimitive.content
@@ -336,4 +340,95 @@ class ServeIssueReportTest {
       assertEquals(locator, ServeIssueReport.locatorFromBody(block), name)
     }
   }
+
+  @Test
+  fun `the writer emits one block per component of an umbrella report`() {
+    // The other half of the multi-component contract: `parity-issues.test.mjs` asserts the producer
+    // reads these bodies back as one row per block. An issue like m3-catalog#42 names three
+    // components; one block can name one, so the body is their concatenation, in order.
+    val fixture =
+      Json.parseToJsonElement(
+          File("../scripts/design-artifacts/fixtures/parity-locators.json").readText()
+        )
+        .jsonObject
+    val bodies =
+      fixture["bodies"]!!.jsonArray.map { it.jsonObject }.filter { it.containsKey("writers") }
+    assertEquals(1, bodies.size, "the fixture must keep exercising the writer")
+    for (case in bodies) {
+      val name = case["name"]!!.jsonPrimitive.content
+      val locators =
+        case["writers"]!!
+          .jsonArray
+          .map { it.jsonObject }
+          .map { writer ->
+            ServeIssueReport.Locator(
+              repository = writer["repository"]!!.jsonPrimitive.content,
+              system = writer["system"]!!.jsonPrimitive.content,
+              componentId = writer["componentId"]!!.jsonPrimitive.content,
+              previewId = writer["previewId"]!!.jsonPrimitive.content,
+              referenceId = writer["referenceId"]!!.jsonPrimitive.content,
+              variant = writer["variant"]!!.jsonPrimitive.content,
+              overrides =
+                writer["overrides"]!!.jsonObject.entries.associate {
+                  it.key to it.value.jsonPrimitive.content
+                },
+            )
+          }
+      val body = case["body"]!!.jsonPrimitive.content
+      assertEquals(body, locators.joinToString("") { ServeIssueReport.locatorBlock(it) }, name)
+      assertEquals(locators, ServeIssueReport.locatorsFromBody(body), name)
+      // The single-locator reader keeps its old answer: the first block a body carries.
+      assertEquals(locators.first(), ServeIssueReport.locatorFromBody(body), name)
+    }
+  }
+
+  @Test
+  fun `a bounds rectangle is refused unless it names the plane v1 settled on`() {
+    // D1: both tag-index producers publish render pixels and the canonical-plane transform belongs
+    // to the comparison. A rectangle carrying any other space would be compared against a baseline
+    // measured somewhere else, which is how an element that never moved reports as `moved`.
+    val bounds = ServeIssueReport.Bounds(x = 18, y = 18, width = 24, height = 24)
+    assertEquals(
+      """{"height":24,"space":"render-pixels","width":24,"x":18,"y":18}""",
+      ServeIssueReport.canonicalBounds(bounds),
+    )
+    val block =
+      ServeIssueReport.locatorBlock(
+        ServeIssueReport.Locator(
+          repository = "yschimke/m3-catalog",
+          system = "m3-catalog",
+          componentId = "IconButton/Tonal",
+          previewId = "iconbutton-tonal__ideal__default__light",
+          referenceId = "iconbutton-tonal-figma",
+          variant = "ideal/default/light",
+          overrides = emptyMap(),
+          element = "glyph",
+          bounds = bounds,
+        )
+      )
+    assertEquals(bounds, ServeIssueReport.locatorFromBody(block)?.bounds)
+    assertEquals("glyph", ServeIssueReport.locatorFromBody(block)?.element)
+    assertNull(
+      ServeIssueReport.locatorFromBody(block.replace("render-pixels", "display-pixels")),
+      "another plane is refused rather than stored as a guess",
+    )
+    assertNull(
+      ServeIssueReport.locatorFromBody(
+        block.replace(
+          """{"height":24,"space":"render-pixels","width":24,"x":18,"y":18}""",
+          """{"x":18,"y":18,"width":24,"height":24,"space":"render-pixels"}""",
+        )
+      ),
+      "non-canonical key order is refused, as it is for overrides",
+    )
+  }
+
+  private fun boundsOf(writer: JsonObject): ServeIssueReport.Bounds =
+    ServeIssueReport.Bounds(
+      x = writer["x"]!!.jsonPrimitive.int,
+      y = writer["y"]!!.jsonPrimitive.int,
+      width = writer["width"]!!.jsonPrimitive.int,
+      height = writer["height"]!!.jsonPrimitive.int,
+      space = writer["space"]!!.jsonPrimitive.content,
+    )
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -426,12 +426,12 @@ class ServeIssueReportTest {
   }
 
   @Test
-  fun `a field value is read the same way both engines read it, and edge whitespace cannot survive`() {
-    // `key: value` lines, and both parsers trim the value — so a tag with edge whitespace does not
-    // survive the wire no matter what the writer emits. Trimming here rather than at read time is
-    // what makes the emitted bytes say what will actually be indexed; emitting it verbatim would
-    // just move the mangling to the reader, where nobody sees it. `v1` cannot express such a tag,
-    // and batch 03 must not select one without a format change.
+  fun `a tag keeps its edge whitespace, and a field value is read the way both engines read it`() {
+    // A tag index keys on the exact string, so `" glyph "` and `"glyph"` are different elements and
+    // normalising one into the other would point an acceptance at the wrong one — or at none. The
+    // quoting is what makes keeping it safe: both parsers trim the *line* value, and the spaces
+    // live
+    // inside the quotes where that trim cannot reach them.
     val locator =
       ServeIssueReport.locator(
         ServeIssueReport.Context(
@@ -443,16 +443,14 @@ class ServeIssueReportTest {
           element = "  glyph  ",
         )
       )
-    assertEquals("glyph", locator?.element)
+    assertEquals("  glyph  ", locator?.element)
     val block = ServeIssueReport.locatorBlock(locator!!)
+    assertTrue("""element: "  glyph  """" in block, block)
     assertEquals(locator, ServeIssueReport.locatorFromBody(block), "the block round-trips")
-    // The reader trims both ends, so a hand-edited body with a trailing space reads the same value
-    // this side and in the producer — which trims both ends too.
-    assertEquals(
-      "glyph",
-      ServeIssueReport.locatorFromBody(block.replace("element: glyph", "element: glyph  "))
-        ?.element,
-    )
+    // And the line is read the same way here and in the producer: both trim both ends, so a body
+    // hand-edited to pad *outside* the quotes still reads the same tag.
+    val padded = block.replace("""element: "  glyph  """", """element: "  glyph  "  """)
+    assertEquals("  glyph  ", ServeIssueReport.locatorFromBody(padded)?.element)
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -421,6 +422,53 @@ class ServeIssueReportTest {
       ),
       "non-canonical key order is refused, as it is for overrides",
     )
+  }
+
+  @Test
+  fun `a field value is read the same way both engines read it, and edge whitespace cannot survive`() {
+    // `key: value` lines, and both parsers trim the value — so a tag with edge whitespace does not
+    // survive the wire no matter what the writer emits. Trimming here rather than at read time is
+    // what makes the emitted bytes say what will actually be indexed; emitting it verbatim would
+    // just move the mangling to the reader, where nobody sees it. `v1` cannot express such a tag,
+    // and batch 03 must not select one without a format change.
+    val locator =
+      ServeIssueReport.locator(
+        ServeIssueReport.Context(
+          repo = "yschimke/m3-catalog",
+          previewId = "iconbutton-tonal__ideal__default__light",
+          system = "m3-catalog",
+          componentId = "IconButton/Tonal",
+          referenceId = "iconbutton-tonal-figma",
+          element = "  glyph  ",
+        )
+      )
+    assertEquals("glyph", locator?.element)
+    val block = ServeIssueReport.locatorBlock(locator!!)
+    assertEquals(locator, ServeIssueReport.locatorFromBody(block), "the block round-trips")
+    // The reader trims both ends, so a hand-edited body with a trailing space reads the same value
+    // this side and in the producer — which trims both ends too.
+    assertEquals(
+      "glyph",
+      ServeIssueReport.locatorFromBody(block.replace("element: glyph", "element: glyph  "))
+        ?.element,
+    )
+  }
+
+  @Test
+  fun `an invalid rectangle cannot be constructed, let alone written into a report`() {
+    // The writer must not be able to emit a rectangle its own producer refuses: the reporter would
+    // file a body that looks right and the whole issue would drop out of the index when the
+    // workflow next ran. Batch 03's drag selection starts in display pixels, so the missed
+    // conversion is a real path — and this is where it stops, at construction.
+    assertFailsWith<IllegalArgumentException> {
+      ServeIssueReport.Bounds(x = 0, y = 0, width = 24, height = 24, space = "display-pixels")
+    }
+    assertFailsWith<IllegalArgumentException> {
+      ServeIssueReport.Bounds(x = -1, y = 0, width = 24, height = 24)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      ServeIssueReport.Bounds(x = 0, y = 0, width = 0, height = 24)
+    }
   }
 
   private fun boundsOf(writer: JsonObject): ServeIssueReport.Bounds =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -316,7 +316,7 @@ class ServeIssueReportTest {
     val written =
       fixture["cases"]!!.jsonArray.map { it.jsonObject }.filter { it.containsKey("writer") }
     // A fixture that silently stopped carrying writer cases would pass every assertion below.
-    assertEquals(5, written.size, "the fixture must keep exercising the writer")
+    assertEquals(6, written.size, "the fixture must keep exercising the writer")
     for (case in written) {
       val name = case["name"]!!.jsonPrimitive.content
       val writer = case["writer"]!!.jsonObject
@@ -409,6 +409,7 @@ class ServeIssueReportTest {
       )
     assertEquals(bounds, ServeIssueReport.locatorFromBody(block)?.bounds)
     assertEquals("glyph", ServeIssueReport.locatorFromBody(block)?.element)
+    assertTrue("""element: "glyph"""" in block, "the tag is written as a JSON string")
     assertNull(
       ServeIssueReport.locatorFromBody(block.replace("render-pixels", "display-pixels")),
       "another plane is refused rather than stored as a guess",
@@ -451,6 +452,34 @@ class ServeIssueReportTest {
       "glyph",
       ServeIssueReport.locatorFromBody(block.replace("element: glyph", "element: glyph  "))
         ?.element,
+    )
+  }
+
+  @Test
+  fun `a tag cannot become syntax, however it is spelled`() {
+    // A `testTag` is arbitrary text and the block is line-oriented, so a bare value carrying a
+    // newline would not stay one field: `row\nrevision: injected` would read back as an element
+    // plus a revision nobody wrote, and a fence delimiter inside a tag could end the block early
+    // and drop the whole issue from the index. JSON quoting is what makes the value inert.
+    val locator =
+      ServeIssueReport.locator(
+        ServeIssueReport.Context(
+          repo = "yschimke/m3-catalog",
+          previewId = "iconbutton-tonal__ideal__default__light",
+          system = "m3-catalog",
+          componentId = "IconButton/Tonal",
+          referenceId = "iconbutton-tonal-figma",
+          element = "row\nrevision: injected",
+        )
+      )!!
+    val block = ServeIssueReport.locatorBlock(locator)
+    assertTrue("""element: "row\nrevision: injected"""" in block, block)
+    val read = ServeIssueReport.locatorFromBody(block)
+    assertEquals("row\nrevision: injected", read?.element)
+    assertNull(read?.revision, "the injected line is part of the tag, not a field of its own")
+    // A bare tag is refused rather than read as syntax.
+    assertNull(
+      ServeIssueReport.locatorFromBody(block.replace(""""row\nrevision: injected"""", "row"))
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssuesStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityIssuesStoreTest.kt
@@ -44,6 +44,33 @@ class ServeParityIssuesStoreTest {
   private fun load() = ServeParityIssuesStore.load(File("/bundle"), fs)
 
   @Test
+  fun `an umbrella issue keeps a row per component, and a true duplicate still collapses`() {
+    // One issue may name several components — the producer emits a row each so the report reaches
+    // every component page it is about. Deduping by repository + number alone kept an arbitrary one
+    // of them, which is the silent half of the failure: the issue still appeared, just not where
+    // the rest of it belonged.
+    write(
+      ParityIssues(
+        generatedAt = "2026-08-15T10:00:00Z",
+        issues =
+          listOf(
+            issue().copy(component = "Button/Elevated"),
+            issue().copy(component = "Card/Elevated"),
+            issue().copy(component = "ToggleButton/Elevated"),
+            // Same repository, number AND component: a genuine duplicate, and still one row.
+            issue().copy(component = "Card/Elevated"),
+          ),
+      )
+    )
+    val rows = assertNotNull(load()).issues
+    assertEquals(
+      listOf("Button/Elevated", "Card/Elevated", "ToggleButton/Elevated"),
+      rows.map { it.component },
+    )
+    assertEquals(listOf(40, 40, 40), rows.map { it.number }, "the rows are one issue")
+  }
+
+  @Test
   fun `loads valid open and closed rows`() {
     write(
       ParityIssues(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebParityIssueBandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebParityIssueBandTest.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The parity dashboard's issue bands, once an issue may occupy **several rows**.
+ *
+ * An umbrella report names one component per locator block and the index carries a row each, so
+ * both bands have to say what they mean: the open band groups by component and counts components,
+ * and the closed band is flat, carries no component on a row, and therefore counts issues.
+ */
+class ServeWebParityIssueBandTest {
+
+  private fun issue(number: Int, component: String, state: String) =
+    ParityIssue(
+      repository = "yschimke/m3-catalog",
+      number = number,
+      title = "Elevated previews do not match the kit's Level 1 shadow",
+      url = "https://github.com/yschimke/m3-catalog/issues/$number",
+      state = state,
+      area = "component",
+      parity = "known-difference",
+      system = "m3-catalog",
+      component = component,
+      previewIds = listOf("${component.lowercase().replace('/', '-')}__ideal__default__light"),
+    )
+
+  private fun page(issues: List<ParityIssue>): String =
+    ServeWeb.parityPage(
+      moduleLabel = "m3-catalog",
+      dashboard =
+        ServeParityDashboard.Dashboard(
+          coverage =
+            ServeParityDashboard.Coverage(
+              components = 3,
+              mapped = 3,
+              unmapped = emptyList(),
+              unmappedOverflow = 0,
+            ),
+          feed = emptyList(),
+          components = emptyList(),
+          gaps = emptyList(),
+        ),
+      token = "t",
+      parityIssues = issues,
+    )
+
+  private val elevated = listOf("Button/Elevated", "Card/Elevated", "ToggleButton/Elevated")
+
+  @Test
+  fun `one open umbrella issue is one row per component, counted as components`() {
+    val html = page(elevated.map { issue(42, it, "open") })
+    // Three sections, one per component, each naming the issue once…
+    for (component in elevated) assertTrue(component in html, component)
+    assertEquals(3, Regex("#42 ").findAll(html).count(), "the issue appears under each component")
+    // …and the heading counts the components, which is what it says.
+    assertTrue("Components with open issues (3)" in html, html.substringAfter("cp-status-sec"))
+  }
+
+  @Test
+  fun `one closed umbrella issue is listed once, not once per component`() {
+    // The closed band is flat and its rows carry no component, so three rows would render as three
+    // identical links under a count claiming three closed issues.
+    val html = page(elevated.map { issue(42, it, "closed") })
+    assertEquals(1, Regex("#42 ").findAll(html).count(), "one link, not one per row")
+    assertTrue("Closed issues (1)" in html, html)
+  }
+
+  @Test
+  fun `two closed issues on one component stay two`() {
+    // The collapse is by issue identity, not by "anything that repeats": two genuinely different
+    // issues that happen to share a component are two rows and two links.
+    val html =
+      page(listOf(issue(42, "Card/Elevated", "closed"), issue(85, "Card/Elevated", "closed")))
+    assertTrue("Closed issues (2)" in html, html)
+    assertEquals(1, Regex("#42 ").findAll(html).count())
+    assertEquals(1, Regex("#85 ").findAll(html).count())
+  }
+}

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -12,10 +12,12 @@
 > scoped acceptance, element selection, resolution automation — is still a proposal**, and that
 > measurement is the reason to read it again before implementing it.
 >
-> **One thing Phase 1 was supposed to ship and did not:** batch 01 required `element` and `bounds`
-> to be **reserved as optional `v1` fields** before the writer, the parser and the shared fixture
-> froze. Neither engine carries them, and both ignore unknown keys — so batch 03 cannot add the
-> selection to `v1` without a permissive parser silently discarding it. See §7.
+> **`v1` erratum, since delivered:** batch 01 required `element` and `bounds` to be **reserved as
+> optional fields** before the writer, the parser and the shared fixture froze, and Phase 1 shipped
+> without them. Both are now reserved and round-tripped by both engines, `bounds` carrying its plane
+> explicitly (D1), and a body may now carry **one block per component** so an umbrella report
+> reaches every component page it names. §2 has the contract; §7 records what those two decisions
+> settled.
 
 The preview server can already tell you that a component's render and its design reference disagree.
 It cannot tell you whether anyone *knows*. Every comparison is scored from scratch on every page
@@ -122,6 +124,27 @@ and every part of it is already computable on the serve host:
 | `variant` | the axis segments already inside the preview id — **axes only**. Live overrides are *not* folded in here; they travel in their own `overrides` field, because two representations of one fact means two ways to spell it and no rule for which wins |
 | `overrides` | the whole normalised override map the render lane received (display fields, size fields, overlay toggles, `knob.*`, `rc.*`) — the same set §4 matches acceptances on |
 | `revision` | `repo@branch` provenance + the compose-ai-tools version that rendered it |
+| `element` | **reserved**, unwritten until batch 03 — the `testTag` a selection resolved to |
+| `bounds` | **reserved**, unwritten until batch 03 — `{"height":…,"space":"render-pixels","width":…,"x":…,"y":…}` |
+
+**A body may carry one block per component, and that is how an umbrella report is indexed.** One
+issue legitimately spans several components — m3-catalog#42's Elevated shadow level covers
+`Button/`, `Card/` and `ToggleButton/Elevated` — and a block can only name one. So `parseLocators`
+reads every fence in the body and the index emits **one row per block**, keyed by issue *and*
+component. The blocks must agree: one `repository`, one `system`, and no component twice, since two
+rows with one identity collapse against each other in the reader. The alternative — splitting the
+umbrella into one issue per component — was rejected because it multiplies the backlog and loses the
+one fact that matters most about those issues, that they share a cause.
+
+**`element` and `bounds` are reserved now and written later, deliberately.** Batch 01 called for
+both before the writer, the parsers and the shared fixture froze; that did not happen, and both
+parsers ignore unknown keys, so a batch-03 report carrying a selection would have been indexed with
+the selection silently discarded — no strict-parser rejection to notice it. `bounds` names its space
+rather than being a bare rectangle, and `v1` accepts only `render-pixels`: per D1 both tag-index
+producers publish render pixels and the canonical-plane transform is a step of the **comparison**, a
+plane being a property of a comparison and the index a property of a render. A rectangle with no
+space is exactly what makes an element that never moved report as `moved`. Both values are canonical
+JSON on the same code-point rule the overrides carry.
 
 Two rules worth writing into the schema doc so they survive contact with a second implementer:
 
@@ -189,6 +212,10 @@ simply not there.
   preview id carrying no `__` axes. "No axes" is a fact about the preview, not a mangled body. Every
   *other* field must be non-blank: an emptied `system` or `preview` means the block no longer names
   one component, and that is a mangled body.
+- **`element` and `bounds` are absent or non-blank.** Reserved fields, so most blocks carry
+  neither; a *blank* one is a mangled body rather than an absent field. A `bounds` naming any space
+  other than `render-pixels`, carrying a non-integer or negative extent, a zero width or height, or
+  keys in insertion order rather than code-point order, is refused rather than stored as a guess.
 - **`overrides` keys sort by Unicode code point, not by UTF-16 code unit.** The distinction is
   invisible until a key is astral-plane: JavaScript's default `Array.prototype.sort` orders
   surrogates (`D800`–`DFFF`) below `E000`–`FFFF`, so a canonical block written by
@@ -452,10 +479,15 @@ the actual open question:
   per-pixel rather than aggregate, so it is bounded either way, but the surface it applies to is two
   orders of magnitude larger.
 
-So the question before the conformance fixtures freeze is not "refuse large masks", it is: does an
-acceptance **require** an element gate — which makes #41 inexpressible until the bar's parts are
-tagged — or is a geometric whole-component acceptance allowed, accepting that it re-invalidates on
-every render change and that the churn is the price of expressing #41 at all?
+***Settled: a geometric acceptance is allowed, and an element gate is preferred wherever an element
+exists.*** Requiring the gate outright would make #41 inexpressible until the bar's parts are
+tagged, which puts Phase 2's tag work in front of Phase 3 and leaves the pilot with #40 and #87
+alone. So `v1` permits an acceptance with no `element`, at the price the three bullets above
+describe — it re-invalidates on every render change, and its churn is the cost of being able to
+express #41 at all. An acceptance that *can* name an element must: the gate is what separates "the
+glyph disappeared" from "the glyph is still the wrong colour", and dropping it when it is available
+buys nothing. Refusing masks above a coverage fraction was the third option and was rejected as
+exactly the global threshold the epic's non-goals rule out.
 
 ---
 
@@ -1978,40 +2010,39 @@ Sequenced so each step is independently useful and nothing is blocked on the cro
   does not apply at `1.0`. It had to be settled rather than left open, because the full-scope
   matching rule depends on it. Say so if you want the looser reading; it is a `v1` schema decision
   either way.
-- **One issue, several components.** *Measured, not hypothetical — see "The pilot population" in
-  §3.* Three of `m3-catalog`'s ten known differences are umbrella reports: #42 names three
-  components, #93 spans `Button/*` and `Fab/*`, and #91 names five. The locator carries one
-  `component` and one `preview`, so none of them can be indexed whole. **#91 is not fixed by this
-  decision either way** — its interaction variants are unauthored, so each piece of a split still
-  has no `preview` to name; it belongs with the missing-subject cases below. Two ways out, and they are not equivalent: **split** the umbrella into one issue
-  per component (keeps the contract as written, multiplies the backlog, and loses the fact that the
-  five share a cause), or let a body carry **one locator block per component** and key index rows
-  by issue × component (`previewIds` / `referenceIds` are already arrays on the row; the producer
-  currently refuses a second block outright). **That second option is not a producer-only change:**
-  `ServeParityIssuesStore.sanitize` dedupes with `distinctBy { it.repository to it.number }` before
-  anything component-aware runs, so two rows for one issue collapse to an arbitrary one of them at
-  load time and the umbrella issue would still surface on a single component. Changing the row
-  identity in *both* engines, plus a fixture carrying one repository/number across two components,
-  is part of the decision rather than a follow-up. Either way this is a `v1` wire decision and wants
-  settling before the conformance fixtures freeze, not after two engines have been written against
-  them.
-- **`element` and `bounds` were never reserved in `v1`, and Phase 1 froze without them.** Batch 01
-  called for both as optional fields *before* the writer, the parser and the shared fixture froze,
-  precisely so batch 03 would not have to bump the version to add a selection. Neither
-  `ServeIssueReport.locatorBlock` nor `parseLocator` mentions them today, and both ignore unknown
-  keys — the permissive-parser failure that requirement existed to prevent, so a batch-03 report
-  carrying a selection would be indexed with the selection silently dropped. It cannot simply be
-  fixed now: batch 01 also says `bounds` may not be a bare rectangle, and which plane it is
-  expressed in is [D1](parity-batches/00-decisions.md), still open. So the choice is to answer D1
-  and reserve both fields as a `v1` erratum before anything else writes a locator, or to accept that
-  element selection arrives as `compose-parity-locator/v2`. Cheaper now than after a backlog of
-  filed reports.
+- **One issue, several components.** ***Settled: one locator block per component.*** *Measured, not
+  hypothetical — see "The pilot population" in §3.* Three of `m3-catalog`'s ten known differences
+  are umbrella reports: #42 names three components, #93 spans `Button/*` and `Fab/*`, and #91 names
+  five. A block names one component, so a body carries one block each and the index emits a row per
+  block, keyed by issue × component. Splitting the umbrella into one issue per component was the
+  alternative and was rejected: it multiplies the backlog and loses the fact that the pieces share a
+  cause. **The reader was half of this**, and the half that would have been missed:
+  `ServeParityIssuesStore.sanitize` deduped with `distinctBy { it.repository to it.number }` before
+  anything component-aware ran, so the rows collapsed to an arbitrary one at load time and the issue
+  still reached exactly one component page. Identity is now repository + number + component in both
+  engines, with the shared fixture carrying a body that names two components and one that names the
+  same component twice. **#91 is not fixed by this either way** — its interaction variants are
+  unauthored, so each piece of a split still has no `preview` to name; it belongs with the
+  missing-subject cases below.
+- **`element` and `bounds` were never reserved in `v1`.** ***Settled: reserved as a `v1` erratum,
+  after answering D1.*** Batch 01 called for both as optional fields *before* the writer, the parser
+  and the shared fixture froze, precisely so batch 03 would not have to bump the version to add a
+  selection — and Phase 1 shipped without them. Since both parsers ignore unknown keys, that would
+  have been the permissive failure the requirement existed to prevent: a report carrying a selection
+  indexed with the selection dropped and no error anywhere. Reserving them meant settling
+  [D1](parity-batches/00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in)
+  first, since a rectangle with no plane is the ambiguity that makes an unmoved element report as
+  `moved`; D1 is answered **(a)** — the index publishes render-pixel bounds and names its space, the
+  canonical-plane transform belongs to the comparison — so `v1` accepts `render-pixels` and nothing
+  else. Doing it now cost a fixture case and two parsers; the alternative was a `v2` bump across the
+  writer, the producer and the reader once selection landed.
 - **A parity report needs its subject to be in the catalog.** Three of the ten (#85, #95, #86) are
   about a `DropdownMenu` and an expanded full-screen search view that this catalog does not publish
   — no preview, no reference, nothing to compare, however the locator is shaped. Two more (#89,
   #93) are missing-constant reports whose renders match: those *could* be indexed, since the
-  producer never inspects a pixel, but there is nothing for §4 to accept — a question about what
-  belongs on a component page rather than a limit. Either way §4's population is four issues across
-  six acceptance sites (#40, #41, #87, and #42 three times), not ten. Worth deciding whether the
-  catalog should grow the missing stickers, and whether an upstream-ergonomics report belongs in the
-  index.
+  producer never inspects a pixel, but there is nothing for §4 to accept. ***Settled: index them.***
+  A reader asking "why can't I name this size?" is standing on the component page, which is where
+  the answer belongs — so they carry locators and `area:component` like any other report, and simply
+  never carry an acceptance. §4's population is unchanged by that: four issues across six acceptance
+  sites (#40, #41, #87, and #42 three times), not ten. Still open: whether the catalog should grow
+  the stickers the three missing-subject reports are about.

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -124,15 +124,17 @@ and every part of it is already computable on the serve host:
 | `variant` | the axis segments already inside the preview id — **axes only**. Live overrides are *not* folded in here; they travel in their own `overrides` field, because two representations of one fact means two ways to spell it and no rule for which wins |
 | `overrides` | the whole normalised override map the render lane received (display fields, size fields, overlay toggles, `knob.*`, `rc.*`) — the same set §4 matches acceptances on |
 | `revision` | `repo@branch` provenance + the compose-ai-tools version that rendered it |
-| `element` | **reserved**, unwritten until batch 03 — the `testTag` a selection resolved to |
+| `element` | **reserved**, unwritten until batch 03 — the `testTag` a selection resolved to, as a **JSON string** (`element: "glyph"`) |
 | `bounds` | **reserved**, unwritten until batch 03 — `{"height":…,"space":"render-pixels","width":…,"x":…,"y":…}` |
 
 **A body may carry one block per component, and that is how an umbrella report is indexed.** One
 issue legitimately spans several components — m3-catalog#42's Elevated shadow level covers
 `Button/`, `Card/` and `ToggleButton/Elevated` — and a block can only name one. So `parseLocators`
 reads every fence in the body and the index emits **one row per block**, keyed by issue *and*
-component. The blocks must agree: one `repository`, one `system`, and no component twice, since two
-rows with one identity collapse against each other in the reader. The alternative — splitting the
+component. The blocks must agree: one `repository`, one `system`, no component twice — two rows with
+one identity collapse against each other in the reader — and **no preview twice**, because
+`issuesForPreview` matches rows by preview id as well as by component, so one preview named by two
+blocks would carry the same issue twice and count two in its badge. The alternative — splitting the
 umbrella into one issue per component — was rejected because it multiplies the backlog and loses the
 one fact that matters most about those issues, that they share a cause.
 
@@ -144,7 +146,13 @@ rather than being a bare rectangle, and `v1` accepts only `render-pixels`: per D
 producers publish render pixels and the canonical-plane transform is a step of the **comparison**, a
 plane being a property of a comparison and the index a property of a render. A rectangle with no
 space is exactly what makes an element that never moved report as `moved`. Both values are canonical
-JSON on the same code-point rule the overrides carry.
+JSON on the same code-point rule the overrides carry — and `element` is a **quoted JSON string**
+rather than a bare value, which is load-bearing rather than tidy: a `testTag` is arbitrary text, the
+block is line-oriented, and a bare tag containing a newline does not stay one field. `row⏎revision:
+injected` would read back as an element plus a revision nobody wrote, and a tag carrying a fence
+delimiter could end the block early and take the whole issue out of the index. Quoting also makes a
+tag with leading or trailing whitespace expressible, which a format whose readers trim cannot
+otherwise carry.
 
 Two rules worth writing into the schema doc so they survive contact with a second implementer:
 
@@ -213,7 +221,8 @@ simply not there.
   *other* field must be non-blank: an emptied `system` or `preview` means the block no longer names
   one component, and that is a mangled body.
 - **`element` and `bounds` are absent or non-blank.** Reserved fields, so most blocks carry
-  neither; a *blank* one is a mangled body rather than an absent field. A `bounds` naming any space
+  neither; a *blank* one is a mangled body rather than an absent field, as is an `element` that is
+  not a canonical JSON string (a bare tag, or `""`). A `bounds` naming any space
   other than `render-pixels`, carrying a non-integer or negative extent, a zero width or height, or
   keys in insertion order rather than code-point order, is refused rather than stored as a guess.
 - **`overrides` keys sort by Unicode code point, not by UTF-16 code unit.** The distinction is

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -152,7 +152,9 @@ block is line-oriented, and a bare tag containing a newline does not stay one fi
 injected` would read back as an element plus a revision nobody wrote, and a tag carrying a fence
 delimiter could end the block early and take the whole issue out of the index. Quoting also makes a
 tag with leading or trailing whitespace expressible, which a format whose readers trim cannot
-otherwise carry.
+otherwise carry — so the writer records the selected tag **verbatim**. A tag index keys on the exact
+string, and normalising `" glyph "` into `"glyph"` would point an acceptance at a different element,
+or at none.
 
 Two rules worth writing into the schema doc so they survive contact with a second implementer:
 

--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -42,6 +42,15 @@ both rely on.
 the canonical-plane transform is a step of the comparison. Then relax or keep `space` validation
 deliberately rather than by accident.
 
+> **Answered: (a).** A plane is a property of a comparison and the index is a property of a render,
+> and (b) would make the published `tags/index.json` depend on the acceptances — breaking the
+> "publishing must not require a re-render" property batches 02 and 05 both rely on. It is also what
+> both producers already do, so (a) is a correction to the doc rather than a change to the code.
+>
+> Settled here because the `compose-parity-locator/v1` erratum needed it: the reserved `bounds`
+> field names its space and `v1` accepts `render-pixels` only. §2 of the contract carries the rule,
+> and both parsers refuse any other space rather than storing the guess.
+
 ## D2 — which surface carries the report form
 
 **Blocks:** 01 directly — it decides which page the form is built on, and 01 builds it. 02 and 03

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -50,6 +50,13 @@ Rules that are not negotiable, each because it has a silent failure mode:
   means a strict parser rejects the report while a permissive one silently discards the selection.
   Reserving them costs a line each here and a fixture; retrofitting them costs a version bump across
   three consumers.
+
+  > **This did not happen when the batch shipped, and landed later as a `v1` erratum.** Both fields
+  > are now reserved and round-tripped by the writer, the producer and the shared fixture, with
+  > `bounds` naming its plane per [D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in)
+  > (`render-pixels` only). The failure it nearly caused is worth keeping in view: both parsers
+  > ignore unknown keys, so nothing would have rejected a batch-03 report — the selection would have
+  > been dropped in silence.
 - **`bounds` cannot be a bare rectangle — it needs its space settled at the same time.** Three
   coordinate spaces are in play and they do not agree: a tag selection's bounds come from the index in
   **render pixels** ([D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in)), a

--- a/docs/design/parity-batches/03-element-selection.md
+++ b/docs/design/parity-batches/03-element-selection.md
@@ -1,11 +1,12 @@
 # Batch 03 — element selection on the focused comparison
 
 **Issue:** [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803).
-**Depends on:** [01](01-locator-and-report.md) (the selection rides into the locator) **and
-[00](00-decisions.md) D1** — a selection persists authoring-time `bounds`, and until the plane
-question is settled those bounds get written in a space nobody has agreed on. Recording them in the
-wrong space makes an unmoved element fail the movement gate later, which is the exact failure the
-element gate exists to detect. The tag index half of this issue's original prerequisite is **already
+**Depends on:** [01](01-locator-and-report.md) (the selection rides into the locator). **D1 is
+answered (a)** and both fields are reserved in `v1`, so the plane question that used to block this
+batch is settled: bounds are recorded in render pixels and named as such, and the canonical-plane
+transform is the comparison's step. Recording them in another space would make an unmoved element
+fail the movement gate later — the exact failure the element gate exists to detect — which is why
+both parsers refuse one. The tag index half of this issue's original prerequisite is **already
 done** — see below.
 **Blocks:** the element gates in [batch 05](05-acceptance-engines.md).
 **Ships:** **yes.** Click an element, report *that element* rather than "somewhere in this picture".
@@ -95,13 +96,17 @@ The index already carries `{count, bounds}` per tag, which is everything a selec
 Into the locator block from batch 01, as the `element` selector plus its authoring-time `bounds` —
 the same fields the acceptance schema (batch 04) will carry.
 
-**These must be declared as optional `v1` fields in batch 01, not added to `v1` here.** Batch 01
-freezes `compose-parity-locator/v1` — writer, parser and shared fixture — and batch 02's index schema
-is built against it. If this batch then introduces two new keys into the same `v1` block, a strict
-parser rejects the report as mangled and a permissive one silently drops the selection, so the new
-affordance is absent from every downstream consumer while appearing to work in the browser. Either
-reserve `element` and `bounds` as optional in 01, or version the contract here and update the
-producer and reader fixtures together. Reserving them in 01 is much the cheaper of the two.
+**Both fields are already reserved — this batch fills them, it does not add them.** Batch 01 called
+for that and shipped without it; the reservation landed afterwards as a `v1` erratum, so
+`compose-parity-locator/v1` now carries `element` and `bounds` as optional fields that the writer
+emits when set and both parsers round-trip. Nothing writes them yet, which is this batch's job.
+
+`bounds` is not a bare rectangle: it carries `{"height":…,"space":"render-pixels","width":…,"x":…,"y":…}`
+as canonical JSON, and `v1` accepts no other space —
+[D1](00-decisions.md#d1--which-plane-the-element-tag-index-reports-bounds-in) is answered (a), so the
+tag index publishes render pixels and the canonical-plane transform belongs to the comparison. A
+selection recorded in display pixels is refused by both parsers rather than stored; if this batch
+needs a drag selection, convert it into render pixels before serialising.
 
 ## Traps
 

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -87,10 +87,19 @@ differences" suggests. Two counts, and they are not the same number:
   most of the bar, #87's a 2dp ring, and #42's a shadow surrounding each component.
 
 The per-issue verdicts and what each implies are in
-[the pilot population](../COMPONENT_PARITY_WORKFLOW.md#the-pilot-population-measured); batch 00's D1
-and D5 should be answered against those numbers rather than against the worked example. D1 also
-gates a second thing now: batch 01's `element` / `bounds` reservation never landed, so batch 03
-inherits either a `v1` erratum or a version bump.
+[the pilot population](../COMPONENT_PARITY_WORKFLOW.md#the-pilot-population-measured); batch 00's D5
+should be answered against those numbers rather than against the worked example.
+
+**Four decisions have since been settled, and two of them changed the wire:**
+
+- **D1 is answered (a)** — the tag index publishes render-pixel bounds and names its space; the
+  canonical-plane transform belongs to the comparison.
+- **An umbrella issue carries one locator block per component**, and index rows are keyed by issue ×
+  component in both engines. This unblocks #42 and #93.
+- **`element` and `bounds` are reserved in `v1`** — batch 01's requirement, landed late as an
+  erratum, so batch 03 adds a selection to the existing version rather than bumping to `v2`.
+- **An acceptance may be geometric**, with an element gate required wherever an element exists. #41
+  and #87 are expressible; batch 04 must carry both shapes.
 
 ## Conventions every batch inherits
 

--- a/scripts/design-artifacts/fixtures/parity-locators.json
+++ b/scripts/design-artifacts/fixtures/parity-locators.json
@@ -36,6 +36,8 @@
             "knob.quote": "a=\"b\"",
             "knob.text": "日本語"
           },
+          "element": null,
+          "bounds": null,
           "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
         }
       }
@@ -64,6 +66,8 @@
           "referenceId": "iconbutton-tonal-figma",
           "variant": "ideal/default/light",
           "overrides": {},
+          "element": null,
+          "bounds": null,
           "revision": null
         }
       }
@@ -92,6 +96,8 @@
           "referenceId": "iconbutton-figma",
           "variant": "",
           "overrides": {},
+          "element": null,
+          "bounds": null,
           "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
         }
       }
@@ -126,6 +132,8 @@
             "！b": "1",
             "😀a": "2"
           },
+          "element": null,
+          "bounds": null,
           "revision": null
         }
       }
@@ -146,6 +154,143 @@
       "parse": {
         "ok": false,
         "error": "empty locator field(s): system"
+      }
+    },
+    {
+      "name": "element-and-bounds",
+      "why": "The two fields batch 01 reserved for batch 03's selection. Nothing writes them yet; both engines must round-trip them now, because adding a key to a frozen v1 later is refused by a strict parser and silently dropped by a permissive one.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {},
+        "element": "glyph",
+        "bounds": {
+          "space": "render-pixels",
+          "x": 18,
+          "y": 18,
+          "width": 24,
+          "height": 24
+        },
+        "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"height\":24,\"space\":\"render-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {},
+          "element": "glyph",
+          "bounds": {
+            "height": 24,
+            "space": "render-pixels",
+            "width": 24,
+            "x": 18,
+            "y": 18
+          },
+          "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+        }
+      }
+    },
+    {
+      "name": "bounds-in-another-space",
+      "why": "D1 settles that the tag index publishes render-pixel bounds and the canonical-plane transform belongs to the comparison. A rectangle in the display plane is the failure that makes an element which never moved report as moved, so v1 refuses any other space rather than storing the guess.",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"height\":24,\"space\":\"display-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "bounds space must be render-pixels"
+      }
+    },
+    {
+      "name": "bounds-not-canonical",
+      "why": "Same rule the overrides carry: the block is canonical bytes, so two records are comparable without parsing. Key order here is insertion order, not code-point order.",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"x\":18,\"y\":18,\"width\":24,\"height\":24,\"space\":\"render-pixels\"}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "bounds are not canonical JSON"
+      }
+    }
+  ],
+  "bodies": [
+    {
+      "$comment": "Whole issue bodies rather than single blocks: these exercise parseLocators, and the Kotlin side asserts its writer emits the same bytes for each block in order.",
+      "name": "umbrella-two-components",
+      "why": "One issue legitimately spans several components — m3-catalog#42's Elevated shadow level covers three. One block can name one component, so the body carries one block each and the index emits one row per block.",
+      "writers": [
+        {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "componentId": "Button/Elevated",
+          "previewId": "button-elevated__ideal__default__light",
+          "referenceId": "button-elevated__ideal__default__light",
+          "variant": "ideal/default/light",
+          "overrides": {}
+        },
+        {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "componentId": "Card/Elevated",
+          "previewId": "card-elevated__ideal__default__light__compact",
+          "referenceId": "card-elevated__ideal__default__light__compact",
+          "variant": "ideal/default/light/compact",
+          "overrides": {}
+        }
+      ],
+      "body": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Card/Elevated\npreview: card-elevated__ideal__default__light__compact\nreference: card-elevated__ideal__default__light__compact\nvariant: ideal/default/light/compact\noverrides: {}\n```\n",
+      "parse": {
+        "ok": true,
+        "locators": [
+          {
+            "repository": "yschimke/m3-catalog",
+            "system": "m3-catalog",
+            "component": "Button/Elevated",
+            "previewId": "button-elevated__ideal__default__light",
+            "referenceId": "button-elevated__ideal__default__light",
+            "variant": "ideal/default/light",
+            "overrides": {},
+            "element": null,
+            "bounds": null,
+            "revision": null
+          },
+          {
+            "repository": "yschimke/m3-catalog",
+            "system": "m3-catalog",
+            "component": "Card/Elevated",
+            "previewId": "card-elevated__ideal__default__light__compact",
+            "referenceId": "card-elevated__ideal__default__light__compact",
+            "variant": "ideal/default/light/compact",
+            "overrides": {},
+            "element": null,
+            "bounds": null,
+            "revision": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "umbrella-repeats-a-component",
+      "why": "Two rows with one identity collapse against each other in the reader, so a body that names the same component twice is refused rather than silently halved.",
+      "body": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "duplicate component in locator blocks: Button/Elevated"
+      }
+    },
+    {
+      "name": "umbrella-disagrees-about-the-repository",
+      "why": "The blocks describe one issue; a body whose blocks name different repositories cannot be joined to the issue that carries it.",
+      "body": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n```compose-parity-locator/v1\nrepository: yschimke/wear-m3-catalog\nsystem: m3-catalog\ncomponent: Card/Elevated\npreview: card-elevated__ideal__default__light__compact\nreference: card-elevated__ideal__default__light__compact\nvariant: ideal/default/light/compact\noverrides: {}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "locator blocks disagree about the repository"
       }
     }
   ]

--- a/scripts/design-artifacts/fixtures/parity-locators.json
+++ b/scripts/design-artifacts/fixtures/parity-locators.json
@@ -158,7 +158,7 @@
     },
     {
       "name": "element-and-bounds",
-      "why": "The two fields batch 01 reserved for batch 03's selection. Nothing writes them yet; both engines must round-trip them now, because adding a key to a frozen v1 later is refused by a strict parser and silently dropped by a permissive one.",
+      "why": "The two fields batch 01 reserved for batch 03's selection. Nothing writes them yet; both engines must round-trip them now, because adding a key to a frozen v1 later is refused by a strict parser and silently dropped by a permissive one. The tag is a JSON string: a testTag is arbitrary text, and a line-oriented block cannot carry a newline, a fence delimiter or edge whitespace unquoted.",
       "writer": {
         "repository": "yschimke/m3-catalog",
         "system": "m3-catalog",
@@ -177,7 +177,7 @@
         },
         "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
       },
-      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"height\":24,\"space\":\"render-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: \"glyph\"\nbounds: {\"height\":24,\"space\":\"render-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
       "parse": {
         "ok": true,
         "locator": {
@@ -203,7 +203,7 @@
     {
       "name": "bounds-in-another-space",
       "why": "D1 settles that the tag index publishes render-pixel bounds and the canonical-plane transform belongs to the comparison. A rectangle in the display plane is the failure that makes an element which never moved report as moved, so v1 refuses any other space rather than storing the guess.",
-      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"height\":24,\"space\":\"display-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: \"glyph\"\nbounds: {\"height\":24,\"space\":\"display-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
       "parse": {
         "ok": false,
         "error": "bounds space must be render-pixels"
@@ -212,10 +212,49 @@
     {
       "name": "bounds-not-canonical",
       "why": "Same rule the overrides carry: the block is canonical bytes, so two records are comparable without parsing. Key order here is insertion order, not code-point order.",
-      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"x\":18,\"y\":18,\"width\":24,\"height\":24,\"space\":\"render-pixels\"}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: \"glyph\"\nbounds: {\"x\":18,\"y\":18,\"width\":24,\"height\":24,\"space\":\"render-pixels\"}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
       "parse": {
         "ok": false,
         "error": "bounds are not canonical JSON"
+      }
+    },
+    {
+      "name": "element-unquoted",
+      "why": "A bare tag is what makes `row\\nrevision: injected` parse as two fields — an element silently truncated and a revision nobody wrote. v1 takes a JSON string so the value cannot become syntax.",
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: glyph\nbounds: {\"height\":24,\"space\":\"render-pixels\",\"width\":24,\"x\":18,\"y\":18}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "element must be a JSON string"
+      }
+    },
+    {
+      "name": "element-with-a-newline",
+      "why": "The injection this encoding exists to stop, written out: the tag carries a line break and its escape keeps it one field instead of opening `revision:`.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {},
+        "element": "row\nrevision: injected"
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: \"row\\nrevision: injected\"\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {},
+          "element": "row\nrevision: injected",
+          "bounds": null,
+          "revision": null
+        }
       }
     }
   ],
@@ -291,6 +330,15 @@
       "parse": {
         "ok": false,
         "error": "locator blocks disagree about the repository"
+      }
+    },
+    {
+      "name": "umbrella-repeats-a-preview",
+      "why": "A served preview belongs to one component, and issuesForPreview matches rows by preview id as well as by component — two blocks claiming one preview would put the same issue on that page twice and make its badge say two.",
+      "body": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Card/Elevated\npreview: button-elevated__ideal__default__light\nreference: card-elevated__ideal__default__light__compact\nvariant: ideal/default/light/compact\noverrides: {}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "duplicate preview in locator blocks: button-elevated__ideal__default__light"
       }
     }
   ]

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -33,6 +33,26 @@ const PARITY = new Set(["regression", "known-difference", "verification-needed"]
 const REQUIRED_FIELDS = ["repository", "system", "component", "preview", "reference", "variant", "overrides"];
 
 /**
+ * Reserved in `v1` for the selection batch 03 records, and unwritten until then.
+ *
+ * Batch 01 called for both keys *before* the writer, the parsers and the shared fixture froze, and
+ * that did not happen: element selection would then have had to add two keys to a `v1` that strict
+ * parsers reject and permissive ones — these two, which ignore unknown fields — silently discard.
+ * A report carrying a selection would have been indexed with the selection dropped and no error
+ * anywhere. Reserving them now costs a fixture case; retrofitting them costs a version bump across
+ * the writer, this producer and the Kotlin reader.
+ *
+ * `bounds` names its space rather than being a bare rectangle, per D1: the tag index publishes
+ * `render-pixels` and the canonical-plane transform belongs to the comparison, so a rectangle with
+ * no space is exactly the ambiguity that makes an element which never moved report as `moved`.
+ * `v1` therefore accepts only the space both producers actually emit.
+ */
+const OPTIONAL_FIELDS = ["element", "bounds"];
+const BOUNDS_SPACE = "render-pixels";
+/** Code-point order, which is what [canonicalJson] produces and what the writer emits. */
+const BOUNDS_KEYS = ["height", "space", "width", "x", "y"];
+
+/**
  * The subset whose value may not be blank. `variant` is the exception and the reason this list is
  * separate from [REQUIRED_FIELDS]: `ServeIssueReport.variantFor` returns "" for a preview id that
  * carries no `__` axes, and "no axes" is a fact about the preview, not a mangled body.
@@ -59,6 +79,32 @@ function compareCodePoints(a, b) {
   return left.length - right.length;
 }
 
+/** Re-serialise an object with its keys in code-point order — the writer's rule, for both maps. */
+function canonicalJson(value) {
+  return JSON.stringify(Object.fromEntries(Object.keys(value).sort(compareCodePoints).map((key) => [key, value[key]])));
+}
+
+function parseBounds(raw) {
+  let bounds;
+  try { bounds = JSON.parse(raw); } catch { return { error: "invalid bounds JSON" }; }
+  if (!bounds || Array.isArray(bounds) || typeof bounds !== "object") return { error: "bounds must be an object" };
+  const keys = Object.keys(bounds).sort(compareCodePoints);
+  if (keys.length !== BOUNDS_KEYS.length || keys.some((key, i) => key !== BOUNDS_KEYS[i])) {
+    return { error: `bounds must carry exactly ${BOUNDS_KEYS.join(", ")}` };
+  }
+  if (bounds.space !== BOUNDS_SPACE) return { error: `bounds space must be ${BOUNDS_SPACE}` };
+  for (const key of ["x", "y", "width", "height"]) {
+    const value = bounds[key];
+    if (!Number.isSafeInteger(value) || value < 0) return { error: `bounds ${key} must be a non-negative integer` };
+  }
+  if (bounds.width < 1 || bounds.height < 1) return { error: "bounds must have a positive extent" };
+  // Same rule the overrides carry: the block is canonical bytes, so a record and its re-serialised
+  // form are comparable without parsing. A hand-edited body that reorders the keys is refused
+  // rather than quietly accepted into a fingerprint someone later compares by string.
+  if (canonicalJson(bounds) !== raw) return { error: "bounds are not canonical JSON" };
+  return { bounds };
+}
+
 export function canonicalIssueUrl(value) {
   const match = /^https:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/issues\/([1-9][0-9]*)\/?$/i.exec(String(value ?? "").trim());
   if (!match) return null;
@@ -74,17 +120,59 @@ export function canonicalIssueUrl(value) {
  */
 export const NO_LOCATOR = "missing locator block";
 
-/** Parse exactly one visible locator fence. A malformed or duplicate block is an explicit error. */
-export function parseLocator(body) {
+/**
+ * Parse **every** visible locator fence in a body.
+ *
+ * One issue may legitimately name several components: an umbrella report like the Elevated shadow
+ * level covers `Button/`, `Card/` and `ToggleButton/Elevated`, and one block can only say one of
+ * them. Each block is a complete locator; [buildIssueIndex] emits one row per block, so the issue
+ * reaches every component page it is about. What a body may **not** do is contradict itself — the
+ * blocks share one repository and one system, and no component may appear twice, since two rows
+ * with one identity would collapse against each other in the reader.
+ */
+export function parseLocators(body) {
   const text = String(body ?? "");
   const matches = [...text.matchAll(FENCE)];
-  // Count openers too: one that never closed is invisible to [FENCE], and a body carrying a good
-  // block plus a dangling opener is ambiguous about which frame it describes.
   const openers = [...text.matchAll(FENCE_OPEN)].length;
-  if (matches.length > 1 || openers > 1) return { ok: false, error: "multiple locator blocks" };
-  if (matches.length === 0) return { ok: false, error: openers ? "unterminated locator block" : NO_LOCATOR };
+  // An opener with no closer is invisible to [FENCE]; if the counts disagree, some block in this
+  // body failed to close and the body is damaged rather than merely multi-component.
+  if (openers > matches.length) return { ok: false, error: "unterminated locator block" };
+  if (matches.length === 0) return { ok: false, error: NO_LOCATOR };
+  const locators = [];
+  for (const [index, match] of matches.entries()) {
+    const parsed = parseLocatorBlock(match[1]);
+    if (!parsed.ok) return matches.length === 1 ? parsed : { ok: false, error: `locator block ${index + 1}: ${parsed.error}` };
+    locators.push(parsed.locator);
+  }
+  const [first] = locators;
+  for (const locator of locators.slice(1)) {
+    if (locator.repository !== first.repository) return { ok: false, error: "locator blocks disagree about the repository" };
+    if (locator.system !== first.system) return { ok: false, error: "locator blocks disagree about the system" };
+  }
+  const components = new Set();
+  for (const locator of locators) {
+    if (components.has(locator.component)) return { ok: false, error: `duplicate component in locator blocks: ${locator.component}` };
+    components.add(locator.component);
+  }
+  return { ok: true, locators };
+}
+
+/**
+ * Parse a body carrying exactly one fence. Kept beside [parseLocators] because most callers — and
+ * every per-block case in the shared fixture — describe a single locator, and because "this body
+ * says two different things" is a distinct answer from "here are its two components".
+ */
+export function parseLocator(body) {
+  const parsed = parseLocators(body);
+  if (!parsed.ok) return parsed;
+  if (parsed.locators.length > 1) return { ok: false, error: "multiple locator blocks" };
+  return { ok: true, locator: parsed.locators[0] };
+}
+
+/** Parse the content of one fence — every line between its delimiters. */
+function parseLocatorBlock(content) {
   const fields = Object.create(null);
-  for (const line of matches[0][1].split(/\r?\n/)) {
+  for (const line of content.split(/\r?\n/)) {
     const colon = line.indexOf(":");
     if (colon < 1) return { ok: false, error: `malformed locator line: ${line}` };
     const key = line.slice(0, colon).trim();
@@ -99,13 +187,22 @@ export function parseLocator(body) {
   const blank = NON_EMPTY_FIELDS.filter((key) => fields[key] === "");
   if (blank.length) return { ok: false, error: `empty locator field(s): ${blank.join(", ")}` };
   if (Object.hasOwn(fields, "revision") && fields.revision === "") return { ok: false, error: "empty locator field(s): revision" };
+  for (const key of OPTIONAL_FIELDS) {
+    if (Object.hasOwn(fields, key) && fields[key] === "") return { ok: false, error: `empty locator field(s): ${key}` };
+  }
   if (!REPO.test(fields.repository)) return { ok: false, error: "invalid repository" };
   let overrides;
   try { overrides = JSON.parse(fields.overrides); } catch { return { ok: false, error: "invalid overrides JSON" }; }
   if (!overrides || Array.isArray(overrides) || typeof overrides !== "object") return { ok: false, error: "overrides must be an object" };
   const canonicalOverrides = Object.fromEntries(Object.keys(overrides).sort(compareCodePoints).map((key) => [key, overrides[key]]));
-  if (JSON.stringify(canonicalOverrides) !== fields.overrides) return { ok: false, error: "overrides are not canonical JSON" };
-  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
+  if (canonicalJson(canonicalOverrides) !== fields.overrides) return { ok: false, error: "overrides are not canonical JSON" };
+  let bounds = null;
+  if (Object.hasOwn(fields, "bounds")) {
+    const parsed = parseBounds(fields.bounds);
+    if (parsed.error) return { ok: false, error: parsed.error };
+    bounds = parsed.bounds;
+  }
+  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, element: Object.hasOwn(fields, "element") ? fields.element : null, bounds, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
 }
 
 function labelValue(labels, prefix, allowed) {
@@ -126,29 +223,35 @@ export function buildIssueIndex(issues, { generatedAt = new Date().toISOString()
   for (const issue of issues ?? []) {
     const identity = canonicalIssueUrl(issue?.html_url ?? issue?.url);
     if (!identity) { onError(issue, "invalid issue URL"); continue; }
-    const parsed = parseLocator(issue?.body);
+    const parsed = parseLocators(issue?.body);
     if (!parsed.ok && parsed.error === NO_LOCATOR) {
       const labelled = Boolean(labelValue(issue?.labels, "area:", AREA) ?? labelValue(issue?.labels, "parity:", PARITY));
       onSkip(issue, { labelled });
       continue;
     }
     if (!parsed.ok) { onError(issue, parsed.error); continue; }
-    if (parsed.locator.repository !== identity.repository) { onError(issue, "locator repository does not match issue URL"); continue; }
-    const row = {
-      repository: identity.repository,
-      number: identity.number,
-      title: String(issue?.title ?? "").trim(),
-      url: identity.url,
-      state: issue?.state === "closed" ? "closed" : "open",
-      area: labelValue(issue?.labels, "area:", AREA),
-      parity: labelValue(issue?.labels, "parity:", PARITY),
-      system: parsed.locator.system,
-      component: parsed.locator.component,
-      previewIds: [parsed.locator.previewId],
-      referenceIds: [parsed.locator.referenceId],
-    };
-    if (!row.title) { onError(issue, "missing title"); continue; }
-    byIdentity.set(`${row.repository}/${row.number}`, row);
+    if (parsed.locators[0].repository !== identity.repository) { onError(issue, "locator repository does not match issue URL"); continue; }
+    const title = String(issue?.title ?? "").trim();
+    if (!title) { onError(issue, "missing title"); continue; }
+    // One row per locator, so an umbrella issue reaches every component it names. The row carries
+    // the identity only: a selection recorded in the locator belongs to the acceptance that cites
+    // it, not to an index whose whole job is "which issues touch this component".
+    for (const locator of parsed.locators) {
+      const row = {
+        repository: identity.repository,
+        number: identity.number,
+        title,
+        url: identity.url,
+        state: issue?.state === "closed" ? "closed" : "open",
+        area: labelValue(issue?.labels, "area:", AREA),
+        parity: labelValue(issue?.labels, "parity:", PARITY),
+        system: locator.system,
+        component: locator.component,
+        previewIds: [locator.previewId],
+        referenceIds: [locator.referenceId],
+      };
+      byIdentity.set(`${row.repository}/${row.number}#${row.component}`, row);
+    }
   }
-  return { schema: ISSUES_SCHEMA, generatedAt, issues: [...byIdentity.values()].sort((a, b) => a.repository.localeCompare(b.repository) || a.number - b.number) };
+  return { schema: ISSUES_SCHEMA, generatedAt, issues: [...byIdentity.values()].sort((a, b) => a.repository.localeCompare(b.repository) || a.number - b.number || a.component.localeCompare(b.component)) };
 }

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -84,6 +84,25 @@ function canonicalJson(value) {
   return JSON.stringify(Object.fromEntries(Object.keys(value).sort(compareCodePoints).map((key) => [key, value[key]])));
 }
 
+/**
+ * `element` is a **JSON string**, not a bare value, and that is load-bearing rather than tidy.
+ *
+ * The block is line-oriented `key: value`, so a bare tag containing a newline does not stay one
+ * field: `row\nrevision: injected` parses as element `row` plus a revision nobody wrote, and a tag
+ * carrying a fence delimiter can end the block early and take the whole issue out of the index. Tag
+ * indexes preserve arbitrary strings, so the writer cannot assume the tag is well-behaved. JSON
+ * quoting makes every such value expressible and unambiguous — and, incidentally, is the only way a
+ * tag with leading or trailing whitespace survives a format whose readers trim.
+ */
+function parseElement(raw) {
+  let element;
+  try { element = JSON.parse(raw); } catch { return { error: "element must be a JSON string" }; }
+  if (typeof element !== "string") return { error: "element must be a JSON string" };
+  if (element === "") return { error: "empty locator field(s): element" };
+  if (JSON.stringify(element) !== raw) return { error: "element is not canonical JSON" };
+  return { element };
+}
+
 function parseBounds(raw) {
   let bounds;
   try { bounds = JSON.parse(raw); } catch { return { error: "invalid bounds JSON" }; }
@@ -150,9 +169,16 @@ export function parseLocators(body) {
     if (locator.system !== first.system) return { ok: false, error: "locator blocks disagree about the system" };
   }
   const components = new Set();
+  const previews = new Set();
   for (const locator of locators) {
     if (components.has(locator.component)) return { ok: false, error: `duplicate component in locator blocks: ${locator.component}` };
     components.add(locator.component);
+    // A served preview belongs to one component, and `issuesForPreview` matches rows by preview id
+    // as well as by component — so two blocks claiming one preview put the same issue on that
+    // preview's page twice and make its badge say two issues. That is a mistyped body, not a shape
+    // the index should carry.
+    if (previews.has(locator.previewId)) return { ok: false, error: `duplicate preview in locator blocks: ${locator.previewId}` };
+    previews.add(locator.previewId);
   }
   return { ok: true, locators };
 }
@@ -196,13 +222,19 @@ function parseLocatorBlock(content) {
   if (!overrides || Array.isArray(overrides) || typeof overrides !== "object") return { ok: false, error: "overrides must be an object" };
   const canonicalOverrides = Object.fromEntries(Object.keys(overrides).sort(compareCodePoints).map((key) => [key, overrides[key]]));
   if (canonicalJson(canonicalOverrides) !== fields.overrides) return { ok: false, error: "overrides are not canonical JSON" };
+  let element = null;
+  if (Object.hasOwn(fields, "element")) {
+    const parsed = parseElement(fields.element);
+    if (parsed.error) return { ok: false, error: parsed.error };
+    element = parsed.element;
+  }
   let bounds = null;
   if (Object.hasOwn(fields, "bounds")) {
     const parsed = parseBounds(fields.bounds);
     if (parsed.error) return { ok: false, error: parsed.error };
     bounds = parsed.bounds;
   }
-  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, element: Object.hasOwn(fields, "element") ? fields.element : null, bounds, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
+  return { ok: true, locator: { repository: fields.repository.toLowerCase(), system: fields.system, component: fields.component, previewId: fields.preview, referenceId: fields.reference, variant: fields.variant, overrides: canonicalOverrides, element, bounds, revision: Object.hasOwn(fields, "revision") ? fields.revision : null } };
 }
 
 function labelValue(labels, prefix, allowed) {

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { NO_LOCATOR, buildIssueIndex, canonicalIssueUrl, parseLocator } from "./parity-issues.mjs";
+import { NO_LOCATOR, buildIssueIndex, canonicalIssueUrl, parseLocator, parseLocators } from "./parity-issues.mjs";
 
 const body = `Difference details.\n\n\`\`\`compose-parity-locator/v1
 repository: yschimke/m3-catalog
@@ -16,7 +16,7 @@ revision: yschimke/m3-catalog@main
 \`\`\``;
 
 test("a locator round-trips the exact identity and canonical overrides", () => {
-  assert.deepEqual(parseLocator(body), { ok: true, locator: { repository: "yschimke/m3-catalog", system: "m3", component: "IconButton/Tonal", previewId: "iconbutton-tonal__ideal__default__light", referenceId: "iconbutton-tonal-figma", variant: "ideal/default/light", overrides: { fontScale: "1.5", "knob.label": "Send;now=x" }, revision: "yschimke/m3-catalog@main" } });
+  assert.deepEqual(parseLocator(body), { ok: true, locator: { repository: "yschimke/m3-catalog", system: "m3", component: "IconButton/Tonal", previewId: "iconbutton-tonal__ideal__default__light", referenceId: "iconbutton-tonal-figma", variant: "ideal/default/light", overrides: { fontScale: "1.5", "knob.label": "Send;now=x" }, element: null, bounds: null, revision: "yschimke/m3-catalog@main" } });
 });
 
 test("mangled blocks are reported instead of silently skipped", () => {
@@ -98,8 +98,10 @@ test("a locator that fails to close is broken, not absent", () => {
   assert.deepEqual(skips, [], "a broken locator must never be skipped");
   // A body that merely names the fence in prose still carries no locator.
   assert.equal(parseLocator("I pasted a compose-parity-locator/v1 block once.").error, NO_LOCATOR);
-  // And a good block followed by a dangling opener is ambiguous, not usable.
-  assert.equal(parseLocator(shared.cases[0].block + "\n```compose-parity-locator/v1\nrepository: a/b\n").error, "multiple locator blocks");
+  // And a good block followed by a dangling opener is a body with an unclosed block in it. Since a
+  // body may now carry several blocks, the openers and the complete fences are counted against each
+  // other: more openers than fences means one of them never closed, whichever one it was.
+  assert.equal(parseLocator(shared.cases[0].block + "\n```compose-parity-locator/v1\nrepository: a/b\n").error, "unterminated locator block");
 });
 
 test("a fence indented the way CommonMark allows is still a locator", () => {
@@ -115,4 +117,66 @@ test("a fence indented the way CommonMark allows is still a locator", () => {
   assert.equal(parseLocator(indent(good.block, 4)).error, NO_LOCATOR);
   // An indented block that fails to close is still broken rather than absent.
   assert.equal(parseLocator("  ```compose-parity-locator/v1\n  repository: a/b\n").error, "unterminated locator block");
+});
+
+for (const shape of shared.bodies) {
+  test(`shared locator fixture body: ${shape.name}`, () => {
+    assert.deepEqual(parseLocators(shape.body), shape.parse, shape.why);
+  });
+}
+
+test("an umbrella issue reaches every component it names", () => {
+  // m3-catalog#42's shape: one issue, three components, one row each. The index row is keyed by
+  // issue AND component, so `issuesForPreview`'s component join lights up all three pages from one
+  // report instead of an arbitrary one of them.
+  const umbrella = shared.bodies.find((shape) => shape.name === "umbrella-two-components");
+  const index = buildIssueIndex(
+    [{ html_url: "https://github.com/yschimke/m3-catalog/issues/42", title: "Elevated shadow level", body: umbrella.body, state: "open", labels: [{ name: "area:component" }] }],
+    { generatedAt: "2026-08-15T10:00:00Z" },
+  );
+  assert.deepEqual(index.issues.map((row) => row.component), ["Button/Elevated", "Card/Elevated"]);
+  assert.deepEqual([...new Set(index.issues.map((row) => row.number))], [42], "the rows are one issue");
+  assert.deepEqual(index.issues.map((row) => row.previewIds[0]), ["button-elevated__ideal__default__light", "card-elevated__ideal__default__light__compact"]);
+  // Every row carries the issue's own facts; only the locator half differs between them.
+  for (const row of index.issues) {
+    assert.equal(row.title, "Elevated shadow level");
+    assert.equal(row.area, "component");
+    assert.equal(row.state, "open");
+  }
+});
+
+test("a body whose blocks contradict each other is rejected, not half-indexed", () => {
+  for (const name of ["umbrella-repeats-a-component", "umbrella-disagrees-about-the-repository"]) {
+    const shape = shared.bodies.find((body) => body.name === name);
+    const errors = [];
+    const index = buildIssueIndex(
+      [{ html_url: "https://github.com/yschimke/m3-catalog/issues/42", title: "Elevated shadow level", body: shape.body, state: "open" }],
+      { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error) },
+    );
+    assert.deepEqual(index.issues, [], name);
+    assert.deepEqual(errors, [shape.parse.error], name);
+  }
+});
+
+test("a broken block names which one it is, once there is more than one", () => {
+  const umbrella = shared.bodies.find((shape) => shape.name === "umbrella-two-components");
+  const damaged = umbrella.body.replace("component: Card/Elevated", "component Card/Elevated");
+  assert.equal(parseLocators(damaged).error, "locator block 2: malformed locator line: component Card/Elevated");
+  // With a single block there is no ordinal worth carrying — the error is about the only locator.
+  assert.match(parseLocators(shared.cases[0].block.replace("system:", "system")).error, /^malformed locator line:/);
+});
+
+test("the reserved selection fields round-trip, and refuse a rectangle with no settled space", () => {
+  // Nothing writes these until batch 03. They are reserved now because adding a key to a frozen v1
+  // afterwards is rejected by a strict parser and silently discarded by a permissive one — and both
+  // engines here are permissive, so the selection would have vanished with no error at all.
+  const reserved = shared.cases.find((shape) => shape.name === "element-and-bounds");
+  const parsed = parseLocator(reserved.block);
+  assert.equal(parsed.locator.element, "glyph");
+  assert.deepEqual(parsed.locator.bounds, { height: 24, space: "render-pixels", width: 24, x: 18, y: 18 });
+  // A blank value is a mangled body rather than an absent field.
+  assert.equal(parseLocator(reserved.block.replace("element: glyph", "element:")).error, "empty locator field(s): element");
+  // Extent has to be real: a zero-width rectangle selects nothing but would suppress its own row.
+  assert.match(parseLocator(reserved.block.replace('"width":24', '"width":0')).error, /positive extent|not canonical/);
+  assert.match(parseLocator(reserved.block.replace('"x":18', '"x":-1')).error, /non-negative integer|not canonical/);
 });

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -174,9 +174,29 @@ test("the reserved selection fields round-trip, and refuse a rectangle with no s
   const parsed = parseLocator(reserved.block);
   assert.equal(parsed.locator.element, "glyph");
   assert.deepEqual(parsed.locator.bounds, { height: 24, space: "render-pixels", width: 24, x: 18, y: 18 });
-  // A blank value is a mangled body rather than an absent field.
-  assert.equal(parseLocator(reserved.block.replace("element: glyph", "element:")).error, "empty locator field(s): element");
+  // A blank value is a mangled body rather than an absent field, quoted or not.
+  assert.equal(parseLocator(reserved.block.replace('element: "glyph"', "element:")).error, "empty locator field(s): element");
+  assert.equal(parseLocator(reserved.block.replace('"glyph"', '""')).error, "empty locator field(s): element");
+  // The tag is a JSON string precisely so it cannot become syntax: a newline inside it stays inside
+  // it, instead of opening a field the reporter never wrote.
+  const injected = shared.cases.find((shape) => shape.name === "element-with-a-newline");
+  const parsedInjection = parseLocator(injected.block);
+  assert.equal(parsedInjection.locator.element, "row\nrevision: injected");
+  assert.equal(parsedInjection.locator.revision, null, "the injected line is part of the tag, not a field");
   // Extent has to be real: a zero-width rectangle selects nothing but would suppress its own row.
   assert.match(parseLocator(reserved.block.replace('"width":24', '"width":0')).error, /positive extent|not canonical/);
   assert.match(parseLocator(reserved.block.replace('"x":18', '"x":-1')).error, /non-negative integer|not canonical/);
+});
+
+test("two blocks may not claim the same preview", () => {
+  // `issuesForPreview` matches rows by preview id as well as by component, so one preview named by
+  // two blocks would show the same issue twice on that page and count two in its badge.
+  const shape = shared.bodies.find((body) => body.name === "umbrella-repeats-a-preview");
+  const errors = [];
+  const index = buildIssueIndex(
+    [{ html_url: "https://github.com/yschimke/m3-catalog/issues/42", title: "Elevated shadow level", body: shape.body, state: "open" }],
+    { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error) },
+  );
+  assert.deepEqual(index.issues, []);
+  assert.deepEqual(errors, [shape.parse.error]);
 });


### PR DESCRIPTION
## Summary

Two `v1` wire decisions from #3680, settled and implemented together because they touch the same two engines and one shared fixture — and because both get more expensive with every report filed against the frozen contract.

### One issue may name several components

m3-catalog#42's Elevated shadow level covers `Button/`, `Card/` and `ToggleButton/Elevated`; a block names one component, so the issue could not be indexed at all. A body may now carry **one block per component**: `parseLocators` reads every fence and the index emits **one row per block**, keyed by issue *and* component. The blocks must agree — one `repository`, one `system`, no component twice — because two rows with one identity collapse against each other.

Splitting the umbrella into one issue per component was the alternative; rejected because it multiplies the backlog and loses the one fact that matters most about those issues, that they share a cause.

**The reader was half of this, and the half that would have been missed.** `ServeParityIssuesStore.sanitize` deduped with `distinctBy { it.repository to it.number }` *before* anything component-aware ran, so the producer's rows collapsed to an arbitrary one at load time and the umbrella issue still reached exactly one component page — the silent half of the failure. Identity is now repository + number + component in both engines. The parity dashboard's "Components with open issues (N)" counted rows, which this change would have made wrong (one issue naming three components would read as three); it counts components now.

### `element` and `bounds` are reserved

Batch 01 required both as optional fields **before** the writer, the parser and the shared fixture froze. Phase 1 shipped without them, and both parsers ignore unknown keys — so a batch-03 report carrying a selection would have been indexed with the selection dropped and no error anywhere. Nothing writes them yet; batch 03 (#3803) fills them.

`bounds` names its plane rather than being a bare rectangle:

```
bounds: {"height":24,"space":"render-pixels","width":24,"x":18,"y":18}
```

**D1 is answered (a)** — both tag-index producers publish render pixels and the canonical-plane transform belongs to the *comparison*, a plane being a property of a comparison and the index a property of a render. So `v1` accepts `render-pixels` and refuses any other space rather than storing the guess that makes an element which never moved report as `moved`. Canonical JSON on the same code-point key rule the overrides already carry.

### The fixture is still the thing that keeps the engines honest

`scripts/design-artifacts/fixtures/parity-locators.json` gains a writer case for the reserved fields, two negative `bounds` cases (wrong space, non-canonical key order), and a new `bodies` section carrying three whole issue bodies for `parseLocators`. Kotlin asserts the writer emits those bytes; the producer asserts it parses them back. Neither side can move the contract without failing the other's test.

## Decisions recorded

`COMPONENT_PARITY_WORKFLOW.md` §2 documents both changes; §7's open questions become **settled**, including two the code doesn't touch:

- **An acceptance may be geometric**, with an element gate required wherever an element exists. Requiring it outright would make #41 inexpressible until the bar's parts are tagged; refusing masks above a coverage fraction was rejected as the global threshold the non-goals rule out. Batch 04 must carry both shapes.
- **Upstream-ergonomics reports are indexed** (#89, #93) — they can never carry an acceptance, but a reader asking "why can't I name this size?" is standing on the component page.

`00-decisions.md` records D1's answer; batches 01 and 03 are corrected (01 notes the requirement it shipped without; 03 no longer blocks on the plane question, and its "these must be declared in batch 01" section now says they already are).

## Test plan

- `node --test scripts/design-artifacts/parity-issues.test.mjs` — **24 pass**, up from 12. New: the three fixture bodies, an umbrella issue producing one row per component with the issue's own facts on each, contradictory bodies rejected rather than half-indexed, block ordinals in errors once there is more than one block, and the reserved fields round-tripping while a rectangle in another space is refused.
- Confirmed the new tests do not pass against the unpatched producer: with `parity-issues.mjs` stashed the suite cannot even load (`parseLocators` does not exist), and the per-case fixture assertions fail individually once it does.
- `./gradlew :cli:test --tests "*ServeIssueReportTest*" --tests "*ServeParityIssuesStoreTest*" --tests "*ServeWebFixtureTest*" --tests "*ServeCatalogStoreTest*"` — 0 failures across all four XML reports. New Kotlin cases: the writer emitting one block per component of an umbrella body, `bounds` refused unless it names the settled plane, and a reader case proving three components of one issue survive while a true duplicate still collapses.
- `./gradlew :cli:ktfmtCheck` clean.

Not a visual change — wire format, producer/reader plumbing and their fixtures. No rendered surface is touched; the one UI line that changes is the dashboard's component count, which is exercised by `ServeWebFixtureTest`.

Refs #3680, #3803, #3807.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VX7zLzArzh11fpgG2fkgqm)_