### PR TITLE
fix(auth): name the requested capabilities in the handoff line

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -255,8 +255,17 @@ internal class AuthCommand(
       println("  ${opened.approveUrl}")
       println("  verification code: ${opened.userCode}")
       println()
+      // The capabilities belong in THIS line, not just in --json. It is the sentence an agent
+      // relays into a chat window, and the approval page asks for them explicitly — so omitting
+      // them made the relayed message understate the consent being sought, on the one feature whose
+      // entire premise is that the human sees what they are agreeing to. Printed as the server
+      // clamped them, so a capability this host does not offer is absent here too rather than
+      // promising a checkbox that will not appear.
+      val requestedCapabilities =
+        if (opened.requestedCapabilities.isEmpty()) ""
+        else " + ${opened.requestedCapabilities.joinToString(", ")}"
       println(
-        "  They will be asked to grant: ${opened.requestedScope} · " +
+        "  They will be asked to grant: ${opened.requestedScope}$requestedCapabilities · " +
           ServeAgentGrants.formatDuration(opened.requestedTtlSeconds) +
           (if (label.isNotEmpty()) " · \"$label\"" else "")
       )


### PR DESCRIPTION
Follow-up to #4456, which merged while this was being written.

## What

`auth request` prints one sentence an agent relays into a chat window:

```
  They will be asked to grant: preview · 1h · "before/after for the PR body"
```

It listed the scope, the TTL and the label — never the capabilities. So an agent asking for `images` told its human it wanted `preview`, while the approval page in front of them also asked for permission to publish images on the operator's origin.

That is the wrong sentence to get wrong. This feature rests entirely on the human seeing what they are agreeing to, and the relayed line is where they see it first.

## Verified against a live box

Where the host offers the capability:

```
  They will be asked to grant: preview + images · 1h · "before/after for the PR body"
```

Where it does not (the server clamps it away), the line is unchanged from before:

```
  They will be asked to grant: preview · 1h · "clamped"
```

Printed as the server clamped them, so the relay never promises a checkbox that will not appear on the page.

## Test plan

- Full `:cli:test` — green.
- `:cli:ktfmtFormatMain` — clean.
- Both cases above run end to end against a real `serve` host, one with `--agent-grant-capabilities images` and one without.

Text-only change to a terminal string; no rendered surface is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_0183vYxNWkruzAcLrLcMjCjj)_