### PR TITLE
feat(discovery): reject @CaptureGutter combined with @ScrollingPreview

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -59,45 +59,16 @@ package ee.schimke.composeai.preview
  *   there, and a component that declares one publishes its still and its recording on the same
  *   canvas rather than two artefacts disagreeing about its bounds.
  *
- * It is **not meant to apply** to a `@ScrollingPreview` capture, and that is a decision rather than
- * a gap. A LONG capture's bounds are the stitched scroll extent — many viewports of a list, not a
- * component — and a scroll GIF's are the declared viewport. Neither is "the component plus what it
- * draws outside itself", so there is no edge for a gutter to sit on, and adding transparent dp
- * around a scroll strip would be decorative padding wearing this annotation's name. A scroll drive
- * that declines falls through to an ordinary still, which does carry the gutter.
- *
- * CMP Desktop implements that exclusion by simply handing its scroll renderer no gutter. Android
- * cannot: it grows **one** hosting window per preview and captures every job for that preview
- * inside it, so its `LONG` slices and `GIF` frames trim the gutter back off after capture instead.
- * `TOP` is untouched either way: it is the undriven first viewport, which is a still and does carry
- * the gutter.
- *
- * Two Android frame shapes are **unsupported** in combination with a scrolling mode, and keep the
- * gutter on their scroll products rather than taking a trim that would be worse than none: a
- * **round device**, whose circular mask is baked into the capture (cropping it leaves an oversized,
- * and for an asymmetric gutter off-centre, circle rather than the watch shape), and
- * **`showSystemUi`**, whose synthetic status and nav bars are painted against the edges of the
- * grown window (trimming those edges slices the chrome rather than the gutter). Making either work
- * means composing the scroll pass in an un-grown window rather than post-processing it. A
- * scrollable hosted in a **full-screen** dialog — a `ModalBottomSheet` — keeps it as well. Those
- * frames are cropped to the dialog's own window rect instead of reaching the hosting-window trim,
- * and for a centred `Dialog` that rect *is* the component, so the gutter is excluded correctly
- * there; a full-screen window's rect is the whole grown frame, so nothing is removed. None of the
- * three is a combination worth the machinery: a gutter exists to keep a component's shadow, and a
- * scroll product has no component edge to keep one on.
- *
- * `END` is the exception on Android, and knowingly so. It is the one scroll mode whose product is
- * an ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y
- * / semantics / layout-inspector products, a round device's baked-in mask — all of which describe
- * the hosting window. Trimming the PNG underneath them would buy the right frame size and lose
- * every other product's agreement with it, so an Android `END` capture keeps the gutter while the
- * CMP Desktop one does not.
- *
- * Two caveats are still open. That Android `END` divergence is one. The other is a held **desktop
- * recording** of a *wrapped* preview, which is sized from the sandbox bound rather than the
- * measured content — that one predates gutters entirely, so the gutter term merely rides on top of
- * a frame that was already the wrong size. Both are tracked in compose-ai-tools#4467 — read them as
- * the current limits of the contract above, not as licence to rely on them.
+ * It **cannot be combined with** a `@ScrollingPreview`, and that is a decision rather than a gap. A
+ * LONG capture's bounds are the stitched scroll extent — many viewports of a list, not a component
+ * — and a scroll GIF's are the declared viewport; even a settled END/TOP frame is one viewport of a
+ * screen, not a component with an edge for the gutter to sit on. Adding transparent dp around a
+ * scroll strip would be decorative padding wearing this annotation's name, and honouring it per
+ * lane meant a thicket of divergences — a baked-in round mask, a displaced focus overlay, sidecars
+ * keyed to a grown window (compose-ai-tools#4467). So a function that declares both annotations is
+ * **rejected at discovery**: it is skipped with an actionable warning naming the function, and
+ * contributes nothing to `previews.json`. Remove one annotation — the two describe different things
+ * and a preview cannot be both at once.
  *
  * A **rotated** capture (`orientation = landscape`, which the daemon reduces to a width↔height
  * swap) keeps the declared edges verbatim: a gutter edge names a direction the component draws in —

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CaptureGutter.kt
@@ -65,10 +65,11 @@ package ee.schimke.composeai.preview
  * screen, not a component with an edge for the gutter to sit on. Adding transparent dp around a
  * scroll strip would be decorative padding wearing this annotation's name, and honouring it per
  * lane meant a thicket of divergences — a baked-in round mask, a displaced focus overlay, sidecars
- * keyed to a grown window (compose-ai-tools#4467). So a function that declares both annotations is
- * **rejected at discovery**: it is skipped with an actionable warning naming the function, and
- * contributes nothing to `previews.json`. Remove one annotation — the two describe different things
- * and a preview cannot be both at once.
+ * keyed to a grown window (compose-ai-tools#4467). So a function that declares a (non-zero) gutter
+ * alongside `@ScrollingPreview` is **rejected at discovery**: it is skipped with an actionable
+ * warning naming the function, and contributes nothing to `previews.json`. Remove one annotation —
+ * the two describe different things and a preview cannot be both at once. (An all-zero gutter is
+ * equivalent to no annotation, per [all], so it does not trip this and the scroll capture stands.)
  *
  * A **rotated** capture (`orientation = landscape`, which the daemon reduces to a width↔height
  * swap) keeps the declared edges verbatim: a gutter edge names a direction the component draws in —

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -151,26 +151,36 @@ class IncrementalDiscovery(
       if (!matchesFile) continue
       for (method in classInfo.methodInfo) {
         val annotations = method.annotationInfo?.toList().orEmpty()
+        val direct = collectDirectPreviews(annotations)
+        val expansions =
+          if (direct.isNotEmpty()) direct
+          else annotations.flatMap { resolveMultiPreview(it, scanResult, mutableSetOf()) }
+        if (expansions.isEmpty()) continue
+
         // Mirror the authoritative pass's rejection of `@CaptureGutter` + `@ScrollingPreview`
-        // (PreviewDiscovery). Without this, a full pass correctly drops the combination from
+        // (PreviewDiscovery). Without it, a full pass correctly drops the combination from
         // `previews.json`, but the first source edit re-adds the function here — the diff sees a
         // previously-absent id and treats it as an addition — so the daemon would expose an
         // unguttered, unscrolled preview until the next full discovery. `@CaptureGutter` may be
-        // hoisted onto a multi-preview annotation, so the check walks the meta-annotation closure
-        // the same way `resolveMultiPreview` does.
-        if (declaresGutterAndScrolling(annotations, scanResult)) continue
-        val direct = collectDirectPreviews(annotations)
-        if (direct.isNotEmpty()) {
-          for (ann in direct) {
-            results.add(toDto(classInfo, method, ann, sourceKey))
-          }
+        // hoisted onto a multi-preview annotation, so the check walks the meta-annotation closure.
+        //
+        // Best-effort, like the rest of this path: it resolves the closure through the scoped scan,
+        // so a `@CaptureGutter` hoisted onto a *dependency-JAR* annotation (outside the narrowed
+        // classpath) is not seen here and slips through until the next full discovery corrects it;
+        // and once a rejected function is out of the index, a fix that removes one annotation may
+        // not re-trip `cheapPrefilter` (its regex carries only the known preview FQNs), so recovery
+        // likewise waits for a full pass. Both match the incremental path's standing v1 contract
+        // (see [scanForFile] / the class kdoc), where identity is authoritative and details settle
+        // on the next full discovery.
+        if (declaresGutterAndScrolling(annotations, scanResult)) {
+          System.err.println(
+            "compose-ai-daemon: IncrementalDiscovery skipping '${classInfo.name}.${method.name}'" +
+              " — @CaptureGutter cannot be combined with @ScrollingPreview; remove one annotation."
+          )
           continue
         }
-        for (ann in annotations) {
-          val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
-          for (resolvedAnn in resolved) {
-            results.add(toDto(classInfo, method, resolvedAnn, sourceKey))
-          }
+        for (ann in expansions) {
+          results.add(toDto(classInfo, method, ann, sourceKey))
         }
       }
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -178,34 +178,53 @@ class IncrementalDiscovery(
   }
 
   /**
-   * True when a method declares both `@CaptureGutter` and `@ScrollingPreview` — a contradiction the
-   * authoritative discovery pass rejects (see `PreviewDiscovery`). `@ScrollingPreview` targets
-   * FUNCTION only, so it is always a direct method annotation; `@CaptureGutter` also targets
-   * ANNOTATION_CLASS, so it can be hoisted onto a multi-preview annotation and has to be found by
-   * walking the meta-annotation closure.
+   * True when a method declares `@ScrollingPreview` together with an **effective** `@CaptureGutter`
+   * — the contradiction the authoritative pass rejects (see `PreviewDiscovery`).
+   *
+   * Must match that pass clause for clause, or a source save diverges from the full
+   * `previews.json`: an all-zero gutter (`@CaptureGutter()`, or edges that all clamp to `0`) is
+   * equivalent to no annotation there (`extractCaptureGutter` returns `null`), so such a function
+   * is KEPT — checking the annotation's mere presence would wrongly drop it here and make the live
+   * daemon shed a preview the full pass emitted.
+   *
+   * `@ScrollingPreview` targets FUNCTION only, so it is always a direct method annotation;
+   * `@CaptureGutter` also targets ANNOTATION_CLASS, so it can be hoisted onto a multi-preview
+   * annotation and is found by walking the meta-annotation closure.
    */
   private fun declaresGutterAndScrolling(
     annotations: List<AnnotationInfo>,
     scanResult: ScanResult,
   ): Boolean {
-    val fqns = mutableSetOf<String>()
-    collectAnnotationFqns(annotations, scanResult, mutableSetOf(), fqns)
-    return CAPTURE_GUTTER_FQN in fqns && SCROLLING_PREVIEW_FQN in fqns
+    var hasScrolling = false
+    var gutter: AnnotationInfo? = null
+    val visited = mutableSetOf<String>()
+    fun walk(anns: List<AnnotationInfo>) {
+      for (ann in anns) {
+        if (ann.name == SCROLLING_PREVIEW_FQN) hasScrolling = true
+        if (ann.name == CAPTURE_GUTTER_FQN && gutter == null) gutter = ann
+        if (!visited.add(ann.name)) continue
+        val annClass = scanResult.getClassInfo(ann.name) ?: continue
+        walk(annClass.annotationInfo.toList())
+      }
+    }
+    walk(annotations)
+    return hasScrolling && gutter?.let { hasEffectiveGutter(it) } == true
   }
 
-  /** Every annotation FQN reachable from [annotations], transitively through annotation classes. */
-  private fun collectAnnotationFqns(
-    annotations: List<AnnotationInfo>,
-    scanResult: ScanResult,
-    visited: MutableSet<String>,
-    out: MutableSet<String>,
-  ) {
-    for (ann in annotations) {
-      if (!visited.add(ann.name)) continue
-      out.add(ann.name)
-      val annClass = scanResult.getClassInfo(ann.name) ?: continue
-      collectAnnotationFqns(annClass.annotationInfo.toList(), scanResult, visited, out)
+  /**
+   * Whether a `@CaptureGutter` resolves to a non-zero gutter — mirrors `PreviewDiscovery`'s
+   * `extractCaptureGutter` / `CaptureGutterDp.isEmpty()`: a per-edge `INHERIT_GUTTER` (`-1`) takes
+   * `all`, negatives clamp to `0`, and an all-zero result is "no gutter".
+   */
+  private fun hasEffectiveGutter(ann: AnnotationInfo): Boolean {
+    val pv = ann.parameterValues
+    val all = (pv.getValue("all") as? Int) ?: 0
+    fun edge(name: String): Int {
+      val raw = (pv.getValue(name) as? Int) ?: INHERIT_GUTTER
+      val resolved = if (raw == INHERIT_GUTTER) all else raw
+      return resolved.coerceIn(0, MAX_CAPTURE_GUTTER_DP)
     }
+    return edge("start") > 0 || edge("top") > 0 || edge("end") > 0 || edge("bottom") > 0
   }
 
   private fun collectDirectPreviews(annotations: List<AnnotationInfo>): List<AnnotationInfo> {
@@ -334,6 +353,13 @@ class IncrementalDiscovery(
      */
     private const val CAPTURE_GUTTER_FQN = "ee.schimke.composeai.preview.CaptureGutter"
     private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
+
+    /**
+     * Mirrors `preview.INHERIT_GUTTER` / `MAX_CAPTURE_GUTTER_DP` (a per-edge "take `all`" sentinel,
+     * and the per-edge dp ceiling). Duplicated for the same layering reason as the FQNs above.
+     */
+    private const val INHERIT_GUTTER = -1
+    private const val MAX_CAPTURE_GUTTER_DP = 64
 
     /** Synthesised `@Repeatable` containers; same FQN set as the gradle plugin. */
     private val CONTAINER_FQNS: Set<String> =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -151,6 +151,14 @@ class IncrementalDiscovery(
       if (!matchesFile) continue
       for (method in classInfo.methodInfo) {
         val annotations = method.annotationInfo?.toList().orEmpty()
+        // Mirror the authoritative pass's rejection of `@CaptureGutter` + `@ScrollingPreview`
+        // (PreviewDiscovery). Without this, a full pass correctly drops the combination from
+        // `previews.json`, but the first source edit re-adds the function here — the diff sees a
+        // previously-absent id and treats it as an addition — so the daemon would expose an
+        // unguttered, unscrolled preview until the next full discovery. `@CaptureGutter` may be
+        // hoisted onto a multi-preview annotation, so the check walks the meta-annotation closure
+        // the same way `resolveMultiPreview` does.
+        if (declaresGutterAndScrolling(annotations, scanResult)) continue
         val direct = collectDirectPreviews(annotations)
         if (direct.isNotEmpty()) {
           for (ann in direct) {
@@ -167,6 +175,37 @@ class IncrementalDiscovery(
       }
     }
     return results
+  }
+
+  /**
+   * True when a method declares both `@CaptureGutter` and `@ScrollingPreview` — a contradiction the
+   * authoritative discovery pass rejects (see `PreviewDiscovery`). `@ScrollingPreview` targets
+   * FUNCTION only, so it is always a direct method annotation; `@CaptureGutter` also targets
+   * ANNOTATION_CLASS, so it can be hoisted onto a multi-preview annotation and has to be found by
+   * walking the meta-annotation closure.
+   */
+  private fun declaresGutterAndScrolling(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+  ): Boolean {
+    val fqns = mutableSetOf<String>()
+    collectAnnotationFqns(annotations, scanResult, mutableSetOf(), fqns)
+    return CAPTURE_GUTTER_FQN in fqns && SCROLLING_PREVIEW_FQN in fqns
+  }
+
+  /** Every annotation FQN reachable from [annotations], transitively through annotation classes. */
+  private fun collectAnnotationFqns(
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+    visited: MutableSet<String>,
+    out: MutableSet<String>,
+  ) {
+    for (ann in annotations) {
+      if (!visited.add(ann.name)) continue
+      out.add(ann.name)
+      val annClass = scanResult.getClassInfo(ann.name) ?: continue
+      collectAnnotationFqns(annClass.annotationInfo.toList(), scanResult, visited, out)
+    }
   }
 
   private fun collectDirectPreviews(annotations: List<AnnotationInfo>): List<AnnotationInfo> {
@@ -287,6 +326,14 @@ class IncrementalDiscovery(
         "androidx.compose.desktop.ui.tooling.preview.Preview",
         "androidx.wear.tiles.tooling.preview.Preview",
       )
+
+    /**
+     * `@CaptureGutter` / `@ScrollingPreview` FQNs, mirrored from `:gradle-plugin`'s
+     * `PreviewDiscovery` for the same layering reason as [DEFAULT_PREVIEW_ANNOTATION_FQNS]: the two
+     * cannot be combined, and this path must reject the pair to match the authoritative pass.
+     */
+    private const val CAPTURE_GUTTER_FQN = "ee.schimke.composeai.preview.CaptureGutter"
+    private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
 
     /** Synthesised `@Repeatable` containers; same FQN set as the gradle plugin. */
     private val CONTAINER_FQNS: Set<String> =

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -186,6 +186,13 @@ class IncrementalDiscoveryTest {
     // Either annotation on its own still surfaces.
     assertTrue("gutter-only must survive; got $methods", "gutterOnlyPreview" in methods)
     assertTrue("scroll-only must survive; got $methods", "scrollOnlyPreview" in methods)
+    // An all-zero gutter is equivalent to no annotation, so scroll + zero-gutter is NOT the
+    // forbidden combination — it must survive, matching the authoritative pass rather than being
+    // dropped on the annotation's bare presence.
+    assertTrue(
+      "zero-gutter + scroll must survive; got $methods",
+      "zeroGutterScrollingPreview" in methods,
+    )
   }
 
   @Test

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -166,6 +166,29 @@ class IncrementalDiscoveryTest {
   }
 
   @Test
+  fun `scanForFile drops a function that combines @CaptureGutter with @ScrollingPreview`() {
+    // The authoritative pass (PreviewDiscovery) rejects that combination; the incremental scan must
+    // too, or a source edit re-adds the rejected preview to the index (issue #4467 / #4488 review).
+    val syntheticKt = Path.of(System.getProperty("java.io.tmpdir"), "GutterScrollFixtures.kt")
+    val results = discovery.scanForFile(syntheticKt)
+    val methods = results.map { it.methodName }.toSet()
+
+    // Both contradictory combinations are dropped — the direct one and the one whose gutter is
+    // hoisted onto a multi-preview annotation, which the guard's meta-closure walk has to catch.
+    assertFalse(
+      "the direct gutter+scroll combination must be skipped; got $methods",
+      "gutteredScrollingPreview" in methods,
+    )
+    assertFalse(
+      "the hoisted gutter+scroll combination must be skipped; got $methods",
+      "hoistedGutterScrollingPreview" in methods,
+    )
+    // Either annotation on its own still surfaces.
+    assertTrue("gutter-only must survive; got $methods", "gutterOnlyPreview" in methods)
+    assertTrue("scroll-only must survive; got $methods", "scrollOnlyPreview" in methods)
+  }
+
+  @Test
   fun `scanForFile returns emptySet when no class on classpath sources to the saved file`() {
     val syntheticKt = Path.of(System.getProperty("java.io.tmpdir"), "DefinitelyNotAFixture.kt")
     val results = discovery.scanForFile(syntheticKt)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -170,7 +170,18 @@ class IncrementalDiscoveryTest {
     // The authoritative pass (PreviewDiscovery) rejects that combination; the incremental scan must
     // too, or a source edit re-adds the rejected preview to the index (issue #4467 / #4488 review).
     val syntheticKt = Path.of(System.getProperty("java.io.tmpdir"), "GutterScrollFixtures.kt")
-    val results = discovery.scanForFile(syntheticKt)
+    // Capture stderr so the rejection diagnostic (which the full pass emits as a warning) can be
+    // asserted — the incremental path must name the function it drops, not remove it silently.
+    val savedErr = System.err
+    val captured = java.io.ByteArrayOutputStream()
+    val results =
+      try {
+        System.setErr(java.io.PrintStream(captured, true, "UTF-8"))
+        discovery.scanForFile(syntheticKt)
+      } finally {
+        System.setErr(savedErr)
+      }
+    val diagnostics = captured.toString("UTF-8")
     val methods = results.map { it.methodName }.toSet()
 
     // Both contradictory combinations are dropped — the direct one and the one whose gutter is
@@ -192,6 +203,12 @@ class IncrementalDiscoveryTest {
     assertTrue(
       "zero-gutter + scroll must survive; got $methods",
       "zeroGutterScrollingPreview" in methods,
+    )
+    // The drop is announced, not silent: the diagnostic names the rejected function(s).
+    assertTrue(
+      "rejection must be reported to stderr; got: $diagnostics",
+      "gutteredScrollingPreview" in diagnostics &&
+        "@CaptureGutter cannot be combined with @ScrollingPreview" in diagnostics,
     )
   }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/GutterScrollFixtures.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/GutterScrollFixtures.kt
@@ -1,0 +1,32 @@
+package ee.schimke.composeai.daemon.fixtures
+
+import ee.schimke.composeai.preview.CaptureGutter
+import ee.schimke.composeai.preview.ScrollingPreview
+
+/**
+ * Fixtures for `IncrementalDiscovery`'s rejection of `@CaptureGutter` + `@ScrollingPreview`. The
+ * incremental scan must drop that combination the same way the authoritative `PreviewDiscovery`
+ * pass does, or a source edit would re-add a rejected preview to the daemon's index.
+ *
+ * Four methods: the two contradictory combinations (one direct, one with the gutter hoisted onto a
+ * multi-preview annotation) must be skipped; the two single-annotation controls must survive.
+ */
+class GutterScrollFixtures {
+  @TestPreview(name = "guttered-scroll")
+  @CaptureGutter(all = 4)
+  @ScrollingPreview
+  fun gutteredScrollingPreview() {}
+
+  @HoistedGutterTestPreview @ScrollingPreview fun hoistedGutterScrollingPreview() {}
+
+  @TestPreview(name = "gutter-only") @CaptureGutter(all = 4) fun gutterOnlyPreview() {}
+
+  @TestPreview(name = "scroll-only") @ScrollingPreview fun scrollOnlyPreview() {}
+}
+
+/** A multi-preview annotation carrying a hoisted gutter — the meta-closure the guard must walk. */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+@TestPreview(name = "hoisted")
+@CaptureGutter(all = 4)
+annotation class HoistedGutterTestPreview

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/GutterScrollFixtures.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/GutterScrollFixtures.kt
@@ -22,6 +22,13 @@ class GutterScrollFixtures {
   @TestPreview(name = "gutter-only") @CaptureGutter(all = 4) fun gutterOnlyPreview() {}
 
   @TestPreview(name = "scroll-only") @ScrollingPreview fun scrollOnlyPreview() {}
+
+  // An all-zero gutter is equivalent to no annotation (PreviewDiscovery drops it), so this is NOT
+  // the forbidden combination — it must survive, exactly as the full pass keeps it.
+  @TestPreview(name = "zero-gutter-scroll")
+  @CaptureGutter(all = 0)
+  @ScrollingPreview
+  fun zeroGutterScrollingPreview() {}
 }
 
 /** A multi-preview annotation carrying a hoisted gutter — the meta-closure the guard must walk. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/TestPreview.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/TestPreview.kt
@@ -10,7 +10,7 @@ package ee.schimke.composeai.daemon.fixtures
  * `IncrementalDiscovery.toDto` has something to read.
  */
 @Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 annotation class TestPreview(val name: String = "", val group: String = "")
 
 /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/preview/PreviewAnnotationStubs.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/preview/PreviewAnnotationStubs.kt
@@ -1,0 +1,18 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Synthetic `@CaptureGutter` / `@ScrollingPreview` stubs at their **real FQNs**, used by
+ * `IncrementalDiscoveryTest` to exercise the gutter+scroll rejection without pulling
+ * `:preview-annotations` (a Compose-adjacent artifact) onto the `:daemon:core` test classpath — the
+ * same layering reason `TestPreview` is a stub rather than the real `@Preview`.
+ *
+ * `RUNTIME` retention so ClassGraph's annotation reader sees them. `@CaptureGutter` keeps the
+ * ANNOTATION_CLASS target so the hoisted-onto-a-multi-preview case can be exercised.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+annotation class CaptureGutter(val all: Int = 0)
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ScrollingPreview

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -300,10 +300,12 @@ PNG beside it carried the gutter — the component is the same size in both, onl
   Rather than honour the pair per lane — which meant a thicket of divergences (a baked-in round
   mask, a displaced focus overlay, sidecars keyed to a grown window, and an `END` frame that came
   out `frame + gutter` on Android but `frame` on CMP Desktop) — **discovery rejects the combination**
-  (`PreviewDiscovery`): a function with both annotations is skipped with a warning naming it and
-  never reaches `previews.json`, so no lane ever has to reconcile them. This closes the scroll items
-  of [#4467](https://github.com/yschimke/compose-ai-tools/issues/4467) by removing the case, not by
-  making every lane agree on it.
+  (`PreviewDiscovery`): a function that declares a *non-zero* gutter alongside `@ScrollingPreview` is
+  skipped with a warning naming it and never reaches `previews.json`, so no lane ever has to
+  reconcile them. (An all-zero `@CaptureGutter()` is equivalent to no annotation, so it does not trip
+  the rejection and the scroll capture stands — both discovery paths agree on that.) This closes the
+  scroll items of [#4467](https://github.com/yschimke/compose-ai-tools/issues/4467) by removing the
+  case, not by making every lane agree on it.
 
   Fixed-axis Android **motion** frames (an `@AnimatedPreview` / `@InteractionPreview`, which *do*
   combine with a gutter) used to disagree with the still by a pixel at fractional densities, because

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -293,45 +293,21 @@ PNG beside it carried the gutter — the component is the same size in both, onl
   frame of a recording shares one canvas, exactly as a still does, so the gutter is as well-defined
   there; the desktop GIF row above is the fixture that pins it
   ([#4452](https://github.com/yschimke/compose-ai-tools/issues/4452)).
-* **Scrolling captures — no, by decision.** A `@ScrollingPreview` LONG capture's bounds are the
-  stitched scroll extent and a scroll GIF's are the declared viewport. Neither is "the component
-  plus what it draws outside itself", so there is no edge for a gutter to sit on and extending
-  either would be padding the sheet under the annotation's name. A declined scroll drive falls
-  through to an ordinary still, which does carry the gutter.
+* **Scrolling captures — rejected outright.** A gutter and a `@ScrollingPreview` on one function
+  are a contradiction, not a combination: a LONG capture's bounds are the stitched scroll extent, a
+  GIF's the declared viewport, and even a settled END/TOP frame is one viewport of a screen — none
+  is "the component plus what it draws outside itself", so there is no edge for a gutter to sit on.
+  Rather than honour the pair per lane — which meant a thicket of divergences (a baked-in round
+  mask, a displaced focus overlay, sidecars keyed to a grown window, and an `END` frame that came
+  out `frame + gutter` on Android but `frame` on CMP Desktop) — **discovery rejects the combination**
+  (`PreviewDiscovery`): a function with both annotations is skipped with a warning naming it and
+  never reaches `previews.json`, so no lane ever has to reconcile them. This closes the scroll items
+  of [#4467](https://github.com/yschimke/compose-ai-tools/issues/4467) by removing the case, not by
+  making every lane agree on it.
 
-  CMP Desktop hands its scroll renderer no gutter at all. Android grows **one** hosting window per
-  preview and captures every job for that preview inside it, so it cannot express the exclusion in
-  the window — its `LONG` slices and `GIF` frames trim the gutter back off after capture instead.
-  `TOP` is untouched on both lanes: the undriven first viewport is a still, and stills carry the
-  gutter.
-
-  Two Android frame shapes are **unsupported** with a gutter and keep it on their scroll products,
-  because trimming would be worse than not trimming: a **round device** (the circular mask is baked
-  into the capture, so cropping leaves an oversized — and for an asymmetric gutter, off-centre —
-  circle instead of the watch shape) and **`showSystemUi`** (`SystemBarsFrame` wraps the gutter box,
-  so the chrome is painted against the *grown* window's edges and trimming slices the bars). Both
-  need the scroll pass composed in an un-grown window rather than post-processed. A scrollable
-  hosted in a **full-screen** dialog (`ModalBottomSheet`) keeps it too: those frames are cropped to
-  the dialog's own window rect rather than reaching the hosting-window trim, and a full-screen
-  window's rect is the whole grown frame. A centred `Dialog` is fine — its rect *is* the component,
-  so the gutter is excluded correctly. None of the three is a combination any preview declares.
-
-  **`END` still diverges on Android**, knowingly. It is the one scroll mode whose product is an
-  ordinary still, so it shares the whole still post-capture chain — the focus overlay, the a11y /
-  semantics / layout-inspector products, a round device's baked-in mask — every one of which
-  describes the hosting window. Trimming the PNG underneath them would buy the right frame size and
-  lose every other product's agreement with it. Composing `END` in an un-grown window (a second
-  render pass, the way a settled still already splits) is the fix; until then a guttered `END`
-  capture is `frame + gutter` on Android and `frame` on CMP Desktop.
-
-  One further divergence remains open: a held **desktop recording** of a *wrapped* preview is sized
-  from the sandbox bound rather than the measured content — that one predates gutters. Tracked, with
-  the `END` divergence above, in
-  [#4467](https://github.com/yschimke/compose-ai-tools/issues/4467).
-
-  Fixed-axis Android **motion** frames used to disagree with the still by a pixel at fractional
-  densities, because the hosting window can only grow in whole dp; both now derive from one
-  `fixedAxisTargetPx`
+  Fixed-axis Android **motion** frames (an `@AnimatedPreview` / `@InteractionPreview`, which *do*
+  combine with a gutter) used to disagree with the still by a pixel at fractional densities, because
+  the hosting window can only grow in whole dp; both now derive from one `fixedAxisTargetPx`
   ([#4471](https://github.com/yschimke/compose-ai-tools/pull/4471)).
 * **Rotation does not rotate the edges.** `orientation = landscape` reduces to a
   `widthPx ↔ heightPx` swap, and the routers trade the *wrap flags* with it because a wrap flag

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2083,7 +2083,13 @@ object PreviewDiscovery {
     // actionable message, the same way an unsupported `@XrSubspacePreview` parameter is handled
     // above, so the author removes one annotation rather than shipping a gutter that some products
     // keep and others drop.
-    if (captureGutter != null && scrollSpecs.isNotEmpty()) {
+    //
+    // Keyed on the *presence* of `@ScrollingPreview`, not on `scrollSpecs` being non-empty: a
+    // degenerate `@ScrollingPreview(modes = [])` produces no specs yet still declares the
+    // combination the contract forbids, and the author who wrote both annotations should hear about
+    // it rather than have the empty-modes case quietly keep its gutter.
+    val declaresScrollingPreview = annotations.any { it.name == SCROLLING_PREVIEW_FQN }
+    if (captureGutter != null && declaresScrollingPreview) {
       warnings.add(
         "composePreview: skipping '${classInfo.name}.${method.name}' — @CaptureGutter cannot be " +
           "combined with @ScrollingPreview. A scroll capture has no component edge for a gutter " +

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2072,6 +2072,25 @@ object PreviewDiscovery {
     // COMPONENT draws past its bounds, so it holds for every `@Preview` expansion of the function
     // — light and dark, every size cell, every override variant — not for one of them.
     val captureGutter = extractCaptureGutter(annotations)
+    // `@CaptureGutter` and `@ScrollingPreview` on one function is a contradiction, not a
+    // combination. A gutter says "the component draws this far past its own bounds"; a scroll
+    // capture has no such bounds — a LONG stitch's are the scrolled extent, a GIF's the declared
+    // viewport, and an END/TOP still is one settled frame of a screen, not a component with an
+    // edge for the gutter to sit on. CMP Desktop already renders scroll products with no gutter at
+    // all, and the per-lane divergences of trying to honour both (issue #4467) — a baked-in round
+    // mask, a displaced focus overlay, sidecars keyed to the grown window — are exactly why the
+    // combination is unsupported rather than silently half-applied. Skip the whole function with an
+    // actionable message, the same way an unsupported `@XrSubspacePreview` parameter is handled
+    // above, so the author removes one annotation rather than shipping a gutter that some products
+    // keep and others drop.
+    if (captureGutter != null && scrollSpecs.isNotEmpty()) {
+      warnings.add(
+        "composePreview: skipping '${classInfo.name}.${method.name}' — @CaptureGutter cannot be " +
+          "combined with @ScrollingPreview. A scroll capture has no component edge for a gutter " +
+          "to sit on (see @CaptureGutter's kdoc and RENDER_LANE_PARITY.md). Remove one annotation."
+      )
+      return
+    }
     val firstNewPreviewIndex = previews.size
     fun tagFunctionLevel() {
       if (catalogEntry == null && captureGutter == null) return

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2888,6 +2888,16 @@ class DiscoveryFunctionalTest {
       fun ScrollOnlyPreview() {
           Box(modifier = Modifier.size(50.dp).background(Color.Green))
       }
+
+      // Control: an all-zero gutter is equivalent to no annotation, so this is NOT the forbidden
+      // combination — it survives as an ordinary scroll product.
+      @CaptureGutter(all = 0)
+      @ScrollingPreview(modes = [ScrollMode.LONG])
+      @Preview(name = "Zero gutter scroll")
+      @Composable
+      fun ZeroGutterScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Gray))
+      }
       """
         .trimIndent()
     )
@@ -2922,6 +2932,12 @@ class DiscoveryFunctionalTest {
       .isEqualTo(CaptureGutterDp(start = 4, top = 4, end = 4, bottom = 5))
     val scrollOnly = manifest.previews.single { it.functionName == "ScrollOnlyPreview" }
     assertThat(scrollOnly.dataProducts.single().kind).isEqualTo("render/scroll/long")
+
+    // An all-zero gutter is equivalent to no annotation, so scroll + zero-gutter is kept — the
+    // rejection is scoped to an *effective* gutter, not the annotation's bare presence.
+    val zeroGutterScroll = manifest.previews.single { it.functionName == "ZeroGutterScrollPreview" }
+    assertThat(zeroGutterScroll.params.captureGutter).isNull()
+    assertThat(zeroGutterScroll.dataProducts.single().kind).isEqualTo("render/scroll/long")
   }
 
   @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2790,6 +2790,128 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
+  fun `composePreviewDiscover rejects @CaptureGutter combined with @ScrollingPreview`() {
+    val projectDir = createCmpTestProject()
+
+    // Both annotations stubbed at their canonical FQNs — discovery matches by FQN, same as the
+    // single-annotation tests above.
+    val fqnDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    fqnDir.mkdirs()
+    File(fqnDir, "CaptureGutter.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+        annotation class CaptureGutter(
+          val all: Int = 0,
+          val start: Int = -1,
+          val top: Int = -1,
+          val end: Int = -1,
+          val bottom: Int = -1,
+        )
+        """
+          .trimIndent()
+      )
+    File(fqnDir, "ScrollingPreview.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        enum class ScrollMode { TOP, END, LONG, GIF }
+        enum class ScrollAxis { VERTICAL, HORIZONTAL }
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class ScrollingPreview(
+            val modes: Array<ScrollMode> = [ScrollMode.END],
+            val maxScrollPx: Int = 0,
+            val reduceMotion: Boolean = true,
+            val axis: ScrollAxis = ScrollAxis.VERTICAL,
+            val frameIntervalMs: Int = 80,
+        )
+        """
+          .trimIndent()
+      )
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.unit.dp
+      import ee.schimke.composeai.preview.CaptureGutter
+      import ee.schimke.composeai.preview.ScrollMode
+      import ee.schimke.composeai.preview.ScrollingPreview
+
+      // The contradiction: a gutter says "the component draws past its own bounds", a scroll
+      // capture has no such bounds. Rejected at discovery so the author removes one rather than
+      // shipping a gutter some products keep and others drop.
+      @CaptureGutter(all = 4, bottom = 5)
+      @ScrollingPreview(modes = [ScrollMode.END])
+      @Preview(name = "Guttered scroll")
+      @Composable
+      fun GutteredScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+
+      // Control: gutter alone is still discovered with its gutter intact.
+      @CaptureGutter(all = 4, bottom = 5)
+      @Preview(name = "Gutter only")
+      @Composable
+      fun GutterOnlyPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+      }
+
+      // Control: scroll alone is still discovered as a scroll product.
+      @ScrollingPreview(modes = [ScrollMode.LONG])
+      @Preview(name = "Scroll only")
+      @Composable
+      fun ScrollOnlyPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Green))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewDiscover", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    // Warn-and-skip, not a hard build failure — matches every other unsupported-combination skip.
+    assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.output).contains("test.PreviewsKt.GutteredScrollPreview")
+    assertThat(result.output).contains("@CaptureGutter cannot be combined with @ScrollingPreview")
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    // The offending function contributes nothing — no still, no scroll product.
+    assertThat(manifest.previews.map { it.functionName }).doesNotContain("GutteredScrollPreview")
+
+    // Both controls survive with their respective intent intact, proving the guard is scoped to
+    // the combination rather than to either annotation on its own.
+    val gutterOnly = manifest.previews.single { it.functionName == "GutterOnlyPreview" }
+    assertThat(gutterOnly.params.captureGutter)
+      .isEqualTo(CaptureGutterDp(start = 4, top = 4, end = 4, bottom = 5))
+    val scrollOnly = manifest.previews.single { it.functionName == "ScrollOnlyPreview" }
+    assertThat(scrollOnly.dataProducts.single().kind).isEqualTo("render/scroll/long")
+  }
+
+  @Test
   fun `composePreviewDiscover records @PreviewParameter provider FQN`() {
     val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2863,6 +2863,16 @@ class DiscoveryFunctionalTest {
           Box(modifier = Modifier.size(50.dp).background(Color.Red))
       }
 
+      // Even the degenerate empty-modes form is rejected: it declares @ScrollingPreview, which is
+      // what the contract forbids alongside a gutter, even though it produces no scroll specs.
+      @CaptureGutter(all = 4, bottom = 5)
+      @ScrollingPreview(modes = [])
+      @Preview(name = "Empty-modes guttered scroll")
+      @Composable
+      fun EmptyModesGutteredScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Yellow))
+      }
+
       // Control: gutter alone is still discovered with its gutter intact.
       @CaptureGutter(all = 4, bottom = 5)
       @Preview(name = "Gutter only")
@@ -2892,6 +2902,7 @@ class DiscoveryFunctionalTest {
     // Warn-and-skip, not a hard build failure — matches every other unsupported-combination skip.
     assertThat(result.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     assertThat(result.output).contains("test.PreviewsKt.GutteredScrollPreview")
+    assertThat(result.output).contains("test.PreviewsKt.EmptyModesGutteredScrollPreview")
     assertThat(result.output).contains("@CaptureGutter cannot be combined with @ScrollingPreview")
 
     val manifest =
@@ -2899,8 +2910,10 @@ class DiscoveryFunctionalTest {
         File(projectDir, "build/compose-previews/previews.json").readText()
       )
 
-    // The offending function contributes nothing — no still, no scroll product.
-    assertThat(manifest.previews.map { it.functionName }).doesNotContain("GutteredScrollPreview")
+    // The offending functions contribute nothing — no still, no scroll product. The empty-modes
+    // form is rejected on the annotation's presence, not on it having produced any scroll spec.
+    assertThat(manifest.previews.map { it.functionName })
+      .containsNoneOf("GutteredScrollPreview", "EmptyModesGutteredScrollPreview")
 
     // Both controls survive with their respective intent intact, proving the guard is scoped to
     // the combination rather than to either annotation on its own.


### PR DESCRIPTION
Closes the open scroll half of #4467 by removing the case rather than reconciling it per lane.

## Why

`@CaptureGutter` and `@ScrollingPreview` on one function are a contradiction, not a combination. A gutter says "the component draws this far past its own bounds"; a scroll capture has no such bounds — a LONG stitch's are the scrolled extent, a GIF's the declared viewport, and even a settled END/TOP frame is one viewport of a screen, not a component with an edge for the gutter to sit on.

Honouring the pair per lane was exactly the part of #4467 that stayed open:

- CMP Desktop hands its scroll renderer no gutter at all.
- Android grows one hosting window per preview, so `LONG`/`GIF` had to trim the gutter back off after capture.
- `END` diverged outright — `frame + gutter` on Android, `frame` on Desktop — because its product is an ordinary still that shares the whole post-capture chain (focus overlay, a11y/semantics/layout-inspector sidecars, a baked-in round mask), all keyed to the grown window. Fixing it properly needs an un-grown second render pass.

No preview in the repo actually declares both annotations (verified across samples, fixtures, and tests), so the machinery to make `END` agree would be built for zero users.

## What

Discovery now rejects the combination: a function carrying both annotations is skipped with an actionable warning naming it, and contributes nothing to `previews.json`. This is the same warn-and-skip idiom `PreviewDiscovery` already uses for unsupported `@XrSubspacePreview` parameters — not a hard build failure. The daemon consumes `previews.json`, so this single chokepoint covers the batch and daemon lanes alike (its `IncrementalDiscovery` only carries identity fields; gutter/scroll params always come from here).

Either annotation on its own is untouched.

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test` — green.
- `./gradlew :gradle-plugin:functionalTest --tests '*rejects @CaptureGutter*'` — green. New end-to-end test compiles a project with a gutter+scroll function plus gutter-only and scroll-only controls, and asserts the combo is skipped with the warning while both controls survive with their intent intact. Verified red against the un-guarded discovery.
- `ktfmtCheck` — clean on all changed files.

Text-only change (discovery plumbing + docs); no rendered surface changes, so no visual evidence applies. KDoc on `@CaptureGutter` and `docs/RENDER_LANE_PARITY.md` updated to state the combination is rejected rather than half-supported per lane.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFZsM7PxPecadiVjWQTyAR)_