### PR TITLE
docs(parity): record D6 and batch 03's deliberately-open follow-ups

### DIFF
--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -128,6 +128,39 @@ wrong.
 
 ---
 
+## D6 — the render generation a selection is allowed to describe
+
+**Blocks:** 05 (the element gate reads the index against a frame), and the hardening of the gate 03
+already shipped.
+
+Batch 03 gates selection on two predicates: `frameIsReplayedBaked` (this request is not pinned, not
+override-bearing, and the host cannot re-render) and `ServeHost.annotationsFollowBakedFrame` (this
+host's `.annotations` are a replay of published data rather than a fresh capture). Together they
+establish that the frame on screen **is** a replay of the baked render, which is what makes published
+bounds meaningful at all.
+
+What they cannot establish is that it is a replay of the *same* baked render. The baked PNG is served
+`public, max-age=300, stale-while-revalidate=3600` while the tag and annotation lanes are `no-store`,
+so for a window after a catalog republishes, a viewer can hold last generation's pixels beside this
+generation's boxes. Nothing on the page carries a generation, so nothing can notice.
+
+| Option | Consequence |
+| --- | --- |
+| **(a) Stamp a generation on the render and refuse selection when the layers disagree.** | Changes how baked renders are addressed and cached. Closes the window rather than narrowing it, and 05's element gate needs the same stamp to resolve an index against a frame. **Chosen.** |
+| (b) Ship as-is and document the window. | A box is wrong only in the minutes after a republish, and the drag path is unaffected. But the wrongness is silent and lands in an acceptance's authoring-time baseline, where it later reports an unchanged element as *moved*. |
+| (c) Withhold the tag picker on cached deployments. | Safest, and costs the affordance on exactly the public deployments the parity workflow runs on. |
+
+(a) is chosen. The cost of (b) is the failure mode this whole batch's gating exists to prevent — a
+false invalidation with a plausible explanation attached — and it is worse than a missing check
+because nothing surfaces it. (c) trades the feature away on the deployments that need it.
+
+Until (a) lands, the shipped gates stand: they are correct about the *lane*, and the residual window
+is generational only. See
+[`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) and the comments on
+`annotationsFollowBakedFrame`.
+
+---
+
 ## Loose ends (not blocking; file or fix opportunistically)
 
 - **`stampPreviewDensities` has the same fold bug** `previewsByFunctionReplacing` was written to fix:

--- a/docs/design/parity-batches/00-decisions.md
+++ b/docs/design/parity-batches/00-decisions.md
@@ -133,16 +133,34 @@ wrong.
 **Blocks:** 05 (the element gate reads the index against a frame), and the hardening of the gate 03
 already shipped.
 
-Batch 03 gates selection on two predicates: `frameIsReplayedBaked` (this request is not pinned, not
-override-bearing, and the host cannot re-render) and `ServeHost.annotationsFollowBakedFrame` (this
-host's `.annotations` are a replay of published data rather than a fresh capture). Together they
-establish that the frame on screen **is** a replay of the baked render, which is what makes published
-bounds meaningful at all.
+Batch 03 gates the two selection sources **separately**, and the difference matters to whoever
+implements this:
 
-What they cannot establish is that it is a replay of the *same* baked render. The baked PNG is served
-`public, max-age=300, stale-while-revalidate=3600` while the tag and annotation lanes are `no-store`,
-so for a window after a catalog republishes, a viewer can hold last generation's pixels beside this
-generation's boxes. Nothing on the page carries a generation, so nothing can notice.
+- **The tag picker** is offered when `frameIsReplayedBaked` holds — this request is not pinned, carries
+  no override parameters, and the host's PNG lane cannot re-render (`!canApplyOverrides`) — and the
+  published index is non-empty.
+- **An annotation box** is clickable only when `frameIsReplayedBaked` **and**
+  `ServeHost.annotationsFollowBakedFrame` hold. The second is the stricter one and exists because
+  both live catalog wrappers keep the PNG baked for an override-free browse while asking their daemon
+  for annotations *first*: a baked frame with freshly captured annotations is the same mismatch by
+  another route, so the host states which lane its annotations follow rather than having it inferred
+  from a neighbouring flag.
+
+A generation stamp must respect that split. Coupling the tag picker to the annotation predicate would
+withhold a perfectly good index on hosts whose published tags do describe the frame.
+
+What neither predicate can establish is that the frame is a replay of the *same* baked render. The
+baked PNG is served `public, max-age=300, stale-while-revalidate=3600`. The tag route sets `no-store`
+— and **the `.annotations` route sets no `Cache-Control` at all**, so it inherits whatever heuristic
+freshness a browser or intermediary chooses, which is weaker than the tag lane and not a guarantee of
+anything. Either way, for a window after a catalog republishes a viewer can hold last generation's
+pixels beside this generation's boxes. Nothing on the page carries a generation, so nothing can
+notice.
+
+**(a) therefore has a prerequisite:** give the annotations response the same explicit no-store policy
+the tag route already has (`DYNAMIC_RESOURCE_CACHE_CONTROL`), so both lanes have a stated freshness
+before a generation is stamped on top of them. A stamp is worth nothing if the payload carrying it
+can itself be served from a cache of unknown age.
 
 | Option | Consequence |
 | --- | --- |

--- a/docs/design/parity-batches/03-element-selection.md
+++ b/docs/design/parity-batches/03-element-selection.md
@@ -157,6 +157,37 @@ report with no `| Raw comparison |` row, where before it filed the server's body
 - The viewer's annotation rendering is byte-identical before and after the `inspect.js`
   generalisation, proved by the snapshot harness.
 
+## Left open, deliberately
+
+Three things came out of the review of [#4465](https://github.com/yschimke/compose-ai-tools/pull/4465)
+and were decided rather than absorbed. None blocks the batch's "done when"; each is written down here
+so the next reader finds a decision instead of a gap.
+
+- **The render generation** — the shipped gates prove the frame is a replay of the baked render, not
+  that it is the *same* replay. Promoted to [00's D6](00-decisions.md#d6--the-render-generation-a-selection-is-allowed-to-describe)
+  and answered (a): stamp a generation. Batch 05's element gate needs it regardless, so it belongs
+  there rather than as a patch to this batch's predicates.
+
+- **Report-body placeholders should carry a per-response nonce.** `fillReport` now matches
+  `{{render}}` and `{{rawScores}}` by exact anchor — a whole markdown link destination and a whole
+  table row — which fixed the reachable bug: a bare substring replace rewrote the first occurrence
+  anywhere in the body, so catalog-authored text carrying either literal was edited instead while the
+  real link kept its placeholder. A nonce would make the remaining case (catalog text authored in the
+  same shape as the anchor) unreachable rather than merely unlikely. **Follow-up PR** — the
+  substitution contract is shared by the Kotlin writer and the browser filler, so it moves with its
+  own fixtures.
+
+- **Authored layout boxes are not selectable.** A static bundle whose Actual annotations carry layout
+  entries but no typography draws those boxes through `ReferenceCompare`'s inline payload, which has
+  no selection handlers, so the box-click path is absent on that data shape. The drag still is not,
+  which is why this narrows a choice rather than removing the feature. **Follow-up PR**, and not a
+  one-line change: `ReferenceCompare` draws one payload over *both* panels, and reference annotations
+  are measured over the reference raster while actual ones are measured over the baked PNG. Two
+  planes, one component, distinguished per panel rather than per entry. The shape is a per-panel
+  `selectable` flag the Actual panel alone receives, emitting the same `cp-element-pick` event and
+  gated on the same predicate — with fixtures for the asymmetry, since getting it wrong writes
+  reference-raster bounds into a locator that declares `render-pixels`.
+
 ## Visual evidence
 
 Mandatory. Before/after of the comparison page with the derived layers mounted and a selection

--- a/docs/design/parity-batches/05-acceptance-engines.md
+++ b/docs/design/parity-batches/05-acceptance-engines.md
@@ -5,12 +5,17 @@
 [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809) (publish).
 **Depends on:** [04](04-acceptance-schema.md) (schema + fixtures — freeze it first, both sides build
 against one definition), [03](03-element-selection.md) (element gates must not be enabled without a
-selection path), [00](00-decisions.md) **D1, D3 and D5**.
+selection path), [00](00-decisions.md) **D1, D3, D5 and D6**.
 **Ships:** **yes.** Accepted and unaccepted scores reported separately, on a real catalog.
 
 **Read first:** [`../COMPONENT_PARITY_WORKFLOW.md`](../COMPONENT_PARITY_WORKFLOW.md) §4 — the ten
 invariants **and** the open-problems list; `format-compare.js`'s `scorePlanes` **in full** before
-touching a line of it.
+touching a line of it; and
+[00's D6](00-decisions.md#d6--the-render-generation-a-selection-is-allowed-to-describe), because the
+element gate resolves a published index against a frame and there is no shared generation to resolve
+it against yet. An element gate built before D6 lands reads bounds from one render and pixels from
+another whenever a catalog has republished recently — and reports an element that never moved as
+*moved*, which is the failure this epic's gating exists to prevent.
 
 The three issues are one batch because the whole point is that the two engines agree bit for bit, and
 "agree" is not testable one engine at a time. Publish rides along because an engine nobody's catalog

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -32,7 +32,7 @@ to.
 | [02](02-issue-index.md) — issue index end to end | [#3804](https://github.com/yschimke/compose-ai-tools/issues/3804), [#3805](https://github.com/yschimke/compose-ai-tools/issues/3805), [#3806](https://github.com/yschimke/compose-ai-tools/issues/3806) | 01 | **yes** — open issues on the pages |
 | [03](03-element-selection.md) — element selection | [#3803](https://github.com/yschimke/compose-ai-tools/issues/3803) | 01, **00 D1** | **yes** — click an element to report it |
 | [04](04-acceptance-schema.md) — acceptance schema | [#3807](https://github.com/yschimke/compose-ai-tools/issues/3807) | **00 D1, D5** | no (contract + fixtures) |
-| [05](05-acceptance-engines.md) — both engines + publish | [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808), [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809), [#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) | 03, 04, **00 D3** | **yes** — accepted vs unaccepted scores |
+| [05](05-acceptance-engines.md) — both engines + publish | [#3808](https://github.com/yschimke/compose-ai-tools/issues/3808), [#3809](https://github.com/yschimke/compose-ai-tools/issues/3809), [#3810](https://github.com/yschimke/compose-ai-tools/issues/3810) | 03, 04, **00 D3, D6** | **yes** — accepted vs unaccepted scores |
 | [06](06-resolution-and-docs.md) — resolution, closure, docs | [#3811](https://github.com/yschimke/compose-ai-tools/issues/3811), [#3812](https://github.com/yschimke/compose-ai-tools/issues/3812) | 02, 05 | **yes** — the loop closes |
 
 **01 and 02 can run ahead of everything else** once 00's D2 and D4 are answered — two decisions, not
@@ -103,6 +103,12 @@ should be answered against those numbers rather than against the worked example.
   erratum, so batch 03 adds a selection to the existing version rather than bumping to `v2`.
 - **An acceptance may be geometric**, with an element gate required wherever an element exists. #41
   and #87 are expressible; batch 04 must carry both shapes.
+
+**D6 was added after batch 03 shipped**, from what building the selector exposed: the gates that
+decide whether a selection may be recorded prove the frame is a *replay* of the baked render but not
+that it is the *same* replay, because nothing on the page carries a render generation. Answered (a)
+— stamp one — which 05's element gate needs regardless. Batch 03's shipped gates stand meanwhile;
+the residual window is generational only.
 
 ## Conventions every batch inherits
 

--- a/docs/design/parity-batches/README.md
+++ b/docs/design/parity-batches/README.md
@@ -17,10 +17,10 @@ batch** — these files say what to do, not why, and the why is load-bearing thr
               │                                                ├─► 05 ──► 06
               ├─ D1,D5 ──────────────► 04 schema ──────────────┘  engines  resolution
               │                                                            + docs
-              └─ D3 ────────────────────────────────────────► 05 engines
+              └─ D3,D6 ─────────────────────────────────────► 05 engines
 ```
 
-**Every arrow out of 00 is a hard prerequisite, not a suggestion.** Each of D1–D5 blocks a batch
+**Every arrow out of 00 is a hard prerequisite, not a suggestion.** Each of D1–D6 blocks a batch
 because deciding it late means rewriting work rather than adding to it — a locator built before D2/D4
 records the wrong frame, and a fixture set frozen before D5 encodes a guess both engines then conform
 to.


### PR DESCRIPTION
Batch 03 ([#4465](https://github.com/yschimke/compose-ai-tools/pull/4465)) shipped with three questions answered in review threads and nowhere else. A decision recorded only in a comment on a merged PR is a decision the next reader will not find — and 00's own closing line is that a decision made in code and not written down is how the previous three pixel pipelines went wrong.

## What changed

**`00-decisions.md` gains D6 — the render generation a selection is allowed to describe.** It is promoted into 00 rather than left as a batch-03 note because it blocks **05's element gate**, not only 03's predicates.

Batch 03 gates its two selection sources separately, and D6 records the split because a generation stamp has to respect it. The **tag picker** needs `frameIsReplayedBaked` — not pinned, no override parameters, and the host's PNG lane cannot re-render (`!canApplyOverrides`) — plus a non-empty published index. An **annotation box** needs that *and* `ServeHost.annotationsFollowBakedFrame`, the stricter predicate, because both live catalog wrappers keep the PNG baked for an override-free browse while asking their daemon for annotations first. Coupling the picker to the annotation predicate would withhold a perfectly good index on hosts whose published tags do describe the frame.

What neither predicate establishes is that the frame is a replay of the *same* baked render. The baked PNG is `public, max-age=300, stale-while-revalidate=3600`; the tag route sets `no-store`, and the `.annotations` route sets no `Cache-Control` at all, so it inherits whatever heuristic freshness an intermediary picks. Either way, for a window after a republish a viewer can hold last generation's pixels beside this generation's boxes, and nothing on the page carries a generation to compare.

Answered **(a) — stamp one**, with the rejected options recorded beside it: shipping the window costs a silent wrong baseline that later reports an unchanged element as *moved*, and withholding the picker trades the affordance away on exactly the public deployments the parity workflow runs on. (a) carries a prerequisite — give the annotations response the explicit no-store the tag route already has, since stamping a generation onto a payload servable from a cache of unknown age buys nothing.

The shipped gates stand meanwhile: they are correct about the *lane*, and the residual window is generational only.

**`03-element-selection.md` gains a "Left open, deliberately" section** for the two that stay follow-ups, each with the reasoning that makes it a follow-up rather than an omission:

- **Report-body placeholder nonce.** Exact-anchor matching already fixed the reachable bug (a substring replace rewrote the first occurrence anywhere in the body, editing catalog-authored text while the real link kept its placeholder). A nonce makes the remaining case — catalog text authored in the same shape as a whole markdown link destination or a whole table row — unreachable rather than merely unlikely. It moves a substitution contract the Kotlin writer and the browser filler share, so it travels with its own fixtures.
- **Authored layout boxes are not selectable.** A static bundle whose Actual annotations carry layout entries but no typography draws those boxes through `ReferenceCompare`'s inline payload, which has no selection handlers. The drag still works there, so this narrows one of two ways to choose rather than removing the feature. Not a one-line change either: `ReferenceCompare` draws one payload over *both* panels, and reference annotations are measured over the reference raster while actual ones are measured over the baked PNG — two coordinate planes in one component, distinguished per panel rather than per entry. The recorded shape is a per-panel `selectable` flag the Actual panel alone receives, with fixtures for the asymmetry, since getting it wrong writes reference-raster bounds into a locator that declares `render-pixels`.

**`README.md` and `05-acceptance-engines.md`** carry D6 into the places an implementer actually reads: 05's `Depends on` header, its **Read first** list with what goes wrong without it, the order graph's last arrow, and the dependency table.

## Test plan

Documentation only — no code, no fixtures, no rendered surfaces, so text-only evidence is the correct kind here. Verified against the source rather than from memory:

- `renderAnnotationsResponse` ends at `call.respondBytes(outcome.json, ContentType.Application.Json)` with no `Cache-Control`, while `handleTagIndex` appends `DYNAMIC_RESOURCE_CACHE_CONTROL` (`"no-store"`). No global `CachingHeaders` install or response interceptor supplies one — every cache policy in `ServeHttpServer` is per-route.
- `tagsDescribeFrame = frameIsReplayedBaked && tagIndex.isNotEmpty()` and `annotationsSelectable = frameIsReplayedBaked && renderHost.annotationsFollowBakedFrame` — the two gates the doc now describes separately.
- The new `00-decisions.md#d6--…` anchor matches the existing `#d1--which-plane-…` links already used from `01` and `03`, so the cross-reference resolves rather than landing at the top of the file.
- The README table, the order graph, 05's header and D6's own **Blocks:** line all agree that D6 blocks 05, as that directory's header contract requires.

Refs #3803, #3808.
