### PR TITLE
test(samples): declare themes on the RemoteCompose sample

### DIFF
--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/ThemeCatalogs.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/ThemeCatalogs.kt
@@ -1,0 +1,102 @@
+package com.example.sampleremotecompose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+import androidx.wear.compose.material3.ColorScheme
+import androidx.wear.compose.material3.MaterialTheme
+import ee.schimke.composeai.preview.WearThemeCatalog
+
+/**
+ * Declared themes for this sample — the half that was missing when a RemoteCompose catalog first
+ * met a theme selector in the wild.
+ *
+ * ## Why this module in particular
+ *
+ * This is the only module in the repo that renders Remote Compose through **approach 2**:
+ * `@PreviewWrapper(RemotePreviewWrapper::class)` on an ordinary `@Preview`, so the wrapper — not
+ * the body — installs the capture. `:samples:design-catalog-remote-m3` pairs Remote Compose with
+ * `@WearThemeCatalog` already, but through **approach 1** (`RemoteSticker { … }` inside the body),
+ * where a theme provider composes outside the capture by construction and nothing can go wrong.
+ *
+ * Approach 2 plus a declared theme is the combination that had no home here, and it is exactly the
+ * one `yschimke/meshcore-mobile` shipped. A `themeProvider` override used to REPLACE a preview's
+ * declared `@PreviewWrapper`, which for these previews deletes the capture the body needs: every
+ * `RemoteBox` / `RemoteColumn` / `RemoteRow` then lands on the plain UI applier and the render dies
+ * with `IllegalStateException: Invalid applier` before drawing a pixel. Every widget preview in
+ * that catalog failed the moment the serve theme optimiser began pre-rendering each preview under
+ * each declared theme. The renderer now nests a theme override outside a structural wrapper instead
+ * (`isStructuralPreviewWrapper` in `:data-render-core`); these providers exist so the shape that
+ * broke is present upstream rather than only downstream.
+ *
+ * ## What a theme here does and does not reach
+ *
+ * It does not repaint the widgets, and that is not a bug to fix. `RemotePreviewWrapper` captures
+ * its content with `captureSingleRemoteDocument` inside a `remember`, which is a **separate
+ * composition** — no `CompositionContext` is threaded from the enclosing one, so composition locals
+ * (a `MaterialTheme` among them) do not cross into the recorded document. A theme selected against
+ * one of these previews therefore renders the same pixels it renders untinted. What must be true is
+ * that it *renders at all*.
+ *
+ * Where the theme is live is the synthetic specimen sheet `@WearThemeCatalog` makes the renderer
+ * emit per provider: a canned Wear M3 role + type-scale grid composed inside `Wrap`, which reads
+ * the scheme below and differs per theme. Re-theming a recorded document is a different mechanism
+ * entirely — named-value overrides on the replay path — and `:samples:design-catalog-remote-m3`'s
+ * `RemoteThemeCatalogs.kt` is the worked example of it.
+ *
+ * ## Coverage this does and does not add — measured, not assumed
+ *
+ * It does **not** reproduce the bug, and it is worth being precise about why, because the obvious
+ * assumption is wrong.
+ *
+ * No offline lane applies a `themeProvider` at all: `composePreviewRenderAll` wraps only the canned
+ * specimen grid in a provider, never an ordinary preview, so these sheets keep rendering either
+ * way. The interesting case is a live `serve` session, and that was tried: pack this module
+ * (`bundle pack --module samples:remotecompose`), serve it on a Robolectric daemon, and request
+ * `render/<RemoteButtonWithBorderPreview>.png?themeProvider=<RemoteSampleCoralThemeCatalog>`. The
+ * provider is accepted (a bogus one 400s, so the declared set is enforced) and the render returns
+ * 200 — **on a daemon with the nesting fix and on one with it reverted, byte for byte identical.**
+ *
+ * The reason is that `bundle pack` records `ir/<id>.rc` for exactly these `@PreviewWrapper`
+ * previews, and a bundle-backed session replays those bytes rather than recomposing the body. No
+ * wrapper is resolved on a replay, so there is nothing for a theme override to drop. A recorded
+ * document is immune to this bug by construction.
+ *
+ * `yschimke/meshcore-mobile`'s catalog recomposes the same shape instead, which is why it broke:
+ * `GET /meshcore-mobile/render/app-deviceinfowidgetemptypreview__…png?themeProvider=<its app
+ * theme>` answered `500 render failed: IllegalStateException: Invalid applier` against the unfixed
+ * server while the un-themed render of the same preview answered 200.
+ *
+ * So the automatic guard remains `themeProviderOverrideNestsAroundStructuralWrapper` in
+ * `:daemon:android` and `:daemon:desktop`, which drives the decision directly. What these providers
+ * add is narrower and honest: the approach-2 + declared-theme *shape* now exists upstream, on a
+ * module carrying the real `RemotePreviewWrapper` that neither daemon's test classpath has, ready
+ * for a lane that renders it through recomposition. Anyone wiring that lane should assert against a
+ * recomposed render — an IR replay will pass no matter what the wrapper logic does.
+ *
+ * Wear M3 rather than phone M3 because `androidx.compose.material3` reaches this module only at
+ * runtime (via `wear-compose-remote-material3`), while `androidx.wear.compose:compose-material3` is
+ * on the compile classpath — and this module deliberately pins versions instead of taking the
+ * Compose BOM (see its `build.gradle.kts`), so adding a phone-M3 compile dependency to write two
+ * theme providers would be a poor trade.
+ *
+ * Each provider declares its own `Wrap`: the renderer resolves the method reflectively **on the
+ * concrete class**, so an implementation inherited from a shared base is a `NoSuchMethodException`
+ * and the sheet fails to render.
+ */
+@WearThemeCatalog(name = "Remote Default", group = "Remote")
+class RemoteSampleDefaultThemeCatalog : PreviewWrapperProvider {
+  @Composable override fun Wrap(content: @Composable () -> Unit) = MaterialTheme { content() }
+}
+
+/** Warm coral primary — the palette the specimen sheet is read against the default with. */
+@WearThemeCatalog(name = "Remote Coral", group = "Remote")
+class RemoteSampleCoralThemeCatalog : PreviewWrapperProvider {
+  @Composable
+  override fun Wrap(content: @Composable () -> Unit) =
+    MaterialTheme(
+      colorScheme = ColorScheme(primary = Color(0xFFFF6F61), secondary = Color(0xFFFFB4A9))
+    ) {
+      content()
+    }
+}


