### PR TITLE
fix(gutter): trim fixed-axis Android motion frames to the still's pixel target

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/AndroidInteractionRenderer.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/AndroidInteractionRenderer.kt
@@ -71,6 +71,11 @@ internal fun handleInteractionCapture(
    * carries the shadow (compose-ai-tools#4452).
    */
   dialogGutter: DialogWindowCapture.DialogCropGutter = DialogWindowCapture.DialogCropGutter(),
+  /**
+   * The pixel size a fixed axis's frames must come out at, shared with the still so the two cannot
+   * drift (issue #4467). Empty for a wrapped preview and for every scroll product.
+   */
+  fixedAxisTarget: DialogWindowCapture.FixedAxisTarget = DialogWindowCapture.FixedAxisTarget(),
 ): Boolean {
   val frameInterval = interaction.frameIntervalMs.coerceAtLeast(1)
   val timeline =
@@ -110,7 +115,7 @@ internal fun handleInteractionCapture(
 
   val frameOptions =
     RoborazziOptions(recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound))
-  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter)
+  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter, fixedAxisTarget)
 
   // Read off the clock rather than recomputed from the script: the settle tick, the per-frame
   // advances and the frame count all move independently, and a caller's bookkeeping that

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
@@ -99,7 +99,15 @@ internal object DialogWindowCapture {
   data class FixedAxisTarget(val widthPx: Int? = null, val heightPx: Int? = null) {
     internal fun applyTo(file: File) {
       if (widthPx == null && heightPx == null) return
-      resizeFixedAxesPng(file, widthPx, heightPx)
+      // A frame that won't decode is left alone rather than throwing. On the multi-frame paths
+      // this runs inside `captureDecodableFrame`'s capture lambda, and that retry only absorbs a
+      // transient Robolectric encode glitch when `FramePngReader.decode` is the thing that meets
+      // it — an `IIOException` raised *here* escapes the loop and turns a frame that would have
+      // re-encoded cleanly into an error sidecar. Skipping leaves the bad bytes on disk for the
+      // decode below to catch and re-capture, and the fresh frame gets trimmed on the next
+      // attempt. Only the decode failure is swallowed; anything else still propagates.
+      runCatching { resizeFixedAxesPng(file, widthPx, heightPx) }
+        .onFailure { if (it !is javax.imageio.IIOException) throw it }
     }
   }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/DialogWindowCapture.kt
@@ -50,7 +50,10 @@ internal object DialogWindowCapture {
    * support exists to prevent (compose-ai-tools#4452). Scroll products deliberately pass nothing: a
    * scrolling capture is documented as carrying no gutter.
    */
-  class StableDialogCrop(private val gutter: DialogCropGutter = DialogCropGutter()) {
+  class StableDialogCrop(
+    private val gutter: DialogCropGutter = DialogCropGutter(),
+    private val fixedAxisTarget: FixedAxisTarget = FixedAxisTarget(),
+  ) {
     private var cropRect: android.graphics.Rect? = null
 
     @OptIn(ExperimentalRoborazziApi::class)
@@ -61,13 +64,42 @@ internal object DialogWindowCapture {
     ): CaptureRoot {
       val root = resolveCaptureRoot(rule)
       root.interaction.captureRoboImage(file = file, roborazziOptions = roborazziOptions)
-      val semanticsRoot = root.semanticsRoot ?: return root
-      val window = shownDialogWindow(semanticsRoot) ?: return root
+      val semanticsRoot = root.semanticsRoot
+      val window = semanticsRoot?.let { shownDialogWindow(it) }
+      if (semanticsRoot == null || window == null) {
+        // Not a dialog preview: the frame is the hosting window, which the gutter grew in whole
+        // **dp**. Trim it to the pixel target the still uses. Same precedence the still path
+        // applies — a dialog crop frames the component itself, so it wins and this is skipped.
+        fixedAxisTarget.applyTo(file)
+        return root
+      }
       val rect =
         cropRect
           ?: dialogWindowCropRect(file, semanticsRoot, window, gutter)?.also { cropRect = it }
       if (rect != null) cropPngToRect(file, rect)
       return root
+    }
+  }
+
+  /**
+   * The exact pixel size a **fixed** axis's capture must come out at, or `null` per axis for an
+   * axis that wraps (and is therefore already the measured content plus its gutter).
+   *
+   * A Robolectric resource qualifier has no unit but dp, so the hosting window grows by
+   * `ceil(totalGutterPx / density)` dp — at a fractional density that is more pixels than the
+   * gutter actually resolves to. Two 4 dp edges at density 2.625 are 11 + 11 = 22 px, while the
+   * qualifier grows 9 dp ≈ 24 px. The still has always corrected for that; motion products encoded
+   * the qualifier-sized frame, so the same preview published a PNG at `frame + 22` and a GIF beside
+   * it at `frame + 24` (compose-ai-tools#4467). Passing the target through to every per-frame
+   * capture is what makes the two agree.
+   *
+   * All-null is the un-corrected behaviour, which is what a fully wrapped preview and every scroll
+   * product want.
+   */
+  data class FixedAxisTarget(val widthPx: Int? = null, val heightPx: Int? = null) {
+    internal fun applyTo(file: File) {
+      if (widthPx == null && heightPx == null) return
+      resizeFixedAxesPng(file, widthPx, heightPx)
     }
   }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1242,6 +1242,38 @@ abstract class RobolectricRenderTestBase(
         qualifierDensity,
         previewRendersRtl(params.locale),
       )
+    // The pixel size a fixed axis's capture has to come out at, resolved ONCE and used by both
+    // the still's post-capture resize and every motion handler's per-frame trim. Two derivations
+    // of the same number is exactly how the two drifted apart (issue #4467): the qualifier can
+    // only grow the window in whole dp, so at a fractional density it overshoots the gutter's
+    // real pixel extent, and only the still corrected for it.
+    //
+    // In PIXELS added to the frame's own pixel width, rather than resolving the summed dp: the
+    // box laid the gutter out in per-edge rounded pixels, and re-deriving it from dp here would
+    // disagree with it by one at a fractional density.
+    val fixedAxisTarget =
+      DialogWindowCapture.FixedAxisTarget(
+        widthPx =
+          fixedAxisTargetPx(
+            wrapped = wrapWidth,
+            hasDevice = params.device != null,
+            declaredDp = params.widthDp,
+            frameDp = widthDp,
+            leadingGutterDp = qualifierGutter.start,
+            trailingGutterDp = qualifierGutter.end,
+            density = qualifierDensity,
+          ),
+        heightPx =
+          fixedAxisTargetPx(
+            wrapped = wrapHeight,
+            hasDevice = params.device != null,
+            declaredDp = params.heightDp,
+            frameDp = heightDp,
+            leadingGutterDp = qualifierGutter.top,
+            trailingGutterDp = qualifierGutter.bottom,
+            density = qualifierDensity,
+          ),
+      )
     applyPreviewQualifiers(
       widthDp =
         widthDp + captureGutterAxisDp(qualifierGutter.start, qualifierGutter.end, qualifierDensity),
@@ -1924,6 +1956,7 @@ abstract class RobolectricRenderTestBase(
                       curveCapture = animationCurveCapture,
                       glimmerEnvironment = job.capture.glimmerEnvironment?.toConnectorEnvironment(),
                       dialogGutter = motionDialogGutter,
+                      fixedAxisTarget = fixedAxisTarget,
                     )
                     .also { handled ->
                       // The clock has been driven well past `currentTime`
@@ -1959,6 +1992,7 @@ abstract class RobolectricRenderTestBase(
                       outputFile = outputFile,
                       glimmerEnvironment = job.capture.glimmerEnvironment?.toConnectorEnvironment(),
                       dialogGutter = motionDialogGutter,
+                      fixedAxisTarget = fixedAxisTarget,
                     )
                     .also { handled ->
                       // Inside the guarded body — see the animated capture above.
@@ -2016,6 +2050,7 @@ abstract class RobolectricRenderTestBase(
                     padArgb = resolveBackgroundColor(params).toArgb(),
                     measuredContent = { measured },
                     dialogGutter = motionDialogGutter,
+                    fixedAxisTarget = fixedAxisTarget,
                     glimmerEnvironment = job.capture.glimmerEnvironment?.toConnectorEnvironment(),
                     // The handler reports what it actually drove, measured off `mainClock`
                     // itself, so the marker cannot drift from the clock the way a re-derived
@@ -2221,30 +2256,14 @@ abstract class RobolectricRenderTestBase(
                 !focusGifHandled &&
                 !interactionHandled
             ) {
-              val resizeDensity = params.density ?: 2.0f
               // A fixed axis is resized to the frame it declared PLUS its capture gutter: the
               // gutter is canvas the author asked for, so trimming back to the bare frame would
-              // drop the shadow it exists to keep. In PIXELS, added to the frame's own pixel
-              // width, rather than resolving the summed dp — the box laid the gutter out in
-              // rounded pixels, and re-deriving it from dp here would disagree with it by one at a
-              // fractional density.
-              val resizeGutter = params.captureGutter ?: CaptureGutterDp()
-              val resizeGutterWPx =
-                captureGutterEdgePx(resizeGutter.start, resizeDensity) +
-                  captureGutterEdgePx(resizeGutter.end, resizeDensity)
-              val resizeGutterHPx =
-                captureGutterEdgePx(resizeGutter.top, resizeDensity) +
-                  captureGutterEdgePx(resizeGutter.bottom, resizeDensity)
+              // drop the shadow it exists to keep. Shared with the motion handlers — see
+              // `fixedAxisTarget`.
               resizeFixedAxesPng(
                 file = outputFile,
-                targetWidth =
-                  if (!wrapWidth && params.device == null && params.widthDp != null)
-                    (widthDp * resizeDensity).roundHalfUpPx() + resizeGutterWPx
-                  else null,
-                targetHeight =
-                  if (!wrapHeight && params.device == null && params.heightDp != null)
-                    (heightDp * resizeDensity).roundHalfUpPx() + resizeGutterHPx
-                  else null,
+                targetWidth = fixedAxisTarget.widthPx,
+                targetHeight = fixedAxisTarget.heightPx,
               )
             }
 
@@ -2620,7 +2639,7 @@ private fun cropPngTopLeft(file: File, wrapWidth: Boolean, wrapHeight: Boolean, 
   javax.imageio.ImageIO.write(cropped, "PNG", file)
 }
 
-private fun resizeFixedAxesPng(file: File, targetWidth: Int?, targetHeight: Int?) {
+internal fun resizeFixedAxesPng(file: File, targetWidth: Int?, targetHeight: Int?) {
   if (targetWidth == null && targetHeight == null) return
   if (!file.exists()) return
   val original = javax.imageio.ImageIO.read(file) ?: return
@@ -2666,6 +2685,40 @@ private fun resizeFixedAxesPng(file: File, targetWidth: Int?, targetHeight: Int?
     g.dispose()
   }
   javax.imageio.ImageIO.write(resized, "PNG", file)
+}
+
+/**
+ * The exact pixel size one **fixed** axis's capture must be trimmed to, or `null` when the axis is
+ * not one this correction applies to.
+ *
+ * Null for a **wrapped** axis (its capture is already `measured + gutter`, cropped to the box's own
+ * bounds — nothing to correct) and for a **device** frame (the device dictates the size; a preview
+ * that names one is asking for that frame, not for its own dp).
+ *
+ * Otherwise the declared frame in pixels PLUS the gutter in pixels. The gutter term is summed from
+ * per-edge rounded pixels rather than converted from summed dp, because that is how
+ * [MeasuredWrapBox] laid it out — re-deriving it from dp would disagree with the pixels on the
+ * canvas by one at a fractional density.
+ *
+ * This is deliberately NOT how the hosting window was grown: a Robolectric resource qualifier has
+ * no unit but dp, so the window grew by `ceil(totalGutterPx / density)` dp, which at a fractional
+ * density overshoots. Two 4 dp edges at density 2.625 resolve to 11 + 11 = 22 px while the
+ * qualifier adds 9 dp ≈ 24 px. The overshoot is transparent canvas, and trimming it here is what
+ * keeps a preview's still and its motion products the same size (issue #4467).
+ */
+internal fun fixedAxisTargetPx(
+  wrapped: Boolean,
+  hasDevice: Boolean,
+  declaredDp: Int?,
+  frameDp: Int,
+  leadingGutterDp: Int,
+  trailingGutterDp: Int,
+  density: Float,
+): Int? {
+  if (wrapped || hasDevice || declaredDp == null) return null
+  return (frameDp * density).roundHalfUpPx() +
+    captureGutterEdgePx(leadingGutterDp, density) +
+    captureGutterEdgePx(trailingGutterDp, density)
 }
 
 private fun Float.roundHalfUpPx(): Int = kotlin.math.floor(this + 0.5f).toInt().coerceAtLeast(1)
@@ -3716,6 +3769,11 @@ private fun handleAnimatedCapture(
    * this the GIF would come back tight while the still beside it carries the shadow.
    */
   dialogGutter: DialogWindowCapture.DialogCropGutter = DialogWindowCapture.DialogCropGutter(),
+  /**
+   * The pixel size a fixed axis's frames must come out at, shared with the still so the two cannot
+   * drift (issue #4467). Empty for a wrapped preview and for every scroll product.
+   */
+  fixedAxisTarget: DialogWindowCapture.FixedAxisTarget = DialogWindowCapture.FixedAxisTarget(),
 ): Boolean {
   val framesDir = File(outputFile.parentFile, "${outputFile.nameWithoutExtension}_anim_frames")
   framesDir.deleteRecursively()
@@ -3727,7 +3785,7 @@ private fun handleAnimatedCapture(
   val frameIntervalMs = animation.frameIntervalMs.coerceAtLeast(10)
 
   val frameFiles = mutableListOf<File>()
-  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter)
+  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter, fixedAxisTarget)
 
   // Settle the composition by ticking one frame so any
   // LaunchedEffect(Unit) { … } has fired before the inspector reads
@@ -3968,6 +4026,11 @@ private fun handleFocusGifCapture(
   glimmerEnvironment: ConnectorGlimmerEnvironment? = null,
   /** See [handleAnimatedCapture]'s `dialogGutter`. */
   dialogGutter: DialogWindowCapture.DialogCropGutter = DialogWindowCapture.DialogCropGutter(),
+  /**
+   * The pixel size a fixed axis's frames must come out at, shared with the still so the two cannot
+   * drift (issue #4467). Empty for a wrapped preview and for every scroll product.
+   */
+  fixedAxisTarget: DialogWindowCapture.FixedAxisTarget = DialogWindowCapture.FixedAxisTarget(),
 ): Boolean {
   if (focusGif.steps.isEmpty()) return false
   val framesDir = File(outputFile.parentFile, "${outputFile.nameWithoutExtension}_focus_frames")
@@ -3977,7 +4040,7 @@ private fun handleFocusGifCapture(
   val frameRoborazziOptions =
     RoborazziOptions(recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound))
   val frameFiles = mutableListOf<File>()
-  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter)
+  val stableDialogCrop = DialogWindowCapture.StableDialogCrop(dialogGutter, fixedAxisTarget)
 
   try {
     focusGif.steps.forEachIndexed { i, step ->

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FixedAxisMotionTargetTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FixedAxisMotionTargetTest.kt
@@ -4,6 +4,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.file.Files
 import javax.imageio.ImageIO
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -115,6 +116,27 @@ class FixedAxisMotionTargetTest {
     DialogWindowCapture.FixedAxisTarget(widthPx = 337).applyTo(file)
     // The wrapped axis keeps whatever the measured crop gave it.
     assertEquals(337 to 200, decode(file))
+  }
+
+  @Test
+  fun `an undecodable frame is left for the capture retry, not thrown out of it`() {
+    // Robolectric's native backend occasionally flushes a per-frame PNG whose signature and IEND
+    // are intact but whose IDAT stream `ImageIO` refuses. `captureDecodableFrame` re-captures
+    // those — but only when `FramePngReader.decode` is what meets the bad bytes. A throw from the
+    // trim escapes that loop and writes an error sidecar for a frame that would have re-encoded
+    // cleanly, so the trim skips instead and leaves the bytes for the decode to catch.
+    val file = Files.createTempFile("corrupt", ".png").toFile()
+    file.deleteOnExit()
+    val good = png(339, 200).readBytes()
+    // Header and trailer intact, interior shredded — the shape of the real glitch.
+    val corrupt = good.copyOf()
+    for (i in 40 until corrupt.size - 12) corrupt[i] = 0
+    file.writeBytes(corrupt)
+
+    DialogWindowCapture.FixedAxisTarget(widthPx = 337, heightPx = 198).applyTo(file)
+
+    // Untouched: the retry gets the same bytes to reject, and re-captures.
+    assertArrayEquals(corrupt, file.readBytes())
   }
 
   private fun target(

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FixedAxisMotionTargetTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/FixedAxisMotionTargetTest.kt
@@ -1,0 +1,146 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * A guttered preview's still and its motion products have to come out the same size on the Android
+ * lane (issue #4467).
+ *
+ * The trap: a Robolectric resource qualifier is dp-only, so the hosting window grows by
+ * `ceil(totalGutterPx / density)` dp — more pixels than the gutter actually resolves to whenever
+ * the density is fractional. The still has always been trimmed back to the exact pixel target;
+ * motion products encoded the qualifier-sized frame, so the same component published a PNG and a
+ * GIF that disagreed about its own bounds by a pixel or two. Both now derive from
+ * [fixedAxisTargetPx] — one number, so they cannot drift.
+ */
+class FixedAxisMotionTargetTest {
+
+  /** The AS phone default, and the reason this bug exists at all. */
+  private val fractionalDensity = 2.625f
+
+  @Test
+  fun `a fixed axis targets the declared frame plus the gutter's real pixels`() {
+    // 120 dp at 2.625 is 315 px; two 4 dp edges round to 11 px each ⇒ 337.
+    assertEquals(
+      337,
+      fixedAxisTargetPx(
+        wrapped = false,
+        hasDevice = false,
+        declaredDp = 120,
+        frameDp = 120,
+        leadingGutterDp = 4,
+        trailingGutterDp = 4,
+        density = fractionalDensity,
+      ),
+    )
+  }
+
+  @Test
+  fun `the target is not what the dp-only qualifier grew the window to`() {
+    // This is the divergence being closed. The qualifier can only add whole dp, and it must not
+    // round DOWN or the window ends up short of `component + gutter` and the crop eats a pixel of
+    // shadow — so it adds `ceil(22 / 2.625)` = 9 dp, and the frame comes back wider than the
+    // gutter resolves to. Encoding that straight into a GIF is what made a still and its motion
+    // capture disagree.
+    val qualifierDp = 120 + captureGutterAxisDp(4, 4, fractionalDensity)
+    assertEquals(129, qualifierDp)
+    val qualifierPx = Math.round(qualifierDp * fractionalDensity)
+    assertEquals(339, qualifierPx)
+    // Two pixels of transparent overshoot, which the trim removes.
+    assertEquals(
+      2,
+      qualifierPx -
+        fixedAxisTargetPx(
+          wrapped = false,
+          hasDevice = false,
+          declaredDp = 120,
+          frameDp = 120,
+          leadingGutterDp = 4,
+          trailingGutterDp = 4,
+          density = fractionalDensity,
+        )!!,
+    )
+  }
+
+  @Test
+  fun `an integral density has nothing to correct`() {
+    assertEquals(
+      120 * 2 + 16,
+      fixedAxisTargetPx(
+        wrapped = false,
+        hasDevice = false,
+        declaredDp = 120,
+        frameDp = 120,
+        leadingGutterDp = 4,
+        trailingGutterDp = 4,
+        density = 2.0f,
+      ),
+    )
+  }
+
+  @Test
+  fun `wrapped axes, device frames and undeclared axes opt out`() {
+    // A wrapped axis is cropped to the measured box, which already reports `child + gutter`.
+    assertNull(target(wrapped = true))
+    // A preview that names a device is asking for that device's frame, not for its own dp.
+    assertNull(target(hasDevice = true))
+    assertNull(target(declaredDp = null))
+  }
+
+  @Test
+  fun `applying an empty target leaves the frame byte-identical`() {
+    val file = png(40, 30)
+    val before = file.readBytes()
+    DialogWindowCapture.FixedAxisTarget().applyTo(file)
+    assertEquals(before.size, file.readBytes().size)
+    assertEquals(40 to 30, decode(file))
+  }
+
+  @Test
+  fun `applying a target trims the overshoot off a captured frame`() {
+    val file = png(339, 200)
+    DialogWindowCapture.FixedAxisTarget(widthPx = 337, heightPx = 198).applyTo(file)
+    assertEquals(337 to 198, decode(file))
+  }
+
+  @Test
+  fun `a target only constrains the axis it names`() {
+    val file = png(339, 200)
+    DialogWindowCapture.FixedAxisTarget(widthPx = 337).applyTo(file)
+    // The wrapped axis keeps whatever the measured crop gave it.
+    assertEquals(337 to 200, decode(file))
+  }
+
+  private fun target(
+    wrapped: Boolean = false,
+    hasDevice: Boolean = false,
+    declaredDp: Int? = 120,
+  ): Int? =
+    fixedAxisTargetPx(
+      wrapped = wrapped,
+      hasDevice = hasDevice,
+      declaredDp = declaredDp,
+      frameDp = 120,
+      leadingGutterDp = 4,
+      trailingGutterDp = 4,
+      density = fractionalDensity,
+    )
+
+  private fun png(width: Int, height: Int): File {
+    val file = Files.createTempFile("frame", ".png").toFile()
+    file.deleteOnExit()
+    ImageIO.write(BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB), "PNG", file)
+    return file
+  }
+
+  private fun decode(file: File): Pair<Int, Int> {
+    val img = ImageIO.read(file) ?: error("frame failed to decode")
+    return img.width to img.height
+  }
+}


### PR DESCRIPTION
Closes item **2** of #4467.

## The divergence

A Robolectric resource qualifier has no unit but dp, so `@CaptureGutter` grows the hosting window by `ceil(totalGutterPx / density)` dp. It has to round *up* — rounding down would leave the window short of `component + gutter` and the crop would eat a pixel of shadow. At a fractional density that overshoots:

| | 4 dp + 4 dp gutter, density 2.625 |
|---|---|
| gutter's real pixel extent | 11 + 11 = **22 px** |
| what the dp-only qualifier grows | ceil(22 / 2.625) = 9 dp ≈ **24 px** |

The still corrected for it (`resizeFixedAxesPng` to `frame + gutterPx` exactly). Motion products bypassed that resize and encoded the qualifier-sized frame — so one component published a PNG at `frame + 22` and a GIF beside it at `frame + 24`. Two artefacts of one preview disagreeing about its own bounds is precisely the failure `@CaptureGutter`'s motion support exists to prevent.

## The fix

The two derivations of "how big is a fixed axis" are how they drifted apart, so there is now one: `fixedAxisTargetPx` resolves it once per render, and both the still's post-capture resize and the motion handlers take it as `DialogWindowCapture.FixedAxisTarget`.

`StableDialogCrop` applies it per frame, with the **same precedence the still path uses** — a dialog crop frames the component itself, so it wins and a dialog capture is untouched (the `capturedDialogWindow == null` guard on the still side, mirrored).

Opted out, all matching existing behaviour:
- **wrapped axes** — already consistent; `MeasuredWrapBox` reports `child + gutter` and the motion crop takes it,
- **device frames** — a preview naming a device is asking for that frame, not its own dp,
- **scroll products** — pass nothing, unchanged; a scrolling capture is documented as carrying no gutter (that's item 1 of #4467, separate PR).

Note the trim is a crop, not a rescale — `resizeFixedAxesPng` blits 1:1 and only edge-replicates when growing, so the component's pixels are not resampled.

## Test plan

- `./gradlew ktfmtFormat :renderer-android:testDebugUnitTest` — **BUILD SUCCESSFUL**, no failures.
- New `FixedAxisMotionTargetTest`:
  - the target is `frame + per-edge-rounded gutter px` at a fractional density (337 for 120 dp + 4/4 dp at 2.625),
  - it is deliberately **not** the qualifier's dp-rounded growth (339) — the 2 px of transparent overshoot is asserted explicitly, so a future "simplification" back to summed dp fails here,
  - an integral density has nothing to correct,
  - wrapped / device / undeclared axes return null,
  - the per-frame trim crops the named axis and leaves the other alone; an empty target is a no-op.

No visual surface changes to embed — this corrects motion-frame *dimensions* on a fractional density, and the pixel arithmetic is pinned in the tests above rather than eyeballed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFZsM7PxPecadiVjWQTyAR)_