### PR TITLE
fix(render): nest a themeProvider override around a structural @PreviewWrapper

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.isStructuralPreviewWrapper
 import ee.schimke.composeai.data.render.extensions.loadIrReplayClass
 import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
@@ -2596,6 +2597,9 @@ private fun resolvePreviewInvocation(
  * `:renderer-android` does the equivalent in
  * [ee.schimke.composeai.renderer.PreviewRenderStrategy]'s ComposePreviewStrategy.
  *
+ * A [themeProviderFqn] override normally REPLACES the declared wrapper; [resolveWrapperStack] owns
+ * that decision, including the structural-wrapper case where the two nest instead (theme outside).
+ *
  * **Why the FQN comes from the spec rather than `Method.annotations`.** The upstream
  * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has `AnnotationRetention.BINARY`
  * (issue #1440): it's emitted into the class file but not retained at runtime, so
@@ -2617,23 +2621,66 @@ internal fun InvokeWithOptionalWrapper(
   themeProviderFqn: String? = null,
   previewArgs: List<Any?> = emptyList(),
 ) {
-  val wrapper =
+  val wrappers =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
-      // A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF
-      // its own `@PreviewWrapper` — but only when it actually loads. On a stale/misspelled FQN,
-      // `loadWrapperByFqnOrNull` logs and returns null; we then fall back to the preview's declared
-      // wrapper rather than stripping it (which would drop a required `@PreviewWrapper` and
-      // misrender). A blank/absent themeProvider skips straight to the declared wrapper.
-      themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
-        ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+      resolveWrapperStack(composableMethod, wrapperFqnFromSpec, themeProviderFqn)
     }
-  if (wrapper == null) {
-    InvokeComposable(composableMethod, previewArgs)
+  val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
+  val declared = wrappers.declared
+  val inner: @Composable () -> Unit =
+    if (declared == null) {
+      body
+    } else {
+      { declared.first.invoke(currentComposer, declared.second, body) }
+    }
+  val theme = wrappers.theme
+  if (theme == null) {
+    inner()
   } else {
-    val (wrapMethod, wrapperInstance) = wrapper
-    val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
-    wrapMethod.invoke(currentComposer, wrapperInstance, body)
+    theme.first.invoke(currentComposer, theme.second, inner)
   }
+}
+
+/**
+ * The wrapper(s) [InvokeWithOptionalWrapper] composes around a preview body, outermost first: an
+ * optional `themeProvider` [theme] around an optional declared `@PreviewWrapper` [declared].
+ */
+private class WrapperStack(
+  val theme: Pair<ComposableMethod, Any>?,
+  val declared: Pair<ComposableMethod, Any>?,
+)
+
+/**
+ * Decide which wrappers a render composes around the preview body.
+ *
+ * A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF its
+ * own `@PreviewWrapper` — a declared wrapper is nearly always the preview's own theme, and swapping
+ * it is the entire point of the viewer's theme selector (keeping both would let the inner one
+ * shadow the chosen one). Two exceptions keep the declared wrapper:
+ * - the override doesn't load. On a stale / misspelled FQN `loadWrapperByFqnOrNull` logs and
+ *   returns null; falling back to the declared wrapper beats stripping it and misrendering.
+ * - the declared wrapper is **structural** ([isStructuralPreviewWrapper]) — it installs the surface
+ *   the body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
+ *   leaves a `RemoteBox` / `RemoteColumn` / `RemoteRow` body on the plain UI applier and throws
+ *   `IllegalStateException: Invalid applier`. Here the theme nests OUTSIDE the structural wrapper
+ *   rather than replacing it, so the request is honoured as far as it can be and the render stands
+ *   up either way.
+ *
+ * A blank / absent themeProvider skips straight to the declared wrapper.
+ */
+private fun resolveWrapperStack(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+  themeProviderFqn: String?,
+): WrapperStack {
+  val declaredFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec)
+  val theme = themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
+  val keepDeclared =
+    theme == null || (declaredFqn != null && isStructuralPreviewWrapper(declaredFqn))
+  return WrapperStack(
+    theme = theme,
+    declared = if (keepDeclared) declaredFqn?.let { loadWrapperByFqnOrNull(it) } else null,
+  )
 }
 
 /**
@@ -2679,12 +2726,20 @@ internal fun resolveWrapperOrNull(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String? = null,
 ): Pair<ComposableMethod, Any>? {
-  val wrapperFqn =
-    wrapperFqnFromSpec?.takeIf { it.isNotBlank() }
-      ?: resolveWrapperFqnViaReflection(composableMethod)
-      ?: return null
+  val wrapperFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec) ?: return null
   return loadWrapperByFqnOrNull(wrapperFqn)
 }
+
+/**
+ * The FQN of the preview's declared `@PreviewWrapper` provider — the spec-supplied one when
+ * present, otherwise the best-effort reflective read. Split out of [resolveWrapperOrNull] so
+ * [resolveWrapperStack] can ask about the wrapper (is it structural?) before deciding to load it.
+ */
+private fun declaredWrapperFqnOrNull(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+): String? =
+  wrapperFqnFromSpec?.takeIf { it.isNotBlank() } ?: resolveWrapperFqnViaReflection(composableMethod)
 
 /**
  * Fallback path used only when [resolveWrapperOrNull] was called without a spec-supplied FQN.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionFixtures.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
 
 /**
  * Wrapper class for [PreviewWrapperResolutionTest] and [WrappedPreviewRenderTest]. Mirrors the
@@ -32,6 +33,20 @@ class GreenBorderWrapper {
   @Composable
   fun Wrap(content: @Composable () -> Unit) {
     Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1B5E20))) {
+      Box(modifier = Modifier.fillMaxSize().padding(8.dp)) { content() }
+    }
+  }
+}
+
+/**
+ * A second border wrapper in a colour [GreenBorderWrapper] can't be confused with, so a test that
+ * composes two wrappers at once can tell which one painted which pixels. Stands in for a selected
+ * `@ThemeCatalog` theme in [WrappedPreviewRenderTest]'s structural-nesting coverage.
+ */
+class BlueBorderWrapper {
+  @Composable
+  fun Wrap(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF1565C0))) {
       Box(modifier = Modifier.fillMaxSize().padding(8.dp)) { content() }
     }
   }
