### PR TITLE
fix(daemon): invalidate the live projection when a dispatch renders

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -873,22 +873,25 @@ class DesktopRecordingSession(
         // [stop] result carries `scriptEvents`); the dispatch's side effects on the held scene
         // are what live mode cares about.
         val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
-        // Projected ONCE per tick, and *before* any dispatch. Two reasons, both from the #4470
-        // review. Correctness: the reverse map has to answer "what was under the pointer on the
-        // screen the user clicked", so a click that navigates away, or a scroll that slides a
-        // different item under the pointer, must not be mapped against the screen its own dispatch
-        // produced. Cost: laying out per event would put a full `scene.render()` between every
-        // queued pointer move, and a burst of them would push the recorder past its frame cadence.
-        // One projection is enough for the whole drain — nothing re-renders until the frame below,
-        // so the screen genuinely has not changed between these events.
+        // Projected *before* each dispatch, and reused for as long as it stays current. The
+        // reverse map has to answer "what was under the pointer on the screen the user clicked",
+        // so a click that navigates away, or a scroll that slides a different item under the
+        // pointer, must not be mapped against the screen its own dispatch produced.
+        //
+        // Keyed on `renderGeneration` rather than projected once per tick: a dispatch can render.
+        // `ScenePointerDispatch.press` settles a frame of its own, so after the first click of a
+        // drain the layout really has moved and a cached projection would name a node from the
+        // previous screen. A burst of pointer *moves* renders nothing, so those still share one
+        // projection — which is the case worth saving, since laying out per event would put a full
+        // `scene.render()` between every move and push the recorder past its frame cadence.
         var tickRoot: ComposeSemanticsNode? = null
-        var tickRootProjected = false
+        var tickRootGeneration = -1L
         while (true) {
           val next = liveInputs.poll() ?: break
           val scriptEvent = next.toScriptEvent(tMs)
-          if (!tickRootProjected) {
+          if (tickRoot == null || tickRootGeneration != state.renderGeneration) {
             tickRoot = engine.laidOutSemanticsRoot(state)
-            tickRootProjected = true
+            tickRootGeneration = state.renderGeneration
           }
           scriptHandlers.dispatch(scriptEvent, ctx)
           captureLiveEvent(scriptEvent, tickRoot)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -774,6 +774,9 @@ class RenderEngine(
    */
   @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
   internal fun layOutForSemantics(state: SceneState) {
+    // Same timestamp, new generation: the composition is unmoved, but any projection taken before
+    // this pass described an older layout.
+    state.recordFrameNanos(state.lastRenderedFrameNanos)
     withPreviewLocale(state.spec.localeTag) {
       state.scene.render(nanoTime = state.lastRenderedFrameNanos).close()
     }
@@ -1288,9 +1291,22 @@ class RenderEngine(
      */
     internal var lastRenderedFrameNanos: Long = 0L
 
+    /**
+     * How many times this scene has been rendered.
+     *
+     * A projected semantics tree is a snapshot of one layout pass, so this is what tells a caller
+     * holding one whether it is still current. A live tick can dispatch several queued inputs
+     * before its next frame, and `ScenePointerDispatch.press` renders a settling frame of its own —
+     * so "nothing re-renders between queued events" is not true in general, and a cached projection
+     * has to be invalidated rather than assumed (compose-ai-tools#4470 review).
+     */
+    internal var renderGeneration: Long = 0L
+      private set
+
     /** Note that the scene has just been (or is about to be) rendered at [nanoTime]. */
     internal fun recordFrameNanos(nanoTime: Long) {
       lastRenderedFrameNanos = nanoTime
+      renderGeneration++
     }
 
     /** Advances [virtualFrameNanos] by one 60 Hz frame and returns the new timestamp. */

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHeldSceneLayoutTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHeldSceneLayoutTest.kt
@@ -21,7 +21,8 @@ import org.junit.rules.TemporaryFolder
  *    jumps it back on the next real frame — a large forward delta to every in-flight animation,
  *    followed by an equally large negative one.
  * 2. **The ordering.** In live mode the reverse map that turns a pixel click into a stable handle
- *    has to run against the screen the user clicked, not the screen the click produced.
+ *    has to run against the screen the user clicked, not the screen the click produced — and a
+ *    cached projection has to be invalidated when a dispatch renders, which a press does.
  */
 class DesktopHeldSceneLayoutTest {
 
@@ -100,6 +101,42 @@ class DesktopHeldSceneLayoutTest {
         SOME_LATE_FRAME_NANOS,
         state.lastRenderedFrameNanos,
       )
+    } finally {
+      engine.tearDown(state)
+    }
+  }
+
+  @Test
+  fun `a render bumps the generation a cached projection is keyed on`() {
+    // A projected semantics tree is a snapshot of one layout pass. The live tick loop reuses one
+    // across queued inputs, which is only sound while the scene hasn't re-rendered — and a
+    // dispatch CAN render (`ScenePointerDispatch.press` settles a frame). This counter is what
+    // makes that detectable instead of assumed.
+    val engine = RenderEngine(outputDir = tempFolder.newFolder("generation-renders"))
+    val state =
+      engine.setUp(
+        RenderSpec(
+          className = FIXTURE_CLASS,
+          functionName = "TristateClickSquare",
+          widthPx = 120,
+          heightPx = 60,
+          density = 1.0f,
+          outputBaseName = "generation",
+        ),
+        classLoader = javaClass.classLoader,
+      )
+    try {
+      val start = state.renderGeneration
+      engine.layOutForSemantics(state)
+      val afterLayout = state.renderGeneration
+      assertTrue("a layout pass is a render", afterLayout > start)
+      // …and it is the generation that moves, not the clock. Both properties are load-bearing:
+      // the timestamp keeps animations still, the generation invalidates stale projections.
+      assertEquals(0L, state.lastRenderedFrameNanos)
+
+      // A settling frame — what a press dispatches mid-drain — must invalidate too.
+      engine.renderSettlingFrame(state, nanoTime = state.lastRenderedFrameNanos)
+      assertTrue("a settling frame is a render", state.renderGeneration > afterLayout)
     } finally {
       engine.tearDown(state)
     }


### PR DESCRIPTION
Follow-up to #4470 (merged), fixing a defect in the change it made.

## The defect

#4470 moved the live reverse-map's semantics projection to **before** dispatch, so a click that navigates away is recorded as a click on the node the user aimed at rather than the one the click produced. It projected **once per tick**, on the reasoning that nothing re-renders between queued events.

That reasoning is wrong. `ScenePointerDispatch.press` settles a frame of its own (`DesktopSceneInput.kt`), so after the first click of a drain the layout really has moved — and the next queued input was reverse-mapped against the previous screen. The same defect the projection was moved to avoid, one event later. Caught by Codex on #4474, where the merged code showed up in the diff.

## The fix

`SceneState.renderGeneration` counts renders. The tick loop keys its cached projection on it: re-projected whenever the scene has rendered since, reused otherwise.

That keeps the cost saving where it's actually available — a burst of pointer **moves** renders nothing, so those still share one projection, which is the case that mattered (laying out per event would put a full `scene.render()` between every move and push the recorder past its frame cadence). A press pays for a fresh projection, correctly.

`layOutForSemantics` bumps the generation *without* moving the clock: the composition is unmoved, but any projection taken before it describes an older layout.

## Test plan

- `./gradlew ktfmtCheck :daemon:desktop:test :daemon:core:test` — **BUILD SUCCESSFUL**, no failures.
- New case in `DesktopHeldSceneLayoutTest` pins that a layout pass and a settling frame each bump the generation while `lastRenderedFrameNanos` stays put. Both halves are load-bearing and pull in opposite directions: the timestamp is what keeps animations still across a layout pass, the generation is what stops a stale projection being reused.

Text-only evidence — daemon target-resolution plumbing, no visual surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFZsM7PxPecadiVjWQTyAR)_