### PR TITLE
fix: address unresolved recent PR review findings

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -2248,15 +2248,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         // local file has no system id and answers null, which is correct: nothing on the site can
         // claim to be that bundle's catalog.
         pinnedCatalogSystem = { mode ->
-          val source =
+          val supplier =
             when (mode) {
-              PlaygroundMode.CMP -> cmpBundle
+              PlaygroundMode.CMP -> cmpSupplier
               PlaygroundMode.ANDROID,
-              PlaygroundMode.REMOTE_COMPOSE -> androidBundle
+              PlaygroundMode.REMOTE_COMPOSE -> androidSupplier
             }
-          (source?.let { PlaygroundBundleSource.parse(it) }
-              as? PlaygroundBundleSource.ServedCatalog)
-            ?.system
+          supplier?.servedCatalogSystem
         },
         captureRemoteDocument = { snippet -> rcCapture?.capture(snippet) },
         publishRemoteDocument = { name, bytes, checked ->

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSource.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSource.kt
@@ -115,6 +115,17 @@ class PlaygroundClasspathSupplier(
   /** How this mode's bundle was named, for `/status.json` and startup logs. */
   fun describeSource(): String = source.describe()
 
+  /**
+   * The served catalog this supplier was classified as at startup, or null for a local bundle.
+   *
+   * Classification is intentionally exposed from the supplier rather than recomputed from the raw
+   * flag: a separator-less value consults the filesystem when it is parsed, and that filesystem can
+   * change during a long-running serve process. Consumers must keep using the identity that the
+   * classpath supplier itself resolved.
+   */
+  val servedCatalogSystem: String?
+    get() = (source as? PlaygroundBundleSource.ServedCatalog)?.system
+
   fun classpath(): PlaygroundCompileService.Classpath? {
     resolved?.let {
       return it

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3621,6 +3621,7 @@ class ServeHttpServer(
           tagIndex.isEmpty() -> "This catalog publishes no element tag index for this preview."
           else -> null
         }
+      val allParityIssues = renderHost.parityIssues()?.issues.orEmpty()
       markGeneration("static-page", pageCacheControl())
       call.respondText(
         ServeWeb.referenceComparisonPage(
@@ -3744,11 +3745,12 @@ class ServeHttpServer(
                 )
               },
           parityIssues =
-            renderHost.parityIssues()?.issues.orEmpty().filter { issue ->
+            allParityIssues.filter { issue ->
               preview.id in issue.previewIds ||
                 reference.id in issue.referenceIds ||
                 (preview.componentId != null && issue.component == preview.componentId)
             },
+          acceptanceIssues = allParityIssues,
           revisions = revisions,
           overrides = overrideParams,
           reportIssue = reportIssue,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -9525,6 +9525,13 @@ $rows
     knownDifferences: KnownDifferenceScope? = null,
     parityIssues: List<ParityIssue> = emptyList(),
     /**
+     * The complete issue index used to resolve acceptance lifecycle state. [parityIssues] remains
+     * the comparison-filtered list rendered in the Issues panel; an acceptance can legitimately
+     * refer to an issue whose independently published preview/reference locators are stale, so the
+     * lifecycle join must not inherit that display filter.
+     */
+    acceptanceIssues: List<ParityIssue> = parityIssues,
+    /**
      * The catalog change feed the footer offers as **Changelog** and the head declares as this
      * page's RSS alternate. Empty when the server runs with the feed lane off. See [siteFooter].
      */
@@ -9739,7 +9746,7 @@ ${if (annotationsSelectable) "          data-cp-selectable=\"1\"\n" else ""}    
           candidateUrl = actual,
           scope = scope,
           issues =
-            parityIssues
+            acceptanceIssues
               .map { issue ->
                 KnownDifferenceIssue(
                   repository = issue.repository,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSourceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBundleSourceTest.kt
@@ -94,6 +94,25 @@ class PlaygroundClasspathSupplierTest {
     }
 
   @Test
+  fun `the startup source classification remains available without reparsing`() {
+    val served =
+      PlaygroundClasspathSupplier(
+        source = PlaygroundBundleSource.ServedCatalog("compose-m3"),
+        locateServedBundle = { null },
+        resolve = { classpath },
+      )
+    val local =
+      PlaygroundClasspathSupplier(
+        source = PlaygroundBundleSource.LocalPath("compose-m3"),
+        locateServedBundle = { null },
+        resolve = { classpath },
+      )
+
+    assertEquals("compose-m3", served.servedCatalogSystem)
+    assertNull(local.servedCatalogSystem)
+  }
+
+  @Test
   fun `a served catalog resolves on first use, not at construction`() {
     val bundle = bundleFile()
     var located: File? = null

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebKnownDifferenceContextTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebKnownDifferenceContextTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.cli.serve
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ServeWebKnownDifferenceContextTest {
+
+  private fun issue(number: Int, previewIds: List<String>) =
+    ParityIssue(
+      repository = "example/catalog",
+      number = number,
+      title = "Issue $number",
+      url = "https://github.com/example/catalog/issues/$number",
+      state = "closed",
+      previewIds = previewIds,
+    )
+
+  @Test
+  fun `acceptance lifecycle receives the full issue index while the panel stays filtered`() {
+    val preview = ServePreview(id = "preview", label = "Preview")
+    val reference =
+      DesignReference(
+        id = "reference",
+        previewId = preview.id,
+        raster = DesignReferenceRaster(path = "reference.png", sha256 = "a".repeat(64)),
+      )
+    val visible = issue(41, listOf(preview.id))
+    val lifecycleOnly = issue(99, listOf("old-preview-locator"))
+
+    val html =
+      ServeWeb.referenceComparisonPage(
+        moduleLabel = "catalog",
+        preview = preview,
+        reference = reference,
+        references = listOf(reference),
+        token = "token",
+        knownDifferences =
+          KnownDifferenceScope(
+            system = "catalog",
+            component = "Button",
+            previewId = preview.id,
+            referenceId = reference.id,
+            variant = "default",
+            referenceSha256 = reference.raster.sha256,
+          ),
+        parityIssues = listOf(visible),
+        acceptanceIssues = listOf(visible, lifecycleOnly),
+      )
+
+    assertTrue("\"number\":99" in html, "full issue evidence must reach the lifecycle payload")
+    assertTrue("#41 Issue 41" in html, "the matching issue must remain visible in the panel")
+    assertFalse("#99 Issue 99" in html, "stale locators must not leak into the filtered panel")
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -117,8 +117,7 @@ class IncrementalDiscovery(
    * Fail-safe: returns `emptySet` on any scan failure (and writes a stderr diagnostic).
    */
   fun scanForFile(file: Path): Set<PreviewInfoDto> {
-    val target = classpathElementForFile(file)
-    val scanRoots = if (target != null) listOf(target) else classpath
+    val scanRoots = scanRootsForFile(file)
     return try {
       ClassGraph()
         .enableMethodInfo()
@@ -135,6 +134,23 @@ class IncrementalDiscovery(
       )
       emptySet()
     }
+  }
+
+  internal fun scanRootsForFile(file: Path): List<Path> {
+    val target = classpathElementForFile(file)
+    // Keep the changed module's class output scoped, but retain dependency JARs: a method can use a
+    // dependency-provided multi-preview annotation whose meta-annotation carries @CaptureGutter.
+    // Scanning only `target` makes that annotation class unresolvable and re-adds a combination the
+    // authoritative pass rejected. Other module output directories stay excluded, preserving the
+    // cheap one-file scan this path exists for.
+    return if (target != null)
+      buildList {
+        add(target)
+        classpath.filterTo(this) { root ->
+          root != target && root.fileName?.toString()?.endsWith(".jar", ignoreCase = true) == true
+        }
+      }
+    else classpath
   }
 
   private fun collectPreviews(scanResult: ScanResult, file: Path): Set<PreviewInfoDto> {
@@ -164,14 +180,11 @@ class IncrementalDiscovery(
         // unguttered, unscrolled preview until the next full discovery. `@CaptureGutter` may be
         // hoisted onto a multi-preview annotation, so the check walks the meta-annotation closure.
         //
-        // Best-effort, like the rest of this path: it resolves the closure through the scoped scan,
-        // so a `@CaptureGutter` hoisted onto a *dependency-JAR* annotation (outside the narrowed
-        // classpath) is not seen here and slips through until the next full discovery corrects it;
-        // and once a rejected function is out of the index, a fix that removes one annotation may
-        // not re-trip `cheapPrefilter` (its regex carries only the known preview FQNs), so recovery
-        // likewise waits for a full pass. Both match the incremental path's standing v1 contract
-        // (see [scanForFile] / the class kdoc), where identity is authoritative and details settle
-        // on the next full discovery.
+        // Best-effort, like the rest of this path: once a rejected function is out of the index, a
+        // fix that removes one annotation may not re-trip `cheapPrefilter` (its regex carries only
+        // the known preview FQNs), so recovery can wait for a full pass. That matches the
+        // incremental path's standing v1 contract (see [scanForFile] / the class kdoc), where
+        // identity is authoritative and details settle on the next full discovery.
         if (declaresGutterAndScrolling(annotations, scanResult)) {
           System.err.println(
             "compose-ai-daemon: IncrementalDiscovery skipping '${classInfo.name}.${method.name}'" +

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -117,7 +117,8 @@ class IncrementalDiscovery(
    * Fail-safe: returns `emptySet` on any scan failure (and writes a stderr diagnostic).
    */
   fun scanForFile(file: Path): Set<PreviewInfoDto> {
-    val scanRoots = scanRootsForFile(file)
+    val target = classpathElementForFile(file)
+    val scanRoots = scanRootsForTarget(target)
     return try {
       ClassGraph()
         .enableMethodInfo()
@@ -126,7 +127,7 @@ class IncrementalDiscovery(
         .overrideClasspath(scanRoots.map { it.toAbsolutePath().toString() })
         .ignoreParentClassLoaders()
         .scan()
-        .use { scanResult -> collectPreviews(scanResult, file) }
+        .use { scanResult -> collectPreviews(scanResult, file, target) }
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: IncrementalDiscovery.scanForFile($file) failed " +
@@ -136,8 +137,10 @@ class IncrementalDiscovery(
     }
   }
 
-  internal fun scanRootsForFile(file: Path): List<Path> {
-    val target = classpathElementForFile(file)
+  internal fun scanRootsForFile(file: Path): List<Path> =
+    scanRootsForTarget(classpathElementForFile(file))
+
+  private fun scanRootsForTarget(target: Path?): List<Path> {
     // Keep the changed module's class output scoped, but retain dependency JARs: a method can use a
     // dependency-provided multi-preview annotation whose meta-annotation carries @CaptureGutter.
     // Scanning only `target` makes that annotation class unresolvable and re-adds a combination the
@@ -153,11 +156,23 @@ class IncrementalDiscovery(
     else classpath
   }
 
-  private fun collectPreviews(scanResult: ScanResult, file: Path): Set<PreviewInfoDto> {
+  private fun collectPreviews(
+    scanResult: ScanResult,
+    file: Path,
+    target: Path?,
+  ): Set<PreviewInfoDto> {
     val sourceKey = file.toString()
     val basename = file.fileName?.toString().orEmpty()
+    val targetRoot = target?.let { runCatching { it.toAbsolutePath().normalize() }.getOrNull() }
     val results = LinkedHashSet<PreviewInfoDto>()
     for (classInfo in scanResult.allClasses) {
+      // The dependency JARs in the scan roots are there to resolve annotation metadata only (see
+      // [scanRootsForFile]). A JAR class compiled from the same source basename as the edited file
+      // (both modules having a `Previews.kt` is entirely normal) would otherwise satisfy the
+      // basename match below and be emitted under this file's `sourceKey`, polluting the
+      // incremental index with foreign previews. Preview candidates therefore have to originate
+      // from the edited module's own class output.
+      if (!originatesFrom(classInfo, targetRoot)) continue
       // The bytecode SourceFile attribute is just the basename; we accept either the absolute
       // path stored on the index (when sourceFile happens to be absolute) or the bytecode
       // basename match. This mirrors the index's diff-key heuristic in [PreviewIndex.diff].
@@ -198,6 +213,23 @@ class IncrementalDiscovery(
       }
     }
     return results
+  }
+
+  /**
+   * Whether [classInfo] was loaded from [targetRoot] — the changed module's own class output.
+   *
+   * Fail-open: with no resolved target the scan is already the full classpath (no dependency-only
+   * roots were added), and a classpath element ClassGraph can't expose as a file (a `jrt:` module,
+   * say) can't be compared, so both cases keep the class as a candidate. Dropping a real preview is
+   * worse than the pollution this guard exists to prevent, and neither case is the JAR-vs-module
+   * ambiguity it targets.
+   */
+  private fun originatesFrom(classInfo: ClassInfo, targetRoot: Path?): Boolean {
+    if (targetRoot == null) return true
+    val element = runCatching { classInfo.classpathElementFile }.getOrNull() ?: return true
+    val elementPath =
+      runCatching { element.toPath().toAbsolutePath().normalize() }.getOrNull() ?: return true
+    return elementPath == targetRoot
   }
 
   /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.daemon
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -253,5 +255,57 @@ class IncrementalDiscoveryTest {
     } finally {
       root.toFile().deleteRecursively()
     }
+  }
+
+  @Test
+  fun `scoped scan does not return previews sourced from a dependency jar`() {
+    // The dependency JARs are retained so annotation metadata resolves, but a JAR class compiled
+    // from the same source basename as the edited file must not be reported under that file: two
+    // modules both having a `Previews.kt` is ordinary, and emitting the foreign previews pollutes
+    // the incremental index after a save (#4499 review).
+    val root = Files.createTempDirectory("incremental-dep-jar")
+    try {
+      val packagePath = "ee/schimke/composeai/daemon/fixtures"
+      // The module's own class output: it holds the package directory (so the source → classpath
+      // heuristic resolves to it) but none of the fixture classes.
+      val targetRoot = root.resolve("target")
+      Files.createDirectories(targetRoot.resolve(packagePath))
+      // The dependency: the compiled fixture classes, whose bytecode `SourceFile` is
+      // `TestPreview.kt` — the same basename as the file being scanned.
+      val dependencyJar = jarOfFixtureClasses(root.resolve("dependency.jar"), packagePath)
+      val source = root.resolve("project/src/main/kotlin/$packagePath/TestPreview.kt")
+      Files.createDirectories(source.parent)
+
+      val scoped =
+        IncrementalDiscovery(
+          classpath = listOf(targetRoot, dependencyJar),
+          knownPreviewAnnotationFqns = setOf(testPreviewFqn),
+        )
+
+      assertEquals(listOf(targetRoot, dependencyJar), scoped.scanRootsForFile(source))
+      assertEquals(emptySet<PreviewInfoDto>(), scoped.scanForFile(source))
+    } finally {
+      root.toFile().deleteRecursively()
+    }
+  }
+
+  /** Packages the compiled `TestPreviewFixtures` classes off the test classpath into [jar]. */
+  private fun jarOfFixtureClasses(jar: Path, packagePath: String): Path {
+    val classesDir =
+      testClasspath.firstOrNull { Files.isDirectory(it.resolve(packagePath)) }
+        ?: error("fixture classes not found on the test classpath")
+    val entries =
+      Files.list(classesDir.resolve(packagePath)).use { stream ->
+        stream.filter { it.fileName.toString().startsWith("TestPreviewFixtures") }.toList()
+      }
+    assertTrue("expected compiled fixture classes in $classesDir", entries.isNotEmpty())
+    JarOutputStream(Files.newOutputStream(jar)).use { out ->
+      for (entry in entries) {
+        out.putNextEntry(JarEntry("$packagePath/${entry.fileName}"))
+        out.write(Files.readAllBytes(entry))
+        out.closeEntry()
+      }
+    }
+    return jar
   }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -230,4 +230,28 @@ class IncrementalDiscoveryTest {
     val results = brokenDiscovery.scanForFile(syntheticKt)
     assertEquals(emptySet<PreviewInfoDto>(), results)
   }
+
+  @Test
+  fun `scoped scan keeps dependency jars but excludes other class directories`() {
+    val root = Files.createTempDirectory("incremental-roots")
+    try {
+      val target = Files.createDirectories(root.resolve("target/com/example"))
+      val targetRoot = target.parent.parent
+      val other = Files.createDirectories(root.resolve("other/com/example"))
+      val otherRoot = other.parent.parent
+      val dependencyJar = Files.createFile(root.resolve("annotations.jar"))
+      val source = root.resolve("project/src/main/kotlin/com/example/Preview.kt")
+      Files.createDirectories(source.parent)
+
+      val scoped =
+        IncrementalDiscovery(
+          classpath = listOf(targetRoot, otherRoot, dependencyJar),
+          knownPreviewAnnotationFqns = setOf(testPreviewFqn),
+        )
+
+      assertEquals(listOf(targetRoot, dependencyJar), scoped.scanRootsForFile(source))
+    } finally {
+      root.toFile().deleteRecursively()
+    }
+  }
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1545,8 +1545,105 @@ object PreviewDiscovery {
     )
 
   private fun File.declaresPreviewAnnotation(): Boolean = runCatching {
-    PREVIEW_SOURCE_ANNOTATION.containsMatchIn(readText())
+    PREVIEW_SOURCE_ANNOTATION.containsMatchIn(readText().kotlinCodeOnly())
   }.getOrDefault(false)
+
+  /**
+   * Blank comments and literals while preserving line breaks, so the source-level integrity guard
+   * sees annotations in Kotlin code rather than examples embedded in KDoc, block comments, or
+   * strings. Kotlin block comments nest, so a regex replacement is not sufficient here.
+   */
+  private fun String.kotlinCodeOnly(): String {
+    val out = StringBuilder(length)
+    var i = 0
+    var blockDepth = 0
+    var lineComment = false
+    var quote: Char? = null
+    var tripleQuoted = false
+    var escaped = false
+    fun blank(c: Char) {
+      out.append(if (c == '\n' || c == '\r') c else ' ')
+    }
+    while (i < length) {
+      val c = this[i]
+      val next = getOrNull(i + 1)
+      if (lineComment) {
+        blank(c)
+        if (c == '\n' || c == '\r') lineComment = false
+        i++
+        continue
+      }
+      if (blockDepth > 0) {
+        when {
+          c == '/' && next == '*' -> {
+            blank(c)
+            blank(next)
+            blockDepth++
+            i += 2
+          }
+          c == '*' && next == '/' -> {
+            blank(c)
+            blank(next)
+            blockDepth--
+            i += 2
+          }
+          else -> {
+            blank(c)
+            i++
+          }
+        }
+        continue
+      }
+      if (quote != null) {
+        if (tripleQuoted && startsWith("\"\"\"", i)) {
+          repeat(3) { blank(this[i + it]) }
+          i += 3
+          quote = null
+          tripleQuoted = false
+        } else {
+          blank(c)
+          if (!tripleQuoted) {
+            if (escaped) escaped = false
+            else if (c == '\\') escaped = true
+            else if (c == quote) quote = null
+          }
+          i++
+        }
+        continue
+      }
+      when {
+        c == '/' && next == '/' -> {
+          blank(c)
+          blank(next)
+          lineComment = true
+          i += 2
+        }
+        c == '/' && next == '*' -> {
+          blank(c)
+          blank(next)
+          blockDepth = 1
+          i += 2
+        }
+        startsWith("\"\"\"", i) -> {
+          repeat(3) { blank(this[i + it]) }
+          quote = '\"'
+          tripleQuoted = true
+          i += 3
+        }
+        c == '\"' || c == '\'' -> {
+          blank(c)
+          quote = c
+          escaped = false
+          i++
+        }
+        else -> {
+          out.append(c)
+          i++
+        }
+      }
+    }
+    return out.toString()
+  }
 
   private fun File.isTestSourceSetFile(): Boolean {
     val marker = "/src/"

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -280,6 +280,55 @@ class LottieAssetDiscoveryTest {
   }
 
   @Test
+  fun `preview examples in comments and strings do not flag empty compiled outputs`() {
+    val project = tempDir.newFolder("documented-asset-only")
+    val classes = project.resolve("classes").apply { mkdirs() }
+    val source =
+      project.resolve("src/main/kotlin/Examples.kt").apply {
+        parentFile.mkdirs()
+        writeText(
+          """
+          package example
+
+          /*
+          @Preview
+          fun blockExample() = Unit
+            /* @NestedPreview fun nested() = Unit */
+          */
+          /**
+           * @Preview
+           * fun kdocExample() = Unit
+           */
+          val sample = """ + "\"\"\"" + """
+          @Preview
+          fun stringExample() = Unit
+          """ + "\"\"\"" + """
+          """
+            .trimIndent()
+        )
+      }
+    val resources = project.resolve("resources").apply { mkdirs() }
+    resources.resolve("spin.json").writeText("""{"v":"5.7.0","layers":[]}""")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classes),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(source),
+          moduleName = ":assets",
+          variantName = "desktop",
+          projectDirectory = project,
+          failOnEmpty = false,
+          resourceDirs = listOf(resources),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    assertThat(outcome.warnings.joinToString("\n")).doesNotContain("empty build-cache entry")
+    assertThat(outcome.manifest.previews).hasSize(1)
+  }
+
+  @Test
   fun `supported preview annotation names flag empty compiled outputs`() {
     val project = tempDir.newFolder("supported-preview-names")
     val classes = project.resolve("classes").apply { mkdirs() }

--- a/scripts/design-artifacts/build-known-difference-fixtures.mjs
+++ b/scripts/design-artifacts/build-known-difference-fixtures.mjs
@@ -1065,9 +1065,9 @@ for (const [id, title, delta, status, why] of [
       "Its sibling above sits on `0.25 × 8 = 2`, which double arithmetic gets exactly right, so it " +
       "says nothing about how the boundary is computed. `0.145 × 200` is `28.999999999999996`, so a " +
       "displacement of exactly 29 — the inclusive boundary — is `element-moved` under a scaled " +
-      "tolerance and `valid` under a decimal or ratio consumer: the same bytes, two verdicts, from " +
-      "the last binary digit. Comparing `displacement / min(width, height)` against the recorded " +
-      "tolerance is exact here, because `29 / 200` and the literal `0.145` are the same double.",
+      "floating-point tolerance but `valid` under the required exact cross-product comparison: the " +
+      "same bytes, two verdicts, from the last binary digit. The tolerance's canonical decimal is " +
+      "an integer number of millionths, so both sides can be compared losslessly as integers.",
     document: document([record]),
     files: glyphFiles(world, record),
     comparison: glyphComparison(world, {

--- a/scripts/design-artifacts/fixtures/known-differences/cases/gate-element-at-tolerance-inexact-product/case.json
+++ b/scripts/design-artifacts/fixtures/known-differences/cases/gate-element-at-tolerance-inexact-product/case.json
@@ -1,7 +1,7 @@
 {
   "title": "A displacement at a tolerance whose product is not exact in binary",
   "site": null,
-  "why": "Its sibling above sits on `0.25 × 8 = 2`, which double arithmetic gets exactly right, so it says nothing about how the boundary is computed. `0.145 × 200` is `28.999999999999996`, so a displacement of exactly 29 — the inclusive boundary — is `element-moved` under a scaled tolerance and `valid` under a decimal or ratio consumer: the same bytes, two verdicts, from the last binary digit. Comparing `displacement / min(width, height)` against the recorded tolerance is exact here, because `29 / 200` and the literal `0.145` are the same double.",
+  "why": "Its sibling above sits on `0.25 × 8 = 2`, which double arithmetic gets exactly right, so it says nothing about how the boundary is computed. `0.145 × 200` is `28.999999999999996`, so a displacement of exactly 29 — the inclusive boundary — is `element-moved` under a scaled floating-point tolerance but `valid` under the required exact cross-product comparison: the same bytes, two verdicts, from the last binary digit. The tolerance's canonical decimal is an integer number of millionths, so both sides can be compared losslessly as integers.",
   "comparison": {
     "system": "m3",
     "component": "IconButton/Tonal",

--- a/scripts/design-artifacts/known-differences.mjs
+++ b/scripts/design-artifacts/known-differences.mjs
@@ -1454,13 +1454,11 @@ function elementCauses(element, tagIndex) {
     Math.abs(bounds.x + bounds.width - (baseline.x + baseline.width)),
     Math.abs(bounds.y + bounds.height - (baseline.y + baseline.height)),
   );
-  // **Compared as a ratio, not against a scaled tolerance.** `tolerance × min(width, height)` is a
-  // float multiplication and lands just under the true value often enough to matter: with tolerance
-  // `0.145` and a 200px baseline it gives `28.999999999999996`, so a displacement of exactly 29 —
-  // which *is* the inclusive boundary — reports `element-moved` here and `valid` in a consumer using
-  // decimals or the ratio. Dividing instead makes the boundary exact wherever the recorded tolerance
-  // is: `29 / 200` and the literal `0.145` are the same double, because both are the nearest double
-  // to the same real number.
+  // **Compared by exact cross multiplication, never floating-point ratio or product.** The
+  // tolerance grammar makes the decimal an exact multiple of `1 / ELEMENT_TOLERANCE_SCALE`, so the
+  // inclusive gate is `displacement × scale <= toleranceMicros × minDimension`. Both sides must be
+  // arbitrary-precision integers: a ratio happens to fix the familiar `0.145 × 200` boundary, but
+  // diverges again at schema-valid safe-integer bounds (pinned by the large-products fixture).
   const minDimension = Math.min(baseline.width, baseline.height);
   // **Exact integer arithmetic, in `BigInt`.** `element.tolerance` is spelled as a plain decimal
   // with at most six fraction digits, so it is an exact multiple of `1 / SCALE` and scaling recovers

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -318,12 +318,24 @@ export class RealGradleApi implements GradleApi {
             if (opts.cancellationKey) {
                 this.queuedRuns.set(opts.cancellationKey, queued);
             }
+            const forgetQueued = () => {
+                if (
+                    opts.cancellationKey &&
+                    this.queuedRuns.get(opts.cancellationKey) === queued
+                ) {
+                    this.queuedRuns.delete(opts.cancellationKey);
+                }
+            };
             const afterRepairs = () => {
                 if (queued.cancelled) {
                     throw new Error(
                         `gradlew ${opts.taskName} cancelled before start`,
                     );
                 }
+                // From this point cancellation must target the child registered by the recursive
+                // run. Keeping the queued marker until that child exits makes cancelRunTask return
+                // after marking an already-started queue entry and leaves the Gradle process alive.
+                forgetQueued();
                 return this.runTask(opts);
             };
             return Promise.all(repairsInFlight)
@@ -331,14 +343,7 @@ export class RealGradleApi implements GradleApi {
                     if (queued.cancelled) return afterRepairs();
                     throw error;
                 })
-                .finally(() => {
-                    if (
-                        opts.cancellationKey &&
-                        this.queuedRuns.get(opts.cancellationKey) === queued
-                    ) {
-                        this.queuedRuns.delete(opts.cancellationKey);
-                    }
-                });
+                .finally(forgetQueued);
         }
         const gradlewPath =
             process.platform === "win32"
@@ -350,9 +355,20 @@ export class RealGradleApi implements GradleApi {
         );
         const repairArgs =
             repairModules.length > 0 ? CANCELLATION_REPAIR_ARGS : [];
+        // A daemon bootstrap and several other module-owned tasks do not compile consumer sources.
+        // A repair invocation must include a task that can actually recreate the missing classes,
+        // otherwise the postcondition below turns a successful bootstrap into a permanent failure.
+        const requestedTasks = [opts.taskName, ...(opts.args ?? [])];
+        const repairCompileTasks = repairModules
+            .map(
+                (moduleDir) =>
+                    `:${moduleDir.split(path.sep).join(":")}:composePreviewDiscover`,
+            )
+            .filter((task) => !requestedTasks.includes(task));
         const gradleArgs = [
             opts.taskName,
             ...(opts.args ?? []),
+            ...repairCompileTasks,
             ...this.extraArgs,
             ...repairArgs,
         ];

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -1222,6 +1222,7 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         fs.writeFileSync(cmpFile, renamed, "utf-8");
 
         let renamePhaseError: Error | null = null;
+        let newRenderOutputs: string[] = [];
         try {
             api.resetMessages();
             // The file-system watcher observes the write above. Starting a
@@ -1326,13 +1327,8 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 reRefreshedRenamed,
                 "renamed preview id disappeared on the verification refresh",
             );
-            const newRenderOutputs = (reRefreshedRenamed.captures ?? []).map(
-                (c) =>
-                    fullRenderPath(
-                        repoRoot,
-                        reRefreshed.moduleDir,
-                        c.renderOutput,
-                    ),
+            newRenderOutputs = (reRefreshedRenamed.captures ?? []).map((c) =>
+                fullRenderPath(repoRoot, reRefreshed.moduleDir, c.renderOutput),
             );
             observations.newRenderOutputs = newRenderOutputs;
             assert.ok(
@@ -1402,6 +1398,31 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
             afterRevert.previews.map((p) => p.id).sort(),
             baselineIds,
             "id set after reverting the rename diverged from the pre-edit baseline",
+        );
+
+        // The daemon save above restores discovery state, but batch renders are owned by
+        // composePreviewRenderAll. Refresh once more after the save queue settles so a focused E
+        // run cannot leave the original PNG deleted and the temporary renamed PNG behind.
+        assertRefreshRendered(
+            api,
+            await refreshWithinBudget(
+                ":samples:cmp cleanup render",
+                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                api.triggerRefresh(cmpFile, true, "full"),
+                describeCmpPanelState,
+            ),
+            ":samples:cmp cleanup render",
+        );
+        await waitFor(
+            "batch artifacts after reverting the rename",
+            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
+            500,
+            () =>
+                oldRenderOutputs.every((p) => fs.existsSync(p)) &&
+                newRenderOutputs.every((p) => !fs.existsSync(p))
+                    ? true
+                    : undefined,
+            describeCmpPanelState,
         );
 
         dumpTranscript(repoRoot, "scenario-E-rename-preview", observations);

--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -1366,64 +1366,78 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
         } finally {
             fs.writeFileSync(cmpFile, original, "utf-8");
         }
-        if (renamePhaseError) throw renamePhaseError;
 
-        // --- Revert: the original RedBoxPreview must come back, renamed gone ---
-        api.resetMessages();
-        // The restore write in `finally` has its own watcher event. Join it
-        // through the save queue too, otherwise cleanup recreates the same
-        // double-refresh race as the rename.
-        api.triggerSave(cmpFile);
-        const afterRevert = await waitFor(
-            "setPreviews after reverting the rename",
-            budgetWithin(deadlineAt, RENDER_ROUND_TRIP_BUDGET_MS),
-            500,
-            () => {
-                const msgs = api.getPostedMessages();
-                return latestSetPreviewsMatching(msgs, (m) => {
-                    if (m.previews.length === 0) return false;
-                    if (!m.moduleDir.includes(cmpNeedle)) return false;
-                    return (
-                        m.previews.some((p) => OLD.test(p.id)) &&
-                        !m.previews.some((p) => NEW.test(p.id))
-                    );
-                });
-            },
-            describeCmpPanelState,
-        );
-        observations.afterRevertIds = afterRevert.previews
-            .map((p) => p.id)
-            .sort();
-        assert.deepStrictEqual(
-            afterRevert.previews.map((p) => p.id).sort(),
-            baselineIds,
-            "id set after reverting the rename diverged from the pre-edit baseline",
-        );
-
-        // The daemon save above restores discovery state, but batch renders are owned by
-        // composePreviewRenderAll. Refresh once more after the save queue settles so a focused E
-        // run cannot leave the original PNG deleted and the temporary renamed PNG behind.
-        assertRefreshRendered(
-            api,
-            await refreshWithinBudget(
-                ":samples:cmp cleanup render",
-                budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
-                api.triggerRefresh(cmpFile, true, "full"),
+        // Revert + cleanup runs even when the rename phase threw: the source is
+        // restored above, but the batch artifacts (original PNG deleted, temporary
+        // renamed PNG present) are only put back by the cleanup render below, and a
+        // rethrow here would leave every later scenario in this serial suite reading
+        // corrupted artifacts. On a failed rename phase this is best-effort cleanup —
+        // its own errors are reported but must not mask the original failure.
+        try {
+            // --- Revert: the original RedBoxPreview must come back, renamed gone ---
+            api.resetMessages();
+            // The restore write in `finally` has its own watcher event. Join it
+            // through the save queue too, otherwise cleanup recreates the same
+            // double-refresh race as the rename.
+            api.triggerSave(cmpFile);
+            const afterRevert = await waitFor(
+                "setPreviews after reverting the rename",
+                budgetWithin(deadlineAt, RENDER_ROUND_TRIP_BUDGET_MS),
+                500,
+                () => {
+                    const msgs = api.getPostedMessages();
+                    return latestSetPreviewsMatching(msgs, (m) => {
+                        if (m.previews.length === 0) return false;
+                        if (!m.moduleDir.includes(cmpNeedle)) return false;
+                        return (
+                            m.previews.some((p) => OLD.test(p.id)) &&
+                            !m.previews.some((p) => NEW.test(p.id))
+                        );
+                    });
+                },
                 describeCmpPanelState,
-            ),
-            ":samples:cmp cleanup render",
-        );
-        await waitFor(
-            "batch artifacts after reverting the rename",
-            budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
-            500,
-            () =>
-                oldRenderOutputs.every((p) => fs.existsSync(p)) &&
-                newRenderOutputs.every((p) => !fs.existsSync(p))
-                    ? true
-                    : undefined,
-            describeCmpPanelState,
-        );
+            );
+            observations.afterRevertIds = afterRevert.previews
+                .map((p) => p.id)
+                .sort();
+            assert.deepStrictEqual(
+                afterRevert.previews.map((p) => p.id).sort(),
+                baselineIds,
+                "id set after reverting the rename diverged from the pre-edit baseline",
+            );
+
+            // The daemon save above restores discovery state, but batch renders are owned by
+            // composePreviewRenderAll. Refresh once more after the save queue settles so a focused E
+            // run cannot leave the original PNG deleted and the temporary renamed PNG behind.
+            assertRefreshRendered(
+                api,
+                await refreshWithinBudget(
+                    ":samples:cmp cleanup render",
+                    budgetWithin(deadlineAt, REFRESH_BUDGET_MS),
+                    api.triggerRefresh(cmpFile, true, "full"),
+                    describeCmpPanelState,
+                ),
+                ":samples:cmp cleanup render",
+            );
+            await waitFor(
+                "batch artifacts after reverting the rename",
+                budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
+                500,
+                () =>
+                    oldRenderOutputs.every((p) => fs.existsSync(p)) &&
+                    newRenderOutputs.every((p) => !fs.existsSync(p))
+                        ? true
+                        : undefined,
+                describeCmpPanelState,
+            );
+        } catch (cleanupError) {
+            if (!renamePhaseError) throw cleanupError;
+            console.error(
+                "scenario E: rename cleanup failed after the phase error",
+                cleanupError,
+            );
+        }
+        if (renamePhaseError) throw renamePhaseError;
 
         dumpTranscript(repoRoot, "scenario-E-rename-preview", observations);
     });

--- a/vscode-extension/src/test/realGradleApi.test.ts
+++ b/vscode-extension/src/test/realGradleApi.test.ts
@@ -146,7 +146,11 @@ describe("RealGradleApi task ledger", () => {
     });
 });
 
-describe("RealGradleApi cancellation repair", () => {
+describe("RealGradleApi cancellation repair", function () {
+    // These tests intentionally wait on real child processes. CI hosts can suspend the Node event
+    // loop while Gradle workers contend for CPU, so Mocha's wall-clock timeout is not meaningful;
+    // every individual wait is bounded by the child scripts and cancellation path instead.
+    this.timeout(0);
     let tmp: string;
 
     beforeEach(() => {
@@ -322,6 +326,124 @@ describe("RealGradleApi cancellation repair", () => {
         assert.strictEqual(api.gradleInvocations.length, 3);
         assert.strictEqual(api.gradleInvocations[1].repaired, true);
         assert.strictEqual(api.gradleInvocations[2].repaired, undefined);
+    });
+
+    it("cancels the child after a queued run starts", async () => {
+        const output = classOutputDir("kotlin", "jvm", "main");
+        const classFile = path.join(output, "PreviewsKt.class");
+        fs.writeFileSync(
+            path.join(tmp, "gradlew"),
+            [
+                "#!/bin/sh",
+                'case " $* " in',
+                '  *" --rerun-tasks "*)',
+                "    sleep 0.1",
+                `    touch ${JSON.stringify(classFile)}`,
+                "    exit 0",
+                "    ;;",
+                "esac",
+                "sleep 10",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+        const api = new RealGradleApi(tmp);
+
+        const damaged = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "damage",
+        });
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            cancellationKey: "damage",
+        });
+        await damaged.catch(() => undefined);
+
+        const repair = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "repair",
+        });
+        const queued = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewCompile",
+            showOutputColors: false,
+            cancellationKey: "queued",
+        });
+
+        for (let i = 0; i < 40 && api.gradleInvocations.length < 3; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
+        assert.strictEqual(
+            api.gradleInvocations.length,
+            3,
+            "queued child never started",
+        );
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewCompile",
+            cancellationKey: "queued",
+        });
+
+        await repair;
+        await assert.rejects(queued, /cancelled/);
+        assert.strictEqual(api.gradleInvocations[2].status, "cancelled");
+    });
+
+    it("adds a compile-capable task when repairing a daemon bootstrap", async () => {
+        const output = classOutputDir("kotlin", "jvm", "main");
+        const classFile = path.join(output, "PreviewsKt.class");
+        fs.writeFileSync(path.join(tmp, "gradlew"), "#!/bin/sh\nsleep 10\n", {
+            mode: 0o755,
+        });
+        const api = new RealGradleApi(tmp);
+
+        const damaged = api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            showOutputColors: false,
+            cancellationKey: "damage",
+        });
+        await api.cancelRunTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewRenderAll",
+            cancellationKey: "damage",
+        });
+        await damaged.catch(() => undefined);
+
+        fs.writeFileSync(
+            path.join(tmp, "gradlew"),
+            [
+                "#!/bin/sh",
+                'case " $* " in',
+                '  *" :samples:cmp:composePreviewDiscover "*)',
+                `    touch ${JSON.stringify(classFile)}`,
+                "    exit 0",
+                "    ;;",
+                "esac",
+                "exit 1",
+                "",
+            ].join("\n"),
+            { mode: 0o755 },
+        );
+
+        await api.runTask({
+            projectFolder: tmp,
+            taskName: ":samples:cmp:composePreviewDaemonStart",
+            showOutputColors: false,
+            cancellationKey: "bootstrap",
+        });
+
+        assert.ok(
+            api.gradleInvocations[1].args.includes(
+                ":samples:cmp:composePreviewDiscover",
+            ),
+        );
+        assert.strictEqual(api.gradleInvocations[1].repaired, true);
     });
 
     it("keeps a bundled module task queued and cancellable during repair", async () => {


### PR DESCRIPTION
## Summary

Follow up on verified, still-present review findings from PRs opened in the previous 48 hours:

- preserve the startup classification of playground bundle sources instead of reparsing mutable filesystem state
- join acceptance lifecycle state against the complete issue index while keeping the visible Issues panel comparison-scoped
- retain dependency JARs in incremental discovery so hoisted gutter annotations remain resolvable
- make the empty-compiled-output source heuristic ignore Kotlin comments and string literals
- make cancellation repair invocations compile consumer classes and hand cancellation from queued state to the launched child
- restore batch artifacts after the rename e2e fixture is reverted
- replace obsolete floating-point ratio guidance with the required exact integer comparison

## Review threads

- #4496: bundle classification
- #4494: acceptance lifecycle issue join
- #4491: rename fixture cleanup
- #4488: dependency annotation closure
- #4487: queued cancellation, compile-capable repair, comment-aware source detection
- #4482: obsolete ratio prescription

The MCP stdio EOF finding from #4496 was verified as a false positive: the lambda is the SDK transport builder, not an EOF callback, and the existing hard-disconnect subscription cleanup test passes against SDK 0.15.

## Verification

- focused CLI tests for playground classification and lifecycle context
- IncrementalDiscoveryTest
- focused LottieAssetDiscoveryTest
- RealGradleApi cancellation repair suite
- MCP session hard-disconnect cleanup test
- ktfmtCheckAll
- VS Code extension Prettier check and TypeScript compilation
- exact gate conformance case

The full known-differences suite still has its existing filesystem-sensitive failures on case-insensitive macOS and symlink-restricted execution; the changed exact-gate case passes.