@@ -60,6 +75,23 @@ class RequiredCompositionLocalWrapper {
   fun Wrap(content: @Composable () -> Unit) {
     CompositionLocalProvider(LocalRequiredPreviewEnvironment provides true, content = content)
   }
+}
+
+/**
+ * Declares [RequiredCompositionLocalWrapper] **structural** for the daemon's test classpath —
+ * registered through `src/test/resources/META-INF/services/...PreviewWrapperSubstitutionProvider`,
+ * the same SPI `:data-remotecompose-connector` uses to declare the RemoteCompose wrappers.
+ *
+ * It stands in for `RemotePreviewWrapper`, which the daemon's test classpath doesn't carry: both
+ * install something the preview body cannot compose without (a required local here, the
+ * RemoteCompose applier there), so a `themeProvider` override must nest around it rather than
+ * replace it. Substitutes nothing, so no other test's wrapper resolution changes.
+ */
+class FixtureStructuralWrapperProvider : PreviewWrapperSubstitutionProvider {
+  override fun substituteFor(originalWrapperFqn: String): Class<*>? = null
+
+  override fun isStructural(wrapperFqn: String): Boolean =
+    wrapperFqn == RequiredCompositionLocalWrapper::class.java.name
 }
 
 /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/WrappedPreviewRenderTest.kt
@@ -1,10 +1,13 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.Base64
 import javax.imageio.ImageIO
 import kotlin.math.abs
+import kotlinx.serialization.json.Json
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -212,6 +215,86 @@ class WrappedPreviewRenderTest {
     }
   }
 
