### PR TITLE
fix(share-preview): name the off image lane instead of a bare 404

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -135,11 +135,19 @@ internal class ServeImageUploader(
   private data class ImageAccepted(val url: String? = null, val expiresIn: String? = null)
 
   companion object {
-    /** Appended to a bodyless `404`, which is exactly what a host with no image lane answers. */
+    /**
+     * Appended to a bodyless `404`, which is what a host with no image lane answers — but not
+     * *only* that. [rejectUnsafeUrl] constrains the scheme, the host and the userinfo, never the
+     * path, so a `--serve-url` carrying a stray prefix asks a real image host for
+     * `<base>/typo/images` and gets the same empty 404; so can a proxy in between. Naming the lane
+     * as the certain cause would just relocate the misdiagnosis, so this offers the likely reading
+     * and the cheap thing to check.
+     */
     private const val IMAGE_LANE_OFF =
-      " — that host does not accept image uploads (it was started without --accept-images). " +
-        "Ask its operator to enable the lane, or share these images another way " +
-        "(--mechanism gist / branch)."
+      " — most likely that host does not accept image uploads (it was started without " +
+        "--accept-images); a --serve-url with a stray path would answer the same way, so check " +
+        "the URL too. Otherwise ask its operator to enable the lane, or share these images " +
+        "another way (--mechanism gist / branch)."
 
     private val OCTET_STREAM = "application/octet-stream".toMediaType()
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -92,11 +92,14 @@ internal class ServeImageUploader(
             val detail = response.body?.string()?.trim()?.take(400).orEmpty()
             Result.Failed(
               "$base answered ${response.code}${if (detail.isEmpty()) "" else ": $detail"}" +
-                // A bodyless 404 is what a host WITHOUT `--accept-images` gives: the route was
-                // never registered, so there is nobody to write a refusal. Left bare it reads as
-                // "wrong URL" and sends the caller looking for a typo they didn't make — the host
-                // is right, the lane is simply off, which only its operator can change.
-                if (response.code == 404 && detail.isEmpty()) IMAGE_LANE_OFF else ""
+                // A bodyless 404 — or 405 — is what a host WITHOUT `--accept-images` gives: the
+                // route was never registered, so there is nobody to write a refusal. Which of the
+                // two arrives depends on the box's other routes: a catch-all that matches the path
+                // but not POST answers 405, which is why the server's own
+                // [ServeImageRoutingTest] accepts either. Left bare, both read as "wrong URL" and
+                // send the caller looking for a typo they didn't make — the host is right, the
+                // lane is simply off, which only its operator can change.
+                if (response.code in LANE_ABSENT_CODES && detail.isEmpty()) IMAGE_LANE_OFF else ""
             )
           }
           else -> parse(response.body?.string().orEmpty())
@@ -136,12 +139,18 @@ internal class ServeImageUploader(
 
   companion object {
     /**
-     * Appended to a bodyless `404`, which is what a host with no image lane answers — but not
-     * *only* that. [rejectUnsafeUrl] constrains the scheme, the host and the userinfo, never the
-     * path, so a `--serve-url` carrying a stray prefix asks a real image host for
-     * `<base>/typo/images` and gets the same empty 404; so can a proxy in between. Naming the lane
-     * as the certain cause would just relocate the misdiagnosis, so this offers the likely reading
-     * and the cheap thing to check.
+     * The bodyless statuses an absent image lane produces — 404 where nothing matches the path, 405
+     * where a catch-all matches it but not `POST`.
+     */
+    private val LANE_ABSENT_CODES = setOf(404, 405)
+
+    /**
+     * Appended to a bodyless [LANE_ABSENT_CODES] answer, which is what a host with no image lane
+     * gives — but not *only* that. [rejectUnsafeUrl] constrains the scheme, the host and the
+     * userinfo, never the path, so a `--serve-url` carrying a stray prefix asks a real image host
+     * for `<base>/typo/images` and gets the same empty 404; so can a proxy in between. Naming the
+     * lane as the certain cause would just relocate the misdiagnosis, so this offers the likely
+     * reading and the cheap thing to check.
      */
     private const val IMAGE_LANE_OFF =
       " — most likely that host does not accept image uploads (it was started without " +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -91,7 +91,12 @@ internal class ServeImageUploader(
           !response.isSuccessful -> {
             val detail = response.body?.string()?.trim()?.take(400).orEmpty()
             Result.Failed(
-              "$base answered ${response.code}${if (detail.isEmpty()) "" else ": $detail"}"
+              "$base answered ${response.code}${if (detail.isEmpty()) "" else ": $detail"}" +
+                // A bodyless 404 is what a host WITHOUT `--accept-images` gives: the route was
+                // never registered, so there is nobody to write a refusal. Left bare it reads as
+                // "wrong URL" and sends the caller looking for a typo they didn't make — the host
+                // is right, the lane is simply off, which only its operator can change.
+                if (response.code == 404 && detail.isEmpty()) IMAGE_LANE_OFF else ""
             )
           }
           else -> parse(response.body?.string().orEmpty())
@@ -130,6 +135,12 @@ internal class ServeImageUploader(
   private data class ImageAccepted(val url: String? = null, val expiresIn: String? = null)
 
   companion object {
+    /** Appended to a bodyless `404`, which is exactly what a host with no image lane answers. */
+    private const val IMAGE_LANE_OFF =
+      " — that host does not accept image uploads (it was started without --accept-images). " +
+        "Ask its operator to enable the lane, or share these images another way " +
+        "(--mechanism gist / branch)."
+
     private val OCTET_STREAM = "application/octet-stream".toMediaType()
 
     private val JSON = Json { ignoreUnknownKeys = true }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
@@ -189,6 +189,10 @@ class SharePreviewServeUploadTest {
           .reason
       assertTrue(reason.contains("404"), reason)
       assertTrue(reason.contains("--accept-images"), reason)
+      // A stray path on --serve-url produces the same empty 404 from a host whose lane IS on, so
+      // the message offers the lane as the likely cause and names the other thing to check.
+      assertTrue(reason.contains("most likely"), reason)
+      assertTrue(reason.contains("--serve-url"), reason)
       assertFalse(reason.contains("gho_secret"), reason)
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
@@ -198,6 +198,20 @@ class SharePreviewServeUploadTest {
   }
 
   @Test
+  fun `a bodyless 405 gets the same explanation as a bodyless 404`() {
+    // Disabling the lane can leave a catch-all that matches the path but not POST, so the same
+    // configuration answers 405 instead — ServeImageRoutingTest accepts either.
+    val seen = mutableListOf<Recorded>()
+    withServer(seen, status = 405, body = "") { base ->
+      val reason =
+        (ServeImageUploader(base, "gho_secret").upload(png()) as ServeImageUploader.Result.Failed)
+          .reason
+      assertTrue(reason.contains("405"), reason)
+      assertTrue(reason.contains("--accept-images"), reason)
+    }
+  }
+
+  @Test
   fun `a 404 that explains itself is passed through as the host wrote it`() {
     val seen = mutableListOf<Recorded>()
     withServer(seen, status = 404, body = "no such image") { base ->

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/SharePreviewServeUploadTest.kt
@@ -178,6 +178,34 @@ class SharePreviewServeUploadTest {
   }
 
   @Test
+  fun `a bodyless 404 says the lane is off rather than leaving a bare status`() {
+    // What a serve host started WITHOUT --accept-images actually answers: the route is not
+    // registered, so the 404 carries no body to explain itself. preview.coo.ee answered exactly
+    // this, and "answered 404" alone reads as a wrong URL.
+    val seen = mutableListOf<Recorded>()
+    withServer(seen, status = 404, body = "") { base ->
+      val reason =
+        (ServeImageUploader(base, "gho_secret").upload(png()) as ServeImageUploader.Result.Failed)
+          .reason
+      assertTrue(reason.contains("404"), reason)
+      assertTrue(reason.contains("--accept-images"), reason)
+      assertFalse(reason.contains("gho_secret"), reason)
+    }
+  }
+
+  @Test
+  fun `a 404 that explains itself is passed through as the host wrote it`() {
+    val seen = mutableListOf<Recorded>()
+    withServer(seen, status = 404, body = "no such image") { base ->
+      val reason =
+        (ServeImageUploader(base, "gho_secret").upload(png()) as ServeImageUploader.Result.Failed)
+          .reason
+      assertTrue(reason.contains("no such image"), reason)
+      assertFalse(reason.contains("--accept-images"), reason)
+    }
+  }
+
+  @Test
   fun `a host token rides in the query, where that host's other routes read it`() {
     val seen = mutableListOf<Recorded>()
     withServer(seen, status = 201, body = """{"url":"https://h/i/a.png"}""") { base ->


### PR DESCRIPTION
## What

A serve host started without `--accept-images` never registers `POST /images`, so it answers a **bodyless 404**. `ServeImageUploader` reported that as `<host> answered 404`, which reads as a wrong URL and sends the caller hunting for a typo they did not make — the host is right, the lane is simply off, and only its operator can change that. The refusal now names the cause and the two ways forward.

A 404 that carries a body still passes through exactly as the host wrote it.

## How it was found

Testing the two lanes end to end this session.

**Agent access grants — temporary live render access.** Verified against a local `serve --module :samples:cmp --agent-grants --token …` box, full RFC 8628 device flow:

| Step | Result |
| --- | --- |
| `POST /agent-access/request` (no credential) | requestId + deviceSecret + userCode, request TTL 599s |
| poll before approval | `pending`, `retryAfterSeconds: 3` |
| approval page without `--token` | `401` |
| approval page with `--token` | renders, and shows the same user code the agent printed |
| approve (`scope=live`) | `200`; poll returns `approved`, scopes `[preview, live]`, `approvedBy: operator (token)` |
| `live` grant → `/render/<id>.svg` | `200 image/svg+xml`, 29 872 B — a real daemon render |
| `live` grant → `/render/<id>.png?uiMode=dark` | `200` (on-demand) |
| `preview` grant → the same two, and `/bundle.zip` | `403 "This agent grant covers preview; 'live' was not approved for it."` |
| `preview` grant → baked `/render/<id>.png`, `/status.json` | `200` — ordinary browsing unaffected |
| agent self-revoke, operator revoke from `/status` | both work; bearer dies immediately; `/status.json` shows fingerprints only, never tokens |

The CLI half works too: `auth request --no-wait --json` persists the pending request (mode `0600`), `auth status` promotes the approval into a grant once approved, `auth token` prints only the bearer, `auth revoke` clears it on both sides. TTL is `min(requested, approver's pick, box max)` — an approver can shorten but not extend, which matches the store and is worth knowing when reading the design doc's "chosen by the approver".

**Image upload lane.** Client-side guards all hold: plaintext non-loopback refused, credentials-in-URL refused, a redirect refused by name without following it. Against a local `--accept-images` box the lane refuses correctly at each gate. Against `preview.coo.ee` the upload got the bare `404` this PR fixes — its `/status.json` reports `acceptImages: false`, so the lane is simply not enabled there.

## Test plan

- `./gradlew :cli:test --tests "*SharePreview*"` — green; `SharePreviewServeUploadTest` is 14/14 with two new cases (bodyless 404 names the lane; a 404 with a body is passed through unchanged).
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest` — no changes.
- Manual: `share-preview --mechanism serve --serve-url https://preview.coo.ee` now explains itself instead of printing `answered 404`.

Text-only change (a CLI error string); no visual surface is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183vYxNWkruzAcLrLcMjCjj)_