### PR TITLE
fix(renderer): preserve dark theme on CMP 1.12

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.LocalInspectionTables
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
@@ -49,7 +48,9 @@ import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
 import ee.schimke.composeai.data.render.extensions.compose.CompositionTracing
+import ee.schimke.composeai.data.render.extensions.compose.PreviewSystemTheme
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.data.render.extensions.isStructuralPreviewWrapper
 import ee.schimke.composeai.data.render.extensions.loadPreviewWrapperClass
 import ee.schimke.composeai.data.render.extensions.provides
@@ -293,7 +294,7 @@ class RenderEngine(
    * inspection branch. Interactive sessions pass `false` so `pointerInput` modifiers fire and the
    * preview shows its real, click-aware behaviour.
    */
-  @OptIn(androidx.compose.ui.InternalComposeUiApi::class, ExperimentalResourceApi::class)
+  @OptIn(ExperimentalResourceApi::class)
   fun setUp(
     spec: RenderSpec,
     classLoader: ClassLoader =
@@ -532,10 +533,11 @@ class RenderEngine(
             // probe.
             val systemTheme =
               when (spec.uiMode) {
-                RenderSpec.SpecUiMode.DARK -> SystemTheme.Dark
-                RenderSpec.SpecUiMode.LIGHT -> SystemTheme.Light
-                null -> SystemTheme.Unknown
+                RenderSpec.SpecUiMode.DARK -> PreviewSystemTheme.Dark
+                RenderSpec.SpecUiMode.LIGHT -> PreviewSystemTheme.Light
+                null -> PreviewSystemTheme.Unknown
               }
+            val systemThemeValue = previewSystemThemeValue(systemTheme)
             val previewResources = remember(classLoader) { previewResourceReader(classLoader) }
             CompositionLocalProvider(
               LocalInspectionMode provides inspectionMode,
@@ -555,7 +557,7 @@ class RenderEngine(
               // it to match the transparent harness background below. Defaults false.
               ee.schimke.composeai.preview.slots.LocalPreviewBackgroundCleared provides
                 spec.clearBackground,
-              androidx.compose.ui.LocalSystemTheme provides systemTheme,
+              systemThemeValue,
               LocalDensity provides density,
               // Interactive Lottie scrubbing: a non-null progress lands the captured frame at that
               // timeline position, winning over the composable's authored progress (file-discovered

--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/PreviewSystemTheme.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/PreviewSystemTheme.kt
@@ -1,0 +1,63 @@
+package ee.schimke.composeai.data.render.extensions.compose
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ProvidedValue
+import java.lang.reflect.ParameterizedType
+
+/** A renderer-owned system-theme value, independent of Compose's binary-incompatible enum. */
+public enum class PreviewSystemTheme {
+  Dark,
+  Light,
+  Unknown,
+}
+
+/**
+ * Returns the `LocalSystemTheme` value needed by the Compose version that is actually running.
+ *
+ * Compose Multiplatform 1.12 changed the local's value from `androidx.compose.ui.SystemTheme` to
+ * `org.jetbrains.skiko.SystemTheme` while leaving the erased JVM getter unchanged. Code compiled
+ * against 1.11 therefore still linked on 1.12, but placed the old enum in the new local; the
+ * comparison inside `isSystemInDarkTheme()` could then never succeed. Resolve both the local and
+ * its generic value type from the runtime getter so one renderer binary works on either side of
+ * that change.
+ *
+ * This deliberately keeps the reflection at this single compatibility boundary. Callers receive an
+ * ordinary [ProvidedValue] and can pass it to `CompositionLocalProvider` with their other locals.
+ */
+public fun previewSystemThemeValue(theme: PreviewSystemTheme): ProvidedValue<*> {
+  val binding = RuntimeSystemThemeBinding.value
+  val enumValue =
+    binding.themeClass.enumConstants?.firstOrNull {
+      (it as Enum<*>).name.equals(theme.name, ignoreCase = true)
+    }
+      ?: error(
+        "Compose LocalSystemTheme value type ${binding.themeClass.name} has no ${theme.name} value"
+      )
+  return binding.local.provides(enumValue)
+}
+
+private data class SystemThemeBinding(
+  val local: ProvidableCompositionLocal<Any?>,
+  val themeClass: Class<*>,
+)
+
+private object RuntimeSystemThemeBinding {
+  val value: SystemThemeBinding by lazy {
+    val getterClass = Class.forName("androidx.compose.ui.SystemThemeKt")
+    val getter = getterClass.getMethod("getLocalSystemTheme")
+    @Suppress("UNCHECKED_CAST") val local = getter.invoke(null) as ProvidableCompositionLocal<Any?>
+
+    // Both 1.11 and 1.12 retain this generic signature even though its JVM descriptor is erased.
+    // Fall back to the 1.11 type if a future bytecode transformer strips Signature attributes;
+    // this preserves the oldest supported runtime instead of guessing from Skiko's presence (the
+    // Skiko enum exists on both sides of the change).
+    val themeClass =
+      ((getter.genericReturnType as? ParameterizedType)?.actualTypeArguments?.singleOrNull()
+        as? Class<*>) ?: Class.forName("androidx.compose.ui.SystemTheme")
+
+    require(themeClass.isEnum) {
+      "Compose LocalSystemTheme value type ${themeClass.name} is not an enum"
+    }
+    SystemThemeBinding(local = local, themeClass = themeClass)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,9 @@ compose-bom-compat = "2025.11.01"
 # ref is therefore a SERVE-HOST RELEASE concern, not just a build-hygiene one — see
 # `docs/RENDERER_COMPATIBILITY.md`.
 compose-multiplatform = "1.11.1"
+# Consumer runtime used by renderer forward-compatibility tests. Keep this on the newest CMP line
+# that catalogs are expected to adopt; it intentionally does not affect production compilation.
+compose-multiplatform-forward = "1.12.0-rc01"
 # The Compose M3 design catalog (`:samples:design-catalog-m3`) pins material3
 # FORWARD of `compose-bom-stable` (which carries 1.4.0) solely for the Material 3
 # **inset focus ring** APIs — `LocalRippleThemeConfiguration` +

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -24,6 +24,21 @@ val skikoEncodeProbe: Configuration by configurations.creating {
   description = "A skiko resolved for reflection only, never on a compile or runtime classpath."
 }
 
+/**
+ * The newest Compose line catalogs are allowed to run on, used only by the theme regression test.
+ *
+ * Extending the ordinary test runtime keeps this module's own compiled output and non-Compose
+ * dependencies, while the explicit newer desktop distribution wins Gradle conflict resolution for
+ * Compose and Skiko. This is the consumer shape that exposed the erased LocalSystemTheme enum
+ * change; running only against [libs.versions.compose.multiplatform] would miss it.
+ */
+val composeForwardTestRuntime: Configuration by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+  description = "Renderer tests running on the forward Compose Multiplatform 1.12 runtime."
+  extendsFrom(configurations.testRuntimeClasspath.get())
+}
+
 dependencies {
   implementation(compose.desktop.currentOs)
   implementation(libs.jetbrains.compose.ui)
@@ -59,6 +74,10 @@ dependencies {
   implementation(project(":common-io"))
   // PreviewBackground — the shared showBackground/backgroundColor/uiMode resolution.
   implementation(project(":data-render-core"))
+  // Runtime-aware LocalSystemTheme binding. CMP 1.12 changed the local from the androidx enum to
+  // the Skiko enum without changing its erased JVM getter, so a direct provider silently breaks
+  // dark previews when this 1.11-compiled renderer runs inside a 1.12 catalog.
+  implementation(project(":data-render-compose"))
   // `kind=LOTTIE` previews: DesktopRendererMain inflates a discovered Lottie asset via the
   // `LottiePreview` helper (brings Compottie + Compose foundation transitively).
   implementation(project(":lottie-preview-runtime"))
@@ -93,6 +112,13 @@ dependencies {
   // the test runtime classpath instead would let conflict resolution pick ONE skiko for the whole
   // module, which is precisely the mechanism being guarded against.
   skikoEncodeProbe(libs.skiko.awt.encode.probe)
+
+  // Keep this explicit rather than deriving it from the production pin: the point of the task is
+  // to preserve a second, forward runtime line. `currentOs` chooses the correct native Skiko
+  // artifact on macOS/Linux/Windows; the strict version upgrades that distribution from 1.11.1.
+  composeForwardTestRuntime(compose.desktop.currentOs) {
+    version { strictly(libs.versions.compose.multiplatform.forward.get()) }
+  }
 }
 
 tasks.withType<Test>().configureEach {
@@ -106,6 +132,19 @@ tasks.withType<Test>().configureEach {
     .withNormalizer(ClasspathNormalizer::class)
   doFirst { systemProperty("composeai.test.skikoEncodeProbe", probeJars.asPath) }
 }
+
+val forwardComposeSystemThemeTest by
+  tasks.registering(Test::class) {
+    group = "verification"
+    description = "Runs the light/dark renderer invariant on Compose Multiplatform 1.12.0-rc01."
+    val testSourceSet = sourceSets.test.get()
+    testClassesDirs = testSourceSet.output.classesDirs
+    classpath = testSourceSet.output + sourceSets.main.get().output + composeForwardTestRuntime
+    filter { includeTestsMatching("ee.schimke.composeai.renderer.UiModeSystemThemeTest") }
+    shouldRunAfter(tasks.test)
+  }
+
+tasks.check { dependsOn(forwardComposeSystemThemeTest) }
 
 composeAiMavenPublishing {
   coordinates(

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -29,6 +29,7 @@ import ee.schimke.composeai.daemon.FocusOverlayDesktop
 import ee.schimke.composeai.daemon.FocusOverrideExtension
 import ee.schimke.composeai.daemon.protocol.FocusDirection
 import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.scroll.ScrollAxis
 import java.awt.Rectangle
@@ -130,9 +131,7 @@ data class DesktopFocusIntent(
  * Returns `true` when [outputFile] was written, `false` when the walk found nothing focusable — the
  * caller falls back to the ordinary single-frame render so a misuse still produces a capture.
  */
-// `InternalComposeUiApi` for `LocalSystemTheme` — the same opt-in [renderPreview] carries, and how
-// Compose Desktop's `isSystemInDarkTheme()` is driven.
-@OptIn(ExperimentalTestApi::class, androidx.compose.ui.InternalComposeUiApi::class)
+@OptIn(ExperimentalTestApi::class)
 fun renderFocusPreview(
   className: String,
   functionName: String,
@@ -239,13 +238,14 @@ fun renderFocusPreview(
       mainClock.autoAdvance = false
 
       val systemTheme = systemThemeFromUiMode(uiMode)
+      val systemThemeValue = previewSystemThemeValue(systemTheme)
       setContent {
         val baseProviders: @Composable (@Composable () -> Unit) -> Unit = { inner ->
           if (rtl) {
             CompositionLocalProvider(
               LocalInspectionMode provides true,
               LocalDensity provides sceneDensity,
-              androidx.compose.ui.LocalSystemTheme provides systemTheme,
+              systemThemeValue,
               androidx.compose.ui.platform.LocalLayoutDirection provides
                 androidx.compose.ui.unit.LayoutDirection.Rtl,
             ) {
@@ -255,7 +255,7 @@ fun renderFocusPreview(
             CompositionLocalProvider(
               LocalInspectionMode provides true,
               LocalDensity provides sceneDensity,
-              androidx.compose.ui.LocalSystemTheme provides systemTheme,
+              systemThemeValue,
             ) {
               inner()
             }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopMotionCapture.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.motion.ApngEncoder
 import ee.schimke.composeai.motion.apngDelayFor
 import ee.schimke.composeai.scroll.ScrollGifEncoder
@@ -159,11 +160,6 @@ internal fun motionFormatArg(raw: String?, default: MotionFormatKind): MotionFor
  * disagreeing with the daemon over exactly this, but the animation path never did, so until this
  * became shared code a dark `@AnimatedPreview` on desktop silently captured the light theme.
  */
-// `LocalSystemTheme` is `@InternalComposeUiApi` — opted into here for the same reason the
-// single-frame path does at `DesktopRendererMain`: it is the only seam Compose Desktop's
-// `isSystemInDarkTheme()` reads, so a renderer that must honour `@Preview(uiMode = …)` has no
-// public alternative.
-@OptIn(androidx.compose.ui.InternalComposeUiApi::class)
 @Composable
 internal fun MotionPreviewProviders(
   rtl: Boolean,
@@ -172,11 +168,12 @@ internal fun MotionPreviewProviders(
   content: @Composable () -> Unit,
 ) {
   val systemTheme = systemThemeFromUiMode(uiMode)
+  val systemThemeValue = previewSystemThemeValue(systemTheme)
   if (rtl) {
     CompositionLocalProvider(
       LocalInspectionMode provides false,
       LocalDensity provides sceneDensity,
-      androidx.compose.ui.LocalSystemTheme provides systemTheme,
+      systemThemeValue,
       androidx.compose.ui.platform.LocalLayoutDirection provides
         androidx.compose.ui.unit.LayoutDirection.Rtl,
       content = content,
@@ -185,7 +182,7 @@ internal fun MotionPreviewProviders(
     CompositionLocalProvider(
       LocalInspectionMode provides false,
       LocalDensity provides sceneDensity,
-      androidx.compose.ui.LocalSystemTheme provides systemTheme,
+      systemThemeValue,
       content = content,
     )
   }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -23,6 +23,8 @@ import ee.schimke.composeai.daemon.DeviceFrameDataProducer
 import ee.schimke.composeai.daemon.DisplayFilterConfig
 import ee.schimke.composeai.daemon.DisplayFilterDataProducer
 import ee.schimke.composeai.data.render.LinkBufferComposer
+import ee.schimke.composeai.data.render.extensions.compose.PreviewSystemTheme
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.preview.lottie.LottiePreview
 import ee.schimke.composeai.preview.svg.SvgPreview
@@ -1135,17 +1137,16 @@ private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
 }
 
 /**
- * Maps a `@Preview(uiMode = …)` int to the [androidx.compose.ui.SystemTheme] to provide as
+ * Maps a `@Preview(uiMode = …)` int to the renderer-owned system theme to provide as
  * `LocalSystemTheme`, which Compose Desktop's `isSystemInDarkTheme()` reads. Only the
  * `UI_MODE_NIGHT_*` bits (`0x30` mask) matter: `0x20` (`UI_MODE_NIGHT_YES`) → dark, `0x10`
  * (`UI_MODE_NIGHT_NO`) → light, `UI_MODE_NIGHT_UNDEFINED` → `Unknown` (leaves the JVM's own probe).
  */
-@OptIn(androidx.compose.ui.InternalComposeUiApi::class)
-internal fun systemThemeFromUiMode(uiMode: Int): androidx.compose.ui.SystemTheme =
+internal fun systemThemeFromUiMode(uiMode: Int): PreviewSystemTheme =
   when (uiMode and 0x30) {
-    0x20 -> androidx.compose.ui.SystemTheme.Dark
-    0x10 -> androidx.compose.ui.SystemTheme.Light
-    else -> androidx.compose.ui.SystemTheme.Unknown
+    0x20 -> PreviewSystemTheme.Dark
+    0x10 -> PreviewSystemTheme.Light
+    else -> PreviewSystemTheme.Unknown
   }
 
 /**
@@ -1207,7 +1208,6 @@ internal fun rendersRightToLeft(localeTag: String?): Boolean {
   return ee.schimke.composeai.data.pseudolocale.LocaleDirection.isRtl(effectiveLocaleTag(localeTag))
 }
 
-@OptIn(androidx.compose.ui.InternalComposeUiApi::class)
 internal fun renderPreview(
   className: String,
   functionName: String,
@@ -1342,13 +1342,14 @@ internal fun renderPreview(
     // night bit — otherwise a dark `@Preview` renders its content in light colours (the cover PNG
     // disagreed with the daemon's figma-svg/semantics, which already do this in RenderEngine).
     val systemTheme = systemThemeFromUiMode(uiMode)
+    val systemThemeValue = previewSystemThemeValue(systemTheme)
     scene.setContent {
       val baseProviders: @Composable (@Composable () -> Unit) -> Unit = { inner ->
         if (rtl) {
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,
-            androidx.compose.ui.LocalSystemTheme provides systemTheme,
+            systemThemeValue,
             androidx.compose.ui.platform.LocalLayoutDirection provides
               androidx.compose.ui.unit.LayoutDirection.Rtl,
           ) {
@@ -1358,7 +1359,7 @@ internal fun renderPreview(
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,
-            androidx.compose.ui.LocalSystemTheme provides systemTheme,
+            systemThemeValue,
           ) {
             inner()
           }

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.scroll.DEFAULT_LONG_SCROLL_STEP_FRACTION
 import ee.schimke.composeai.scroll.HOLD_END_MS
@@ -87,9 +88,7 @@ enum class DesktopScrollMode {
  * keeping a shadow, and the annotation's KDoc says exactly that. A declined drive falls back to
  * [renderPreview], which is a still and does apply the gutter.
  */
-// `InternalComposeUiApi` for `LocalSystemTheme`, the same opt-in [renderPreview] carries for the
-// same local — it is how Compose Desktop's `isSystemInDarkTheme()` is driven.
-@OptIn(ExperimentalTestApi::class, androidx.compose.ui.InternalComposeUiApi::class)
+@OptIn(ExperimentalTestApi::class)
 fun renderScrollPreview(
   className: String,
   functionName: String,
@@ -185,6 +184,7 @@ fun renderScrollPreview(
     // `LocalSystemTheme.current`, so a scroll capture that never provided it rendered a dark
     // preview's content in light colours.
     val systemTheme = systemThemeFromUiMode(uiMode)
+    val systemThemeValue = previewSystemThemeValue(systemTheme)
     setContent {
       // Shared with [renderPreview] via `PreviewBackground` so both paths agree — in particular
       // `showBackground = true` on a night preview is NOT white, which is what the local
@@ -202,7 +202,7 @@ fun renderScrollPreview(
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,
-            androidx.compose.ui.LocalSystemTheme provides systemTheme,
+            systemThemeValue,
             androidx.compose.ui.platform.LocalLayoutDirection provides
               androidx.compose.ui.unit.LayoutDirection.Rtl,
           ) {
@@ -212,7 +212,7 @@ fun renderScrollPreview(
           CompositionLocalProvider(
             LocalInspectionMode provides true,
             LocalDensity provides sceneDensity,
-            androidx.compose.ui.LocalSystemTheme provides systemTheme,
+            systemThemeValue,
           ) {
             inner()
           }

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/UiModeSystemThemeTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/UiModeSystemThemeTest.kt
@@ -9,9 +9,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.unit.Density
+import ee.schimke.composeai.data.render.extensions.compose.PreviewSystemTheme
+import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
-import org.jetbrains.skia.EncodedImageFormat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,20 +22,35 @@ import org.junit.Test
  * system-bar chrome — `DesktopRendererMain` provides `LocalSystemTheme` (which Compose Desktop's
  * `isSystemInDarkTheme()` reads) from the night bit. This pins both the [systemThemeFromUiMode]
  * mapping and that providing it actually flips `isSystemInDarkTheme()` in a render — the regression
- * where a dark `@Preview`'s cover PNG rendered its content in light colours.
+ * where a dark `@Preview`'s cover PNG rendered its content in light colours. The same test class is
+ * also run by `forwardComposeSystemThemeTest` on CMP 1.12.0-rc01, whose local holds Skiko's enum.
  */
-@OptIn(androidx.compose.ui.InternalComposeUiApi::class)
 class UiModeSystemThemeTest {
 
   @Test
   fun `uiMode night bits map to the system theme`() {
-    assertEquals(androidx.compose.ui.SystemTheme.Dark, systemThemeFromUiMode(0x20))
-    assertEquals(androidx.compose.ui.SystemTheme.Light, systemThemeFromUiMode(0x10))
-    assertEquals(androidx.compose.ui.SystemTheme.Unknown, systemThemeFromUiMode(0))
+    assertEquals(
+      PreviewSystemTheme.Dark,
+      systemThemeFromUiMode(0x20),
+    )
+    assertEquals(
+      PreviewSystemTheme.Light,
+      systemThemeFromUiMode(0x10),
+    )
+    assertEquals(
+      PreviewSystemTheme.Unknown,
+      systemThemeFromUiMode(0),
+    )
     // Real `@Preview(uiMode = 32)` value carries only the night-yes bit.
-    assertEquals(androidx.compose.ui.SystemTheme.Dark, systemThemeFromUiMode(32))
+    assertEquals(
+      PreviewSystemTheme.Dark,
+      systemThemeFromUiMode(32),
+    )
     // Unrelated bits (e.g. UI_MODE_TYPE_CAR) don't change the night decision.
-    assertEquals(androidx.compose.ui.SystemTheme.Dark, systemThemeFromUiMode(0x20 or 0x03))
+    assertEquals(
+      PreviewSystemTheme.Dark,
+      systemThemeFromUiMode(0x20 or 0x03),
+    )
   }
 
   /** The single center pixel after rendering `isSystemInDarkTheme()`-driven fill under [uiMode]. */
@@ -42,9 +58,7 @@ class UiModeSystemThemeTest {
     val scene = ImageComposeScene(width = 16, height = 16, density = Density(1f))
     try {
       scene.setContent {
-        CompositionLocalProvider(
-          androidx.compose.ui.LocalSystemTheme provides systemThemeFromUiMode(uiMode)
-        ) {
+        CompositionLocalProvider(previewSystemThemeValue(systemThemeFromUiMode(uiMode))) {
           // Green when the composition reports dark, red when light — a direct read of the flip the
           // renderer's provider drives. A bare Layout keeps the fill exactly the sandbox size.
           val fill = if (isSystemInDarkTheme()) Color.Green else Color.Red
@@ -55,7 +69,9 @@ class UiModeSystemThemeTest {
       }
       scene.render()
       val image = scene.render()
-      val png = image.encodeToData(EncodedImageFormat.PNG) ?: error("encode failed")
+      // Use the renderer's late-bound encoder: CMP 1.12 also carries the new three-argument Skiko
+      // encode bridge, so a direct call compiled on 1.11 would fail before pixels can be compared.
+      val png = image.encodePngData() ?: error("encode failed")
       val bmp = ByteArrayInputStream(png.bytes).use { ImageIO.read(it) }
       val rgb = bmp.getRGB(8, 8)
       return Triple((rgb shr 16) and 0xFF, (rgb shr 8) and 0xFF, rgb and 0xFF)
@@ -74,5 +90,13 @@ class UiModeSystemThemeTest {
   fun `night-no uiMode makes isSystemInDarkTheme report light in the render`() {
     val (r, g, b) = centerColor(0x10)
     assertTrue("expected red (light branch) but was ($r,$g,$b)", r > 150 && g < 100 && b < 100)
+  }
+
+  @Test
+  fun `forced dark and light renders use different pixels`() {
+    assertTrue(
+      "dark and light previews must not collapse to the same rendered colour",
+      centerColor(0x20) != centerColor(0x10),
+    )
   }
 }


### PR DESCRIPTION
## Goal

Fix Compose Multiplatform theming so dark desktop previews continue to render with the dark colour scheme on CMP 1.12, despite the runtime `LocalSystemTheme` enum change, while preserving CMP 1.11 compatibility. Add a dark-versus-light regression guard on the forward CMP line.

## Summary

- Added a runtime-aware `LocalSystemTheme` binding in `data/render/compose` that supplies either the AndroidX or Skiko enum expected by the resolved Compose runtime.
- Routed single-frame, scroll, focus, motion, and desktop-daemon rendering through the shared compatibility provider.
- Added a pixel invariant to `UiModeSystemThemeTest` and a `forwardComposeSystemThemeTest` task running it on CMP 1.12.0-rc01; wired the task into `check`.
- Rejected a direct typed `LocalSystemTheme` provider because its erased JVM signature links across CMP versions while silently supplying the wrong enum class.
- Known gap: the compatibility seam still reflects JetBrains' internal JVM getter because CMP 1.12 exposes no public system-theme override for headless renderers.
- Verification: full `:renderer-desktop:test`; CMP 1.11.1 and 1.12.0-rc01 pixel tests; desktop daemon `RenderEngineScrollUiModeTest` and `OverrideIntegrationTest`; scoped `ktfmtCheck`; `git diff --check`.

The repository's compose-preview PR workflow will publish the standard sticky preview-diff comment. The forward-runtime regression is verified directly by `UiModeSystemThemeTest`, which renders and compares the dark and light center pixels under CMP 1.12.0-rc01.
