### PR TITLE
fix(serve): reap optimizer daemons while idle

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -741,7 +741,15 @@ class ServeCatalogLiveHost(
       val previewDaemonId = alias[previewId]
       // Await a cold warm ONCE per preview rather than letting each theme rediscover it. The
       // old per-job loop spent retry budget on this; here it is a precondition of the batch.
-      if (previewDaemonId != null && !warmDaemonIds.contains(previewDaemonId)) {
+      // A shared-pool optimizer deliberately leaves the catalog primary cold. Its background
+      // renders use reapable replicas, so RAM returns between slices instead of accumulating one
+      // permanent primary for every catalog the fair scheduler visits. Without the pool there is
+      // no disposable lane, so retain the ordinary one-time warm.
+      if (
+        (sharedDaemonPool == null || !sharedDaemonRenders) &&
+          previewDaemonId != null &&
+          !warmDaemonIds.contains(previewDaemonId)
+      ) {
         daemonWarmOrScheduling(previewDaemonId)
         // A cold warm is real render work and can run to minutes. Excluding it from both
         // buckets shrank the rate's denominator, so a cold catalog reported a rate it was
@@ -868,7 +876,7 @@ class ServeCatalogLiveHost(
     // all but one would come back Busy — `themeRenderBurstCapacity` is 5 there because different
     // *previews* can run in parallel, which is not what this batch is.
     if (sharedDaemonRenders && sharedDaemonPool != null) {
-      sharedDaemonPool.capacity.coerceIn(1, MAX_OPTIMIZER_BATCH)
+      sharedDaemonPool.backgroundCapacity().coerceIn(1, MAX_OPTIMIZER_BATCH)
     } else {
       1
     }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPool.kt
@@ -134,7 +134,21 @@ class ServeSharedDaemonPool(
     try {
       borrowed = lock.withLock {
         check(!closed) { "shared daemon pool is closed" }
-        val host = available.removeFirstOrNull() ?: openSeatedReplica(background)
+        val host =
+          if (background && !primary.daemonStarted && capacity > 1) {
+            // Do not turn an idle optimizer slice into another permanently-resident catalog
+            // primary. Replicas are owned here and reaped after the burst; the primary is owned by
+            // the catalog host and otherwise survives every optimizer rotation. Production reached
+            // 17 primaries with no traffic that way, and their RAM kept the pressure gate closed.
+            available.firstOrNull { it !== primary }?.also { available.remove(it) }
+              ?: if (replicas.size < capacity - 1) {
+                openSeatedReplica(background = true, avoidPrimaryFallback = replicas.isNotEmpty())
+              } else {
+                awaitAvailableReplica()
+              }
+          } else {
+            available.removeFirstOrNull() ?: openSeatedReplica(background)
+          }
         // Claimed under the lock so exactly one borrow times the cold start.
         cold = coldReplicas.remove(host)
         if (cold) coldStartFrom = clock()
@@ -196,7 +210,10 @@ class ServeSharedDaemonPool(
    * [background] takes the seat from the background remainder instead, so prefetch residency can
    * never occupy the stream reserve — see [render].
    */
-  private fun openSeatedReplica(background: Boolean): ServeHost {
+  private fun openSeatedReplica(
+    background: Boolean,
+    avoidPrimaryFallback: Boolean = false,
+  ): ServeHost {
     var ticket: LiveSeatLimiter.Ticket? = null
     if (liveSeats != null) {
       // countRefusal = false: a miss here does NOT refuse the render. The burst simply narrows
@@ -209,6 +226,7 @@ class ServeSharedDaemonPool(
         if (background) liveSeats.acquireBackground(seatWeight(), dedicatedSlice = false)
         else liveSeats.acquire(seatWeight(), countRefusal = false)
       if (ticket == null) {
+        if (avoidPrimaryFallback) return awaitAvailableReplica()
         while (available.isEmpty() && !closed) hostReturned.await()
         check(!closed) { "shared daemon pool is closed" }
         return available.removeFirst()
@@ -232,6 +250,20 @@ class ServeSharedDaemonPool(
     ticket?.let { seatTickets[replica] = it }
     return replica
   }
+
+  /** Wait for a reapable replica without consuming the idle primary. Caller holds [lock]. */
+  private fun awaitAvailableReplica(): ServeHost {
+    while (available.none { it !== primary } && !closed) hostReturned.await()
+    check(!closed) { "shared daemon pool is closed" }
+    return available.first { it !== primary }.also { available.remove(it) }
+  }
+
+  /**
+   * Width background prefetch may use without waking a cold primary. A visitor-warmed primary is
+   * already resident and can participate; otherwise reserve that slot and use reapable replicas.
+   */
+  fun backgroundCapacity(): Int =
+    if (!primary.daemonStarted && capacity > 1) capacity - 1 else capacity
 
   /**
    * Close every **replica** idle for [idleMillis], returning how many were closed. The primary is

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -7,7 +7,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
-import java.util.Collections
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.zip.ZipInputStream
 import javax.imageio.ImageIO
 import kotlin.test.Test
@@ -202,7 +202,7 @@ class ServeCatalogStoreTest {
 
   @Test
   fun `a catalog publishes every declared preview before its images are fetched`() {
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val fetcher: (String) -> ByteArray? = { url ->
       requested += url
       when {
@@ -261,7 +261,7 @@ class ServeCatalogStoreTest {
 
   @Test
   fun `a published capture is offered on its card and fetched only when watched`() {
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val fetcher: (String) -> ByteArray? = { url ->
       requested += url
       when {
@@ -321,7 +321,7 @@ class ServeCatalogStoreTest {
     // Publishing must not wait for them: the catalog serves (uncropped, briefly) and the pass fills
     // them behind it. Captured rather than run so the assertion is about ordering, not timing.
     val deferred = mutableListOf<Runnable>()
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val result =
       store(
           TrustStore.EMPTY,
@@ -363,7 +363,7 @@ class ServeCatalogStoreTest {
     // The landing page computes a crop for EVERY card while building its HTML. If that filled
     // missing pixels, the first page request would serially download a whole cold catalog on the
     // request thread — reintroducing the stall this lazy path exists to remove, just moved.
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     store(
         TrustStore.EMPTY,
         fetch = { url ->
@@ -450,7 +450,7 @@ class ServeCatalogStoreTest {
     val referencePng = png()
     // Assets are fetched on a pool (ASSET_FETCH_CONCURRENCY), so this capture is written from
     // several threads at once — a plain ArrayList throws ConcurrentModificationException here.
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val catalog =
       """
       {"schema":"design-parity-catalog/v1","system":"compose-m3",
@@ -510,7 +510,7 @@ class ServeCatalogStoreTest {
     val root = tempRoot()
     // Assets are fetched on a pool (ASSET_FETCH_CONCURRENCY), so this capture is written from
     // several threads at once — a plain ArrayList throws ConcurrentModificationException here.
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val catalog =
       """
       {"schema":"design-parity-catalog/v1","system":"compose-m3",
@@ -561,7 +561,7 @@ class ServeCatalogStoreTest {
   @Test
   fun `catalog stages the published parity issue index`() {
     val root = tempRoot()
-    val requested = Collections.synchronizedList(mutableListOf<String>())
+    val requested = CopyOnWriteArrayList<String>()
     val catalog =
       """
       {"schema":"design-parity-catalog/v1","system":"compose-m3",
@@ -2139,7 +2139,7 @@ class ServeCatalogStoreTest {
     // Catalog vectors continue fetching on the background executor after load() publishes the
     // host. Keep the recorder safe while that pass appends, then assert against one locked
     // snapshot rather than iterating a list that can still be changing.
-    val urls = Collections.synchronizedList(mutableListOf<String>())
+    val urls = CopyOnWriteArrayList<String>()
     val trust =
       TrustStore(branches = listOf(TrustedBranch("yschimke/meshcore-mobile", "design-artifacts/*")))
     val store =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSharedDaemonPoolTest.kt
@@ -17,6 +17,39 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ServeSharedDaemonPoolTest {
+  private class LazyHost(private val name: String) : ServeHost {
+    override val previews: List<ServePreview> = emptyList()
+    override val label: String = name
+    private var started = false
+    override val daemonProcessCount: Int
+      get() = if (started) 1 else 0
+
+    override val daemonStarted: Boolean
+      get() = started
+
+    var closed = false
+
+    override fun render(previewId: String, overrides: PreviewOverrides): RenderOutcome {
+      started = true
+      return RenderOutcome.Ok(name.encodeToByteArray())
+    }
+
+    override fun subscribeStream(
+      previewId: String,
+      overrides: PreviewOverrides,
+      codec: StreamCodec?,
+      maxFps: Int?,
+      onUnavailable: ((String) -> Unit)?,
+      onFrame: (StreamFrameParams) -> Unit,
+    ): StreamHandle? = null
+
+    override fun activeStreamCount(): Int = 0
+
+    override fun close() {
+      closed = true
+    }
+  }
+
   private class BlockingHost(
     private val name: String,
     private val entered: CountDownLatch,
@@ -111,6 +144,31 @@ class ServeSharedDaemonPoolTest {
 
     assertEquals(4, replicas.count { it.closed })
     assertEquals(false, primary.closed, "the composite owns the primary daemon")
+  }
+
+  @Test
+  fun `background optimization leaves a cold primary idle and reaps its replica`() {
+    var now = 0L
+    val primary = LazyHost("primary")
+    val replicas = mutableListOf<LazyHost>()
+    val pool =
+      ServeSharedDaemonPool(primary = primary, capacity = 2, clock = { now }) {
+        LazyHost("replica").also(replicas::add)
+      }
+    try {
+      assertEquals(1, pool.backgroundCapacity())
+      assertTrue(pool.render("preview", PreviewOverrides(), background = true) is RenderOutcome.Ok)
+      assertEquals(0, primary.daemonProcessCount, "prefetch must not make the primary resident")
+      assertEquals(1, pool.replicaProcessCount())
+
+      now = ServeSessionRegistry.DEFAULT_DAEMON_IDLE_MILLIS
+      assertEquals(1, pool.reapIdle(ServeSessionRegistry.DEFAULT_DAEMON_IDLE_MILLIS))
+      assertTrue(replicas.single().closed)
+      assertEquals(0, pool.replicaProcessCount(), "quiet time returns the optimizer RAM")
+    } finally {
+      pool.close()
+    }
+    assertFalse(primary.closed, "the composite still owns the untouched primary")
   }
 
   /**

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -896,6 +896,13 @@ When enabled, it yields twice over — both learned from `preview.coo.ee`:
   take turns instead of occupying every live seat, and a visitor's render is never queued behind
   more than one background one. The permit is taken per render, so a catalog that parks for traffic
   hands it straight to the next one.
+- **Background slices leave a cold catalog primary cold.** Theme batches prefer the shared pool's
+  disposable replicas, whose one-minute idle sweep closes their subprocesses and returns their
+  memory between slices. The primary joins a batch only after foreground traffic has already
+  warmed it, or when no background seat exists to open the first replica. Previously the fair
+  scheduler eventually warmed one non-reapable primary per catalog: the public box reached 17
+  resident daemons with no traffic, and that idle RAM kept the pressure gate closed against the
+  optimizer that created it.
 
 **When it isn't running, `/status` says which gate is holding it.** A pass must clear a quiet gate
 before it starts: the whole server has to have been untouched for


### PR DESCRIPTION
## Summary
- keep cold catalog primaries asleep during background theme optimization
- run optimizer batches on reapable shared-daemon replicas and cap cold-primary width accordingly
- let the existing one-minute replica sweep return optimizer RAM between duty cycles
- replace synchronized test capture lists with copy-on-write lists to fix the ConcurrentModificationException seen in PR #4493 Build CLI

## Why
Fair optimizer rotation eventually warmed one non-reapable primary per catalog. The public server reached 17 resident daemons with no traffic; their memory then held the optimizer pressure gate closed. Background slices now prefer disposable replicas, while a primary already warmed by foreground traffic can still participate.

PR #4493 also had two red jobs after merge. Build CLI exposed a real concurrent-iteration race in ServeCatalogStoreTest and is fixed here. Java/Kotlin CodeQL produced no finding; its runner received a shutdown signal during analysis.

## Test plan
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.serve.ServeCatalogStoreTest --tests ee.schimke.composeai.cli.serve.ServeSharedDaemonPoolTest --tests ee.schimke.composeai.cli.serve.ServeCatalogLiveHostTest
- git diff --check origin/main...HEAD