### PR TITLE
fix(scroll): truncate the GIF before re-encoding into it

### DIFF
--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.scroll
 
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.RandomAccessFile
 import javax.imageio.IIOImage
 import javax.imageio.ImageIO
 import javax.imageio.ImageTypeSpecifier
@@ -67,9 +68,17 @@ object ScrollGifEncoder {
     // same size as the 46-frame one, carrying 62KB of the old render inside it. That makes the
     // artifact a function of the build directory's history rather than of its frames, which costs
     // reproducibility and quietly misleads any byte-level comparison of two renders.
-    // [ee.schimke.composeai.daemon.GifEncoder] already deletes; these two encoders should not
-    // disagree about it.
-    outputFile.delete()
+    //
+    // `setLength(0)` rather than `delete()`, because the two need different permissions and only
+    // one of them matches what the write itself needs. Unlinking needs write+execute on the
+    // PARENT DIRECTORY; truncating and writing need write on the FILE. So in a directory that
+    // does not permit unlinking — a sticky `/tmp`, a read-only output dir holding a writable file
+    // — `delete()` returns `false`, nothing checks it, `FileImageOutputStream` opens and
+    // overwrites anyway, and the stale tail survives the fix that was supposed to remove it.
+    // Truncating in place cannot fail where the encode below would succeed, and it throws rather
+    // than returning a boolean, so a genuine permission problem surfaces instead of being encoded
+    // into the artifact.
+    RandomAccessFile(outputFile, "rw").use { it.setLength(0L) }
     FileImageOutputStream(outputFile).use { stream ->
       writer.output = stream
       val param: ImageWriteParam = writer.defaultWriteParam

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
@@ -58,6 +58,18 @@ object ScrollGifEncoder {
     val disposal = disposalMethodFor(frames)
 
     outputFile.parentFile?.mkdirs()
+    // Truncate, rather than write over whatever is there. `FileImageOutputStream` opens a
+    // `RandomAccessFile` in "rw" mode, which does NOT truncate: re-encoding a shorter sequence into
+    // an existing longer file leaves the previous encode's tail past the GIF trailer. Decoders stop
+    // at the trailer and show the right animation, so the only symptom is a file whose LENGTH is
+    // the high-water mark of every render that ever wrote it — measured on `wear-m3-catalog`'s
+    // placeholder recordings, a 28-frame re-render of a 46-frame capture came out byte-for-byte the
+    // same size as the 46-frame one, carrying 62KB of the old render inside it. That makes the
+    // artifact a function of the build directory's history rather than of its frames, which costs
+    // reproducibility and quietly misleads any byte-level comparison of two renders.
+    // [ee.schimke.composeai.daemon.GifEncoder] already deletes; these two encoders should not
+    // disagree about it.
+    outputFile.delete()
     FileImageOutputStream(outputFile).use { stream ->
       writer.output = stream
       val param: ImageWriteParam = writer.defaultWriteParam

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoderDisposalTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoderDisposalTest.kt
@@ -73,6 +73,45 @@ class ScrollGifEncoderDisposalTest {
     )
   }
 
+  /**
+   * Re-encoding into an existing, LONGER file must leave nothing of it behind.
+   *
+   * `FileImageOutputStream` wraps a `RandomAccessFile` opened "rw", which overwrites from offset 0
+   * without truncating. A shorter sequence written over a longer file therefore ends at its own GIF
+   * trailer with the previous encode still sitting past it — invisible to every decoder, and enough
+   * to make the artifact's size a function of what the output directory held before rather than of
+   * the frames handed in. Caught on `wear-m3-catalog`, where a 28-frame re-render of a 46-frame
+   * placeholder capture came out at exactly the 46-frame file's byte count.
+   *
+   * Asserted as "the same frames encode to the same bytes whatever was there first", which is the
+   * property that matters, rather than as "the file got shorter".
+   */
+  @Test
+  fun `re-encoding a shorter sequence does not keep the previous encode's tail`() {
+    val fresh = tmp.newFile("fresh.gif")
+    ScrollGifEncoder.encode(frames = opaqueFrames().take(2), outputFile = fresh, frameDelayMs = 40)
+
+    val reused = tmp.newFile("reused.gif")
+    ScrollGifEncoder.encode(frames = opaqueFrames(), outputFile = reused, frameDelayMs = 40)
+    val longLength = reused.length()
+    ScrollGifEncoder.encode(frames = opaqueFrames().take(2), outputFile = reused, frameDelayMs = 40)
+
+    assertTrue(
+      "fixture is not exercising the bug: the 3-frame encode ($longLength) must be longer " +
+        "than the 2-frame one (${fresh.length()})",
+      longLength > fresh.length(),
+    )
+    assertEquals(
+      "re-encoding kept bytes of the longer encode past its own trailer",
+      fresh.length(),
+      reused.length(),
+    )
+    assertTrue(
+      "same frames, same delays — the bytes must not depend on what the file held first",
+      fresh.readBytes().contentEquals(reused.readBytes()),
+    )
+  }
+
   /** One opaque 8×8 square stepping across an otherwise transparent 40×16 canvas. */
   private fun translucentFrames(): List<BufferedImage> =
     listOf(0, 12, 24).map { x ->


### PR DESCRIPTION
## What was wrong

`ScrollGifEncoder.encode` opens `FileImageOutputStream(outputFile)` on whatever is already at that
path. That wraps a `RandomAccessFile` in `"rw"` mode, which overwrites from offset 0 and **does not
truncate**. Re-encoding a shorter sequence into an existing longer file therefore ends at its own
GIF trailer with the previous encode still sitting past it.

Every decoder stops at the trailer, so the animation is correct and nothing fails. The symptom is
the file's *length*: it becomes the high-water mark of every render that ever wrote that path.

## How it surfaced

On `wear-m3-catalog`, cutting a placeholder motion capture from 46 frames to 28 produced a file
that was **byte-for-byte the same size** as the 46-frame one — 578089 both times, with ~62KB of the
previous render inside the new file. It happened for all three placeholder recordings at once
(578089, 302162, 156958 before and after), which is what made it obvious it was not a coincidence.
Deleting `build/compose-previews/renders/` and re-rendering the identical previews wrote 516034 /
218735 / 110747.

That makes a rendered artifact a function of the output directory's history rather than of the
frames handed in — it costs reproducibility, and it quietly misleads any byte-level comparison of
two renders, which is what a visual-diff workflow is built on.

## The fix

`RandomAccessFile(outputFile, "rw").setLength(0)` before opening the stream — truncate in place.

It started as `outputFile.delete()`, which review correctly flagged: that returns a boolean nothing
was checking, and it can return `false` in exactly the environment where the encode that follows
still succeeds. The two operations need different permissions — unlinking needs write+execute on
the *parent directory*, truncating and writing need write on the *file* — so in a directory that
forbids unlinking (a sticky `/tmp`, a read-only output dir holding a writable file) the delete
fails silently and the stale tail survives the fix meant to remove it. Truncating in place needs
exactly what the encode needs, so it cannot fail where the encode would succeed, and it throws
rather than returning a boolean.

`daemon/core/.../GifEncoder.kt` has the same unchecked `delete()` ahead of its own
`FileImageOutputStream`. Left alone here to keep this change minimal; worth the same treatment in a
follow-up.

## The test

Asserts the property rather than the symptom: the same frames at the same delays must encode to the
same bytes whether or not something longer was there first. It also asserts the fixture is actually
exercising the bug (the 3-frame encode really is longer than the 2-frame one), so it cannot pass
vacuously.

Confirmed to fail on the unfixed encoder:

```
ScrollGifEncoderDisposalTest > re-encoding a shorter sequence does not keep the previous encode's tail FAILED
```

Nothing extra covers the unlink-permission case. An inode-identity assertion was written and
dropped — it passes against the unfixed `delete()` too, because the filesystem reuses the inode of
a file recreated immediately in the same directory (verified, not assumed). Building the permission
scenario directly is no better in a suite that may run as root, where POSIX checks are skipped.

## Verification

```
./gradlew :data-scroll-core:test :data-scroll-core:ktfmtCheck
```

green with the fix, red without it.