### PR TITLE
fix(release): avoid long-path fixtures in Windows XR checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,6 +451,12 @@ jobs:
         with:
           ref: ${{ env.TAG_NAME }}
           persist-credentials: false
+          # This job only builds the native compositor. Keep unrelated conformance fixtures out of
+          # the Windows checkout: one intentionally exercises a 255-character path segment, whose
+          # full repository path exceeds the runner's legacy MAX_PATH limit.
+          sparse-checkout: |
+            .github/actions/build-xr-composite
+            renderers/xr-composite
       - name: Derive plugin version from tag
         shell: bash
         run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"

--- a/.github/workflows/xr-composite-build.yml
+++ b/.github/workflows/xr-composite-build.yml
@@ -54,6 +54,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # A long-path conformance fixture exceeds the default Windows checkout limit, and this
+          # native build does not consume it. Limit checkout to the shared action and its sources.
+          sparse-checkout: |
+            .github/actions/build-xr-composite
+            renderers/xr-composite
 
       # Build + stage into dist/ via the shared composite action (also used by
       # the release asset job in release.yml).

--- a/.github/workflows/xr-composite-release-smoke.yml
+++ b/.github/workflows/xr-composite-release-smoke.yml
@@ -46,6 +46,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # A long-path conformance fixture exceeds the default Windows checkout limit, and this
+          # native build does not consume it. Limit checkout to the shared action and its sources.
+          sparse-checkout: |
+            .github/actions/build-xr-composite
+            renderers/xr-composite
       - uses: ./.github/actions/build-xr-composite
         with:
           platform: ${{ matrix.sdk }}


### PR DESCRIPTION
## Summary

- sparse-checkout only the shared XR build action and compositor sources in the release matrix
- apply the same checkout boundary to the standalone XR build and release-smoke workflows
- avoid the unrelated 255-character path-segment fixture that made actions/checkout fail on Windows before the release asset build started

Fixes the publishing failure in https://github.com/yschimke/compose-ai-tools/actions/runs/32688636170.

After merge, dispatch the Release workflow for v1.33.0 to upload the missing XR asset and finalize the drafted release. Re-running the original failed job would use its original workflow definition.

## Verification

- git diff --check
- parsed all three changed workflow files as YAML
- reproduced the sparse checkout against v1.33.0 and confirmed the build action plus renderers/xr-composite are present while the long-path fixture is absent