### PR TITLE
fix(preview): make the capture gutter reach the paths the first pass missed

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -48,6 +48,19 @@ package ee.schimke.composeai.preview
  * component. Padding chosen to make a sticker sheet breathe belongs to the sheet, outside the
  * capture, where it doesn't move anybody's render bounds.
  *
+ * ### What it reaches
+ *
+ * Both static render lanes — Android (Robolectric) and CMP Desktop — apply it to a preview's
+ * **still** capture, including a `@FocusedPreview` still, and grow the canvas by the same dp on
+ * each so the published bounds never differ by lane.
+ *
+ * Not yet applied to the motion products a preview can also carry — an `@AnimatedPreview` GIF, an
+ * `@InteractionPreview` recording, a scrolling capture — nor to the live daemon lane
+ * (`compose-preview serve`, the VS Code panel). A component that declares a gutter and also records
+ * motion publishes a still with its shadow and a recording without it. Tracked as
+ * compose-ai-tools#4452 and #4443 respectively; a scrolling capture additionally has to settle what
+ * a gutter even means when the bounds are a stitched scroll extent rather than the component.
+ *
  * ### Fixed axes grow too
  *
  * Both kinds of axis gain the gutter, and for the same reason: the promise is that the component

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -262,6 +262,12 @@ lanes apply it — the `CaptureGutterPreviews` fixture pair renders `287×117 �
 Desktop and `262×117 → 284×141` on Android for `@CaptureGutter(all = 4, bottom = 5)`, i.e. the
 same `+22×+24` on each.
 
+Within the static lanes it reaches a preview's **still** capture (a `@FocusedPreview` still
+included) but not its motion products — an `@AnimatedPreview` GIF, an `@InteractionPreview`
+recording or a scrolling capture is still framed tight, so a component that declares a gutter and
+also records motion publishes two artefacts that disagree about its bounds
+([#4452](https://github.com/yschimke/compose-ai-tools/issues/4452)).
+
 The **live daemon** lane does not: the gutter is not on `RenderSpec`, so neither daemon
 `RenderEngine` sees it and a guttered preview streams at its un-guttered size while its snapshot
 PNG carries the gutter. That is a layout difference across lanes, which is exactly what this

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
@@ -152,14 +152,37 @@ internal object DialogWindowCapture {
    * A `ModalBottomSheet`'s window fills the screen, so its rect covers the whole frame and this is
    * a no-op; a centred `Dialog` / `AlertDialog` crops to the dialog itself.
    */
-  fun cropPngToDialogWindow(file: File, root: SemanticsNode, window: android.view.Window) {
-    dialogWindowCropRect(file, root, window)?.let { cropPngToRect(file, it) }
+  /**
+   * [gutter] is the resolved `@CaptureGutter` in pixels, expanding the crop past the dialog window
+   * so an elevation shadow the dialog draws outside its own bounds survives. The dialog is composed
+   * into its own window and cropped to that window's rect here, which is a path the activity-hosted
+   * wrap crop never sees — so without this the gutter reaches every capture except the one whose
+   * component most reliably casts a shadow. Clamped to the captured frame: the dialog sits inside a
+   * full-screen capture, so there is normally room, but a dialog flush against an edge simply gets
+   * less gutter on that side rather than a crop that runs off the image.
+   */
+  fun cropPngToDialogWindow(
+    file: File,
+    root: SemanticsNode,
+    window: android.view.Window,
+    gutter: DialogCropGutter = DialogCropGutter(),
+  ) {
+    dialogWindowCropRect(file, root, window, gutter)?.let { cropPngToRect(file, it) }
   }
+
+  /** Per-edge crop expansion in pixels; all-zero is the pre-`@CaptureGutter` behaviour. */
+  data class DialogCropGutter(
+    val leftPx: Int = 0,
+    val topPx: Int = 0,
+    val rightPx: Int = 0,
+    val bottomPx: Int = 0,
+  )
 
   fun dialogWindowCropRect(
     file: File,
     root: SemanticsNode,
     window: android.view.Window,
+    gutter: DialogCropGutter = DialogCropGutter(),
   ): android.graphics.Rect? {
     if (!file.exists()) return null
     val original = runCatching { javax.imageio.ImageIO.read(file) }.getOrNull() ?: return null
@@ -175,7 +198,14 @@ internal object DialogWindowCapture {
     )
     val left = placed.left.coerceIn(0, original.width - width)
     val top = placed.top.coerceIn(0, original.height - height)
-    return android.graphics.Rect(left, top, left + width, top + height)
+    // Grow outward from the window's own rect, then clamp to the frame. Each edge is clamped
+    // independently so a dialog near one edge keeps the gutter it can have on the other three.
+    return android.graphics.Rect(
+      (left - gutter.leftPx).coerceAtLeast(0),
+      (top - gutter.topPx).coerceAtLeast(0),
+      (left + width + gutter.rightPx).coerceAtMost(original.width),
+      (top + height + gutter.bottomPx).coerceAtMost(original.height),
+    )
   }
 
   private fun cropPngToRect(file: File, rect: android.graphics.Rect) {

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -736,15 +736,25 @@ abstract class RobolectricRenderTestBase(
     val inspectionMode =
       System.getProperty("composeai.render.inspectionMode")?.toBooleanStrictOrNull() ?: true
 
-    // `@CaptureGutter`: the sandbox / frame the composition is hosted in grows by the gutter, and
-    // [MeasuredWrapBox] hands the composable the space back minus it — so the component measures
+    // `@CaptureGutter`: the window the composition is hosted in grows by the gutter, and
+    // [MeasuredWrapBox] hands the composable back its ORIGINAL viewport — so the component measures
     // exactly what it measured without a gutter and the extra pixels are pure canvas. Same rule the
     // desktop lane applies in `composePreviewSceneSize`, so the two lanes agree on the bounds.
+    //
+    // The growth is in dp because a Robolectric qualifier has no other unit, and it is the
+    // **ceiling** of the pixel gutter rather than the declared dp: at a fractional density
+    // (2.625 is the AS phone default) rounding each edge to whole pixels can total more than the
+    // dp figure converts to — `all = 4` is 11px + 11px = 22px, which is 8.4dp, not 8. Rounding down
+    // would leave the window a pixel short of `component + gutter` and the crop would eat a pixel
+    // of shadow. The spare fraction of a dp is transparent canvas outside the crop.
     val gutter = params.captureGutter ?: CaptureGutterDp()
+    val gutterDensity = params.density ?: 2.0f
+    val gutterWidthDp = ceilDpForPx(gutter.start, gutter.end, gutterDensity)
+    val gutterHeightDp = ceilDpForPx(gutter.top, gutter.bottom, gutterDensity)
     val composeOptions =
       RoborazziComposeOptions.Builder()
         .apply {
-          size(widthDp + gutter.horizontal, heightDp + gutter.vertical)
+          size(widthDp + gutterWidthDp, heightDp + gutterHeightDp)
           if (isRound) addOption(RoundScreenOption)
           if (params.fontScale != 1.0f) fontScale(params.fontScale)
           if (params.uiMode != 0) uiMode(params.uiMode)
@@ -1215,9 +1225,18 @@ abstract class RobolectricRenderTestBase(
     // [EmojiCompatRenderSupport].
     EmojiCompatRenderSupport.ensureInitialized(appContext)
 
+    // The viewport qualifier grows by the `@CaptureGutter` here as well as in the Roborazzi
+    // `size(...)` option, and it is THIS one that decides the window the composition is measured
+    // in — it is applied later and wins. Growing only the Roborazzi option left the window at the
+    // declared frame, so the box's `child + gutter` was clamped back to it and the fixed-axis
+    // resize then *upscaled* the too-small capture, stretching the component by the gutter it was
+    // supposed to sit inside.
+    val qualifierDensity = params.density ?: 2.0f
+    val qualifierGutter = params.captureGutter ?: CaptureGutterDp()
     applyPreviewQualifiers(
-      widthDp = widthDp,
-      heightDp = heightDp,
+      widthDp = widthDp + ceilDpForPx(qualifierGutter.start, qualifierGutter.end, qualifierDensity),
+      heightDp =
+        heightDp + ceilDpForPx(qualifierGutter.top, qualifierGutter.bottom, qualifierDensity),
       isRound = isRoundDevice(params.device) && params.kind == PreviewKind.COMPOSE,
       locale = params.locale,
       uiMode = params.uiMode,
@@ -1527,6 +1546,10 @@ abstract class RobolectricRenderTestBase(
                         wrapWidth = wrapWidth,
                         wrapHeight = wrapHeight,
                         gutter = params.captureGutter ?: CaptureGutterDp(),
+                        // The viewport the composable would have had with no gutter — the window
+                        // above is this plus the gutter, and the box hands this back verbatim.
+                        viewportWidthDp = widthDp,
+                        viewportHeightDp = heightDp,
                         onMeasured = { measured = it },
                       ) {
                         strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
@@ -2131,7 +2154,12 @@ abstract class RobolectricRenderTestBase(
                 // var shared across jobs.
                 resolveCaptureRoot().semanticsRoot?.let { root ->
                   DialogWindowCapture.shownDialogWindow(root)?.also { window ->
-                    DialogWindowCapture.cropPngToDialogWindow(outputFile, root, window)
+                    DialogWindowCapture.cropPngToDialogWindow(
+                      outputFile,
+                      root,
+                      window,
+                      dialogCropGutter(params.captureGutter, params.density ?: 2.0f),
+                    )
                   }
                 }
               } else {
@@ -2178,17 +2206,24 @@ abstract class RobolectricRenderTestBase(
               val resizeDensity = params.density ?: 2.0f
               // A fixed axis is resized to the frame it declared PLUS its capture gutter: the
               // gutter is canvas the author asked for, so trimming back to the bare frame would
-              // drop the shadow it exists to keep.
+              // drop the shadow it exists to keep. In PIXELS, added to the frame's own pixel
+              // width, rather than resolving the summed dp — the box laid the gutter out in
+              // rounded pixels, and re-deriving it from dp here would disagree with it by one at a
+              // fractional density.
               val resizeGutter = params.captureGutter ?: CaptureGutterDp()
+              val resizeGutterWPx =
+                edgePx(resizeGutter.start, resizeDensity) + edgePx(resizeGutter.end, resizeDensity)
+              val resizeGutterHPx =
+                edgePx(resizeGutter.top, resizeDensity) + edgePx(resizeGutter.bottom, resizeDensity)
               resizeFixedAxesPng(
                 file = outputFile,
                 targetWidth =
                   if (!wrapWidth && params.device == null && params.widthDp != null)
-                    ((widthDp + resizeGutter.horizontal) * resizeDensity).roundHalfUpPx()
+                    (widthDp * resizeDensity).roundHalfUpPx() + resizeGutterWPx
                   else null,
                 targetHeight =
                   if (!wrapHeight && params.device == null && params.heightDp != null)
-                    ((heightDp + resizeGutter.vertical) * resizeDensity).roundHalfUpPx()
+                    (heightDp * resizeDensity).roundHalfUpPx() + resizeGutterHPx
                   else null,
               )
             }
@@ -2384,6 +2419,8 @@ abstract class RobolectricRenderTestBase(
     wrapWidth: Boolean,
     wrapHeight: Boolean,
     gutter: CaptureGutterDp,
+    viewportWidthDp: Int,
+    viewportHeightDp: Int,
     onMeasured: (IntSize) -> Unit,
     content: @Composable () -> Unit,
   ) {
@@ -2394,16 +2431,21 @@ abstract class RobolectricRenderTestBase(
     val topPx = with(density) { gutter.top.dp.roundToPx() }
     val endPx = with(density) { gutter.end.dp.roundToPx() }
     val bottomPx = with(density) { gutter.bottom.dp.roundToPx() }
+    // The viewport the composable gets is the one it would have had with NO gutter, resolved from
+    // the same dp the un-guttered window would have used — NOT "the enlarged window minus the
+    // rounded edges". Those two differ at a fractional density: at 2.625 a 400dp window is 1050px
+    // and the enlarged one is 1073px, of which subtracting 11px + 11px leaves 1051px — a pixel the
+    // component never had, which is enough to remeasure `fillMaxWidth` content and defeat the
+    // annotation's one promise. Resolving the original dp gives back exactly 1050px.
+    val viewportWidthPx = with(density) { viewportWidthDp.dp.roundToPx() }
+    val viewportHeightPx = with(density) { viewportHeightDp.dp.roundToPx() }
     Box(
       modifier =
         Modifier.layout { measurable, constraints ->
-          // The gutter comes off the available space before the child is measured — the sandbox
-          // was enlarged by exactly this much — so the composable sees the constraints it would
-          // have had without a gutter, and the extra pixels end up as canvas around it rather than
-          // as a smaller box to lay out in. That is the whole difference between this and padding
-          // the preview body (m3-catalog#179).
-          val availWidth = (constraints.maxWidth - startPx - endPx).coerceAtLeast(0)
-          val availHeight = (constraints.maxHeight - topPx - bottomPx).coerceAtLeast(0)
+          // Clamped to the window in case the qualifier resolved a pixel differently than the dp
+          // conversion here — the constraint must stay satisfiable.
+          val availWidth = viewportWidthPx.coerceIn(0, constraints.maxWidth)
+          val availHeight = viewportHeightPx.coerceIn(0, constraints.maxHeight)
           val wrappedConstraints =
             Constraints(
               minWidth = if (wrapWidth) 0 else availWidth,
@@ -2477,6 +2519,49 @@ abstract class RobolectricRenderTestBase(
     // `FocusController.SETTLE_MS` so the connector's around-composable + the renderer's
     // per-capture clock advance share a single source of truth. Don't redeclare it here.
   }
+}
+
+/**
+ * One `@CaptureGutter` edge in pixels at [density]. Rounded per edge, matching what
+ * `MeasuredWrapBox` resolves in composition, so the window growth, the layout and the fixed-axis
+ * resize all agree on where the gutter's pixels are.
+ */
+internal fun edgePx(edgeDp: Int, density: Float): Int = Math.round(edgeDp * density)
+
+/**
+ * Dp the hosting window must grow on one axis to hold both [edgeADp] and [edgeBDp] at [density] —
+ * the **ceiling** of their summed pixels, because a Robolectric qualifier is dp-only and rounding
+ * down would leave the window a pixel short of `component + gutter`, costing a pixel of the shadow
+ * the gutter exists to keep. `0` for an absent gutter, so an un-annotated preview's window is
+ * untouched.
+ */
+internal fun ceilDpForPx(edgeADp: Int, edgeBDp: Int, density: Float): Int {
+  val totalPx = edgePx(edgeADp, density) + edgePx(edgeBDp, density)
+  if (totalPx <= 0) return 0
+  return kotlin.math.ceil(totalPx / density).toInt()
+}
+
+/**
+ * The dialog-window crop expansion for [gutter] at [density] — the same per-edge pixels the wrap
+ * box uses, mapped from start/end onto left/right. Dialog captures are cropped to their own window
+ * rect (see [DialogWindowCapture]), a path the activity-hosted wrap crop never reaches, so without
+ * this the gutter would miss the one component that most reliably casts a shadow.
+ *
+ * Left/right rather than start/end because the crop is applied to already-rendered pixels: an RTL
+ * capture has already been mirrored by the time the rect is computed, so the leading edge is on the
+ * right of the image. That is [DialogWindowCapture]'s own frame of reference, not layout's.
+ */
+internal fun dialogCropGutter(
+  gutter: CaptureGutterDp?,
+  density: Float,
+): DialogWindowCapture.DialogCropGutter {
+  if (gutter == null) return DialogWindowCapture.DialogCropGutter()
+  return DialogWindowCapture.DialogCropGutter(
+    leftPx = edgePx(gutter.start, density),
+    topPx = edgePx(gutter.top, density),
+    rightPx = edgePx(gutter.end, density),
+    bottomPx = edgePx(gutter.bottom, density),
+  )
 }
 
 /**

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DialogWindowCaptureTest.kt
@@ -91,6 +91,30 @@ class DialogWindowCaptureTest {
     assertTrue("the crop must land on the dialog's fill, not the backdrop", png.isEntirely(FILL))
   }
 
+  @Test
+  fun `a capture gutter widens the dialog crop instead of slicing the shadow off`() {
+    rule.setContent {
+      Dialog(onDismissRequest = {}) { Box(modifier = Modifier.size(64.dp).background(FILL)) }
+    }
+    rule.mainClock.advanceTimeBy(SETTLE_MS)
+
+    val png = capture("dialog-gutter.png")
+    val root = resolveRoot()
+    val window = DialogWindowCapture.shownDialogWindow(root)
+    assertNotNull("the dialog's window must be resolvable from its root", window)
+
+    // A dialog is cropped to its own window rect, which is a path the activity-hosted wrap crop
+    // never sees — so `@CaptureGutter` has to reach this crop or the one component that most
+    // reliably casts a shadow is the one component the gutter misses.
+    val gutter =
+      DialogWindowCapture.DialogCropGutter(leftPx = 8, topPx = 8, rightPx = 8, bottomPx = 10)
+    DialogWindowCapture.cropPngToDialogWindow(png, root, window!!, gutter)
+
+    val cropped = ImageIO.read(png)
+    assertEquals("crop grows by the left + right gutter", 64 + 16, cropped.width)
+    assertEquals("crop grows by the top + bottom gutter", 64 + 18, cropped.height)
+  }
+
   @OptIn(ExperimentalMaterial3Api::class)
   @Test
   fun `a full-screen bottom sheet window keeps the whole frame`() {

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -182,6 +182,13 @@ fun renderFocusPreview(
    * [DesktopSettleClock] is needed here.
    */
   settleTargetMs: Long = 0L,
+  /**
+   * `@CaptureGutter` — the same capture-bounds gutter [renderPreview] applies. A focused capture is
+   * framed by the shared [ComposePreviewContentBox], so a component that declares a gutter has to
+   * get it here too: a reviewer diffing the resting and focused stills of one component must see
+   * the state change, not a 22-pixel reframe.
+   */
+  captureGutter: PreviewCaptureGutter = PreviewCaptureGutter.None,
   fileSystem: FileSystem = SystemFileSystem,
 ): Boolean {
   require(focus != null || hoverIndex != null) { "focus or hover intent required" }
@@ -215,7 +222,8 @@ fun renderFocusPreview(
       maxWidthPx = maxWidthPx,
       maxHeightPx = maxHeightPx,
     )
-  val sceneSize = composePreviewSceneSize(widthPx, heightPx, wrapWidth, wrapHeight, sizeBounds)
+  val sceneSize =
+    composePreviewSceneSize(widthPx, heightPx, wrapWidth, wrapHeight, sizeBounds, captureGutter)
   var measured: IntSize? = null
   var focusedBounds: Rectangle? = null
   var landed = false
@@ -271,6 +279,7 @@ fun renderFocusPreview(
               wrapHeight = wrapHeight,
               backgroundColor = bgColor,
               sizeBounds = sizeBounds,
+              gutter = captureGutter,
               onMeasured = { w, h -> measured = IntSize(w, h) },
             ) {
               InvokeFocusComposable(composableMethod, null, previewArgs)
@@ -390,6 +399,7 @@ fun renderFocusPreview(
           widthPx = widthPx,
           heightPx = heightPx,
           device = device,
+          captureGutter = captureGutter,
           fileSystem = fileSystem,
         )
       }
@@ -493,6 +503,7 @@ private fun captureFocusFrame(
   widthPx: Int,
   heightPx: Int,
   device: String?,
+  captureGutter: PreviewCaptureGutter,
   fileSystem: FileSystem,
 ) {
   val bitmap = provider.onRoot().captureToImage()
@@ -509,13 +520,14 @@ private fun captureFocusFrame(
   outputFile.parentFile?.mkdirs()
   val roundClip = isRoundPreviewDevice(device)
   if (((wrapWidth || wrapHeight) && measured != null) || roundClip) {
+    // A fixed axis keeps its declared frame PLUS the capture gutter, exactly as [renderPreview]
+    // does — the scene was enlarged by it and those pixels are the shadow the gutter is for.
     val cropW =
-      (if (wrapWidth && measured != null) measured.width else widthPx).coerceIn(1, sceneSize.width)
+      (if (wrapWidth && measured != null) measured.width else widthPx + captureGutter.horizontalPx)
+        .coerceIn(1, sceneSize.width)
     val cropH =
-      (if (wrapHeight && measured != null) measured.height else heightPx).coerceIn(
-        1,
-        sceneSize.height,
-      )
+      (if (wrapHeight && measured != null) measured.height else heightPx + captureGutter.verticalPx)
+        .coerceIn(1, sceneSize.height)
     val decoded = ByteArrayInputStream(bytes).use { ImageIO.read(it) }
     if (decoded != null) {
       val cropped =

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -626,6 +626,7 @@ fun main(args: Array<String>) {
             settleTargetMs =
               if (settleAfterMs < 0) 0L
               else if (settleAfterMs > 0) settleAfterMs.toLong() else 32L + settleMaxMs.toLong(),
+            captureGutter = captureGutter,
           )
         if (!didCapture) {
           renderPreview(

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/CaptureGutterPreviews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/CaptureGutterPreviews.kt
@@ -1,6 +1,9 @@
 package com.example.sampleandroid
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -8,6 +11,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ee.schimke.composeai.preview.CaptureGutter
@@ -42,4 +46,28 @@ fun ShadowStickerCroppedPreview() {
 @Composable
 fun ShadowStickerGutteredPreview() {
   ElevatedSticker()
+}
+
+/**
+ * A **fill-width** component on a fixed 400dp frame, rendered with and without a gutter — the pair
+ * that pins the gutter's core promise at a fractional density.
+ *
+ * `:samples:android` renders at 2.625, where the dp the hosting window grows by and the pixels each
+ * gutter edge rounds to do not divide evenly. Resolving the child's viewport as "enlarged window
+ * minus the rounded edges" costs it a pixel, and a pixel is all it takes for `fillMaxWidth` content
+ * to measure differently from the un-guttered render — which is precisely what the annotation
+ * promises cannot happen. The pixel test asserts the drawn band is the same width in both.
+ */
+@Preview(name = "Fill fixed", widthDp = 400, showBackground = true)
+@Composable
+fun FillWidthCroppedPreview() {
+  Box(modifier = Modifier.fillMaxWidth().height(48.dp).background(Color(0xFF1B5E20)))
+}
+
+/** The guttered twin of [FillWidthCroppedPreview]. */
+@CaptureGutter(all = 4, bottom = 5)
+@Preview(name = "Fill fixed guttered", widthDp = 400, showBackground = true)
+@Composable
+fun FillWidthGutteredPreview() {
+  Box(modifier = Modifier.fillMaxWidth().height(48.dp).background(Color(0xFF1B5E20)))
 }

--- a/samples/android/src/test/kotlin/com/example/sampleandroid/CaptureGutterPixelTest.kt
+++ b/samples/android/src/test/kotlin/com/example/sampleandroid/CaptureGutterPixelTest.kt
@@ -41,4 +41,38 @@ class CaptureGutterPixelTest {
     assertThat(gutW - bareW).isEqualTo(edge4 * 2)
     assertThat(gutH - bareH).isEqualTo(edge4 + edge5)
   }
+
+  /**
+   * The promise, at a fractional density: a `fillMaxWidth` child on a fixed 400dp frame measures
+   * the *same pixels* with and without a gutter.
+   *
+   * At 2.625 the window grows by a dp figure that doesn't divide evenly into the rounded per-edge
+   * pixels, so deriving the child's viewport by subtracting those edges from the enlarged window
+   * loses a pixel — enough for fill-width content to lay out differently from the un-guttered
+   * render. The green band's drawn width is the component's own measure, so comparing it across the
+   * pair is the assertion that the gutter changed the canvas and nothing else.
+   */
+  @Test
+  fun `a fill-width component measures identically with and without a gutter`() {
+    val bare = drawnWidth(renderFile(rendersDir, "FillWidthCroppedPreview_Fill_fixed"))
+    val guttered =
+      drawnWidth(renderFile(rendersDir, "FillWidthGutteredPreview_Fill_fixed_guttered"))
+    assertThat(guttered).isEqualTo(bare)
+  }
+
+  /** Width of the drawn (non-white) band — the fill-width component's own measured extent. */
+  private fun drawnWidth(file: File): Int {
+    assertThat(file.exists()).isTrue()
+    val img = ImageIO.read(file)
+    val y = img.height / 3
+    var minX = img.width
+    var maxX = -1
+    for (x in 0 until img.width) {
+      if ((img.getRGB(x, y) and 0xFFFFFF) == 0xFFFFFF) continue
+      if (x < minX) minX = x
+      if (x > maxX) maxX = x
+    }
+    check(maxX >= 0) { "row $y of ${file.name} is entirely background" }
+    return maxX - minX + 1
+  }
 }


### PR DESCRIPTION
Follow-up to #4445, which auto-merged while these were being written. Three findings from the Codex review on it, all confirmed against the renderer and all fixed here.

## 1. The Android viewport lost a pixel at fractional density (P2)

The window grew in **dp** while the box subtracted independently **rounded pixel** edges, so at 2.625 a 400dp frame's composable measured 1049px instead of the 1050px it had without a gutter — enough for `fillMaxWidth` content to lay out differently, which defeats the annotation's only promise.

Two halves, both load-bearing:

- The box now resolves the composable's viewport from the **original dp** rather than from "enlarged window minus rounded edges", and the window growth is the **ceiling** of the summed pixel gutter so the extra pixels always fit.
- The growth has to be applied where the viewport is really decided — `applyPreviewQualifiers`, which runs after the Roborazzi `size` option and wins. Growing only the option left the window at the declared frame, so the box's `child + gutter` clamped straight back to it and `resizeFixedAxesPng` then **upscaled** the too-small capture, stretching the component by the gutter it was supposed to sit inside. That was live in #4445 and is what the new fixture catches:

```
before this PR:  guttered fill-width band = 1061px   (component stretched)
after:           guttered fill-width band = 1050px   (identical to un-guttered)
```

## 2. Dialog captures never got the gutter (P1)

A dialog composes into its own window and is cropped to that window's rect by `DialogWindowCapture` — a path the activity-hosted wrap crop never reaches. So the gutter was missing from the one component that most reliably casts a shadow. The crop rect now grows by the same per-edge pixels, clamped **per edge** so a dialog near a frame edge keeps the gutter it can have on the other three.

## 3. Desktop focused captures now carry it (part of P1)

`renderFocusPreview` frames its content with the shared `ComposePreviewContentBox`, so this was one argument: a reviewer diffing the resting and focused stills of one component must see the state change, not a 22-pixel reframe.

## What is still not covered, deliberately

The remaining motion products — `@AnimatedPreview`, `@InteractionPreview`, scroll — place content into the scene **unframed** and derive their crop from observed root bounds via `motionCropSize`, so there is nowhere for a gutter to live without restructuring each. That is real work rather than an argument, and a scrolling capture additionally has to settle what a gutter even means when the bounds are a stitched scroll extent. Filed as #4452 with a proposed patch, and now stated in the annotation's own KDoc and in `RENDER_LANE_PARITY.md` so the gap is declared rather than discovered.

## Test plan

- `:renderer-android:testDebugUnitTest` — `DialogWindowCaptureTest`: new case asserting a gutter widens the dialog crop (64 → 80 × 82) instead of slicing it.
- `:samples:android` — new `FillWidthCroppedPreview` / `FillWidthGutteredPreview` fixture pair (fill-width content on a fixed 400dp frame) plus a `CaptureGutterPixelTest` case asserting the drawn band is **the same width** in both. This is the regression test for finding 1; it fails on #4445's code.
- `:samples:android:composePreviewRenderAll`, `:samples:cmp:composePreviewRenderAll` — re-rendered; the shadow pair is unchanged (287×117 → 309×141 desktop, 262×117 → 284×141 Android), and the fill-width pair is 1050×126 → 1072×150 with the component measuring 1050 in both.
- `:renderer-desktop:test`, `:renderer-android:testDebugUnitTest`, `ktfmtCheckAll` — green.

No new visual surface: the fixtures added here are geometry assertions on an existing one, and the committed before/after strips from #4445 are unchanged by this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqApaZbkNyH1y8ZAu6gPtY)_