### PR TITLE
test(serve): probe the hero's real side overhang, not two pixels inside the card

### DIFF
--- a/vscode-extension/preview-harness/pages-snapshot.spec.mjs
+++ b/vscode-extension/preview-harness/pages-snapshot.spec.mjs
@@ -4099,8 +4099,12 @@ test("contract · the front door's state layer stays under the hero, and the bre
       hitTag: hit?.tagName,
       hitHref: hit?.getAttribute("href"),
       imgTop: img.top,
-      // The hero is wider than the card once scaled — that overhang is what the side probe uses.
-      overhangs: img.width > cb.width && img.top < cb.top,
+      cardRight: cb.right,
+      imgRight: img.right,
+      // The hero is wider AND taller than the card once scaled — those two overhangs are what the
+      // probes below stand on. Asserted, because a fixture whose hero does not actually break out
+      // would make both of them vacuous while still passing.
+      overhangs: img.right > cb.right && img.top < cb.top,
     };
   });
 
@@ -4126,13 +4130,27 @@ test("contract · the front door's state layer stays under the hero, and the bre
   // …and the artwork has not retracted under the pointer standing on it.
   expect(strip.imgTop).toBeCloseTo(inside.imgTop, 0);
 
-  // The side overhang, which reaches over the neighbouring tile's column.
-  await page.mouse.move(box.x + box.width - 2, box.y + 60);
-  expect(
-    await page.evaluate(() =>
-      document.querySelector(".cp-syslist .cp-card").matches(":hover"),
-    ),
-  ).toBe(true);
+  // The side overhang, which reaches over the neighbouring tile's column. Derived from the hovered
+  // image's own right edge, NOT from the card's width: a probe a couple of pixels inside the card
+  // is still over the stretched link overlay, so it would stay green even if the overhang lost
+  // hit-testing entirely — which is the one thing this probe exists to catch.
+  const sideProbeX = (inside.cardRight + inside.imgRight) / 2;
+  expect(sideProbeX).toBeGreaterThan(inside.cardRight);
+  await page.mouse.move(sideProbeX, box.y + 60);
+  const side = await page.evaluate((x) => {
+    const c = document.querySelector(".cp-syslist .cp-card");
+    const hit = document.elementFromPoint(x, c.getBoundingClientRect().top + 60);
+    return {
+      hovered: c.matches(":hover"),
+      // The pointer must be past the card's own box, or it is not on the overhang at all.
+      pastCard: x > c.getBoundingClientRect().right,
+      // …and what it lands on has to belong to THIS card, not the neighbour it paints over.
+      inThisCard: c.contains(hit),
+    };
+  }, sideProbeX);
+  expect(side.pastCard).toBe(true);
+  expect(side.inThisCard).toBe(true);
+  expect(side.hovered).toBe(true);
 });
 
 test("contract · a catalog's sub-groups share rows instead of each claiming one", async ({


### PR DESCRIPTION
Follow-up to #4430, which auto-merged before this landed on it. No production code changes — this repairs one assertion in the contract test that PR added.

## The problem

`contract · the front door's state layer stays under the hero, and the break-out keeps its hover` ends by walking the pointer onto the hero's **side** overhang — the strip of scaled artwork that reaches past the card and over the neighbouring tile's column — and asserting the card stays hovered. It measured that point from the card's own width:

```js
await page.mouse.move(box.x + box.width - 2, box.y + 60);
```

which is two pixels *inside* the card, and therefore over `.cp-sys-open::after`, the stretched link overlay. The assertion would have stayed green even if the real overhang lost hit-testing entirely — precisely the regression the probe was written to catch. Caught by the Codex review bot on #4430.

## The fix

Derive the point from the hovered image's own right edge instead, and assert the geometry the probe depends on rather than assuming it:

- `sideProbeX` is the midpoint between the card's right edge and the scaled image's right edge;
- `side.pastCard` asserts the pointer really is beyond the card's box;
- `side.inThisCard` asserts what it lands on belongs to *this* card, not the neighbour it paints over;
- `side.hovered` is the original claim, now standing on the other three.

The `overhangs` precondition earlier in the test also moves from `img.width > cb.width` to `img.right > cb.right`, since the right edge is what the probe now uses.

## Test plan

- `npx playwright test -c preview-harness/playwright.config.mjs snapshot` — 200 captures, green.
- Verified the probe is no longer vacuous: with the strip probe silenced and only `pointer-events: none` restored on the hero (the exact condition it exists to catch), it fails on its own at `expect(side.inThisCard).toBe(true)`. Before this change, that same mutation left the side probe passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Y1nCzTCsXUSiuuUciTqi)_