### PR TITLE
docs(gutter): correct the open-caveat list after #4471 and #4473

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -92,13 +92,11 @@ package ee.schimke.composeai.preview
  * every other product's agreement with it, so an Android `END` capture keeps the gutter while the
  * CMP Desktop one does not.
  *
- * Three caveats are still open. That Android `END` divergence is one. A fixed-axis Android
- * **motion** product is trimmed to the hosting window rather than to `frame + gutter` in pixels, so
- * at a fractional density it can differ from the still by a pixel. And a held **desktop recording**
- * of a *wrapped* preview is sized from the sandbox bound rather than the measured content — that
- * one predates gutters entirely, so the gutter term merely rides on top of a frame that was already
- * the wrong size. All three are tracked in compose-ai-tools#4467 — read them as the current limits
- * of the contract above, not as licence to rely on them.
+ * Two caveats are still open. That Android `END` divergence is one. The other is a held **desktop
+ * recording** of a *wrapped* preview, which is sized from the sandbox bound rather than the
+ * measured content — that one predates gutters entirely, so the gutter term merely rides on top of
+ * a frame that was already the wrong size. Both are tracked in compose-ai-tools#4467 — read them as
+ * the current limits of the contract above, not as licence to rely on them.
  *
  * A **rotated** capture (`orientation = landscape`, which the daemon reduces to a width↔height
  * swap) keeps the declared edges verbatim: a gutter edge names a direction the component draws in —

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -79,11 +79,12 @@ package ee.schimke.composeai.preview
  * **`showSystemUi`**, whose synthetic status and nav bars are painted against the edges of the
  * grown window (trimming those edges slices the chrome rather than the gutter). Making either work
  * means composing the scroll pass in an un-grown window rather than post-processing it. A
- * scrollable hosted in a **dialog** keeps the gutter as well: those frames are cropped to the
- * dialog's own window rect and never reach the hosting-window trim, which frames the component
- * correctly for a centred `Dialog` but leaves a full-screen `ModalBottomSheet` un-trimmed. None of
- * the three is a combination worth the machinery: a gutter exists to keep a component's shadow, and
- * a scroll product has no component edge to keep one on.
+ * scrollable hosted in a **full-screen** dialog — a `ModalBottomSheet` — keeps it as well. Those
+ * frames are cropped to the dialog's own window rect instead of reaching the hosting-window trim,
+ * and for a centred `Dialog` that rect *is* the component, so the gutter is excluded correctly
+ * there; a full-screen window's rect is the whole grown frame, so nothing is removed. None of the
+ * three is a combination worth the machinery: a gutter exists to keep a component's shadow, and a
+ * scroll product has no component edge to keep one on.
  *
  * `END` is the exception on Android, and knowingly so. It is the one scroll mode whose product is
  * an ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -78,9 +78,12 @@ package ee.schimke.composeai.preview
  * and for an asymmetric gutter off-centre, circle rather than the watch shape), and
  * **`showSystemUi`**, whose synthetic status and nav bars are painted against the edges of the
  * grown window (trimming those edges slices the chrome rather than the gutter). Making either work
- * means composing the scroll pass in an un-grown window rather than post-processing it. Neither is
- * a combination worth the machinery: a gutter exists to keep a component's shadow, and a scroll
- * product has no component edge to keep one on.
+ * means composing the scroll pass in an un-grown window rather than post-processing it. A
+ * scrollable hosted in a **dialog** keeps the gutter as well: those frames are cropped to the
+ * dialog's own window rect and never reach the hosting-window trim, which frames the component
+ * correctly for a centred `Dialog` but leaves a full-screen `ModalBottomSheet` un-trimmed. None of
+ * the three is a combination worth the machinery: a gutter exists to keep a component's shadow, and
+ * a scroll product has no component edge to keep one on.
  *
  * `END` is the exception on Android, and knowingly so. It is the one scroll mode whose product is
  * an ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -324,11 +324,15 @@ PNG beside it carried the gutter — the component is the same size in both, onl
   render pass, the way a settled still already splits) is the fix; until then a guttered `END`
   capture is `frame + gutter` on Android and `frame` on CMP Desktop.
 
