### PR TITLE
fix(recording): correct backdrop, missing frames and scaling in held recordings

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -34,6 +34,9 @@ import kotlin.math.ceil
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.SamplingMode
+import org.jetbrains.skia.Surface
 
 /**
  * Desktop concrete [RecordingSession] driving a virtual frame clock against a held
@@ -128,6 +131,19 @@ class DesktopRecordingSession(
   @Volatile private var maxMeasuredWidthPx: Int = 0
 
   @Volatile private var maxMeasuredHeightPx: Int = 0
+
+  /**
+   * The smallest content size measured over the recording, or `0` before anything was measured.
+   *
+   * The maximum alone cannot answer "did this component grow?", and that question decides whether
+   * the earlier frames need the backdrop laid under them: a frame taken while the component was
+   * smaller is transparent everywhere it had not reached, whatever the final size turns out to be.
+   * Without this the wholesale no-op skips the fill exactly when growth happens to end on the
+   * scene's own bounds (issue #4467).
+   */
+  @Volatile private var minMeasuredWidthPx: Int = 0
+
+  @Volatile private var minMeasuredHeightPx: Int = 0
 
   /**
    * The size the scene actually rendered at, observed rather than recomputed.
@@ -548,6 +564,13 @@ class DesktopRecordingSession(
     val measured = state.measuredContent
     if (measured[0] > maxMeasuredWidthPx) maxMeasuredWidthPx = measured[0]
     if (measured[1] > maxMeasuredHeightPx) maxMeasuredHeightPx = measured[1]
+    // Zero is "not measured yet", not a size — latching it would make every recording look grown.
+    if (measured[0] > 0 && (minMeasuredWidthPx == 0 || measured[0] < minMeasuredWidthPx)) {
+      minMeasuredWidthPx = measured[0]
+    }
+    if (measured[1] > 0 && (minMeasuredHeightPx == 0 || measured[1] < minMeasuredHeightPx)) {
+      minMeasuredHeightPx = measured[1]
+    }
     // Every semantics owner, not just the content box. A `DropdownMenu`, tooltip or dialog paints
     // into an owner of its own, outside the box entirely — so a crop taken from the box alone would
     // cut the popup off, which is a regression against recording the whole scene. The batch motion
@@ -1166,15 +1189,55 @@ class DesktopRecordingSession(
    * encode.
    */
   private fun frameBytes(image: Image, frameIndex: Int): ByteArray {
-    val natural =
-      if (state.spec.overrides?.talkBack == true) talkBackFrameBytes(image, frameIndex)
-      else encodeNaturalPng(image)
-    // Scaled here only when the framing cannot change — see [framingKnownUpFront]. A wrapped
-    // preview's frames stay at scene size until `stop()` knows how big the component ever got.
-    if (!framingKnownUpFront || scale == 1.0f) return natural
+    // Scaling happens here only when the framing cannot change — see [framingKnownUpFront]. A
+    // wrapped preview's frames stay at scene size until `stop()` knows how big the component
+    // ever got.
+    val scaleNow = framingKnownUpFront && scale != 1.0f
     val scaledWidth = (image.width * scale).toInt().coerceAtLeast(1)
     val scaledHeight = (image.height * scale).toInt().coerceAtLeast(1)
-    return scalePngBytes(natural, image.width, image.height, scaledWidth, scaledHeight)
+
+    if (state.spec.overrides?.talkBack == true) {
+      // The overlay is drawn onto finished PNG bytes, so this path has no `Image` left to scale
+      // from and takes the raster scaler.
+      val overlaid = talkBackFrameBytes(image, frameIndex)
+      return if (!scaleNow) overlaid
+      else scalePngBytes(overlaid, image.width, image.height, scaledWidth, scaledHeight)
+    }
+    if (!scaleNow) return encodeNaturalPng(image)
+    // Scaled in Skia and encoded once, rather than encoded, decoded and re-encoded. A live 4K
+    // recording at `scale = 0.25` would otherwise pay full-resolution PNG compression AND
+    // decompression on every tick, which costs capture cadence for nothing (issue #4467).
+    return encodeScaledPng(image, scaledWidth, scaledHeight)
+  }
+
+  /**
+   * [image] drawn into a `width x height` raster surface and encoded once.
+   *
+   * `LINEAR` sampling is the right default for both up- and down-scaling: cheaper than CATMULL_ROM,
+   * no aliasing for typical UI content, and what browsers do for `<img>`. The sampling mode is not
+   * exposed on the wire — a caller wanting a pixel-perfect upscale passes `scale = 1.0` and
+   * resamples client-side.
+   */
+  private fun encodeScaledPng(image: Image, width: Int, height: Int): ByteArray {
+    val surface = Surface.makeRasterN32Premul(width, height)
+    return try {
+      surface.canvas.drawImageRect(
+        image = image,
+        src = Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
+        dst = Rect.makeWH(width.toFloat(), height.toFloat()),
+        samplingMode = SamplingMode.LINEAR,
+        paint = null,
+        strict = true,
+      )
+      val snapshot = surface.makeImageSnapshot()
+      try {
+        snapshot.encodePngData()?.bytes ?: error("encodePngData() returned null (scaled)")
+      } finally {
+        snapshot.close()
+      }
+    } finally {
+      surface.close()
+    }
   }
 
   /**
@@ -1229,7 +1292,18 @@ class DesktopRecordingSession(
     val sceneHeight = if (renderedSceneHeightPx > 0) renderedSceneHeightPx else sceneHeightPx
     val nothingToCrop = naturalWidth == sceneWidth && naturalHeight == sceneHeight
     val nothingToScale = frameWidth == naturalWidth && frameHeight == naturalHeight
-    if (framingKnownUpFront || (nothingToCrop && nothingToScale)) return frameWidth to frameHeight
+    // "Nothing to crop, nothing to scale" is not the whole test. An opaque-background component
+    // that GREW still needs the backdrop laid under its earlier frames, and growth that happens to
+    // finish on the scene's own bounds satisfies both clauses while leaving exactly that work
+    // undone — the case the fill was added for (issue #4467).
+    val grew =
+      (state.spec.wrapWidth && minMeasuredWidthPx in 1 until maxMeasuredWidthPx) ||
+        (state.spec.wrapHeight && minMeasuredHeightPx in 1 until maxMeasuredHeightPx)
+    val backdropOwed =
+      grew && !overlayFramedAgainstScene && (previewBackgroundArgb(state.spec) ushr 24) == 0xFF
+    if (framingKnownUpFront || (nothingToCrop && nothingToScale && !backdropOwed)) {
+      return frameWidth to frameHeight
+    }
 
     fun framed(bytes: ByteArray): ByteArray =
       scalePngBytes(bytes, naturalWidth, naturalHeight, frameWidth, frameHeight)
@@ -1246,7 +1320,12 @@ class DesktopRecordingSession(
     // evidence disagreeing with the frame on disk.
     for (index in 0 until frameCount) {
       val file = File(framesDir, "frame-${"%05d".format(index)}.png")
-      if (!file.isFile) continue
+      // Missing is a failure, exactly as unreadable is. Skipping would let `stop()` report the
+      // original frame count and the finalized dimensions over a set with a hole in it — which the
+      // encoder either rejects, or (ffmpeg's numbered input) silently truncates at the gap.
+      if (!file.isFile) {
+        error("recording '$recordingId': frame ${file.name} is missing at finalization")
+      }
       val bytes = file.readBytes()
       val framedBytes = framed(bytes)
       if (!framedBytes.contentEquals(bytes)) {
@@ -1316,7 +1395,10 @@ class DesktopRecordingSession(
       w,
       h,
       "recording '$recordingId'",
-      backdropArgb = previewBackgroundArgb(state.spec),
+      // No backdrop for a scene-framed recording: nothing is being padded there — the whole
+      // scene is kept precisely so the TalkBack caption stays where it was drawn — and filling
+      // would turn its transparent sandbox opaque merely because a scale was requested.
+      backdropArgb = if (overlayFramedAgainstScene) 0 else previewBackgroundArgb(state.spec),
     )
 
   private fun sceneOffset(px: Int, py: Int): androidx.compose.ui.geometry.Offset {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -133,17 +133,32 @@ class DesktopRecordingSession(
   @Volatile private var maxMeasuredHeightPx: Int = 0
 
   /**
-   * The smallest content size measured over the recording, or `0` before anything was measured.
+   * The smallest and largest **content-box** size measured over the recording — the range that
+   * answers "did this component grow?", which decides whether the earlier frames need the backdrop
+   * laid under them: a frame taken while the component was smaller is transparent everywhere it had
+   * not reached, whatever the final size turns out to be. Without it the wholesale no-op skips the
+   * fill exactly when growth happens to end on the scene's own bounds (issue #4467).
    *
-   * The maximum alone cannot answer "did this component grow?", and that question decides whether
-   * the earlier frames need the backdrop laid under them: a frame taken while the component was
-   * smaller is transparent everywhere it had not reached, whatever the final size turns out to be.
-   * Without this the wholesale no-op skips the fill exactly when growth happens to end on the
-   * scene's own bounds (issue #4467).
+   * Deliberately NOT [maxMeasuredWidthPx]: that one is the *crop* extent, folded with every
+   * semantics owner so a popup outside the content box is not cut off. Comparing a content-box
+   * minimum against a popup-inflated maximum would read a static component with a dropdown reaching
+   * the scene bounds as grown, and fill the whole scene with the opaque background — so the growth
+   * test compares like with like.
+   *
+   * [contentBoundsObserved] is the "nothing measured yet" sentinel rather than a zero minimum: a
+   * wrapped layout can legitimately measure an axis to zero (a collapsed `AnimatedVisibility`, a
+   * zero-sized placeholder), and dropping that leaves a later expansion looking like it was always
+   * its final size.
    */
