### PR TITLE
fix(semantics): finish honouring `placed` across every consumer of the tree

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTags.kt
@@ -88,6 +88,11 @@ object ServeSemanticsTags {
   fun index(payload: ComposeSemanticsPayload): Map<String, TagEntry> {
     val out = LinkedHashMap<String, TagEntry>()
     fun walk(node: ComposeSemanticsNode) {
+      // A trial-measured copy is not a second use of the tag: it was never placed, so it is not on
+      // the frame and its bounds read as the origin. Counting it publishes `count = 2` for a tag
+      // that identifies exactly one node, which a scoped parity consumer rejects as ambiguous.
+      // See `ComposeSemanticsNode.placed`.
+      if (!node.placed) return
       // Blank-or-absent decides *omission*; the key is then the tag VERBATIM. Trimming it would be
       // a second identity rule, and Compose (and `SemanticsTargets.Tag`) match the exact string —
       // so normalising here collapses `"item"` and `" item "` into one entry reporting `count = 2`

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTagsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSemanticsTagsTest.kt
@@ -23,9 +23,44 @@ class ServeSemanticsTagsTest {
     id: String,
     bounds: String,
     testTag: String? = null,
+    placed: Boolean = true,
     children: List<ComposeSemanticsNode> = emptyList(),
   ) =
-    ComposeSemanticsNode(nodeId = id, boundsInRoot = bounds, testTag = testTag, children = children)
+    ComposeSemanticsNode(
+      nodeId = id,
+      boundsInRoot = bounds,
+      testTag = testTag,
+      placed = placed,
+      children = children,
+    )
+
+  @Test
+  fun `a trial-measured copy of a tag is not a second use of it`() {
+    // A `SubcomposeLayout` measuring a trial copy of its content to choose a layout (Wear
+    // `AlertDialogContent`) duplicates every tag in the tree. The copy was never placed, so it is
+    // not on the frame — counting it reports `count = 2` for a tag that identifies exactly one
+    // node, and a scoped parity acceptance then rejects it as ambiguous.
+    val root =
+      node(
+        "root",
+        "0,0,200,200",
+        children =
+          listOf(
+            node("real", "10,10,60,40", testTag = "submit"),
+            node(
+              "trial",
+              "0,0,120,60",
+              placed = false,
+              children = listOf(node("trial-child", "0,0,50,30", testTag = "submit")),
+            ),
+          ),
+      )
+
+    val entry = index(root)["submit"]
+
+    assertEquals(1, entry?.count)
+    assertEquals(AnnotationBounds(10, 10, 50, 30), entry?.bounds)
+  }
 
   private fun index(root: ComposeSemanticsNode) =
     ServeSemanticsTags.index(ComposeSemanticsPayload(root))

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
@@ -81,6 +81,9 @@ fun resolvedNodeText(node: ComposeSemanticsNode): String? {
     }
   val parts = mutableListOf<String>()
   fun collect(n: ComposeSemanticsNode) {
+    // The assertion compares against what the user sees, so an unplaced trial copy must not
+    // contribute its string — it was measured and never drawn. See `ComposeSemanticsNode.placed`.
+    if (!n.placed) return
     n.text?.takeIf { it.isNotEmpty() }?.let { parts.add(it) }
     n.children.forEach(::collect)
   }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingAssertionsTest.kt
@@ -106,6 +106,24 @@ class RecordingAssertionsTest {
   }
 
   @Test
+  fun resolved_node_text_ignores_an_unplaced_trial_copy() {
+    // The assertion compares against what the user sees. A `SubcomposeLayout` trial measure (Wear
+    // `AlertDialogContent`) leaves a second copy of the container's text in the tree that was
+    // measured and never drawn; merging it in would assert against "Submit\nSubmit".
+    val container =
+      node(
+        testTag = "submit",
+        text = null,
+        children =
+          listOf(
+            node(text = "Submit"),
+            node(placed = false, children = listOf(node(text = "Submit"))),
+          ),
+      )
+    assertEquals("Submit", resolvedNodeText(container))
+  }
+
+  @Test
   fun resolved_node_text_is_null_when_nothing_has_text() {
     assertEquals(null, resolvedNodeText(node(testTag = "empty", text = null)))
   }
@@ -177,6 +195,7 @@ class RecordingAssertionsTest {
   private fun node(
     testTag: String? = null,
     text: String? = null,
+    placed: Boolean = true,
     children: List<ComposeSemanticsNode> = emptyList(),
   ): ComposeSemanticsNode =
     ComposeSemanticsNode(
@@ -184,6 +203,7 @@ class RecordingAssertionsTest {
       boundsInRoot = "",
       testTag = testTag,
       text = text,
+      placed = placed,
       children = children,
     )
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -908,6 +908,11 @@ object ComposeSemanticsDataProducer {
  */
 fun ComposeSemanticsNode.toProbeNodes(): List<RecordingProbeNode> = buildList {
   fun visit(node: ComposeSemanticsNode) {
+    // A trial-measured subtree is a second copy of content the frame draws once, and it was never
+    // placed. Probing it gives the recording backend duplicate matches: `assert.textEquals` fails
+    // as ambiguous, and `assert.notVisible` fails for content that was never drawn. See
+    // `ComposeSemanticsNode.placed`.
+    if (!node.placed) return
     val testTag = node.testTag?.takeIf { it.isNotBlank() }
     val text = node.text?.takeIf { it.isNotBlank() }
     val contentDescription = node.label?.takeIf { it.isNotBlank() && it != text }
@@ -952,6 +957,9 @@ fun ComposeSemanticsNode.toProbeNodes(): List<RecordingProbeNode> = buildList {
 private fun ComposeSemanticsNode.mergedDescendantText(): String? {
   val parts = mutableListOf<String>()
   fun collect(n: ComposeSemanticsNode) {
+    // Compose's merged semantics announce what is on screen, so an unplaced trial copy must not
+    // contribute — it would double the container's text. See `ComposeSemanticsNode.placed`.
+    if (!n.placed) return
     n.text?.takeIf { it.isNotBlank() }?.let { parts.add(it) }
     n.children.forEach(::collect)
   }

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsProbeNodesTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsProbeNodesTest.kt
@@ -14,6 +14,7 @@ class ComposeSemanticsProbeNodesTest {
     label: String? = null,
     role: String? = null,
     clickable: Boolean = false,
+    placed: Boolean = true,
     children: List<ComposeSemanticsNode> = emptyList(),
   ) =
     ComposeSemanticsNode(
@@ -24,8 +25,48 @@ class ComposeSemanticsProbeNodesTest {
       label = label,
       role = role,
       clickable = clickable,
+      placed = placed,
       children = children,
     )
+
+  @Test
+  fun anUnplacedTrialSubtreeIsNotProbed() {
+    // Wear `AlertDialogContent` subcomposes a trial copy of the whole dialog to choose a layout and
+    // never places it. Probing that copy gives the recording backend two matches for one on-screen
+    // control: `assert.textEquals` fails as ambiguous, and `assert.notVisible` fails for content
+    // that was never drawn.
+    val probes =
+      node(
+          "root",
+          children =
+            listOf(
+              node("real", testTag = "submit", text = "Submit"),
+              node("trial", placed = false, children = listOf(node("ghost", text = "Submit"))),
+            ),
+        )
+        .toProbeNodes()
+
+    assertEquals(listOf("submit"), probes.mapNotNull { it.testTag })
+    assertEquals(listOf("Submit"), probes.mapNotNull { it.text })
+  }
+
+  @Test
+  fun anUnplacedDescendantDoesNotDoubleAContainersMergedText() {
+    val probes =
+      node(
+          "button",
+          role = "Button",
+          clickable = true,
+          children =
+            listOf(
+              node("label", text = "Add"),
+              node("trial", placed = false, children = listOf(node("ghost", text = "Add"))),
+            ),
+        )
+        .toProbeNodes()
+
+    assertEquals("Add", probes.first { it.role == "Button" }.mergedText)
+  }
 
   @Test
   fun flattensOnlyNodesWithAStableFinder() {

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -37,6 +37,10 @@ object PreviewSlots {
   fun extractSlots(payload: ComposeSemanticsPayload): List<PreviewSlot> {
     val out = mutableListOf<PreviewSlot>()
     fun walk(node: ComposeSemanticsNode) {
+      // A slot marker inside a trial-measured subtree marks nothing: it was never placed, so it has
+      // no box, and publishing it duplicates the real slot at the origin. See
+      // `ComposeSemanticsNode.placed`.
+      if (!node.placed) return
       val tag = node.testTag
       if (tag != null && tag.startsWith(SLOT_TAG_PREFIX)) {
         val parts = tag.removePrefix(SLOT_TAG_PREFIX).split(ATTR_SEP)

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
@@ -31,6 +31,13 @@ object SemanticsDiff {
       "text" to { it.text },
       "mergeMode" to { it.mergeMode },
       "clickable" to { it.clickable.toString() },
+      // Deliberately COMPARED rather than pruned, unlike every drawing/targeting consumer of this
+      // tree. Those answer "what is on the frame?", so a subtree a `SubcomposeLayout` measured and
+      // never placed is noise to them. A diff answers "what changed?", and a node leaving the frame
+      // is the most interesting thing that can happen to it — pruning would report that as no
+      // change at all when `placed` is the only field that moved. Reporting it as a field change
+      // keeps the ref in the map and names what happened. See `ComposeSemanticsNode.placed`.
+      "placed" to { it.placed.toString() },
       "editableText" to { it.editableText },
       "inputText" to { it.inputText },
       "layoutTruncated" to { it.textOverflow?.truncated?.toString() },

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
@@ -29,6 +29,15 @@ object SemanticsRefs {
   fun assign(payload: ComposeSemanticsPayload): ComposeSemanticsPayload =
     ComposeSemanticsPayload(root = assign(payload.root), density = payload.density)
 
+  /**
+   * Assigns over the WHOLE tree, including any subtree that was measured but never placed — the one
+   * walk here that deliberately does not prune on [ComposeSemanticsNode.placed].
+   *
+   * A ref is an identity, not a claim that the node is on the frame: it has to mean the same thing
+   * in every payload the node appears in, or a stored ref stops addressing the same node the moment
+   * a `SubcomposeLayout` changes which arrangement it places. Consumers that care about the frame
+   * (`SemanticsTargets`, the annotation and wireframe walks) filter at the point of use instead.
+   */
   fun assign(root: ComposeSemanticsNode): ComposeSemanticsNode = assignNode(root, ROOT_REF)
 
   /** The anchor token for a node, before sibling disambiguation. */

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher.kt
@@ -162,6 +162,10 @@ object WearScrollSliceStitcher {
   private fun uniqueTextTops(root: ComposeSemanticsNode): Map<String, Int> {
     val rows = mutableListOf<Pair<String, Int>>()
     fun walk(n: ComposeSemanticsNode) {
+      // A trial-measured copy repeats a string that occurs once on the frame, which makes it
+      // non-unique and DROPS it from the anchor set — costing the alignment its best anchors.
+      // See `ComposeSemanticsNode.placed`.
+      if (!n.placed) return
       val t = n.text?.takeIf { it.isNotBlank() } ?: n.layoutText?.takeIf { it.isNotBlank() }
       val b = n.boundsInRoot.split(",").mapNotNull { it.trim().toIntOrNull() }
       if (t != null && b.size == 4 && b[3] > b[1]) rows.add(t to b[1])

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlotsTest.kt
@@ -9,8 +9,41 @@ class PreviewSlotsTest {
   private fun node(
     tag: String? = null,
     bounds: String = "0,0,0,0",
+    placed: Boolean = true,
     children: List<ComposeSemanticsNode> = emptyList(),
-  ) = ComposeSemanticsNode(nodeId = "0", boundsInRoot = bounds, testTag = tag, children = children)
+  ) =
+    ComposeSemanticsNode(
+      nodeId = "0",
+      boundsInRoot = bounds,
+      testTag = tag,
+      placed = placed,
+      children = children,
+    )
+
+  @Test
+  fun `a slot marker inside a trial-measured subtree marks nothing`() {
+    // The copy a `SubcomposeLayout` measures and never places carries the same markers as the
+    // arrangement it chose — at the origin, because an unplaced node has no position.
+    val slots =
+      PreviewSlots.extractSlots(
+        ComposeSemanticsPayload(
+          node(
+            bounds = "0,0,200,200",
+            children =
+              listOf(
+                node(tag = "dp-slot:leadingIcon", bounds = "8,8,40,40"),
+                node(
+                  bounds = "0,0,120,60",
+                  placed = false,
+                  children = listOf(node(tag = "dp-slot:leadingIcon", bounds = "0,0,32,32")),
+                ),
+              ),
+          )
+        )
+      )
+
+    assertEquals(listOf("leadingIcon"), slots.map { it.name })
+  }
 
   @Test
   fun `extracts named, bounded slots from dp-slot testTags, depth-first`() {

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiffTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiffTest.kt
@@ -14,6 +14,7 @@ class SemanticsDiffTest {
     label: String? = null,
     clickable: Boolean = false,
     layoutTruncated: Boolean? = null,
+    placed: Boolean = true,
     children: List<ComposeSemanticsNode> = emptyList(),
   ) =
     ComposeSemanticsNode(
@@ -24,6 +25,7 @@ class SemanticsDiffTest {
       text = text,
       label = label,
       clickable = clickable,
+      placed = placed,
       textOverflow = layoutTruncated?.let { ComposeSemanticsTextOverflow(truncated = it) },
       children = children,
     )
@@ -87,6 +89,20 @@ class SemanticsDiffTest {
     val base = node(children = listOf(node(testTag = "submit", text = "Go")))
     val head = node(children = listOf(node(testTag = "submit", text = "Send")))
     assertEquals("tag:submit", SemanticsDiff.diff(base, head).changed.single().anchor)
+  }
+
+  @Test
+  fun leavingTheFrameIsReportedRatherThanPruned() {
+    // Every drawing and targeting consumer of this tree skips a subtree that was measured and never
+    // placed, because they answer "what is on the frame?". A diff answers "what changed?", so it
+    // keeps the node and names the transition — pruning would report the most interesting thing
+    // that can happen to a node as no change at all.
+    val base = node(children = listOf(node(testTag = "row", text = "One")))
+    val head = node(children = listOf(node(testTag = "row", text = "One", placed = false)))
+    val change = SemanticsDiff.diff(base, head).changed.single()
+    assertEquals("placed", change.changes.single().field)
+    assertEquals("true", change.changes.single().from)
+    assertEquals("false", change.changes.single().to)
   }
 
   @Test

--- a/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
+++ b/data/strings/connector/src/main/kotlin/ee/schimke/composeai/daemon/TextStringsDataProduct.kt
@@ -131,6 +131,12 @@ class TextStringsDataProductRegistry(
     localeTag: String,
     fontScale: Float,
   ) {
+    // `text/strings` is a projection of the text the render DREW. An unplaced subtree was measured
+    // and never placed — a `SubcomposeLayout` trial measure duplicating content the frame draws
+    // once — so emitting it hands the Drawn-text panel and every localisation / readability audit a
+    // phantom string, at the origin, with overflow metrics for a line nobody saw. See
+    // `ComposeSemanticsNode.placed`.
+    if (!node.placed) return
     val semanticsText = node.text?.takeIf { it.isNotBlank() }
     val text =
       node.layoutText?.takeIf { it.isNotBlank() }

--- a/data/strings/connector/src/test/kotlin/ee/schimke/composeai/daemon/TextStringsDataProductRegistryTest.kt
+++ b/data/strings/connector/src/test/kotlin/ee/schimke/composeai/daemon/TextStringsDataProductRegistryTest.kt
@@ -31,6 +31,69 @@ class TextStringsDataProductRegistryTest {
   }
 
   @Test
+  fun `an unplaced trial subtree contributes no drawn text`() {
+    // `text/strings` projects what the render DREW. A `SubcomposeLayout` measuring a trial copy of
+    // its content to choose a layout (Wear `AlertDialogContent`) leaves that copy in the semantics
+    // tree, measured and never placed — so it reports the origin, and emitting it hands the Drawn
+    // text panel and every localisation audit a phantom string nobody saw.
+    val previewId = "com.example.TrialMeasurePreview"
+    writeSemantics(
+      previewId,
+      """
+      {
+        "root": {
+          "nodeId": "1",
+          "boundsInRoot": "0,0,200,200",
+          "children": [
+            { "nodeId": "2", "boundsInRoot": "10,20,90,40", "text": "Title" },
+            {
+              "nodeId": "3",
+              "boundsInRoot": "0,0,200,120",
+              "placed": false,
+              "children": [
+                { "nodeId": "4", "boundsInRoot": "0,0,80,20", "text": "Title" }
+              ]
+            }
+          ]
+        }
+      }
+      """
+        .trimIndent(),
+    )
+    val registry =
+      TextStringsDataProductRegistry(
+        rootDir = rootDir,
+        previewIndex =
+          PreviewIndex.fromMap(
+            path = null,
+            byId =
+              mapOf(
+                previewId to
+                  PreviewInfoDto(
+                    id = previewId,
+                    className = "com.example.TrialKt",
+                    methodName = "TrialMeasurePreview",
+                  )
+              ),
+          ),
+      )
+
+    val outcome =
+      registry.fetch(
+        previewId = previewId,
+        kind = TextStringsDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val texts =
+      (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject["texts"]!!.jsonArray
+    assertEquals(1, texts.size)
+    assertEquals("10,20,90,40", texts[0].jsonObject["boundsInScreen"]!!.jsonPrimitive.content)
+  }
+
+  @Test
   fun `fetch projects text and semantic label separately`() {
     val previewId = "com.example.TextPreview"
     writeSemantics(

--- a/vscode-extension/src/test/semanticsTreeLoader.test.ts
+++ b/vscode-extension/src/test/semanticsTreeLoader.test.ts
@@ -164,6 +164,30 @@ describe("semanticsTreeLoader", () => {
             assert.ok(np.boxes.every((b) => b.level === "info"));
         });
 
+        it("draws no box for an unplaced panel subtree", () => {
+            // Same rule the 2D inspector overlay follows: a node measured but
+            // never placed has no position, so its bounds read as the panel's
+            // origin. A panel hosting a `SubcomposeLayout` trial measure
+            // (Wear `AlertDialogContent`) puts a whole phantom tree there.
+            const tree = validTreeObject();
+            const panel = (tree.root as Record<string, unknown>)
+                .children as Record<string, unknown>[];
+            (panel[0].panelContent as Record<string, unknown>).children = [
+                { nodeId: "2", boundsInRoot: "10,10,40,30" },
+                {
+                    nodeId: "3",
+                    boundsInRoot: "0,0,40,30",
+                    placed: false,
+                    children: [{ nodeId: "4", boundsInRoot: "0,0,20,20" }],
+                },
+            ];
+            const byId = panelWireframesById(parseSpatialSemanticsTree(tree));
+            assert.deepStrictEqual(
+                byId.get("panel")!.boxes.map((b) => b.id),
+                ["panel:1", "panel:2"],
+            );
+        });
+
         it("flags a mergeDescendants node as a warning-level box", () => {
             const byId = panelWireframesById(loadFixtureTree());
             const transport = byId.get("transport")!;

--- a/vscode-extension/src/webview/shared/spatialSemanticsTree.ts
+++ b/vscode-extension/src/webview/shared/spatialSemanticsTree.ts
@@ -46,6 +46,8 @@ export interface SemanticsTreeNode {
     /** "mergeDescendants" | "clearAndSet" | undefined. */
     mergeMode?: string;
     clickable?: boolean;
+    /** Measured AND positioned on the frame. Omitted when true (schema v15). */
+    placed?: boolean;
     children?: SemanticsTreeNode[];
 }
 

--- a/vscode-extension/src/webview/spatial/semanticsTreeLoader.ts
+++ b/vscode-extension/src/webview/spatial/semanticsTreeLoader.ts
@@ -106,6 +106,12 @@ function boxesFromSemantics(
 ): OverlayBox[] {
     const out: OverlayBox[] = [];
     const walk = (node: SemanticsTreeNode): void => {
+        // Same rule as the 2D inspector overlay: a node measured but never
+        // placed has no position, so `boundsInRoot` reads as the origin and
+        // a box for it lands in the panel's top-left corner. A panel hosting
+        // a `SubcomposeLayout` trial measure (Wear `AlertDialogContent`)
+        // puts a whole phantom tree there.
+        if (node.placed === false) return;
         const bounds = parseBounds(node.boundsInRoot);
         if (bounds) {
             out.push({


### PR DESCRIPTION
Follow-up to #4432, which added `placed` to `compose/semantics` and taught the drawing and targeting consumers to skip a subtree that was measured but never placed. Review then raised five more consumers that still read the phantom. Rather than take another batch, this **enumerates every walk over `ComposeSemanticsNode` in the repo and settles each one** — so there is no sixth round to have.

Two of the seven below were not flagged by anyone; they came out of the enumeration.

## Pruned

They answer *"what is on the frame?"*, and a `SubcomposeLayout` trial measure is a duplicate of content the frame draws once, anchored at the origin because an unplaced node has no position.

| consumer | what it did |
| --- | --- |
| `ServeSemanticsTags.index` | counted the copy, publishing `count = 2` for a tag identifying one node — which a scoped parity acceptance rejects as ambiguous |
| `toProbeNodes` / `mergedDescendantText` | duplicate probe matches: `assert.textEquals` ambiguous, `assert.notVisible` failing on content never drawn |
| `RecordingAssertions.resolvedNodeText` | merged the phantom string into a container's text, so an assertion compared against `"Submit\nSubmit"` |
| `TextStringsDataProductRegistry.collectTexts` | emitted phantom drawn text, with overflow metrics for a line nobody saw |
| `PreviewSlots.extractSlots` | published a duplicate slot marker at the origin |
| `WearScrollSliceStitcher.uniqueTextTops` ¹ | the copy made a once-per-slice string non-unique, **dropping** it from the slice-alignment anchors |
| spatial `boxesFromSemantics` | sibling of the 2D overlay fixed in #4432, still drawing the phantom in the XR viewer |

¹ not flagged in review — this one *loses* an anchor rather than adding a box, so it degrades stitching quietly.

## Deliberately NOT pruned

Documented in place, so the asymmetry with everything above is legible rather than looking like an oversight:

- **`SemanticsRefs.assign`** — a ref is an identity, not a claim about the frame. It has to mean the same thing in every payload the node appears in, or a stored ref stops addressing the same node the moment a `SubcomposeLayout` changes which arrangement it places. Consumers filter at the point of use instead.
- **`SemanticsDiff`** — a diff answers *"what changed?"*, and a node leaving the frame is the most interesting thing that can happen to it. Pruning would report that as **no change at all**, since `placed` was not compared. So `placed` joins `COMPARED_FIELDS` and the transition is named. This is a deliberate departure from the review suggestion, which proposed pruning here too.

## Test plan

One test per site, each written to fail without its fix:

- `ServeSemanticsTagsTest` — a trial copy of a tag is not a second use of it (count stays 1, and the real node's box is the one reported).
- `ComposeSemanticsProbeNodesTest` — an unplaced subtree is not probed, and an unplaced descendant does not double a container's merged text.
- `RecordingAssertionsTest` — `resolvedNodeText` ignores the trial copy.
- `TextStringsDataProductRegistryTest` — an unplaced subtree contributes no drawn text.
- `PreviewSlotsTest` — a slot marker inside a trial-measured subtree marks nothing.
- `SemanticsDiffTest` — leaving the frame is *reported* rather than pruned.
- `semanticsTreeLoader.test.ts` — no box for an unplaced panel subtree.

```
./gradlew :cli:test :data-layoutinspector-core:test :data-layoutinspector-connector:test \
          :daemon:core:test :data-strings-connector:test ktfmtCheck      # green
./gradlew :renderer-android:testDebugUnitTest \
  --tests "*ComposeSemanticsCoreFieldsTest*" --tests "*WearAlertDialogTrialMeasureTest*" \
  --tests "*WearScrollSliceStitcherTest*" --tests "*TextStringsTruncationTest*"   # green
node scripts/validate-report-schemas.mjs                                  # 12 payloads / 13 schemas
cd vscode-extension && npm test                                           # 1722 passing
npm run format:check                                                      # clean
```

No schema bump: `placed` shipped in #4432 as v15 and nothing about the wire changes here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UC18daejKkzqTrtwcwHrjs)_