### PR TITLE
fix(rc-compare): flatten onto the diff neutral before scoring in the browser

### DIFF
--- a/scripts/design-artifacts/render-rc-compare-html.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.mjs
@@ -76,6 +76,7 @@
  * them normally: two player renders are a real comparison even when the baked
  * capture is empty.
  */
+import { BG } from "./rc-compare-pixels.mjs";
 
 function esc(s) {
   return String(s ?? "").replace(
@@ -387,6 +388,8 @@ function clientScript(threshold) {
   const MODEL = JSON.parse(document.getElementById("rc-model").textContent);
   const THRESHOLD = ${JSON.stringify(threshold)};
   const MAX_DELTA = 35215; // pixelmatch's maximum YIQ difference, for the threshold scale
+  // The neutral the build-time diffs flatten onto (rc-compare-pixels.mjs BG), as a CSS colour.
+  const BG_CSS = ${JSON.stringify(`rgb(${BG[0]}, ${BG[1]}, ${BG[2]})`)};
   const select = document.getElementById("refselect");
   const status = document.getElementById("refstatus");
   const rows = Array.from(document.querySelectorAll("tr.row"));
@@ -454,11 +457,23 @@ function clientScript(threshold) {
     return images.get(src);
   }
 
+  /**
+   * The image's pixels flattened onto the diff neutral, which is what makes [delta] meaningful.
+   *
+   * The published lane PNGs are the players' own captures, alpha and all — a sticker on
+   * transparency, like the baked PNG. Reading them raw would score RGB the viewer never sees: a
+   * transparent black pixel and an opaque black one are the same three channels, so a coverage
+   * difference could vanish. Painting the neutral first and letting the draw composite over it is
+   * the canvas equivalent of the build-time flattenOnto(BG), so a client-side player-vs-player
+   * score means the same thing as the driver's lane-vs-baked one.
+   */
   function pixels(img) {
     const canvas = document.createElement("canvas");
     canvas.width = img.naturalWidth;
     canvas.height = img.naturalHeight;
     const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    ctx.fillStyle = BG_CSS;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
     ctx.drawImage(img, 0, 0);
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
   }

--- a/scripts/design-artifacts/render-rc-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-rc-compare-html.test.mjs
@@ -9,6 +9,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { BG } from "./rc-compare-pixels.mjs";
 import {
   activeLanes,
   hasCmpWasmLane,
@@ -163,6 +164,20 @@ test("the page is a self-contained document with one column per player", () => {
   // summary line reflects the counts
   assert.match(html, /mean mismatch <strong>38\.15%<\/strong>/);
   assert.match(html, /1 not decodable/);
+});
+
+test("the client-side scorer flattens onto the diff neutral before reading pixels", () => {
+  // The published lane PNGs carry the player's alpha, so a raw canvas read would compare RGB the
+  // viewer never sees — a transparent black pixel and an opaque one are the same three channels.
+  // Painting the neutral first makes a player-vs-player score in the browser mean what the
+  // driver's build-time lane-vs-baked score means.
+  const html = renderRcCompareHtml(model);
+  const scorer = html.slice(html.indexOf("function pixels(img)"));
+  const fill = scorer.indexOf("ctx.fillRect(");
+  const draw = scorer.indexOf("ctx.drawImage(");
+  assert.ok(fill !== -1, "the scratch canvas is painted before the image is drawn onto it");
+  assert.ok(draw > fill, "the image composites over the neutral, not the other way round");
+  assert.match(html, new RegExp(`rgb\\(${BG[0]}, ${BG[1]}, ${BG[2]}\\)`));
 });
 
 test("nothing is diffed by default: no diff images, no score chips, picker on 'none'", () => {


### PR DESCRIPTION
Follow-up to #4448, which merged before this commit reached it (the review finding it answers was raised and fixed while the squash was in flight, so the fix is not on `main`).

## What's wrong

`rc-compare.html`'s reference picker re-scores lane-vs-lane **in the page**, reading each published PNG back off a canvas. `delta()` is pixelmatch's YIQ metric with no alpha term — its comment says so outright ("Both sides are already opaque"), which was true while every lane image was flattened onto the diff neutral at build time.

#4448 made those files the players' own captures, alpha intact. That breaks the assumption: a transparent pixel and an opaque one with the same RGB now score as a match, so a coverage difference vanishes from the client-side number while the build-time number still counts it.

## The fix

Paint the neutral onto the scratch canvas and let the image composite over it — the canvas equivalent of the build-time `flattenOnto(BG)`. Published bytes are untouched; only what the scorer reads changes. `BG` is imported from `rc-compare-pixels.mjs` rather than restated, so the page and the driver can't drift apart.

## Test plan

- `node --test scripts/design-artifacts/render-rc-compare-html.test.mjs` — 27 pass, 0 fail. A new case pins the ordering (neutral filled, then the image composited over it) and that the colour is `BG`.
- Full `node --test` in `scripts/design-artifacts`: 902 tests, 895 pass / 7 skipped / 0 fail.
- Exercised in a real browser against the `remote-m3` compare page (served over http, since canvas readback is blocked on `file://`), with the JS player as reference — flattened vs raw:

  | row | flattened | raw |
  |---|---|---|
  | `SystemThemeSwatchesRemote` | 4.84% (7,744 px) | 4.84% (7,744 px) |
  | row 2 | 5.30% (16,293 px) | 5.02% (15,407 px) |
  | row 3 | 5.31% (16,308 px) | 5.12% (15,736 px) |

  About 900 px per row of real disagreement that the raw read swallowed, exactly where one side painted and the other did not. Row 1, where both sides cover the canvas, is unchanged — and matches the driver's build-time java-vs-js number for that preview.

Text-only change to a page's scoring arithmetic; the rendered lane images themselves are unaffected, so there is no before/after pixel pair to embed. The numbers above are the observable difference.


---
_Generated by [Claude Code](https://claude.ai/code/session_013GjYumFpv7uQLrpRdXnuX7)_