-  @Volatile private var minMeasuredWidthPx: Int = 0
+  @Volatile private var contentBoundsObserved: Boolean = false
 
-  @Volatile private var minMeasuredHeightPx: Int = 0
+  @Volatile private var minContentWidthPx: Int = 0
+
+  @Volatile private var minContentHeightPx: Int = 0
+
+  @Volatile private var maxContentWidthPx: Int = 0
+
+  @Volatile private var maxContentHeightPx: Int = 0
 
   /**
    * The size the scene actually rendered at, observed rather than recomputed.
@@ -564,13 +579,13 @@ class DesktopRecordingSession(
     val measured = state.measuredContent
     if (measured[0] > maxMeasuredWidthPx) maxMeasuredWidthPx = measured[0]
     if (measured[1] > maxMeasuredHeightPx) maxMeasuredHeightPx = measured[1]
-    // Zero is "not measured yet", not a size — latching it would make every recording look grown.
-    if (measured[0] > 0 && (minMeasuredWidthPx == 0 || measured[0] < minMeasuredWidthPx)) {
-      minMeasuredWidthPx = measured[0]
-    }
-    if (measured[1] > 0 && (minMeasuredHeightPx == 0 || measured[1] < minMeasuredHeightPx)) {
-      minMeasuredHeightPx = measured[1]
-    }
+    // The content-box range, kept apart from the crop extent below — see [minContentWidthPx]. A
+    // measured zero is a real measurement here, so the first frame seeds both ends of the range.
+    if (!contentBoundsObserved || measured[0] < minContentWidthPx) minContentWidthPx = measured[0]
+    if (!contentBoundsObserved || measured[1] < minContentHeightPx) minContentHeightPx = measured[1]
+    if (!contentBoundsObserved || measured[0] > maxContentWidthPx) maxContentWidthPx = measured[0]
+    if (!contentBoundsObserved || measured[1] > maxContentHeightPx) maxContentHeightPx = measured[1]
+    contentBoundsObserved = true
     // Every semantics owner, not just the content box. A `DropdownMenu`, tooltip or dialog paints
     // into an owner of its own, outside the box entirely — so a crop taken from the box alone would
     // cut the popup off, which is a regression against recording the whole scene. The batch motion
@@ -1272,6 +1287,23 @@ class DesktopRecordingSession(
    * A no-op for anything already the right size, which is every fixed-size preview at `scale = 1`:
    * those frames are neither re-decoded nor rewritten.
    */
