### PR TITLE
fix(serve): give theme optimization a useful idle window

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -58,8 +58,16 @@ data class OptimizerPressureThresholds(
    * stays permanent is a genuine emergency — see [dutyCycleFloorMemoryAvailableFraction].
    */
   val starvationCapMillis: Long = 30 * 60_000L,
-  /** How long the gate stays open once [starvationCapMillis] is exhausted. `0` disables the cap. */
-  val dutyCycleMillis: Long = 60_000L,
+  /**
+   * How long the gate stays open once [starvationCapMillis] is exhausted. `0` disables the cap.
+   *
+   * This must be comfortably longer than one cold Android daemon warm (34-68s in production). The
+   * old one-minute window was commonly spent entirely in that warm: the next per-batch gate check
+   * saw the window closed and yielded with zero cache entries written. Five minutes matches the
+   * optimizer's normal lane slice, so a concession can pay for the warm and still do useful work
+   * without turning the pressure backstop into an unbounded admission.
+   */
+  val dutyCycleMillis: Long = 5 * 60_000L,
   /**
    * Memory headroom below which the duty cycle never opens, whatever the hold has cost.
    *

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -175,6 +175,37 @@ class HostOptimizerAdmissionTest {
   }
 
   @Test
+  fun `the default duty cycle outlives a cold daemon warm`() {
+    var now = 0L
+    val gate =
+      OptimizerPressureGate(
+        sample = {
+          HostResourceSample(
+            loadPerCpu = 0.17,
+            cpuUtilization = 0.03,
+            memoryAvailableFraction = 0.14,
+          )
+        },
+        thresholds = OptimizerPressureThresholds(sampleIntervalMillis = 0),
+        clock = { now },
+      )
+    assertTrue(gate.snapshot().constrained)
+
+    now = 30 * 60_000L
+    assertFalse(gate.snapshot().constrained, "the starvation cap opens a bounded work window")
+
+    // The deployed Android lanes take up to about 68 seconds merely to warm. The old 60-second
+    // default had already closed here, so a pass reached its first render gate with no work done.
+    now += 70_000L
+    val afterWarm = gate.snapshot()
+    assertFalse(afterWarm.constrained, "the concession must leave time to render after warming")
+    assertNotNull(afterWarm.dutyCycleUntilEpochMillis)
+
+    now = 35 * 60_000L
+    assertTrue(gate.snapshot().constrained, "the longer concession remains bounded")
+  }
+
+  @Test
   fun `an expired duty cycle closes even when sampling has stopped working`() {
     var now = 0L
     var readable = true

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -979,8 +979,11 @@ keep a shut gate from turning the feature off:
   simply never runs — `/status.json` reporting `paused · memory available 15%` with `wear-m3` warmed
   to 5 of its 170 entries over a 15-hour uptime. A steady-state reading is the host's baseline
   rather than an emergency, so after `-Dcomposeai.serve.optimizerStarvationCapMillis` (30 minutes)
-  the gate opens for `…optimizerDutyCycleMillis` (60 seconds), then holds again: hold, admit a
-  slice, hold. The exception is a genuine emergency — memory available under
+  the gate opens for `…optimizerDutyCycleMillis` (5 minutes), then holds again: hold, admit a
+  slice, hold. The window matches the normal optimizer slice and comfortably outlives a cold
+  Android daemon warm (34-68s); the former 60-second window was often spent entirely warming, so
+  its first per-batch pressure check closed the pass before it wrote one cache entry. The exception
+  is a genuine emergency — memory available under
   `…optimizerDutyCycleFloorMemoryAvailableFraction` (`0.05`) never duty-cycles, because slow
   progress is not worth an OOM-killed replica — and neither does a host whose memory reading is
   *missing* (`/proc/meminfo` unreadable while load and CPU still are), since an unverified floor is


### PR DESCRIPTION
## Summary
- extend pressure-gate duty cycles from one minute to five minutes
- leave the 30-minute starvation hold, immediate pressure stops, and 5% memory floor unchanged
- document the production failure mode and add regression coverage

## Why
The live status page showed the optimizer repeatedly paused around the memory recovery dead band. Its bounded duty cycles were opening, but a cold Android daemon takes roughly 34-68 seconds to warm, so the former 60-second concession could close before the first cache entry was rendered. Matching the concession to the normal five-minute optimizer slice leaves useful render time after warming while keeping admission bounded.

## Test plan
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.HostOptimizerAdmissionTest
- git diff --check