### PR TITLE
chore: clean up Kotlin and Gradle warnings

### DIFF
--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/cli/DiscoverPreviewModulesActionTest.kt
@@ -105,7 +105,7 @@ class DiscoverPreviewModulesActionTest {
             "must not query GradleProject — that realizes the whole task graph (#1620)",
           )
           if (type == ComposePreviewModel::class.java) {
-            findModelFor(args!![0] as BasicGradleProject)
+            findModelFor(args[0] as BasicGradleProject)
           } else error("unexpected findModel($type)")
         }
         "toString" -> "FakeBuildController"

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultAbiTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/cli/PreviewResultAbiTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
 class PreviewResultAbiTest {
   @Test
   fun `retains the constructor descriptor from before project directory`() {

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/xr/SpatialSceneTest.kt
@@ -55,8 +55,7 @@ class SpatialSceneTest {
     // The top panel sits above the bottom one — the genuine SpatialColumn stacking.
     assertTrue(top.poseInRoot.translation.y > bottom.poseInRoot.translation.y)
 
-    assertNotNull(scene.environment)
-    assertEquals("color", scene.environment!!.kind)
+    assertEquals("color", assertNotNull(scene.environment).kind)
   }
 
   @Test

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -585,17 +585,18 @@ tasks.named("check") { dependsOn("checkCliDaemonLibraryBoundary") }
 // drifted out of sync with the release manifest and made `compose-preview show` advertise a
 // nonexistent v0.9.0 release. Mirrors `gradle-plugin/build.gradle.kts`'s
 // `generatePluginVersionResource`.
-val generateCliVersionResource by tasks.registering {
-  val outputDir = layout.buildDirectory.dir("generated/cli-version-resource")
-  val cliVersion = project.version.toString()
-  inputs.property("version", cliVersion)
-  outputs.dir(outputDir)
-  doLast {
-    val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
-    file.parentFile.mkdirs()
-    file.writeText("version=$cliVersion\n")
+val generateCliVersionResource =
+  tasks.register("generateCliVersionResource") {
+    val outputDir = layout.buildDirectory.dir("generated/cli-version-resource")
+    val cliVersion = project.version.toString()
+    inputs.property("version", cliVersion)
+    outputs.dir(outputDir)
+    doLast {
+      val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
+      file.parentFile.mkdirs()
+      file.writeText("version=$cliVersion\n")
+    }
   }
-}
 
 sourceSets.main.get().resources.srcDir(generateCliVersionResource)
 
@@ -611,8 +612,8 @@ sourceSets.main.get().resources.srcDir(generateCliVersionResource)
 // are deliberately left out — the player fetches those itself through `WebFonts.ts`; only the four
 // behind the generic families need registering, and they are what `ServeRcFonts.FACES` declares
 // (`ServeRcFontsTest` fails when this list and that table disagree).
-val stageRcFontResources by
-  tasks.registering(Sync::class) {
+val stageRcFontResources =
+  tasks.register<Sync>("stageRcFontResources") {
     description =
       "Stage the vendored generic-family faces the serve viewer registers for its RC lanes."
     from(rootDir.resolve("samples/cmp-wasm-catalog/src/wasmJsMain/resources/fonts")) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessClient.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessClient.kt
@@ -142,7 +142,7 @@ internal class AgentAccessClient(
               "credential in the request"
           )
         }
-        val text = response.body?.string().orEmpty()
+        val text = response.body.string()
         if (!response.isSuccessful) {
           val retryAfter = response.header("Retry-After")?.trim()?.toLongOrNull()?.takeIf { it > 0 }
           val retry = retryAfter?.let { " (retry after ${it}s)" }.orEmpty()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
@@ -68,7 +68,7 @@ class RenderMatrixCommand(args: List<String>) : Command(args) {
     val fontScales = fontScaleRaw?.map { it.toFloatOrNull() }
     if (fontScales?.any { it == null } == true) {
       System.err.println(
-        "render-matrix: --font-scale must be numbers, got '${fontScaleRaw!!.joinToString(",")}'"
+        "render-matrix: --font-scale must be numbers, got '${fontScaleRaw.joinToString(",")}'"
       )
       exitProcess(64)
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2254,7 +2254,9 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
               PlaygroundMode.ANDROID,
               PlaygroundMode.REMOTE_COMPOSE -> androidBundle
             }
-          (source as? PlaygroundBundleSource.ServedCatalog)?.system
+          (source?.let { PlaygroundBundleSource.parse(it) }
+              as? PlaygroundBundleSource.ServedCatalog)
+            ?.system
         },
         captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
         publishRemoteDocument = { name, bytes, checked ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/SharePreviewServeUpload.kt
@@ -97,7 +97,7 @@ internal class ServeImageUploader(
                 "travel to a host you did not name."
             )
           !response.isSuccessful -> {
-            val detail = response.body?.string()?.trim()?.take(400).orEmpty()
+            val detail = response.body.string().trim().take(400)
             Result.Failed(
               "$base answered ${response.code}${if (detail.isEmpty()) "" else ": $detail"}" +
                 // A bodyless 404 — or 405 — is what a host WITHOUT `--accept-images` gives: the
@@ -110,7 +110,7 @@ internal class ServeImageUploader(
                 if (response.code in LANE_ABSENT_CODES && detail.isEmpty()) IMAGE_LANE_OFF else ""
             )
           }
-          else -> parse(response.body?.string().orEmpty())
+          else -> parse(response.body.string())
         }
       }
     } catch (e: Exception) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundSeed.kt
@@ -663,8 +663,7 @@ class PlaygroundSeedResolver(
     fun httpFetch(url: String, maxBytes: Int = DEFAULT_MAX_BYTES): ByteArray? =
       try {
         httpClient.newCall(okhttp3.Request.Builder().url(url).build()).execute().use { response ->
-          if (!response.isSuccessful) null
-          else response.body?.byteStream()?.readNBytes(maxBytes + 1)
+          if (!response.isSuccessful) null else response.body.byteStream().readNBytes(maxBytes + 1)
         }
       } catch (_: Exception) {
         null

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RenderCircuitBreaker.kt
@@ -142,7 +142,7 @@ class RenderCircuitBreaker(
   fun peekReason(): String? = synchronized(lock) { openReason }
 
   /** A render succeeded. Closes a rate-tripped breaker; a fatal one stays open. */
-  fun recordOk() =
+  fun recordOk(): Unit =
     synchronized(lock) {
       push(false)
       if (fatal) return
@@ -153,7 +153,7 @@ class RenderCircuitBreaker(
     }
 
   /** A render failed with [reason]; trips the breaker when fatal or when the rate says so. */
-  fun recordFailure(reason: String) =
+  fun recordFailure(reason: String): Unit =
     synchronized(lock) {
       push(true)
       if (fatal) return

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2773,8 +2773,7 @@ class ServeCatalogStore(
             )
           } else {
             val body = response.body
-            if (body == null) BranchFetch.Unavailable(response.code)
-            else BranchFetch.Ok(readCapped(body.byteStream(), maxBytes))
+            BranchFetch.Ok(readCapped(body.byteStream(), maxBytes))
           }
         }
       } catch (e: java.io.IOException) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -1182,7 +1182,7 @@ internal constructor(
         svgPath
           ?.takeIf { fileSystem.exists(it) }
           ?.let { p -> fileSystem.read(p) { readByteArray() } }
-      if (raw == null || svgPath == null) {
+      if (raw == null) {
         val reason = "render produced no SVG"
         onLog(reason)
         return@withLock SvgOutcome.Failed(reason)
@@ -1256,7 +1256,7 @@ internal constructor(
         svgPath
           ?.takeIf { fileSystem.exists(it) }
           ?.let { p -> fileSystem.read(p) { readByteArray() } }
-      if (raw == null || svgPath == null) {
+      if (raw == null) {
         val reason = "render produced no full-page SVG"
         onLog(reason)
         return@withLock SvgOutcome.Failed(reason)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
@@ -120,7 +120,7 @@ internal object ServeStartupBundles {
     return runCatching {
       httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
         if (!response.isSuccessful) return@use null
-        val body = response.body ?: return@use null
+        val body = response.body
         readCapped(body.byteStream(), maxBytes)
       }
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrlFetch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeUrlFetch.kt
@@ -93,7 +93,7 @@ object ServeUrlFetch {
         return Hop.Redirect(resolved.toString())
       }
       if (!response.isSuccessful) return Hop.Failed
-      val body = response.body ?: return Hop.Failed
+      val body = response.body
       val bytes = readCapped(body.byteStream(), maxBytes) ?: return Hop.Failed
       return Hop.Body(bytes)
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -11959,8 +11959,7 @@ $cards
         val disabled =
           if (pinned == null) "" else " disabled aria-describedby=\"cp-pinned-controls-note\""
         val usageSrc =
-          if (pinned == null) " data-usage-src=\"${WebEscaping.htmlEscape(usageHref ?: "")}\""
-          else ""
+          if (pinned == null) " data-usage-src=\"${WebEscaping.htmlEscape(usageHref)}\"" else ""
         val button =
           "<button type=\"button\" id=\"cp-source-chip\" class=\"cp-spec-chip cp-source-chip$tabClass\"$tabAttrs " +
             "aria-pressed=\"false\" aria-controls=\"cp-source-panel\" " +

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AndroidBundleResourcesTest.kt
@@ -7,6 +7,7 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -136,9 +137,8 @@ class AndroidBundleResourcesTest {
       """<manifest $androidNs package="ee.schimke.meshcore.app">
            <application android:name=".MeshcoreApp" android:theme="@style/T"/>
          </manifest>"""
-    val out = AndroidBundleResources.stripApplicationName(xml)
-    assertTrue(out != null, "expected a rewrite")
-    assertTrue(!out!!.contains("MeshcoreApp"), out)
+    val out = assertNotNull(AndroidBundleResources.stripApplicationName(xml), "expected a rewrite")
+    assertTrue(!out.contains("MeshcoreApp"), out)
     // The theme (and every other attribute) survives — only android:name is removed.
     assertTrue(out.contains("@style/T"), out)
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -128,7 +128,7 @@ class BundleSigningTest {
     val trust = TrustStore(keys = listOf(TrustedKey("ci", keys.publicKeyB64, "Test CI")))
     val verdict = BundleVerifier.verify(file, trust)
     assertTrue(verdict is BundleVerifier.Verdict.Trusted, "expected trusted, got $verdict")
-    val basis = (verdict as BundleVerifier.Verdict.Trusted).primary
+    val basis = verdict.primary
     assertTrue(basis is BundleVerifier.Basis.Signature && basis.keyId == "ci")
   }
 
@@ -181,7 +181,7 @@ class BundleSigningTest {
   fun `unsigned bundle is unverified`() {
     val verdict = BundleVerifier.verify(sampleBundle(), TrustStore.EMPTY)
     assertTrue(verdict is BundleVerifier.Verdict.Unverified)
-    assertEquals("unsigned bundle", (verdict as BundleVerifier.Verdict.Unverified).reason)
+    assertEquals("unsigned bundle", verdict.reason)
   }
 
   @Test
@@ -198,7 +198,7 @@ class BundleSigningTest {
         BundleVerifier.Origin("yschimke/compose-ai-tools", "design-artifacts/compose-m3"),
       )
     assertTrue(verdict is BundleVerifier.Verdict.Trusted)
-    assertTrue((verdict as BundleVerifier.Verdict.Trusted).primary is BundleVerifier.Basis.Branch)
+    assertTrue(verdict.primary is BundleVerifier.Basis.Branch)
   }
 
   /**
@@ -266,7 +266,7 @@ class BundleSigningTest {
       )
     val verdict = BundleVerifier.verify(file, trust)
     assertTrue(verdict is BundleVerifier.Verdict.Trusted)
-    val bases = (verdict as BundleVerifier.Verdict.Trusted).bases
+    val bases = verdict.bases
     // The cryptographic signature is the trust basis; provenance rides along as context.
     assertTrue(bases.first() is BundleVerifier.Basis.Signature)
     assertTrue(bases.any { it is BundleVerifier.Basis.Provenance })

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitCropTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSplitCropTest.kt
@@ -45,9 +45,8 @@ class BundleSplitCropTest {
   @Test
   fun `crops the sticker PNG to its component box`() {
     val png = renderPng(x = 144, y = 159, w = 166, h = 136)
-    val cropped = cropPngToContentBox(png, figmaSvg(144, 159, 166, 136))
-    assertNotNull(cropped)
-    assertEquals(166 to 136, dims(cropped!!.png), "cropped to the figma-svg content box")
+    val cropped = assertNotNull(cropPngToContentBox(png, figmaSvg(144, 159, 166, 136)))
+    assertEquals(166 to 136, dims(cropped.png), "cropped to the figma-svg content box")
     assertEquals(
       144 to 159,
       cropped.cropX to cropped.cropY,
@@ -60,9 +59,8 @@ class BundleSplitCropTest {
     // The layout-derived figma box (144,159,166,136) under-covers a variant whose focus ring is
     // drawn a few px outside it — here opaque pixels span (140,155)…(315,300).
     val png = renderPng(x = 140, y = 155, w = 175, h = 145)
-    val cropped = cropPngToContentBox(png, figmaSvg(144, 159, 166, 136))
-    assertNotNull(cropped)
-    assertEquals(175 to 145, dims(cropped!!.png), "grown to cover the ring's actual pixels")
+    val cropped = assertNotNull(cropPngToContentBox(png, figmaSvg(144, 159, 166, 136)))
+    assertEquals(175 to 145, dims(cropped.png), "grown to cover the ring's actual pixels")
     assertEquals(140 to 155, cropped.cropX to cropped.cropY, "crop origin is the unioned top-left")
   }
 
@@ -83,9 +81,8 @@ class BundleSplitCropTest {
   fun `a box overrunning the image edge is clamped, not thrown`() {
     // A padded box whose origin+size exceeds the 454 canvas still crops safely to the edge.
     val png = renderPng(x = 400, y = 400, w = 60, h = 60)
-    val cropped = cropPngToContentBox(png, figmaSvg(400, 400, 80, 80))
-    assertNotNull(cropped)
-    assertEquals(54 to 54, dims(cropped!!.png), "clamped to the 454 edge (454-400)")
+    val cropped = assertNotNull(cropPngToContentBox(png, figmaSvg(400, 400, 80, 80)))
+    assertEquals(54 to 54, dims(cropped.png), "clamped to the 454 edge (454-400)")
   }
 
   private fun sheetZip(png: ByteArray, svg: String): ByteArray {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -89,11 +89,7 @@ class PreviewListResponseTest {
           ),
         counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
       )
-    val brief = Json {
-      prettyPrint = false
-      encodeDefaults = false
-    }
-      .encodeToString(BriefPreviewListResponse.serializer(), response)
+    val brief = Json.encodeToString(BriefPreviewListResponse.serializer(), response)
 
     // Schema and core fields are present.
     assertTrue(""""schema":"$SHOW_LIST_BRIEF_SCHEMA"""" in brief)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/XrCompositeProvisionTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -114,8 +115,9 @@ class XrCompositeProvisionTest {
       return
     }
     assertEquals(1, fetches)
-    assertTrue(binary != null && binary.isFile, "binary should be unpacked: $logs")
-    assertTrue(File(binary!!.parentFile, "materials/m.txt").isFile, "materials should unpack")
+    val unpacked = assertNotNull(binary, "binary should be unpacked: $logs")
+    assertTrue(unpacked.isFile, "binary should be unpacked: $logs")
+    assertTrue(File(unpacked.parentFile, "materials/m.txt").isFile, "materials should unpack")
   }
 
   @Test
@@ -207,8 +209,9 @@ class XrCompositeProvisionTest {
         log = {},
       )
     assertEquals(1, fetches, "a partial cache must NOT short-circuit — it re-provisions")
-    assertTrue(result != null && result.isFile)
-    assertTrue(File(result!!.parentFile, "materials").isDirectory, "materials/ is now present")
+    val unpacked = assertNotNull(result)
+    assertTrue(unpacked.isFile)
+    assertTrue(File(unpacked.parentFile, "materials").isDirectory, "materials/ is now present")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli.serve
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -63,7 +64,8 @@ class BranchFetchStatsTest {
     val snap = stats.snapshot()!!
     assertEquals(1, snap.unavailable)
     assertEquals(42L, snap.lastFailureAtEpochMillis)
-    assertTrue(snap.lastFailureReason!!.contains("503"), snap.lastFailureReason!!)
+    val reason = assertNotNull(snap.lastFailureReason)
+    assertTrue(reason.contains("503"), reason)
     assertNull(snap.lastThrottleAtEpochMillis, "a 503 is not a rate limit")
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/LiveSeatLimiterTest.kt
@@ -88,15 +88,13 @@ class LiveSeatLimiterTest {
   @Test
   fun `desktop-weight sessions fill the budget then the next is refused`() {
     val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
-    val a = limiter.acquire(1)
-    val b = limiter.acquire(1)
-    assertNotNull(a)
-    assertNotNull(b)
+    val a = assertNotNull(limiter.acquire(1))
+    assertNotNull(limiter.acquire(1))
     assertEquals(0, limiter.availablePermits())
     // Third desktop session over budget → refused (caller closes WS 1013).
     assertNull(limiter.acquire(1))
     // Freeing one reopens a seat.
-    a!!.close()
+    a.close()
     assertEquals(1, limiter.availablePermits())
     val c = limiter.acquire(1)
     assertNotNull(c)
@@ -106,9 +104,8 @@ class LiveSeatLimiterTest {
   fun `an Android session costs its heavier weight and blocks a concurrent desktop one`() {
     val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
     // Weight 2 (Android) consumes the whole budget of 2.
-    val android = limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT)
-    assertNotNull(android)
-    assertEquals(2, android!!.permits)
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(2, android.permits)
     assertEquals(0, limiter.availablePermits())
     // A cheap desktop session can't squeeze in while the heavy one holds both permits.
     assertNull(limiter.acquire(1))
@@ -124,9 +121,8 @@ class LiveSeatLimiterTest {
     // (its weight exceeds the ceiling). Coerce to the budget so it runs solo instead of
     // deadlocking.
     val limiter = LiveSeatLimiter(1)
-    val android = limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT)
-    assertNotNull(android)
-    assertEquals(1, android!!.permits)
+    val android = assertNotNull(limiter.acquire(ServeBundleDaemon.ANDROID_LIVE_SEAT_WEIGHT))
+    assertEquals(1, android.permits)
     assertEquals(0, limiter.availablePermits())
     // …but it does hold the whole box: nothing else runs concurrently.
     assertNull(limiter.acquire(1))
@@ -137,9 +133,8 @@ class LiveSeatLimiterTest {
   @Test
   fun `releasing a ticket is idempotent — a double close returns permits only once`() {
     val limiter = LiveSeatLimiter(2, perPreviewReserve = 0)
-    val a = limiter.acquire(1)
-    assertNotNull(a)
-    a!!.close()
+    val a = assertNotNull(limiter.acquire(1))
+    a.close()
     a.close() // second close is a no-op
     assertEquals(2, limiter.availablePermits())
     // Sanity: the budget didn't inflate past its total.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCompileServiceTest.kt
@@ -239,8 +239,8 @@ class PlaygroundCompileServiceTest {
 
     val resp = svc.run(request(), isSecurityChecked = true)
 
-    assertNotNull(resp.previewToken)
-    assertEquals("/pg/${resp.previewToken}", resp.previewUrl)
+    val previewToken = assertNotNull(resp.previewToken)
+    assertEquals("/pg/$previewToken", resp.previewUrl)
     assertNull(resp.exception)
     assertEquals(
       listOf("/catalog/app.jar".toPath()),
@@ -248,7 +248,7 @@ class PlaygroundCompileServiceTest {
       "compiled against the catalog classpath",
     )
 
-    val token = tokenStore.get(resp.previewToken!!)!!
+    val token = assertNotNull(tokenStore.get(previewToken))
     assertEquals("com.example.SnippetPreview", token.snippet.previewId)
     assertEquals(PlaygroundMode.CMP, token.snippet.mode)
     // The render classpath carries the catalog jars plus the snippet's own compiled classes.
@@ -305,8 +305,7 @@ class PlaygroundCompileServiceTest {
     val resp = svc.run(request(), isSecurityChecked = true)
 
     assertNull(resp.previewToken)
-    assertNotNull(resp.exception)
-    assertTrue(resp.exception!!.contains("@Preview"))
+    assertTrue(assertNotNull(resp.exception).contains("@Preview"))
     assertFalse(fs.exists("/work/run1".toPath()))
   }
 
@@ -379,8 +378,7 @@ class PlaygroundCompileServiceTest {
 
     assertNull(resp.documentUrl)
     assertNull(resp.previewToken)
-    assertNotNull(resp.exception)
-    assertTrue(resp.exception!!.contains("RemoteDocument"))
+    assertTrue(assertNotNull(resp.exception).contains("RemoteDocument"))
     assertTrue(tokenStore.snapshot().isEmpty())
     assertFalse(fs.exists("/work/run1".toPath()), "a capture-less RC run deletes its own work dir")
   }
@@ -393,8 +391,7 @@ class PlaygroundCompileServiceTest {
 
     assertNull(resp.documentUrl)
     assertNull(resp.previewToken)
-    assertNotNull(resp.exception)
-    assertTrue(resp.exception!!.contains("not accepted"))
+    assertTrue(assertNotNull(resp.exception).contains("not accepted"))
     assertTrue(tokenStore.snapshot().isEmpty())
     assertFalse(fs.exists("/work/run1".toPath()))
   }
@@ -573,19 +570,19 @@ class PlaygroundCompileServiceTest {
 
     val alice = svc.acquireEditLease("alice")
     assertTrue(alice.acquired)
-    assertNotNull(alice.lease)
+    val aliceLease = assertNotNull(alice.lease)
     assertEquals(6_000L, alice.expiresAtEpochMs)
 
     val bob = svc.acquireEditLease("bob")
     assertFalse(bob.acquired)
     assertNull(bob.lease, "a busy response never discloses the capability")
-    assertFalse(svc.releaseEditLease("bob", alice.lease!!), "ownership is checked")
+    assertFalse(svc.releaseEditLease("bob", aliceLease), "ownership is checked")
 
     now = 2_000L
     val renewed = svc.acquireEditLease("alice")
     assertEquals(alice.lease, renewed.lease)
     assertEquals(7_000L, renewed.expiresAtEpochMs)
-    assertTrue(svc.releaseEditLease("alice", alice.lease!!))
+    assertTrue(svc.releaseEditLease("alice", aliceLease))
     assertTrue(svc.acquireEditLease("bob").acquired, "release makes the single slot available")
     now = 8_000L
     assertFalse(svc.editLeaseHealth().active, "status observes idle expiry without taking the lock")
@@ -618,13 +615,14 @@ class PlaygroundCompileServiceTest {
     val svc = service(editLeasesEnabled = true)
     val first = svc.acquireEditLease("alice", client = "tab-a")
     val second = svc.acquireEditLease("alice", client = "tab-b")
+    val lease = assertNotNull(first.lease)
 
     assertEquals(first.lease, second.lease)
-    assertTrue(svc.releaseEditLease("alice", first.lease!!, client = "tab-a"))
+    assertTrue(svc.releaseEditLease("alice", lease, client = "tab-a"))
     assertTrue(svc.editLeaseHealth().active)
     assertTrue(fs.metadataOrNull("/work/run1".toPath())?.isDirectory == true)
 
-    assertTrue(svc.releaseEditLease("alice", first.lease!!, client = "tab-b"))
+    assertTrue(svc.releaseEditLease("alice", lease, client = "tab-b"))
     assertFalse(svc.editLeaseHealth().active)
     assertNull(fs.metadataOrNull("/work/run1".toPath()))
   }
@@ -632,7 +630,7 @@ class PlaygroundCompileServiceTest {
   @Test
   fun `reattaching a tab reports the accepted server revision`() {
     val svc = service(editLeasesEnabled = true)
-    val lease = svc.acquireEditLease("alice", client = "tab-a").lease!!
+    val lease = assertNotNull(svc.acquireEditLease("alice", client = "tab-a").lease)
     val response =
       svc.run(
         request().copy(editLease = lease, revision = 7),
@@ -655,7 +653,7 @@ class PlaygroundCompileServiceTest {
         editLeaseTtlMillis = 5_000L,
         nowMillis = { now },
       )
-    val alice = svc.acquireEditLease("alice").lease!!
+    val alice = assertNotNull(svc.acquireEditLease("alice").lease)
     val response =
       svc.run(
         request().copy(editLease = alice, revision = 7),
@@ -665,7 +663,7 @@ class PlaygroundCompileServiceTest {
     assertNotNull(response.previewToken)
 
     now = 6_001L
-    val bob = svc.acquireEditLease("bob").lease!! // Purges Alice's expired lease.
+    val bob = assertNotNull(svc.acquireEditLease("bob").lease) // Purges Alice's expired lease.
     assertEquals(7, svc.editLeaseHealth().lastRevision)
 
     assertTrue(svc.releaseEditLease("bob", bob))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRedeemServiceTest.kt
@@ -31,7 +31,7 @@ class PlaygroundRedeemServiceTest {
       clock = { now },
     )
 
-  private lateinit var service: PlaygroundRedeemService
+  private var service: PlaygroundRedeemService
   private var materializeCount = 0
 
   private val store =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRoutingTest.kt
@@ -199,7 +199,7 @@ class PlaygroundRoutingTest {
       """{"files":[{"name":"Snippet.kt","text":"@Preview @Composable fun P(){}"}],"confType":"compose-cmp"}"""
     postRun(body, server.port).use { resp ->
       assertEquals(200, resp.code)
-      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      val json = Json.parseToJsonElement(resp.body.string()).jsonObject
       assertTrue(
         json["previewToken"]?.jsonPrimitive?.content?.startsWith("pg_") == true,
         "a clean compile mints a pg_ token: $json",
@@ -245,7 +245,7 @@ class PlaygroundRoutingTest {
       assertTrue(retryAfter != null && retryAfter >= 1, "Retry-After should be set: $retryAfter")
       // Answered in the run route's own JSON shape, so the editor surfaces it as a status line
       // rather than as an unparseable body.
-      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      val json = Json.parseToJsonElement(resp.body.string()).jsonObject
       assertTrue(
         json["exception"]?.jsonPrimitive?.content?.contains("Too many requests") == true,
         "the refusal rides the run response contract: $json",
@@ -294,7 +294,7 @@ class PlaygroundRoutingTest {
         resp.header("Content-Type")?.contains("text/html") == true,
         "the editor page is served as HTML",
       )
-      val html = resp.body!!.string()
+      val html = resp.body.string()
       assertTrue(
         html.contains("id=\"pg-source\"") &&
           html.contains("id=\"pg-run\"") &&
@@ -310,7 +310,7 @@ class PlaygroundRoutingTest {
     get("/playground", githubNoRepoServer.port, cookie).use { resp ->
       assertEquals(403, resp.code)
       assertTrue(
-        resp.body!!.string().contains("Playground requires access to yschimke/compose-ai-tools"),
+        resp.body.string().contains("Playground requires access to yschimke/compose-ai-tools"),
         "playground explains the repo-rights gate",
       )
     }
@@ -321,7 +321,7 @@ class PlaygroundRoutingTest {
     val cookie = githubSessionCookie(githubRepoServer.port)
     get("/playground", githubRepoServer.port, cookie).use { resp ->
       assertEquals(200, resp.code)
-      val html = resp.body!!.string()
+      val html = resp.body.string()
       assertTrue(html.contains("id=\"pg-source\""))
       assertTrue(html.contains("id=\"pg-edit-lease\""))
     }
@@ -339,14 +339,14 @@ class PlaygroundRoutingTest {
         )
         .use { resp ->
           assertEquals(200, resp.code)
-          Json.parseToJsonElement(resp.body!!.string()).jsonObject["lease"]!!.jsonPrimitive.content
+          Json.parseToJsonElement(resp.body.string()).jsonObject["lease"]!!.jsonPrimitive.content
         }
     val body =
       """{"files":[{"name":"Snippet.kt","text":"@Preview fun P(){}"}],"confType":"compose-cmp","editLease":"$lease","revision":1}"""
 
     post("/api/1/compiler/run", body, githubRepoServer.port, cookie).use { resp ->
       assertEquals(200, resp.code)
-      val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+      val json = Json.parseToJsonElement(resp.body.string()).jsonObject
       assertEquals("1", json["revision"]?.jsonPrimitive?.content)
       assertEquals(lease, json["editLease"]?.jsonPrimitive?.content)
       assertTrue(json["previewToken"]?.jsonPrimitive?.content?.startsWith("pg_") == true)
@@ -360,7 +360,7 @@ class PlaygroundRoutingTest {
       )
       .use { resp ->
         assertEquals(200, resp.code)
-        val json = Json.parseToJsonElement(resp.body!!.string()).jsonObject
+        val json = Json.parseToJsonElement(resp.body.string()).jsonObject
         assertEquals(lease, json["lease"]?.jsonPrimitive?.content)
         assertEquals("1", json["revision"]?.jsonPrimitive?.content)
       }
@@ -378,7 +378,7 @@ class PlaygroundRoutingTest {
       )
       .use { resp ->
         assertEquals(413, resp.code)
-        assertTrue(resp.body!!.string().contains("exceeds 256KB"))
+        assertTrue(resp.body.string().contains("exceeds 256KB"))
       }
   }
 
@@ -388,7 +388,7 @@ class PlaygroundRoutingTest {
       assertEquals(503, resp.code)
       assertEquals("no-store", resp.header("Cache-Control"))
       assertTrue(
-        resp.body!!.string().contains("Playground unavailable"),
+        resp.body.string().contains("Playground unavailable"),
         "the reserved playground path explains the missing server config",
       )
     }
@@ -410,7 +410,7 @@ class PlaygroundRoutingTest {
         .execute()
         .use { resp ->
           assertEquals(200, resp.code)
-          Json.parseToJsonElement(resp.body!!.string())
+          Json.parseToJsonElement(resp.body.string())
             .jsonObject["previewUrl"]!!
             .jsonPrimitive
             .content

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PsiParseSpikeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PsiParseSpikeTest.kt
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 
 /**
@@ -131,7 +130,7 @@ class PsiParseSpikeTest {
           val callNodes = ktFile.collectDescendantsOfType<KtCallExpression>()
           calls += callNodes.size
           namedArgs += callNodes.sumOf { call ->
-            call.valueArguments.count { (it as? KtValueArgument)?.getArgumentName() != null }
+            call.valueArguments.count { it.getArgumentName() != null }
           }
           qualified += ktFile.collectDescendantsOfType<KtDotQualifiedExpression>().size
         }
@@ -195,14 +194,12 @@ class PsiParseSpikeTest {
       //    placeholder like `${default}`. Worth knowing before anyone bets a redesign on it.
       val overrides = byName["previewOverrideString"].orEmpty()
       val labelled = overrides.filter { call ->
-        call.valueArguments.any { (it as? KtValueArgument)?.getArgumentName() != null }
+        call.valueArguments.any { it.getArgumentName() != null }
       }
       val positional = overrides - labelled.toSet()
       val defaults = labelled.mapNotNull { call ->
         call.valueArguments
-          .firstOrNull {
-            (it as? KtValueArgument)?.getArgumentName()?.asName?.asString() == "default"
-          }
+          .firstOrNull { it.getArgumentName()?.asName?.asString() == "default" }
           ?.getArgumentExpression()
           ?.text
       }
@@ -216,9 +213,7 @@ class PsiParseSpikeTest {
       // Two of them: the bare `("subtitle", "Basket")` and the package-qualified `("k", "v")`.
       assertTrue(positional.size == 2, "expected two positional calls, got ${positional.size}")
       assertTrue(
-        positional.all { call ->
-          call.valueArguments.all { (it as? KtValueArgument)?.getArgumentName() == null }
-        },
+        positional.all { call -> call.valueArguments.all { it.getArgumentName() == null } },
         "a positional call must carry no argument names — that is the whole point",
       )
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -180,7 +180,7 @@ class ServeAdminRoutingTest {
         .build()
     val http = if (followRedirects) client else client.newBuilder().followRedirects(false).build()
     http.newCall(req).execute().use { r ->
-      return r.code to (r.headers["Location"] ?: r.body?.string() ?: "")
+      return r.code to (r.headers["Location"] ?: r.body.string())
     }
   }
 
@@ -282,7 +282,7 @@ class ServeAdminRoutingTest {
 
     val home =
       Request.Builder().url(url("/")).build().let { req ->
-        client.newCall(req).execute().use { it.body?.string() ?: "" }
+        client.newCall(req).execute().use { it.body.string() }
       }
 
     assertTrue(home.contains("href=\"/newcat/\""), "the new catalog is indexed: $home")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
@@ -92,13 +92,13 @@ class ServeAgentGrantImageUploadTest {
         .post(body.toRequestBody(contentType.toMediaType()))
         .build()
     client.newCall(request).execute().use {
-      return it.code to (it.body?.string() ?: "")
+      return it.code to it.body.string()
     }
   }
 
   private fun get(path: String, port: Int = server.port): Pair<Int, String> {
     client.newCall(Request.Builder().url(url(path, port)).build()).execute().use {
-      return it.code to (it.body?.string() ?: "")
+      return it.code to it.body.string()
     }
   }
 
@@ -173,7 +173,7 @@ class ServeAgentGrantImageUploadTest {
     val token = grantedToken()
     upload(token).use { response ->
       assertEquals(201, response.code)
-      val body = response.body!!.string()
+      val body = response.body.string()
       // The finished markdown is the thing the agent came for.
       assertTrue(str(body, "markdown").startsWith("![after.png](http"), body)
       // Attribution names the grant and the human behind it — never a borrowed login.
@@ -186,7 +186,7 @@ class ServeAgentGrantImageUploadTest {
   @Test
   fun `the uploaded image is then fetchable at the url it handed back`() {
     val token = grantedToken()
-    val path = upload(token).use { str(it.body!!.string(), "path") }
+    val path = upload(token).use { str(it.body.string(), "path") }
     // Ungated, exactly like a collaborator's upload: GitHub's proxy fetches a PR body's images
     // anonymously, so a gated URL would never paint.
     client.newCall(Request.Builder().url(url(path)).build()).execute().use {
@@ -202,7 +202,7 @@ class ServeAgentGrantImageUploadTest {
     val token = grantedToken(scope = "live", ask = emptyList())
     upload(token).use { response ->
       assertEquals(401, response.code)
-      assertTrue(response.body!!.string().contains("GitHub token"))
+      assertTrue(response.body.string().contains("GitHub token"))
     }
   }
 
@@ -228,7 +228,7 @@ class ServeAgentGrantImageUploadTest {
         .header(ServeHttpServer.TOKEN_HEADER, token)
         .build()
     client.newCall(request).execute().use {
-      val body = it.body!!.string()
+      val body = it.body.string()
       assertTrue(body.contains("\"capabilities\":[\"images\"]"), body)
       // Never the token, on any surface that describes it.
       assertFalse(body.contains(token), body)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantRoutingTest.kt
@@ -70,7 +70,7 @@ class ServeAgentGrantRoutingTest {
         .apply { token?.let { header(tokenHeader, it) } }
         .build()
     client.newCall(request).execute().use {
-      return it.code to (it.body?.string() ?: "")
+      return it.code to it.body.string()
     }
   }
 
@@ -81,7 +81,7 @@ class ServeAgentGrantRoutingTest {
         .apply { token?.let { header(ServeHttpServer.TOKEN_HEADER, it) } }
         .build()
     client.newCall(request).execute().use {
-      return it.code to (it.body?.string() ?: "")
+      return it.code to it.body.string()
     }
   }
 
@@ -381,7 +381,7 @@ class ServeAgentGrantRoutingTest {
   /** Open the viewer socket with [token] and return the reason it was closed with (or "open"). */
   private fun socketCloseReason(token: String): String {
     val latch = java.util.concurrent.CountDownLatch(1)
-    val reason = java.util.concurrent.atomic.AtomicReference("open")
+    val closeReason = java.util.concurrent.atomic.AtomicReference("open")
     val request =
       Request.Builder()
         .url("ws://127.0.0.1:${server.port}/ws/AnyPreview?session=demo")
@@ -391,13 +391,13 @@ class ServeAgentGrantRoutingTest {
       client.newWebSocket(
         request,
         object : okhttp3.WebSocketListener() {
-          override fun onClosed(webSocket: okhttp3.WebSocket, code: Int, text: String) {
-            reason.set(text)
+          override fun onClosed(webSocket: okhttp3.WebSocket, code: Int, reason: String) {
+            closeReason.set(reason)
             latch.countDown()
           }
 
-          override fun onClosing(webSocket: okhttp3.WebSocket, code: Int, text: String) {
-            reason.set(text)
+          override fun onClosing(webSocket: okhttp3.WebSocket, code: Int, reason: String) {
+            closeReason.set(reason)
             latch.countDown()
           }
 
@@ -406,14 +406,14 @@ class ServeAgentGrantRoutingTest {
             t: Throwable,
             response: okhttp3.Response?,
           ) {
-            reason.set("failure: ${t.message}")
+            closeReason.set("failure: ${t.message}")
             latch.countDown()
           }
         },
       )
     latch.await(15, java.util.concurrent.TimeUnit.SECONDS)
     socket.cancel()
-    return reason.get()
+    return closeReason.get()
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportRouteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBugReportRouteTest.kt
@@ -86,7 +86,7 @@ class ServeBugReportRouteTest {
     val req = Request.Builder().url(url)
     if (token != null) req.header(ServeHttpServer.TOKEN_HEADER, token)
     client.newCall(req.build()).execute().use { r ->
-      return r.code to (r.body?.string() ?: "")
+      return r.code to r.body.string()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -461,8 +461,7 @@ class ServeBundleDaemonTest {
         outcome is AnnotationsOutcome.Ok,
         "typography inspection for ${target.id} should succeed, got $outcome",
       )
-      val payload =
-        Json.parseToJsonElement((outcome as AnnotationsOutcome.Ok).json.decodeToString()).jsonObject
+      val payload = Json.parseToJsonElement(outcome.json.decodeToString()).jsonObject
       val annotations =
         Json.decodeFromJsonElement(
           ListSerializer(DesignAnnotation.serializer()),
@@ -611,10 +610,11 @@ class ServeBundleDaemonTest {
       return
     }
     // Sanity: the descriptor really is the android launch (Robolectric flags present).
-    val parsed = Json {
-      ignoreUnknownKeys = true
-    }
-      .decodeFromString(DaemonLaunchDescriptor.serializer(), state.descriptor.readText())
+    val parsed =
+      descriptorJson.decodeFromString(
+        DaemonLaunchDescriptor.serializer(),
+        state.descriptor.readText(),
+      )
     assertEquals("android", parsed.variant, "wear-m3 bundle should materialize an android daemon")
     assertTrue(
       parsed.systemProperties["robolectric.graphicsMode"] == "NATIVE",
@@ -690,8 +690,8 @@ class ServeBundleDaemonTest {
         val b = host.renderSvg(bId, PreviewOverrides())
         assertTrue(a is SvgOutcome.Ok, "SVG render of $aId should succeed, got $a")
         assertTrue(b is SvgOutcome.Ok, "SVG render of $bId should succeed, got $b")
-        val aBytes = (a as SvgOutcome.Ok).svg
-        val bBytes = (b as SvgOutcome.Ok).svg
+        val aBytes = a.svg
+        val bBytes = b.svg
         assertTrue(aBytes.isNotEmpty() && bBytes.isNotEmpty(), "SVGs must be non-empty")
         // Optional: dump the rendered vectors so a human can eyeball the per-variant difference.
         System.getProperty("composeai.test.svgDumpDir")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -128,7 +128,7 @@ class ServeBundleHostTest {
 
     val ok = host.bakedRender("com.example.Red", PreviewOverrides())
     assertTrue(ok != null, "local pixels must be servable without admission")
-    assertTrue(byteArrayOf(4, 2).contentEquals(ok!!.png))
+    assertTrue(byteArrayOf(4, 2).contentEquals(ok.png))
     assertEquals(RenderOutcome.Generation.BAKED, ok.generation)
     // Nested ids resolve the same way.
     val nested = ServeBundleHost(bundle("group/com.example.Blue" to byteArrayOf(7)), label = "b")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -377,7 +377,7 @@ class ServeCatalogStoreTest {
         },
       )
       .load("compose-m3")
-    val host = registered.getValue("compose-m3") as ServeBundleHost
+    val host = registered.getValue("compose-m3")
     val afterPublish = requested.count { it.endsWith(".png") }
 
     host.previews.forEach { host.contentCrop(it.id) }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
@@ -117,7 +117,7 @@ class ServeDesignPageRoutingTest {
       return Triple(
         response.code,
         response.header("Content-Type").orEmpty(),
-        response.body?.string() ?: "",
+        response.body.string(),
       )
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDocRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDocRoutingTest.kt
@@ -84,7 +84,7 @@ class ServeDocRoutingTest {
     val accepted =
       upload("loading.json", bytes).use { response ->
         assertEquals(201, response.code)
-        Json.parseToJsonElement(response.body!!.string()).jsonObject
+        Json.parseToJsonElement(response.body.string()).jsonObject
       }
     val id = accepted["id"]!!.jsonPrimitive.content
     val path = accepted["url"]!!.jsonPrimitive.content
@@ -95,7 +95,7 @@ class ServeDocRoutingTest {
 
     get(path).use { response ->
       assertEquals(200, response.code)
-      val html = response.body!!.string()
+      val html = response.body.string()
       // The page mounts the format's vendored player against the document's raw bytes…
       assertTrue(html.contains("/doc-player/lottie/bundle.js"), html.take(400))
       assertTrue(html.contains("$path/raw"), "the page points the player at the raw document")
@@ -107,9 +107,9 @@ class ServeDocRoutingTest {
 
     get("$path/raw").use { response ->
       assertEquals(200, response.code)
-      assertTrue(response.body!!.contentType().toString().startsWith("application/json"))
+      assertTrue(response.body.contentType().toString().startsWith("application/json"))
       assertEquals("nosniff", response.header("X-Content-Type-Options"))
-      assertEquals(bytes.toList(), response.body!!.bytes().toList())
+      assertEquals(bytes.toList(), response.body.bytes().toList())
     }
 
     // Past the TTL both lanes stop answering — the page as a styled 404, the raw bytes as a plain
@@ -125,18 +125,18 @@ class ServeDocRoutingTest {
     val path =
       upload("watchface.rc", bytes, "application/octet-stream").use { response ->
         assertEquals(201, response.code)
-        Json.parseToJsonElement(response.body!!.string()).jsonObject["url"]!!.jsonPrimitive.content
+        Json.parseToJsonElement(response.body.string()).jsonObject["url"]!!.jsonPrimitive.content
       }
 
     get(path).use { response ->
-      val html = response.body!!.string()
+      val html = response.body.string()
       assertTrue(html.contains("/doc-player/remotecompose/bundle.js"))
       // The stage is sized from the document's declared header size before the player loads.
       assertTrue(html.contains("width=\"320\" height=\"320\""), html.take(400))
     }
     get("$path/raw").use { response ->
-      assertEquals("application/octet-stream", response.body!!.contentType().toString())
-      assertEquals(bytes.toList(), response.body!!.bytes().toList())
+      assertEquals("application/octet-stream", response.body.contentType().toString())
+      assertEquals(bytes.toList(), response.body.bytes().toList())
     }
   }
 
@@ -144,7 +144,7 @@ class ServeDocRoutingTest {
   fun `an upload that is not a known document is refused`() {
     upload("evil.rc", "<html><script>alert(1)</script></html>".toByteArray(), "text/html").use {
       assertEquals(400, it.code)
-      assertTrue(it.body!!.string().contains("unrecognised document format"))
+      assertTrue(it.body.string().contains("unrecognised document format"))
     }
   }
 
@@ -160,7 +160,7 @@ class ServeDocRoutingTest {
       .execute()
       .use {
         assertEquals(400, it.code)
-        assertTrue(it.body!!.string().contains("allowlist"))
+        assertTrue(it.body.string().contains("allowlist"))
       }
   }
 
@@ -168,7 +168,7 @@ class ServeDocRoutingTest {
   fun `an unknown or malformed permalink is a styled 404`() {
     get("/d/aaaaaaaaaaaaaaaaaaaaaa").use { response ->
       assertEquals(404, response.code)
-      assertTrue(response.body!!.string().contains("expired"))
+      assertTrue(response.body.string().contains("expired"))
     }
     get("/d/..%2F..%2Fetc").use { assertEquals(404, it.code) }
   }
@@ -177,7 +177,7 @@ class ServeDocRoutingTest {
   fun `the upload page and each format's player are served`() {
     get("/docs").use { response ->
       assertEquals(200, response.code)
-      val html = response.body!!.string()
+      val html = response.body.string()
       assertTrue(html.contains("Share a document"))
       // Uploads only: with no allowlisted host the URL field is not rendered (the script still
       // carries its inert wiring, so the check is on the markup).
@@ -194,8 +194,8 @@ class ServeDocRoutingTest {
     for (format in ServeDocFormats.ALL) {
       get(format.playerPath).use { response ->
         assertEquals(200, response.code, "${format.id} player")
-        assertTrue(response.body!!.contentType().toString().startsWith("text/javascript"))
-        assertTrue(response.body!!.bytes().size > 1000, "${format.id} bundle is vendored")
+        assertTrue(response.body.contentType().toString().startsWith("text/javascript"))
+        assertTrue(response.body.bytes().size > 1000, "${format.id} bundle is vendored")
       }
     }
     get("/doc-player/nope/bundle.js").use { assertEquals(404, it.code) }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSiteAuthTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeGithubSiteAuthTest.kt
@@ -266,13 +266,13 @@ class ServeGithubSiteAuthTest {
     get("/", "m3.preview.coo.ee").use {
       assertEquals(200, it.code)
       assertFalse(
-        it.body!!.string().contains("cp-gh-auth"),
+        it.body.string().contains("cp-gh-auth"),
         "a static catalog has no gated lane, so its landing must not offer a sign-in",
       )
     }
     get("/status", "m3.preview.coo.ee").use {
       assertTrue(
-        it.body!!.string().contains("cp-gh-auth"),
+        it.body.string().contains("cp-gh-auth"),
         "…and the withholding is about the catalog's lanes, not about this host's round-trip",
       )
     }
@@ -285,7 +285,7 @@ class ServeGithubSiteAuthTest {
     get("/status", "m3.preview.coo.ee").use {
       assertEquals(200, it.code)
       assertTrue(
-        it.body!!.string().contains("cp-gh-auth"),
+        it.body.string().contains("cp-gh-auth"),
         "a site under the cookie domain can round-trip a sign-in, so it is offered",
       )
     }
@@ -294,7 +294,7 @@ class ServeGithubSiteAuthTest {
     get("/status", "other.preview.coo.ee").use {
       assertEquals(200, it.code)
       assertFalse(
-        it.body!!.string().contains("cp-gh-auth"),
+        it.body.string().contains("cp-gh-auth"),
         "a host outside the site list cannot round-trip, so the control is withheld",
       )
     }
@@ -325,13 +325,13 @@ class ServeGithubSiteAuthTest {
       }
       req("m3.preview.coo.ee").use {
         assertFalse(
-          it.body!!.string().contains("cp-gh-auth"),
+          it.body.string().contains("cp-gh-auth"),
           "the site cannot come back to itself",
         )
       }
       // The pinned callback host itself is unaffected — this is where sign-in always worked.
       req("preview.coo.ee").use {
-        assertTrue(it.body!!.string().contains("cp-gh-auth"), "the main host still offers sign-in")
+        assertTrue(it.body.string().contains("cp-gh-auth"), "the main host still offers sign-in")
       }
     } finally {
       runCatching { hostOnly.stop() }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -508,7 +509,7 @@ class ServeHttpRoutingTest {
   private fun get(path: String): Pair<Int, String> {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}$path").build()
     client.newCall(req).execute().use { r ->
-      return r.code to (r.body?.string() ?: "")
+      return r.code to r.body.string()
     }
   }
 
@@ -524,7 +525,7 @@ class ServeHttpRoutingTest {
   private fun getFull(path: String): Triple<Int, String, okhttp3.Headers> {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}$path").build()
     client.newCall(req).execute().use { r ->
-      return Triple(r.code, r.body?.string() ?: "", r.headers)
+      return Triple(r.code, r.body.string(), r.headers)
     }
   }
 
@@ -532,7 +533,7 @@ class ServeHttpRoutingTest {
   private fun getFullBytes(path: String): Triple<Int, ByteArray, okhttp3.Headers> {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}$path").build()
     client.newCall(req).execute().use { r ->
-      return Triple(r.code, r.body?.bytes() ?: ByteArray(0), r.headers)
+      return Triple(r.code, r.body.bytes(), r.headers)
     }
   }
 
@@ -543,7 +544,7 @@ class ServeHttpRoutingTest {
         .post(ByteArray(0).toRequestBody())
         .build()
     client.newCall(req).execute().use { r ->
-      return r.code to (r.body?.string() ?: "")
+      return r.code to r.body.string()
     }
   }
 
@@ -706,16 +707,15 @@ class ServeHttpRoutingTest {
     val home = get("/")
     assertEquals(200, home.first)
     val cardPath =
-      Regex("<meta property=\"og:image\" content=\"[^\"]*(/social/[0-9a-f]+\\.png)\">")
-        .find(home.second)
-        ?.groupValues
-        ?.get(1)
-    assertTrue(
-      cardPath != null,
-      "the front door advertises a drawn card: ${home.second.take(2000)}",
-    )
+      assertNotNull(
+        Regex("<meta property=\"og:image\" content=\"[^\"]*(/social/[0-9a-f]+\\.png)\">")
+          .find(home.second)
+          ?.groupValues
+          ?.get(1),
+        "the front door advertises a drawn card: ${home.second.take(2000)}",
+      )
 
-    val (code, _, headers) = getFull(cardPath!!)
+    val (code, _, headers) = getFull(cardPath)
     assertEquals(200, code)
     assertTrue(
       headers["Content-Type"].orEmpty().startsWith("image/png"),
@@ -1258,7 +1258,7 @@ class ServeHttpRoutingTest {
           .build()
       client.newCall(req).execute().use { r ->
         assertEquals(200, r.code, "a suspended catalog must resume to serve its capture")
-        assertEquals("capture", r.body?.string())
+        assertEquals("capture", r.body.string())
       }
     } finally {
       suspendedServer.stop()
@@ -1408,7 +1408,7 @@ class ServeHttpRoutingTest {
       var response = 503 to "warming"
       for (attempt in 0 until 50) {
         val req = Request.Builder().url("http://127.0.0.1:${partialServer.port}/readyz").build()
-        client.newCall(req).execute().use { r -> response = r.code to (r.body?.string() ?: "") }
+        client.newCall(req).execute().use { r -> response = r.code to r.body.string() }
         if (response.first == 200) break
         Thread.sleep(100)
       }
@@ -1458,7 +1458,7 @@ class ServeHttpRoutingTest {
       var response = 503 to "warming"
       for (attempt in 0 until 50) {
         val req = Request.Builder().url("http://127.0.0.1:${catalogServer.port}/readyz").build()
-        client.newCall(req).execute().use { r -> response = r.code to (r.body?.string() ?: "") }
+        client.newCall(req).execute().use { r -> response = r.code to r.body.string() }
         if (response.first == 200) break
         Thread.sleep(100)
       }
@@ -1499,7 +1499,7 @@ class ServeHttpRoutingTest {
       Request.Builder().url("http://127.0.0.1:${catalogServer.port}/readyz").build().let { req ->
         client.newCall(req).execute().use { r ->
           assertEquals(503, r.code)
-          assertEquals("warming", r.body?.string())
+          assertEquals("warming", r.body.string())
         }
       }
 
@@ -1509,7 +1509,7 @@ class ServeHttpRoutingTest {
       var response = 503 to "warming"
       for (attempt in 0 until 50) {
         val req = Request.Builder().url("http://127.0.0.1:${catalogServer.port}/readyz").build()
-        client.newCall(req).execute().use { r -> response = r.code to (r.body?.string() ?: "") }
+        client.newCall(req).execute().use { r -> response = r.code to r.body.string() }
         if (response.first == 200) break
         Thread.sleep(100)
       }
@@ -1541,7 +1541,7 @@ class ServeHttpRoutingTest {
       val req = Request.Builder().url("http://127.0.0.1:${brokenServer.port}/readyz").build()
       client.newCall(req).execute().use { r ->
         assertEquals(503, r.code)
-        assertEquals("warming", r.body?.string())
+        assertEquals("warming", r.body.string())
       }
     } finally {
       brokenServer.stop()
@@ -1574,7 +1574,7 @@ class ServeHttpRoutingTest {
     fun fetch(path: String): Pair<Int, String> {
       val req = Request.Builder().url("http://127.0.0.1:${lateServer.port}$path").build()
       client.newCall(req).execute().use { r ->
-        return r.code to (r.body?.string() ?: "")
+        return r.code to r.body.string()
       }
     }
     try {
@@ -1614,7 +1614,7 @@ class ServeHttpRoutingTest {
     fun fetch(path: String): Pair<Int, String> {
       val req = Request.Builder().url("http://127.0.0.1:${privateServer.port}$path").build()
       client.newCall(req).execute().use { response ->
-        return response.code to (response.body?.string() ?: "")
+        return response.code to response.body.string()
       }
     }
     try {
@@ -1649,7 +1649,7 @@ class ServeHttpRoutingTest {
         .build()
     client.newCall(renderReq).execute().use { r ->
       assertEquals(200, r.code)
-      assertEquals("image/png", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
+      assertEquals("image/png", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
     }
 
     val (apiCode, api) = get("/compose-m3/api/previews")
@@ -1730,7 +1730,7 @@ class ServeHttpRoutingTest {
 
     client.newCall(request).execute().use { response ->
       assertEquals(200, response.code)
-      val html = response.body?.string().orEmpty()
+      val html = response.body.string().orEmpty()
       assertTrue(
         html.contains(
           "<meta property=\"og:url\" content=\"https://preview.coo.ee/compose-m3/p/" +
@@ -1931,9 +1931,9 @@ class ServeHttpRoutingTest {
       assertEquals(200, r.code)
       assertEquals(
         "application/octet-stream",
-        r.body?.contentType()?.let { "${it.type}/${it.subtype}" },
+        r.body.contentType()?.let { "${it.type}/${it.subtype}" },
       )
-      assertTrue(rcDocBytes.contentEquals(r.body?.bytes()), "rc bytes served verbatim")
+      assertTrue(rcDocBytes.contentEquals(r.body.bytes()), "rc bytes served verbatim")
     }
   }
 
@@ -1973,11 +1973,11 @@ class ServeHttpRoutingTest {
       Request.Builder().url("http://127.0.0.1:${server.port}/rc-player-wasm/rcPlayer.wasm").build()
     client.newCall(req).execute().use { response ->
       assertEquals(200, response.code)
-      assertEquals("application/wasm", response.body?.contentType().toString())
+      assertEquals("application/wasm", response.body.contentType().toString())
       assertEquals("no-cache", response.header("Cache-Control"))
       assertTrue(response.header("ETag")?.isNotBlank() == true, "wasm response carries an ETag")
       assertTrue(
-        byteArrayOf(0x00, 0x61, 0x73, 0x6d).contentEquals(response.body?.bytes()),
+        byteArrayOf(0x00, 0x61, 0x73, 0x6d).contentEquals(response.body.bytes()),
         "wasm bytes served verbatim",
       )
     }
@@ -2012,8 +2012,8 @@ class ServeHttpRoutingTest {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}/rc-player/bundle.js").build()
     client.newCall(req).execute().use { r ->
       assertEquals(200, r.code)
-      assertEquals("text/javascript", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
-      val body = r.body?.string() ?: ""
+      assertEquals("text/javascript", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
+      val body = r.body.string()
       assertTrue(body.contains("RcdPlayer"), "the bundle exposes the RcdPlayer entry point")
       etag = r.header("ETag") ?: ""
       assertTrue(etag.isNotEmpty(), "carries a content-hash ETag")
@@ -2038,8 +2038,8 @@ class ServeHttpRoutingTest {
     val css =
       client.newCall(cssReq).execute().use { r ->
         assertEquals(200, r.code)
-        assertEquals("text/css", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
-        r.body?.string() ?: ""
+        assertEquals("text/css", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
+        r.body.string()
       }
     for (face in ServeRcFonts.FACES) {
       assertTrue(css.contains("font-family:\"${face.family}\""), "declares ${face.family}: $css")
@@ -2052,8 +2052,8 @@ class ServeHttpRoutingTest {
       Request.Builder().url("http://127.0.0.1:${server.port}/rc-fonts/${face.file}").build()
     client.newCall(faceReq).execute().use { r ->
       assertEquals(200, r.code)
-      assertEquals("font/ttf", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
-      assertTrue((r.body?.contentLength() ?: 0) > 1024, "the face carries its bytes")
+      assertEquals("font/ttf", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
+      assertTrue(r.body.contentLength() > 1024, "the face carries its bytes")
       etag = r.header("ETag") ?: ""
       assertTrue(etag.isNotEmpty(), "carries a content-hash ETag")
     }
@@ -2078,7 +2078,7 @@ class ServeHttpRoutingTest {
     val req = Request.Builder().url("http://127.0.0.1:${server.port}$versionedPath").build()
     client.newCall(req).execute().use { r ->
       assertEquals(200, r.code)
-      assertEquals("text/javascript", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
+      assertEquals("text/javascript", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
       assertEquals("public, max-age=31536000, immutable", r.header("Cache-Control"))
       etag = r.header("ETag") ?: ""
       assertEquals(asset.etag, etag)
@@ -2209,14 +2209,14 @@ class ServeHttpRoutingTest {
         .also { it.start() }
     try {
       val request = Request.Builder().url("http://127.0.0.1:${localServer.port}/").build()
-      val body = client.newCall(request).execute().use { it.body?.string().orEmpty() }
+      val body = client.newCall(request).execute().use { it.body.string().orEmpty() }
       assertTrue(body.contains("href=\"/shared%3Aui/\""), body)
       assertTrue(body.contains("burst"), body)
       assertTrue(body.contains("class=\"cp-component-browser\""), body)
 
       val devRequest =
         Request.Builder().url("http://127.0.0.1:${localServer.port}/?chrome=dev").build()
-      val devBody = client.newCall(devRequest).execute().use { it.body?.string().orEmpty() }
+      val devBody = client.newCall(devRequest).execute().use { it.body.string().orEmpty() }
       assertFalse(devBody.contains("class=\"cp-component-browser\""), devBody)
       assertTrue(
         devBody.contains("data-cp-interface-mode=\"dev\" aria-pressed=\"true\""),
@@ -2234,7 +2234,7 @@ class ServeHttpRoutingTest {
    * request's presentation without changing what the visitor is in afterwards.
    */
   @Test
-  fun `the interface mode comes from a cookie, and ?chrome= outranks it`() {
+  fun `the interface mode comes from a cookie, and the chrome query outranks it`() {
     val localRegistry = ServeSessionRegistry(open = { null })
     localRegistry.register("shared:ui", host = burstHost, pinned = true)
     val localServer =
@@ -2257,7 +2257,7 @@ class ServeHttpRoutingTest {
           .apply { cookie?.let { header("Cookie", it) } }
           .build()
       return client.newCall(request).execute().use {
-        it.body?.string().orEmpty() to it.headers("Vary")
+        it.body.string().orEmpty() to it.headers("Vary")
       }
     }
 
@@ -2323,7 +2323,7 @@ class ServeHttpRoutingTest {
 
     fun get(path: String): Pair<Int, String> {
       val request = Request.Builder().url("http://127.0.0.1:${localServer.port}$path").build()
-      return client.newCall(request).execute().use { it.code to it.body?.string().orEmpty() }
+      return client.newCall(request).execute().use { it.code to it.body.string().orEmpty() }
     }
 
     try {
@@ -2589,7 +2589,7 @@ class ServeHttpRoutingTest {
           r.header("Cache-Control"),
           "the content-hashed hero URL can be cached forever",
         )
-        assertTrue((r.body?.bytes()?.size ?: 0) > 0, "hero bytes are served")
+        assertTrue(r.body.bytes().isNotEmpty(), "hero bytes are served")
         r.header("ETag") ?: error("hero carries no ETag")
       }
     // A conditional request (a cache that chose to revalidate anyway) costs bytes, not a render.
@@ -2720,7 +2720,7 @@ class ServeHttpRoutingTest {
     client.newCall(request).execute().use { response ->
       assertEquals(200, response.code)
       assertEquals("image/png", response.header("Content-Type")?.substringBefore(';'))
-      assertTrue((response.body?.bytes()?.size ?: 0) > 0)
+      assertTrue(response.body.bytes().isNotEmpty())
     }
     assertEquals(404, get("/compose-m3/reference/missing.png").first)
     assertEquals(404, get("/compose-m3/compare/$previewId?reference=missing").first)
@@ -2806,7 +2806,7 @@ class ServeHttpRoutingTest {
     try {
       fun localGet(path: String): Pair<Int, String> {
         val request = Request.Builder().url("http://127.0.0.1:${localServer.port}$path").build()
-        return client.newCall(request).execute().use { it.code to (it.body?.string() ?: "") }
+        return client.newCall(request).execute().use { it.code to it.body.string() }
       }
 
       val (pageCode, page) = localGet("/local/p/$localId")
@@ -2850,8 +2850,8 @@ class ServeHttpRoutingTest {
         .build()
     client.newCall(req).execute().use { r ->
       assertEquals(200, r.code)
-      assertEquals("text/html", r.body?.contentType()?.let { "${it.type}/${it.subtype}" })
-      val body = r.body?.string() ?: ""
+      assertEquals("text/html", r.body.contentType()?.let { "${it.type}/${it.subtype}" })
+      val body = r.body.string()
       assertTrue(body.startsWith("<!doctype html>"), "is an html document: $body")
       assertTrue(body.contains("src=\"data:image/png;base64,"), "embeds the render png: $body")
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageRoutingTest.kt
@@ -168,7 +168,7 @@ class ServeImageRoutingTest {
     val accepted =
       upload().use { response ->
         assertEquals(201, response.code)
-        Json.parseToJsonElement(response.body!!.string()).jsonObject
+        Json.parseToJsonElement(response.body.string()).jsonObject
       }
     val id = accepted["id"]!!.jsonPrimitive.content
     val path = accepted["path"]!!.jsonPrimitive.content
@@ -189,7 +189,7 @@ class ServeImageRoutingTest {
       assertEquals(200, response.code)
       assertTrue(response.header("Content-Type")!!.startsWith("image/png"))
       assertEquals("nosniff", response.header("X-Content-Type-Options"))
-      assertTrue(response.body!!.bytes().contentEquals(ServeImageFixtures.png()))
+      assertTrue(response.body.bytes().contentEquals(ServeImageFixtures.png()))
     }
   }
 
@@ -199,7 +199,7 @@ class ServeImageRoutingTest {
     upload(bearer = null).use { response ->
       assertEquals(401, response.code)
       assertNotNull(response.header("WWW-Authenticate"))
-      val body = response.body!!.string()
+      val body = response.body.string()
       assertTrue(body.contains("yschimke/compose-ai-tools"), body)
     }
     assertEquals(before, imageStore.occupancy().count)
@@ -209,7 +209,7 @@ class ServeImageRoutingTest {
   fun `a real github account without access to the gating repo is refused`() {
     upload(bearer = FakeAuth.OUTSIDER_TOKEN).use { response ->
       assertEquals(403, response.code)
-      assertTrue(response.body!!.string().contains("does not have access"))
+      assertTrue(response.body.string().contains("does not have access"))
     }
     upload(bearer = "gho_madeup").use { response -> assertEquals(401, response.code) }
   }
@@ -218,7 +218,7 @@ class ServeImageRoutingTest {
   fun `an upload that is not an image is refused`() {
     upload(name = "evil.png", bytes = "<html><script>alert(1)</script></html>".toByteArray()).use {
       assertEquals(400, it.code)
-      assertTrue(it.body!!.string().contains("unrecognised"))
+      assertTrue(it.body.string().contains("unrecognised"))
     }
   }
 
@@ -226,7 +226,7 @@ class ServeImageRoutingTest {
   fun `a link 404s once expired, and under a suffix that is not its own`() {
     val path =
       upload().use {
-        Json.parseToJsonElement(it.body!!.string()).jsonObject["path"]!!.jsonPrimitive.content
+        Json.parseToJsonElement(it.body.string()).jsonObject["path"]!!.jsonPrimitive.content
       }
     val id = path.removePrefix("/i/").removeSuffix(".png")
 
@@ -239,7 +239,7 @@ class ServeImageRoutingTest {
       assertEquals(404, response.code)
       // An expired id and one that never existed answer the same way — the 404 says nothing about
       // whether there was ever anything here.
-      assertEquals("not found", response.body!!.string())
+      assertEquals("not found", response.body.string())
     }
   }
 
@@ -274,7 +274,7 @@ class ServeImageRoutingTest {
   @Test
   fun `the presented token is never echoed back`() {
     upload().use { response ->
-      val body = response.body!!.string()
+      val body = response.body.string()
       assertFalse(body.contains(FakeAuth.TOKEN), body)
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeImageStoreTest.kt
@@ -72,7 +72,7 @@ class ServeImageStoreTest {
     val notAnImage = store.put(bytes = "<html>nope</html>".toByteArray())
     assertTrue(notAnImage is ServeImageStore.Result.Failed)
     assertTrue(
-      (notAnImage as ServeImageStore.Result.Failed).reason.contains("unrecognised"),
+      notAnImage.reason.contains("unrecognised"),
       notAnImage.reason,
     )
     assertTrue(store.put(bytes = ByteArray(0)) is ServeImageStore.Result.Failed)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferencesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferencesTest.kt
@@ -93,7 +93,7 @@ class ServeKnownDifferencesTest {
     assertTrue(artifact is ServeKnownDifferences.Artifact.Bytes)
     assertEquals(
       "not really a png",
-      String((artifact as ServeKnownDifferences.Artifact.Bytes).bytes),
+      String(artifact.bytes),
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLandingIrReplayThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeLandingIrReplayThemeTest.kt
@@ -105,7 +105,7 @@ class ServeLandingIrReplayThemeTest {
     val request = Request.Builder().url("http://127.0.0.1:${server.port}/$system/").build()
     return client.newCall(request).execute().use { response ->
       assertEquals(200, response.code, "landing for $system")
-      response.body?.string().orEmpty()
+      response.body.string().orEmpty()
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeMotionIndexRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeMotionIndexRoutingTest.kt
@@ -95,7 +95,7 @@ class ServeMotionIndexRoutingTest {
       return Triple(
         response.code,
         response.header("Content-Type").orEmpty(),
-        response.body?.string() ?: "",
+        response.body.string(),
       )
     }
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivityStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityActivityStoreTest.kt
@@ -20,6 +20,7 @@ class ServeParityActivityStoreTest {
   private val fileSystem = FakeFileSystem()
   private val root = "/bundle".toPath()
   private val json = Json { prettyPrint = true }
+  private val wireJson = Json { ignoreUnknownKeys = true }
 
   private val sha = "4e73ec2b9f0a1c3d5e7f9a1b3c5d7e9f0a1b3c5d"
 
@@ -243,21 +244,23 @@ class ServeParityActivityStoreTest {
     val loaded =
       assertNotNull(
         ServeParityActivityStore.sanitize(
-          Json { ignoreUnknownKeys = true }.decodeFromString<ParityActivity>(fixture.readText())
+          wireJson.decodeFromString<ParityActivity>(fixture.readText())
         ),
         "the emitter's output must survive the reader's validation",
       )
 
-    assertEquals("yschimke/m3-catalog", loaded.code?.repo)
-    assertEquals(1, loaded.code?.events?.size)
+    val code = assertNotNull(loaded.code)
+    val figma = assertNotNull(loaded.figma)
+    assertEquals("yschimke/m3-catalog", code.repo)
+    assertEquals(1, code.events.size)
     // `+00:00` offsets, not just `Z` — git's `%aI` emits the former and the reader must take it.
-    assertEquals("2026-08-05T10:00:00+00:00", loaded.code?.events?.single()?.at)
-    assertEquals("ocdacdEsnHipMJD3egzxKb", loaded.figma?.fileKey)
-    assertEquals(1, loaded.figma?.versions?.size)
+    assertEquals("2026-08-05T10:00:00+00:00", code.events.single().at)
+    assertEquals("ocdacdEsnHipMJD3egzxKb", figma.fileKey)
+    assertEquals(1, figma.versions.size)
     // The comment resolved to the preview it specifies, which is what makes the page a parity view.
     assertEquals(
       listOf("switch-on__ideal__default__light"),
-      loaded.figma?.comments?.single()?.previewIds,
+      figma.comments.single().previewIds,
     )
     assertEquals(MappingGap.Kind.UNMAPPED_DESIGN_NODE, loaded.gaps.single().kind)
 
@@ -268,8 +271,7 @@ class ServeParityActivityStoreTest {
     // `ServeParityDashboard` just filters unknown ids out and renders a row with no target. So
     // assert the *shape*, not only the value: a discovery id here is a bug even if it parses.
     val eventPreviewIds =
-      loaded.code!!.events.flatMap { it.previewIds } +
-        loaded.figma!!.comments.flatMap { it.previewIds }
+      code.events.flatMap { it.previewIds } + figma.comments.flatMap { it.previewIds }
     assertTrue(eventPreviewIds.isNotEmpty(), "the fixture must exercise the join")
     for (id in eventPreviewIds) {
       assertFalse(
@@ -289,13 +291,11 @@ class ServeParityActivityStoreTest {
       "the published feed must produce inbound links against a catalog serving those ids",
     )
     // …and every outbound link the page will build from it resolves.
-    assertNotNull(
-      ServeParityActivityStore.commitUrl(loaded.code?.repo, loaded.code!!.events.single().sha)
-    )
+    assertNotNull(ServeParityActivityStore.commitUrl(code.repo, code.events.single().sha))
     assertNotNull(
       ServeParityActivityStore.nodeUrl(
-        loaded.figma?.fileKey,
-        loaded.figma?.comments?.single()?.nodeId,
+        figma.fileKey,
+        figma.comments.single().nodeId,
       )
     )
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -350,7 +350,7 @@ class ServePinnedRevisionTest {
     val ogImage =
       Regex("<meta property=\"og:image\" content=\"([^\"]+)\"").find(pinned)?.groupValues?.get(1)
     assertTrue(ogImage?.contains("at=$oldCommit") == true, pinned)
-    assertFalse(ogImage?.contains("themeProvider") == true, pinned)
+    assertFalse(ogImage.contains("themeProvider"), pinned)
     assertFalse(pinned.contains("data-usage-src="), pinned)
     assertFalse(pinned.contains("try in playground"), pinned)
     // An id that still exists uses the same canonical name on Current and pinned pages.
@@ -761,7 +761,7 @@ class ServePinnedRevisionTest {
 
   private fun get(url: String): Pair<Int, ByteArray> =
     client.newCall(Request.Builder().url(url).build()).execute().use { response ->
-      response.code to (response.body?.bytes() ?: ByteArray(0))
+      response.code to response.body.bytes()
     }
 
   private fun bytes(url: String): ByteArray {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiterTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRateLimiterTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -74,14 +75,13 @@ class ServeRateLimiterTest {
     // The issue's actual complaint: two clients issuing back-to-back long compiles hold both host
     // slots indefinitely. A per-caller concurrency of 1 is what stops one of them doing it alone.
     val l = limiter(permits = 100, maxConcurrent = 1)
-    val held = l.take("gh:alice")
-    assertTrue(held != null)
+    val held = assertNotNull(l.take("gh:alice"))
     val second = l.tryAcquire("gh:alice")
     assertIs<ServeRateLimiter.Decision.Throttled>(second)
     assertTrue(second.reason.contains("in flight"), second.reason)
     // …while a different caller is unaffected — this bounds one caller, not the host.
     assertTrue(l.cycle("gh:bob"))
-    held!!.release()
+    held.release()
     assertTrue(l.cycle("gh:alice"), "the slot frees when their own work finishes")
   }
 
@@ -130,16 +130,15 @@ class ServeRateLimiterTest {
   fun `a new caller is refused rather than growing the map past its cap`() {
     val l = limiter(permits = 2, maxKeys = 2)
     // Both slots held by callers with work in flight — nothing is sweepable, by construction.
-    val a = l.take("ip:10.0.0.1")
-    val b = l.take("ip:10.0.0.2")
-    assertTrue(a != null && b != null)
+    val a = assertNotNull(l.take("ip:10.0.0.1"))
+    val b = assertNotNull(l.take("ip:10.0.0.2"))
     val refused = l.tryAcquire("ip:10.0.0.3")
     assertIs<ServeRateLimiter.Decision.Throttled>(refused)
     assertTrue(refused.reason.contains("active callers"), refused.reason)
     assertEquals(2, l.trackedCallers())
     // …and the space is reclaimable once those callers go quiet.
-    a!!.release()
-    b!!.release()
+    a.release()
+    b.release()
     now += 60_000
     assertTrue(l.cycle("ip:10.0.0.3"))
   }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHostTest.kt
@@ -295,7 +295,7 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertTrue(out is SvgOutcome.Ok)
-      assertEquals("svg:DARK:null:null", (out as SvgOutcome.Ok).svg.decodeToString())
+      assertEquals("svg:DARK:null:null", out.svg.decodeToString())
     }
   }
 
@@ -307,7 +307,7 @@ class ServeRenderHostTest {
       assertTrue(out is SvgOutcome.Ok)
       assertEquals(
         "svg-long:$previewId:null:null:null",
-        (out as SvgOutcome.Ok).svg.decodeToString(),
+        out.svg.decodeToString(),
       )
       // The fetch carries the force flag + a serialized overrides bag (default here).
       val params = session.lastScrollFetchParams as JsonObject
@@ -341,11 +341,11 @@ class ServeRenderHostTest {
       assertTrue(dark is SvgOutcome.Ok && light is SvgOutcome.Ok)
       assertEquals(
         "svg-long:$previewId:DARK:null:null",
-        (dark as SvgOutcome.Ok).svg.decodeToString(),
+        dark.svg.decodeToString(),
       )
       assertEquals(
         "svg-long:$previewId:LIGHT:null:null",
-        (light as SvgOutcome.Ok).svg.decodeToString(),
+        light.svg.decodeToString(),
       )
       assertEquals(2, session.scrollFetchCount.get(), "each distinct override re-renders")
       // Re-requesting the dark capsule is a cache hit — no third fetch, and its bytes are intact.
@@ -432,7 +432,7 @@ class ServeRenderHostTest {
       // A dark SVG request must re-render dark, not return the shared file's stale light SVG.
       val out = h.renderSvg(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertTrue(out is SvgOutcome.Ok)
-      assertEquals("svg:DARK:null:null", (out as SvgOutcome.Ok).svg.decodeToString())
+      assertEquals("svg:DARK:null:null", out.svg.decodeToString())
     }
   }
 
@@ -445,7 +445,7 @@ class ServeRenderHostTest {
       val payload =
         Json.decodeFromString(
           PreviewSlotsPayload.serializer(),
-          (out as SlotsOutcome.Ok).json.decodeToString(),
+          out.json.decodeToString(),
         )
       assertEquals(previewId, payload.previewId)
       assertEquals(listOf("leadingIcon", "supporting"), payload.slots.map { it.name })
@@ -474,8 +474,7 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderAnnotations(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertTrue(out is AnnotationsOutcome.Ok)
-      val payload =
-        Json.parseToJsonElement((out as AnnotationsOutcome.Ok).json.decodeToString()).jsonObject
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
       assertEquals(previewId, payload["previewId"]?.jsonPrimitive?.content)
       val annotations =
         Json.decodeFromJsonElement(
@@ -617,8 +616,7 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderA11y(previewId, PreviewOverrides(uiMode = UiMode.DARK))
       assertTrue(out is A11yOutcome.Ok)
-      val payload =
-        Json.parseToJsonElement((out as A11yOutcome.Ok).json.decodeToString()).jsonObject
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
       assertEquals(previewId, payload["previewId"]?.jsonPrimitive?.content)
       assertEquals(1, payload.getValue("nodes").jsonArray.size)
       assertEquals(1, payload.getValue("findings").jsonArray.size)
@@ -647,8 +645,7 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderA11y(previewId, PreviewOverrides())
       assertTrue(out is A11yOutcome.Ok)
-      val payload =
-        Json.parseToJsonElement((out as A11yOutcome.Ok).json.decodeToString()).jsonObject
+      val payload = Json.parseToJsonElement(out.json.decodeToString()).jsonObject
       assertEquals(1, payload.getValue("nodes").jsonArray.size)
       assertTrue(payload.getValue("findings").jsonArray.isEmpty())
       assertTrue(payload.getValue("touchTargets").jsonArray.isEmpty())
@@ -779,7 +776,7 @@ class ServeRenderHostTest {
     host(session).use { h ->
       val out = h.renderSvg(previewId, PreviewOverrides())
       assertTrue(out is SvgOutcome.Ok)
-      val svg = (out as SvgOutcome.Ok).svg.decodeToString()
+      val svg = out.svg.decodeToString()
       val expected = java.util.Base64.getEncoder().encodeToString(byteArrayOf(1, 2, 3))
       assertTrue(svg.contains("data:image/png;base64,$expected"), "raster inlined: $svg")
       assertTrue(!svg.contains("figma-raster/"), "no dangling external ref remains: $svg")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusLiveFramesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusLiveFramesTest.kt
@@ -131,5 +131,5 @@ class ServeStatusLiveFramesTest {
     client
       .newCall(Request.Builder().url("http://127.0.0.1:${server.port}$path").build())
       .execute()
-      .use { it.code to (it.body?.string() ?: "") }
+      .use { it.code to it.body.string() }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -138,7 +138,7 @@ class ServeStatusTest {
     val req = Request.Builder().url(url)
     if (token != null) req.header(ServeHttpServer.TOKEN_HEADER, token)
     client.newCall(req.build()).execute().use { r ->
-      return r.code to (r.body?.string() ?: "")
+      return r.code to r.body.string()
     }
   }
 
@@ -689,7 +689,7 @@ class ServeStatusTest {
       fun statusJson(): String {
         val url = "http://127.0.0.1:${srv.port}/status.json"
         client.newCall(Request.Builder().url(url).build()).execute().use {
-          return it.body?.string() ?: ""
+          return it.body.string()
         }
       }
       // Resident: a live read, not a snapshot.
@@ -707,9 +707,7 @@ class ServeStatusTest {
 
       val homeUrl = "http://127.0.0.1:${srv.port}/"
       val home =
-        client.newCall(Request.Builder().url(homeUrl).build()).execute().use {
-          it.body?.string() ?: ""
-        }
+        client.newCall(Request.Builder().url(homeUrl).build()).execute().use { it.body.string() }
       assertTrue(home.contains("href=\"/confetti-wear/\""), home)
       assertTrue(home.contains("Confetti Wear"), home)
       assertEquals(
@@ -740,9 +738,7 @@ class ServeStatusTest {
       // document even though its facts are now a snapshot rather than a live read.
       val htmlUrl = "http://127.0.0.1:${srv.port}/status"
       val html =
-        client.newCall(Request.Builder().url(htmlUrl).build()).execute().use {
-          it.body?.string() ?: ""
-        }
+        client.newCall(Request.Builder().url(htmlUrl).build()).execute().use { it.body.string() }
       assertFalse(
         html.contains("untrusted"),
         "a suspended trusted catalog is not downgraded: $html",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplayLaneTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeThemeReplayLaneTest.kt
@@ -141,7 +141,7 @@ class ServeThemeReplayLaneTest {
       .execute()
       .use {
         assertEquals(200, it.code, path)
-        it.body?.string().orEmpty()
+        it.body.string().orEmpty()
       }
 
   private fun themeOption(theme: ServeTheme) = "\"theme:${theme.providerFqn}\""

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTopLevelSiteTest.kt
@@ -131,7 +131,7 @@ class ServeTopLevelSiteTest {
     cookie: String? = null,
   ): Triple<Int, String, String?> {
     client.newCall(request(path, host, cookie)).execute().use { r ->
-      return Triple(r.code, r.body?.string() ?: "", r.header("Location"))
+      return Triple(r.code, r.body.string(), r.header("Location"))
     }
   }
 
@@ -763,7 +763,7 @@ class ServeTopLevelSiteTest {
     val result = admin.unregister("compose-m3")
     assertTrue(result is ServeCatalogAdmin.Result.Conflict, "$result")
     assertTrue(
-      (result as ServeCatalogAdmin.Result.Conflict).reason.contains(siteHost),
+      result.reason.contains(siteHost),
       result.reason,
     )
     // A catalog no site names retires as before.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
@@ -37,7 +37,7 @@ class ServeTrustAdminTest {
       )
 
     assertTrue(result is ServeTrustAdmin.Result.Ok)
-    assertNull((result as ServeTrustAdmin.Result.Ok).warning)
+    assertNull(result.warning)
     // The point of the change: in force on the running server, no restart.
     assertTrue(store.get().trustsBranch("yschimke/horologist", "design-artifacts/horologist"))
     // ...and durable, so it survives the next roll.
@@ -162,8 +162,7 @@ class ServeTrustAdminTest {
       admin.add(AdminTrustEntry(kind = "branch", repo = "a/one", branch = "design-artifacts/*"))
 
     val ok = result as ServeTrustAdmin.Result.Ok
-    assertNotNull(ok.warning)
-    assertTrue(ok.warning!!.contains("not persisted"))
+    assertTrue(assertNotNull(ok.warning).contains("not persisted"))
     assertTrue(store.get().trustsBranch("a/one", "design-artifacts/x"))
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -22,6 +22,7 @@ import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -2268,11 +2269,13 @@ class ServeWebFixtureTest {
     // fixture carries several renderable nodes, so an existence check stays green while this
     // particular overlay regresses to a span or points somewhere else.
     val manifestNode =
-      Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:1"[^>]*>""").find(designPageHtml)
-    assertTrue(manifestNode != null, "the manifest-linked node 1:1 is emitted at all")
+      assertNotNull(
+        Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:1"[^>]*>""").find(designPageHtml),
+        "the manifest-linked node 1:1 is emitted at all",
+      )
     assertEquals(
       "a",
-      manifestNode!!.groupValues[1],
+      manifestNode.groupValues[1],
       "a node with a renderable preview is emitted as an anchor",
     )
     // The whole final segment, not a prefix: `/p/com.example.ProfileCardPreviewLegacy` contains
@@ -2282,8 +2285,11 @@ class ServeWebFixtureTest {
     // anchor for scripted navigation — precisely the inert-destination regression this is here to
     // catch — would keep it green.
     val hrefOf = { tag: String -> Regex("""\shref="([^"]*)"""").find(tag)?.groupValues?.get(1) }
-    val manifestHref = hrefOf(manifestNode.value)
-    assertTrue(manifestHref != null, "the manifest node carries a real href attribute")
+    val manifestHref =
+      assertNotNull(
+        hrefOf(manifestNode.value),
+        "the manifest node carries a real href attribute",
+      )
     // Matched through the route delimiter. `substringAfterLast` returns the WHOLE string when the
     // delimiter is absent, so a bare `href="com.example.ProfileCardPreview"` — which resolves
     // relative to the current page and navigates nowhere near the preview — would have passed.
@@ -2291,7 +2297,7 @@ class ServeWebFixtureTest {
       "com.example.ProfileCardPreview",
       // The capture must be the FINAL segment. Unanchored, `/p/<id>/other` still yields `<id>` —
       // and the server registers only the exact `/p/{name}` routes, so that URL navigates nowhere.
-      Regex("""/p/([^/?#]+)(?:[?#]|$)""").find(manifestHref!!)?.groupValues?.get(1),
+      Regex("""/p/([^/?#]+)(?:[?#]|$)""").find(manifestHref)?.groupValues?.get(1),
       "…and its destination is THAT preview, on the preview route",
     )
     // …and one WITHOUT code is still a link, to the design file — the only destination it has. The
@@ -2302,11 +2308,13 @@ class ServeWebFixtureTest {
     // exists and no span does": the renderable nodes satisfy a bare existence check on their own,
     // so this one could regress to a div and go unnoticed.
     val unlinkedNode =
-      Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:6"[^>]*>""").find(designPageHtml)
-    assertTrue(unlinkedNode != null, "the unlinked node 1:6 is emitted at all")
+      assertNotNull(
+        Regex("""<(\w+) class="cp-page-node" [^>]*data-cp-node="1:6"[^>]*>""").find(designPageHtml),
+        "the unlinked node 1:6 is emitted at all",
+      )
     assertEquals(
       "a",
-      unlinkedNode!!.groupValues[1],
+      unlinkedNode.groupValues[1],
       "an unlinked node stays an anchor rather than becoming inert",
     )
     // The WHOLE href, compared as one string. Checking parts independently loses whatever part is

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -304,14 +304,15 @@ val daemonRuntimeClasspathFile = layout.buildDirectory.file("daemon-harness/runt
 // finished registering its variants. The descriptor task itself is registered eagerly so
 // `:daemon:harness`'s `androidDaemonClasspath` configuration can wire up `dependsOn`
 // without needing afterEvaluate semantics.
-val writeDaemonClasspath by tasks.registering {
-  description =
-    "Resolves :daemon:android's debug runtime classpath + testFixtures into a text " +
-      "file the harness's RealAndroidHarnessLauncher reads at test time. (D-harness.v2)"
-  group = "verification"
-  val outputFileProvider = daemonRuntimeClasspathFile
-  outputs.file(outputFileProvider)
-}
+val writeDaemonClasspath =
+  tasks.register("writeDaemonClasspath") {
+    description =
+      "Resolves :daemon:android's debug runtime classpath + testFixtures into a text " +
+        "file the harness's RealAndroidHarnessLauncher reads at test time. (D-harness.v2)"
+    group = "verification"
+    val outputFileProvider = daemonRuntimeClasspathFile
+    outputs.file(outputFileProvider)
+  }
 
 // AGP's SDK android.jar — needed on the spawned daemon's classpath so JUnit / Robolectric can
 // introspect annotations referencing `android.app.Application` etc. before sandbox bootstrap. The
@@ -395,16 +396,17 @@ afterEvaluate {
 // Consumable configuration that surfaces the classpath text file as an artifact. The harness
 // declares a counterpart `androidDaemonClasspath` configuration with matching attributes and
 // reads `it.singleFile`. Plain-text content; no AGP transforms involved on the consumer side.
-val daemonHarnessClasspathFile by configurations.creating {
-  isCanBeConsumed = true
-  isCanBeResolved = false
-  attributes {
-    attribute(
-      Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
-      "android",
-    )
+val daemonHarnessClasspathFile =
+  configurations.create("daemonHarnessClasspathFile") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    attributes {
+      attribute(
+        Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
+        "android",
+      )
+    }
   }
-}
 
 // AGP `testFixtures { enable = true }` ships `daemon-android-<version>-test-fixtures.aar` as
 // part of the published `release` component. The fixture composables (`RedSquare`/`BlueSquare`/

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -91,17 +91,19 @@ dependencies {
 // real release back to VS Code instead of the `0.0.0-dev` fallback. Mirrors
 // `gradle-plugin/build.gradle.kts`'s `generatePluginVersionResource` and `cli/build.gradle.kts`'s
 // `generateCliVersionResource`.
-val generateDaemonVersionResource by tasks.registering {
-  val outputDir = layout.buildDirectory.dir("generated/daemon-version-resource")
-  val daemonVersion = project.version.toString()
-  inputs.property("version", daemonVersion)
-  outputs.dir(outputDir)
-  doLast {
-    val file = outputDir.get().file("ee/schimke/composeai/daemon/daemon-version.properties").asFile
-    file.parentFile.mkdirs()
-    file.writeText("version=$daemonVersion\n")
+val generateDaemonVersionResource =
+  tasks.register("generateDaemonVersionResource") {
+    val outputDir = layout.buildDirectory.dir("generated/daemon-version-resource")
+    val daemonVersion = project.version.toString()
+    inputs.property("version", daemonVersion)
+    outputs.dir(outputDir)
+    doLast {
+      val file =
+        outputDir.get().file("ee/schimke/composeai/daemon/daemon-version.properties").asFile
+      file.parentFile.mkdirs()
+      file.writeText("version=$daemonVersion\n")
+    }
   }
-}
 
 sourceSets.main.get().resources.srcDir(generateDaemonVersionResource)
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/FigmaSvgFidelity.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/FigmaSvgFidelity.kt
@@ -163,6 +163,7 @@ object FigmaSvgFidelity {
   }
 
   /** Skia fallback: renders shapes/paths (no SVG text) at native size via [loadSvgPainter]. */
+  @Suppress("DEPRECATION") // The resources API cannot load the generated in-memory SVG text.
   private fun rasterizeWithSkia(svgText: String, w: Int, h: Int): BufferedImage? {
     val density = Density(1f)
     val painter = loadSvgPainter(ByteArrayInputStream(svgText.toByteArray()), density)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1782,7 +1782,7 @@ class RenderEngine(
       return
     }
 
-    val cap = intent.maxScrollPx?.takeIf { it > 0 }?.toFloat() ?: Float.POSITIVE_INFINITY
+    val cap = intent.maxScrollPx.takeIf { it > 0 }?.toFloat() ?: Float.POSITIVE_INFINITY
     val startPx = initial.value()
     var scrolledPx = 0f
     for (step in 0 until END_DRIVE_MAX_STEPS) {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TouchOverlayPinchRecordingTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/TouchOverlayPinchRecordingTest.kt
@@ -295,7 +295,7 @@ class TouchOverlayPinchRecordingTest {
 @Composable
 fun PinchableSquare() {
   var scale by remember { mutableStateOf(1f) }
-  val transformableState = rememberTransformableState { zoomChange, _, _ ->
+  val transformableState = rememberTransformableState { _, zoomChange, _, _ ->
     scale = (scale * zoomChange).coerceIn(0.5f, 3.0f)
   }
   Box(

--- a/daemon/harness/build.gradle.kts
+++ b/daemon/harness/build.gradle.kts
@@ -103,16 +103,17 @@ dependencies {
 // configuration that produces a single text-file artifact listing the absolute paths of every
 // JAR on its `debugRuntimeClasspath` + `debugTestFixturesRuntimeClasspath`. Plain-text artefact
 // — no AGP variants on the consumer side. See that module's `writeDaemonClasspath` task.
-val androidDaemonClasspath: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-  attributes {
-    attribute(
-      Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
-      "android",
-    )
+val androidDaemonClasspath =
+  configurations.create("androidDaemonClasspath") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes {
+      attribute(
+        Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
+        "android",
+      )
+    }
   }
-}
 
 dependencies { androidDaemonClasspath(project(":daemon:android")) }
 
@@ -180,75 +181,80 @@ tasks.register<JavaExec>("runFakeDaemonMain") {
 // Configuration-cache discipline: a dedicated `classloaderForensicsLib` configuration captures the
 // `:daemon:core` jars at configuration time so the doLast lambda doesn't reach through
 // `project(...)` at execution time (cross-project task references aren't config-cache-safe).
-val classloaderForensicsLib: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-  description = "Resolved JARs for the ClassloaderForensics library (used by dumpClassloaderDiff)."
-}
+val classloaderForensicsLib =
+  configurations.create("classloaderForensicsLib") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    description =
+      "Resolved JARs for the ClassloaderForensics library (used by dumpClassloaderDiff)."
+  }
 
 dependencies { classloaderForensicsLib(project(":daemon:core")) }
 
-val dumpClassloaderDiff by tasks.registering {
-  description =
-    "Diff the standalone (:renderer-android) and daemon (:daemon:android) classloader " +
-      "forensics dumps. Writes daemon/harness/build/reports/classloader-forensics/diff.{md,json}. v1 — " +
-      "developer-invoked diagnostic, not a CI gate."
-  group = "verification"
-  // Reference the sibling modules' forensics dumps by path anchored at the build root — Isolated
-  // Projects forbids reaching into another project's `layout`. Dev-only diagnostic inputs.
-  val standaloneJson =
-    layout.settingsDirectory.file(
-      "renderers/android/build/reports/classloader-forensics/standalone.json"
-    )
-  val daemonJson =
-    layout.settingsDirectory.file("daemon/android/build/reports/classloader-forensics/daemon.json")
-  val diffMdFile = layout.buildDirectory.file("reports/classloader-forensics/diff.md")
-  val diffJsonFile = layout.buildDirectory.file("reports/classloader-forensics/diff.json")
-  inputs.file(standaloneJson)
-  inputs.file(daemonJson)
-  outputs.file(diffMdFile)
-  outputs.file(diffJsonFile)
+val dumpClassloaderDiff =
+  tasks.register("dumpClassloaderDiff") {
+    description =
+      "Diff the standalone (:renderer-android) and daemon (:daemon:android) classloader " +
+        "forensics dumps. Writes daemon/harness/build/reports/classloader-forensics/diff.{md,json}. v1 — " +
+        "developer-invoked diagnostic, not a CI gate."
+    group = "verification"
+    // Reference the sibling modules' forensics dumps by path anchored at the build root — Isolated
+    // Projects forbids reaching into another project's `layout`. Dev-only diagnostic inputs.
+    val standaloneJson =
+      layout.settingsDirectory.file(
+        "renderers/android/build/reports/classloader-forensics/standalone.json"
+      )
+    val daemonJson =
+      layout.settingsDirectory.file(
+        "daemon/android/build/reports/classloader-forensics/daemon.json"
+      )
+    val diffMdFile = layout.buildDirectory.file("reports/classloader-forensics/diff.md")
+    val diffJsonFile = layout.buildDirectory.file("reports/classloader-forensics/diff.json")
+    inputs.file(standaloneJson)
+    inputs.file(daemonJson)
+    outputs.file(diffMdFile)
+    outputs.file(diffJsonFile)
 
-  // Snapshot the resolved JAR list at configuration time — Provider<Set<FileSystemLocation>> is
-  // configuration-cache-safe; cross-project task references aren't.
-  val libFiles = classloaderForensicsLib.elements
+    // Snapshot the resolved JAR list at configuration time — Provider<Set<FileSystemLocation>> is
+    // configuration-cache-safe; cross-project task references aren't.
+    val libFiles = classloaderForensicsLib.elements
 
-  doLast {
-    val standalone = standaloneJson.asFile
-    val daemon = daemonJson.asFile
-    require(standalone.exists()) {
-      "Configuration A dump missing — run :renderer-android:test --tests \"*ClassloaderForensicsTest\" first.\n" +
-        "Expected: ${standalone.absolutePath}"
+    doLast {
+      val standalone = standaloneJson.asFile
+      val daemon = daemonJson.asFile
+      require(standalone.exists()) {
+        "Configuration A dump missing — run :renderer-android:test --tests \"*ClassloaderForensicsTest\" first.\n" +
+          "Expected: ${standalone.absolutePath}"
+      }
+      require(daemon.exists()) {
+        "Configuration B dump missing — run :daemon:android:test --tests \"*ClassloaderForensicsDaemonTest\" first.\n" +
+          "Expected: ${daemon.absolutePath}"
+      }
+      val urls = libFiles.get().map { it.asFile.toURI().toURL() }.toTypedArray()
+      val parentLoader: ClassLoader =
+        Thread.currentThread().contextClassLoader ?: ClassLoader.getSystemClassLoader()
+      val cl: ClassLoader = URLClassLoader(urls, parentLoader)
+      val forensics =
+        Class.forName("ee.schimke.composeai.daemon.forensics.ClassloaderForensics", true, cl)
+      val instance = forensics.getField("INSTANCE").get(null)
+      val fileClass = File::class.java
+      val diffMethod = forensics.getMethod("diff", fileClass, fileClass, fileClass, fileClass)
+      val diffMd = diffMdFile.get().asFile
+      val diffJson = diffJsonFile.get().asFile
+      diffMd.parentFile.mkdirs()
+      diffMethod.invoke(instance, standalone, daemon, diffMd, diffJson)
+      logger.lifecycle("Classloader forensics diff written to: ${diffMd.absolutePath}")
+      logger.lifecycle("                                  + : ${diffJson.absolutePath}")
     }
-    require(daemon.exists()) {
-      "Configuration B dump missing — run :daemon:android:test --tests \"*ClassloaderForensicsDaemonTest\" first.\n" +
-        "Expected: ${daemon.absolutePath}"
-    }
-    val urls = libFiles.get().map { it.asFile.toURI().toURL() }.toTypedArray()
-    val parentLoader: ClassLoader =
-      Thread.currentThread().contextClassLoader ?: ClassLoader.getSystemClassLoader()
-    val cl: ClassLoader = URLClassLoader(urls, parentLoader)
-    val forensics =
-      Class.forName("ee.schimke.composeai.daemon.forensics.ClassloaderForensics", true, cl)
-    val instance = forensics.getField("INSTANCE").get(null)
-    val fileClass = File::class.java
-    val diffMethod = forensics.getMethod("diff", fileClass, fileClass, fileClass, fileClass)
-    val diffMd = diffMdFile.get().asFile
-    val diffJson = diffJsonFile.get().asFile
-    diffMd.parentFile.mkdirs()
-    diffMethod.invoke(instance, standalone, daemon, diffMd, diffJson)
-    logger.lifecycle("Classloader forensics diff written to: ${diffMd.absolutePath}")
-    logger.lifecycle("                                  + : ${diffJson.absolutePath}")
   }
-}
 
 // D-harness.v1.5b — regenerate the in-repo PNG baselines under
 // `daemon/harness/baselines/desktop/<scenario>/`. Runs every real-mode scenario in
 // "capture" mode: pixel-diffs are skipped and the captured PNG always overwrites the baseline.
 // See `daemon/harness/CONTRIBUTING.md` for when to run this. Two runs in a row should
 // produce byte-identical PNGs; if they don't, the renderer has a non-determinism worth chasing.
-val regenerateBaselines by
-  tasks.registering(Test::class) {
+val regenerateBaselines =
+  tasks.register<Test>("regenerateBaselines") {
     description =
       "Run every harness scenario in capture mode; overwrites in-repo baseline PNGs " +
         "(D-harness.v1.5b + v2). Pick target with `-Ptarget=desktop|android`; defaults to " +

--- a/data/fonts/google/src/main/kotlin/ee/schimke/composeai/fonts/google/GoogleFonts.kt
+++ b/data/fonts/google/src/main/kotlin/ee/schimke/composeai/fonts/google/GoogleFonts.kt
@@ -382,7 +382,7 @@ private fun httpGet(url: String, userAgent: String): String? =
 private fun httpGetBytes(url: String, userAgent: String): ByteArray? = runCatching {
   val request = Request.Builder().url(url).header("User-Agent", userAgent).build()
   fontHttpClient.newCall(request).execute().use { response ->
-    if (response.isSuccessful) response.body?.bytes() else null
+    if (response.isSuccessful) response.body.bytes() else null
   }
 }
   .getOrNull()

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ModifierTokenResolver.kt
@@ -661,6 +661,7 @@ internal object ModifierTokenResolver {
   private fun unpackFloat2(packed: Long): Float = Float.fromBits((packed and 0xFFFFFFFFL).toInt())
 
   /** The `GraphicsLayerScope.() -> Unit` a lambda-form `graphicsLayer` element holds, if any. */
+  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
   private fun layerBlock(modifier: Any): Any? =
     generateSequence(modifier.javaClass as Class<*>?) { it.superclass }
       .flatMap { it.declaredFields.asSequence() }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -142,7 +142,7 @@ object FigmaLayeredSvg {
       sb.append("""<g transform="translate(${model.tx}, ${model.ty})">""").append('\n')
       sb
         .append("  ")
-        .append(backgroundRectSvg(model.backgroundRect!!, model.deviceBackground!!))
+        .append(backgroundRectSvg(model.backgroundRect, model.deviceBackground))
         .append('\n')
       sb.append("</g>\n")
     }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -1583,7 +1583,7 @@ data class FigmaSvgModel(
         // hairline).
         strokeWidthPx =
           if (stroke != null || strokeGradient != null) {
-            val dp = tokens?.borderWidth?.removeSuffix("dp")?.toDoubleOrNull()
+            val dp = tokens.borderWidth?.removeSuffix("dp")?.toDoubleOrNull()
             ((dp?.let { it * ctx.density } ?: ctx.density.toDouble()) * scaleMean).coerceAtLeast(
               1.0
             )

--- a/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgPaddedIconTest.kt
+++ b/data/layoutinspector/core/src/test/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgPaddedIconTest.kt
@@ -78,8 +78,9 @@ class FigmaSvgPaddedIconTest {
     assertEquals(63, icon.bottom - icon.top)
     // The layout slot handed to the emitter is that same drawn rect, so the fit is 63/24 — not the
     // 105/24 the node box would have given.
-    assertEquals(63, icon.vector!!.layoutWidth)
-    assertEquals(63, icon.vector!!.layoutHeight)
+    val vector = requireNotNull(icon.vector)
+    assertEquals(63, vector.layoutWidth)
+    assertEquals(63, vector.layoutHeight)
   }
 
   @Test

--- a/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/PlaceholderStateOverrideExtensionTest.kt
+++ b/data/preview-overrides/connector/src/test/kotlin/ee/schimke/composeai/daemon/PlaceholderStateOverrideExtensionTest.kt
@@ -34,7 +34,7 @@ class PlaceholderStateOverrideExtensionTest {
     // it carries this marker. `serve` (the consumer this override exists for) never calls
     // `extensions/enable`, so without it `?placeholderActive=` would parse, cache, and advertise
     // while silently rendering the preview's own state.
-    assertTrue(extension is AlwaysOnPreviewOverrideExtension)
+    assertTrue(AlwaysOnPreviewOverrideExtension::class.java.isAssignableFrom(extension.javaClass))
     // Always-on planners are also handed an empty bag on a no-override render; abstaining there is
     // what keeps an unforced render byte-identical.
     assertNull(extension.plan(PreviewOverrides()))

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -68,18 +68,21 @@ dependencies {
 }
 
 // Functional tests use Gradle TestKit
-val functionalTest by sourceSets.creating {
-  compileClasspath += sourceSets.main.get().output
-  runtimeClasspath += sourceSets.main.get().output
-}
+val functionalTest =
+  sourceSets.create("functionalTest") {
+    compileClasspath += sourceSets.main.get().output
+    runtimeClasspath += sourceSets.main.get().output
+  }
 
-val functionalTestImplementation by configurations.getting {
-  extendsFrom(configurations.testImplementation.get())
-}
+val functionalTestImplementation =
+  configurations.getByName("functionalTestImplementation") {
+    extendsFrom(configurations.testImplementation.get())
+  }
 
-val functionalTestRuntimeOnly by configurations.getting {
-  extendsFrom(configurations.testRuntimeOnly.get())
-}
+val functionalTestRuntimeOnly =
+  configurations.getByName("functionalTestRuntimeOnly") {
+    extendsFrom(configurations.testRuntimeOnly.get())
+  }
 
 val functionalTestTask =
   tasks.register<Test>("functionalTest") {
@@ -208,38 +211,41 @@ fun resolveAndroidSdk(rootDir: java.io.File): String {
 // Bake the plugin's own version into a resource so it can resolve a matching
 // `renderer-android` AAR at runtime for external consumers (who apply the
 // plugin via Maven Central rather than includeBuild).
-val generatePluginVersionResource by tasks.registering {
-  val outputDir = layout.buildDirectory.dir("generated/plugin-version-resource")
-  val pluginVersion = project.version.toString()
-  // XR `*-testing` fake versions the plugin injects onto a consumer's
-  // `composePreviewRenderXr` classpath (see AndroidPreviewSupport). Baked from the
-  // catalog so the render-path injection can't drift from `:renderer-xr` / the XR
-  // samples — bump once in `gradle/libs.versions.toml` and all sites follow.
-  val xrCompose = libs.versions.xr.compose.get()
-  val xrRuntimeTesting = libs.versions.xr.runtime.testing.get()
-  val xrScenecoreTesting = libs.versions.xr.scenecore.testing.get()
-  val xrArcoreTesting = libs.versions.xr.arcore.testing.get()
-  inputs.property("version", pluginVersion)
-  inputs.property("xrCompose", xrCompose)
-  inputs.property("xrRuntimeTesting", xrRuntimeTesting)
-  inputs.property("xrScenecoreTesting", xrScenecoreTesting)
-  inputs.property("xrArcoreTesting", xrArcoreTesting)
-  outputs.dir(outputDir)
-  doLast {
-    val base = outputDir.get().file("ee/schimke/composeai/plugin/plugin-version.properties").asFile
-    base.parentFile.mkdirs()
-    base.writeText("version=$pluginVersion\n")
-    val xr = outputDir.get().file("ee/schimke/composeai/plugin/xr-fake-versions.properties").asFile
-    xr.writeText(
-      buildString {
-        append("compose=$xrCompose\n")
-        append("runtimeTesting=$xrRuntimeTesting\n")
-        append("scenecoreTesting=$xrScenecoreTesting\n")
-        append("arcoreTesting=$xrArcoreTesting\n")
-      }
-    )
+val generatePluginVersionResource =
+  tasks.register("generatePluginVersionResource") {
+    val outputDir = layout.buildDirectory.dir("generated/plugin-version-resource")
+    val pluginVersion = project.version.toString()
+    // XR `*-testing` fake versions the plugin injects onto a consumer's
+    // `composePreviewRenderXr` classpath (see AndroidPreviewSupport). Baked from the
+    // catalog so the render-path injection can't drift from `:renderer-xr` / the XR
+    // samples — bump once in `gradle/libs.versions.toml` and all sites follow.
+    val xrCompose = libs.versions.xr.compose.get()
+    val xrRuntimeTesting = libs.versions.xr.runtime.testing.get()
+    val xrScenecoreTesting = libs.versions.xr.scenecore.testing.get()
+    val xrArcoreTesting = libs.versions.xr.arcore.testing.get()
+    inputs.property("version", pluginVersion)
+    inputs.property("xrCompose", xrCompose)
+    inputs.property("xrRuntimeTesting", xrRuntimeTesting)
+    inputs.property("xrScenecoreTesting", xrScenecoreTesting)
+    inputs.property("xrArcoreTesting", xrArcoreTesting)
+    outputs.dir(outputDir)
+    doLast {
+      val base =
+        outputDir.get().file("ee/schimke/composeai/plugin/plugin-version.properties").asFile
+      base.parentFile.mkdirs()
+      base.writeText("version=$pluginVersion\n")
+      val xr =
+        outputDir.get().file("ee/schimke/composeai/plugin/xr-fake-versions.properties").asFile
+      xr.writeText(
+        buildString {
+          append("compose=$xrCompose\n")
+          append("runtimeTesting=$xrRuntimeTesting\n")
+          append("scenecoreTesting=$xrScenecoreTesting\n")
+          append("arcoreTesting=$xrArcoreTesting\n")
+        }
+      )
+    }
   }
-}
 
 sourceSets.main.get().resources.srcDir(generatePluginVersionResource)
 

--- a/gradle-plugin/gradle-plugin-config/build.gradle.kts
+++ b/gradle-plugin/gradle-plugin-config/build.gradle.kts
@@ -63,7 +63,7 @@ dependencies {
 // which the runtime plugin owns — both jars can share a buildscript classpath, so the resource
 // paths
 // must not collide). Read back by `ConfigPluginVersion`.
-val generateConfigPluginVersionResource by tasks.registering {
+val generateConfigPluginVersionResource = tasks.register("generateConfigPluginVersionResource") {
   val outputDir = layout.buildDirectory.dir("generated/config-plugin-version-resource")
   val pluginVersion = project.version.toString()
   inputs.property("version", pluginVersion)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -113,7 +113,7 @@ class McpSession(
               }
               configure(session)
               session.connect(
-                StdioServerTransport(input.asSource().buffered(), output.asSink().buffered())
+                StdioServerTransport(input.asSource().buffered(), output.asSink().buffered()) {}
               )
               while (!closed.isDone) {
                 delay(100)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonLaunchDescriptorJailTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonLaunchDescriptorJailTest.kt
@@ -12,6 +12,8 @@ import org.junit.Test
  */
 class DaemonLaunchDescriptorJailTest {
 
+  private val descriptorJson = Json { encodeDefaults = true }
+
   private val plain =
     DaemonLaunchDescriptor(
       schemaVersion = 2,
@@ -49,7 +51,7 @@ class DaemonLaunchDescriptorJailTest {
 
     val parsed =
       DaemonLaunchDescriptor.parse(
-        Json { encodeDefaults = true }.encodeToString(DaemonLaunchDescriptor.serializer(), jailed)
+        descriptorJson.encodeToString(DaemonLaunchDescriptor.serializer(), jailed)
       )
 
     assertThat(parsed.jailCommand).containsExactly("unshare", "--net").inOrder()

--- a/rc-player/compose/build.gradle.kts
+++ b/rc-player/compose/build.gradle.kts
@@ -59,9 +59,9 @@ kotlin {
       // sees `Rc_player_runtimeRcPlayerEvent` and `Rc_player_protocolRcDocument` in the callbacks
       // and parameters it actually has to name. Exporting is only legal because each module already
       // depends on the next with `api`, which is what those declarations were for.
-      export(project(":rc-player-runtime"))
-      export(project(":rc-player-protocol"))
-      export(project(":rc-player-trace"))
+      export(project.dependencies.project(":rc-player-runtime"))
+      export(project.dependencies.project(":rc-player-protocol"))
+      export(project.dependencies.project(":rc-player-trace"))
       xcframework.add(this)
     }
   }

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -75,15 +75,9 @@ object EmbeddedDesktopRenderSessions : RenderSessionFactory {
       System.setProperty(k, v)
       val restore: () -> Unit =
         if (previous == null) {
-          {
-            System.clearProperty(k)
-            Unit
-          }
+          { System.clearProperty(k) }
         } else {
-          {
-            System.setProperty(k, previous)
-            Unit
-          }
+          { System.setProperty(k, previous) }
         }
       restores += restore
     }

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -18,11 +18,12 @@ plugins {
  * beside it without letting it near anything that runs, so the shape can be read off the real
  * artifact rather than off a hand-written stand-in.
  */
-val skikoEncodeProbe: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-  description = "A skiko resolved for reflection only, never on a compile or runtime classpath."
-}
+val skikoEncodeProbe =
+  configurations.create("skikoEncodeProbe") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    description = "A skiko resolved for reflection only, never on a compile or runtime classpath."
+  }
 
 /**
  * The newest Compose line catalogs are allowed to run on, used only by the theme regression test.
@@ -32,12 +33,13 @@ val skikoEncodeProbe: Configuration by configurations.creating {
  * Compose and Skiko. This is the consumer shape that exposed the erased LocalSystemTheme enum
  * change; running only against [libs.versions.compose.multiplatform] would miss it.
  */
-val composeForwardTestRuntime: Configuration by configurations.creating {
-  isCanBeConsumed = false
-  isCanBeResolved = true
-  description = "Renderer tests running on the forward Compose Multiplatform 1.12 runtime."
-  extendsFrom(configurations.testRuntimeClasspath.get())
-}
+val composeForwardTestRuntime =
+  configurations.create("composeForwardTestRuntime") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    description = "Renderer tests running on the forward Compose Multiplatform 1.12 runtime."
+    extendsFrom(configurations.testRuntimeClasspath.get())
+  }
 
 dependencies {
   implementation(compose.desktop.currentOs)
@@ -133,8 +135,8 @@ tasks.withType<Test>().configureEach {
   doFirst { systemProperty("composeai.test.skikoEncodeProbe", probeJars.asPath) }
 }
 
-val forwardComposeSystemThemeTest by
-  tasks.registering(Test::class) {
+val forwardComposeSystemThemeTest =
+  tasks.register<Test>("forwardComposeSystemThemeTest") {
     group = "verification"
     description = "Runs the light/dark renderer invariant on Compose Multiplatform 1.12.0-rc01."
     val testSourceSet = sourceSets.test.get()

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopAnimatedRenderer.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import java.io.File

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import ee.schimke.composeai.daemon.FocusController

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopInteractionRenderer.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
-import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import ee.schimke.composeai.motion.InteractionScript
 import ee.schimke.composeai.motion.InteractionTimeline

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopScrollRenderer.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onRoot
-import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import ee.schimke.composeai.data.render.extensions.compose.previewSystemThemeValue
 import ee.schimke.composeai.io.SystemFileSystem

--- a/runtimes/slots/build.gradle.kts
+++ b/runtimes/slots/build.gradle.kts
@@ -60,12 +60,13 @@ kotlin {
     // (`PreviewSlots.SLOT_TAG_PREFIX`); a test asserts this module's copy agrees so the two can't
     // drift. JVM-only (the reader + junit are JVM), so it lives in the JVM test source set and the
     // marker's common runtime classpath stays serialization-free.
-    val jvmTest by getting {
-      dependencies {
-        implementation(project(":data-layoutinspector-core"))
-        implementation(libs.junit)
+    val jvmTest =
+      getByName("jvmTest") {
+        dependencies {
+          implementation(project(":data-layoutinspector-core"))
+          implementation(libs.junit)
+        }
       }
-    }
   }
 }
 

--- a/runtimes/svg/src/main/kotlin/ee/schimke/composeai/preview/svg/SvgPreview.kt
+++ b/runtimes/svg/src/main/kotlin/ee/schimke/composeai/preview/svg/SvgPreview.kt
@@ -34,6 +34,7 @@ import java.io.ByteArrayInputStream
  *   recolors a monochrome icon. Defaults to `null` (draw the SVG's own colors).
  */
 @Composable
+@Suppress("DEPRECATION") // The resources API cannot construct a Painter from caller-supplied bytes.
 fun SvgPreview(
   asset: String,
   modifier: Modifier = Modifier,

--- a/samples/cmp-android-only/build.gradle.kts
+++ b/samples/cmp-android-only/build.gradle.kts
@@ -59,5 +59,10 @@ kotlin {
       @Suppress("DEPRECATION") implementation(compose.material3)
       implementation("org.jetbrains.compose.ui:ui-tooling-preview:1.10.3")
     }
+
+    // This regression fixture intentionally has no test compilation. KMP creates commonTest by
+    // default even though the Android-only target cannot consume it, so remove that unused source
+    // set instead of emitting a configuration warning on every build.
+    remove(getByName("commonTest"))
   }
 }

--- a/samples/cmp/src/main/kotlin/com/example/samplecmp/PinchToZoomPreview.kt
+++ b/samples/cmp/src/main/kotlin/com/example/samplecmp/PinchToZoomPreview.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun PinchToZoomPreview() {
   var scale by remember { mutableStateOf(1f) }
-  val transformableState = rememberTransformableState { zoomChange, _, _ ->
+  val transformableState = rememberTransformableState { _, zoomChange, _, _ ->
     scale = (scale * zoomChange).coerceIn(MIN_SCALE, MAX_SCALE)
   }
   Box(

--- a/samples/design-catalog-m3-shared/build.gradle.kts
+++ b/samples/design-catalog-m3-shared/build.gradle.kts
@@ -80,23 +80,25 @@ kotlin {
     // it can only back the desktop `actual`s of the `catalogOverride*` wrappers (the `wasmJs`
     // actuals return the author default). Desktop is the target the renderer / daemon builds, so
     // that's exactly where the knobs resolve against real daemon seeds.
-    val desktopMain by getting {
-      dependencies { implementation(project(":data-preview-overrides-runtime")) }
-    }
+    val desktopMain =
+      getByName("desktopMain") {
+        dependencies { implementation(project(":data-preview-overrides-runtime")) }
+      }
 
     // JVM-runnable unit tests for the pure-Kotlin theme-choice logic (the `theme.colors` serialized
     // app-palette round-trip). Desktop is the JVM target the renderer builds, so `desktopTest` runs
     // under `check` without dragging a wasmJs test toolchain in.
-    val desktopTest by getting {
-      dependencies {
-        implementation(kotlin("test"))
-        // `runComposeUiTest` — drives a real composition and dispatches real clicks, so
-        // `CatalogInteractivityTest` can assert the thing a static render can never show: that a
-        // click actually moves the UI, and that it does so identically on both render lanes.
-        implementation(libs.jetbrains.compose.ui.test)
-        @Suppress("DEPRECATION") implementation(compose.desktop.currentOs)
+    val desktopTest =
+      getByName("desktopTest") {
+        dependencies {
+          implementation(kotlin("test"))
+          // `runComposeUiTest` — drives a real composition and dispatches real clicks, so
+          // `CatalogInteractivityTest` can assert the thing a static render can never show: that a
+          // click actually moves the UI, and that it does so identically on both render lanes.
+          implementation(libs.jetbrains.compose.ui.test)
+          @Suppress("DEPRECATION") implementation(compose.desktop.currentOs)
+        }
       }
-    }
   }
 }
 

--- a/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerTextPlatformJvm.kt
+++ b/third_party/rc-embedded-player-jvm/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerTextPlatformJvm.kt
@@ -20,7 +20,7 @@ import androidx.compose.remote.core.RemoteContext
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import ee.schimke.composeai.rcembedded.jvm.GoogleFontTypefaceResolver
 import kotlin.math.roundToInt
 import org.jetbrains.skia.Font
@@ -273,7 +273,7 @@ internal fun DrawScope.drawTextAtOriginPlatform(
   blob.use {
     // The blob's first baseline sits an ascent below its own origin, so shifting up by that puts
     // the baseline on `y` — the same origin `measureTextInkBounds` reports against.
-    drawContext.canvas.nativeCanvas.drawTextBlob(it, x, y - it.firstBaseline, spec.toSkiaPaint())
+    drawContext.canvas.skiaCanvas.drawTextBlob(it, x, y - it.firstBaseline, spec.toSkiaPaint())
   }
 }
 
@@ -417,7 +417,7 @@ internal fun DrawScope.drawTextOnPathPlatform(
     index++
   }
 
-  val canvas = drawContext.canvas.nativeCanvas
+  val canvas = drawContext.canvas.skiaCanvas
   val paint = spec.toSkiaPaint()
   for ((font, placed) in placements) {
     if (placed.isEmpty()) continue

--- a/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/GraphPaintContext.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/GraphPaintContext.kt
@@ -49,7 +49,7 @@ import androidx.compose.remote.core.operations.paint.PaintBundle
  */
 internal class GraphPaintContext(context: RemoteContext) : PaintContext(context) {
 
-  override fun getText(id: Int): String? = mContext?.getText(id)
+  override fun getText(id: Int): String? = mContext.getText(id)
 
   override fun layoutComplexText(
     textId: Int,

--- a/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerDispatch.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerDispatch.kt
@@ -188,9 +188,7 @@ internal fun RcPlayerComponent(component: Component, modifier: Modifier = Modifi
     }
   } else {
     // Non-LayoutComponent component reached dispatch — skip gracefully instead of crashing.
-    println(
-      "Warning: unsupported component ${component?.let { it::class.java.simpleName }}; rendering nothing"
-    )
+    println("Warning: unsupported component ${component::class.java.simpleName}; rendering nothing")
   }
 }
 

--- a/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerDrawing.kt
+++ b/third_party/rc-embedded-player/src/main/kotlin/ee/schimke/composeai/rcembedded/player/RcPlayerDrawing.kt
@@ -906,7 +906,7 @@ internal fun DrawScope.executeOperations(
         val color = data.color
         if (mainCanvas == null) mainCanvas = drawContext.canvas
         if (bitmapId == 0) {
-          drawContext.canvas = mainCanvas!!
+          drawContext.canvas = mainCanvas
         } else {
           // The mutable-copy + erase dance lives in the image seam so this op names no
           // framework bitmap; it hands back the ImageBitmap view to point the canvas at


### PR DESCRIPTION
## Summary
- remove unnecessary null assertions, safe calls, casts, and fallback branches across production and test code
- migrate deprecated Compose, OkHttp, MCP, and Gradle APIs where supported
- keep narrowly scoped deprecation suppressions only where no replacement API exists

## Verification
- ./gradlew compileKotlin compileTestKotlin --continue --rerun-tasks
- ./gradlew :cli:compileTestKotlin --rerun-tasks
- ./gradlew :cli:test ktfmtCheckAll

The remaining build notices are toolchain-originated: Gradle embedded Kotlin 2.4.0 versus KGP 2.4.10, plus Android Gradle Plugin internals.