### PR DESCRIPTION
Follow-up to #4449 (the `Invalid applier` fix). This commit was pushed seconds after that PR was squash-merged, so it missed the merge — reopened here on a branch restarted from `main`.

## Why

`:samples:remotecompose` is the only module rendering Remote Compose through **approach 2** — `@PreviewWrapper(RemotePreviewWrapper::class)` on an ordinary `@Preview`, so the wrapper installs the capture. It declared no themes, so the combination that broke `yschimke/meshcore-mobile` (approach 2 + a declared `@ThemeCatalog`) existed nowhere upstream.

`:samples:design-catalog-remote-m3` already pairs Remote Compose with `@WearThemeCatalog`, but through **approach 1** (`RemoteSticker { … }` inside the body), where a theme provider composes outside the capture by construction and nothing can go wrong. That is why the gap went unnoticed.

## What

Two `@WearThemeCatalog` providers. Wear M3 rather than phone M3 because `androidx.compose.material3` reaches this module only at runtime (via `wear-compose-remote-material3`) while `androidx.wear.compose:compose-material3` is on the compile classpath — and the module deliberately pins versions instead of taking the Compose BOM, so adding a phone-M3 compile dependency to write two providers would be a poor trade.

## Visual evidence

`composePreviewRenderAll` emits one specimen sheet per provider. Both render, and they differ on exactly the two roles the Coral scheme sets — so the providers are live, not inert:

**`Remote Default`**