+  /**
+   * A `themeProvider` override must NEST around a **structural** `@PreviewWrapper`, not replace it.
+   *
+   * Replacing is right for the ordinary case — a declared wrapper is nearly always the preview's
+   * own theme, and swapping it is what the viewer's theme selector is for. It is wrong when the
+   * wrapper installs the surface the body composes against: dropping
+   * `@PreviewWrapper(RemotePreviewWrapper::class)` leaves a `RemoteBox` / `RemoteColumn` /
+   * `RemoteRow` body on the plain UI applier and the render dies with `IllegalStateException:
+   * Invalid applier` before drawing anything. That is what took out every `meshcore-mobile` widget
+   * preview once the serve theme optimiser started pre-rendering each preview under each declared
+   * `@ThemeCatalog` theme — four renders, four failures, 60-280ms each.
+   *
+   * [RequiredCompositionLocalWrapper] stands in for the RemoteCompose wrapper (declared structural
+   * on the test classpath by [FixtureStructuralWrapperProvider]): its
+   * [WrapperRequiredFixturePreview] body `check`s the local the wrapper installs, so a replaced
+   * wrapper throws exactly as the applier mismatch does. [BlueBorderWrapper] plays the selected
+   * theme. Blue edges prove the theme composed outermost, and the body's own `0xFF66BB6A` green in
+   * the centre proves the structural wrapper survived underneath it.
+   */
+  @Test
+  fun themeProviderOverrideNestsAroundStructuralWrapper() {
+    val outputDir = tempFolder.newFolder("renders-structural-theme")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "structural",
+              className = "ee.schimke.composeai.daemon.PreviewWrapperResolutionFixturesKt",
+              functionName = "WrapperRequiredFixturePreview",
+              params =
+                PreviewParamsEntry(
+                  widthDp = 32,
+                  heightDp = 32,
+                  density = 1.0f,
+                  wrapperClassName = "ee.schimke.composeai.daemon.RequiredCompositionLocalWrapper",
+                ),
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val themed =
+        renderAndDecode(
+          host,
+          "previewId=structural;overrides=" +
+            encodeThemeProviderBag("ee.schimke.composeai.daemon.BlueBorderWrapper"),
+          "structural-themed",
+        )
+      // The theme wrapper is outermost, so its 8.dp blue band owns the edges...
+      assertEdgePixelsAreBlue(themed)
+      // ...and the body drew at all, which it only does when the structural wrapper installed its
+      // local. Before the fix the render failed outright with the wrapper's `check` message.
+      val centre = themed.getRGB(themed.width / 2, themed.height / 2)
+      val r = (centre shr 16) and 0xFF
+      val g = (centre shr 8) and 0xFF
+      val b = centre and 0xFF
+      assertTrue(
+        "centre should be the body's 0xFF66BB6A but was rgb($r,$g,$b) — the structural " +
+          "@PreviewWrapper was replaced by the themeProvider instead of nested inside it.",
+        g > r && g > b && g > 120 && r > 60,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /** A base64 `overrides=` bag carrying only a `themeProvider` selection. */
+  private fun encodeThemeProviderBag(fqn: String): String {
+    val json = Json { encodeDefaults = false }
+    val bytes =
+      json
+        .encodeToString(PreviewOverrides.serializer(), PreviewOverrides(themeProvider = fqn))
+        .toByteArray(Charsets.UTF_8)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,
@@ -253,6 +336,27 @@ class WrappedPreviewRenderTest {
           "If body-red, the daemon skipped @PreviewWrapper's Wrap{} — regression in " +
           "RenderEngine.setContent's InvokeWithOptionalWrapper call site.",
         g > r && g > b && g > 60,
+      )
+    }
+  }
+
+  /**
+   * Blue twin of [assertEdgePixelsAreGreen], for the render whose outermost wrapper is
+   * [BlueBorderWrapper]'s `0xFF1565C0` band.
+   */
+  private fun assertEdgePixelsAreBlue(img: BufferedImage) {
+    val w = img.width
+    val h = img.height
+    val samples = listOf(w / 2 to 2, w / 2 to (h - 3), 2 to (h / 2), (w - 3) to (h / 2))
+    for ((x, y) in samples) {
+      val rgb = img.getRGB(x, y)
+      val r = (rgb shr 16) and 0xFF
+      val g = (rgb shr 8) and 0xFF
+      val b = rgb and 0xFF
+      assertTrue(
+        "edge pixel ($x,$y) should be theme-blue (~0x1565C0) but was rgb($r,$g,$b) — the " +
+          "themeProvider override did not compose around the structural wrapper.",
+        b > r && b > g && b > 100,
       )
     }
   }

--- a/daemon/android/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
+++ b/daemon/android/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.daemon.FixtureStructuralWrapperProvider

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.CompositionTracing
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.isStructuralPreviewWrapper
 import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.data.theme.ThemePayload
@@ -2468,6 +2469,9 @@ private fun InvokeComposable(composableMethod: ComposableMethod, previewArgs: Li
  * composables require the RemoteCompose applier the wrapper installs. Mirrors the Android daemon
  * and `:renderer-android`'s `PreviewRenderStrategy`.
  *
+ * A [themeProviderFqn] override normally REPLACES the declared wrapper; [resolveWrapperStack] owns
+ * that decision, including the structural-wrapper case where the two nest instead (theme outside).
+ *
  * **Why the FQN comes from the spec rather than `Method.annotations`.** The upstream
  * `androidx.compose.ui.tooling.preview.PreviewWrapper` annotation has `AnnotationRetention.BINARY`
  * (issue #1440): it's emitted into the class file but not retained at runtime. The gradle plugin's
@@ -2486,22 +2490,66 @@ private fun InvokeWithOptionalWrapper(
   themeProviderFqn: String? = null,
   previewArgs: List<Any?> = emptyList(),
 ) {
-  val wrapper =
+  val wrappers =
     remember(composableMethod, wrapperFqnFromSpec, themeProviderFqn) {
-      // A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF
-      // its own `@PreviewWrapper` — but only when it actually loads. On a stale/misspelled FQN,
-      // `loadWrapperByFqnOrNull` logs and returns null; we then fall back to the preview's declared
-      // wrapper rather than stripping it. A blank/absent themeProvider skips straight to it.
-      themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
-        ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
+      resolveWrapperStack(composableMethod, wrapperFqnFromSpec, themeProviderFqn)
     }
-  if (wrapper == null) {
-    InvokeComposable(composableMethod, previewArgs)
+  val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
+  val declared = wrappers.declared
+  val inner: @Composable () -> Unit =
+    if (declared == null) {
+      body
+    } else {
+      { declared.first.invoke(currentComposer, declared.second, body) }
+    }
+  val theme = wrappers.theme
+  if (theme == null) {
+    inner()
   } else {
-    val (wrapMethod, wrapperInstance) = wrapper
-    val body: @Composable () -> Unit = { InvokeComposable(composableMethod, previewArgs) }
-    wrapMethod.invoke(currentComposer, wrapperInstance, body)
+    theme.first.invoke(currentComposer, theme.second, inner)
   }
+}
+
+/**
+ * The wrapper(s) [InvokeWithOptionalWrapper] composes around a preview body, outermost first: an
+ * optional `themeProvider` [theme] around an optional declared `@PreviewWrapper` [declared].
+ */
+private class WrapperStack(
+  val theme: Pair<ComposableMethod, Any>?,
+  val declared: Pair<ComposableMethod, Any>?,
+)
+
+/**
+ * Decide which wrappers a render composes around the preview body.
+ *
+ * A `themeProvider` override wraps the preview in an app-declared theme provider IN PLACE OF its
+ * own `@PreviewWrapper` — a declared wrapper is nearly always the preview's own theme, and swapping
+ * it is the entire point of the viewer's theme selector (keeping both would let the inner one
+ * shadow the chosen one). Two exceptions keep the declared wrapper:
+ * - the override doesn't load. On a stale / misspelled FQN `loadWrapperByFqnOrNull` logs and
+ *   returns null; falling back to the declared wrapper beats stripping it and misrendering.
+ * - the declared wrapper is **structural** ([isStructuralPreviewWrapper]) — it installs the surface
+ *   the body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
+ *   leaves a `RemoteBox` / `RemoteColumn` / `RemoteRow` body on the plain UI applier and throws
+ *   `IllegalStateException: Invalid applier`. Here the theme nests OUTSIDE the structural wrapper
+ *   rather than replacing it, so the request is honoured as far as it can be and the render stands
+ *   up either way.
+ *
+ * A blank / absent themeProvider skips straight to the declared wrapper.
+ */
+private fun resolveWrapperStack(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+  themeProviderFqn: String?,
+): WrapperStack {
+  val declaredFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec)
+  val theme = themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
+  val keepDeclared =
+    theme == null || (declaredFqn != null && isStructuralPreviewWrapper(declaredFqn))
+  return WrapperStack(
+    theme = theme,
+    declared = if (keepDeclared) declaredFqn?.let { loadWrapperByFqnOrNull(it) } else null,
+  )
 }
 
 /**
@@ -2524,12 +2572,20 @@ internal fun resolveWrapperOrNull(
   composableMethod: ComposableMethod,
   wrapperFqnFromSpec: String? = null,
 ): Pair<ComposableMethod, Any>? {
-  val wrapperFqn =
-    wrapperFqnFromSpec?.takeIf { it.isNotBlank() }
-      ?: resolveWrapperFqnViaReflection(composableMethod)
-      ?: return null
+  val wrapperFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec) ?: return null
   return loadWrapperByFqnOrNull(wrapperFqn)
 }
+
+/**
+ * The FQN of the preview's declared `@PreviewWrapper` provider — the spec-supplied one when
+ * present, otherwise the best-effort reflective read. Split out of [resolveWrapperOrNull] so
+ * [resolveWrapperStack] can ask about the wrapper (is it structural?) before deciding to load it.
+ */
+private fun declaredWrapperFqnOrNull(
+  composableMethod: ComposableMethod,
+  wrapperFqnFromSpec: String?,
+): String? =
+  wrapperFqnFromSpec?.takeIf { it.isNotBlank() } ?: resolveWrapperFqnViaReflection(composableMethod)
 
 private fun resolveWrapperFqnViaReflection(composableMethod: ComposableMethod): String? {
   val jvmMethod = composableMethod.asMethod()

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/FixtureStructuralWrapperProvider.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/FixtureStructuralWrapperProvider.kt
@@ -1,0 +1,18 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
+
+/**
+ * Declares [RequiredEnvironmentWrapper] **structural** for the desktop daemon's test classpath —
+ * registered through `src/test/resources/META-INF/services/...PreviewWrapperSubstitutionProvider`,
+ * the same SPI `:data-remotecompose-connector` uses for the RemoteCompose wrappers.
+ *
+ * It stands in for `RemotePreviewWrapper`, which this classpath doesn't carry. Substitutes nothing,
+ * so no other test's wrapper resolution changes.
+ */
+class FixtureStructuralWrapperProvider : PreviewWrapperSubstitutionProvider {
+  override fun substituteFor(originalWrapperFqn: String): Class<*>? = null
+
+  override fun isStructural(wrapperFqn: String): Boolean =
+    wrapperFqn == "ee.schimke.composeai.daemon.RequiredEnvironmentWrapper"
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1181,6 +1181,73 @@ class OverrideIntegrationTest {
   }
 
   /**
+   * A `themeProvider` override must NEST around a **structural** `@PreviewWrapper` rather than
+   * replace it.
+   *
+   * Replacing is right for the ordinary case — a declared wrapper is nearly always the preview's
+   * own theme, and swapping it is exactly what the viewer's theme selector is for
+   * ([themeProviderOverrideWrapsPreviewInDeclaredTheme] above). It is wrong when the wrapper
+   * installs the surface the body composes against: dropping
+   * `@PreviewWrapper(RemotePreviewWrapper::class)` leaves a `RemoteBox` / `RemoteColumn` /
+   * `RemoteRow` body on the plain UI applier and the render dies with `IllegalStateException:
+   * Invalid applier`. That is what took out every `meshcore-mobile` widget preview once the serve
+   * theme optimiser began pre-rendering each preview under each declared `@ThemeCatalog` theme.
+   *
+   * [RequiredEnvironmentWrapper] stands in for the RemoteCompose wrapper — declared structural on
+   * this classpath by [FixtureStructuralWrapperProvider], and its [WrapperRequiredSquare] body
+   * `check`s the local it installs, so a replaced wrapper fails the render the same way the applier
+   * mismatch does. The body then paints the ambient primary, so the blue fill proves the theme is
+   * the OUTER wrapper of the two.
+   */
+  @Test
+  fun themeProviderOverrideNestsAroundStructuralWrapper() {
+    val outputDir = tempFolder.newFolder("renders-structural-theme")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "structural",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "WrapperRequiredSquare",
+              widthPx = 200,
+              heightPx = 120,
+              density = 1.0f,
+              outputBaseName = "structural",
+              // The wrapper FQN only travels nested, exactly as the gradle plugin writes it.
+              params =
+                PreviewParamsEntry(
+                  wrapperClassName = "ee.schimke.composeai.daemon.RequiredEnvironmentWrapper"
+                ),
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      // Renders at all → the structural wrapper survived the override (before the fix this threw
+      // "Required app preview environment was not installed" and produced no PNG)...
+      val themed =
+        renderAndDecode(
+          host,
+          "previewId=structural;overrides=" +
+            encodeThemeProviderBag("ee.schimke.composeai.daemon.BluePrimaryThemeProvider"),
+          "structural-themed",
+        )
+      // ...and the theme composed OUTSIDE it, so the body reads the declared theme's primary.
+      val bluePct = pixelMatchPct(themed, expectedRgb = 0x1565C0, perChannelTolerance = 8)
+      assertTrue(
+        "a themeProvider override must still apply around a structural wrapper; got " +
+          "${"%.2f".format(bluePct * 100)}% of the declared theme's blue primary",
+        bluePct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
    * A stale / misspelled `themeProvider` must fall back to the preview's declared
    * `@PreviewWrapper`, not strip it (which would drop a required wrapper and misrender — the case a
    * shared URL with a removed provider hits). The manifest pins `wrapperClassName =

--- a/daemon/desktop/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
+++ b/daemon/desktop/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.daemon.FixtureStructuralWrapperProvider

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -31,11 +31,13 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -1076,6 +1078,40 @@ class BluePrimaryThemeProvider {
   @Composable
   fun Wrap(content: @Composable () -> Unit) =
     MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF1565C0))) { content() }
+}
+
+/**
+ * App-owned preview environment used to model a **structural** wrapper — one that installs the
+ * surface its body composes against rather than a look. The renderer cannot provide it itself, so
+ * it must survive every render mode, including a `themeProvider` override that replaces an ordinary
+ * (theme-shaped) declared wrapper.
+ *
+ * Stands in for `RemotePreviewWrapper`, which this classpath doesn't carry: dropping that one
+ * leaves a `RemoteBox` / `RemoteColumn` / `RemoteRow` body on the plain UI applier and the render
+ * throws `IllegalStateException: Invalid applier`; dropping this one throws out of
+ * [WrapperRequiredSquare]'s `check`. Same failure shape, no alpha dependency.
+ */
+private val LocalRequiredPreviewEnvironment = staticCompositionLocalOf { false }
+
+@Suppress("unused") // instantiated reflectively by the daemon's InvokeWithOptionalWrapper
+class RequiredEnvironmentWrapper {
+  @Composable
+  fun Wrap(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalRequiredPreviewEnvironment provides true, content = content)
+  }
+}
+
+/**
+ * Fails before drawing unless [RequiredEnvironmentWrapper] ran; otherwise paints the *ambient*
+ * `MaterialTheme.colorScheme.primary`, so one render answers both questions a nested wrapper stack
+ * raises — did the structural wrapper survive, and did the theme reach the body.
+ */
+@Composable
+fun WrapperRequiredSquare() {
+  check(LocalRequiredPreviewEnvironment.current) {
+    "Required app preview environment was not installed"
+  }
+  Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primary))
 }
 
 /**

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeWrapperSubstitution.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeWrapperSubstitution.kt
@@ -10,12 +10,25 @@ import ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionPro
  * reach the running player, and when it isn't the original upstream behaviour applies. Discovered
  * via the `META-INF/services/...PreviewWrapperSubstitutionProvider` file in this module's
  * resources.
+ *
+ * The same service also declares every RemoteCompose wrapper **structural** (see
+ * [ee.schimke.composeai.data.render.extensions.isStructuralPreviewWrapper]): these wrappers capture
+ * their content into a RemoteCompose document, so a `themeProvider` override that replaced one
+ * would leave the body emitting `RemoteBox` / `RemoteColumn` / `RemoteRow` against the plain UI
+ * applier and throw `IllegalStateException: Invalid applier`. Both the connector's own wrappers and
+ * the upstream FQN are listed, because the check runs on the wrapper the preview *declared*, before
+ * substitution.
  */
 class RemoteComposeWrapperSubstitution : PreviewWrapperSubstitutionProvider {
   override fun substituteFor(originalWrapperFqn: String): Class<*>? =
     if (originalWrapperFqn == UPSTREAM_REMOTE_PREVIEW_WRAPPER_FQN) {
       RemoteOverridablePreviewWrapper::class.java
     } else null
+
+  override fun isStructural(wrapperFqn: String): Boolean =
+    wrapperFqn == UPSTREAM_REMOTE_PREVIEW_WRAPPER_FQN ||
+      wrapperFqn == RemoteOverridablePreviewWrapper::class.java.name ||
+      wrapperFqn == RemoteEmbeddedPreviewWrapper::class.java.name
 
   private companion object {
     const val UPSTREAM_REMOTE_PREVIEW_WRAPPER_FQN =

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeWrapperSubstitutionTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeWrapperSubstitutionTest.kt
@@ -1,9 +1,11 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
+import ee.schimke.composeai.data.render.extensions.isStructuralPreviewWrapper
 import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import java.util.ServiceLoader
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -56,5 +58,32 @@ class RemoteComposeWrapperSubstitutionTest {
     // `String` is a stand-in — any always-loadable class works as the "fall through" probe.
     val resolved = loadPreviewWrapperClass("java.lang.String")
     assertEquals(String::class.java, resolved)
+  }
+
+  /**
+   * Every RemoteCompose wrapper must read as **structural**, so the serve viewer's declared-theme
+   * selector (and the theme optimiser that pre-renders every preview under every theme) nests a
+   * theme around the wrapper instead of replacing it. Replacing it drops the capture the body needs
+   * and the render dies with `IllegalStateException: Invalid applier` — the whole `meshcore-mobile`
+   * widget set did exactly that.
+   *
+   * Both the connector's own wrappers and the upstream FQN are asserted: the check runs against the
+   * wrapper the preview *declared*, which is the upstream one, before substitution swaps it.
+   */
+  @Test
+  fun `remote compose wrappers are structural`() {
+    val provider = RemoteComposeWrapperSubstitution()
+    assertTrue(
+      provider.isStructural("androidx.compose.remote.tooling.preview.RemotePreviewWrapper")
+    )
+    assertTrue(provider.isStructural(RemoteOverridablePreviewWrapper::class.java.name))
+    assertTrue(provider.isStructural(RemoteEmbeddedPreviewWrapper::class.java.name))
+    assertFalse(provider.isStructural("com.example.AppLightThemeProvider"))
+  }
+
+  @Test
+  fun `isStructuralPreviewWrapper sees the connector's declaration through the SPI`() {
+    assertTrue(isStructuralPreviewWrapper(RemoteOverridablePreviewWrapper::class.java.name))
+    assertFalse(isStructuralPreviewWrapper("com.example.AppLightThemeProvider"))
   }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitution.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitution.kt
@@ -25,7 +25,60 @@ interface PreviewWrapperSubstitutionProvider {
    * resolution to the next provider (or fall through to a direct `Class.forName` on the original).
    */
   fun substituteFor(originalWrapperFqn: String): Class<*>?
+
+  /**
+   * Whether [wrapperFqn] is a **structural** wrapper — see [isStructuralPreviewWrapper]. Providers
+   * that only rewrite a wrapper class leave this at the default; a connector that owns a wrapper
+   * installing its own applier / capture surface (the RemoteCompose one) declares it here so a
+   * `themeProvider` override nests around it instead of replacing it.
+   */
+  fun isStructural(wrapperFqn: String): Boolean = false
 }
+
+/**
+ * Wrappers known to be structural without any connector on the classpath.
+ *
+ * Upstream `RemotePreviewWrapper` is the load-bearing entry: it captures its content into a
+ * RemoteCompose document, so the content composes against the RemoteCompose applier rather than the
+ * UI one. Named here (rather than only in `:data-remotecompose-connector`) because the crash it
+ * prevents happens whether or not the connector is present — the connector's substitute is declared
+ * structural by the connector itself.
+ */
+private val BUILT_IN_STRUCTURAL_WRAPPER_FQNS =
+  setOf("androidx.compose.remote.tooling.preview.RemotePreviewWrapper")
+
+/**
+ * Whether a `@PreviewWrapper` provider is **structural** — it installs the surface its preview body
+ * is composed against (an applier, a capture, a player) rather than merely dressing the body in a
+ * look.
+ *
+ * The distinction exists because of the viewer's declared-theme selector. A `themeProvider`
+ * override normally replaces the preview's own `@PreviewWrapper`: a declared wrapper is nearly
+ * always the preview's theme, and swapping it is the whole point of the selector (keeping both
+ * would let the inner theme shadow the chosen one — the failure
+ * `ee.schimke.composeai.discovery.PreviewThemeShadowing` warns about).
+ *
+ * A structural wrapper is not a look and cannot be swapped out. Dropping
+ * `@PreviewWrapper(RemotePreviewWrapper::class)` leaves a `RemoteBox` / `RemoteColumn` /
+ * `RemoteRow` body composing against the plain UI applier, which throws `IllegalStateException:
+ * Invalid applier` before a single pixel is drawn — as it did for every widget preview in the
+ * `meshcore-mobile` catalog once the serve theme optimiser started rendering them under each
+ * declared `@ThemeCatalog` theme. Renderers therefore **nest** a theme override around a structural
+ * wrapper (theme outside, structural wrapper inside) instead of replacing it.
+ *
+ * Consults [PreviewWrapperSubstitutionProvider.isStructural] on every registered service, so a
+ * connector's own wrapper classes count too, then falls back to [BUILT_IN_STRUCTURAL_WRAPPER_FQNS].
+ */
+fun isStructuralPreviewWrapper(
+  wrapperFqn: String,
+  classLoader: ClassLoader =
+    Thread.currentThread().contextClassLoader
+      ?: PreviewWrapperSubstitutionProvider::class.java.classLoader,
+): Boolean =
+  wrapperFqn in BUILT_IN_STRUCTURAL_WRAPPER_FQNS ||
+    ServiceLoader.load(PreviewWrapperSubstitutionProvider::class.java, classLoader)
+      .asSequence()
+      .any { it.isStructural(wrapperFqn) }
 
 /**
  * Resolves a preview-wrapper FQN to the class the renderer should actually instantiate.

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/StructuralPreviewWrapperTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/StructuralPreviewWrapperTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.data.render.extensions
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards [isStructuralPreviewWrapper] — the check that keeps a `themeProvider` override from
+ * replacing a wrapper the preview body cannot compose without.
+ *
+ * The built-in entry (upstream `RemotePreviewWrapper`) has to answer true with no connector on the
+ * classpath, because the crash it prevents — `IllegalStateException: Invalid applier` out of every
+ * RemoteCompose widget preview rendered under a declared theme — does not depend on the connector
+ * being present. The SPI half is covered by the fake provider registered through this module's test
+ * `META-INF/services/...PreviewWrapperSubstitutionProvider` resource, exactly as
+ * `:data-remotecompose-connector` registers its real one.
+ */
+class StructuralPreviewWrapperTest {
+
+  @Test
+  fun `upstream RemotePreviewWrapper is structural without any connector`() {
+    assertTrue(
+      isStructuralPreviewWrapper(
+        "androidx.compose.remote.tooling.preview.RemotePreviewWrapper",
+        javaClass.classLoader,
+      )
+    )
+  }
+
+  @Test
+  fun `a registered provider can declare its own wrapper structural`() {
+    assertTrue(
+      isStructuralPreviewWrapper(
+        "ee.schimke.composeai.data.render.extensions.FakeStructuralWrapper",
+        javaClass.classLoader,
+      )
+    )
+  }
+
+  @Test
+  fun `an ordinary theme wrapper is not structural`() {
+    // The common case: an app's @ThemeCatalog provider, which a themeProvider override is
+    // *supposed* to replace. Answering true here would silently disable the theme selector by
+    // letting the preview's own theme shadow the chosen one.
+    assertFalse(
+      isStructuralPreviewWrapper("com.example.AppLightThemeProvider", javaClass.classLoader)
+    )
+  }
+}
+
+/**
+ * Registered via `src/test/resources/META-INF/services/...PreviewWrapperSubstitutionProvider`.
+ * Substitutes nothing — it exists only to prove the structural half of the SPI is consulted.
+ */
+class FakeStructuralWrapperProvider : PreviewWrapperSubstitutionProvider {
+  override fun substituteFor(originalWrapperFqn: String): Class<*>? = null
+
+  override fun isStructural(wrapperFqn: String): Boolean =
+    wrapperFqn == "ee.schimke.composeai.data.render.extensions.FakeStructuralWrapper"
+}

--- a/data/render/core/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
+++ b/data/render/core/src/test/resources/META-INF/services/ee.schimke.composeai.data.render.extensions.PreviewWrapperSubstitutionProvider
@@ -1,0 +1,1 @@
+ee.schimke.composeai.data.render.extensions.FakeStructuralWrapperProvider


### PR DESCRIPTION
Fixes the `render failed: IllegalStateException: Invalid applier` failures showing on [preview.coo.ee/status](https://preview.coo.ee/status) for the `meshcore-mobile` session.

## The bug, confirmed against production

`meshcore-mobile` carries eight RemoteCompose widget previews annotated `@PreviewWrapper(RemotePreviewWrapper::class)` — that wrapper is what installs the RemoteCompose capture their bodies compose against. It is also the first catalog to combine those with `@ThemeCatalog` providers.

`InvokeWithOptionalWrapper` (duplicated in `daemon/android` and `daemon/desktop`) treated a `themeProvider` override as a **replacement** for the declared `@PreviewWrapper`:

```kotlin
themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
  ?: resolveWrapperOrNull(composableMethod, wrapperFqnFromSpec)
```

Correct for the ordinary case — a declared wrapper is nearly always the preview's own theme, and swapping it is the point of the viewer's theme selector. Fatal for a wrapper that installs a *surface*: with `RemotePreviewWrapper` gone the body's `RemoteBox` / `RemoteColumn` / `RemoteRow` land on the plain UI applier and the render throws before drawing.

Reproduced directly against the running (unfixed) server, which is what pins the diagnosis rather than inferring it from timing:

```
GET /meshcore-mobile/render/app-deviceinfowidgetemptypreview__ideal__default__compact.png
  → 200

GET …same preview…?themeProvider=ee.schimke.meshcore.app.ui.theme.MeshcoreAppLightThemeCatalog
  → 500  render failed: IllegalStateException: Invalid applier
```

That preview sorts first in the catalog's id list, which is where the theme optimiser's cursor starts — matching `/status.json`'s four failures at +278/62/68/75 ms with `lastBatchWidth: 1`: one preview against each of the app module's four declared themes, before the pass yielded its slice.

Published catalog renders were never affected (`failedRenders: 0`); only live renders carry `themeProvider`.

## The fix

A `@PreviewWrapper` provider can be declared **structural** — it installs the surface the body composes against rather than a look — and a theme override **nests around** it (theme outside, structural wrapper inside) instead of replacing it.

- `isStructuralPreviewWrapper()` in `:data-render-core`, with upstream `RemotePreviewWrapper` built in (the crash does not depend on the connector being present) plus an `isStructural` hook on the existing `PreviewWrapperSubstitutionProvider` SPI — no new service file for connectors that already register.
- `:data-remotecompose-connector` declares the upstream FQN and its own `RemoteOverridablePreviewWrapper` / `RemoteEmbeddedPreviewWrapper` structural.
- Both render engines resolve a `WrapperStack` rather than one-or-the-other. `resolveWrapperOrNull`'s FQN lookup is split into `declaredWrapperFqnOrNull` so the structural question can be asked before the class is loaded.

Unchanged: a blank/absent `themeProvider` still goes straight to the declared wrapper, and a stale or misspelled one still falls back to it (`badThemeProviderFallsBackToDeclaredWrapper` still passes).

## Test plan

New coverage, all passing:

- `:data-render-core` — `StructuralPreviewWrapperTest`: the built-in FQN, the SPI path via a fake provider, and an ordinary theme wrapper answering false (answering true there would silently disable the theme selector).
- `:data-remotecompose-connector` — every RemoteCompose wrapper reads structural, directly and through `isStructuralPreviewWrapper`.
- `:daemon:android` — `WrappedPreviewRenderTest.themeProviderOverrideNestsAroundStructuralWrapper`
- `:daemon:desktop` — `OverrideIntegrationTest.themeProviderOverrideNestsAroundStructuralWrapper`

Both integration tests use a required-CompositionLocal wrapper as a stand-in for `RemotePreviewWrapper` (the alpha artifact is on neither daemon's test classpath), declared structural through a test-scoped SPI registration. **Both were verified to fail with the fix reverted:**

```
java.lang.IllegalStateException: Required app preview environment was not installed
	at ee.schimke.composeai.daemon.RedFixturePreviewsKt.WrapperRequiredSquare(RedFixturePreviews.kt:1111)
```

Full suites for the four touched modules: 313 tests, 4 failures, all in `DesktopRecordingSessionTest` and **all four reproduce identically on a clean `origin/main` worktree** — pre-existing, unrelated.

## Second commit: declaring themes on the RemoteCompose sample

`:samples:remotecompose` is the only module rendering Remote Compose through **approach 2** (`@PreviewWrapper(RemotePreviewWrapper::class)` on an ordinary `@Preview`). It declared no themes, so the combination that broke meshcore existed nowhere upstream — `:samples:design-catalog-remote-m3` pairs Remote Compose with `@WearThemeCatalog` already, but through **approach 1** (`RemoteSticker { … }` in the body), where a theme composes outside the capture by construction and nothing can go wrong.

Two `@WearThemeCatalog` providers close that gap. Wear M3 rather than phone M3 because `androidx.compose.material3` reaches this module only at runtime while `androidx.wear.compose:compose-material3` is on the compile classpath, and the module deliberately pins versions instead of taking the Compose BOM.

Both specimen sheets render and differ on exactly the two roles the Coral scheme sets (`primary #FFFF6F61`, `secondary #FFFFB4A9`):

| `Remote Default` | `Remote Coral` |
| --- | --- |
| primary `#FFE9DDFF`, secondary `#FFDEE0FF` | primary `#FFFF6F61`, secondary `#FFFFB4A9` |

**What it does not buy, tested rather than assumed.** The obvious expectation is that this makes the bug reproducible on a serve host. It does not. Packing the module and serving it on a Robolectric daemon, a themed render of a `@PreviewWrapper` preview returns 200 **byte-for-byte identically with the nesting fix and with it reverted** — the provider is genuinely accepted (a bogus one 400s, so the declared set is enforced), but `bundle pack` records `ir/<id>.rc` for exactly those previews and a bundle-backed session replays those bytes instead of recomposing. No wrapper is resolved on a replay, so there is nothing for a theme override to drop. meshcore-mobile recomposes the same shape, which is why it broke.

So the automatic guard remains the two daemon tests, which drive the decision directly. What the sample adds is narrower: the approach-2 + declared-theme shape now exists upstream on a module carrying the real `RemotePreviewWrapper`, ready for a lane that renders it through recomposition. The KDoc records this, including the warning that such a lane must assert against a recomposed render — an IR replay passes no matter what the wrapper logic does.

No before/after pixels for the fix itself: it is render-path plumbing, a no-op unless a `themeProvider` override meets a structural wrapper, and the pixels it restores are meshcore-mobile's existing widget renders, which currently produce no PNG at all under a theme selection (the 500 above). The sample's two new specimen sheets are new renders rather than changed ones.
