### PR TITLE
fix(design-artifacts): measure a reference's placement, never estimate it

### DIFF
--- a/docs/design/evidence/reference-content-placement/README.md
+++ b/docs/design/evidence/reference-content-placement/README.md
@@ -92,14 +92,24 @@ knows for a fact from the placement it just performed, so it passes that in:
 
 All 107 cells in the issue are the first kind; the checkbox residue is the second.
 
+One place the check cannot speak, and says so rather than inventing an answer: a catalog publishing
+with `--reference-backdrop`. The reference's box is measured before the backdrop goes on, but the
+sticker's cannot be — a `showBackground` preview is opaque edge to edge, so its alpha bounds the
+watch face and never the component. Those pairs are counted in the tally as out of scope instead of
+comparing 1:1 by construction.
+
 `splitbutton-filled__ideal__xl` is the case that shows the uniform test working. Its reference is
 371x126 against a 1049x105 render — but the kit node is 400x136 with no empty margin anywhere, so
 the placement has nothing to crop and this change does not move it. Width ratio 0.35 against height
 ratio 1.2 is not uniform, so the gate leaves it to `geometry`: the kit's XL split button is 136dp
 tall and the render's is 40dp, which is a defect in the component, not in the export.
 
-One rounding note, because it is easy to get wrong and invisible when you do: the placed dimensions
-are rounded before the resample, so the offset has to be measured against the scale that was
-actually applied rather than the one that was asked for. Against the unrounded factor, a 300-unit
-vector fitted to 151px published as 150 — a column short, silently. `centreOn` derives the offset
-from `placedWidth / width` and clamps content that fits so the rounding cannot push it off an edge.
+One note on the arithmetic, because it is easy to get wrong and invisible when you do: **nothing
+about the placement is estimated from `scale`.** The raster is resampled first and the content's box
+is then read off the result, and the offset and the fits-or-not clamp both come from that. Two
+different bugs came from estimating it instead, each costing a row or column with no sign anywhere:
+centring on the unrounded factor published a 300-unit vector fitted to 151px as 150, and a `ceil` on
+a fractional edge reported a content box that really occupied 25 rows as 26, read that as "does not
+fit", skipped the clamp meant to protect it and cropped it. The measurement is windowed to the rect
+the caller nominated, so naming a sub-rect of a raster that draws more than one thing still means
+what it says.

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -413,6 +413,8 @@ fs.mkdirSync(referencesDir, { recursive: true });
 let written = 0;
 /** Published references whose content is a uniform rescale of their sticker's; see reference-scale.mjs. */
 const scaleFindings = [];
+/** References standing on a declared stage, whose sticker's alpha cannot locate its component. */
+let stagedScaleChecks = 0;
 /** How the backdrop landed, for the summary — silence would read as "every reference got one". */
 const backdropTally = { disc: 0, frame: 0, skipped: 0 };
 /** Reference id -> a `{ layout }` shim; `referenceAnnotations` reads only that field. */
@@ -532,9 +534,17 @@ for (const record of records) {
     }
   }
 
+  // Measured BEFORE any backdrop, and this is not an ordering detail. A backdrop fills the sticker's
+  // whole stage — a watch face, a full frame — so afterwards the alpha channel bounds the ground
+  // rather than the component, on both sides, and every such pair would compare 1:1 no matter how
+  // far apart the two components actually were. Everything else that moves the artwork (the fit,
+  // the placement) has already happened by here, so this is still what the lane will see.
+  const drawnBox = alphaBounds(raster.data, raster.width, raster.height);
+
   // Lay the sticker's own ground under the artwork, last, so it covers the letterboxing the fit may
   // just have added: the scorer crops to the content box, and a reference whose box is the artwork
   // alone gets blown up to the size of a watch face before it is compared with one.
+  let onStage = false;
   if (BACKDROP) {
     const stage = stickerStage(record, target);
     if (stage) {
@@ -543,15 +553,18 @@ for (const record of records) {
         data: applyBackdrop(raster.data, raster.width, raster.height, stage, BACKDROP),
       };
       backdropTally[stage.kind]++;
+      onStage = true;
     } else {
       backdropTally.skipped++;
     }
   }
 
-  // Checked on the PUBLISHED pixels rather than on the source raster, so a backdrop, a fit and a
-  // placement are all already in it — this asks what the comparison lane will actually see.
-  const drawnBox = alphaBounds(raster.data, raster.width, raster.height);
-  const stickerBox = stickerContent(record);
+  // The sticker's side of that problem has no fix here: a `showBackground` preview is opaque edge
+  // to edge, so its alpha locates the ground and never the component, and there is nothing to
+  // compare the reference's box against. Say so in the tally rather than publishing a 1:1 that was
+  // never measured.
+  const stickerBox = onStage ? null : stickerContent(record);
+  if (onStage) stagedScaleChecks++;
   const finding = scaleFinding(drawnBox, stickerBox);
   if (finding) {
     const verdict = scaleVerdict(rescaledHere);
@@ -588,6 +601,13 @@ if (scaleFindings.length > 0) {
     `design-references: ${scaleFindings.length} of ${written} published reference(s) draw their ` +
       `component at a uniform scale from their sticker's — ${exports} rescaled by this export, ` +
       `${scaleFindings.length - exports} published at full density and still a different size`,
+  );
+}
+if (stagedScaleChecks > 0) {
+  console.log(
+    `design-references: ${stagedScaleChecks} reference(s) stand on a declared stage, so their ` +
+      `sticker's alpha bounds the ground rather than the component and the scale check does not ` +
+      `apply to them`,
   );
 }
 

