### PR TITLE
fix(parity): allow a signed bounds origin, refuse a reused reference, fix the pilot counts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReport.kt
@@ -178,7 +178,13 @@ internal object ServeIssueReport {
      */
     init {
       require(space == RENDER_PIXELS) { "bounds space must be $RENDER_PIXELS, was $space" }
-      require(x >= 0 && y >= 0) { "bounds origin must be non-negative, was ($x, $y)" }
+      // The origin may be **negative**, deliberately: a uniquely tagged node can extend above or
+      // left of the render root, and both tag-index producers emit signed coordinates for that case
+      // — `ServeSemanticsTags` asks only for `right > left` / `bottom > top`, `tag-index.mjs`
+      // parses
+      // `-?\d+`, and `ServeTagIndex` validates only the extent. Requiring a non-negative origin
+      // here would mean batch 03 could not copy the bounds the index handed it. Clipping is the
+      // comparison's plane transform's business, not this constructor's.
       require(width >= 1 && height >= 1) {
         "bounds must have a positive extent, was ${width}x$height"
       }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeIssueReportTest.kt
@@ -316,7 +316,7 @@ class ServeIssueReportTest {
     val written =
       fixture["cases"]!!.jsonArray.map { it.jsonObject }.filter { it.containsKey("writer") }
     // A fixture that silently stopped carrying writer cases would pass every assertion below.
-    assertEquals(6, written.size, "the fixture must keep exercising the writer")
+    assertEquals(7, written.size, "the fixture must keep exercising the writer")
     for (case in written) {
       val name = case["name"]!!.jsonPrimitive.content
       val writer = case["writer"]!!.jsonObject
@@ -490,9 +490,10 @@ class ServeIssueReportTest {
     assertFailsWith<IllegalArgumentException> {
       ServeIssueReport.Bounds(x = 0, y = 0, width = 24, height = 24, space = "display-pixels")
     }
-    assertFailsWith<IllegalArgumentException> {
-      ServeIssueReport.Bounds(x = -1, y = 0, width = 24, height = 24)
-    }
+    // A negative origin is NOT invalid: a tagged node can extend above or left of the render root,
+    // and both tag-index producers publish signed coordinates for exactly that. Refusing it would
+    // leave batch 03 unable to record the bounds the index handed it.
+    assertEquals(-4, ServeIssueReport.Bounds(x = -4, y = -2, width = 24, height = 24).x)
     assertFailsWith<IllegalArgumentException> {
       ServeIssueReport.Bounds(x = 0, y = 0, width = 0, height = 24)
     }

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -423,19 +423,21 @@ because they lead different places.
 | [#40](https://github.com/yschimke/m3-catalog/issues/40) | `IconButton/Tonal` glyph colour | **yes** | one component, one preview, a 23.6% pixel delta inside the glyph |
 | [#41](https://github.com/yschimke/m3-catalog/issues/41) | `ShortNavigationBar` measures items at full bar width | **yes** | one component, one preview (`__compact`) |
 | [#87](https://github.com/yschimke/m3-catalog/issues/87) | `Checkbox` box padding 2dp vs 4dp | **yes** | one component, one preview |
-| [#42](https://github.com/yschimke/m3-catalog/issues/42) | Elevated shadow level | no — but see §4 | names **three** components — `Button/Elevated`, `Card/Elevated`, `ToggleButton/Elevated`. Not indexable whole; still three acceptance sites |
+| [#42](https://github.com/yschimke/m3-catalog/issues/42) | Elevated shadow level | **expressible since the erratum** | names **three** components — `Button/Elevated`, `Card/Elevated`, `ToggleButton/Elevated` — so its body carries three blocks and the index three rows. Three acceptance sites too |
 | [#91](https://github.com/yschimke/m3-catalog/issues/91) | no hover/press state drawn | no | **five** components, and the variants it is about are deliberately *not authored* — there is no preview id to name |
 | [#85](https://github.com/yschimke/m3-catalog/issues/85) | `DropdownMenu` corner 4dp vs 16dp | no | the catalog publishes **no menu component**: no `images/menu-*`, no reference, no preview |
 | [#95](https://github.com/yschimke/m3-catalog/issues/95) | menu container colour and item icon size | no | same — the subject is not in the bundle |
 | [#86](https://github.com/yschimke/m3-catalog/issues/86) | expanded full-screen search corner | no | `Search/Bar` publishes `default`, `query`, `avatar` and `container-docked`; the full-screen view is not among them |
 | [#89](https://github.com/yschimke/m3-catalog/issues/89) | no slider size scale on `SliderDefaults` | not yet — **a choice, not a limit** | the size previews exist and score **98.1–99.5%**: the catalog transcribed the kit's numbers by hand, so a locator would name a comparison that matches. Indexable whenever we want it on the page; what it cannot have is an acceptance |
-| [#93](https://github.com/yschimke/m3-catalog/issues/93) | no `ButtonDefaults.SmallContainerHeight`, no default FAB icon size | not yet — **a choice**, plus two families | same missing-constant shape, no pixel delta, and it spans `Button/*` and `Fab/*` |
+| [#93](https://github.com/yschimke/m3-catalog/issues/93) | no `ButtonDefaults.SmallContainerHeight`, no default FAB icon size | not yet — **a choice** | same missing-constant shape and no pixel delta; spanning `Button/*` and `Fab/*` stopped being a limit once a body could carry a block each |
 
 Two limits and one judgement, and only the last is about masks:
 
-1. **One issue, several components** (#42, #93, and #91 as well as its other problem). The locator
-   carries exactly one `component` and one `preview`, and the index row is keyed by issue number, so
-   an umbrella report can join to at most one component page. `previewIds` / `referenceIds` are arrays on the row, which suggests the shape
+1. **One issue, several components** (#42, #93, and #91 as well as its other problem). *Solved by
+   the erratum, and left here because it is what the measurement found.* The locator carried exactly
+   one `component` and one `preview` and the index row was keyed by issue number, so an umbrella
+   report could join to at most one component page. A body now carries one block per component and
+   the index a row per block. `previewIds` / `referenceIds` are arrays on the row, which suggests the shape
    was anticipated; the *writer* has no way to fill them. Note that `issuesForPreview` already joins
    on `component` as well as on the exact preview id, so an indexed issue surfaces on **every**
    preview of its component — the gap is across components, not across variants.
@@ -454,18 +456,19 @@ Two limits and one judgement, and only the last is about masks:
    limit (1) again. What neither can have is an **acceptance**: they describe a constant the library
    does not publish, and the renders already match. Indexing them is a question about whether an
    upstream-ergonomics report belongs on a component page. §4's population is the smaller number
-   either way: **four issues could carry a locator today (#40, #41, #87, #89), and four are
-   acceptance candidates across six sites (#40, #41, #87, and #42 three times)** — different counts
-   answering different questions, and not even the same four.
+   either way: **six issues can carry a locator (#40, #41, #87, #89, and — since the erratum — #42
+   and #93), and four are acceptance candidates across six sites (#40, #41, #87, and #42 three
+   times)** — different counts answering different questions, and not even the same issues.
 
-**What this means for §4 — and note that §4 counts differently from §3.** An index row is one issue
-on one component; an acceptance is one preview, and §4's closure rule is built on the fact that
-**several acceptances may point at one tracking issue** ("mandatory per acceptance but not *unique*
-to one"). So the two halves of this epic disagree about #42 on purpose: it cannot be indexed whole,
-and it is still three acceptances — `button-elevated`, `card-elevated`,
-`togglebutton-elevated` at 81.2%, 87.0% and 81.5% published match — sharing issue #42, closable only
-once all three resolve. The acceptance population is therefore **four issues and six sites** (#40,
-#41, #87, and #42 three times), not the three rows in the index.
+**What this means for §4 — and note that §4 still counts differently from §3.** An index row is one
+issue on one component; an acceptance is one preview, and §4's closure rule is built on the fact
+that **several acceptances may point at one tracking issue** ("mandatory per acceptance but not
+*unique* to one"). The erratum aligned the two for #42 — three blocks, three rows, three acceptances
+(`button-elevated`, `card-elevated`, `togglebutton-elevated` at 81.2%, 87.0% and 81.5% published
+match), closable only once all three resolve — but the counts still differ, because an issue can be
+indexable with nothing to accept (#89, #93) and an acceptance is per *preview* rather than per
+component. The acceptance population is **four issues and six sites** (#40, #41, #87, and #42 three
+times) against six indexable issues.
 
 The model is designed around #40 — a small mask over one element, a recorded accepted-candidate
 crop, the gates of the evaluation order — and #40 fits it exactly. But of those six sites only #40's

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -77,14 +77,17 @@ Batches 01 and 02 were merged and unreachable for a while: nothing *called* them
 the acceptance schema is for, and it came out smaller and more awkward than "a dozen known
 differences" suggests. Two counts, and they are not the same number:
 
-- **Four of m3-catalog's ten can carry a locator** — #40, #41 and #87 do; #89 could, and is left out
-  only because there is nothing to accept in it. Of the rest, three (#85, #95, #86) are about
-  components this catalog does not publish, #91's variants are unauthored, and #42 and #93 name
-  several components each, which one locator cannot say.
+- **Six of m3-catalog's ten can carry a locator, now that a body may carry one block per
+  component** — #40, #41 and #87 already do; #42 (three blocks) and #93 (two) became expressible
+  with the erratum below; #89 could, and is left out only because there is nothing to accept in it.
+  The four that remain out are not a locator problem: #85, #95 and #86 are about components this
+  catalog does not publish, and #91's variants are unauthored, so after any split each piece still
+  has no preview to name.
 - **Four are acceptance candidates, across six sites** — #40, #41, #87, plus #42 three times over:
-  an acceptance is per preview, and §4 lets several of them share one tracking issue, so the case
-  the index cannot hold whole is still three acceptances. Only #40's mask is glyph-sized; #41's is
-  most of the bar, #87's a 2dp ring, and #42's a shadow surrounding each component.
+  an acceptance is per preview, and §4 lets several of them share one tracking issue. Only #40's
+  mask is glyph-sized; #41's is most of the bar, #87's a 2dp ring, and #42's a shadow surrounding
+  each component. #93 is indexable but has no pixel delta to accept, which is why the two counts
+  still name different issues.
 
 The per-issue verdicts and what each implies are in
 [the pilot population](../COMPONENT_PARITY_WORKFLOW.md#the-pilot-population-measured); batch 00's D5

--- a/scripts/design-artifacts/fixtures/parity-locators.json
+++ b/scripts/design-artifacts/fixtures/parity-locators.json
@@ -256,6 +256,50 @@
           "revision": null
         }
       }
+    },
+    {
+      "name": "bounds-above-the-render-root",
+      "why": "A uniquely tagged node can extend above or left of the render root, and both tag-index producers emit signed coordinates for it. A validator refusing a negative origin would mean batch 03 could not copy the bounds it was handed; clipping belongs to the comparison's plane transform.",
+      "writer": {
+        "repository": "yschimke/m3-catalog",
+        "system": "m3-catalog",
+        "componentId": "IconButton/Tonal",
+        "previewId": "iconbutton-tonal__ideal__default__light",
+        "referenceId": "iconbutton-tonal-figma",
+        "variant": "ideal/default/light",
+        "overrides": {},
+        "element": "glyph",
+        "bounds": {
+          "space": "render-pixels",
+          "x": -4,
+          "y": -2,
+          "width": 24,
+          "height": 24
+        },
+        "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+      },
+      "block": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: IconButton/Tonal\npreview: iconbutton-tonal__ideal__default__light\nreference: iconbutton-tonal-figma\nvariant: ideal/default/light\noverrides: {}\nelement: \"glyph\"\nbounds: {\"height\":24,\"space\":\"render-pixels\",\"width\":24,\"x\":-4,\"y\":-2}\nrevision: yschimke/m3-catalog@design-artifacts/m3-catalog\n```\n",
+      "parse": {
+        "ok": true,
+        "locator": {
+          "repository": "yschimke/m3-catalog",
+          "system": "m3-catalog",
+          "component": "IconButton/Tonal",
+          "previewId": "iconbutton-tonal__ideal__default__light",
+          "referenceId": "iconbutton-tonal-figma",
+          "variant": "ideal/default/light",
+          "overrides": {},
+          "element": "glyph",
+          "bounds": {
+            "height": 24,
+            "space": "render-pixels",
+            "width": 24,
+            "x": -4,
+            "y": -2
+          },
+          "revision": "yschimke/m3-catalog@design-artifacts/m3-catalog"
+        }
+      }
     }
   ],
   "bodies": [
@@ -339,6 +383,15 @@
       "parse": {
         "ok": false,
         "error": "duplicate preview in locator blocks: button-elevated__ideal__default__light"
+      }
+    },
+    {
+      "name": "umbrella-repeats-a-reference",
+      "why": "DesignReference.id is unique within a served session and the focused comparison selects rows by it, so two blocks sharing one reference would render the same issue twice on that page.",
+      "body": "```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Button/Elevated\npreview: button-elevated__ideal__default__light\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light\noverrides: {}\n```\n```compose-parity-locator/v1\nrepository: yschimke/m3-catalog\nsystem: m3-catalog\ncomponent: Card/Elevated\npreview: card-elevated__ideal__default__light__compact\nreference: button-elevated__ideal__default__light\nvariant: ideal/default/light/compact\noverrides: {}\n```\n",
+      "parse": {
+        "ok": false,
+        "error": "duplicate reference in locator blocks: button-elevated__ideal__default__light"
       }
     }
   ]

--- a/scripts/design-artifacts/parity-issues.mjs
+++ b/scripts/design-artifacts/parity-issues.mjs
@@ -113,9 +113,14 @@ function parseBounds(raw) {
   }
   if (bounds.space !== BOUNDS_SPACE) return { error: `bounds space must be ${BOUNDS_SPACE}` };
   for (const key of ["x", "y", "width", "height"]) {
-    const value = bounds[key];
-    if (!Number.isSafeInteger(value) || value < 0) return { error: `bounds ${key} must be a non-negative integer` };
+    if (!Number.isSafeInteger(bounds[key])) return { error: `bounds ${key} must be an integer` };
   }
+  // The **origin may be negative**: a uniquely tagged node can extend above or left of the render
+  // root, and both tag-index producers emit signed coordinates for exactly that case
+  // (`ServeSemanticsTags` asks only for `right > left` / `bottom > top`, `tag-index.mjs` parses
+  // `-?\d+`, and `ServeTagIndex` validates only the extent). Refusing a signed origin here would
+  // mean batch 03 could not copy the bounds it was handed. Clipping belongs to the comparison's
+  // plane transform, not to this validator.
   if (bounds.width < 1 || bounds.height < 1) return { error: "bounds must have a positive extent" };
   // Same rule the overrides carry: the block is canonical bytes, so a record and its re-serialised
   // form are comparable without parsing. A hand-edited body that reorders the keys is refused
@@ -170,6 +175,7 @@ export function parseLocators(body) {
   }
   const components = new Set();
   const previews = new Set();
+  const references = new Set();
   for (const locator of locators) {
     if (components.has(locator.component)) return { ok: false, error: `duplicate component in locator blocks: ${locator.component}` };
     components.add(locator.component);
@@ -179,6 +185,11 @@ export function parseLocators(body) {
     // the index should carry.
     if (previews.has(locator.previewId)) return { ok: false, error: `duplicate preview in locator blocks: ${locator.previewId}` };
     previews.add(locator.previewId);
+    // Same reasoning for the reference: `DesignReference.id` is unique within a served session, and
+    // the focused comparison selects rows by it, so two blocks sharing one reference would render
+    // the same issue twice on that comparison's page.
+    if (references.has(locator.referenceId)) return { ok: false, error: `duplicate reference in locator blocks: ${locator.referenceId}` };
+    references.add(locator.referenceId);
   }
   return { ok: true, locators };
 }

--- a/scripts/design-artifacts/parity-issues.test.mjs
+++ b/scripts/design-artifacts/parity-issues.test.mjs
@@ -185,13 +185,27 @@ test("the reserved selection fields round-trip, and refuse a rectangle with no s
   assert.equal(parsedInjection.locator.revision, null, "the injected line is part of the tag, not a field");
   // Extent has to be real: a zero-width rectangle selects nothing but would suppress its own row.
   assert.match(parseLocator(reserved.block.replace('"width":24', '"width":0')).error, /positive extent|not canonical/);
-  assert.match(parseLocator(reserved.block.replace('"x":18', '"x":-1')).error, /non-negative integer|not canonical/);
+  // A negative origin is valid: a tagged node can sit above or left of the render root, and the tag
+  // index publishes signed coordinates for it.
+  const above = shared.cases.find((shape) => shape.name === "bounds-above-the-render-root");
+  assert.deepEqual(parseLocator(above.block).locator.bounds, { height: 24, space: "render-pixels", width: 24, x: -4, y: -2 });
 });
 
 test("two blocks may not claim the same preview", () => {
   // `issuesForPreview` matches rows by preview id as well as by component, so one preview named by
   // two blocks would show the same issue twice on that page and count two in its badge.
   const shape = shared.bodies.find((body) => body.name === "umbrella-repeats-a-preview");
+  const errors = [];
+  const index = buildIssueIndex(
+    [{ html_url: "https://github.com/yschimke/m3-catalog/issues/42", title: "Elevated shadow level", body: shape.body, state: "open" }],
+    { generatedAt: "2026-08-15T10:00:00Z", onError: (_, error) => errors.push(error) },
+  );
+  assert.deepEqual(index.issues, []);
+  assert.deepEqual(errors, [shape.parse.error]);
+});
+
+test("two blocks may not claim the same reference", () => {
+  const shape = shared.bodies.find((body) => body.name === "umbrella-repeats-a-reference");
   const errors = [];
   const index = buildIssueIndex(
     [{ html_url: "https://github.com/yschimke/m3-catalog/issues/42", title: "Elevated shadow level", body: shape.body, state: "open" }],


### PR DESCRIPTION
## Summary

Three review findings that arrived after #4426 auto-merged, so they land as a follow-up rather than on that branch. The first would have blocked the batch the reserved fields exist for.

### A tagged element can sit above or left of the render root

`Bounds` required a non-negative origin. Both tag-index producers publish **signed** coordinates for exactly that case, and nothing downstream objects:

| Producer / reader | What it checks |
| --- | --- |
| `ServeSemanticsTags.hasArea()` | `right > left && bottom > top` — nothing about sign |
| `scripts/design-artifacts/tag-index.mjs` | parses `-?\d+` |
| `ServeTagIndex` | rejects only `width <= 0 \|\| height <= 0` |

So batch 03 could not have copied the bounds the index handed it: construction would have thrown, and the producer would have refused the report. The origin may be negative now; width and height must still be positive, and clipping stays the comparison's plane transform's business, per D1. Fixture case `bounds-above-the-render-root` carries `{"height":24,"space":"render-pixels","width":24,"x":-4,"y":-2}` through both engines.

### Two blocks may not reuse a reference

`DesignReference.id` is unique within a served session and `handleReferenceComparison` selects rows by it, so two blocks sharing one would render the same umbrella issue twice on that comparison — the same failure the duplicate-preview check already covered, one field over.

### The pilot counts contradicted the decision recorded below them

`parity-batches/README.md` still said four issues can carry a locator and that #42 and #93 "name several components each, which one locator cannot say" — true before the erratum, false in the same file that then explains a body may carry one block per component. It is **six** now (#40, #41, #87, #89, #42, #93); the four that remain out are not a locator problem (#85, #95, #86 are unpublished components, #91's variants are unauthored). §3's table and the §7 bullet say the same. The acceptance count stays **four issues across six sites**, because an issue can be indexable with nothing to accept — that is why the two numbers still name different issues.

## Test plan

- `node --test scripts/design-artifacts/parity-issues.test.mjs` — **31 pass** (was 28): the signed-origin fixture, and a body reusing a reference refused rather than half-indexed.
- `./gradlew :cli:test --tests "*ServeIssueReportTest*" --tests "*ServeWebParityIssueBandTest*" --tests "*ServeParityIssuesStoreTest*"` — 0 failures. The Kotlin assertion that a negative origin throws is now the assertion that it round-trips, and the fixture's writer-case count moves 6 → 7.
- `./gradlew :cli:ktfmtCheck` clean.
- Verified after rebasing onto `main` (post-#4426), not just on the branch it was written against.

Not a visual change — wire validation, one producer rule, and docs.

Refs #3680, #3803.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VX7zLzArzh11fpgG2fkgqm)_