-  Two further divergences remain open: fixed-axis Android **motion** frames are trimmed to the
-  hosting window rather than to `frame + gutter` px (a pixel's disagreement with the still at a
-  fractional density), and a held **desktop recording** of a *wrapped* preview is sized from the
-  sandbox bound rather than the measured content — that one predates gutters. All are tracked in
+  One further divergence remains open: a held **desktop recording** of a *wrapped* preview is sized
+  from the sandbox bound rather than the measured content — that one predates gutters. Tracked, with
+  the `END` divergence above, in
   [#4467](https://github.com/yschimke/compose-ai-tools/issues/4467).
+
+  Fixed-axis Android **motion** frames used to disagree with the still by a pixel at fractional
+  densities, because the hosting window can only grow in whole dp; both now derive from one
+  `fixedAxisTargetPx`
+  ([#4471](https://github.com/yschimke/compose-ai-tools/pull/4471)).
 * **Rotation does not rotate the edges.** `orientation = landscape` reduces to a
   `widthPx ↔ heightPx` swap, and the routers trade the *wrap flags* with it because a wrap flag
   names an axis of the frame. A gutter edge names a direction the component draws in — `bottom` is

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -310,8 +310,11 @@ PNG beside it carried the gutter — the component is the same size in both, onl
   into the capture, so cropping leaves an oversized — and for an asymmetric gutter, off-centre —
   circle instead of the watch shape) and **`showSystemUi`** (`SystemBarsFrame` wraps the gutter box,
   so the chrome is painted against the *grown* window's edges and trimming slices the bars). Both
-  need the scroll pass composed in an un-grown window rather than post-processed, and neither is a
-  combination any preview declares.
+  need the scroll pass composed in an un-grown window rather than post-processed. A scrollable
+  hosted in a **dialog** keeps the gutter too — those frames are cropped to the dialog's own window
+  rect and never reach the hosting-window trim, which is right for a centred `Dialog` and leaves a
+  full-screen `ModalBottomSheet` un-trimmed. None of the three is a combination any preview
+  declares.
 
   **`END` still diverges on Android**, knowingly. It is the one scroll mode whose product is an
   ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y /

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -311,10 +311,10 @@ PNG beside it carried the gutter — the component is the same size in both, onl
   circle instead of the watch shape) and **`showSystemUi`** (`SystemBarsFrame` wraps the gutter box,
   so the chrome is painted against the *grown* window's edges and trimming slices the bars). Both
   need the scroll pass composed in an un-grown window rather than post-processed. A scrollable
-  hosted in a **dialog** keeps the gutter too — those frames are cropped to the dialog's own window
-  rect and never reach the hosting-window trim, which is right for a centred `Dialog` and leaves a
-  full-screen `ModalBottomSheet` un-trimmed. None of the three is a combination any preview
-  declares.
+  hosted in a **full-screen** dialog (`ModalBottomSheet`) keeps it too: those frames are cropped to
+  the dialog's own window rect rather than reaching the hosting-window trim, and a full-screen
+  window's rect is the whole grown frame. A centred `Dialog` is fine — its rect *is* the component,
+  so the gutter is excluded correctly. None of the three is a combination any preview declares.
 
   **`END` still diverges on Android**, knowingly. It is the one scroll mode whose product is an
   ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y /

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1296,6 +1296,12 @@ abstract class RobolectricRenderTestBase(
     //    inside it, so the chrome is painted against the edges of the *grown* window and trimming
     //    those edges slices the bars instead of the gutter.
     //
+    // A scrollable hosted in a **dialog** keeps it too, for a structural reason rather than a
+    // decision: `StableDialogCrop` crops those frames to the dialog's own window rect and never
+    // reaches the hosting-window trim. For a centred `Dialog` that is right — the crop frames the
+    // component already — but a full-screen one (`ModalBottomSheet`) crops to the whole frame, so
+    // the gutter simply survives.
+    //
     // Both are combinations no preview in this repo declares (a gutter keeps a component's shadow;
     // a scroll product has no component edge to keep one on), and making them work means composing
     // the scroll pass in an un-grown window rather than post-processing. Documented in

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1296,11 +1296,12 @@ abstract class RobolectricRenderTestBase(
     //    inside it, so the chrome is painted against the edges of the *grown* window and trimming
     //    those edges slices the bars instead of the gutter.
     //
-    // A scrollable hosted in a **dialog** keeps it too, for a structural reason rather than a
-    // decision: `StableDialogCrop` crops those frames to the dialog's own window rect and never
-    // reaches the hosting-window trim. For a centred `Dialog` that is right — the crop frames the
-    // component already — but a full-screen one (`ModalBottomSheet`) crops to the whole frame, so
-    // the gutter simply survives.
+    // A scrollable hosted in a **full-screen** dialog keeps it too, for a structural reason rather
+    // than a decision: `StableDialogCrop` crops those frames to the dialog's own window rect
+    // instead of reaching the hosting-window trim. The scroll handlers pass that crop no gutter,
+    // so a centred `Dialog` comes out at its own unexpanded rect and the gutter is excluded
+    // correctly — but a `ModalBottomSheet`'s window fills the screen, so its rect is the whole
+    // grown frame and nothing is removed.
     //
     // Both are combinations no preview in this repo declares (a gutter keeps a component's shadow;
     // a scroll product has no component edge to keep one on), and making them work means composing

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollGutterTrimTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollGutterTrimTest.kt
@@ -21,11 +21,12 @@ import org.junit.Test
  * and captures every job in it, so the still keeps the gutter and the scroll products trim it back
  * off here.
  *
- * Round devices and `showSystemUi` frames are **unsupported** in this combination and keep the
- * gutter — a baked-in circular mask and window-edge system chrome both make a post-hoc trim worse
- * than none. `END` is out of scope too: its product is an ordinary still sharing the whole still
- * post-capture chain, so it keeps the gutter on this lane — see `@CaptureGutter`'s kdoc and
- * issue #4467.
+ * Round devices, `showSystemUi` frames and dialog-hosted scrollables are **unsupported** in this
+ * combination and keep the gutter — a baked-in circular mask and window-edge system chrome both
+ * make a post-hoc trim worse than none, and a dialog frame is cropped to its own window rect before
+ * the hosting-window trim would ever see it. `END` is out of scope too: its product is an ordinary
+ * still sharing the whole still post-capture chain, so it keeps the gutter on this lane — see
+ * `@CaptureGutter`'s kdoc and issue #4467.
  */
 class ScrollGutterTrimTest {
 

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollGutterTrimTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollGutterTrimTest.kt
@@ -21,12 +21,12 @@ import org.junit.Test
  * and captures every job in it, so the still keeps the gutter and the scroll products trim it back
  * off here.
  *
- * Round devices, `showSystemUi` frames and dialog-hosted scrollables are **unsupported** in this
- * combination and keep the gutter — a baked-in circular mask and window-edge system chrome both
- * make a post-hoc trim worse than none, and a dialog frame is cropped to its own window rect before
- * the hosting-window trim would ever see it. `END` is out of scope too: its product is an ordinary
- * still sharing the whole still post-capture chain, so it keeps the gutter on this lane — see
- * `@CaptureGutter`'s kdoc and issue #4467.
+ * Round devices, `showSystemUi` frames and **full-screen** dialog windows are **unsupported** in
+ * this combination and keep the gutter — a baked-in circular mask and window-edge system chrome
+ * both make a post-hoc trim worse than none, and a full-screen dialog's crop rect is the whole
+ * grown frame. A centred `Dialog` is fine: its rect is the component, so the gutter is excluded.
+ * `END` is out of scope too: its product is an ordinary still sharing the whole still post-capture
+ * chain, so it keeps the gutter on this lane — see `@CaptureGutter`'s kdoc and issue #4467.
  */
 class ScrollGutterTrimTest {
 


### PR DESCRIPTION
Docs-only follow-up to #4473 (merged), closing its last two review findings. No behaviour change.

## 1. Dialog-hosted scroll captures are unsupported too

A scrollable hosted in a `Dialog` / `ModalBottomSheet` keeps the `@CaptureGutter` on its `LONG` / `GIF` products, for a **structural** reason rather than a decision: `StableDialogCrop` crops those frames to the dialog's own window rect and never reaches the hosting-window trim. For a centred `Dialog` that's right — the crop frames the component already — but a full-screen `ModalBottomSheet` crops to the whole frame, so the gutter survives and `LONG` stitches against an un-guttered viewport plan.

Same class as the round-device and `showSystemUi` cases already named beside it, and the same answer: named in the KDoc, `RENDER_LANE_PARITY.md` and `ScrollGutterTrimTest`'s KDoc rather than detected and special-cased. The fix for all three is composing the scroll pass in an un-grown window — #4467.

## 2. The fixed-axis motion caveat is stale — #4471 closed it

Both documents still listed fixed-axis Android motion frames as diverging from the still by a pixel at fractional densities. I wrote that while #4471 was in flight so the docs wouldn't claim a fix that hadn't landed, then never took it back out. `fixedAxisTargetPx` now feeds the still's resize *and* all three motion handlers, so the two can't drift.

Telling contributors a resolved issue is a live API limitation is worse than not mentioning it, so the count drops from three caveats to two — the Android `END` divergence and the wrapped desktop recording, both genuinely open (the latter is #4474, currently draft). `RENDER_LANE_PARITY.md` keeps one line recording that the motion disagreement existed and how it closed, since a measured record of parity is what that document is for.

## Test plan

- `./gradlew ktfmtCheck` — **BUILD SUCCESSFUL** (the KDoc rewrap needed `ktfmtFormat`).
- `:renderer-android:testDebugUnitTest` and `:daemon:android:testDebugUnitTest` were green on this content before #4473 merged; nothing executable has changed since.