--- a/scripts/design-artifacts/png-resample.mjs
+++ b/scripts/design-artifacts/png-resample.mjs
@@ -158,19 +158,42 @@ export function alphaBounds(data, width, height) {
 }
 
 /**
- * Where to start drawing a `placed`-long axis so that the content between `from` and `from + span`
- * (in source units, scaled by `scale`) sits centred in `target`.
- *
- * Clamped so that content which fits is never pushed off the edge by the resample's rounding. When
- * it does not fit — the content is larger than the canvas and something has to go — the fractional
- * edge is what goes, and the clamp does not apply.
+ * The tight box of non-transparent pixels inside `region` of an RGBA raster, or null when it holds
+ * none. Windowed rather than whole-raster so a caller that deliberately nominates a sub-rect keeps
+ * its meaning: only the artwork it named decides the placement.
  */
-function centreOn(from, span, scale, placed, target) {
-  const start = Math.floor(from * scale);
-  const end = Math.min(placed, Math.ceil((from + span) * scale));
-  let offset = Math.floor((target - span * scale) / 2 - from * scale);
-  if (end - start <= target) offset = Math.min(Math.max(offset, -start), target - end);
-  return offset;
+function drawnBoundsIn(data, width, region) {
+  let minX = region.x1;
+  let minY = region.y1;
+  let maxX = -1;
+  let maxY = -1;
+  for (let y = region.y0; y < region.y1; y++) {
+    const row = y * width * 4;
+    for (let x = region.x0; x < region.x1; x++) {
+      if (data[row + x * 4 + 3] === 0) continue;
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+  }
+  if (maxX < 0) return null;
+  return { x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1 };
+}
+
+/**
+ * Where to start drawing a `placed`-long axis so the content occupying `[start, start + size)` of
+ * it sits centred in `target`, clamped so content that fits is never pushed off an edge.
+ *
+ * `start` and `size` are measured in the RESAMPLED raster, not estimated from the source by the
+ * scale. Estimating was wrong twice over: once against the unrounded factor, and once more when a
+ * `ceil` on a fractional edge reported a 25-row content box as 26, skipped the clamp as "does not
+ * fit", and cropped the row it was protecting.
+ */
+function centreOn(start, size, target) {
+  const offset = Math.floor((target - size) / 2) - start;
+  if (size > target) return offset;
+  return Math.min(Math.max(offset, -start), target - (start + size));
 }
 
 /**
@@ -202,24 +225,36 @@ export function placeRgba(data, width, height, targetWidth, targetHeight, conten
   const scale = Math.min(1, targetWidth / keep.width, targetHeight / keep.height);
   const placedWidth = Math.max(1, Math.round(width * scale));
   const placedHeight = Math.max(1, Math.round(height * scale));
-  // Centre the CONTENT on the canvas, then say where that puts the frame around it.
-  //
-  // Measured against the scale the resample ACTUALLY applied, not the one asked for: the placed
-  // dimensions are rounded, and offsetting by the unrounded factor pushed a content box that was
-  // meant to fill the canvas a pixel past its edge — a 300-unit vector fitted to 151px published
-  // as 150, one column short, with no sign of it anywhere.
-  const scaleX = placedWidth / width;
-  const scaleY = placedHeight / height;
-  const box = {
-    width: placedWidth,
-    height: placedHeight,
-    x: centreOn(keep.x, keep.width, scaleX, placedWidth, targetWidth),
-    y: centreOn(keep.y, keep.height, scaleY, placedHeight, targetHeight),
-  };
   const placed =
     placedWidth === width && placedHeight === height
       ? data
       : resampleRgba(data, width, height, placedWidth, placedHeight);
+
+  // Where the content actually ended up, read off the resampled raster. The placed dimensions are
+  // rounded and a bilinear edge lands where it lands, so anything derived from `scale` alone is an
+  // estimate — and an estimate a pixel out either crops the artwork or mis-centres it.
+  const scaleX = placedWidth / width;
+  const scaleY = placedHeight / height;
+  const window = {
+    x0: Math.max(0, Math.floor(keep.x * scaleX) - 1),
+    y0: Math.max(0, Math.floor(keep.y * scaleY) - 1),
+    x1: Math.min(placedWidth, Math.ceil((keep.x + keep.width) * scaleX) + 1),
+    y1: Math.min(placedHeight, Math.ceil((keep.y + keep.height) * scaleY) + 1),
+  };
+  const drawn = drawnBoundsIn(placed, placedWidth, window) ?? {
+    x: window.x0,
+    y: window.y0,
+    width: Math.max(1, window.x1 - window.x0),
+    height: Math.max(1, window.y1 - window.y0),
+  };
+
+  // Centre the CONTENT on the canvas, then say where that puts the frame around it.
+  const box = {
+    width: placedWidth,
+    height: placedHeight,
+    x: centreOn(drawn.x, drawn.width, targetWidth),
+    y: centreOn(drawn.y, drawn.height, targetHeight),
+  };
   if (box.width === targetWidth && box.height === targetHeight && box.x === 0 && box.y === 0) {
     return { data: placed, box };
   }

--- a/scripts/design-artifacts/png-resample.test.mjs
+++ b/scripts/design-artifacts/png-resample.test.mjs
@@ -216,3 +216,23 @@ test("placeRgba keeps content that exactly fits, despite the resample's rounding
   const { data: out } = placeRgba(data, 380, 380, 151, 151, content);
   assert.deepEqual(alphaBounds(out, 151, 151), { x: 0, y: 0, width: 151, height: 151 });
 });
+
+test("placeRgba keeps content that fits after an asymmetric reduction", () => {
+  // A tall narrow artwork in the corner of a much larger raster: the reduction rounds 63 -> 30, and
+  // the content really occupies 25 of those rows. Estimating it from the scale said 26, read that
+  // as "does not fit", skipped the clamp and cropped the top row.
+  const content = { x: 0, y: 0, width: 10, height: 53 };
+  const data = raster(50, 63, (x, y) => (x < 10 && y < 53 ? [0, 0, 0, 255] : [0, 0, 0, 0]));
+  const { data: out } = placeRgba(data, 50, 63, 25, 25, content);
+  assert.deepEqual(alphaBounds(out, 25, 25), { x: 10, y: 0, width: 5, height: 25 });
+});
+
+test("placeRgba nominates only the content it was given", () => {
+  // Two separated marks; the caller names the left one. The right one is drawn but must not decide
+  // the placement — otherwise a deliberately narrowed rect silently means nothing.
+  const data = raster(40, 10, (x, y) =>
+    (x < 4 && y < 10) || (x >= 36 && y < 10) ? [0, 0, 0, 255] : [0, 0, 0, 0],
+  );
+  const { box } = placeRgba(data, 40, 10, 20, 10, { x: 0, y: 0, width: 4, height: 10 });
+  assert.equal(box.x, 8);
+});


### PR DESCRIPTION
Follow-up to #4429, which auto-merged before these two review findings were addressed. Both are real; both are pixel-level defects in code that PR added.

## 1. The placement was estimated from `scale`, and rounding lives between

`placeRgba` derived both the offset and the fits-or-not clamp from the requested scale. Two separate roundings sit between that number and where the artwork actually ends up, and each cost a row or column, silently:

- centring on the **unrounded** factor published a 300-unit vector fitted to 151px as **150** (fixed in #4429);
- a `ceil` on a fractional edge then reported a content box that really occupies **25** rows as 26, read that as "does not fit", skipped the clamp that exists to protect it, and cropped the row. A 50x63 raster with 10x53 content at (0,0) onto 25x25 published **5x24**.

So nothing is estimated any more: the raster is resampled **first** and the content's box is read off the result, with the offset and the clamp both derived from that. The read is windowed to the rect the caller nominated, so naming a sub-rect of a raster that draws more than one thing still means what it says.

```
asym 50x63->25x25    5x25     (was 5x24)
380->151             151x151
shape 998->252       252x252
button ->219x84      218x84
```

## 2. The scale check could not work under `--reference-backdrop`

`applyBackdrop` fills the sticker's whole stage — a watch face, a full frame — so afterwards the alpha channel bounds the *ground* rather than the component, on both sides. Every backdrop-enabled pair therefore compared 1:1 by construction, however far apart the two components actually were, and wear-m3-catalog would have got a diagnostic that could only ever say "fine".

The reference's box is now measured **before** the backdrop goes on. The sticker's cannot be measured at all — a `showBackground` preview is opaque edge to edge — so those pairs are counted in the tally as out of scope rather than reported as a match nobody took:

```
design-references: N reference(s) stand on a declared stage, so their sticker's alpha bounds the
ground rather than the component and the scale check does not apply to them
```

## Visual evidence

No change: the published geometry for every m3-catalog cell in #4429 is byte-identical after this, which is the point — these fix cases that PR's own evidence did not reach. The replay over the merged pipeline still gives 218x84, 74x84, 53x53, 252x252 and 47x47 against renders of 219x84, 74x84, 53x53, 252x252 and 55x53, and the committed evidence image is unchanged.

## Test plan

- `node --test scripts/design-artifacts/png-resample.test.mjs scripts/design-artifacts/reference-scale.test.mjs scripts/design-artifacts/reference-layout.test.mjs` — 43 pass, on top of merged `main`.
- Two new cases: the asymmetric reduction that was cropping a row, and one proving a nominated sub-rect still decides the placement when the raster draws something else too.
- Re-ran the m3-catalog replay against the merged pipeline; all five documented cells unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U23fPGqtbE97WZcm9SBaLr)_