### PR TITLE
fix(serve): survive a shadowed embedded player, and stop starving theme optimization

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -41,6 +41,33 @@ data class OptimizerPressureThresholds(
    * where a permanent latch is not.
    */
   val maxRecoveryMillis: Long = 10 * 60_000L,
+  /**
+   * Longest a hold whose stop threshold keeps **re-tripping** may withhold admission before the
+   * gate opens for [dutyCycleMillis]. `0` restores the old permanent latch.
+   *
+   * [maxRecoveryMillis] bounds the dead band; this bounds the other permanent latch, and it is the
+   * one production actually sat in. preview.coo.ee runs 17 resident render daemons on an 8 GB box,
+   * so `MemAvailable` there is a steady 14-15% — under the 15% stop side on every sample. Nothing
+   * is recovering, so the dead-band cap never engages, and theme optimization simply never ran:
+   * `/status.json` reported `paused · memory available 15%` with `wear-m3` warmed to 5 of its 170
+   * entries across a 15-hour uptime.
+   *
+   * A steady-state reading is the host's baseline, not an emergency, and best-effort work that
+   * never runs is indistinguishable from work that was never scheduled. So the same reasoning
+   * [maxRecoveryMillis] records applies: bound the hold, admit a slice, let it trip again. What
+   * stays permanent is a genuine emergency — see [dutyCycleFloorMemoryAvailableFraction].
+   */
+  val starvationCapMillis: Long = 30 * 60_000L,
+  /** How long the gate stays open once [starvationCapMillis] is exhausted. */
+  val dutyCycleMillis: Long = 60_000L,
+  /**
+   * Memory headroom below which the duty cycle never opens, whatever the hold has cost.
+   *
+   * The stop side (15%) is "back off"; this is "the next allocation may be the one that OOM-kills
+   * the replica". A host there keeps the permanent latch, because slow progress is not worth a
+   * killed server.
+   */
+  val dutyCycleFloorMemoryAvailableFraction: Double = 0.05,
 ) {
   companion object {
     /**
@@ -68,6 +95,12 @@ data class OptimizerPressureThresholds(
         sampleIntervalMillis =
           millis("optimizerSampleIntervalMillis") ?: defaults.sampleIntervalMillis,
         maxRecoveryMillis = millis("optimizerMaxRecoveryMillis") ?: defaults.maxRecoveryMillis,
+        starvationCapMillis =
+          millis("optimizerStarvationCapMillis") ?: defaults.starvationCapMillis,
+        dutyCycleMillis = millis("optimizerDutyCycleMillis") ?: defaults.dutyCycleMillis,
+        dutyCycleFloorMemoryAvailableFraction =
+          fraction("optimizerDutyCycleFloorMemoryAvailableFraction")
+            ?: defaults.dutyCycleFloorMemoryAvailableFraction,
       )
     }
 
@@ -107,6 +140,12 @@ data class OptimizerPressureSnapshot(
   val cpuUtilization: Double? = null,
   val memoryAvailableFraction: Double? = null,
   val sampledAtEpochMillis: Long? = null,
+  /** How long the current uninterrupted hold has withheld admission, or null when open. */
+  val heldMillis: Long? = null,
+  /** Set while the starvation cap has opened the gate on a host that is still over a threshold. */
+  val dutyCycleUntilEpochMillis: Long? = null,
+  /** How many times the starvation cap has had to open this gate since the server started. */
+  val dutyCycles: Int = 0,
 )
 
 /**
@@ -119,6 +158,12 @@ data class OptimizerPressureSnapshot(
  * Because the stop and resume sides differ, a reading can settle between them and satisfy neither.
  * [OptimizerPressureThresholds.maxRecoveryMillis] bounds how long that costs: hysteresis delays
  * resumption, and this is what stops it preventing resumption outright.
+ *
+ * A reading that stays on the *stop* side is the other way a hold becomes permanent, and it is the
+ * one a busy host reaches by simply being busy. [OptimizerPressureThresholds.starvationCapMillis]
+ * bounds that one the same way: after the cap the gate opens for a bounded window, then holds
+ * again. Only a host under [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction]
+ * keeps the latch.
  */
 class OptimizerPressureGate(
   private val sample: () -> HostResourceSample?,
@@ -135,6 +180,17 @@ class OptimizerPressureGate(
 
   /** When the current hold last saw every stop threshold clear — the [maxRecoveryMillis] anchor. */
   private var recoveringSince = Long.MIN_VALUE
+
+  /** Whether the pressure logic itself wants to hold, before the starvation cap has its say. */
+  private var held = false
+
+  /** When the current uninterrupted hold began — the [starvationCapMillis] anchor. */
+  private var heldSince = Long.MIN_VALUE
+
+  /** End of the window the starvation cap has opened, or [Long.MIN_VALUE] when not duty-cycling. */
+  private var dutyCycleUntil = Long.MIN_VALUE
+
+  private var dutyCycles = 0
 
   fun snapshot(): OptimizerPressureSnapshot =
     synchronized(lock) {
@@ -156,13 +212,16 @@ class OptimizerPressureGate(
       // Only what actually stopped us has to come back: a hold taken for memory should not also
       // wait on a CPU reading that never crossed its own stop threshold.
       val safe = trippedBy.all { it.recovered(current, thresholds) }
-      val constrained =
+      val holding =
         if (tripped.isNotEmpty()) {
           trippedBy = trippedBy + tripped.map { it.first }
           safeSince = Long.MIN_VALUE
           recoveringSince = Long.MIN_VALUE
           true
-        } else if (!cached.constrained) {
+        } else if (!held) {
+          // `held`, not the published `constrained`: a starvation duty cycle publishes an open gate
+          // while the hold is still on, and reading that back would end the hold without the quiet
+          // window it is owed.
           false
         } else {
           // Nothing is over a stop threshold any more, so the hold is now bounded either way:
@@ -180,27 +239,68 @@ class OptimizerPressureGate(
             }
           !quiet && !recoveryExhausted
         }
-      if (!constrained) {
+      if (holding) {
+        if (!held) heldSince = now
+      } else {
         trippedBy = emptySet()
         safeSince = Long.MIN_VALUE
         recoveringSince = Long.MIN_VALUE
+        heldSince = Long.MIN_VALUE
+        dutyCycleUntil = Long.MIN_VALUE
       }
+      held = holding
+      val constrained = holding && !dutyCycling(current, now)
       cached =
         OptimizerPressureSnapshot(
           constrained = constrained,
           reason =
             when {
+              !holding -> null
               tripped.isNotEmpty() -> tripped.joinToString(", ") { it.second }
-              constrained -> recoveringReason(current)
-              else -> null
+              else -> recoveringReason(current)
             },
           loadPerCpu = current.loadPerCpu,
           cpuUtilization = current.cpuUtilization,
           memoryAvailableFraction = current.memoryAvailableFraction,
           sampledAtEpochMillis = now,
+          heldMillis = if (holding) (now - heldSince).coerceAtLeast(0L) else null,
+          dutyCycleUntilEpochMillis = dutyCycleUntil.takeIf { it > now },
+          dutyCycles = dutyCycles,
         )
       cached
     }
+
+  /**
+   * Whether the starvation cap should let this held gate through right now.
+   *
+   * Opens a [OptimizerPressureThresholds.dutyCycleMillis] window once a hold has withheld admission
+   * for [OptimizerPressureThresholds.starvationCapMillis], then re-arms: hold, admit a slice, hold
+   * again. The window is closed early — and never opened — while memory sits under
+   * [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction], so the one case that can
+   * actually kill the server keeps the permanent latch.
+   *
+   * The reason string keeps naming the reading that is holding, because it still is: a duty cycle
+   * is progress *despite* the pressure, not an all-clear. `dutyCycles` on `/status.json` is what
+   * says the host has been running on it.
+   */
+  private fun dutyCycling(sample: HostResourceSample, now: Long): Boolean {
+    if (thresholds.starvationCapMillis <= 0L) return false
+    val starved =
+      sample.memoryAvailableFraction?.let {
+        it < thresholds.dutyCycleFloorMemoryAvailableFraction
+      } == true
+    if (starved) {
+      dutyCycleUntil = Long.MIN_VALUE
+      return false
+    }
+    if (now < dutyCycleUntil) return true
+    if (heldSince == Long.MIN_VALUE) return false
+    if (now - heldSince < thresholds.starvationCapMillis) return false
+    dutyCycleUntil = now + thresholds.dutyCycleMillis.coerceAtLeast(0L)
+    heldSince = dutyCycleUntil
+    dutyCycles++
+    return now < dutyCycleUntil
+  }
 
   /**
    * Why a hold with no reading over a stop threshold is still held.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -58,7 +58,7 @@ data class OptimizerPressureThresholds(
    * stays permanent is a genuine emergency — see [dutyCycleFloorMemoryAvailableFraction].
    */
   val starvationCapMillis: Long = 30 * 60_000L,
-  /** How long the gate stays open once [starvationCapMillis] is exhausted. */
+  /** How long the gate stays open once [starvationCapMillis] is exhausted. `0` disables the cap. */
   val dutyCycleMillis: Long = 60_000L,
   /**
    * Memory headroom below which the duty cycle never opens, whatever the hold has cost.
@@ -192,6 +192,9 @@ class OptimizerPressureGate(
 
   private var dutyCycles = 0
 
+  /** What was over a stop threshold on the previous sample — the [newlyTripped] baseline. */
+  private var lastTripped = emptySet<PressureSignal>()
+
   fun snapshot(): OptimizerPressureSnapshot =
     synchronized(lock) {
       val now = clock()
@@ -213,10 +216,14 @@ class OptimizerPressureGate(
       // Only what actually stopped us has to come back: a hold taken for memory should not also
       // wait on a CPU reading that never crossed its own stop threshold.
       val safe = trippedBy.all { it.recovered(current, thresholds) }
-      // Read before the merge below: a signal crossing its stop threshold for the FIRST time in
-      // this hold is what has to cut a duty cycle short, and after the merge it is
-      // indistinguishable from the signal that has been holding all along.
-      val newlyTripped = tripped.map { it.first }.filterNot { it in trippedBy }
+      // What is over a stop threshold *right now*, and what was over one on the previous sample.
+      // The difference is what has to cut a duty cycle short. Comparing against `trippedBy` would
+      // not do: that set accumulates for the life of the hold, so a signal that tripped once, went
+      // quiet, and spiked again while memory kept the hold alive would read as "already tripped"
+      // and buy the rest of the window.
+      val activeSignals = tripped.map { it.first }.toSet()
+      val newlyTripped = activeSignals - lastTripped
+      lastTripped = activeSignals
       val holding =
         if (tripped.isNotEmpty()) {
           trippedBy = trippedBy + tripped.map { it.first }
@@ -310,9 +317,11 @@ class OptimizerPressureGate(
   private fun dutyCycling(
     sample: HostResourceSample,
     now: Long,
-    newlyTripped: List<PressureSignal>,
+    newlyTripped: Set<PressureSignal>,
   ): Boolean {
-    if (thresholds.starvationCapMillis <= 0L) return false
+    // A zero-length window admits nothing, so it is not a duty cycle — counting one would leave
+    // `/status.json` reporting concessions the gate never made. Both knobs disable the cap.
+    if (thresholds.starvationCapMillis <= 0L || thresholds.dutyCycleMillis <= 0L) return false
     // An unknown memory reading is not a safe one. `LinuxHostResourceSampler` returns a partial
     // sample when `/proc/meminfo` is unreadable but load and CPU are not, and a load hold would
     // then earn a concession with the OOM floor unverified. A host that never reports memory keeps
@@ -332,10 +341,10 @@ class OptimizerPressureGate(
     if (now < dutyCycleUntil) return true
     if (heldSince == Long.MIN_VALUE) return false
     if (now - heldSince < thresholds.starvationCapMillis) return false
-    dutyCycleUntil = now + thresholds.dutyCycleMillis.coerceAtLeast(0L)
+    dutyCycleUntil = now + thresholds.dutyCycleMillis
     heldSince = dutyCycleUntil
     dutyCycles++
-    return now < dutyCycleUntil
+    return true
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -213,6 +213,10 @@ class OptimizerPressureGate(
       // Only what actually stopped us has to come back: a hold taken for memory should not also
       // wait on a CPU reading that never crossed its own stop threshold.
       val safe = trippedBy.all { it.recovered(current, thresholds) }
+      // Read before the merge below: a signal crossing its stop threshold for the FIRST time in
+      // this hold is what has to cut a duty cycle short, and after the merge it is
+      // indistinguishable from the signal that has been holding all along.
+      val newlyTripped = tripped.map { it.first }.filterNot { it in trippedBy }
       val holding =
         if (tripped.isNotEmpty()) {
           trippedBy = trippedBy + tripped.map { it.first }
@@ -250,7 +254,7 @@ class OptimizerPressureGate(
         dutyCycleUntil = Long.MIN_VALUE
       }
       held = holding
-      val constrained = holding && !dutyCycling(current, now)
+      val constrained = holding && !dutyCycling(current, now, newlyTripped)
       cached =
         OptimizerPressureSnapshot(
           constrained = constrained,
@@ -293,21 +297,35 @@ class OptimizerPressureGate(
    *
    * Opens a [OptimizerPressureThresholds.dutyCycleMillis] window once a hold has withheld admission
    * for [OptimizerPressureThresholds.starvationCapMillis], then re-arms: hold, admit a slice, hold
-   * again. The window is closed early — and never opened — while memory sits under
-   * [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction], so the one case that can
-   * actually kill the server keeps the permanent latch.
+   * again. The window is closed early — and never opened — while memory sits under (or cannot be
+   * read against) [OptimizerPressureThresholds.dutyCycleFloorMemoryAvailableFraction], so the one
+   * case that can actually kill the server keeps the permanent latch; and closed early when a
+   * signal that was not already holding crosses its stop threshold, so the concession never covers
+   * pressure it did not answer for.
    *
    * The reason string keeps naming the reading that is holding, because it still is: a duty cycle
    * is progress *despite* the pressure, not an all-clear. `dutyCycles` on `/status.json` is what
    * says the host has been running on it.
    */
-  private fun dutyCycling(sample: HostResourceSample, now: Long): Boolean {
+  private fun dutyCycling(
+    sample: HostResourceSample,
+    now: Long,
+    newlyTripped: List<PressureSignal>,
+  ): Boolean {
     if (thresholds.starvationCapMillis <= 0L) return false
-    val starved =
-      sample.memoryAvailableFraction?.let {
-        it < thresholds.dutyCycleFloorMemoryAvailableFraction
-      } == true
-    if (starved) {
+    // An unknown memory reading is not a safe one. `LinuxHostResourceSampler` returns a partial
+    // sample when `/proc/meminfo` is unreadable but load and CPU are not, and a load hold would
+    // then earn a concession with the OOM floor unverified. A host that never reports memory keeps
+    // the permanent latch, which is the conservative half of that trade.
+    val headroom = sample.memoryAvailableFraction
+    if (headroom == null || headroom < thresholds.dutyCycleFloorMemoryAvailableFraction) {
+      dutyCycleUntil = Long.MIN_VALUE
+      return false
+    }
+    // "A high reading stops admission immediately" is the gate's contract, and an open window must
+    // not buy a *different* signal up to `dutyCycleMillis` of grace. The signal that earned the
+    // concession may stay over its threshold — that is the whole point — but a new one closes it.
+    if (newlyTripped.isNotEmpty()) {
       dutyCycleUntil = Long.MIN_VALUE
       return false
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -363,6 +363,11 @@ class OptimizerPressureGate(
     // A zero-length window admits nothing, so it is not a duty cycle — counting one would leave
     // `/status.json` reporting concessions the gate never made. Both knobs disable the cap.
     if (thresholds.starvationCapMillis <= 0L || thresholds.dutyCycleMillis <= 0L) return false
+    // `dutyCycleUntil` means "a window is live", and it has to be retired the moment one elapses:
+    // the two early closes below anchor at `now` because they are cutting a live window short, and
+    // a stale marker makes them do that to a window that already ran its course — re-anchoring a
+    // cap that was correctly anchored at the window's end when it opened.
+    if (dutyCycleUntil != Long.MIN_VALUE && now >= dutyCycleUntil) closeWindow(at = dutyCycleUntil)
     // An unknown memory reading is not a safe one. `LinuxHostResourceSampler` returns a partial
     // sample when `/proc/meminfo` is unreadable but load and CPU are not, and a load hold would
     // then earn a concession with the OOM floor unverified. A host that never reports memory keeps

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -304,7 +304,7 @@ class OptimizerPressureGate(
    */
   private fun cachedClosingExpiredDutyCycle(now: Long): OptimizerPressureSnapshot {
     if (!held || dutyCycleUntil == Long.MIN_VALUE || now < dutyCycleUntil) return cached
-    closeWindow(now)
+    closeWindow(at = dutyCycleUntil)
     // `heldMillis` is recomputed rather than carried over: the cached value was taken while the
     // window was open, and republishing it would report a gate that has been shut for hours as
     // having withheld admission for however long it had at the moment the sampler died.
@@ -323,16 +323,21 @@ class OptimizerPressureGate(
     else null
 
   /**
-   * Ends the open window, if any, and re-arms the cap from [now].
+   * Ends the open window, if any, and re-arms the cap from [at].
    *
    * A window cut short — by new pressure, or by memory dropping under the floor — must not leave
    * the next concession measured from the end it never reached: that would withhold admission for
-   * up to `starvationCapMillis + dutyCycleMillis`, which is not what the cap says it does.
+   * up to `starvationCapMillis + dutyCycleMillis`, which is not what the cap says it does. So a
+   * live window closes at `now`.
+   *
+   * A window that simply *elapsed* is the other case, and it anchors at its scheduled end even when
+   * nothing observed the expiry until later: the concession was served in full, and a sampler that
+   * went blind for the next nine seconds is not a reason to charge the host another cap for them.
    */
-  private fun closeWindow(now: Long) {
+  private fun closeWindow(at: Long) {
     if (dutyCycleUntil == Long.MIN_VALUE) return
     dutyCycleUntil = Long.MIN_VALUE
-    capAnchor = now
+    capAnchor = at
   }
 
   /**
@@ -364,14 +369,14 @@ class OptimizerPressureGate(
     // the permanent latch, which is the conservative half of that trade.
     val headroom = sample.memoryAvailableFraction
     if (headroom == null || headroom < thresholds.dutyCycleFloorMemoryAvailableFraction) {
-      closeWindow(now)
+      closeWindow(at = now)
       return false
     }
     // "A high reading stops admission immediately" is the gate's contract, and an open window must
     // not buy a *different* signal up to `dutyCycleMillis` of grace. The signal that earned the
     // concession may stay over its threshold — that is the whole point — but a new one closes it.
     if (newlyTripped.isNotEmpty()) {
-      closeWindow(now)
+      closeWindow(at = now)
       return false
     }
     if (now < dutyCycleUntil) return true

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -195,9 +195,10 @@ class OptimizerPressureGate(
   fun snapshot(): OptimizerPressureSnapshot =
     synchronized(lock) {
       val now = clock()
-      if (now < nextSampleAt) return@synchronized cached
+      if (now < nextSampleAt) return@synchronized cachedClosingExpiredDutyCycle(now)
       nextSampleAt = now + thresholds.sampleIntervalMillis.coerceAtLeast(0L)
-      val current = runCatching(sample).getOrNull() ?: return@synchronized cached
+      val current =
+        runCatching(sample).getOrNull() ?: return@synchronized cachedClosingExpiredDutyCycle(now)
       val tripped = buildList {
         current.loadPerCpu
           ?.takeIf { it >= thresholds.stopLoadPerCpu }
@@ -269,6 +270,23 @@ class OptimizerPressureGate(
         )
       cached
     }
+
+  /**
+   * The cached snapshot, with an elapsed duty-cycle window closed first.
+   *
+   * Both paths that reuse [cached] — inside the sample interval, and when sampling fails outright —
+   * would otherwise publish an open gate for as long as they last. Inside the sample interval that
+   * is at most one interval; when `/proc` stops being readable it is forever, and the 60-second
+   * window becomes a permanent admission of optimizer work under pressure nobody can see any more.
+   * The window is a *bounded* concession, so it expires on the clock rather than on the next
+   * successful reading.
+   */
+  private fun cachedClosingExpiredDutyCycle(now: Long): OptimizerPressureSnapshot {
+    if (!held || dutyCycleUntil == Long.MIN_VALUE || now < dutyCycleUntil) return cached
+    dutyCycleUntil = Long.MIN_VALUE
+    cached = cached.copy(constrained = true, dutyCycleUntilEpochMillis = null)
+    return cached
+  }
 
   /**
    * Whether the starvation cap should let this held gate through right now.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -184,8 +184,14 @@ class OptimizerPressureGate(
   /** Whether the pressure logic itself wants to hold, before the starvation cap has its say. */
   private var held = false
 
-  /** When the current uninterrupted hold began — the [starvationCapMillis] anchor. */
-  private var heldSince = Long.MIN_VALUE
+  /**
+   * When the next concession is measured from — moved to the end of each window the cap opens, and
+   * to the moment a window is cut short, so the cap always means "at most this long without one".
+   */
+  private var capAnchor = Long.MIN_VALUE
+
+  /** When the current uninterrupted hold began. Reporting only — `heldMillis` on `/status.json`. */
+  private var holdStartedAt = Long.MIN_VALUE
 
   /** End of the window the starvation cap has opened, or [Long.MIN_VALUE] when not duty-cycling. */
   private var dutyCycleUntil = Long.MIN_VALUE
@@ -252,12 +258,16 @@ class OptimizerPressureGate(
           !quiet && !recoveryExhausted
         }
       if (holding) {
-        if (!held) heldSince = now
+        if (!held) {
+          holdStartedAt = now
+          capAnchor = now
+        }
       } else {
         trippedBy = emptySet()
         safeSince = Long.MIN_VALUE
         recoveringSince = Long.MIN_VALUE
-        heldSince = Long.MIN_VALUE
+        holdStartedAt = Long.MIN_VALUE
+        capAnchor = Long.MIN_VALUE
         dutyCycleUntil = Long.MIN_VALUE
       }
       held = holding
@@ -275,7 +285,7 @@ class OptimizerPressureGate(
           cpuUtilization = current.cpuUtilization,
           memoryAvailableFraction = current.memoryAvailableFraction,
           sampledAtEpochMillis = now,
-          heldMillis = if (holding) (now - heldSince).coerceAtLeast(0L) else null,
+          heldMillis = heldMillis(now, holding),
           dutyCycleUntilEpochMillis = dutyCycleUntil.takeIf { it > now },
           dutyCycles = dutyCycles,
         )
@@ -294,9 +304,35 @@ class OptimizerPressureGate(
    */
   private fun cachedClosingExpiredDutyCycle(now: Long): OptimizerPressureSnapshot {
     if (!held || dutyCycleUntil == Long.MIN_VALUE || now < dutyCycleUntil) return cached
-    dutyCycleUntil = Long.MIN_VALUE
-    cached = cached.copy(constrained = true, dutyCycleUntilEpochMillis = null)
+    closeWindow(now)
+    // `heldMillis` is recomputed rather than carried over: the cached value was taken while the
+    // window was open, and republishing it would report a gate that has been shut for hours as
+    // having withheld admission for however long it had at the moment the sampler died.
+    cached =
+      cached.copy(
+        constrained = true,
+        dutyCycleUntilEpochMillis = null,
+        heldMillis = heldMillis(now, holding = true),
+      )
     return cached
+  }
+
+  /** How long the current hold has withheld admission, or null when the gate is not holding. */
+  private fun heldMillis(now: Long, holding: Boolean): Long? =
+    if (holding && holdStartedAt != Long.MIN_VALUE) (now - holdStartedAt).coerceAtLeast(0L)
+    else null
+
+  /**
+   * Ends the open window, if any, and re-arms the cap from [now].
+   *
+   * A window cut short — by new pressure, or by memory dropping under the floor — must not leave
+   * the next concession measured from the end it never reached: that would withhold admission for
+   * up to `starvationCapMillis + dutyCycleMillis`, which is not what the cap says it does.
+   */
+  private fun closeWindow(now: Long) {
+    if (dutyCycleUntil == Long.MIN_VALUE) return
+    dutyCycleUntil = Long.MIN_VALUE
+    capAnchor = now
   }
 
   /**
@@ -328,21 +364,21 @@ class OptimizerPressureGate(
     // the permanent latch, which is the conservative half of that trade.
     val headroom = sample.memoryAvailableFraction
     if (headroom == null || headroom < thresholds.dutyCycleFloorMemoryAvailableFraction) {
-      dutyCycleUntil = Long.MIN_VALUE
+      closeWindow(now)
       return false
     }
     // "A high reading stops admission immediately" is the gate's contract, and an open window must
     // not buy a *different* signal up to `dutyCycleMillis` of grace. The signal that earned the
     // concession may stay over its threshold — that is the whole point — but a new one closes it.
     if (newlyTripped.isNotEmpty()) {
-      dutyCycleUntil = Long.MIN_VALUE
+      closeWindow(now)
       return false
     }
     if (now < dutyCycleUntil) return true
-    if (heldSince == Long.MIN_VALUE) return false
-    if (now - heldSince < thresholds.starvationCapMillis) return false
+    if (capAnchor == Long.MIN_VALUE) return false
+    if (now - capAnchor < thresholds.starvationCapMillis) return false
     dutyCycleUntil = now + thresholds.dutyCycleMillis
-    heldSince = dutyCycleUntil
+    capAnchor = dutyCycleUntil
     dutyCycles++
     return true
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5198,8 +5198,22 @@ class ServeHttpServer(
      */
     private fun optimizerGateText(admission: ThemeOptimizerAdmissionSnapshot): String {
       val needs = "needs ${admission.idleThresholdMillis / 1000}s quiet"
+      // A host whose steady state sits on a stop threshold runs on the starvation cap's bounded
+      // windows rather than on an open gate. Without saying so, `/status` reads as an ordinary
+      // healthy gate that just happens to make very slow progress. Appended rather than returned
+      // early, because the quiet gate still has its own say: a duty cycle answers host pressure,
+      // not "is the server idle".
+      val pressure = admission.pressure
+      val cycles = pressure?.dutyCycles ?: 0
+      val dutyCycles =
+        when {
+          pressure?.dutyCycleUntilEpochMillis != null ->
+            " · duty cycle $cycles" + (pressure.reason?.let { " · $it" } ?: "")
+          cycles > 0 -> " · ${countLabel(cycles, "duty cycle")}"
+          else -> ""
+        }
       if (admission.paused) {
-        return "paused" + (admission.pauseReason?.let { " · $it" } ?: "")
+        return "paused" + (admission.pauseReason?.let { " · $it" } ?: "") + dutyCycles
       }
       val idle =
         admission.serverIdleMillis
@@ -5215,10 +5229,10 @@ class ServeHttpServer(
                 ServeBackgroundWork.IDLE_BLOCKED_BY_CATALOG_LOAD -> "catalogs loading"
                 else -> "server busy"
               }
-            return "closed · $why · $needs"
+            return "closed · $why · $needs$dutyCycles"
           }
       val open = idle >= admission.idleThresholdMillis
-      return "${if (open) "open" else "closed"} · idle ${idle / 1000}s · $needs"
+      return "${if (open) "open" else "closed"} · idle ${idle / 1000}s · $needs$dutyCycles"
     }
 
     fun toResponse(): StatusResponse {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -272,6 +272,64 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `a signal that tripped earlier in the hold still closes a later window`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.95, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    // CPU trips at the start of the hold and then goes quiet; memory keeps the hold alive, so
+    // `trippedBy` still remembers CPU for the rest of it. A second CPU spike is new pressure all
+    // the same, and must not be filtered out as "already tripped".
+    assertTrue(gate.snapshot().constrained)
+    now = 1_000
+    sample = sample.copy(cpuUtilization = 0.03)
+    assertTrue(gate.snapshot().constrained)
+
+    now = 11_000
+    assertFalse(gate.snapshot().constrained, "the cap opens a window")
+    now = 11_500
+    sample = sample.copy(cpuUtilization = 0.95)
+    val stopped = gate.snapshot()
+    assertTrue(stopped.constrained, "the CPU spike is new pressure, whenever it last happened")
+    assertNull(stopped.dutyCycleUntilEpochMillis)
+  }
+
+  @Test
+  fun `a zero-length window is not counted as a duty cycle`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 0,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertTrue(gate.snapshot().constrained, "a window that admits nothing is not a concession")
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained)
+    assertEquals(0, held.dutyCycles, "and must not be reported as one: $held")
+  }
+
+  @Test
   fun `the duty cycle stays shut while memory cannot be read at all`() {
     var now = 0L
     // `/proc/meminfo` unreadable while load and CPU are fine: the sampler reports a partial sample

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -241,6 +241,62 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `a newly tripped signal closes an open duty cycle`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // The memory reading that earned the concession may stay over its threshold — that is the
+    // point — but CPU crossing its own stop side is new pressure the window never answered for,
+    // and "a high reading stops admission immediately" outranks it.
+    sample = sample.copy(cpuUtilization = 0.95)
+    now = 10_500
+    val stopped = gate.snapshot()
+    assertTrue(stopped.constrained, "a new signal must cut the window short")
+    assertNull(stopped.dutyCycleUntilEpochMillis)
+    assertTrue(stopped.reason.orEmpty().contains("CPU 95%"), "and name itself: $stopped")
+  }
+
+  @Test
+  fun `the duty cycle stays shut while memory cannot be read at all`() {
+    var now = 0L
+    // `/proc/meminfo` unreadable while load and CPU are fine: the sampler reports a partial sample
+    // rather than none, and an unverified OOM floor must not buy a concession.
+    val sample =
+      HostResourceSample(loadPerCpu = 0.90, cpuUtilization = 0.10, memoryAvailableFraction = null)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained, "an unknown memory reading is not a safe one")
+    assertEquals(0, held.dutyCycles)
+  }
+
+  @Test
   fun `a zero starvation cap keeps the hold permanent`() {
     var now = 0L
     val sample =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -175,6 +175,49 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `an expired duty cycle closes even when sampling has stopped working`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // `/proc` stops answering mid-window. The cached snapshot says "open"; without expiring it on
+    // the clock the concession becomes permanent, under pressure nothing can observe any more.
+    readable = false
+    now = 10_500
+    assertFalse(gate.snapshot().constrained, "the window itself is still running")
+    now = 11_000
+    val closed = gate.snapshot()
+    assertTrue(closed.constrained, "an elapsed window must close without a fresh reading")
+    assertNull(closed.dutyCycleUntilEpochMillis)
+    now = 60_000
+    assertTrue(gate.snapshot().constrained)
+  }
+
+  @Test
   fun `the duty cycle never opens on a host that is genuinely out of memory`() {
     var now = 0L
     val sample =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -305,6 +305,79 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `a window cut short re-arms the cap from when it actually closed`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+
+    // Cut short 100ms in. The next concession is owed 10s from *here*, not 10s from the end the
+    // window never reached — otherwise the cap silently becomes cap + window.
+    now = 10_100
+    sample = sample.copy(cpuUtilization = 0.95)
+    assertTrue(gate.snapshot().constrained)
+    sample = sample.copy(cpuUtilization = 0.03)
+
+    now = 20_099
+    assertTrue(gate.snapshot().constrained)
+    now = 20_100
+    assertFalse(gate.snapshot().constrained, "the cap runs from the early close")
+  }
+
+  @Test
+  fun `a hold closed while sampling is broken keeps reporting how long it has held`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    assertEquals(0, gate.snapshot().heldMillis)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained)
+    // The hold is still on during the window, and it started at t=0 — the cap bookkeeping moving
+    // its own anchor to the window end must not make the reported duration collapse to zero.
+    assertEquals(10_000, gate.snapshot().heldMillis)
+
+    readable = false
+    now = 3_600_000
+    val stale = gate.snapshot()
+    assertTrue(stale.constrained)
+    assertEquals(3_600_000, stale.heldMillis, "an hour held must not report as zero: $stale")
+  }
+
+  @Test
   fun `a zero-length window is not counted as a duty cycle`() {
     var now = 0L
     val sample =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -136,6 +136,119 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `a hold whose stop threshold keeps re-tripping duty-cycles instead of latching forever`() {
+    var now = 0L
+    // The preview.coo.ee steady state: an idle box whose 17 resident daemons keep MemAvailable a
+    // hair under the stop side, so every sample re-trips and nothing ever "recovers".
+    val sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val thresholds =
+      OptimizerPressureThresholds(
+        sampleIntervalMillis = 0,
+        starvationCapMillis = 10_000,
+        dutyCycleMillis = 1_000,
+      )
+    val gate = OptimizerPressureGate(sample = { sample }, thresholds = thresholds, clock = { now })
+    assertTrue(gate.snapshot().constrained)
+
+    now = 9_999
+    assertTrue(gate.snapshot().constrained, "the cap must not open early")
+    assertEquals(9_999, gate.snapshot().heldMillis)
+
+    now = 10_000
+    val open = gate.snapshot()
+    assertFalse(open.constrained, "a bounded duty cycle beats never optimizing at all")
+    assertEquals(1, open.dutyCycles)
+    assertEquals(11_000, open.dutyCycleUntilEpochMillis)
+    assertTrue(
+      open.reason.orEmpty().contains("memory available 14%"),
+      "the reading is still what is holding, so keep naming it: $open",
+    )
+
+    now = 11_000
+    assertTrue(gate.snapshot().constrained, "the window is bounded too")
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "the cap re-arms from the end of the window")
+    assertEquals(2, gate.snapshot().dutyCycles)
+  }
+
+  @Test
+  fun `the duty cycle never opens on a host that is genuinely out of memory`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.02)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 100_000
+    val held = gate.snapshot()
+    assertTrue(held.constrained, "below the floor the latch is the correct failure mode")
+    assertEquals(0, held.dutyCycles)
+  }
+
+  @Test
+  fun `a zero starvation cap keeps the hold permanent`() {
+    var now = 0L
+    val sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0, starvationCapMillis = 0),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10 * 60_000
+    assertTrue(gate.snapshot().constrained)
+    assertEquals(0, gate.snapshot().dutyCycles)
+  }
+
+  @Test
+  fun `recovery clears the starvation clock`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.1, cpuUtilization = 0.1, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            resumeQuietMillis = 0,
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 5_000
+    sample = sample.copy(memoryAvailableFraction = 0.80)
+    val recovered = gate.snapshot()
+    assertFalse(recovered.constrained)
+    assertNull(recovered.heldMillis)
+
+    // A new hold starts its own cap rather than inheriting the previous one's 5s of credit.
+    now = 6_000
+    sample = sample.copy(memoryAvailableFraction = 0.14)
+    assertTrue(gate.snapshot().constrained)
+    now = 15_999
+    assertTrue(gate.snapshot().constrained)
+    now = 16_000
+    assertFalse(gate.snapshot().constrained)
+  }
+
+  @Test
   fun `only the signal that tripped the hold has to recover`() {
     var now = 0L
     var sample =
@@ -240,6 +353,38 @@ class HostOptimizerAdmissionTest {
     assertTrue(snapshot.paused)
     assertTrue(snapshot.pressure?.constrained == true)
     assertTrue(snapshot.pauseReason.orEmpty().contains("load"))
+  }
+
+  @Test
+  fun `background work admits a slice once the starvation cap opens the gate`() {
+    var now = 0L
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 0.17,
+            cpuUtilization = 0.03,
+            memoryAvailableFraction = 0.14,
+          )
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    val work = ServeBackgroundWork(clock = { now }, pressureGate = gate)
+
+    assertNull(work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    assertTrue(work.optimizersPaused())
+
+    now = 10_000
+    assertEquals(true, work.withOptimizerSlot("catalog", waitMillis = 0) { true })
+    val snapshot = work.optimizerAdmissionSnapshot()
+    assertFalse(snapshot.paused, "the duty cycle has to reach the admission path, not just /status")
+    assertEquals(1, snapshot.pressure?.dutyCycles)
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -305,6 +305,48 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `an expiry noticed late still re-arms from the scheduled window end`() {
+    var now = 0L
+    var readable = true
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          if (readable) {
+            HostResourceSample(
+              loadPerCpu = 0.17,
+              cpuUtilization = 0.03,
+              memoryAvailableFraction = 0.14,
+            )
+          } else {
+            null
+          }
+        },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained, "the window opens, scheduled to end at 11s")
+
+    // The sampler goes blind across the expiry and stays blind until 20s. The concession was
+    // served in full, so the next one is due 10s after the scheduled end — charging a fresh cap
+    // from the moment someone happened to look would make blindness cost the host admission.
+    readable = false
+    now = 20_000
+    assertTrue(gate.snapshot().constrained)
+    readable = true
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "due at 21s, not 30s")
+  }
+
+  @Test
   fun `a window cut short re-arms the cap from when it actually closed`() {
     var now = 0L
     var sample =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -305,6 +305,41 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `pressure after a window has elapsed does not re-arm the cap again`() {
+    var now = 0L
+    var sample =
+      HostResourceSample(loadPerCpu = 0.17, cpuUtilization = 0.03, memoryAvailableFraction = 0.14)
+    val gate =
+      OptimizerPressureGate(
+        sample = { sample },
+        thresholds =
+          OptimizerPressureThresholds(
+            sampleIntervalMillis = 0,
+            starvationCapMillis = 10_000,
+            dutyCycleMillis = 1_000,
+          ),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+    now = 10_000
+    assertFalse(gate.snapshot().constrained, "window open, scheduled to end at 11s")
+    now = 11_000
+    assertTrue(gate.snapshot().constrained, "and elapsed, having been served in full")
+
+    // A CPU trip four seconds later is cutting nothing short — the window is long over — so it must
+    // not push the next concession out from 21s to 25s.
+    now = 15_000
+    sample = sample.copy(cpuUtilization = 0.95)
+    assertTrue(gate.snapshot().constrained)
+    sample = sample.copy(cpuUtilization = 0.03)
+
+    now = 20_999
+    assertTrue(gate.snapshot().constrained)
+    now = 21_000
+    assertFalse(gate.snapshot().constrained, "still due 10s after the window that was served")
+  }
+
+  @Test
   fun `an expiry noticed late still re-arms from the scheduled window end`() {
     var now = 0L
     var readable = true

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
@@ -15,6 +15,7 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposePlayerKind
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.render.IrSidecarChannel
 import ee.schimke.composeai.data.render.extensions.IrReplayComposableProvider
+import java.lang.reflect.Modifier
 
 /**
  * Replays a Remote Compose preview from a bundle's captured IR (schema v5): the serialized
@@ -160,11 +161,25 @@ internal fun embeddedPlayerEntryPointPresent(classLoader: ClassLoader?): Boolean
 }
   .getOrDefault(false)
 
-/** Whether [facade] declares [EMBEDDED_PLAYER_ENTRY_POINT] taking exactly [parameters]. */
+/**
+ * Whether [facade] declares [EMBEDDED_PLAYER_ENTRY_POINT] in the exact shape the call site links
+ * against: `public static void` taking exactly [parameters].
+ *
+ * The modifiers and return type are checked alongside the signature because they are separately
+ * load-bearing — the compiled call is an `invokestatic …(…)V`, so a same-named method that is
+ * non-static, non-public or returns something else fails to link just as hard, with
+ * `IncompatibleClassChangeError` / `IllegalAccessError` / `NoSuchMethodError` respectively. A
+ * Kotlin top-level `@Composable fun` always compiles to `public static void` on its `…Kt` facade,
+ * so this costs nothing today; it is here so the predicate answers the question it appears to
+ * answer rather than a near neighbour of it.
+ */
 internal fun declaresEntryPoint(facade: Class<*>, parameters: List<String>): Boolean =
   facade.declaredMethods.any { method ->
     method.name == EMBEDDED_PLAYER_ENTRY_POINT &&
-      method.parameterTypes.map { it.name } == parameters
+      method.parameterTypes.map { it.name } == parameters &&
+      method.returnType == Void.TYPE &&
+      Modifier.isStatic(method.modifiers) &&
+      Modifier.isPublic(method.modifiers)
   }
 
 /**

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt
@@ -72,12 +72,6 @@ class RemoteComposeIrReplay {
 }
 
 /**
- * Whether the vendored embedded player (`:third-party-rc-embedded-player`) is on the runtime
- * classpath. Resolved once per JVM. A consumer that doesn't ship it silently falls back to the view
- * player instead of dying with `NoClassDefFoundError` — the same classloader gate `:daemon:android`
- * uses before registering the Remote Compose extension at all.
- */
-/**
  * The colour subset of the seeded named values, in the shape [ExperimentalRemoteDocumentPlayer]
  * takes (variable name -> ARGB int).
  *
@@ -103,15 +97,85 @@ internal fun Map<String, RemoteNamedValue>.toNamedColorOverrides(): ObjectIntMap
   return MutableObjectIntMap<String>(colors.size).apply { colors.forEach { (n, v) -> put(n, v) } }
 }
 
-internal val isEmbeddedPlayerAvailable: Boolean by lazy {
-  runCatching {
-    Class.forName(
-      "androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayerKt",
-      false,
-      RemoteComposeIrReplay::class.java.classLoader,
-    )
+internal const val EMBEDDED_PLAYER_FACADE =
+  "androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayerKt"
+
+internal const val EMBEDDED_PLAYER_ENTRY_POINT = "ExperimentalRemoteDocumentPlayer"
+
+/**
+ * The parameter types of the [EMBEDDED_PLAYER_ENTRY_POINT] overload the two call sites in this
+ * module compile down to, in declaration order.
+ *
+ * The tail — `Composer, int, int` — is Compose's own ABI (composer, changed mask, defaults mask); a
+ * Kotlin call site that omits defaults still invokes this full method rather than a `$default`
+ * bridge, which is why an argument-order change upstream is a *link* error at render time and not
+ * something the compiler can see.
+ *
+ * Pinned as strings rather than `Class` literals on purpose: the whole point is to answer "is the
+ * method this code was compiled against actually on the runtime classpath" without loading a single
+ * one of those types, so a classpath missing them answers `false` instead of throwing. Kept honest
+ * by `EmbeddedPlayerAvailabilityTest`, which reads this module's own compiled call site out of its
+ * constant pool and asserts the descriptor there is the one this list spells.
+ */
+internal val EMBEDDED_PLAYER_ENTRY_POINT_PARAMETERS: List<String> =
+  listOf(
+    "androidx.compose.remote.player.core.RemoteDocument",
+    "androidx.compose.ui.Modifier",
+    "int",
+    "androidx.collection.ObjectIntMap",
+    "androidx.compose.remote.player.compose.embedded.RcImageLoader",
+    "kotlin.jvm.functions.Function1",
+    "kotlin.jvm.functions.Function2",
+    "kotlin.jvm.functions.Function3",
+    "androidx.compose.runtime.Composer",
+    "int",
+    "int",
+  )
+
+/**
+ * Whether [EMBEDDED_PLAYER_FACADE] on [classLoader] declares the exact entry point this module was
+ * compiled against.
+ *
+ * A class-presence check is NOT enough, and that is not hypothetical. The vendored player
+ * (`:third-party-rc-embedded-player`) shares its package with what `androidx.compose.remote:
+ * remote-player-compose` publishes, and from androidx-main build 16130474 that artifact ships the
+ * embedded player itself — same fully-qualified names, a different
+ * `ExperimentalRemoteDocumentPlayer` signature (`theme` moved to the end, a `customPlugins`
+ * parameter added, our removed `autoUpdate`). Two copies of one class in front of one classloader
+ * means whichever jar comes first wins, so on a runtime classpath carrying both, `Class.forName`
+ * succeeds against a class that does not have the method — and the render dies with
+ * `NoSuchMethodError: 'void
+ * …ExperimentalRemoteDocumentPlayerKt.ExperimentalRemoteDocumentPlayer(…)'`. That error is
+ * non-recoverable by construction, so `serve` disables the catalog's whole live render lane on it
+ * (`remote-m3` on preview.coo.ee, 22 Aug 2026) and falls back to baked PNGs.
+ *
+ * Resolving the *method* instead makes that case what it should always have been: the same graceful
+ * degrade to the View-backed `RemoteDocumentPlayer` a consumer without the player at all gets.
+ */
+internal fun embeddedPlayerEntryPointPresent(classLoader: ClassLoader?): Boolean = runCatching {
+  declaresEntryPoint(
+    Class.forName(EMBEDDED_PLAYER_FACADE, false, classLoader),
+    EMBEDDED_PLAYER_ENTRY_POINT_PARAMETERS,
+  )
+}
+  .getOrDefault(false)
+
+/** Whether [facade] declares [EMBEDDED_PLAYER_ENTRY_POINT] taking exactly [parameters]. */
+internal fun declaresEntryPoint(facade: Class<*>, parameters: List<String>): Boolean =
+  facade.declaredMethods.any { method ->
+    method.name == EMBEDDED_PLAYER_ENTRY_POINT &&
+      method.parameterTypes.map { it.name } == parameters
   }
-    .isSuccess
+
+/**
+ * Whether an embedded player this connector can actually call is on the runtime classpath. Resolved
+ * once per JVM. A consumer that doesn't ship one — or ships one whose entry point has drifted —
+ * silently falls back to the view player instead of dying with `NoClassDefFoundError` /
+ * `NoSuchMethodError`, the same classloader gate `:daemon:android` uses before registering the
+ * Remote Compose extension at all.
+ */
+internal val isEmbeddedPlayerAvailable: Boolean by lazy {
+  embeddedPlayerEntryPointPresent(RemoteComposeIrReplay::class.java.classLoader)
 }
 
 /** Registers [RemoteComposeIrReplay] as the replay composable for `remotecompose` IR. */

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/EmbeddedPlayerAvailabilityTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/EmbeddedPlayerAvailabilityTest.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.daemon
+
+import java.io.DataInputStream
+import java.net.URLClassLoader
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the embedded-player availability gate.
+ *
+ * The gate exists because two different artifacts now define
+ * `androidx.compose.remote.player.compose.embedded.*`: the vendored
+ * `:third-party-rc-embedded-player` and — from androidx-main build 16130474 —
+ * `androidx.compose.remote:remote-player-compose` itself. Their `ExperimentalRemoteDocumentPlayer`
+ * signatures differ, so a class-presence check answers "yes" on a classpath where the call this
+ * module compiled to does not resolve, and the render dies with a `NoSuchMethodError` that `serve`
+ * treats as fatal for the whole catalog render lane.
+ *
+ * [`signature pin matches the call site this module compiles`] is the load-bearing one: it reads
+ * the compiled call site's own constant pool, so the pinned parameter list cannot silently drift
+ * away from what the bytecode actually invokes — including when the vendored player is re-vendored
+ * from a newer upstream.
+ */
+class EmbeddedPlayerAvailabilityTest {
+
+  /** A facade shaped like the real one, for the matching logic itself. */
+  @Suppress("FunctionNaming", "unused")
+  object FakeFacade {
+    @JvmStatic
+    fun ExperimentalRemoteDocumentPlayer(document: String, theme: Int, flags: Long) = Unit
+  }
+
+  private val fakeParameters = listOf("java.lang.String", "int", "long")
+
+  @Test
+  fun `matches a facade declaring exactly the expected parameters`() {
+    assertTrue(declaresEntryPoint(FakeFacade::class.java, fakeParameters))
+  }
+
+  @Test
+  fun `rejects a facade whose parameters are reordered`() {
+    // Upstream's drift is exactly this shape: `theme` moved, an extra parameter appended.
+    assertFalse(
+      declaresEntryPoint(FakeFacade::class.java, listOf("int", "java.lang.String", "long"))
+    )
+    assertFalse(declaresEntryPoint(FakeFacade::class.java, fakeParameters + "boolean"))
+    assertFalse(declaresEntryPoint(FakeFacade::class.java, fakeParameters.dropLast(1)))
+  }
+
+  @Test
+  fun `absent facade is unavailable rather than an error`() {
+    // A loader with no classpath and no parent sees none of the Remote Compose artifacts, which is
+    // the "consumer doesn't ship the player at all" case.
+    assertFalse(embeddedPlayerEntryPointPresent(URLClassLoader(emptyArray(), null)))
+    assertFalse(embeddedPlayerEntryPointPresent(null))
+  }
+
+  @Test
+  fun `signature pin matches the call site this module compiles`() {
+    val descriptor =
+      invokedDescriptor(
+        owner = EMBEDDED_PLAYER_FACADE.replace('.', '/'),
+        method = EMBEDDED_PLAYER_ENTRY_POINT,
+        inClass = RemoteComposeIrReplay::class.java,
+      )
+    assertEquals(
+      "the pinned parameter list must be what the compiled call site actually invokes",
+      descriptorOf(EMBEDDED_PLAYER_ENTRY_POINT_PARAMETERS),
+      descriptor,
+    )
+  }
+
+  /** `listOf("int", "java.lang.String")` -> `"(ILjava/lang/String;)V"`. */
+  private fun descriptorOf(parameters: List<String>): String =
+    parameters.joinToString(separator = "", prefix = "(", postfix = ")V") { name ->
+      when (name) {
+        "int" -> "I"
+        "long" -> "J"
+        "boolean" -> "Z"
+        else -> "L${name.replace('.', '/')};"
+      }
+    }
+
+  /**
+   * The descriptor [inClass] invokes `owner.method` with, read straight out of its constant pool.
+   *
+   * Only the three constant kinds this needs are decoded (`Methodref`, `Class`, `NameAndType`);
+   * everything else is skipped by its fixed width, which is all a constant-pool walk requires.
+   */
+  private fun invokedDescriptor(owner: String, method: String, inClass: Class<*>): String {
+    val bytes =
+      checkNotNull(
+          inClass.classLoader.getResourceAsStream(inClass.name.replace('.', '/') + ".class")
+        ) {
+          "no class file for ${inClass.name}"
+        }
+        .use { it.readBytes() }
+    DataInputStream(bytes.inputStream()).use { input ->
+      check(input.readInt() == -0x35014542) { "not a class file" } // 0xCAFEBABE
+      input.readUnsignedShort() // minor
+      input.readUnsignedShort() // major
+      val count = input.readUnsignedShort()
+      val utf8 = HashMap<Int, String>()
+      val classIndex = HashMap<Int, Int>()
+      val nameAndType = HashMap<Int, Pair<Int, Int>>()
+      val methodRefs = ArrayList<Pair<Int, Int>>()
+      var index = 1
+      while (index < count) {
+        when (val tag = input.readUnsignedByte()) {
+          1 -> utf8[index] = input.readUTF()
+          7 -> classIndex[index] = input.readUnsignedShort()
+          10,
+          11 -> methodRefs += input.readUnsignedShort() to input.readUnsignedShort()
+          12 -> nameAndType[index] = input.readUnsignedShort() to input.readUnsignedShort()
+          8,
+          16,
+          19,
+          20 -> input.skipBytes(2)
+          15 -> input.skipBytes(3)
+          3,
+          4,
+          9,
+          17,
+          18 -> input.skipBytes(4)
+          5,
+          6 -> {
+            input.skipBytes(8)
+            index++ // longs and doubles take two constant-pool slots
+          }
+          else -> error("unexpected constant tag $tag")
+        }
+        index++
+      }
+      val descriptor = methodRefs.firstNotNullOfOrNull { (ownerRef, nameAndTypeRef) ->
+        val ownerName = classIndex[ownerRef]?.let(utf8::get)
+        val (nameRef, descriptorRef) =
+          nameAndType[nameAndTypeRef] ?: return@firstNotNullOfOrNull null
+        if (ownerName == owner && utf8[nameRef] == method) utf8[descriptorRef] else null
+      }
+      return checkNotNull(descriptor) { "$inClass does not invoke $owner.$method" }
+    }
+  }
+}

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/EmbeddedPlayerAvailabilityTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/EmbeddedPlayerAvailabilityTest.kt
@@ -49,6 +49,21 @@ class EmbeddedPlayerAvailabilityTest {
     assertFalse(declaresEntryPoint(FakeFacade::class.java, fakeParameters.dropLast(1)))
   }
 
+  /** Same name and parameters, but not the `public static void` an `invokestatic …(…)V` needs. */
+  @Suppress("FunctionNaming", "unused")
+  object WrongShapeFacade {
+    @JvmStatic
+    fun ExperimentalRemoteDocumentPlayer(document: String, theme: Int, flags: Long): String = ""
+
+    @JvmStatic private fun ExperimentalRemoteDocumentPlayer(document: String, theme: Int) = Unit
+  }
+
+  @Test
+  fun `rejects a facade whose entry point is not public static void`() {
+    assertFalse(declaresEntryPoint(WrongShapeFacade::class.java, fakeParameters))
+    assertFalse(declaresEntryPoint(WrongShapeFacade::class.java, listOf("java.lang.String", "int")))
+  }
+
   @Test
   fun `absent facade is unavailable rather than an error`() {
     // A loader with no classpath and no parent sees none of the Remote Compose artifacts, which is

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -982,7 +982,11 @@ keep a shut gate from turning the feature off:
   the gate opens for `…optimizerDutyCycleMillis` (60 seconds), then holds again: hold, admit a
   slice, hold. The exception is a genuine emergency — memory available under
   `…optimizerDutyCycleFloorMemoryAvailableFraction` (`0.05`) never duty-cycles, because slow
-  progress is not worth an OOM-killed replica. Set the cap to `0` to restore the permanent latch.
+  progress is not worth an OOM-killed replica — and neither does a host whose memory reading is
+  *missing* (`/proc/meminfo` unreadable while load and CPU still are), since an unverified floor is
+  not a cleared one. A signal that was not already holding crossing its stop threshold closes an
+  open window immediately, so the concession never covers pressure it did not answer for. Set the
+  cap to `0` to restore the permanent latch.
   `/status.json` publishes `themeOptimizer.pressure.heldMillis`, `…dutyCycleUntilEpochMillis` and a
   cumulative `…dutyCycles`, and the status page's gate row says `duty cycle` beside the reading that
   is still holding — a box running on the cap is making progress *despite* pressure, not because it

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -985,8 +985,9 @@ keep a shut gate from turning the feature off:
   progress is not worth an OOM-killed replica — and neither does a host whose memory reading is
   *missing* (`/proc/meminfo` unreadable while load and CPU still are), since an unverified floor is
   not a cleared one. A signal that was not already holding crossing its stop threshold closes an
-  open window immediately, so the concession never covers pressure it did not answer for. Set the
-  cap to `0` to restore the permanent latch.
+  open window immediately (measured against the previous sample, so a signal that tripped earlier in
+  the same hold and spiked again still counts), so the concession never covers pressure it did not
+  answer for. Set either the cap or the window length to `0` to restore the permanent latch.
   `/status.json` publishes `themeOptimizer.pressure.heldMillis`, `…dutyCycleUntilEpochMillis` and a
   cumulative `…dutyCycles`, and the status page's gate row says `duty cycle` beside the reading that
   is still holding — a box running on the cap is making progress *despite* pressure, not because it

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -971,7 +971,22 @@ keep a shut gate from turning the feature off:
   resumption, not prevent it, and a bounded duty cycle — admit, maybe trip again, wait again — is
   the right failure mode for best-effort work where a permanent latch is not. A reading still on
   the wrong side of a *stop* threshold is untouched by the cap and holds the gate as long as it
-  lasts.
+  lasts — up to the starvation cap below.
+- **A reading parked on a stop side is bounded too, by a duty cycle.** The dead-band cap above only
+  covers a hold where nothing is over a stop threshold. The public box hit the other permanent
+  latch: 17 resident render daemons on an 8 GB host keep `MemAvailable` at a steady 14-15%, so
+  every sample re-trips the `0.15` memory stop, nothing ever "recovers", and theme optimization
+  simply never runs — `/status.json` reporting `paused · memory available 15%` with `wear-m3` warmed
+  to 5 of its 170 entries over a 15-hour uptime. A steady-state reading is the host's baseline
+  rather than an emergency, so after `-Dcomposeai.serve.optimizerStarvationCapMillis` (30 minutes)
+  the gate opens for `…optimizerDutyCycleMillis` (60 seconds), then holds again: hold, admit a
+  slice, hold. The exception is a genuine emergency — memory available under
+  `…optimizerDutyCycleFloorMemoryAvailableFraction` (`0.05`) never duty-cycles, because slow
+  progress is not worth an OOM-killed replica. Set the cap to `0` to restore the permanent latch.
+  `/status.json` publishes `themeOptimizer.pressure.heldMillis`, `…dutyCycleUntilEpochMillis` and a
+  cumulative `…dutyCycles`, and the status page's gate row says `duty cycle` beside the reading that
+  is still holding — a box running on the cap is making progress *despite* pressure, not because it
+  cleared.
 - **The thresholds themselves are tunable**, because what counts as constrained is a property of
   the host: `-Dcomposeai.serve.optimizerStopMemoryAvailableFraction`,
   `…optimizerResumeMemoryAvailableFraction`, and the matching `…StopLoadPerCpu` /

--- a/third_party/rc-embedded-player/PROVENANCE.md
+++ b/third_party/rc-embedded-player/PROVENANCE.md
@@ -29,19 +29,38 @@ inside it. Vendoring is the only way to depend on it.
 to the androidx.dev snapshot line — **now ships the embedded player itself**: 138 class files under
 `androidx/compose/remote/player/compose/embedded/`, the very package these sources are vendored into.
 
-Eight of them collide by fully-qualified name with the vendored copies:
+**45 of the 56 files vendored here collide by fully-qualified name** — measured against build
+`16130474`, the snapshot `settings.gradle.kts` pins today, by comparing the top-level names in this
+source tree against the classes in that artifact. That is the whole player, not a fringe: `RcPlayer`,
+every layout and modifier file, `RcPlayerDrawing`, `RcPlayerPaint`, `ExperimentalRemoteDocumentPlayer`
+— and `AndroidColorThemeResolver`, which is one of the local modifications below (the theme-fallback
+fix). So which bytes run is decided by classpath ordering, not by this directory: if the upstream
+class wins, the local delta silently is not there, and the embedded lane's pixels change with nothing
+in any log to say why.
+
+**Since 22 Aug 2026 it is no longer silent — it takes a catalog's live render lane down.** Upstream
+reshaped the entry point itself: `ExperimentalRemoteDocumentPlayer` moved `theme` to the end, added a
+`customPlugins: CustomPluginRegistry?` parameter, and (unlike the copy here) kept `autoUpdate`
+removed — so the descriptor the connector compiles against does not exist on the upstream class. With
+upstream's copy first on the classpath, every `remote-m3` render on preview.coo.ee died with
 
 ```
-AndroidColorThemeResolver     GraphContext         RcImageLoader
-DrawablePainter               GraphPaintContext    RemoteImageSupport
-EmbeddedPlayerTypefaceResolver                     SnapshotRemoteComposeState
+render failed: NoSuchMethodError: 'void androidx.compose.remote.player.compose.embedded
+  .ExperimentalRemoteDocumentPlayerKt.ExperimentalRemoteDocumentPlayer(RemoteDocument, Modifier,
+  int, ObjectIntMap, RcImageLoader, Function1, Function2, Function3, Composer, int, int)'
 ```
 
-**`AndroidColorThemeResolver` is on that list, and it is one of the local modifications below** —
-the theme-fallback fix. So which bytes run is decided by classpath ordering, not by this directory:
-if the upstream class wins, the local delta silently is not there, and the embedded lane's pixels
-change with nothing in any log to say why. `:samples:remotecompose:assembleDebug` still *builds*
-(measured), so there is no error to notice either.
+and `serve` — correctly — treats a `NoSuchMethodError` as non-recoverable and disables the catalog's
+whole live render lane, falling back to baked PNGs.
+`:samples:remotecompose:assembleDebug` still *builds*, so the compile says nothing about any of this.
+
+The connector no longer takes the class's presence as proof it can be called:
+`isEmbeddedPlayerAvailable`
+([`RemoteComposeIrReplay.kt`](../../data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeIrReplay.kt))
+resolves the exact entry point and falls back to the View-backed player when it is absent, so a
+shadowed classpath degrades instead of killing the lane. That is a seatbelt, not the fix — the
+embedded lane is *unavailable* on such a classpath, which is why the decision below still has to be
+made.
 
 Reproduce the overlap:
 


### PR DESCRIPTION
Both issues visible on https://preview.coo.ee/status when this was written.

## 1. `remote-m3`'s live render lane is disabled

```
2026-08-22 18:02 UTC  remote-m3  2826ms  render failed: NoSuchMethodError:
  'void androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayerKt
   .ExperimentalRemoteDocumentPlayer(RemoteDocument, Modifier, int, ObjectIntMap, RcImageLoader, …)'
```

**Root cause.** androidx-main build `16130474` — the snapshot `settings.gradle.kts` pins — publishes the embedded player inside `androidx.compose.remote:remote-player-compose`. That is the same package `:third-party-rc-embedded-player` vendors: **45 of its 56 files now collide by fully-qualified name** (measured against the artifact). Upstream also reshaped the entry point — `theme` moved to the end, a `customPlugins: CustomPluginRegistry?` parameter appeared — so the descriptor the connector compiles against does not exist on upstream's class. With upstream's copy first on the classpath, `isEmbeddedPlayerAvailable`'s class-presence check still answered "yes", the call link-errored, and `serve` — correctly — treats `NoSuchMethodError` as non-recoverable and disables the catalog's whole live lane in favour of baked PNGs.

Verified against the published artifact:

```
$ javap androidx.compose.remote.player.compose.embedded.ExperimentalRemoteDocumentPlayerKt
public static final void ExperimentalRemoteDocumentPlayer(RemoteDocument, Modifier,
  ObjectIntMap, RcImageLoader, Function1, Function2, Function3, int, CustomPluginRegistry,
  Composer, int, int);
```

**Fix.** The gate resolves the exact method — name, parameter list, `public static void` — rather than the class, so a shadowed or drifted classpath falls back to the View-backed `RemoteDocumentPlayer`, the same graceful degrade a consumer that ships no embedded player already gets, instead of killing the lane. `EmbeddedPlayerAvailabilityTest` reads the compiled call site out of its own constant pool and asserts the pinned parameter list is the descriptor actually invoked, so the pin cannot drift silently on a re-vendor.

This is a seatbelt, not the cure: on such a classpath the embedded lane is *unavailable*, and live `remote-m3` renders come from the View player, so they will differ slightly from the embedded-player baked PNGs. The three real options (retire the vendored module for the published artifact, relocate its package, or strip `embedded/` from the dependency) were already tracked in `PROVENANCE.md`; that section is updated with the measured overlap and the production failure so the decision is made against facts rather than the stale "no published artifact" premise.

## 2. Theme optimisation is paused, permanently

`/status.json` reported `themeOptimizer.paused: true`, `pauseReason: "memory available 15%"`, `memoryAvailableFraction: 0.1458` — with the box at 3% CPU and load 0.17 per CPU. `wear-m3` had warmed **5 of its 170** entries across a 15-hour uptime.

The pressure gate's memory stop side is `0.15`, and 17 resident render daemons on an 8 GB host hold `MemAvailable` at a steady 14–15%. So every sample re-tripped the stop, nothing ever entered "recovering", and the existing `maxRecoveryMillis` cap — which only bounds a hold where *no* reading is over a stop threshold — never engaged. A permanent latch, reached by the box simply doing its job.

**Fix.** Bound that hold the same way the dead band is bounded: after `optimizerStarvationCapMillis` (30 min) the gate opens for `optimizerDutyCycleMillis` (60 s), then holds again — hold, admit a slice, hold. Guardrails, each with a test:

- a host below `optimizerDutyCycleFloorMemoryAvailableFraction` (5%) keeps the permanent latch — slow progress is not worth an OOM-killed replica — and so does one whose memory reading is missing entirely, since an unverified floor is not a cleared one;
- a signal that was not already holding crossing its stop threshold closes an open window immediately, so the concession never covers pressure it did not answer for;
- a window expires on the clock even if sampling has stopped working, so a blind sampler cannot leave it open forever;
- the cap re-arms from when a window actually closed (cut short) or from its scheduled end (served in full), so it never exceeds its stated maximum and blindness never costs the host admission it earned.

Zero on either knob restores the permanent latch. `/status.json` gains `pressure.heldMillis`, `pressure.dutyCycleUntilEpochMillis` and a cumulative `pressure.dutyCycles`, and the status page's gate row says `duty cycle N · memory available 14%` — progress *despite* pressure reads differently from a gate that cleared.

## Deployment note

The connector ships inside each catalog's `liveBundle`, so `remote-m3` picks the first fix up only when its delivery branch is regenerated (`design-artifacts.yml`) — `data/` is not on that workflow's push trigger, so it needs a manual dispatch after this lands. The optimizer fix is in `:cli` and arrives with the next server image.

## Test plan

- [x] `./gradlew :cli:test` — 26 `HostOptimizerAdmissionTest` cases pass, the pre-existing dead-band and hysteresis ones unchanged
- [x] `./gradlew :data-remotecompose-connector:testDebugUnitTest` — 5 new `EmbeddedPlayerAvailabilityTest` cases plus the existing suite
- [x] `./gradlew :samples:design-catalog-remote-m3:composePreviewRenderAll` — 117 artifacts rendered on this branch. Locally the vendored player wins classpath order, so the embedded lane still runs and the renders are unchanged; the guard changes behaviour only where upstream's copy shadows it (which is the deployed bundle)
- [x] `./gradlew ktfmtFormat` on both modules

No visual surface changes: the guard is a no-op on any classpath where the embedded player is genuinely callable, and the optimizer change touches admission timing only. The CMP/Wasm parity lane flagged `IndeterminateCircularProgressRemote` once mid-review and cleared on the next run (0.02% → 0.56% → 0.77% → 0.25% across runs of unchanged rendering code); it is the one continuously-animated document in the set, and both sides of the comparison re-render each run.

Ten review threads from the Codex bot were addressed across six rounds, all on the duty-cycle bookkeeping and the player guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjZgBjmH4PoaSTeippYPHj)_