![Remote Default theme specimen sheet](https://raw.githubusercontent.com/yschimke/compose-ai-tools/b5f9ca2aad2cb5f84a1d2a606b661a400bc5d7eb/renders/samples:remotecompose/wearthemecatalog__Remote_Default.png)

**`Remote Coral`**

![Remote Coral theme specimen sheet](https://raw.githubusercontent.com/yschimke/compose-ai-tools/b5f9ca2aad2cb5f84a1d2a606b661a400bc5d7eb/renders/samples:remotecompose/wearthemecatalog__Remote_Coral.png)

| role | `Remote Default` | `Remote Coral` |
| --- | --- | --- |
| `primary` | `#FFE9DDFF` | `#FFFF6F61` |
| `secondary` | `#FFDEE0FF` | `#FFFFB4A9` |

Every other role, and the whole type scale, is identical between the two sheets. These are new renders rather than changed ones, so there is no before/after pair to diff — the sheets did not exist before this commit. The preview-diff bot agrees: 2 new variants, and all 11 pre-existing previews **Unchanged**, which is the check that this is purely additive.

## What this does NOT buy — tested rather than assumed

The obvious expectation is that this makes the bug reproducible on a serve host. **It does not**, and the KDoc says so, because the assumption is wrong in a way that would waste the next person's afternoon.

Packing the module (`bundle pack --module samples:remotecompose`) and serving it on a Robolectric daemon, then requesting `render/<RemoteButtonWithBorderPreview>.png?themeProvider=<RemoteSampleCoralThemeCatalog>`:

- the provider is genuinely accepted — a bogus FQN returns `400`, so the declared-theme set is enforced;
- the render returns `200` with `X-Compose-Preview-Generation: daemon`;
- and it is **byte-for-byte identical on a daemon carrying #4449's nesting fix and on one with it reverted** (same SHA-256, 9551 bytes).

The reason: `bundle pack` records `ir/<id>.rc` for exactly these `@PreviewWrapper` previews, and a bundle-backed session replays those bytes instead of recomposing the body. No wrapper is resolved on a replay, so there is nothing for a theme override to drop. A recorded document is immune to this bug by construction.

meshcore-mobile recomposes the same shape, which is why it broke — confirmed against the live server at the time:

```
GET /meshcore-mobile/render/app-deviceinfowidgetemptypreview__ideal__default__compact.png
  → 200
GET …same preview…?themeProvider=ee.schimke.meshcore.app.ui.theme.MeshcoreAppLightThemeCatalog
  → 500  render failed: IllegalStateException: Invalid applier
```

So the automatic guard remains `themeProviderOverrideNestsAroundStructuralWrapper` in `:daemon:android` and `:daemon:desktop` (landed in #4449), which drives the decision directly and fails when the fix is reverted. What this commit adds is narrower and worth stating plainly: the approach-2 + declared-theme *shape* now exists upstream, on a module carrying the real `RemotePreviewWrapper` that neither daemon's test classpath has, ready for a lane that renders it through recomposition. The KDoc warns that such a lane must assert against a recomposed render — an IR replay will pass no matter what the wrapper logic does.

## Test plan

- `:samples:remotecompose:compileDebugKotlin` — green against current `main`.
- `:samples:remotecompose:composePreviewRenderAll` — green; 13 previews plus the two new specimen sheets.
- `ktfmtFormat` clean.
- CI green on `f5d766d`.

## Note on the a11y bot comment

The accessibility report on this PR flags 8 `SpeakableTextPresentCheck` errors — a `RemoteComposePlayer` view with no screen-reader label — across `RemoteButton*`, `RemoteShaderGradient`, `RemoteWidgetSquircle` and the animated-progress previews. **None of those are touched by this diff**, which adds a single new file containing two theme providers; the two previews this PR actually adds are not in the list. The a11y lane is change-scoped to the modules a PR touches, so this is simply the first PR to run it against `samples:remotecompose`. Left alone deliberately: a Remote Compose preview draws a `RemoteDocument` through a player `View` rather than a Compose tree, so there is no semantics node to label from the preview side — the same structural exemption meshcore-mobile's `catalog.spec.json` documents for its widget previews. Worth its own change if the player should carry a default label; not something to smuggle into this one.