+  /**
+   * Every frame this recording claims to have written is still on disk, by index — not a glob of
+   * [framesDir], for the reasons the rewrite loop below spells out.
+   *
+   * Missing is a failure, exactly as unreadable is. Skipping would let `stop()` report the original
+   * frame count and the finalized dimensions over a set with a hole in it — which the encoder
+   * either rejects, or (ffmpeg's numbered input) silently truncates at the gap.
+   */
+  private fun requireContiguousFrames(frameCount: Int) {
+    for (index in 0 until frameCount) {
+      val name = "frame-${"%05d".format(index)}.png"
+      if (!File(framesDir, name).isFile) {
+        error("recording '$recordingId': frame $name is missing at finalization")
+      }
+    }
+  }
+
   private fun finalizeFrames(
     pendingPixels: List<PendingPixelAssert>,
     frameCount: Int,
@@ -1297,10 +1329,17 @@ class DesktopRecordingSession(
     // finish on the scene's own bounds satisfies both clauses while leaving exactly that work
     // undone — the case the fill was added for (issue #4467).
     val grew =
-      (state.spec.wrapWidth && minMeasuredWidthPx in 1 until maxMeasuredWidthPx) ||
-        (state.spec.wrapHeight && minMeasuredHeightPx in 1 until maxMeasuredHeightPx)
+      contentBoundsObserved &&
+        ((state.spec.wrapWidth && minContentWidthPx < maxContentWidthPx) ||
+          (state.spec.wrapHeight && minContentHeightPx < maxContentHeightPx))
     val backdropOwed =
       grew && !overlayFramedAgainstScene && (previewBackgroundArgb(state.spec) ushr 24) == 0xFF
+    // Ahead of the fast path, not inside the rewrite loop: a hole in the frame set is a failure for
+    // EVERY recording, and the recordings that take the no-op return — fixed-size ones above all —
+    // would otherwise have `stop()` report success and the original frame count over a set with a
+    // gap in it. `isFile` per index costs a stat and no decode, so the no-decode/no-rewrite
+    // optimization survives intact.
+    requireContiguousFrames(frameCount)
     if (framingKnownUpFront || (nothingToCrop && nothingToScale && !backdropOwed)) {
       return frameWidth to frameHeight
     }
@@ -1320,12 +1359,6 @@ class DesktopRecordingSession(
     // evidence disagreeing with the frame on disk.
     for (index in 0 until frameCount) {
       val file = File(framesDir, "frame-${"%05d".format(index)}.png")
-      // Missing is a failure, exactly as unreadable is. Skipping would let `stop()` report the
-      // original frame count and the finalized dimensions over a set with a hole in it — which the
-      // encoder either rejects, or (ffmpeg's numbered input) silently truncates at the gap.
-      if (!file.isFile) {
-        error("recording '$recordingId': frame ${file.name} is missing at finalization")
-      }
       val bytes = file.readBytes()
       val framedBytes = framed(bytes)
       if (!framedBytes.contentEquals(bytes)) {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingWrappedFrameTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingWrappedFrameTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
@@ -410,6 +411,191 @@ class DesktopRecordingWrappedFrameTest {
       translucent,
       img.getRGB(0, 0),
     )
+  }
+
+  @Test
+  fun `a growing recording is padded even when growth lands on the scene bounds`() {
+    // The trap in "nothing to crop, nothing to scale": growth that finishes exactly on the
+    // sandbox satisfies both clauses while still owing the backdrop under every earlier frame.
+    // The fixture is 60 dp wide in a 60 dp sandbox, growing 30 -> 90 dp tall in a 90 dp one, so
+    // the final size IS the scene and the wholesale skip would fire.
+    val outputDir = tempFolder.newFolder("renders-grow-to-bounds")
+    val recordingsRoot = tempFolder.newFolder("recordings-grow-to-bounds")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == GROWTH_PREVIEW_ID)
+            RenderSpec(
+              className = STICKER_CLASS,
+              functionName = "ExpandingClickBlock",
+              widthPx = 60,
+              heightPx = 90,
+              wrapWidth = true,
+              wrapHeight = true,
+              density = 1.0f,
+              showBackground = true,
+              backgroundColor = 0xFFFFFFFF,
+              outputBaseName = "grow-to-bounds",
+            )
+          else null
+        },
+      )
+    host.start()
+    try {
+      host
+        .acquireRecordingSession(
+          GROWTH_PREVIEW_ID,
+          "rec-grow-bounds",
+          javaClass.classLoader ?: ClassLoader.getSystemClassLoader(),
+          FPS,
+          1.0f,
+          null,
+        )
+        .use { session ->
+          session.postScript(
+            listOf(
+              RecordingScriptEvent(tMs = 0L, kind = "recording.probe"),
+              RecordingScriptEvent(tMs = 100L, kind = "input.click", pixelX = 30, pixelY = 15),
+              RecordingScriptEvent(tMs = 400L, kind = "recording.probe"),
+            )
+          )
+          val result = session.stop()
+          assertEquals(60 to 90, result.frameWidthPx to result.frameHeightPx)
+          // Frame 0 was taken while the block was 60x30, so everything below it was bare scene.
+          // With the backdrop laid under it that area is white; without, it stays transparent.
+          val first = ImageIO.read(File(result.framesDir, "frame-00000.png"))
+          assertEquals(
+            "space the component had not grown into must carry the backdrop",
+            0xFFFFFFFF.toInt(),
+            first.getRGB(30, 85),
+          )
+        }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun `a missing frame fails finalization rather than truncating the recording`() {
+    // Skipping would let stop() report the original count and finalized dimensions over a set
+    // with a hole in it — which the encoder rejects, or ffmpeg's numbered input truncates at.
+    val outputDir = tempFolder.newFolder("renders-missing")
+    val recordingsRoot = tempFolder.newFolder("recordings-missing")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID)
+            RenderSpec(
+              className = STICKER_CLASS,
+              functionName = "WrapContentStickerPreview",
+              widthPx = SANDBOX_WIDTH_PX,
+              heightPx = SANDBOX_HEIGHT_PX,
+              wrapWidth = true,
+              wrapHeight = true,
+              density = 2.0f,
+              showBackground = true,
+              outputBaseName = "missing-frame",
+            )
+          else null
+        },
+      )
+    host.start()
+    try {
+      host
+        .acquireRecordingSession(
+          FIXTURE_PREVIEW_ID,
+          "rec-missing",
+          javaClass.classLoader ?: ClassLoader.getSystemClassLoader(),
+          FPS,
+          1.0f,
+          null,
+          live = true,
+        )
+        .use { session ->
+          // Live mode, because scripted playback writes its frames INSIDE `stop()` — deleting one
+          // beforehand would prove nothing. The tick thread writes as it goes, so a frame really
+          // can vanish between being written and being reframed.
+          Thread.sleep(250L)
+          val frame0 = File(recordingsRoot, "frames/rec-missing/frame-00000.png")
+          assertTrue("the tick thread should have written frames by now", frame0.isFile)
+          assertTrue("could not delete the frame under test", frame0.delete())
+          val thrown = runCatching { session.stop() }.exceptionOrNull()
+          assertTrue("expected finalization to fail, got $thrown", thrown is IllegalStateException)
+        }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun `a scene-framed TalkBack recording is not given a backdrop`() {
+    // A TalkBack recording keeps the whole scene so its caption stays where it was drawn — nothing
+    // is being padded, so nothing should be filled. Passing the preview background in anyway would
+    // turn the transparent sandbox around the component opaque merely because a scale was asked
+    // for, which the scene-framing exists to avoid.
+    val outputDir = tempFolder.newFolder("renders-tb-backdrop")
+    val recordingsRoot = tempFolder.newFolder("recordings-tb-backdrop")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID)
+            RenderSpec(
+              className = STICKER_CLASS,
+              functionName = "WrapContentStickerPreview",
+              widthPx = 200,
+              heightPx = 200,
+              wrapWidth = true,
+              wrapHeight = true,
+              density = 1.0f,
+              showBackground = true,
+              backgroundColor = 0xFFFFFFFF,
+              outputBaseName = "tb-backdrop",
+              overrides = PreviewOverrides(talkBack = true),
+            )
+          else null
+        },
+      )
+    host.start()
+    try {
+      host
+        .acquireRecordingSession(
+          FIXTURE_PREVIEW_ID,
+          "rec-tb-backdrop",
+          javaClass.classLoader ?: ClassLoader.getSystemClassLoader(),
+          FPS,
+          2.0f,
+          null,
+        )
+        .use { session ->
+          session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "recording.probe")))
+          val result = session.stop()
+          // Scene kept whole (200x200) and scaled by 2 — the scale is honoured, the crop is not
+          // taken.
+          assertEquals(400 to 400, result.frameWidthPx to result.frameHeightPx)
+          val img = ImageIO.read(File(result.framesDir, "frame-00000.png"))
+          // The sticker is far smaller than its 200 dp sandbox, so the far corner is sandbox. It
+          // must still be transparent: filling it would be the defect.
+          assertEquals(
+            "a scene-framed recording's sandbox must not be filled",
+            0,
+            img.getRGB(390, 390) ushr 24,
+          )
+        }
+    } finally {
+      host.shutdown()
+    }
   }
 
   /** The still of the same fixture through the same engine, for the comparison above. */

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingWrappedFrameTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingWrappedFrameTest.kt
@@ -598,6 +598,114 @@ class DesktopRecordingWrappedFrameTest {
     }
   }
 
