### PR TITLE
feat(serve): let an approved agent grant carry image-upload access

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessClient.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessClient.kt
@@ -68,11 +68,21 @@ internal class AgentAccessClient(
   }
 
   /** `POST /agent-access/request`. */
-  fun open(label: String, scope: String, ttlSeconds: Long): Result<OpenResponse> {
+  fun open(
+    label: String,
+    scope: String,
+    ttlSeconds: Long,
+    capabilities: List<String> = emptyList(),
+  ): Result<OpenResponse> {
     val body =
       JSON.encodeToString(
         OpenRequestBody.serializer(),
-        OpenRequestBody(label = label, scope = scope, ttlSeconds = ttlSeconds),
+        OpenRequestBody(
+          label = label,
+          scope = scope,
+          ttlSeconds = ttlSeconds,
+          capabilities = capabilities,
+        ),
       )
     return post("/agent-access/request", body, OpenResponse.serializer())
   }
@@ -154,7 +164,13 @@ internal class AgentAccessClient(
   // so every field is defaulted and unknown ones are ignored.
 
   @kotlinx.serialization.Serializable
-  private data class OpenRequestBody(val label: String, val scope: String, val ttlSeconds: Long)
+  private data class OpenRequestBody(
+    val label: String,
+    val scope: String,
+    val ttlSeconds: Long,
+    /** Omitted by an older CLI, ignored by an older host — defaulted on both sides. */
+    val capabilities: List<String> = emptyList(),
+  )
 
   @kotlinx.serialization.Serializable
   private data class PollRequestBody(val requestId: String, val deviceSecret: String)
@@ -172,6 +188,8 @@ internal class AgentAccessClient(
     val requestedTtlSeconds: Long = 0,
     val maxScope: String = "",
     val maxTtlSeconds: Long = 0,
+    val requestedCapabilities: List<String> = emptyList(),
+    val maxCapabilities: List<String> = emptyList(),
   )
 
   @kotlinx.serialization.Serializable
@@ -180,6 +198,7 @@ internal class AgentAccessClient(
     val token: String? = null,
     val tokenHeader: String? = null,
     val scopes: List<String> = emptyList(),
+    val capabilities: List<String> = emptyList(),
     val expiresInSeconds: Long? = null,
     val approvedBy: String? = null,
     val retryAfterSeconds: Long? = null,
@@ -190,6 +209,7 @@ internal class AgentAccessClient(
   data class WhoamiResponse(
     val active: Boolean = false,
     val scopes: List<String> = emptyList(),
+    val capabilities: List<String> = emptyList(),
     val expiresInSeconds: Long? = null,
     val approvedBy: String? = null,
     val label: String? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
@@ -50,6 +50,11 @@ internal open class AgentAccessStore(
     val origin: String,
     val token: String,
     val scopes: List<String> = emptyList(),
+    /**
+     * Independent permissions the approver ticked ([ServeAgentGrantCapability]). Defaulted, so a
+     * file written by an older CLI reads back without complaint.
+     */
+    val capabilities: List<String> = emptyList(),
     val approvedBy: String = "",
     val label: String = "",
     /** Wall-clock epoch millis. Past ⇒ the entry is dropped on the next read. */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.ServeAgentGrantCapability
 import ee.schimke.composeai.cli.serve.ServeAgentGrantScope
 import ee.schimke.composeai.cli.serve.ServeAgentGrants
 import kotlin.system.exitProcess
@@ -144,6 +145,24 @@ internal class AuthCommand(
         code = 64,
       )
     }
+    // Same treatment as `--scope`, for the same reason: a mistyped capability that reached the
+    // server would simply be dropped there, and the agent would learn it had less access than it
+    // asked for only when an upload was refused — after a human had already approved something.
+    val capabilities =
+      args
+        .flagValuesAll("--capability")
+        .flatMap { it.split(',', ' ') }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { raw ->
+          ServeAgentGrantCapability.parse(raw)?.wire
+            ?: fail(
+              "unknown --capability '$raw' — expected one of " +
+                ServeAgentGrantCapability.entries.joinToString(", ") { it.wire },
+              code = 64,
+            )
+        }
+        .distinct()
     val ttlRaw = args.flagValue("--ttl")
     val ttl =
       ServeAgentGrants.parseDurationSeconds(ttlRaw)
@@ -167,7 +186,10 @@ internal class AuthCommand(
     }
 
     val opened =
-      when (val r = client.open(label = label, scope = scope, ttlSeconds = ttl)) {
+      when (
+        val r =
+          client.open(label = label, scope = scope, ttlSeconds = ttl, capabilities = capabilities)
+      ) {
         is AgentAccessClient.Result.Ok -> r.value
         is AgentAccessClient.Result.Err -> fail(r.reason)
       }
@@ -268,6 +290,7 @@ internal class AuthCommand(
           origin = client.origin,
           token = outcome.token.orEmpty(),
           scopes = outcome.scopes,
+          capabilities = outcome.capabilities,
           approvedBy = outcome.approvedBy.orEmpty(),
           label = label,
           expiresAtMillis = System.currentTimeMillis() + (outcome.expiresInSeconds ?: 0) * 1000,
@@ -449,8 +472,10 @@ internal class AuthCommand(
           "unverified" -> " · could not reach the server to confirm"
           else -> ""
         }
+      val capabilities =
+        if (entry.capabilities.isEmpty()) "" else " + ${entry.capabilities.joinToString(", ")}"
       println(
-        "${entry.origin} — ${entry.scopes.joinToString(", ").ifEmpty { "preview" }} · " +
+        "${entry.origin} — ${entry.scopes.joinToString(", ").ifEmpty { "preview" }}$capabilities · " +
           "expires in ${ServeAgentGrants.formatDuration(left)}" +
           (if (entry.approvedBy.isNotEmpty()) " · approved by ${entry.approvedBy}" else "") +
           (if (entry.label.isNotEmpty()) " · \"${entry.label}\"" else "") +
@@ -537,6 +562,7 @@ internal class AuthCommand(
                 origin = pending.origin,
                 token = token,
                 scopes = polled.scopes,
+                capabilities = polled.capabilities,
                 approvedBy = polled.approvedBy.orEmpty(),
                 label = pending.label,
                 expiresAtMillis =
@@ -737,6 +763,9 @@ internal class AuthCommand(
                   Prints a link and a verification code, then waits for approval.
           --server <url>     The preview server (or ${'$'}COMPOSE_PREVIEW_SERVER).
           --scope <name>     preview | live | playground. Cumulative; default preview.
+          --capability <name> An extra, non-cumulative permission to ask for, repeatable or
+                             comma-separated: currently `images` (upload rendered previews,
+                             on a server that offers it). The approver ticks it separately.
           --ttl <duration>   How long to ask for, e.g. 45m / 2h (default 1h). The approver
                              chooses the actual lifetime, up to the server's ceiling.
           --label <text>     What the access is for; shown on the approval page.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -243,6 +243,8 @@ internal class AuthCommand(
           expiresInSeconds = opened.expiresInSeconds,
           requestedScope = opened.requestedScope,
           requestedTtlSeconds = opened.requestedTtlSeconds,
+          requestedCapabilities = opened.requestedCapabilities,
+          maxCapabilities = opened.maxCapabilities,
         ),
       )
       if ("--no-wait" in args) return
@@ -798,6 +800,16 @@ internal class AuthCommand(
     val expiresInSeconds: Long,
     val requestedScope: String,
     val requestedTtlSeconds: Long,
+    /**
+     * What survived the server's clamp, and what it would grant at all.
+     *
+     * Both matter to `--no-wait`, which emits this record and then exits: there is no later grant
+     * object to learn from, so without these a caller cannot tell that `images` was dropped by a
+     * host that does not offer it — and would send a human through an approval that cannot
+     * authorize the upload it was opened for.
+     */
+    val requestedCapabilities: List<String> = emptyList(),
+    val maxCapabilities: List<String> = emptyList(),
   )
 
   @Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -303,6 +303,7 @@ internal class AuthCommand(
         GrantedJson(
           server = client.origin,
           scopes = outcome.scopes,
+          capabilities = outcome.capabilities,
           approvedBy = outcome.approvedBy.orEmpty(),
           expiresInSeconds = outcome.expiresInSeconds ?: 0,
           stored = saved == true,
@@ -438,6 +439,7 @@ internal class AuthCommand(
               StatusEntryJson(
                 server = entry.origin,
                 scopes = entry.scopes,
+                capabilities = entry.capabilities,
                 approvedBy = entry.approvedBy,
                 label = entry.label,
                 expiresInSeconds = left,
@@ -802,6 +804,12 @@ internal class AuthCommand(
   private data class GrantedJson(
     val server: String,
     val scopes: List<String>,
+    /**
+     * The independent permissions actually granted. Structured output that omitted these read
+     * identically whether `images` was ticked or declined, so automation could not tell an
+     * authorized upload from one that was about to be refused without attempting it.
+     */
+    val capabilities: List<String> = emptyList(),
     val approvedBy: String,
     val expiresInSeconds: Long,
     val stored: Boolean,
@@ -828,6 +836,7 @@ internal class AuthCommand(
   private data class StatusEntryJson(
     val server: String,
     val scopes: List<String>,
+    val capabilities: List<String> = emptyList(),
     val approvedBy: String,
     val label: String,
     val expiresInSeconds: Long,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -142,6 +142,7 @@ internal object CliFlagValidation {
             "--accept-images",
             "--agent-grants",
             "--agent-grant-scopes",
+            "--agent-grant-capabilities",
             "--agent-grant-max-ttl",
             "--agent-grant-max-active",
             "--agent-grant-rate-limit",
@@ -298,7 +299,17 @@ internal object CliFlagValidation {
       "init-script" to setOf("--path", "--print"),
       "pin" to setOf("--cli", "--json", "--remove", "--unset"),
       "auth" to
-        setOf("--server", "--scope", "--ttl", "--label", "--no-wait", "--json", "--help", "-h"),
+        setOf(
+          "--server",
+          "--scope",
+          "--capability",
+          "--ttl",
+          "--label",
+          "--no-wait",
+          "--json",
+          "--help",
+          "-h",
+        ),
       "version" to emptySet(),
       "help" to setOf("--all"),
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -109,6 +109,8 @@ internal object CliFlags {
       "--github-auth-scope",
       "--github-auth-users",
       "--agent-grant-scopes",
+      "--agent-grant-capabilities",
+      "--capability",
       "--agent-grant-max-ttl",
       "--agent-grant-max-active",
       "--agent-grant-rate-limit",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2448,13 +2448,44 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
     // would offer `images`, a human would tick it, and the upload would 404 on a route that was
     // never registered. Refused at startup, where the operator can fix it, rather than discovered
     // by an agent twenty minutes into a task.
-    if (ServeAgentGrantCapability.IMAGES in agentGrantCapabilities && !acceptImages) {
+    //
+    // [imageLaneConfigured], not `acceptImages`: the flag alone is not a lane. Without a repository
+    // to gate on, [openImageLane] declines to build one and says so — and a box that keeps starting
+    // for some other reason would then have offered a capability whose every upload 404s.
+    if (ServeAgentGrantCapability.IMAGES in agentGrantCapabilities && !imageLaneConfigured) {
       System.err.println(
         "serve: --agent-grant-capabilities images refused — this server does not run the image " +
-          "lane, so a granted upload would have nowhere to go. Add --accept-images (with " +
-          "--image-upload-repo, or --github-auth-repo), or drop the capability."
+          "lane, so a granted upload would have nowhere to go. Add --accept-images AND a " +
+          "repository to gate it on (--image-upload-repo, or --github-auth-repo), or drop the " +
+          "capability."
       )
-      throw IllegalArgumentException("--agent-grant-capabilities images needs --accept-images")
+      throw IllegalArgumentException("--agent-grant-capabilities images needs the image lane")
+    }
+    // **The approver must hold what they are passing on**, and on a GitHub-gated box that is
+    // checked against `--github-auth-repo` — the only repository a session's cached verdict speaks
+    // for. When the image lane gates on a DIFFERENT repository, that verdict says nothing about
+    // whether the approver could upload there themselves, so ticking `images` would let someone
+    // with access to the OAuth repo alone mint a grant that publishes to a repo they have no rights
+    // on. The session stores a login and a boolean, not the visitor's token, so there is nothing
+    // here to re-ask GitHub with; the honest answer is to refuse the combination at startup rather
+    // than to approximate the check.
+    val imageRepository = imageUploadRepository
+    if (
+      ServeAgentGrantCapability.IMAGES in agentGrantCapabilities &&
+        githubAuth != null &&
+        !imageRepository.isNullOrBlank() &&
+        !imageRepository.equals(githubAuthRepo, ignoreCase = true)
+    ) {
+      System.err.println(
+        "serve: --agent-grant-capabilities images refused — the image lane gates on " +
+          "'$imageRepository' but sign-in gates on '${githubAuthRepo ?: "nothing"}', and a " +
+          "signed-in approver's access is only ever verified against the latter. Point " +
+          "--image-upload-repo at --github-auth-repo (or drop it, since it falls back), or drop " +
+          "the capability."
+      )
+      throw IllegalArgumentException(
+        "--agent-grant-capabilities images needs --image-upload-repo to match --github-auth-repo"
+      )
     }
     if (agentGrantCapabilities.isNotEmpty()) {
       System.err.println(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -38,6 +38,7 @@ import ee.schimke.composeai.cli.serve.PlaygroundSandboxProbe
 import ee.schimke.composeai.cli.serve.PlaygroundSeedResolver
 import ee.schimke.composeai.cli.serve.PlaygroundTokenStore
 import ee.schimke.composeai.cli.serve.RenderOutcome
+import ee.schimke.composeai.cli.serve.ServeAgentGrantCapability
 import ee.schimke.composeai.cli.serve.ServeAgentGrantScope
 import ee.schimke.composeai.cli.serve.ServeAgentGrantStore
 import ee.schimke.composeai.cli.serve.ServeAgentGrants
@@ -736,6 +737,23 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       }
       ?.coerceIn(60L, ServeAgentGrantStore.HARD_MAX_GRANT_TTL_SECONDS)
       ?: ServeAgentGrantStore.DEFAULT_MAX_GRANT_TTL_SECONDS
+
+  /**
+   * The independent capabilities a grant on this box may carry (`--agent-grant-capabilities
+   * images`), defaulting to **none**.
+   *
+   * Deliberately its own flag rather than another name in `--agent-grant-scopes`: a capability is
+   * not a rung on that ladder ([ServeAgentGrantCapability]), and an operator raising the scope
+   * ceiling to `live` has said nothing about whether an agent may publish an image on their origin.
+   * Two decisions, two flags.
+   */
+  private val agentGrantCapabilities: Set<ServeAgentGrantCapability> =
+    args.flagValue("--agent-grant-capabilities")?.let {
+      // Throws on an unknown name, same as `--agent-grant-scopes`: a typo here would silently
+      // withhold a capability the operator believes they turned on, and they would go looking for
+      // the bug in the agent.
+      ServeAgentGrantCapability.parseAll(it)
+    } ?: emptySet()
 
   /** How many grants may be live at once (`--agent-grant-max-active`). */
   private val agentGrantMaxActive: Int =
@@ -2426,9 +2444,29 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           "and run Kotlin on this host."
       )
     }
+    // A capability for a lane this box does not run is a promise it cannot keep: the approval page
+    // would offer `images`, a human would tick it, and the upload would 404 on a route that was
+    // never registered. Refused at startup, where the operator can fix it, rather than discovered
+    // by an agent twenty minutes into a task.
+    if (ServeAgentGrantCapability.IMAGES in agentGrantCapabilities && !acceptImages) {
+      System.err.println(
+        "serve: --agent-grant-capabilities images refused — this server does not run the image " +
+          "lane, so a granted upload would have nowhere to go. Add --accept-images (with " +
+          "--image-upload-repo, or --github-auth-repo), or drop the capability."
+      )
+      throw IllegalArgumentException("--agent-grant-capabilities images needs --accept-images")
+    }
+    if (agentGrantCapabilities.isNotEmpty()) {
+      System.err.println(
+        "serve: agent grants may carry " +
+          ServeAgentGrantCapability.wireNames(agentGrantCapabilities).joinToString(", ") +
+          " when a human ticks it — an approved agent can then upload without a GitHub credential."
+      )
+    }
     return ServeAgentGrantStore(
       maxGrantTtlSeconds = agentGrantMaxTtlSeconds,
       maxScope = agentGrantMaxScope,
+      maxCapabilities = agentGrantCapabilities,
       maxActiveGrants = agentGrantMaxActive,
       // The audit trail. A grant is a credential this box minted on someone's say-so, so the say-so
       // belongs in the operator's log where a mint, an eviction and a revoke are all visible — the
@@ -4514,6 +4552,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
                           default preview,live). 'playground' lets an approved agent compile and run
                           Kotlin on this host, and can only be approved by someone who has access to
                           --github-auth-repo themselves.
+        --agent-grant-capabilities <list>
+                          Extra permissions a grant may carry beside its scope, chosen separately by
+                          the approver: currently 'images' (upload rendered previews through the
+                          image lane, needs --accept-images). Off by default — a scope ceiling says
+                          nothing about these.
         --agent-grant-max-ttl <duration>
                           Longest grant this server will mint, e.g. 90m / 2h / 3600 (default 8h,
                           hard ceiling 24h). The approver picks the actual lifetime on the page.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewCommand.kt
@@ -315,12 +315,22 @@ class SharePreviewCommand(
       System.err.println(it)
       exitProcess(64)
     }
+    // A GitHub credential is what the host's *default* gate wants — but it is not the only way to
+    // be admitted any more. A host may let an agent access grant carry the `images` capability
+    // (see docs/design/AGENT_ACCESS_GRANTS.md), and the entire point of that is to upload without
+    // holding a GitHub token at all. So a missing credential is only fatal when there is no host
+    // credential either: with a grant in hand the host is the one entitled to decide, and refusing
+    // here would mean this client vetoing an approval a human already gave.
+    val hostToken = serveHostToken
     val credential =
       when (val r = AgentGithubToken.resolve(githubTokenFile, ghToken = ::ghAuthToken)) {
         is AgentGithubToken.Result.Ok -> r
         is AgentGithubToken.Result.Err -> {
-          System.err.println(r.message)
-          exitProcess(1)
+          if (hostToken == null) {
+            System.err.println(r.message)
+            exitProcess(1)
+          }
+          null
         }
       }
 
@@ -334,7 +344,7 @@ class SharePreviewCommand(
       return
     }
 
-    val uploader = ServeImageUploader(url, credential.token, serveHostToken)
+    val uploader = ServeImageUploader(url, credential?.token, hostToken)
     val uploaded = LinkedHashMap<String, String>()
     var expiresIn: String? = null
     for (image in images) {
@@ -362,7 +372,8 @@ class SharePreviewCommand(
         files = images.map { SharePreviewFile(it.absolutePath, it.name, uploaded[it.name]) },
         markdown = rewritten,
         expiresIn = expiresIn,
-        credentialSource = credential.source,
+        // Null when a grant admitted the upload — there was no GitHub credential to have a source.
+        credentialSource = credential?.source,
         serveUrlSource = resolvedServeUrl?.source?.display,
       )
     )
@@ -687,9 +698,13 @@ class SharePreviewCommand(
           return
         }
         val expiry = response.expiresIn?.let { " (links expire in $it)" } ?: ""
+        // "authenticated from …" names the GitHub credential's source; with an agent grant there
+        // is no such credential, and saying so is the honest version of that sentence.
+        val admitted =
+          response.credentialSource?.let { "authenticated from $it" }
+            ?: "authenticated by the agent access grant for this host"
         println(
-          "Uploaded ${response.files.size} image(s) to ${response.rawBaseUrl}$expiry, " +
-            "authenticated from ${response.credentialSource}"
+          "Uploaded ${response.files.size} image(s) to ${response.rawBaseUrl}$expiry, $admitted"
         )
         response.files.forEach { f -> f.rawUrl?.let { println("  ${f.name}: $it") } }
         response.markdown?.let {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -49,7 +49,15 @@ import okhttp3.RequestBody.Companion.asRequestBody
  */
 internal class ServeImageUploader(
   baseUrl: String,
-  private val token: String,
+  /**
+   * The GitHub credential, or **null** when the caller holds none.
+   *
+   * Null is not an error case here: a host that admits an agent grant carrying `images` wants no
+   * GitHub token, and sending an empty bearer would be worse than sending none — the host would ask
+   * GitHub about the empty string and refuse a caller it was about to admit. So the header is
+   * omitted entirely, and [hostToken] (the grant) is what identifies the caller.
+   */
+  private val token: String?,
   /** The host's own browse token (`--token`), for a serve box that isn't `--public`. */
   private val hostToken: String? = null,
   private val client: OkHttpClient =
@@ -75,7 +83,7 @@ internal class ServeImageUploader(
     val request =
       Request.Builder()
         .url("$base/images?name=${encodeQuery(label)}${hostToken.tokenQuery()}")
-        .header("Authorization", "Bearer $token")
+        .apply { token?.let { header("Authorization", "Bearer $it") } }
         .header("Accept", "application/json")
         .post(file.asRequestBody(OCTET_STREAM))
         .build()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantCapability.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantCapability.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.cli.serve
+
+/**
+ * What a grant may do **beside** its scope rung — see
+ * [docs/design/AGENT_ACCESS_GRANTS.md](../../../../../../../../docs/design/AGENT_ACCESS_GRANTS.md).
+ *
+ * [ServeAgentGrantScope] is a ladder: each rung implies the ones below it, because each names a
+ * strictly larger amount of this box's CPU and trust. A capability is the other shape — an
+ * **independent** permission that does not sit anywhere on that ladder and must not be dragged
+ * along by it.
+ *
+ * [IMAGES] is the worked example, and the reason this type exists rather than a fourth rung.
+ * Uploading a PNG is not "more" than opening a render daemon and not "less" than running a Kotlin
+ * snippet; it is sideways from both. As a rung between `live` and `playground` it would have made
+ * every playground grant an uploader and every uploader a daemon-starter, neither of which anyone
+ * asked for. So scope answers *how much of this machine may the agent spend*, and a capability
+ * answers *may it also do this specific thing* — and the two are chosen separately, by the same
+ * human, on the same page.
+ *
+ * The set is therefore unordered and non-cumulative, which is also why the approval page draws
+ * these as checkboxes where the scopes are radios: independent boxes describe independent
+ * permissions honestly.
+ */
+enum class ServeAgentGrantCapability(
+  /** The wire/CLI name — lowercase, stable, what `--capability` and the JSON carry. */
+  val wire: String,
+  /** One line for the approval page: what the human is actually agreeing to. */
+  val humanDescription: String,
+) {
+  /**
+   * Upload rendered images through the image lane (`POST /images`), so the returned URLs can be
+   * embedded in a pull-request body.
+   *
+   * Only meaningful on a box that runs that lane at all (`--accept-images`); `serve` refuses to
+   * offer this capability otherwise, rather than minting grants for a route that does not exist.
+   *
+   * Note what an upload actually publishes: the image is served from an unguessable but
+   * **unauthenticated** URL, because GitHub's camo proxy fetches a PR body's images anonymously. So
+   * this is a publication right on the operator's origin, which is why it is off unless the
+   * operator opts in and a human ticks it.
+   */
+  IMAGES(
+    "images",
+    "Upload rendered preview images, published at unlisted URLs on this server for 7 days",
+  );
+
+  companion object {
+    /** Parse one wire name, case-insensitively; null when it names nothing. */
+    fun parse(value: String?): ServeAgentGrantCapability? {
+      val wanted = value?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
+      return entries.firstOrNull { it.wire == wanted }
+    }
+
+    /**
+     * Parse a comma/space-separated list, ignoring blanks.
+     *
+     * **Throws** on a name that means nothing, so a typo in `--agent-grant-capabilities` fails the
+     * server's startup instead of silently withholding a capability the operator believes they
+     * enabled — the same trade [ServeAgentGrantScope.parseHighest] makes, for the same reason.
+     */
+    fun parseAll(list: String?): Set<ServeAgentGrantCapability> {
+      val names =
+        list
+          ?.split(',', ' ')
+          ?.map { it.trim() }
+          ?.filter { it.isNotEmpty() }
+          .orEmpty()
+          .ifEmpty {
+            return emptySet()
+          }
+      return names
+        .map {
+          parse(it)
+            ?: throw IllegalArgumentException(
+              "unknown agent-grant capability '$it' (known: ${entries.joinToString(", ") { c -> c.wire }})"
+            )
+        }
+        .toSet()
+    }
+
+    /** Wire names, in declaration order — for JSON, the CLI and the audit line. */
+    fun wireNames(capabilities: Set<ServeAgentGrantCapability>): List<String> =
+      entries.filter { it in capabilities }.map { it.wire }
+  }
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantCapability.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantCapability.kt
@@ -41,7 +41,10 @@ enum class ServeAgentGrantCapability(
    */
   IMAGES(
     "images",
-    "Upload rendered preview images, published at unlisted URLs on this server for 7 days",
+    // No lifetime in this sentence: `--image-ttl` is an operator setting, so a hard-coded "for 7
+    // days" would understate the exposure on any box configured for longer — on the one page whose
+    // job is to state accurately what is being agreed to.
+    "Upload rendered preview images, published at unlisted URLs on this server until they expire",
   );
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
@@ -31,6 +31,13 @@ class ServeAgentGrantStore(
   val maxGrantTtlSeconds: Long = DEFAULT_MAX_GRANT_TTL_SECONDS,
   /** The most privileged scope any grant here may carry — the operator's ceiling. */
   val maxScope: ServeAgentGrantScope = ServeAgentGrantScope.DEFAULT_MAX,
+  /**
+   * The capabilities ([ServeAgentGrantCapability]) any grant here may carry — the operator's other
+   * ceiling, and empty by default. Separate from [maxScope] because capabilities are not rungs: a
+   * box that grants `live` has said nothing about whether an agent may also publish an image on its
+   * origin, and must not be read as having said yes.
+   */
+  val maxCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
   private val maxActiveGrants: Int = DEFAULT_MAX_ACTIVE_GRANTS,
   private val maxPendingRequests: Int = DEFAULT_MAX_PENDING_REQUESTS,
   private val clock: () -> Long = System::currentTimeMillis,
@@ -71,6 +78,11 @@ class ServeAgentGrantStore(
     val requestedScope: ServeAgentGrantScope,
     /** Seconds of access the agent asked for; the approver may grant this or less. */
     val requestedTtlSeconds: Long,
+    /**
+     * The capabilities the agent asked for, already narrowed to this box's ceiling. The approver
+     * may grant these or fewer — never more, for the same reason the scope can only be narrowed.
+     */
+    val requestedCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
     val createdAtMillis: Long,
     val expiresAtMillis: Long,
     @Volatile var state: State = State.PENDING,
@@ -114,6 +126,8 @@ class ServeAgentGrantStore(
     /** The bearer. Returned exactly once (the poll response) and never rendered again. */
     val token: String,
     val scope: ServeAgentGrantScope,
+    /** The independent permissions this grant carries beside its rung. Usually empty. */
+    val capabilities: Set<ServeAgentGrantCapability> = emptySet(),
     /** The label from the request, carried through so `/status` says what this is for. */
     val label: String,
     /** GitHub login, or `operator (token)` — see [ServeAgentGrants]. */
@@ -127,6 +141,12 @@ class ServeAgentGrantStore(
 
     /** True when this grant is at or above [wanted]. The one question every gate asks. */
     fun allows(wanted: ServeAgentGrantScope): Boolean = scope.implies(wanted)
+
+    /**
+     * True when this grant carries [wanted]. Deliberately **not** implied by any scope: the rung
+     * says how much of the machine the agent may spend, and a capability is a separate yes.
+     */
+    fun allows(wanted: ServeAgentGrantCapability): Boolean = wanted in capabilities
 
     /**
      * A short, stable, non-reversible handle on the token, for `/status` and the audit log. SHA-256
@@ -164,8 +184,11 @@ class ServeAgentGrantStore(
     client: String,
     requestedScope: ServeAgentGrantScope,
     requestedTtlSeconds: Long,
+    requestedCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
   ): Request? =
-    synchronized(this) { openRequestLocked(label, client, requestedScope, requestedTtlSeconds) }
+    synchronized(this) {
+      openRequestLocked(label, client, requestedScope, requestedTtlSeconds, requestedCapabilities)
+    }
 
   /**
    * The cap has to be checked and the entry inserted under **one** lock.
@@ -181,6 +204,7 @@ class ServeAgentGrantStore(
     client: String,
     requestedScope: ServeAgentGrantScope,
     requestedTtlSeconds: Long,
+    requestedCapabilities: Set<ServeAgentGrantCapability>,
   ): Request? {
     val now = clock()
     purge(now)
@@ -218,6 +242,10 @@ class ServeAgentGrantStore(
         client = sanitizeLabel(client),
         requestedScope = minOf(requestedScope, maxScope),
         requestedTtlSeconds = requestedTtlSeconds.coerceIn(1, maxGrantTtlSeconds),
+        // Narrowed at the door, like the scope: the approval page must never offer a capability
+        // this box would refuse to mint, and an agent asking for one it cannot have should learn
+        // that from the response it already reads rather than from a silent omission later.
+        requestedCapabilities = requestedCapabilities intersect maxCapabilities,
         createdAtMillis = now,
         expiresAtMillis = now + requestTtlSeconds * 1000,
       )
@@ -251,6 +279,7 @@ class ServeAgentGrantStore(
     approvedBy: String,
     scope: ServeAgentGrantScope,
     ttlSeconds: Long,
+    capabilities: Set<ServeAgentGrantCapability> = emptySet(),
   ): Grant? {
     synchronized(this) {
       // Lookup, expiry validation and the state transition all inside the lock. Split across it,
@@ -265,12 +294,18 @@ class ServeAgentGrantStore(
       }
       val now = clock()
       val granted = minOf(scope, request.requestedScope, maxScope)
+      // Three-way intersection, exactly like the scope's three-way `minOf`: what the approver
+      // ticked, what the agent asked for, and what this box permits at all. A tampered form field
+      // therefore buys nothing here either.
+      val grantedCapabilities =
+        capabilities intersect request.requestedCapabilities intersect maxCapabilities
       val ttl = ttlSeconds.coerceIn(1, minOf(request.requestedTtlSeconds, maxGrantTtlSeconds))
       val grant =
         Grant(
           id = mintId(),
           token = mintToken(),
           scope = granted,
+          capabilities = grantedCapabilities,
           label = request.label,
           approvedBy = approvedBy,
           issuedAtMillis = now,
@@ -287,6 +322,7 @@ class ServeAgentGrantStore(
       request.state = Request.State.APPROVED
       audit(
         "agent-grant: minted ${grant.fingerprint} scope=${granted.wire} " +
+          capabilityAuditField(grantedCapabilities) +
           "ttl=${ttl}s approver=$approvedBy label=\"${grant.label}\""
       )
       return grant
@@ -465,6 +501,15 @@ class ServeAgentGrantStore(
    * the page said *approved*, and the agent's next poll found its id gone and was told the request
    * had expired.
    */
+  /**
+   * `caps=images ` for the audit line, or nothing at all when a grant carries none — which is the
+   * overwhelmingly common case, and a trailing `caps=` on every line would be noise that trains the
+   * reader to skip the field on the lines where it matters.
+   */
+  private fun capabilityAuditField(capabilities: Set<ServeAgentGrantCapability>): String =
+    if (capabilities.isEmpty()) ""
+    else "caps=${ServeAgentGrantCapability.wireNames(capabilities).joinToString(",")} "
+
   private fun evictOverflow(keep: Grant) {
     while (grants.size > maxActiveGrants) {
       val oldest =

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrants.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrants.kt
@@ -47,6 +47,13 @@ object ServeAgentGrants {
     val scope: String = "",
     /** Requested lifetime. Clamped to the box's `--agent-grant-max-ttl`. */
     @SerialName("ttlSeconds") val ttlSeconds: Long = 0,
+    /**
+     * Independent permissions wanted beside [scope], by wire name ([ServeAgentGrantCapability]).
+     * Unknown names are ignored rather than refused: this is an agent describing what it would
+     * like, and a newer client naming a capability this server has never heard of should get the
+     * rest of its request honoured, not a 400.
+     */
+    val capabilities: List<String> = emptyList(),
   )
 
   /**
@@ -70,6 +77,10 @@ object ServeAgentGrants {
     /** The most privileged scope this server will grant at all, so an agent can stop asking. */
     val maxScope: String,
     val maxTtlSeconds: Long,
+    /** What was requested after clamping, so an agent can see a capability was dropped. */
+    val requestedCapabilities: List<String> = emptyList(),
+    /** Every capability this server will grant at all — empty on a box that offers none. */
+    val maxCapabilities: List<String> = emptyList(),
   )
 
   @Serializable data class PollRequest(val requestId: String = "", val deviceSecret: String = "")
@@ -88,6 +99,8 @@ object ServeAgentGrants {
     /** Where to put [token] — spelled out so an agent needn't know this server's conventions. */
     val tokenHeader: String? = null,
     val scopes: List<String> = emptyList(),
+    /** Independent permissions the human actually ticked. Usually empty. */
+    val capabilities: List<String> = emptyList(),
     val expiresInSeconds: Long? = null,
     val approvedBy: String? = null,
     /** How long the agent should wait before polling again. */
@@ -109,6 +122,7 @@ object ServeAgentGrants {
   data class WhoamiResponse(
     val active: Boolean,
     val scopes: List<String> = emptyList(),
+    val capabilities: List<String> = emptyList(),
     val expiresInSeconds: Long? = null,
     val approvedBy: String? = null,
     val label: String? = null,
@@ -133,17 +147,36 @@ object ServeAgentGrants {
     /** Display name, and what the audit line records: a GitHub login, or `operator (token)`. */
     val name: String,
     val ceiling: ServeAgentGrantScope,
+    /**
+     * The capabilities this approver may pass on — the same "never grant what you do not hold"
+     * rule, applied to the half of a grant that is not a rung.
+     *
+     * [ServeAgentGrantCapability.IMAGES] is the case that makes it concrete. The image lane admits
+     * a caller who has **write access to the gating repository**, so a signed-in visitor without
+     * that access cannot upload — and must not be able to hand an agent a token that does. It is
+     * the identical argument to the playground's, which is why the two are computed from the same
+     * `repositoryAccess` bit.
+     */
+    val capabilityCeiling: Set<ServeAgentGrantCapability> = emptySet(),
   ) {
     companion object {
       /** The holder of `--token` on a box with no GitHub auth: the operator, so no narrowing. */
-      fun operator(storeCeiling: ServeAgentGrantScope): Approver =
-        Approver("operator (token)", storeCeiling)
+      fun operator(
+        storeCeiling: ServeAgentGrantScope,
+        storeCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+      ): Approver = Approver("operator (token)", storeCeiling, storeCapabilities)
 
-      fun github(login: String, repositoryAccess: Boolean, storeCeiling: ServeAgentGrantScope) =
+      fun github(
+        login: String,
+        repositoryAccess: Boolean,
+        storeCeiling: ServeAgentGrantScope,
+        storeCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+      ) =
         Approver(
           name = "@$login",
           ceiling =
             if (repositoryAccess) storeCeiling else minOf(storeCeiling, ServeAgentGrantScope.LIVE),
+          capabilityCeiling = if (repositoryAccess) storeCapabilities else emptySet(),
         )
     }
   }
@@ -196,6 +229,18 @@ object ServeAgentGrants {
    * ceiling is the agent's own restraint and is honoured — the page never offers to *widen* a
    * request, because the agent has not told its human it wants more.
    */
+  /**
+   * The capabilities an approver may actually tick: the same three-way narrowing the scopes get —
+   * what the agent asked for, what this approver holds, and what the box permits — so the form can
+   * never offer something the POST would then refuse.
+   */
+  fun selectableCapabilities(
+    requested: Set<ServeAgentGrantCapability>,
+    approver: Approver,
+    storeCeiling: Set<ServeAgentGrantCapability>,
+  ): Set<ServeAgentGrantCapability> =
+    requested intersect approver.capabilityCeiling intersect storeCeiling
+
   fun selectableScopes(
     requested: ServeAgentGrantScope,
     approver: Approver,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -2320,6 +2320,20 @@ class ServeHttpServer(
     // Address-only, never [rateLimitKey]: that one prefers a signed-in cookie login, which on a
     // GitHub-auth host can be the same string the post-verification charge below uses — the two
     // budgets would then share one bucket and halve what the operator configured.
+    // A grant the operator ticked `images` on is an identity in its own right, and it is checked
+    // BEFORE the GitHub round trip — not as a fallback after one fails. A human operator of this
+    // box already made the access decision, by hand, minutes ago and for a bounded window; asking
+    // GitHub again would be asking a second question nobody needs answered, and would make an
+    // agent's upload depend on a credential the whole grant flow exists so it need not hold.
+    grantedImageIdentity()?.let { granted ->
+      val permit = acquireImagePermit(granted.budgetKey) ?: return
+      try {
+        acceptImageUpload(store, granted.login)
+      } finally {
+        permit.release()
+      }
+      return
+    }
     val verifyPermit = acquireImagePermit(clientAddressKey()) ?: return
     val identity =
       try {
@@ -2333,67 +2347,78 @@ class ServeHttpServer(
     // address of an agent in CI is shared or ephemeral, and the identity is the thing we actually
     // know. The key comes from the gate, not from the login — see [Identity.Ok.budgetKey].
     val permit = acquireImagePermit(identity.budgetKey) ?: return
-    val login = identity.login
     try {
-      val name = call.request.queryParameters["name"]
-      // Cap the body as it streams in — receiving it whole first would let a client OOM the server
-      // regardless of the store's own cap.
-      val body =
-        withContext(Dispatchers.IO) { call.receiveStream().use { readCapped(it, MAX_IMAGE_BYTES) } }
-          ?: run {
-            call.respondText(
-              "image exceeds ${MAX_IMAGE_BYTES / (1024 * 1024)}MB",
-              status = HttpStatusCode.PayloadTooLarge,
-            )
-            return
-          }
-      // isSecurityChecked = true: the identity gate above cleared this caller. The store still
-      // defends in depth (format sniff, size + count caps, TTL).
-      when (
-        val result =
-          withContext(Dispatchers.IO) {
-            store.add(name, body, uploadedBy = login, isSecurityChecked = true)
-          }
-      ) {
-        is ServeImageStore.Result.Ok -> {
-          val image = result.image
-          // Absolute, because the caller is about to paste it somewhere this server will never see
-          // — a PR body renders on github.com, where a relative path means nothing. Built from the
-          // forwarded origin, so a host behind Caddy hands back its public https:// name.
-          val url = externalOrigin() + image.path
-          val size = image.dimensions
-          call.respondText(
-            JSON.encodeToString(
-              ImageAcceptedResponse.serializer(),
-              ImageAcceptedResponse(
-                id = image.id,
-                name = image.name,
-                format = image.format.label,
-                formatId = image.format.id,
-                bytes = image.sizeBytes,
-                width = size?.width,
-                height = size?.height,
-                path = image.path,
-                url = url,
-                // The line the caller actually wanted. Handing back the finished markdown is not a
-                // convenience: an agent that assembles it itself is one backtick away from the
-                // `![alt](`url`)` shape that renders as literal text and silently loses the
-                // evidence the upload existed to provide.
-                markdown = "![${image.name}]($url)",
-                uploadedBy = image.uploadedBy,
-                expiresIn = ServeWeb.humanDuration(store.remainingSeconds(image)),
-                expiresAtEpochSeconds = image.expiresAtMillis / 1000,
-              ),
-            ),
-            ContentType.Application.Json,
-            HttpStatusCode.Created,
-          )
-        }
-        is ServeImageStore.Result.Failed ->
-          call.respondText(result.reason, status = HttpStatusCode.BadRequest)
-      }
+      acceptImageUpload(store, identity.login)
     } finally {
       permit.release()
+    }
+  }
+
+  /**
+   * Store the posted image and answer `201` with the line the caller pastes.
+   *
+   * Split out of [handleImageUpload] because there are now two ways to have been admitted — a
+   * verified GitHub credential, or an agent grant the operator ticked `images` on — and exactly one
+   * thing to do afterwards. [login] is whatever the admitting gate decided attribution should read
+   * as, and is what `uploadedBy` reports.
+   */
+  private suspend fun RoutingContext.acceptImageUpload(store: ServeImageStore, login: String) {
+    val name = call.request.queryParameters["name"]
+    // Cap the body as it streams in — receiving it whole first would let a client OOM the server
+    // regardless of the store's own cap.
+    val body =
+      withContext(Dispatchers.IO) { call.receiveStream().use { readCapped(it, MAX_IMAGE_BYTES) } }
+        ?: run {
+          call.respondText(
+            "image exceeds ${MAX_IMAGE_BYTES / (1024 * 1024)}MB",
+            status = HttpStatusCode.PayloadTooLarge,
+          )
+          return
+        }
+    // isSecurityChecked = true: the identity gate above cleared this caller. The store still
+    // defends in depth (format sniff, size + count caps, TTL).
+    when (
+      val result =
+        withContext(Dispatchers.IO) {
+          store.add(name, body, uploadedBy = login, isSecurityChecked = true)
+        }
+    ) {
+      is ServeImageStore.Result.Ok -> {
+        val image = result.image
+        // Absolute, because the caller is about to paste it somewhere this server will never see
+        // — a PR body renders on github.com, where a relative path means nothing. Built from the
+        // forwarded origin, so a host behind Caddy hands back its public https:// name.
+        val url = externalOrigin() + image.path
+        val size = image.dimensions
+        call.respondText(
+          JSON.encodeToString(
+            ImageAcceptedResponse.serializer(),
+            ImageAcceptedResponse(
+              id = image.id,
+              name = image.name,
+              format = image.format.label,
+              formatId = image.format.id,
+              bytes = image.sizeBytes,
+              width = size?.width,
+              height = size?.height,
+              path = image.path,
+              url = url,
+              // The line the caller actually wanted. Handing back the finished markdown is not a
+              // convenience: an agent that assembles it itself is one backtick away from the
+              // `![alt](`url`)` shape that renders as literal text and silently loses the
+              // evidence the upload existed to provide.
+              markdown = "![${image.name}]($url)",
+              uploadedBy = image.uploadedBy,
+              expiresIn = ServeWeb.humanDuration(store.remainingSeconds(image)),
+              expiresAtEpochSeconds = image.expiresAtMillis / 1000,
+            ),
+          ),
+          ContentType.Application.Json,
+          HttpStatusCode.Created,
+        )
+      }
+      is ServeImageStore.Result.Failed ->
+        call.respondText(result.reason, status = HttpStatusCode.BadRequest)
     }
   }
 
@@ -2416,6 +2441,33 @@ class ServeHttpServer(
         null
       }
     }
+  }
+
+  /**
+   * The upload identity of a live agent grant carrying [ServeAgentGrantCapability.IMAGES], or null
+   * when this call presents no such grant (in which case the GitHub gate has its say as before).
+   *
+   * This is the whole of the link between the grant lane and the image lane, and it is small on
+   * purpose: a grant does not become a GitHub account here, it becomes *an admitted caller with a
+   * name*. Two details carry the weight.
+   *
+   * **Attribution names the grant and the human behind it**, so `uploadedBy` on the stored image
+   * and in the `201` reads `agent grant 682daf65 (approved by @yschimke)` rather than borrowing a
+   * login nobody authenticated. An operator reading `/status` can tell a grant's upload from a
+   * collaborator's at a glance, and the approver is on the record either way.
+   *
+   * **The budget key is the grant**, not the address and not a login: a grant is already bounded
+   * (it expires, it is revocable, and the box caps how many are live), so per-grant is the bucket
+   * that matches what was actually handed out. Two grants approved for two different tasks do not
+   * throttle each other, and one grant cannot spend another's budget.
+   */
+  private fun RoutingContext.grantedImageIdentity(): ServeImageUploadAuth.Identity.Ok? {
+    val grant = agentGrantFor(call) ?: return null
+    if (!grant.allows(ServeAgentGrantCapability.IMAGES)) return null
+    return ServeImageUploadAuth.Identity.Ok(
+      login = "agent grant ${grant.fingerprint} (approved by ${grant.approvedBy})",
+      budgetKey = "grant:${grant.id}",
+    )
   }
 
   /**
@@ -5304,11 +5356,13 @@ class ServeHttpServer(
                 pendingRequests = store.pendingRequests().size,
                 maxScope = store.maxScope.wire,
                 maxTtlSeconds = store.maxGrantTtlSeconds,
+                maxCapabilities = ServeAgentGrantCapability.wireNames(store.maxCapabilities),
                 grants =
                   live.map { grant ->
                     AgentGrantDto(
                       fingerprint = grant.fingerprint,
                       scopes = grant.scopes.map { it.wire },
+                      capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities),
                       approvedBy = grant.approvedBy,
                       expiresInSeconds = grant.secondsUntilExpiry(now),
                       label = grant.label,
@@ -8376,6 +8430,7 @@ class ServeHttpServer(
         id = grant.id,
         fingerprint = grant.fingerprint,
         scopes = grant.scopes.joinToString(", ") { it.wire },
+        capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities).joinToString(", "),
         label = grant.label,
         approvedBy = grant.approvedBy,
         expiresInText = ServeAgentGrants.formatDuration(grant.secondsUntilExpiry(now)),
@@ -8451,6 +8506,11 @@ class ServeHttpServer(
             return
           }
       val scope = ServeAgentGrantScope.parse(parsed.scope) ?: ServeAgentGrantScope.DEFAULT_REQUEST
+      // Unknown names are dropped rather than refused — see [OpenRequest.capabilities]. The store
+      // narrows what survives to this box's ceiling, so asking for `images` on a box that offers
+      // none is not an error, it simply is not in the request that comes back.
+      val capabilities =
+        parsed.capabilities.mapNotNull { ServeAgentGrantCapability.parse(it) }.toSet()
       val ttl =
         parsed.ttlSeconds.takeIf { it > 0 } ?: ServeAgentGrantStore.DEFAULT_GRANT_TTL_SECONDS
       val request =
@@ -8466,6 +8526,7 @@ class ServeHttpServer(
           client = clientAddress(),
           requestedScope = scope,
           requestedTtlSeconds = ttl,
+          requestedCapabilities = capabilities,
         )
       if (request == null) {
         call.response.headers.append(HttpHeaders.RetryAfter, "60")
@@ -8491,6 +8552,9 @@ class ServeHttpServer(
             requestedTtlSeconds = request.requestedTtlSeconds,
             maxScope = store.maxScope.wire,
             maxTtlSeconds = store.maxGrantTtlSeconds,
+            requestedCapabilities =
+              ServeAgentGrantCapability.wireNames(request.requestedCapabilities),
+            maxCapabilities = ServeAgentGrantCapability.wireNames(store.maxCapabilities),
           ),
         ),
         ContentType.Application.Json,
@@ -8540,6 +8604,7 @@ class ServeHttpServer(
               token = outcome.grant.token,
               tokenHeader = TOKEN_HEADER,
               scopes = outcome.grant.scopes.map { it.wire },
+              capabilities = ServeAgentGrantCapability.wireNames(outcome.grant.capabilities),
               expiresInSeconds = outcome.grant.secondsUntilExpiry(System.currentTimeMillis()),
               approvedBy = outcome.grant.approvedBy,
               message = "approved by ${outcome.grant.approvedBy}",
@@ -8585,6 +8650,7 @@ class ServeHttpServer(
         ServeAgentGrants.WhoamiResponse(
           active = true,
           scopes = grant.scopes.map { it.wire },
+          capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities),
           expiresInSeconds = grant.secondsUntilExpiry(System.currentTimeMillis()),
           approvedBy = grant.approvedBy,
           label = grant.label,
@@ -8658,6 +8724,16 @@ class ServeHttpServer(
     val selectable =
       ServeAgentGrants.selectableScopes(request.requestedScope, approver, store.maxScope)
     val withheld = ServeAgentGrantScope.upTo(request.requestedScope).filterNot { it in selectable }
+    val selectableCapabilities =
+      ServeAgentGrants.selectableCapabilities(
+        request.requestedCapabilities,
+        approver,
+        store.maxCapabilities,
+      )
+    // Named separately from the scope's withheld list because the reason differs and the page says
+    // so: a capability the agent asked for that this approver may not pass on.
+    val withheldCapabilities =
+      request.requestedCapabilities.filterNot { it in selectableCapabilities }
     val skin = call.siteSkin()
     markGeneration("static-page", "no-store")
     call.respondText(
@@ -8681,7 +8757,10 @@ class ServeHttpServer(
         version = BUNDLE_VERSION,
         siteName = skin.first,
         themeCss = skin.second,
+        selectableCapabilities =
+          ServeAgentGrantCapability.entries.filter { it in selectableCapabilities },
         withheldScopes = withheld,
+        withheldCapabilities = withheldCapabilities,
         withheldReason = "you do not hold it yourself on this server, so you cannot pass it on",
       ),
       ContentType.Text.Html,
@@ -8753,10 +8832,16 @@ class ServeHttpServer(
       form["scope"].orEmpty().mapNotNull { ServeAgentGrantScope.parse(it) }.maxOrNull()
         ?: ServeAgentGrantScope.PREVIEW
     val chosen = minOf(ticked, approver.ceiling)
+    // Capabilities ARE checkboxes — they are independent, so a box per capability describes the
+    // outcome honestly (the scopes' radio is the opposite case, see above). Absent means unticked
+    // means not granted, which is why nothing here defaults to the request.
+    val tickedCapabilities =
+      form["capability"].orEmpty().mapNotNull { ServeAgentGrantCapability.parse(it) }.toSet()
+    val chosenCapabilities = tickedCapabilities intersect approver.capabilityCeiling
     val ttl =
       form["ttl"]?.firstOrNull()?.let { ServeAgentGrants.parseDurationSeconds(it) }
         ?: ServeAgentGrantStore.DEFAULT_GRANT_TTL_SECONDS
-    val grant = store.approve(requestId, approver.name, chosen, ttl)
+    val grant = store.approve(requestId, approver.name, chosen, ttl, chosenCapabilities)
     if (grant == null) {
       respondAgentGrantNotice(
         heading = "Nothing to approve",
@@ -8774,7 +8859,14 @@ class ServeHttpServer(
           ServeAgentGrants.formatDuration(grant.secondsUntilExpiry(System.currentTimeMillis())) +
           ". You can end it early from the server status page at any time.",
       detail =
-        "Scopes: ${grant.scopes.joinToString(", ") { it.wire }} · grant ${grant.fingerprint}",
+        buildString {
+          append("Scopes: ${grant.scopes.joinToString(", ") { it.wire }}")
+          if (grant.capabilities.isNotEmpty()) {
+            val names = ServeAgentGrantCapability.wireNames(grant.capabilities).joinToString(", ")
+            append(" · also: $names")
+          }
+          append(" · grant ${grant.fingerprint}")
+        },
     )
   }
 
@@ -8802,9 +8894,14 @@ class ServeHttpServer(
     val auth = githubAuth
     if (auth != null) {
       val login = auth.currentLogin(call) ?: return null
-      return ServeAgentGrants.Approver.github(login, auth.hasRepositoryAccess(call), store.maxScope)
+      return ServeAgentGrants.Approver.github(
+        login,
+        auth.hasRepositoryAccess(call),
+        store.maxScope,
+        store.maxCapabilities,
+      )
     }
-    return ServeAgentGrants.Approver.operator(store.maxScope)
+    return ServeAgentGrants.Approver.operator(store.maxScope, store.maxCapabilities)
   }
 
   /**
@@ -9562,6 +9659,8 @@ private data class AgentAccessDto(
   /** The operator's ceiling — the most privileged scope this box will ever grant. */
   val maxScope: String,
   val maxTtlSeconds: Long,
+  /** Every capability this box will grant at all. Empty unless the operator opted in. */
+  val maxCapabilities: List<String> = emptyList(),
   /** One entry per live grant: fingerprint, scopes, approver, seconds left. Never a token. */
   val grants: List<AgentGrantDto> = emptyList(),
 )
@@ -9570,6 +9669,7 @@ private data class AgentAccessDto(
 private data class AgentGrantDto(
   val fingerprint: String,
   val scopes: List<String>,
+  val capabilities: List<String> = emptyList(),
   val approvedBy: String,
   val expiresInSeconds: Long,
   val label: String,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -5525,6 +5525,11 @@ ${captureControlsHtml().prependIndent("          ")}
     approver: String,
     selectableScopes: List<ServeAgentGrantScope>,
     maxTtlSeconds: Long,
+    /**
+     * Independent permissions this approver may tick, already narrowed like [selectableScopes].
+     * Empty on almost every box — the whole feature is opt-in twice over.
+     */
+    selectableCapabilities: List<ServeAgentGrantCapability> = emptyList(),
     approveCsrf: String,
     denyCsrf: String,
     /**
@@ -5540,6 +5545,8 @@ ${captureControlsHtml().prependIndent("          ")}
      * says "you can't grant this" rather than silently omitting a row the agent asked for.
      */
     withheldScopes: List<ServeAgentGrantScope> = emptyList(),
+    /** Capabilities the agent asked for that this approver may not pass on. Same treatment. */
+    withheldCapabilities: List<ServeAgentGrantCapability> = emptyList(),
     withheldReason: String = "",
   ): String {
     val esc = WebEscaping::htmlEscape
@@ -5573,6 +5580,44 @@ ${captureControlsHtml().prependIndent("          ")}
         """
           .trimIndent()
       }
+    // **Checkboxes here, radios above**, and the difference is not cosmetic. The scopes are a
+    // ladder, so one control that picks a rung is the only honest way to draw them. A capability
+    // implies nothing and is implied by nothing, so it is its own yes/no — and unticking one says
+    // exactly what it looks like it says.
+    //
+    // Nothing is pre-ticked. An extra permission should be an act, not a default someone clicks
+    // past: the agent asking for it is not the human agreeing to it, and this page exists to keep
+    // those two separate.
+    val capabilityRows =
+      selectableCapabilities.joinToString("\n") { capability ->
+        """
+        <label class="cp-grant-scope">
+          <input type="checkbox" name="capability" value="${esc(capability.wire)}">
+          <span class="cp-grant-scope-name">${esc(capability.wire)}</span>
+          <span class="cp-grant-scope-what">${esc(capability.humanDescription)}</span>
+        </label>
+        """
+          .trimIndent()
+      }
+    val capabilityFieldset =
+      if (selectableCapabilities.isEmpty()) ""
+      else
+        """
+        <fieldset class="cp-grant-fieldset">
+          <legend>Anything else the agent may do</legend>
+          $capabilityRows
+        </fieldset>
+        """
+          .trimIndent()
+    val withheldCapabilityNote =
+      if (withheldCapabilities.isEmpty()) ""
+      else
+        """
+        <p class="cp-grant-withheld">Also asked for, not offered: ${
+          esc(withheldCapabilities.joinToString(", ") { it.wire })
+        } — ${esc(withheldReason)}</p>
+        """
+          .trimIndent()
     val withheld =
       if (withheldScopes.isEmpty()) ""
       else
@@ -5621,7 +5666,9 @@ ${captureControlsHtml().prependIndent("          ")}
             <legend>What the agent may do</legend>
             $scopeRows
           </fieldset>
+          $capabilityFieldset
           $withheld
+          $withheldCapabilityNote
           <label class="cp-grant-ttl">
             <span>Access expires after</span>
             <select name="ttl">
@@ -7018,6 +7065,11 @@ ${captureControlsHtml().prependIndent("          ")}
     val id: String,
     val fingerprint: String,
     val scopes: String,
+    /**
+     * Pre-formatted capability list, or empty. Its own column rather than appended to [scopes]: a
+     * capability is not a rung, and a cell reading `preview, live, images` would say it was.
+     */
+    val capabilities: String = "",
     val label: String,
     val approvedBy: String,
     val expiresInText: String,
@@ -7094,7 +7146,7 @@ ${captureControlsHtml().prependIndent("          ")}
     if (view.agentGrants.isEmpty() && view.agentGrantRequests.isEmpty()) return ""
     val liveRows =
       if (view.agentGrants.isEmpty())
-        "<tr><td colspan=\"6\" class=\"cp-empty\">No agent currently holds access.</td></tr>"
+        "<tr><td colspan=\"7\" class=\"cp-empty\">No agent currently holds access.</td></tr>"
       else
         view.agentGrants.joinToString("\n") { grant ->
           val revoke =
@@ -7105,6 +7157,7 @@ ${captureControlsHtml().prependIndent("          ")}
                 "<button class=\"cp-grant-revoke\" type=\"submit\">Revoke</button></form>"
           "<tr><td><code>${esc(grant.fingerprint)}</code></td>" +
             "<td>${esc(grant.scopes)}</td>" +
+            "<td>${if (grant.capabilities.isBlank()) "—" else esc(grant.capabilities)}</td>" +
             "<td>${if (grant.label.isBlank()) "—" else esc(grant.label)}</td>" +
             "<td>${esc(grant.approvedBy)}</td>" +
             "<td>${esc(grant.expiresInText)}</td>" +
@@ -7136,7 +7189,7 @@ ${captureControlsHtml().prependIndent("          ")}
       """
       <p class="cp-status-sec" id="agent-grants">Agent access</p>
       <div class="cp-status-scroll"><table class="cp-grant-table">
-        <thead><tr><th>Grant</th><th>Scopes</th><th>Purpose</th><th>Approved by</th><th>Expires in</th><th></th></tr></thead>
+        <thead><tr><th>Grant</th><th>Scopes</th><th>Also</th><th>Purpose</th><th>Approved by</th><th>Expires in</th><th></th></tr></thead>
         <tbody>
         $liveRows
         </tbody>

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
@@ -1,0 +1,260 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+/**
+ * The link between the two lanes: an agent grant the operator ticked `images` on may upload through
+ * `POST /images`, holding **no GitHub credential at all**.
+ *
+ * The GitHub gate on this server refuses every token it is shown ([RefusingAuth]), which is what
+ * makes each success here evidence: nothing in this file can pass by accident through the path that
+ * already worked, so an accepted upload was admitted by the grant and by nothing else.
+ */
+class ServeAgentGrantImageUploadTest {
+
+  /** A gate that admits nobody, so only the grant lane can ever produce a `201` here. */
+  private class RefusingAuth(override val repository: String = "yschimke/compose-ai-tools") :
+    ServeImageUploadAuth {
+    override fun identify(bearerToken: String?): ServeImageUploadAuth.Identity =
+      if (bearerToken.isNullOrBlank()) ServeImageUploadAuth.Identity.Missing
+      else ServeImageUploadAuth.Identity.Refused(403, "no.")
+  }
+
+  private val operatorToken = "operator-secret-token"
+
+  private val registry = ServeSessionRegistry(open = { null })
+
+  private val grants =
+    ServeAgentGrantStore(
+      maxScope = ServeAgentGrantScope.LIVE,
+      maxCapabilities = setOf(ServeAgentGrantCapability.IMAGES),
+      maxGrantTtlSeconds = 3600,
+    )
+
+  private val server: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = operatorToken,
+        sessions = registry,
+        defaultSessionId = "none",
+        isPublic = false,
+        agentGrants = grants,
+        imageStore = ServeImageStore(ttlSeconds = 600),
+        imageUploadAuth = RefusingAuth(),
+      )
+      .also { it.start() }
+  }
+
+  /** A second box whose operator never opted into the capability at all. */
+  private val closedGrants =
+    ServeAgentGrantStore(maxScope = ServeAgentGrantScope.LIVE, maxGrantTtlSeconds = 3600)
+
+  private val closedServer: ServeHttpServer by lazy {
+    ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = operatorToken,
+        sessions = ServeSessionRegistry(open = { null }),
+        defaultSessionId = "none",
+        isPublic = false,
+        agentGrants = closedGrants,
+        imageStore = ServeImageStore(ttlSeconds = 600),
+        imageUploadAuth = RefusingAuth(),
+      )
+      .also { it.start() }
+  }
+
+  private val client = OkHttpClient.Builder().followRedirects(false).build()
+
+  private fun url(path: String, port: Int = server.port) = "http://127.0.0.1:$port$path"
+
+  private fun post(
+    path: String,
+    body: String,
+    contentType: String = "application/json",
+    port: Int = server.port,
+  ): Pair<Int, String> {
+    val request =
+      Request.Builder()
+        .url(url(path, port))
+        .post(body.toRequestBody(contentType.toMediaType()))
+        .build()
+    client.newCall(request).execute().use {
+      return it.code to (it.body?.string() ?: "")
+    }
+  }
+
+  private fun get(path: String, port: Int = server.port): Pair<Int, String> {
+    client.newCall(Request.Builder().url(url(path, port)).build()).execute().use {
+      return it.code to (it.body?.string() ?: "")
+    }
+  }
+
+  private fun field(html: String, name: String): String =
+    Regex("name=\"$name\" value=\"([^\"]*)\"").find(html)?.groupValues?.get(1)
+      ?: error("no $name field in the page")
+
+  private fun json(text: String) = Json.parseToJsonElement(text).jsonObject
+
+  private fun str(text: String, key: String) = json(text)[key]!!.jsonPrimitive.content
+
+  /**
+   * Drive the whole device flow and return the bearer. [ask] is what the agent requests, [tick] is
+   * what the human actually ticks — separately, because "asked for" and "granted" are the two
+   * things this feature must never conflate.
+   */
+  private fun grantedToken(
+    scope: String = "preview",
+    ask: List<String> = listOf("images"),
+    tick: List<String> = ask,
+    port: Int = server.port,
+  ): String {
+    val asked = ask.joinToString(",") { "\"$it\"" }
+    val (_, opened) =
+      post(
+        "/agent-access/request",
+        """{"scope":"$scope","label":"embed a render","capabilities":[$asked]}""",
+        port = port,
+      )
+    val requestId = str(opened, "requestId")
+    val secret = str(opened, "deviceSecret")
+    val (_, page) = get("/agent-access/$requestId?token=$operatorToken", port = port)
+    val ticked = tick.joinToString("") { "&capability=$it" }
+    val (approveCode, _) =
+      post(
+        "/agent-access/$requestId?token=$operatorToken",
+        "action=approve&csrf=${field(page, "csrf")}&scope=$scope&ttl=1800$ticked",
+        contentType = "application/x-www-form-urlencoded",
+        port = port,
+      )
+    assertEquals(200, approveCode)
+    val (_, polled) =
+      post(
+        "/agent-access/poll",
+        """{"requestId":"$requestId","deviceSecret":"$secret"}""",
+        port = port,
+      )
+    assertEquals("approved", str(polled, "status"))
+    return str(polled, "token")
+  }
+
+  private fun upload(token: String?, port: Int = server.port) =
+    client
+      .newCall(
+        Request.Builder()
+          .url(url("/images?name=after.png", port))
+          .apply { token?.let { header(ServeHttpServer.TOKEN_HEADER, it) } }
+          .post(ServeImageFixtures.png().toRequestBody("application/octet-stream".toMediaType()))
+          .build()
+      )
+      .execute()
+
+  @AfterTest
+  fun tearDown() {
+    server.stop()
+    closedServer.stop()
+    registry.close()
+  }
+
+  @Test
+  fun `a ticked images grant uploads with no github credential at all`() {
+    val token = grantedToken()
+    upload(token).use { response ->
+      assertEquals(201, response.code)
+      val body = response.body!!.string()
+      // The finished markdown is the thing the agent came for.
+      assertTrue(str(body, "markdown").startsWith("![after.png](http"), body)
+      // Attribution names the grant and the human behind it — never a borrowed login.
+      val uploadedBy = str(body, "uploadedBy")
+      assertTrue(uploadedBy.startsWith("agent grant "), uploadedBy)
+      assertTrue(uploadedBy.contains("operator (token)"), uploadedBy)
+    }
+  }
+
+  @Test
+  fun `the uploaded image is then fetchable at the url it handed back`() {
+    val token = grantedToken()
+    val path = upload(token).use { str(it.body!!.string(), "path") }
+    // Ungated, exactly like a collaborator's upload: GitHub's proxy fetches a PR body's images
+    // anonymously, so a gated URL would never paint.
+    client.newCall(Request.Builder().url(url(path)).build()).execute().use {
+      assertEquals(200, it.code)
+      assertEquals("image/png", it.header("Content-Type"))
+    }
+  }
+
+  @Test
+  fun `a grant without the capability is refused, however wide its scope`() {
+    // `live` outranks `preview` on the scope ladder and still confers nothing here: a capability is
+    // not a rung, and no amount of scope may add up to one.
+    val token = grantedToken(scope = "live", ask = emptyList())
+    upload(token).use { response ->
+      assertEquals(401, response.code)
+      assertTrue(response.body!!.string().contains("GitHub token"))
+    }
+  }
+
+  @Test
+  fun `asking is not granting — an unticked capability confers nothing`() {
+    val token = grantedToken(ask = listOf("images"), tick = emptyList())
+    upload(token).use { assertEquals(401, it.code) }
+  }
+
+  @Test
+  fun `a box that never offered the capability cannot have it posted into a grant`() {
+    // The form is client state: this posts `capability=images` at a server whose ceiling is empty.
+    val token = grantedToken(port = closedServer.port)
+    upload(token, port = closedServer.port).use { assertEquals(401, it.code) }
+  }
+
+  @Test
+  fun `the poll and whoami both report what was actually granted`() {
+    val token = grantedToken()
+    val request =
+      Request.Builder()
+        .url(url("/agent-access/whoami"))
+        .header(ServeHttpServer.TOKEN_HEADER, token)
+        .build()
+    client.newCall(request).execute().use {
+      val body = it.body!!.string()
+      assertTrue(body.contains("\"capabilities\":[\"images\"]"), body)
+      // Never the token, on any surface that describes it.
+      assertFalse(body.contains(token), body)
+    }
+  }
+
+  @Test
+  fun `the approval page offers the capability as its own checkbox`() {
+    val (_, opened) =
+      post(
+        "/agent-access/request",
+        """{"scope":"preview","label":"embed a render","capabilities":["images"]}""",
+      )
+    val (code, page) = get("/agent-access/${str(opened, "requestId")}?token=$operatorToken")
+    assertEquals(200, code)
+    assertTrue(page.contains("""<input type="checkbox" name="capability" value="images">"""), page)
+    // Unticked by default: an extra permission is an act, not something to click past.
+    assertFalse(page.contains("""value="images" checked"""), page)
+  }
+
+  @Test
+  fun `an images grant still cannot spend the box's cpu`() {
+    // The two halves stay independent in both directions: `images` says nothing about `live`.
+    val token = grantedToken(scope = "preview", ask = listOf("images"))
+    val request =
+      Request.Builder().url(url("/bundle.zip")).header(ServeHttpServer.TOKEN_HEADER, token).build()
+    client.newCall(request).execute().use { assertEquals(403, it.code) }
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2978,6 +2978,30 @@ class ServeWebFixtureTest {
         withheldReason = "you do not hold it yourself on this server, so you cannot pass it on",
       )
 
+    // The same page on a box that offers a CAPABILITY beside the scopes — the second fieldset, its
+    // checkboxes unticked, and one capability the approver may not pass on. Its own fixture rather
+    // than a variant of the one above, because the control that matters here (an independent
+    // checkbox, where the scopes are a radio) only exists on a box whose operator opted in, and a
+    // golden that never renders it would let that control change unseen.
+    val agentAccessCapabilities =
+      ServeWeb.agentGrantApprovalPage(
+        requestId = "9c2Qk1pTf0Xb7hLm4nRzQA",
+        userCode = "KX7M-9QD4",
+        label = "embed the before/after in the PR body",
+        client = "203.0.113.42",
+        requestedScope = ServeAgentGrantScope.LIVE,
+        requestedTtlSeconds = 1800,
+        expiresInSeconds = 540,
+        approver = "@yschimke",
+        selectableScopes = listOf(ServeAgentGrantScope.PREVIEW, ServeAgentGrantScope.LIVE),
+        selectableCapabilities = listOf(ServeAgentGrantCapability.IMAGES),
+        maxTtlSeconds = 8 * 3600,
+        approveCsrf = "fixed-approve-seal",
+        denyCsrf = "fixed-deny-seal",
+        formAction = "/agent-access/9c2Qk1pTf0Xb7hLm4nRzQA",
+        version = version,
+      )
+
     // What the approver lands on afterwards.
     val agentAccessGranted =
       ServeWeb.agentGrantNoticePage(
@@ -3445,6 +3469,7 @@ class ServeWebFixtureTest {
         "serve-viewer-nav-collapsed.html" to viewerNavCollapsed,
         "serve-notfound.html" to notFound,
         "serve-agent-access.html" to agentAccess,
+        "serve-agent-access-capabilities.html" to agentAccessCapabilities,
         "serve-agent-access-granted.html" to agentAccessGranted,
         "serve-docs-upload.html" to docUpload,
         "serve-playground.html" to playground,

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -226,6 +226,11 @@ services:
       # default of 1 would break every box without an OAuth app). `0` opts out explicitly.
       SERVE_AGENT_GRANTS: "${SERVE_AGENT_GRANTS:-}"
       SERVE_AGENT_GRANT_SCOPES: "${SERVE_AGENT_GRANT_SCOPES:-}"
+      # Non-cumulative permissions a grant may carry beside its scope — currently `images`, which
+      # lets an approved agent use the image lane above without a GitHub credential of its own.
+      # Needs SERVE_ACCEPT_IMAGES; `serve` refuses to start otherwise rather than offering a
+      # checkbox whose grant would 404.
+      SERVE_AGENT_GRANT_CAPABILITIES: "${SERVE_AGENT_GRANT_CAPABILITIES:-}"
       SERVE_AGENT_GRANT_MAX_TTL: "${SERVE_AGENT_GRANT_MAX_TTL:-}"
       SERVE_AGENT_GRANT_MAX_ACTIVE: "${SERVE_AGENT_GRANT_MAX_ACTIVE:-}"
       SERVE_AGENT_GRANT_RATE_LIMIT: "${SERVE_AGENT_GRANT_RATE_LIMIT:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -402,6 +402,9 @@ if [[ "${SERVE_AGENT_GRANTS:-}" == "1" || "${SERVE_AGENT_GRANTS:-}" == "true" ]]
   args+=(--agent-grants)
   [[ -n "${SERVE_AGENT_GRANT_SCOPES:-}" ]] &&
     args+=(--agent-grant-scopes "${SERVE_AGENT_GRANT_SCOPES}")
+  # Independent of the scope ceiling above, and refused by `serve` unless the image lane is on.
+  [[ -n "${SERVE_AGENT_GRANT_CAPABILITIES:-}" ]] &&
+    args+=(--agent-grant-capabilities "${SERVE_AGENT_GRANT_CAPABILITIES}")
   [[ -n "${SERVE_AGENT_GRANT_MAX_TTL:-}" ]] &&
     args+=(--agent-grant-max-ttl "${SERVE_AGENT_GRANT_MAX_TTL}")
   [[ -n "${SERVE_AGENT_GRANT_MAX_ACTIVE:-}" ]] &&

--- a/docs/design/AGENT_ACCESS_GRANTS.md
+++ b/docs/design/AGENT_ACCESS_GRANTS.md
@@ -132,7 +132,10 @@ Three edges are worth stating, since none of them is obvious:
 1. **The approver must hold it themselves.** On a GitHub-gated box, ticking `images` requires the
    approver's own session to carry `repositoryAccess` — the identical rule, and the identical
    `repositoryAccess` bit, that governs `playground`. Someone who could not upload cannot mint a
-   token that can.
+   token that can. That bit speaks for `--github-auth-repo` and nothing else, so a box whose image
+   lane gates on a **different** repository is refused this capability at startup: the verdict a
+   session carries would not be about the repository the upload actually publishes to, and
+   approximating it is how "the approver must hold it" quietly becomes false.
 2. **A capability for a lane the box does not run is refused at startup.** `--agent-grant-capabilities
    images` without `--accept-images` fails `serve` rather than offering a checkbox whose grant would
    404 on a route that was never registered.

--- a/docs/design/AGENT_ACCESS_GRANTS.md
+++ b/docs/design/AGENT_ACCESS_GRANTS.md
@@ -107,7 +107,41 @@ an on-demand daemon render, and `/bundle.zip` renders the whole catalog. Those a
 `live` exists to describe, so they check the scope themselves; a bare replay stays `preview`,
 because refusing it would break ordinary browsing for a grant that was given exactly that.
 
-**The ingest lanes are outside the scope system entirely.** `POST /bundles/{name}` and `POST /docs`
+**A capability is not a rung, and is chosen separately.** Scope answers *how much of this machine
+may the agent spend*; some permissions are not on that ladder at all. `images` is the one that
+exists: uploading a PNG through the [image lane](../public-preview-server.md#uploading-a-preview-image---accept-images)
+is not "more" than starting a render daemon and not "less" than compiling a snippet — it is sideways
+from both. As a fourth rung it would have made every `playground` grant an uploader and every
+uploader a daemon-starter, so it is a **set** beside the scope
+([`ServeAgentGrantCapability`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantCapability.kt))
+rather than a value on it, with its own operator ceiling (`--agent-grant-capabilities`, default
+empty) and its own checkbox on the approval page. Radios for the ladder, checkboxes for the set:
+independent boxes describe independent permissions honestly, and nothing is pre-ticked.
+
+What the image lane then accepts is a grant carrying `images` **instead of** a GitHub credential,
+and the argument is that a grant says something stronger than the credential it replaces. The lane's
+GitHub check asks *does this account have write access to the gating repo* — a proxy for "is this
+person trusted here". A grant answers *a human operator of this box approved this specific agent,
+for these minutes, and their name is on it*. So attribution improves rather than degrades:
+`uploadedBy` reads `agent grant 682daf65 (approved by @yschimke)`, which is more than a login and
+names the human who said yes. The rate-limit bucket is the grant, not an address or a login, because
+a grant is already the bounded thing.
+
+Three edges are worth stating, since none of them is obvious:
+
+1. **The approver must hold it themselves.** On a GitHub-gated box, ticking `images` requires the
+   approver's own session to carry `repositoryAccess` — the identical rule, and the identical
+   `repositoryAccess` bit, that governs `playground`. Someone who could not upload cannot mint a
+   token that can.
+2. **A capability for a lane the box does not run is refused at startup.** `--agent-grant-capabilities
+   images` without `--accept-images` fails `serve` rather than offering a checkbox whose grant would
+   404 on a route that was never registered.
+3. **Revoking a grant does not unpublish what it uploaded.** The grant dies in minutes; the image
+   link lives for `--image-ttl` (7 days by default), because the upload was authorized when it
+   happened. An operator who needs the picture gone needs the image lane's own controls, not the
+   revoke button.
+
+**The other ingest lanes are outside the scope system entirely.** `POST /bundles/{name}` and `POST /docs`
 run through the same `rejectBadToken` as everything else, so a `preview` grant would have satisfied
 them — letting an agent granted "browse this server's catalogs" publish a document or replace a
 named runtime bundle. They take [`rejectBadTokenForIngest`](../../cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt)
@@ -172,9 +206,9 @@ internet mint itself credentials.
 ## What it is not
 
 - **Not a session.** No cookies, no refresh, no sliding expiry. It ends when it ends.
-- **Not an identity.** A grant does not become a GitHub login for the purposes of anything that
-  writes — the image-upload lane still wants a real GitHub credential, because what it does with one
-  is push to a repository.
+- **Not an identity.** A grant does not become a GitHub login. Where it now admits an upload
+  (`images`, above) it does so **as itself** — the audit line and `uploadedBy` name the grant and its
+  approver, never a GitHub account — and it confers nothing anywhere else that a login would.
 - **Not admin.** `--admin-token` routes are outside every scope. Nothing an agent can be granted
   reconfigures the box.
 
@@ -185,6 +219,8 @@ internet mint itself credentials.
 ```
 compose-preview auth request --server https://preview.coo.ee \
     --scope live --ttl 2h --label "fix wear-m3-catalog#68"
+compose-preview auth request --server https://preview.coo.ee \
+    --capability images --label "embed before/after in the PR body"
 compose-preview auth status
 compose-preview auth token      # prints the bearer, for scripting
 compose-preview auth revoke

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2726,8 +2726,10 @@ compose-preview auth request --server https://preview.coo.ee --capability images
 compose-preview share-preview report.md before.png after.png --mechanism serve
 ```
 
-`share-preview` picks the stored grant up on its own (the host token resolves `--token` →
-`$COMPOSE_PREVIEW_TOKEN` → the grant store), so nothing else about the invocation changes. The
+`share-preview` picks the stored grant up on its own (its host token resolves `--serve-token` →
+`$COMPOSE_PREVIEW_SERVE_TOKEN` → the grant store — the `serve`-prefixed names, since this command
+also carries a *GitHub* credential and the two must not be confusable), so nothing else about the
+invocation changes. The
 upload is attributed to the grant and its approver — `uploadedBy` reads
 `agent grant 682daf65 (approved by @yschimke)` — and the capability is off unless the operator asked
 for it *and* a human ticked it, so nothing here widens what an existing box already does.

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2710,8 +2710,14 @@ an operator who runs the lane may let a grant carry the `images` capability, and
 per request.
 
 ```bash
-# The operator, once, at startup:
-compose-preview serve --public --accept-images --image-upload-repo yschimke/compose-ai-tools \
+# The operator, once, at startup. The --github-auth-* block is not decoration: a --public box with
+# no sign-in has no way to tell an operator from a visitor, so --agent-grants is refused there —
+# somebody has to be able to approve. --image-upload-repo is omitted deliberately, so the image
+# lane gates on --github-auth-repo; naming a DIFFERENT repository is refused with this capability,
+# because a signed-in approver's access is only ever verified against the sign-in one.
+compose-preview serve --public --accept-images \
+    --github-auth-client-id "$ID" --github-auth-client-secret "$SECRET" \
+    --github-auth-cookie-secret "$COOKIE" --github-auth-repo yschimke/compose-ai-tools \
     --agent-grants --agent-grant-capabilities images
 
 # The agent, per task — prints a link and a code for a human to approve:

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -2702,7 +2702,32 @@ holding its link. The client refuses to
 send the credential over plaintext to anything but a loopback host, refuses a URL with credentials
 in it, and never follows a redirect while carrying it.
 
-**Who may upload.** Not "anyone", on any host, ever — including a `--public` one:
+**Or an agent grant, with no GitHub credential at all.** A hosted agent session often cannot satisfy
+the rule below — Claude Code on the web, for instance, injects its GitHub credential only for
+`api.github.com`, so what reaches this host is a placeholder the host then asks GitHub about and is
+told nothing useful. The [agent access grant](design/AGENT_ACCESS_GRANTS.md) flow is the way through:
+an operator who runs the lane may let a grant carry the `images` capability, and a human ticks it
+per request.
+
+```bash
+# The operator, once, at startup:
+compose-preview serve --public --accept-images --image-upload-repo yschimke/compose-ai-tools \
+    --agent-grants --agent-grant-capabilities images
+
+# The agent, per task — prints a link and a code for a human to approve:
+compose-preview auth request --server https://preview.coo.ee --capability images \
+    --label "before/after for #4446"
+compose-preview share-preview report.md before.png after.png --mechanism serve
+```
+
+`share-preview` picks the stored grant up on its own (the host token resolves `--token` →
+`$COMPOSE_PREVIEW_TOKEN` → the grant store), so nothing else about the invocation changes. The
+upload is attributed to the grant and its approver — `uploadedBy` reads
+`agent grant 682daf65 (approved by @yschimke)` — and the capability is off unless the operator asked
+for it *and* a human ticked it, so nothing here widens what an existing box already does.
+
+**Who may upload with a GitHub credential.** Not "anyone", on any host, ever — including a `--public`
+one:
 
 - The caller sends `Authorization: Bearer <github-token>`, and the server asks **GitHub** who that is
   and whether they have access to `--image-upload-repo` (falling back to `--github-auth-repo`). The

--- a/vscode-extension/preview-harness/fixtures/pages/serve-agent-access-capabilities.html
+++ b/vscode-extension/preview-harness/fixtures/pages/serve-agent-access-capabilities.html
@@ -66,7 +66,7 @@
         </div>
 
         <dl class="cp-grant-facts">
-          <dt>Purpose</dt><dd>fix wear-m3-catalog#68 &lt;the focus ring&gt;</dd>
+          <dt>Purpose</dt><dd>embed the before/after in the PR body</dd>
           <dt>Asked from</dt><dd>203.0.113.42</dd>
           <dt>Approving as</dt><dd>@yschimke</dd>
           <dt>This request expires in</dt><dd>9m</dd>
@@ -87,15 +87,22 @@
   <span class="cp-grant-scope-what">Open live preview sessions, which start a render daemon on this machine<span class="cp-grant-scope-implies">also includes preview</span></span>
 </label>
           </fieldset>
+                  <fieldset class="cp-grant-fieldset">
+          <legend>Anything else the agent may do</legend>
+          <label class="cp-grant-scope">
+  <input type="checkbox" name="capability" value="images">
+  <span class="cp-grant-scope-name">images</span>
+  <span class="cp-grant-scope-what">Upload rendered preview images, published at unlisted URLs on this server until they expire</span>
+</label>
+        </fieldset>
           
-          <p class="cp-grant-withheld">Not offered: playground — you do not hold it yourself on this server, so you cannot pass it on</p>
           
           <label class="cp-grant-ttl">
             <span>Access expires after</span>
             <select name="ttl">
               <option value="900">15m</option>
+<option value="1800" selected>30m</option>
 <option value="3600">1h</option>
-<option value="7200" selected>2h</option>
 <option value="14400">4h</option>
 <option value="28800">8h</option>
             </select>


### PR DESCRIPTION
## Why

`share-preview --mechanism serve` exists for the box that has no `gh` and no push rights — a hosted agent session — and then asks that box for the one thing it usually cannot produce: a GitHub credential with write access to the gating repo. Claude Code on the web injects its credential only for `api.github.com`, so what reaches a preview host is a placeholder string; the host asks GitHub about it and refuses an upload nobody could have made. Measured this session against a local `--accept-images` box: `403 GitHub user yschimke does not have access to yschimke/compose-ai-tools`, because that credential reports `permissions: {push:false, pull:false}` on every repo in reach.

The grant flow already answers the same question, and answers it better. The image lane's GitHub check asks *does this account have write access to the gating repo* — a proxy for "is this person trusted here". A grant answers *a human operator of this box approved this specific agent, for these minutes, and their name is on it*.

## The shape, and why it isn't a fourth scope

`ServeAgentGrantScope` is a **ladder** — each rung implies the ones below, because each names strictly more of the machine. An upload is sideways from both neighbours: not "more" than starting a render daemon, not "less" than compiling a snippet. As a rung between `live` and `playground` it would have made every playground grant an uploader and every uploader a daemon-starter.

So capabilities are a **set beside the scope**, not a value on it — new `ServeAgentGrantCapability`, currently just `images`. Radios for the ladder, checkboxes for the set, and nothing pre-ticked: the agent asking is not the human agreeing.

## Visual evidence

The approval page is the surface this feature changes, so it gets a fixture of its own — `serve-agent-access-capabilities`, the page on a box whose operator opted in. The second fieldset is the new control; note the checkbox is **unticked**, while the scopes above stay a radio.

![Approval page with the images capability offered, dark](https://raw.githubusercontent.com/yschimke/compose-ai-tools/bfe5e227665bb64e728783a513dd26a60f660d12/renders/serve-agent-access-capabilities.dark.png)

![Approval page with the images capability offered, light](https://raw.githubusercontent.com/yschimke/compose-ai-tools/bfe5e227665bb64e728783a513dd26a60f660d12/renders/serve-agent-access-capabilities.light.png)

There is no "before" for these: the fixture is new, because the existing `serve-agent-access` golden renders on a box that offers no capabilities and so shows an empty fieldset. Regenerating that one alone would have left the checkbox in no golden at all — which is why the variant exists rather than just a refreshed baseline.

The diff bot also reports `serve-viewer-exploded-controls` as changed in both themes. That one is **not from this PR**: the before capture was taken mid-comparison (toolbar reads `comparing…`, side panel `rendering…`) and the after shows the settled state (`69.2% match · view diff →`). A capture race in the harness on an async surface, unrelated to anything here.

## What guards it

- **Opt-in twice.** `--agent-grant-capabilities images` (default none) *and* a human ticking the box per request.
- **Refused at startup** unless the image lane is actually configured — the flag *and* a gating repository — rather than offering a checkbox whose grant would 404 on a route that was never registered.
- **The approver must hold it.** On a GitHub-gated host, ticking `images` requires the approver's own `repositoryAccess` — the same rule, and the same bit, that governs `playground`. That bit speaks for `--github-auth-repo` only, so a box whose image lane gates on a *different* repository is refused this capability at startup rather than having the check approximated.
- **Three-way intersection at approval** (asked ∩ ticked ∩ box ceiling), so a tampered form field buys nothing — same as the scope's `minOf`.
- **Scope stays independent in both directions**: an `images` grant at `preview` scope still gets `403` on `/bundle.zip`.

Attribution improves rather than degrades: `uploadedBy` reads `agent grant 13b27ab6802d (approved by operator (token))`, naming the human who said yes instead of borrowing a login. The rate-limit bucket is the grant, which is already the bounded thing (expires, revocable, capped). One edge worth knowing, and it's in the design doc: **revoking a grant does not unpublish what it uploaded** — the link lives out `--image-ttl`, because the upload was authorized when it happened.

`share-preview` also stops demanding a GitHub token when a grant is stored for the host. Refusing locally would mean this client vetoing an approval a human already gave.

## Verified end to end

Against a live box (`--accept-images --agent-grants --agent-grant-capabilities images`), with **`GITHUB_TOKEN` and `GH_TOKEN` unset**:

```
$ compose-preview auth request --server http://127.0.0.1:8133 --capability images --no-wait --json
$ # human opens the link, ticks the box, approves
$ compose-preview auth status
http://127.0.0.1:8133 — preview + images · expires in 29m · approved by operator (token)

$ env -u GITHUB_TOKEN -u GH_TOKEN compose-preview share-preview report.md before.png after.png --mechanism serve
Uploaded 2 image(s) to http://127.0.0.1:8133 (links expire in 6d 23h), authenticated by the agent access grant for this host
  before.png: http://127.0.0.1:8133/i/sKLMoDLU6Hl-kF9xyLtmow.png
```

Re-fetched byte-identical to the source render (`cmp` clean, `200 image/png`). Audit line: `agent-grant: minted 13b27ab6802d scope=preview caps=images ttl=1800s approver=operator (token)`. Both startup guards verified by running them.

## Test plan

- New `ServeAgentGrantImageUploadTest` — 8/8 green, over real HTTP, with a GitHub gate that **refuses everything**, so each `201` is evidence the grant alone admitted it. Covers: upload with no credential; the image fetchable afterwards; a `live` grant without the capability refused; asked-but-unticked refused; a box that never offered it refused even when the form posts it; `whoami`/poll reporting; the checkbox rendered unticked; and an `images` grant still barred from `/bundle.zip`.
- Full `:cli:test` — 3,085 tests green. (The first push ran only pattern-scoped suites and missed `ServeWebFixtureTest`, which CI then caught; the golden is regenerated and the full suite is what gates now.)
- `:cli:ktfmtFormatMain :cli:ktfmtFormatTest` — clean.

Docs: `AGENT_ACCESS_GRANTS.md` gains the capability model and its edges, and the "not an identity" paragraph is rewritten rather than left contradicting the code. `public-preview-server.md` gains the operator + agent recipe. `SERVE_AGENT_GRANT_CAPABILITIES` is wired through the deploy image so a box can actually turn it on.

**Known follow-up, not in this PR:** `docs/AGENTS.md:32` requires a new consumer-facing flag to be reflected in `yschimke/skills` (SKILL.md + installer). `--capability images` qualifies. That is a second repository and a second PR, outside this session's scope, so it is flagged rather than half-done.