### PR TITLE
fix(semantics): mirror the `placed` diff field into the TypeScript differ

### DIFF
--- a/vscode-extension/src/test/semanticsDiff.test.ts
+++ b/vscode-extension/src/test/semanticsDiff.test.ts
@@ -38,6 +38,32 @@ describe("semanticsDiff", () => {
         });
     });
 
+    it("reports a node leaving the frame, mirroring the Kotlin differ", () => {
+        // `placed` is COMPARED rather than pruned: every other consumer of this tree skips an
+        // unplaced subtree, but a diff that pruned it would report a node leaving the frame as
+        // no change at all.
+        const base = { root: node({ testTag: "row", text: "One" }) };
+        const head = {
+            root: node({ testTag: "row", text: "One", placed: false }),
+        };
+
+        const delta = diffSemantics(base, head);
+
+        assert.strictEqual(delta.changed.length, 1);
+        assert.deepStrictEqual(delta.changed[0].changes, [
+            { field: "placed", from: "true", to: "false" },
+        ]);
+    });
+
+    it("treats an omitted placed as true, so a pre-v15 snapshot is not a change", () => {
+        // The producer omits the field when true. Comparing raw values would report every v14
+        // snapshot as having changed against a v15 one.
+        const base = { root: node({ testTag: "row" }) };
+        const head = { root: node({ testTag: "row", placed: true }) };
+
+        assert.ok(semanticsDeltaIsEmpty(diffSemantics(base, head)));
+    });
+
     it("reports identical trees as an empty delta", () => {
         const tree = () => ({
             root: node({ testTag: "greeting", text: "Hello" }),

--- a/vscode-extension/src/webview/shared/semanticsDiff.ts
+++ b/vscode-extension/src/webview/shared/semanticsDiff.ts
@@ -21,6 +21,11 @@ export interface SemanticsNode {
     text?: string | null;
     mergeMode?: string | null;
     clickable?: boolean;
+    /**
+     * Measured AND positioned on the frame (schema v15). Omitted when true,
+     * so read it as `placed !== false` rather than trusting the raw value.
+     */
+    placed?: boolean;
     editableText?: string | null;
     inputText?: string | null;
     /** Resolved line/overflow metrics, consolidated under one object in schema v6 (#1903). */
@@ -129,6 +134,11 @@ const COMPARED_FIELDS: Array<[string, Extractor]> = [
     ["text", (n) => asStr(n.text)],
     ["mergeMode", (n) => asStr(n.mergeMode)],
     ["clickable", (n) => String(n.clickable ?? false)],
+    // Compared, not pruned — see the Kotlin `SemanticsDiff.COMPARED_FIELDS`: a node leaving the
+    // frame is the most interesting thing that can happen to it, and every OTHER consumer of this
+    // tree skips unplaced subtrees. The producer omits the field when true, so an absent value
+    // has to normalise to `true` or a v14 snapshot would read as a change against a v15 one.
+    ["placed", (n) => String(n.placed ?? true)],
     ["editableText", (n) => asStr(n.editableText)],
     ["inputText", (n) => asStr(n.inputText)],
     ["layoutTruncated", (n) => asBool(n.textOverflow?.truncated)],


### PR DESCRIPTION
Follow-up to #4441, closing a divergence that PR introduced.

## What was wrong

#4441 added `placed` to `SemanticsDiff.COMPARED_FIELDS` on the Kotlin side, deliberately: every *other* consumer of the semantics tree prunes a subtree that was measured but never placed, while a diff has to **report** a node leaving the frame rather than hide it.

The VS Code history panel does not call that differ. It diffs client-side through its own port in `vscode-extension/src/webview/shared/semanticsDiff.ts`, whose header comment reads:

> Semantic fields compared between two nodes sharing a ref, in stable report order. **Mirrors the Kotlin COMPARED_FIELDS exactly.**

After #4441 it did not. A node that only transitioned placed → unplaced showed as **semantically identical** in the history panel while the daemon, CLI and MCP all reported the change — the worst shape for a diff tool, because "no change" is indistinguishable from "nothing happened".

## The default is the load-bearing part

The producer omits `placed` when it is true (schema v15, additive), so the extractor normalises an absent value to `true`:

```ts
["placed", (n) => String(n.placed ?? true)],
```

Comparing raw values instead would report **every** pre-v15 snapshot as changed against a v15 one — turning a silent false negative into a noisy false positive across the whole stored history. The field sits directly after `clickable`, matching the Kotlin order, because the list is documented as being in stable report order.

## Test plan

Two cases in `semanticsDiff.test.ts`, the file that already ports the Kotlin differ's assertions:

- a node leaving the frame is reported as `placed: true → false`;
- an omitted `placed` equals an explicit `true`, so a pre-v15 snapshot is not a change.

```
cd vscode-extension && npm test        # 1724 passing
npm run format:check                   # clean
```

No Kotlin change, no schema change — `placed` shipped in #4432 as v15 and this only teaches the client-side port about it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UC18daejKkzqTrtwcwHrjs)_