+  @Test
+  fun `a missing frame fails a fixed-size recording too`() {
+    // The frame check has to run BEFORE the no-op fast path, or every recording that takes that
+    // path — fixed-size ones above all — reports success and the original count over a set with a
+    // hole in it (#4481 review).
+    val outputDir = tempFolder.newFolder("renders-missing-fixed")
+    val recordingsRoot = tempFolder.newFolder("recordings-missing-fixed")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID)
+            RenderSpec(
+              className = STICKER_CLASS,
+              functionName = "TristateClickSquare",
+              widthPx = FIXED_WIDTH_PX,
+              heightPx = FIXED_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "missing-frame-fixed",
+            )
+          else null
+        },
+      )
+    host.start()
+    try {
+      host
+        .acquireRecordingSession(
+          FIXTURE_PREVIEW_ID,
+          "rec-missing-fixed",
+          javaClass.classLoader ?: ClassLoader.getSystemClassLoader(),
+          FPS,
+          1.0f,
+          null,
+          live = true,
+        )
+        .use { session ->
+          Thread.sleep(250L)
+          val frame0 = File(recordingsRoot, "frames/rec-missing-fixed/frame-00000.png")
+          assertTrue("the tick thread should have written frames by now", frame0.isFile)
+          assertTrue("could not delete the frame under test", frame0.delete())
+          val thrown = runCatching { session.stop() }.exceptionOrNull()
+          assertTrue("expected finalization to fail, got $thrown", thrown is IllegalStateException)
+        }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun `a popup reaching the scene bounds is not mistaken for content growth`() {
+    // The crop extent folds every semantics owner in so a popup is not cut off; the growth range
+    // must not, or a static component with a dropdown out at the sandbox edge reads as grown and
+    // the backdrop floods the transparent sandbox around the popup (#4481 review).
+    val outputDir = tempFolder.newFolder("renders-popup")
+    val recordingsRoot = tempFolder.newFolder("recordings-popup")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = outputDir),
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID)
+            RenderSpec(
+              className = STICKER_CLASS,
+              functionName = "PopupBesideStaticBlock",
+              widthPx = 400,
+              heightPx = 800,
+              wrapWidth = true,
+              wrapHeight = true,
+              density = 1.0f,
+              showBackground = true,
+              outputBaseName = "popup-static",
+            )
+          else null
+        },
+      )
+    host.start()
+    try {
+      host
+        .acquireRecordingSession(
+          FIXTURE_PREVIEW_ID,
+          "rec-popup",
+          javaClass.classLoader ?: ClassLoader.getSystemClassLoader(),
+          FPS,
+          1.0f,
+          null,
+        )
+        .use { session ->
+          session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "recording.probe")))
+          val result = session.stop()
+          val frame = File(result.framesDir, "frame-00000.png")
+          val img =
+            ByteArrayInputStream(frame.readBytes()).use { ImageIO.read(it) }
+              ?: error("frame failed to decode")
+          // Between the 60x30 block and the popup out at (300, 700): sandbox, and it should stay
+          // transparent. A false growth reading fills this with the opaque preview background.
+          val alpha = img.getRGB(200, 400) ushr 24
+          assertEquals("sandbox around the popup must stay transparent", 0, alpha)
+        }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   /** The still of the same fixture through the same engine, for the comparison above. */
   private fun renderStill(label: String): Pair<Int, Int> {
     val engine = RenderEngine(outputDir = tempFolder.newFolder("renders-$label"))

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -64,9 +64,11 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
 
 /**
  * Test fixtures for [RenderEngineTest] / [JsonRpcDesktopIntegrationTest]. Lives in the test source
@@ -948,6 +950,23 @@ fun TristateClickSquare() {
 @Composable
 fun HalfSandboxBlock() {
   Box(modifier = Modifier.size(width = 400.dp, height = 800.dp).background(Color(0xFFEF5350)))
+}
+
+/**
+ * Static wrap-content block with a **popup** reaching the sandbox bounds (issue #4467 review).
+ *
+ * The content box never changes size; the popup paints into a semantics owner of its own, well
+ * outside it. That is the case that separates the *crop* extent — which must fold the popup in, or
+ * the dropdown gets cut off — from the *growth* range, which must not: reading this recording as
+ * grown would flood the transparent sandbox around the popup with the opaque preview background.
+ */
+@Composable
+fun PopupBesideStaticBlock() {
+  Box(modifier = Modifier.size(width = 60.dp, height = 30.dp).background(Color(0xFFEF5350))) {
+    Popup(offset = IntOffset(300, 700)) {
+      Box(modifier = Modifier.size(20.dp).background(Color(0xFF1E88E5)))
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Follow-up to #4474 (tracked on #4467). Four defects in the deferred-reframe path that landed with it.

## What

1. **A TalkBack recording was given a backdrop it doesn't want.** The overlay frames itself against the scene, so the deferred backdrop fill painted the preview background over pixels the overlay had already framed. `backdropArgb` is now `0` when the overlay owns the framing.
2. **Growth landing exactly on the scene bound skipped the backdrop fill.** With nothing left to crop and nothing to scale, the early return in `finalizeFrames` fired before the fill, so the padded region stayed transparent under an opaque preview background. The session now tracks the *minimum* measured extent alongside the maximum and keeps filling when the content grew.
3. **A frame missing at finalization was silently skipped**, truncating the recording rather than reporting it. It now fails with the recording id and frame name.
4. **Fixed-size scaling round-tripped every frame through PNG.** `frameBytes` encoded a natural PNG, decoded it, scaled with AWT, and re-encoded. It now scales on the Skia surface and encodes once.

Non-visual: this changes recording *plumbing*, and the three behaviours that are visible (1–3) are asserted on pixels in the new tests rather than being renderable `@Preview` surfaces.

## Test plan

`./gradlew :daemon:desktop:test :daemon:core:test :daemon:desktop:ktfmtCheck :daemon:core:ktfmtCheck` — green.

Three new tests in `DesktopRecordingWrappedFrameTest`, each **verified red against the unfixed code** before being kept:

- `a scene-framed TalkBack recording is not given a backdrop`
- `a growing recording is padded even when growth lands on the scene bounds`
- `a missing frame fails finalization rather than truncating the recording` (runs in live mode so the tick thread writes frames before `stop()`, which a scripted recording would not)

(4) has no dedicated test: it is a pixel-equivalent encode path with no non-brittle behavioural assertion available, so it rides on the existing scaled-recording tests staying green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFZsM7PxPecadiVjWQTyAR)_