### PR TITLE
fix(ci): unpin Gradle after serializing cancellation repair

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -167,14 +167,6 @@
         "@types/vscode"
       ],
       "enabled": false
-    },
-    {
-      "description": "Gradle wrapper: hold at 9.7.0. Under 9.7.1 a second build invocation in one session leaves `:samples:cmp`'s Kotlin output with zero .class files, so `composePreviewDiscover` writes an assets-only manifest and `composePreviewRender` then fails with 'matched no previews' — the `interactive-e-g` shard of VS Code Extension E2E went red the moment 9.7.1 landed (#4318) and stayed red across unrelated commits. Measured with three dispatched five-shard runs: 9.7.1 fails, both pins reverted passes, and wrapper-only-reverted ALSO passes — which is why `org.gradle:gradle-tooling-api` is deliberately NOT pinned here (it is on 9.7.1 and innocent; the refresh path shells out to gradlew rather than driving the tooling API). Written as an exact-version REGEX rather than a `<=9.7.0` range: the `gradle-wrapper` manager resolves through the `gradle` versioning module, which does not support npm-style ranges, so a comparison constraint is not applied and the pin would silently let 9.7.1 straight back in. Same shape as the `slf4j-nop` exact pin above. Pinning to exactly 9.7.0 also holds back 9.7.2+, which is deliberate — every later release is equally unverified against this regression, and nothing should move without an e2e run. This cap is temporary and #4364 tracks removing it — close that issue by deleting this rule, and dispatch the e2e on the branch before merging, since a push run can be cancelled by the next merge and prove nothing.",
-      "matchManagers": [
-        "gradle-wrapper"
-      ],
-      "matchCurrentValue": "/^9\\.7\\.0$/",
-      "allowedVersions": "/^9\\.7\\.0$/"
     }
   ]
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -800,10 +800,12 @@ object PreviewDiscovery {
     // breaking on it.
     val previewAnnotationsMissing = scanClassCount > 0 && reachablePreviewFqns.isEmpty()
     val codePreviewCount = allPreviews.count { it.params.kind !in ASSET_PREVIEW_KINDS }
-    // Preserve asset-only modules as valid: the stricter failure applies only when the original
-    // zero-preview contract fires, or when the source/output invariant above proves compilation is
-    // empty. This catches #3600 without making --fail-on-empty reject intentional asset catalogs.
-    if ((normalized.isEmpty() || emptyCompiledOutputs) && input.failOnEmpty) {
+    // Preserve intentional asset-only modules as valid, but never accept a module whose source
+    // declares @Preview while its compiled outputs are empty. That state is a broken/cancelled
+    // compilation, not "zero previews", and writing an assets-only manifest over the previous
+    // healthy one hides the actual fault (#4364). failOnEmpty continues to control only the
+    // legitimate zero-preview case.
+    if (emptyCompiledOutputs || (normalized.isEmpty() && input.failOnEmpty)) {
       val failureSummary =
         if (emptyCompiledOutputs) {
           "empty compiled outputs ($codePreviewCount code previews; ${allPreviews.size} total)"
@@ -812,7 +814,7 @@ object PreviewDiscovery {
         }
       val diagnostics =
         buildEmptyDiagnostics(
-          header = "composePreview: failOnEmpty diagnostics ($failureSummary):",
+          header = "composePreview: discovery failure diagnostics ($failureSummary):",
           existingClassDirs = existingClassDirs,
           allClassDirs = input.classDirs,
           projectJars = existingProjectJars,
@@ -829,7 +831,11 @@ object PreviewDiscovery {
           "the @Preview annotation class is not on the ClassGraph classpath " +
             "(dependency-jar filter dropped every jar carrying it)"
         } else {
-          "with failOnEmpty=true"
+          if (emptyCompiledOutputs) {
+            "compiled outputs are empty; rerun with --no-build-cache --rerun-tasks"
+          } else {
+            "with failOnEmpty=true"
+          }
         }
       return Outcome.Failure(
         reason =

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -67,10 +67,10 @@ object PreviewDiscovery {
     /**
      * Source files belonging to the compilation represented by [activeClassDirs]. [sourceFiles] can
      * contain every source set so discovery can map class metadata back to source paths, but
-     * inactive source sets must not trigger the empty-compile integrity guard. Empty falls back to
-     * [sourceFiles] for non-Gradle callers.
+     * inactive source sets must not trigger the empty-compile integrity guard. `null` falls back to
+     * [sourceFiles] for callers that do not model compilations; an empty list is authoritative.
      */
-    val activeSourceFiles: List<File> = emptyList(),
+    val activeSourceFiles: List<File>? = null,
     /**
      * Logical module name surfaced via [PreviewManifest.module]. Bazel rules use the target label;
      * Gradle uses the project path.
@@ -488,7 +488,7 @@ object PreviewDiscovery {
     // Check only the active compilation output. [Input.classDirs] deliberately contains fallback
     // layouts for discovery compatibility; stale classes in an inactive target must not hide an
     // empty cache restore in the compilation that just ran.
-    val integritySourceFiles = input.activeSourceFiles.ifEmpty { input.sourceFiles }
+    val integritySourceFiles = input.activeSourceFiles ?: input.sourceFiles
     val previewSourceFiles = integritySourceFiles.filter {
       it.isFile && !it.isTestSourceSetFile() && it.declaresPreviewAnnotation()
     }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -80,7 +80,7 @@ class LottieAssetDiscoveryTest {
   }
 
   @Test
-  fun `asset preview cannot mask empty compiled outputs`() {
+  fun `asset preview cannot mask empty compiled outputs when failOnEmpty is false`() {
     val project = tempDir.newFolder("empty-compile")
     val classes = project.resolve("classes").apply { mkdirs() }
     val source =
@@ -103,10 +103,12 @@ class LottieAssetDiscoveryTest {
           failOnEmpty = false,
           resourceDirs = listOf(resources),
         )
-      ) as PreviewDiscovery.Outcome.Success
+      )
 
-    assertThat(outcome.manifest.previews).hasSize(1)
-    val warning = outcome.warnings.joinToString("\n")
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Failure::class.java)
+    val failure = outcome as PreviewDiscovery.Outcome.Failure
+    assertThat(failure.reason).contains("empty compiled outputs")
+    val warning = failure.warnings.joinToString("\n")
     assertThat(warning).contains("active class outputs contain 0 .class files")
     assertThat(warning).contains("--no-build-cache --rerun-tasks")
     assertThat(warning).contains("classFiles=0")
@@ -201,7 +203,7 @@ class LottieAssetDiscoveryTest {
           failOnEmpty = false,
           resourceDirs = listOf(resources),
         )
-      ) as PreviewDiscovery.Outcome.Success
+      ) as PreviewDiscovery.Outcome.Failure
 
     val warning = outcome.warnings.joinToString("\n")
     assertThat(warning).contains("active class outputs contain 0 .class files")
@@ -271,7 +273,7 @@ class LottieAssetDiscoveryTest {
               failOnEmpty = false,
               resourceDirs = listOf(resources),
             )
-          ) as PreviewDiscovery.Outcome.Success
+          ) as PreviewDiscovery.Outcome.Failure
 
         assertThat(outcome.warnings.joinToString("\n"))
           .contains("active class outputs contain 0 .class files")

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -248,6 +248,38 @@ class LottieAssetDiscoveryTest {
   }
 
   @Test
+  fun `explicitly empty active sources do not fall back to inactive preview sources`() {
+    val project = tempDir.newFolder("empty-active-source-set")
+    val classes = project.resolve("classes/kotlin/desktop/main").apply { mkdirs() }
+    val inactiveSource =
+      project.resolve("src/androidMain/kotlin/AndroidPreview.kt").apply {
+        parentFile.mkdirs()
+        writeText("@NotificationPreview\nfun preview() = Unit")
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classes),
+          activeClassDirs = listOf(classes),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(inactiveSource),
+          activeSourceFiles = emptyList(),
+          moduleName = ":app",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = false,
+          resourceDirs = listOf(resources),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    assertThat(outcome.warnings.joinToString("\n")).doesNotContain("empty build-cache entry")
+    assertThat(outcome.manifest.previews).hasSize(1)
+  }
+
+  @Test
   fun `supported preview annotation names flag empty compiled outputs`() {
     val project = tempDir.newFolder("supported-preview-names")
     val classes = project.resolve("classes").apply { mkdirs() }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -3733,7 +3733,7 @@ class DiscoveryFunctionalTest {
     // Diagnostics block: classDirs listing (directory existence + class counts)
     // and the ClassGraph summary. These are the two lines users need to see to
     // disambiguate "wrong class dir" from "wrong @Preview FQN".
-    assertThat(result.output).contains("composePreview: failOnEmpty diagnostics")
+    assertThat(result.output).contains("composePreview: discovery failure diagnostics")
     assertThat(result.output).contains("classDirs (")
     assertThat(result.output).contains("ClassGraph scan:")
     // The sample had Compose classes but no @Preview — we should see the

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -72,6 +72,18 @@ export function moduleDirForTask(taskName: string): string | undefined {
     return path.join(...segments.slice(0, -1));
 }
 
+/** Module directories owned by every task in a combined Gradle invocation. */
+export function moduleDirsForInvocation(
+    taskName: string,
+    args: ReadonlyArray<string> = [],
+): ReadonlyArray<string> {
+    return [taskName, ...args].reduce<string[]>((modules, task) => {
+        const moduleDir = moduleDirForTask(task);
+        if (moduleDir && !modules.includes(moduleDir)) modules.push(moduleDir);
+        return modules;
+    }, []);
+}
+
 /** Directories a module's compiled classes can land in, relative to its project dir. */
 const CLASS_OUTPUT_ROOTS = [
     path.join("build", "classes"),
@@ -206,6 +218,12 @@ export class RealGradleApi implements GradleApi {
      */
     private readonly moduleRepairs = new Map<string, Promise<void>>();
 
+    /** Runs waiting for a module repair, keyed so cancellation can stop them before they spawn. */
+    private readonly queuedRuns = new Map<
+        string,
+        { taskName: string; cancelled: boolean }
+    >();
+
     /** @see invocations */
     get gradleInvocations(): ReadonlyArray<GradleInvocationRecord> {
         return this.invocations;
@@ -255,18 +273,22 @@ export class RealGradleApi implements GradleApi {
      * walk. Either way the module stops being suspect — this is the build that either repairs it
      * or proves it was fine.
      */
-    private repairArgsFor(
+    private repairModulesFor(
         projectFolder: string,
-        taskName: string,
+        moduleDirs: ReadonlyArray<string>,
     ): ReadonlyArray<string> {
-        const moduleDir = moduleDirForTask(taskName);
-        if (!moduleDir || !this.unvettedModules.has(moduleDir)) return [];
-        if (!hasEmptyClassOutputs(projectFolder, moduleDir)) return [];
-        this.onLog(
-            `[realGradleApi] ${moduleDir} has compiled output directories with no .class files ` +
-                `after a cancelled build — rerunning with ${CANCELLATION_REPAIR_ARGS.join(" ")}`,
-        );
-        return CANCELLATION_REPAIR_ARGS;
+        return moduleDirs.filter((moduleDir) => {
+            if (!this.unvettedModules.has(moduleDir)) return false;
+            if (!hasEmptyClassOutputs(projectFolder, moduleDir)) {
+                this.unvettedModules.delete(moduleDir);
+                return false;
+            }
+            this.onLog(
+                `[realGradleApi] ${moduleDir} has compiled output directories with no .class files ` +
+                    `after a cancelled build — rerunning with ${CANCELLATION_REPAIR_ARGS.join(" ")}`,
+            );
+            return true;
+        });
     }
 
     runTask(opts: {
@@ -280,24 +302,54 @@ export class RealGradleApi implements GradleApi {
         }) => void;
         cancellationKey?: string;
     }): Promise<void> {
-        const moduleDir = moduleDirForTask(opts.taskName);
-        const repairInFlight = moduleDir
-            ? this.moduleRepairs.get(moduleDir)
-            : undefined;
-        if (repairInFlight) {
+        const moduleDirs = moduleDirsForInvocation(opts.taskName, opts.args);
+        const repairsInFlight = [
+            ...new Set(
+                moduleDirs
+                    .map((moduleDir) => this.moduleRepairs.get(moduleDir))
+                    .filter((repair): repair is Promise<void> => !!repair),
+            ),
+        ];
+        if (repairsInFlight.length > 0) {
             this.onLog(
-                `[realGradleApi] ${moduleDir} cancellation repair is still running — queueing ${opts.taskName}`,
+                `[realGradleApi] cancellation repair is still running for ${moduleDirs.join(", ")} — queueing ${opts.taskName}`,
             );
-            return repairInFlight.then(() => this.runTask(opts));
+            const queued = { taskName: opts.taskName, cancelled: false };
+            if (opts.cancellationKey) {
+                this.queuedRuns.set(opts.cancellationKey, queued);
+            }
+            const afterRepairs = () => {
+                if (queued.cancelled) {
+                    throw new Error(
+                        `gradlew ${opts.taskName} cancelled before start`,
+                    );
+                }
+                return this.runTask(opts);
+            };
+            return Promise.all(repairsInFlight)
+                .then(afterRepairs, (error) => {
+                    if (queued.cancelled) return afterRepairs();
+                    throw error;
+                })
+                .finally(() => {
+                    if (
+                        opts.cancellationKey &&
+                        this.queuedRuns.get(opts.cancellationKey) === queued
+                    ) {
+                        this.queuedRuns.delete(opts.cancellationKey);
+                    }
+                });
         }
         const gradlewPath =
             process.platform === "win32"
                 ? path.join(this.gradlewDir, "gradlew.bat")
                 : path.join(this.gradlewDir, "gradlew");
-        const repairArgs = this.repairArgsFor(
+        const repairModules = this.repairModulesFor(
             opts.projectFolder,
-            opts.taskName,
+            moduleDirs,
         );
+        const repairArgs =
+            repairModules.length > 0 ? CANCELLATION_REPAIR_ARGS : [];
         const gradleArgs = [
             opts.taskName,
             ...(opts.args ?? []),
@@ -421,20 +473,26 @@ export class RealGradleApi implements GradleApi {
                 }
             });
         });
-        if (repairArgs.length === 0 || !moduleDir) return invocation;
+        if (repairModules.length === 0) return invocation;
 
         const repair = invocation.then(() => {
-            if (hasEmptyClassOutputs(opts.projectFolder, moduleDir)) {
-                throw new Error(
-                    `gradlew ${gradleArgs.join(" ")} completed but ${moduleDir} still has no .class files`,
-                );
+            for (const moduleDir of repairModules) {
+                if (hasEmptyClassOutputs(opts.projectFolder, moduleDir)) {
+                    throw new Error(
+                        `gradlew ${gradleArgs.join(" ")} completed but ${moduleDir} still has no .class files`,
+                    );
+                }
+                this.unvettedModules.delete(moduleDir);
             }
-            this.unvettedModules.delete(moduleDir);
         });
-        this.moduleRepairs.set(moduleDir, repair);
+        for (const moduleDir of repairModules) {
+            this.moduleRepairs.set(moduleDir, repair);
+        }
         return repair.finally(() => {
-            if (this.moduleRepairs.get(moduleDir) === repair) {
-                this.moduleRepairs.delete(moduleDir);
+            for (const moduleDir of repairModules) {
+                if (this.moduleRepairs.get(moduleDir) === repair) {
+                    this.moduleRepairs.delete(moduleDir);
+                }
             }
         });
     }
@@ -448,6 +506,17 @@ export class RealGradleApi implements GradleApi {
         // keyed by `cancellationKey`. Without a key there's nothing
         // specific to cancel (gradleService always supplies one).
         const key = opts.cancellationKey;
+        const queued = key ? this.queuedRuns.get(key) : undefined;
+        if (queued) {
+            if (!queued.cancelled) {
+                queued.cancelled = true;
+                this.cancelledTaskNames.push(queued.taskName);
+                this.onLog(
+                    `[realGradleApi] cancel ${queued.taskName} (key=${key}) — dropping queued run`,
+                );
+            }
+            return;
+        }
         const child = key ? this.liveChildren.get(key) : undefined;
         if (!child || child.pid === undefined || child.exitCode !== null) {
             return;

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -195,6 +195,17 @@ export class RealGradleApi implements GradleApi {
      */
     private readonly unvettedModules = new Set<string>();
 
+    /**
+     * Cancellation repairs currently rebuilding a module's class output.
+     *
+     * Gradle 9.7.1 made the race this guards deterministic: terminating the wrapper client can
+     * return before daemon-side output cleanup has completely settled. Starting the repair and a
+     * save-triggered compile together then lets one invocation snapshot/cache the other's empty
+     * output directory. Keep every later invocation for that module behind the one cache-bypassing
+     * repair; unrelated modules remain free to build in parallel.
+     */
+    private readonly moduleRepairs = new Map<string, Promise<void>>();
+
     /** @see invocations */
     get gradleInvocations(): ReadonlyArray<GradleInvocationRecord> {
         return this.invocations;
@@ -250,7 +261,6 @@ export class RealGradleApi implements GradleApi {
     ): ReadonlyArray<string> {
         const moduleDir = moduleDirForTask(taskName);
         if (!moduleDir || !this.unvettedModules.has(moduleDir)) return [];
-        this.unvettedModules.delete(moduleDir);
         if (!hasEmptyClassOutputs(projectFolder, moduleDir)) return [];
         this.onLog(
             `[realGradleApi] ${moduleDir} has compiled output directories with no .class files ` +
@@ -270,6 +280,16 @@ export class RealGradleApi implements GradleApi {
         }) => void;
         cancellationKey?: string;
     }): Promise<void> {
+        const moduleDir = moduleDirForTask(opts.taskName);
+        const repairInFlight = moduleDir
+            ? this.moduleRepairs.get(moduleDir)
+            : undefined;
+        if (repairInFlight) {
+            this.onLog(
+                `[realGradleApi] ${moduleDir} cancellation repair is still running — queueing ${opts.taskName}`,
+            );
+            return repairInFlight.then(() => this.runTask(opts));
+        }
         const gradlewPath =
             process.platform === "win32"
                 ? path.join(this.gradlewDir, "gradlew.bat")
@@ -312,7 +332,7 @@ export class RealGradleApi implements GradleApi {
         const diagE2e = process.env.COMPOSE_PREVIEW_E2E_EXTERNAL === "1";
         const stdoutDiagRe =
             /BUILD\s+(SUCCESSFUL|FAILED)|composePreviewApplied|FAILURE|^Configuring |Could not resolve|Exception/m;
-        return new Promise((resolve, reject) => {
+        const invocation = new Promise<void>((resolve, reject) => {
             const child = spawn(gradlewPath, gradleArgs, {
                 cwd: opts.projectFolder,
                 env: { ...process.env },
@@ -400,6 +420,22 @@ export class RealGradleApi implements GradleApi {
                     );
                 }
             });
+        });
+        if (repairArgs.length === 0 || !moduleDir) return invocation;
+
+        const repair = invocation.then(() => {
+            if (hasEmptyClassOutputs(opts.projectFolder, moduleDir)) {
+                throw new Error(
+                    `gradlew ${gradleArgs.join(" ")} completed but ${moduleDir} still has no .class files`,
+                );
+            }
+            this.unvettedModules.delete(moduleDir);
+        });
+        this.moduleRepairs.set(moduleDir, repair);
+        return repair.finally(() => {
+            if (this.moduleRepairs.get(moduleDir) === repair) {
+                this.moduleRepairs.delete(moduleDir);
+            }
         });
     }
 

--- a/vscode-extension/src/test/realGradleApi.test.ts
+++ b/vscode-extension/src/test/realGradleApi.test.ts
@@ -199,7 +199,7 @@ describe("RealGradleApi cancellation repair", () => {
     });
 
     it("reruns the next build for a module a cancellation left with no classes", async () => {
-        classOutputDir("kotlin", "jvm", "main");
+        const output = classOutputDir("kotlin", "jvm", "main");
         const api = new RealGradleApi(tmp);
 
         const running = api.runTask({
@@ -216,6 +216,17 @@ describe("RealGradleApi cancellation repair", () => {
         await running.catch(() => {
             /* cancellation rejects by contract */
         });
+        fs.writeFileSync(
+            path.join(tmp, "gradlew"),
+            [
+                "#!/bin/sh",
+                `touch ${JSON.stringify(path.join(output, "PreviewsKt.class"))}`,
+                'echo "> Task :samples:cmp:composePreviewRender"',
+                "exit 0",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
 
         await api.runTask({
             projectFolder: tmp,
@@ -241,6 +252,66 @@ describe("RealGradleApi cancellation repair", () => {
             showOutputColors: false,
             cancellationKey: "key-3",
         });
+        assert.strictEqual(api.gradleInvocations[2].repaired, undefined);
+    });
+
+    it("queues same-module builds behind an in-flight cancellation repair", async () => {
+        const output = classOutputDir("kotlin", "jvm", "main");
+        const classFile = path.join(output, "PreviewsKt.class");
+        const script = [
+            "#!/bin/sh",
+            `if [ -f ${JSON.stringify(classFile)} ]; then exit 0; fi`,
+            'case " $* " in',
+            '  *" --rerun-tasks "*)',
+            "    sleep 0.2",
+            `    touch ${JSON.stringify(classFile)}`,
+            "    exit 0",
+            "    ;;",
+            "esac",
+            "sleep 10",
+        ].join("\n");
+        fs.writeFileSync(path.join(tmp, "gradlew"), `${script}\n`, {
+            mode: 0o755,
+        });
+        const api = new RealGradleApi(tmp);
+
+        const damaged = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "key-1",
+        });
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            cancellationKey: "key-1",
+        });
+        await damaged.catch(() => {
+            /* expected */
+        });
+
+        const repair = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "key-2",
+        });
+        const queued = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewCompile",
+            showOutputColors: false,
+            cancellationKey: "key-3",
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.strictEqual(
+            api.gradleInvocations.length,
+            2,
+            "the compile spawned before the repair completed",
+        );
+        await Promise.all([repair, queued]);
+        assert.strictEqual(api.gradleInvocations.length, 3);
+        assert.strictEqual(api.gradleInvocations[1].repaired, true);
         assert.strictEqual(api.gradleInvocations[2].repaired, undefined);
     });
 

--- a/vscode-extension/src/test/realGradleApi.test.ts
+++ b/vscode-extension/src/test/realGradleApi.test.ts
@@ -7,6 +7,7 @@ import {
     RealGradleApi,
     hasEmptyClassOutputs,
     moduleDirForTask,
+    moduleDirsForInvocation,
     parseTaskOutcomes,
 } from "./electron/realGradleApi";
 
@@ -184,6 +185,14 @@ describe("RealGradleApi cancellation repair", () => {
             undefined,
         );
         assert.strictEqual(moduleDirForTask(":help"), undefined);
+        assert.deepStrictEqual(
+            moduleDirsForInvocation("composePreviewApplied", [
+                ":samples:cmp:composePreviewDaemonStart",
+                ":samples:cmp:composePreviewDiscover",
+                "--no-build-cache",
+            ]),
+            [path.join("samples", "cmp")],
+        );
     });
 
     it("calls a module with output roots but no class files empty", () => {
@@ -313,6 +322,73 @@ describe("RealGradleApi cancellation repair", () => {
         assert.strictEqual(api.gradleInvocations.length, 3);
         assert.strictEqual(api.gradleInvocations[1].repaired, true);
         assert.strictEqual(api.gradleInvocations[2].repaired, undefined);
+    });
+
+    it("keeps a bundled module task queued and cancellable during repair", async () => {
+        const output = classOutputDir("kotlin", "jvm", "main");
+        const classFile = path.join(output, "PreviewsKt.class");
+        fs.writeFileSync(
+            path.join(tmp, "gradlew"),
+            [
+                "#!/bin/sh",
+                'case " $* " in',
+                '  *" --rerun-tasks "*)',
+                "    sleep 0.2",
+                `    touch ${JSON.stringify(classFile)}`,
+                "    exit 0",
+                "    ;;",
+                "esac",
+                "sleep 10",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+        const api = new RealGradleApi(tmp);
+
+        const damaged = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "key-1",
+        });
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            cancellationKey: "key-1",
+        });
+        await damaged.catch(() => {
+            /* expected */
+        });
+
+        const repair = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "key-2",
+        });
+        const queued = api.runTask({
+            projectFolder: tmp,
+            taskName: "composePreviewApplied",
+            args: [":samples:cmp:composePreviewDiscover"],
+            showOutputColors: false,
+            cancellationKey: "key-3",
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.strictEqual(api.gradleInvocations.length, 2);
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: "composePreviewApplied",
+            cancellationKey: "key-3",
+        });
+        await assert.rejects(queued, /cancelled before start/);
+        await repair;
+        assert.strictEqual(
+            api.gradleInvocations.length,
+            2,
+            "the cancelled bundled invocation still spawned",
+        );
+        assert.ok(api.cancelledTasks.includes("composePreviewApplied"));
     });
 
     it("leaves a healthy module's next build alone after a cancellation", async () => {


### PR DESCRIPTION
## Summary

- upgrade the Gradle wrapper from 9.7.0 to 9.7.1 and remove the temporary Renovate cap
- serialize same-module e2e builds behind the cache-bypassing cancellation repair, preventing a save-triggered compile from racing the repair over an empty output directory
- make preview discovery reject empty compiled outputs even when `failOnEmpty` is false, so it cannot replace a healthy manifest with an assets-only one

## Root cause

The failing workflow log shows scenario D canceling a CMP render, followed by a cache-bypassing repair render and a save-triggered CMP compile starting concurrently. Under Gradle 9.7.1, terminating the wrapper client can return before daemon-side output cleanup has fully settled. The overlapping invocation can then snapshot and cache the temporarily empty class directory. The old repair guard was consumed before the repair completed, so it did not protect that second invocation.

The fix makes repair single-flight per module and clears the damaged-module marker only after the repair succeeds and class files are present.

## Validation

- `./gradlew :gradle-plugin:preview-discovery:test`
- `./gradlew ktfmtCheckAll`
- `npm test -- --grep RealGradleApi`
- `npm run format:check`
- workflow dispatch: https://github.com/yschimke/compose-ai-tools/actions/runs/32698950779
  - `interactive-e-g`: green under Gradle 9.7.1 (7m34s)
  - all five shards green (`interactive-e-g` 7m34s; `interactive-a-d` 9m48s; `cmp-smoke` 9m38s; `wear` 8m29s; `cached-preload` 12m51s)

`npm run lint` is currently not runnable because the package declares a lint script but no ESLint dependency; TypeScript compilation passed as part of the focused npm test.

Fixes #4364
