### PR TITLE
chore: delete dead code, dedupe zip extraction, trim restated comments

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -833,7 +833,7 @@ private class ExtractSubcommand(private val args: List<String>) {
         .absoluteFile
     target.mkdirs()
     val zipBytes = BundleReader.extractZipBytes(file)
-    safeExtractZip(zipBytes, target)
+    expandZipBytesSafely(zipBytes, target)
     println("extracted ${file.name} → ${target.path}")
   }
 }
@@ -1889,40 +1889,6 @@ internal fun resolveInBundleTarget(
     sourceIsUrl -> null
     else -> inputPath
   }
-
-/**
- * Extracts a zip safely — every entry's resolved target path is verified to live inside [target].
- * Defeats Zip Slip (`../../etc/passwd`-style entry names) reported by CodeQL / Codex on the v1
- * extract path; same call site is shared by `extract` and `render`.
- */
-private fun safeExtractZip(
-  zipBytes: ByteArray,
-  target: File,
-  fileSystem: FileSystem = SystemFileSystem,
-) {
-  val targetPath = target.canonicalFile.toPath()
-  ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
-    while (true) {
-      val entry = zin.nextEntry ?: break
-      // Resolve + normalize the entry against the target and verify containment via
-      // Path.startsWith — rejects "../" traversal and absolute entry names alike, and is the form
-      // CodeQL's java/zipslip recognizes as sanitization (the prior canonicalFile +
-      // String.startsWith guard was equally safe but flagged as a false positive).
-      val resolved = targetPath.resolve(entry.name).normalize()
-      if (!resolved.startsWith(targetPath)) {
-        throw SecurityException("bundle entry escapes target dir: ${entry.name} → $resolved")
-      }
-      val candidate = resolved.toFile()
-      if (entry.isDirectory) {
-        candidate.mkdirs()
-      } else {
-        candidate.parentFile?.mkdirs()
-        fileSystem.write(candidate.path.toPath()) { writeAll(zin.source()) }
-      }
-      zin.closeEntry()
-    }
-  }
-}
 
 /**
  * In-CLI mirror of the bundle's on-disk schema. We re-declare the data classes here (rather than

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonSupport.kt
@@ -44,7 +44,7 @@ internal fun extractBundleClassesAndManifest(
         }
         "classes/app.jar" -> {
           val appJarBytes = zin.readBytes()
-          expandBundleJarBytesSafely(appJarBytes, classesDir, fileSystem)
+          expandZipBytesSafely(appJarBytes, classesDir, fileSystem, "bundle: app jar entry")
           sawAppJar = true
         }
       }
@@ -99,26 +99,25 @@ internal fun extractBundleIrArtifacts(
 }
 
 /**
- * Unpack an app jar's bytes into [targetDir], rejecting Zip Slip. Shares its containment-check
- * shape with `BundleCommand`'s `safeExtractZip` (a bundle's own zip) — duplicated rather than
- * reused since this one unpacks an in-memory *jar's* bytes, a different call shape.
+ * Unpack a zip or jar's [bytes] into [targetDir], rejecting Zip Slip. Resolve + normalize +
+ * `Path.startsWith` is the containment check CodeQL's `java/zipslip` recognizes as sanitization; an
+ * equally safe `canonicalFile` + `String.startsWith` guard is reported as a false positive.
+ *
+ * [what] names the offending entry in the rejection message ("bundle entry", "app jar entry", …).
  */
-internal fun expandBundleJarBytesSafely(
-  appJarBytes: ByteArray,
+internal fun expandZipBytesSafely(
+  bytes: ByteArray,
   targetDir: File,
   fileSystem: FileSystem = SystemFileSystem,
+  what: String = "bundle entry",
 ) {
   val targetPath = targetDir.canonicalFile.toPath()
-  ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
+  ZipInputStream(ByteArrayInputStream(bytes)).use { zin ->
     while (true) {
       val entry = zin.nextEntry ?: break
-      // Resolve + normalize the entry against the target and verify containment via
-      // Path.startsWith — the form CodeQL's java/zipslip recognizes as sanitization.
       val resolved = targetPath.resolve(entry.name).normalize()
       if (!resolved.startsWith(targetPath)) {
-        throw SecurityException(
-          "bundle: app jar entry escapes target dir: ${entry.name} → $resolved"
-        )
+        throw SecurityException("$what escapes target dir: ${entry.name} → $resolved")
       }
       val candidate = resolved.toFile()
       if (entry.isDirectory) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -6,7 +6,6 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -16,8 +15,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
-import okio.Path.Companion.toPath
-import okio.source
 
 /**
  * Re-renders a packed `.png` (PNG+ZIP polyglot bundle) outside of any Gradle project: extract the
@@ -417,40 +414,10 @@ class BundleRenderer(
     // from `ir/` rather than from reflected consumer bytecode. Expand the consumer classes only
     // when the bundle carries them; the caller validates that a class-backed preview isn't left
     // without its jar.
-    appJarBytes?.let { expandJarBytes(it, classesDir) }
-    return Triple(bundleJsonNonNull, previewsJsonNonNull, appJarBytes != null)
-  }
-
-  /**
-   * Unpack [appJarBytes] (a JAR-format zip) into [targetDir]. Each entry's resolved path is
-   * verified to live inside [targetDir] — defeats Zip Slip on a malformed/hostile bundle, same
-   * defense as `safeExtractZip` in BundleCommand.
-   */
-  private fun expandJarBytes(appJarBytes: ByteArray, targetDir: File) {
-    val targetPath = targetDir.canonicalFile.toPath()
-    ZipInputStream(ByteArrayInputStream(appJarBytes)).use { zin ->
-      while (true) {
-        val entry: ZipEntry = zin.nextEntry ?: break
-        // Resolve + normalize the entry against the target and verify containment via
-        // Path.startsWith — the form CodeQL's java/zipslip recognizes as sanitization (the prior
-        // canonicalFile + String.startsWith guard was equally safe but flagged as a false
-        // positive).
-        val resolved = targetPath.resolve(entry.name).normalize()
-        if (!resolved.startsWith(targetPath)) {
-          throw SecurityException(
-            "bundle render: app jar entry escapes target dir: ${entry.name} → $resolved"
-          )
-        }
-        val candidate = resolved.toFile()
-        if (entry.isDirectory) {
-          candidate.mkdirs()
-        } else {
-          candidate.parentFile?.mkdirs()
-          fileSystem.write(candidate.path.toPath()) { writeAll(zin.source()) }
-        }
-        zin.closeEntry()
-      }
+    appJarBytes?.let {
+      expandZipBytesSafely(it, classesDir, fileSystem, "bundle render: app jar entry")
     }
+    return Triple(bundleJsonNonNull, previewsJsonNonNull, appJarBytes != null)
   }
 
   private fun spawnRenderer(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -482,13 +482,6 @@ internal class McpCommand(
     if (updated != text) fileSystem.write(path) { writeUtf8(updated) }
   }
 
-  private fun parseDescriptor(file: File): JsonObject? =
-    try {
-      JSON.parseToJsonElement(fileSystem.read(file.path.toPath()) { readUtf8() }).jsonObject
-    } catch (_: Exception) {
-      null
-    }
-
   private fun defaultAntigravityConfig(): File =
     File(System.getProperty("user.home"), ".gemini/antigravity/mcp_config.json")
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2680,13 +2680,6 @@ class ServeCatalogStore(
     private const val ASSET_FETCH_CONCURRENCY = 12
 
     /**
-     * Images planned per fetch wave. Each wave is additionally clamped to the images still needed,
-     * so the `maxImages` ceiling keeps counting *successes* — a wave that comes back short is
-     * followed by another rather than truncating the catalog.
-     */
-    private const val IMAGE_FETCH_WAVE = 64
-
-    /**
      * Images fetched before a catalog publishes: its hero (which the front door paints) plus a
      * couple of others, so "the branch can serve pixels" is proven without one missing file being
      * able to fail the catalog. Everything else arrives on first use.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3570,38 +3570,22 @@ class ServeHttpServer(
         )
       val revisions = catalogRevisions(renderHost, preview.id)
       val pinned = revisions.pinned != null
-      // Whether a TAG selection would describe the frame on screen. All three conditions are about
-      // the same thing: `tagIndexForPreview` is the published static index, measured in CI over the
-      // baked render, and both live host wrappers delegate it to their baked host. So it describes
-      // the frame here when the frame is the baked one — no overrides re-rendering it, no pin
-      // replaying a different commit's pixels — and a host that publishes no index at all has
-      // nothing to offer either way.
-      //
-      // **This is a necessary condition, not a sufficient one, and the gap is caching.** On a
-      // public server an override-free baked `/render/<id>.png` is served
-      // `STATIC_RESOURCE_CACHE_CONTROL` while this index is `no-store`, so within that window a
-      // client can pair pixels from the previous catalog generation with a freshly-fetched index —
-      // the same-frame invariant broken by a republish rather than by an override. Closing it needs
-      // the image and the index to carry a shared generation, which is the coupling batch 05 has to
-      // build before an element gate may read this at all; recording a slightly wrong baseline is
-      // latent until a gate measures against it. Tracked, not fixed here: it changes the render
-      // lane's URL and caching contract, which is more than this batch should move on its own.
-      //
-      // Getting this wrong is not a missing feature, it is a wrong record: a tag selection persists
-      // the index's bounds into the locator as the acceptance's baseline, so bounds from another
-      // frame survive into a record that later reports an unchanged element as moved. The element
-      // gates in batch 05 need a shared render generation before they can do better than this;
-      // until then the honest answer on a re-rendered frame is to offer the drag and say why.
       // Whether the frame on screen is the catalog's BAKED render, replayed rather than produced
-      // for this request. Everything a selection records as an authoring-time baseline has to come
-      // from the same frame the reporter is looking at, and this is the one condition under which
-      // the server can promise that for a product fetched by a SEPARATE request.
-      //
+      // for this request — the one condition under which the server can promise that a product
+      // fetched by a SEPARATE request (`.png` vs `.annotations`) describes the same frame.
       // `canApplyOverrides` is false exactly for the hosts that replay baked pixels for an
-      // override-free browse (a static bundle, and a live-catalog wrapper whose browsing lane is
-      // baked); a daemon-backed host renders per request, so its `.png` and its `.annotations` are
-      // two renders and may disagree wherever output varies — animation, conditional composition,
-      // live data. A pin or an override re-renders on any host.
+      // override-free browse; a daemon-backed host renders per request, so its two products may
+      // disagree wherever output varies (animation, conditional composition, live data). A pin or
+      // an override re-renders on any host, and `tagIndexForPreview` is the published static index
+      // measured in CI over the baked render.
+      //
+      // Necessary but NOT sufficient, and the gap is caching: an override-free baked
+      // `/render/<id>.png` is served `STATIC_RESOURCE_CACHE_CONTROL` while this index is
+      // `no-store`, so a client can pair previous-generation pixels with a freshly-fetched index.
+      // Closing it needs the image and the index to carry a shared generation — batch 05's
+      // coupling, which also moves the render lane's URL and caching contract. It matters because
+      // a tag selection persists the index's bounds as the acceptance baseline, so bounds from
+      // another frame survive into a record that later reports an unchanged element as moved.
       val frameIsReplayedBaked =
         !pinned && overrideParams.isEmpty() && !renderHost.canApplyOverrides
       val tagIndex = renderHost.tagIndexForPreview(preview.id)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -189,36 +189,6 @@ object ServeWeb {
   private fun viewerViewCountHtml(views: Long): String =
     if (views <= 0) "" else "<span class=\"cp-viewer-engage\">${formatViews(views)}</span>"
 
-  /**
-   * A title-bar disclosure toggle: a [label] naming the axis it folds, plus the [value] that axis
-   * currently holds. Both halves matter. A bare "State" would make the reader open the row to learn
-   * what they are looking at — the very cost the fold was meant to remove — so a closed toggle
-   * reads "State · M wide" and the row underneath is genuinely optional.
-   *
-   * Shares `.cp-drawer-toggle` with the two drawer toggles it now sits beside, so the four
-   * disclosures on this page cannot drift apart visually; `aria-expanded` + `aria-controls` are
-   * what make it a disclosure rather than four buttons that happen to look alike.
-   *
-   * [valueId] labels the value span when something client-side has to keep it current (the theme,
-   * which changes without a page load).
-   */
-  private fun disclosureToggleHtml(
-    id: String,
-    controls: String,
-    label: String,
-    value: String,
-    open: Boolean,
-    valueId: String? = null,
-  ): String {
-    val valueIdAttr = valueId?.let { " id=\"${WebEscaping.htmlEscape(it)}\"" } ?: ""
-    return "<button type=\"button\" class=\"cp-drawer-toggle cp-axis-toggle\"" +
-      " id=\"${WebEscaping.htmlEscape(id)}\" aria-expanded=\"$open\"" +
-      " aria-controls=\"${WebEscaping.htmlEscape(controls)}\">" +
-      "<span class=\"cp-toggle-label\">${WebEscaping.htmlEscape(label)}</span>" +
-      "<span class=\"cp-toggle-value\"$valueIdAttr>${WebEscaping.htmlEscape(value)}</span>" +
-      "</button>"
-  }
-
   private fun formatViews(views: Long): String =
     "${formatCount(views)} ${if (views == 1L) "view" else "views"}"
 
@@ -290,18 +260,6 @@ object ServeWeb {
    * public links).
    */
   private fun querySuffix(query: String): String = if (query.isEmpty()) "" else "?$query"
-
-  /**
-   * Producer-trust badge for a bundle/catalog session ([BundleVerifier.summary]); empty for a live
-   * daemon-backed module (trust applies to detached bundles/catalogs, not the operator's own served
-   * module). Positive trust is intentionally silent; only an unverified producer earns a visible
-   * warning badge.
-   */
-  private fun trustBadge(trust: String?): String {
-    if (trust != "unverified") return ""
-    return " <span class=\"cp-badge cp-badge--unverified\" " +
-      "title=\"producer trust: unverified\">⚠ untrusted</span>"
-  }
 
   /**
    * The viewer's compact producer warning. Trusted catalogs carry no badge; an unverified one is
@@ -581,15 +539,6 @@ object ServeWeb {
    */
   private const val INTERFACE_MODE_COOKIE_ATTRS =
     "; path=/; max-age=$INTERFACE_MODE_COOKIE_MAX_AGE; samesite=lax"
-
-  /**
-   * How many rows the viewer's component subtree shows inline before folding behind its title-bar
-   * toggle — counting the component row, which is itself a render (the default one), not just its
-   * children. Lower than the chip rows this replaced needed, because a tree spends a whole line per
-   * render where a chip row wrapped several onto one: four rows is about the point past which the
-   * list costs more of the fold than the render it sits above.
-   */
-  private const val AXIS_ROWS_INLINE = 4
 
   /**
    * How many theme chips the viewer bar shows inline before folding. Lower than [AXIS_CHIPS_INLINE]
@@ -2888,19 +2837,6 @@ ${captureControlsHtml().prependIndent("          ")}
       TreeVariant(variantLabel(p, axis, crossProduct), href(p), axis)
     }
   }
-
-  /**
-   * Whether this component varies on [axis] (`"state"` or `"props"`), which is what lets the folded
-   * disclosure name the axes it put away. Derived from [componentRenderRows] rather than
-   * re-deriving the axis rules, so the toggle can never claim an axis the subtree underneath it
-   * does not offer.
-   */
-  private fun componentHasAxis(
-    preview: ServePreview,
-    siblings: List<ServePreview>,
-    darkFirst: Boolean,
-    axis: String,
-  ): Boolean = componentRenderRows(preview, siblings, darkFirst) { it.id }.any { it.axis == axis }
 
   private fun componentSubtreeHtml(
     preview: ServePreview,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -554,7 +554,6 @@ open class DesktopHost(
       live = live,
       engine = engine,
       state = state,
-      sandboxStats = sandboxStats,
       framesDir = framesDir,
       encodedDir = encodedDir,
     )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -75,7 +75,6 @@ class DesktopRecordingSession(
   override val live: Boolean = false,
   private val engine: RenderEngine,
   private val state: RenderEngine.SceneState,
-  private val sandboxStats: SandboxLifecycleStats,
   private val framesDir: File,
   private val encodedDir: File,
   private val fileSystem: FileSystem = SystemFileSystem,

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeHost.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeHost.kt
@@ -47,13 +47,6 @@ class FakeHost(
 ) : RenderHost {
 
   /**
-   * Tracks the next "internal request id" the host would assign if anyone called the legacy
-   * `RenderHost.Companion.nextRequestId()` path. Unused for the v0 scenarios but kept so future
-   * fakes can mimic real-host bookkeeping if needed.
-   */
-  private val internalIdSource = AtomicLong(1)
-
-  /**
    * Cache of decoded `<previewId>.error` / `<previewId>.delay-ms` / `<previewId>.metrics.json`
    * sidecar files. Lazy because most fixtures only set one or two of them.
    *

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -117,8 +117,6 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see
-        // classpathArgFile.
         add(classpathArgFile(classpath.map { it.absolutePath }))
         add(mainClass)
       }
@@ -193,8 +191,6 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see
-        // classpathArgFile.
         add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }
@@ -338,8 +334,6 @@ class RealAndroidHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         addHistorySyspropsIfSet()
         addAll(extraJvmArgs)
-        // @argfile so a large harness classpath can't overflow the OS arg limit — see
-        // classpathArgFile.
         add(classpathArgFile(fullClasspath.map { it.absolutePath }))
         add("ee.schimke.composeai.daemon.DaemonMain")
       }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1516,146 +1516,65 @@ internal object AndroidPreviewSupport {
         "testImplementation",
         "androidx.compose.ui:ui-test-junit4:$RENDERER_COMPOSE_FLOOR_VERSION",
       )
-      // Pin `androidx.core:core` to the floor that compose-ui 1.10+ requires.
-      // The renderer's test classpath gets compose-ui via roborazzi-compose's
-      // transitive deps regardless of what the consumer declares, and
+      // Main-variant floor pins for tile-only / non-Compose-UI consumers.
+      //
+      // AGP builds the merged unit-test resource APK (`apk-for-local-test.ap_`) from the
+      // consumer's MAIN variant, while the renderer's compose-ui arrives on the JVM *test*
+      // classpath via roborazzi-compose. A consumer whose main variant carries neither compose-ui
+      // nor its resource dependencies (e.g. wear-os-samples' WearTilesKotlin) is therefore missing
+      // R classes the renderer's classes read, and Robolectric dies at class-init. Each pin below
+      // adds the missing artifact to `${variantName}Implementation` so AGP merges its R class.
+      // All are floors only — Gradle's conflict resolution picks the max, so they are no-ops for
+      // Compose-app consumers already on their own BOM.
+      //
+      // The `reason` strings on the matching `recordInjectedDependency` calls below are the
+      // user-facing version of this (surfaced by `composePreviewDoctor`); the notes here add the
+      // exact failure each pin prevents.
+
       // compose-ui 1.10+'s `InsetsListener.onViewAttachedToWindow` reads
-      // `androidx.core.R.id.tag_compat_insets_dispatch` (added in core
-      // 1.16.0). The merged unit-test resource APK is built from the
-      // consumer's MAIN variant, so on tile-only / older-Compose consumers
-      // (e.g. WearTilesKotlin: no compose-ui in main, transitive core is
-      // pre-1.16) the field is missing and Robolectric crashes the moment
-      // `AndroidComposeView.onAttachedToWindow` runs:
-      //
-      //   `NoSuchFieldError: Class androidx.core.R$id does not have member
-      //   field 'int tag_compat_insets_dispatch'`
-      //
-      // Adding the floor to `${variantName}Implementation` is the same
-      // pattern used for `tiles-renderer` below — a main-variant dep so AGP
-      // includes the R class in the merged test APK. Acts as a floor only:
-      // Gradle picks the higher version when consumers already pin core
-      // >= 1.16 via their own deps (compose-bom 2026.x, etc.), so it's
-      // non-destructive for the common case.
+      // `androidx.core.R.id.tag_compat_insets_dispatch`, added in core 1.16.0:
+      //   NoSuchFieldError: androidx.core.R$id … 'int tag_compat_insets_dispatch'
       project.dependencies.add("${variantName}Implementation", "androidx.core:core:1.16.0")
-      // Pin `androidx.customview:customview-poolingcontainer` for the same
-      // reason as `androidx.core:core` above. compose-ui's
-      // `ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool`
-      // reads `androidx.customview.poolingcontainer.R.id.*` from
-      // `PoolingContainer.<clinit>`, so the merged unit-test resource APK
-      // needs that R class. Tile-only consumers without compose-ui in main
-      // (e.g. WearTilesKotlin) carry no transitive customview-poolingcontainer
-      // on the main variant, so the field lookup crashes Robolectric the
-      // moment `AbstractComposeView.<init>` installs the strategy:
-      //
-      //   `NoClassDefFoundError: Could not initialize class
-      //   androidx.customview.poolingcontainer.PoolingContainer`
-      //   caused by `NoClassDefFoundError:
-      //   androidx/customview/poolingcontainer/R$id`
-      //
-      // 1.0.0 is the only published version (compose-ui 1.9.x → 1.11.x all
-      // depend on it unchanged); the floor here is a no-op for Compose-app
-      // consumers that already get it transitively, and a fix for tile-only
-      // consumers that don't.
+
+      // compose-ui's `ViewCompositionStrategy.DisposeOnDetachedFromWindowOrReleasedFromPool` reads
+      // `androidx.customview.poolingcontainer.R.id.*` from `PoolingContainer.<clinit>`:
+      //   NoClassDefFoundError: androidx/customview/poolingcontainer/R$id
+      // 1.0.0 is the only published version (compose-ui 1.9.x → 1.11.x all depend on it unchanged).
       project.dependencies.add(
         "${variantName}Implementation",
         "androidx.customview:customview-poolingcontainer:1.0.0",
       )
-      // Pin `androidx.activity:activity` to a floor that exposes the
-      // `view_tree_on_back_pressed_dispatcher_owner` resource id. The
-      // renderer's test classpath pulls activity-compose ≥ 1.13 transitively
-      // (via roborazzi-compose), whose `ComponentActivity.initializeViewTreeOwners`
-      // → `ViewTreeOnBackPressedDispatcherOwner.set` reads
-      // `androidx.activity.R.id.view_tree_on_back_pressed_dispatcher_owner`
-      // (added in `androidx.activity:activity:1.5.0`). The merged unit-test
-      // resource APK is built from the consumer's MAIN variant, so on
-      // tile-only consumers whose main pulls only a legacy activity (e.g.
-      // wear-os-samples' WearTilesKotlin resolves `activity:1.1.0` via old
-      // transitives) the field is missing and Robolectric crashes the
-      // moment `createAndroidComposeRule<ComponentActivity>().setContent {}`
-      // runs:
-      //
-      //   `NoSuchFieldError: Class androidx.activity.R$id does not have
-      //   member field 'int view_tree_on_back_pressed_dispatcher_owner'`
-      //
-      // Same `${variantName}Implementation` floor pattern as the
-      // `androidx.core:core` and `customview-poolingcontainer` entries
-      // above — Gradle picks the max with consumer-aligned versions, so
-      // this is a no-op for Compose-app consumers that already get a
-      // newer activity transitively, and a fix for tile-only consumers
-      // that don't.
+
+      // `ComponentActivity.initializeViewTreeOwners` → `ViewTreeOnBackPressedDispatcherOwner.set`
+      // reads `androidx.activity.R.id.view_tree_on_back_pressed_dispatcher_owner`, added in
+      // activity 1.5.0 (WearTilesKotlin resolves 1.1.0 via old transitives):
+      //   NoSuchFieldError: androidx.activity.R$id … 'view_tree_on_back_pressed_dispatcher_owner'
       project.dependencies.add("${variantName}Implementation", "androidx.activity:activity:1.10.0")
-      // Pin `androidx.compose.ui:ui` on the main variant for tile-only /
-      // non-Compose-UI consumers. compose-ui's
-      // `AndroidComposeViewAccessibilityDelegateCompat.<clinit>` reads
-      // `androidx.compose.ui.R.id.*` (via `accessibility_custom_action_*`
-      // / `compose_view_root_id` lookups), so the merged unit-test resource
-      // APK needs the compose-ui R class. The renderer's test classpath
-      // brings compose-ui transitively (via roborazzi-compose / ui-test-*)
-      // — but that's the JVM test classpath only; AGP builds the merged
-      // `apk-for-local-test.ap_` from the consumer's MAIN variant, so on
-      // tile-only consumers without compose-ui in main (e.g. WearTilesKotlin)
-      // the R class is missing and Robolectric crashes the moment
-      // `AndroidComposeView.<init>` triggers the accessibility delegate's
-      // class init:
+
+      // compose-ui's `AndroidComposeViewAccessibilityDelegateCompat.<clinit>` reads
+      // `androidx.compose.ui.R.id.*`:
+      //   NoClassDefFoundError: androidx/compose/ui/R$id
       //
-      //   `NoClassDefFoundError: Could not initialize class
-      //   androidx.compose.ui.platform.AndroidComposeViewAccessibilityDelegateCompat`
-      //   caused by `NoClassDefFoundError: androidx/compose/ui/R$id`
+      // Version, unlike the pins above, is NOT the renderer's compile floor: the merged APK's R
+      // class has to agree with the compose-ui CLASSES on the render classpath. A Compose consumer
+      // keeps Rule 3, so its own BOM wins and both come from it; a Compose-less consumer runs on
+      // OUR compose-ui (the CMP runtime), and pinning main at the 1.9.5 floor mismatches by two
+      // minors — `ui-android` 1.9.5's `R.txt` has no
+      // `androidx_compose_ui_view_compose_view_context`, which the newer classes read.
       //
-      // Same `${variantName}Implementation` floor pattern as the
-      // `androidx.core:core`, `customview-poolingcontainer`, and
-      // `androidx.activity:activity` entries above — Gradle picks the max
-      // with consumer-aligned versions, so this is a no-op for Compose-app
-      // consumers that already get a newer ui via their BOM, and a fix for
-      // tile-only consumers that don't.
-      //
-      // The VERSION is not the same for both, though. This pin decides the R
-      // class in the merged unit-test resource APK, and that has to agree with
-      // the compose-ui CLASSES on the render classpath:
-      //
-      //  * A Compose consumer keeps Rule 3, so its own Compose is what runs and
-      //    its BOM wins over this floor. Classes and resources are both theirs.
-      //  * A Compose-less consumer has Rule 3 off, so the render classpath's
-      //    compose-ui is OURS — the one Compose Multiplatform brings. Pinning
-      //    the main variant at the 1.9.5 floor there mismatches by two minor
-      //    versions, and the merged APK's R class is missing ids the newer
-      //    classes read:
-      //
-      //      NoSuchFieldError: Class androidx.compose.ui.R$id does not have
-      //        member field 'int androidx_compose_ui_view_compose_view_context'
-      //          at ComposeView_androidKt.getComposeViewContext
-      //
-      //    (Verified against the published artifacts: `ui-android` 1.9.5's
-      //    `R.txt` has no such id; [RENDERER_COMPOSE_CMP_RUNTIME_VERSION]'s
-      //    has it.) So a Compose-less consumer gets the CMP runtime version,
-      //    keeping its resources and our classes on the same line.
-      //
-      // Resolved once and reused for the `foundation` pin below AND for both
-      // `recordInjectedDependency` entries: `composePreviewDoctor` exists to
-      // explain this exact compatibility scenario, so reporting the floor while
-      // injecting the CMP runtime version would misreport precisely where the
-      // report is load-bearing.
+      // Resolved once and reused for `foundation` below and for both `recordInjectedDependency`
+      // entries, so `composePreviewDoctor` reports the version actually injected.
       val mainComposeVersion = mainVariantComposeVersion(project, variantName)
       addPluginDependency(
         project,
         "${variantName}Implementation",
         "androidx.compose.ui:ui:$mainComposeVersion",
       )
-      // Pin `androidx.compose.foundation:foundation` on the main variant for
-      // the same reason as compose-ui above — but for class-loading rather
-      // than R.id lookup. `TilePreviewRenderer.TilePreviewComposable` calls
-      // `Modifier.fillMaxSize()` (from `androidx.compose.foundation.layout.SizeKt`)
-      // to fill the renderer's host AndroidView. On tile-only consumers
-      // without compose-foundation in main (e.g. WearTilesKotlin), the class
-      // isn't on the user-classpath component of the merged test APK and
-      // Robolectric crashes the first time the tile compose-tree runs:
-      //
-      //   `NoClassDefFoundError: androidx/compose/foundation/layout/SizeKt`
-      //   at `TilePreviewRendererKt.TilePreviewComposable`
-      //
-      // Same `${variantName}Implementation` floor pattern as compose-ui, and
-      // versioned by the same rule — foundation and ui have to stay on one
-      // line, so this uses [mainVariantComposeVersion] too.
+
+      // Class-loading rather than R.id lookup: `TilePreviewRenderer.TilePreviewComposable` calls
+      // `Modifier.fillMaxSize()` from `androidx.compose.foundation.layout.SizeKt`:
+      //   NoClassDefFoundError: androidx/compose/foundation/layout/SizeKt
+      // Versioned with compose-ui above — foundation and ui have to stay on one line.
       addPluginDependency(
         project,
         "${variantName}Implementation",

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPool.kt
@@ -77,7 +77,6 @@ internal class DesktopRenderWorkerPool(
   private val jvmArgs: List<String>,
   private val maxWorkers: Int,
   private val maxRendersPerWorker: Int,
-  private val renderTimeoutSeconds: Long,
   /**
    * Working directory for every worker, which must be the **task project's** directory:
    * `ExecOperations.javaexec` defaulted to it, so a preview reading a relative path resolved it

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -812,7 +812,6 @@ abstract class RenderPreviewsTask : DefaultTask() {
       jvmArgs = workerJvmArgs(),
       maxWorkers = DesktopRenderWorkerPool.configuredWorkers(),
       maxRendersPerWorker = DesktopRenderWorkerPool.configuredMaxRenders(),
-      renderTimeoutSeconds = DesktopRenderWorkerPool.RENDER_GUARD_SECONDS,
       // `javaexec` defaulted the working directory to the task's project, so a preview reading a
       // relative path resolved it against that subproject. A worker must start there too, or the
       // warm and forked lanes would disagree about what `File("src/main/resources/…")` means.

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DesktopRenderWorkerPoolTest.kt
@@ -198,7 +198,6 @@ class DesktopRenderWorkerPoolTest {
       jvmArgs = listOf("-Dstub.mode=$mode"),
       maxWorkers = 1,
       maxRendersPerWorker = maxRendersPerWorker,
-      renderTimeoutSeconds = 60,
       workingDir = workingDir,
       stderrSink = stderrSink,
       workerMainClass = workerMainClass,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -185,10 +185,6 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
         add(javaBin)
         addAll(descriptor.jvmArgs)
         descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
-        // A full-app render classpath (hundreds of jars) overflows the OS arg limit if passed as a
-        // literal `-cp`, which silently drops the daemon (e.g. --with-semantics capture). Pass it
-        // via a Java @argfile so argv stays short regardless of classpath size (see
-        // classpathArgFile).
         // Inside a jail the parent's temp dir may not exist (bwrap mounts its own /tmp), so the
         // argfile goes in the one directory both sides can see: the daemon's working directory.
         add(

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -3015,28 +3015,6 @@ class DaemonMcpServer(
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
   }
 
-  /**
-   * Resolves the (workspaceId, module) pair the history tools need plus the live daemon — the
-   * daemon owns the configured `HistoryManager`, so every history call goes through it.
-   */
-  private fun resolveHistoryDaemon(
-    args: JsonObject,
-    toolName: String,
-  ): Pair<SupervisedDaemon, String>? {
-    val ws =
-      args["workspaceId"]?.jsonPrimitive?.contentOrNull
-        ?: return null.also {
-          // Caller wraps this null into an errorCallToolResult; we surface the missing-field
-          // message there.
-        }
-    val workspaceId = WorkspaceId(ws)
-    if (supervisor.project(workspaceId) == null) return null
-    val module = args["module"]?.jsonPrimitive?.contentOrNull ?: return null
-    val daemon =
-      runCatching { supervisor.daemonFor(workspaceId, module) }.getOrNull() ?: return null
-    return daemon to module
-  }
-
   private fun toolSetVisible(args: JsonObject): CallToolResult =
     forwardVisibilityCall(args, "set_visible") { daemon, ids -> daemon.client.setVisible(ids) }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -1034,10 +1034,6 @@ private fun CatalogSectionHeader(label: String) {
   BasicText(text = label.uppercase(Locale.ROOT), style = CATALOG_SECTION_STYLE)
 }
 
-/** Cell for a colour role. Fixed geometry: the 40dp swatch plus its row padding and the row gap. */
-private fun swatchCell(label: String, color: Color) =
-  SpecimenCell(CATALOG_SWATCH_ROW_HEIGHT) { CatalogSwatchRow(label = label, color = color) }
-
 /**
  * A colour role drawn as a chip that **sets its own name in the role it pairs with** — `primary`
  * lettered in `onPrimary`, `surfaceContainer` in `onSurface`.

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/SubspaceSceneRecorder.kt
@@ -212,8 +212,6 @@ public object SubspaceSceneRecorder {
   private fun subspaceRootOf(panelNodes: List<SpatialSemanticsNode>): SpatialSemanticsNode =
     SpatialSemanticsTrees.subspaceRoot(panelNodes)
 
-  private fun identityPose(): SpatialPose = SpatialSemanticsTrees.identityPose()
-
   /** First [RootForTest] (the Compose `AndroidComposeView`) in this view's subtree, or null. */
   private fun View.findRootForTest(): RootForTest? {
     if (this is RootForTest) return this


### PR DESCRIPTION
A general quality sweep: dead code, one real duplication, and comments that restate something already written down elsewhere. **Net −293 lines, no behaviour change** — every deletion is either unreachable or a byte-identical twin of code that stays.

Findings came from mechanical scans (unreferenced `private` declarations; cross-file duplicate 8-line windows; long inline comment runs), not from reading at random, so the list is bounded rather than a sample.

## Dead code

Each of these has exactly one occurrence in the tree — its own declaration:

| Symbol | Where |
| --- | --- |
| `disclosureToggleHtml`, `componentHasAxis`, `AXIS_ROWS_INLINE` | `ServeWeb` |
| `trustBadge` | `ServeWeb` — byte-identical twin of the `compactTrustBadge` that *is* called |
| `parseDescriptor` | `McpCommand` |
| `resolveHistoryDaemon` | `DaemonMcpServer` — also carried a `?: return null.also { /* comment only */ }` |
| `swatchCell` | `PreviewRenderStrategy` |
| `IMAGE_FETCH_WAVE` | `ServeCatalogStore` |
| `identityPose` | `SubspaceSceneRecorder` — a one-line delegate to `SpatialSemanticsTrees.identityPose` |
| `internalIdSource` | `FakeHost` — its own KDoc said it was unused and kept "so future fakes can mimic real-host bookkeeping if needed" |

Plus two unused constructor params and their call sites:

- `DesktopRenderWorkerPool.renderTimeoutSeconds` — the class already reads `RENDER_GUARD_SECONDS` directly at both use sites, so the threaded param was never consulted.
- `DesktopRecordingSession.sandboxStats`.

## Redundant code

Three near-identical zip-slip-guarded extractors in `:cli` collapse into one `expandZipBytesSafely`:

- `BundleCommand.safeExtractZip`
- `BundleRenderer.expandJarBytes`
- `BundleDaemonSupport.expandBundleJarBytesSafely`

They differed only in the text of the `SecurityException`, now a `what` parameter. The existing comments asserted the duplication was deliberate — "duplicated rather than reused since this one unpacks an in-memory *jar's* bytes, a different call shape" — but the shapes were `(ByteArray, File, FileSystem)` in all three. The surviving copy keeps the `resolve` + `normalize` + `Path.startsWith` form that CodeQL's `java/zipslip` recognises as sanitization, and the note explaining why the equally-safe `canonicalFile` guard was replaced.

## Comments

Aim was succinct comments with a justified reason to exist, so these cuts remove restatement rather than information. Nothing that documents a contract was touched — I deliberately left `DaemonClasspathDescriptor` and `InteractiveSession` alone despite their high comment ratios, since those are wire-format and cross-backend interface docs where the prose *is* the deliverable.

- **`AndroidPreviewSupport`** (−117 lines). The main-variant floor pins repeated the "Gradle picks the max, so it's a no-op for Compose consumers and a fix for tile-only ones" rationale four times, and each pin's block comment restated the `reason` string on its own `recordInjectedDependency` call — the user-facing text `composePreviewDoctor` prints. The shared rationale is now stated once above the block; each pin keeps a short note naming the exact crash it prevents (`NoSuchFieldError: androidx.core.R$id …`), which is the part the `reason` string doesn't carry. The compose-ui version-selection reasoning is kept in full, since it's the one genuinely non-obvious decision there.
- **`ServeHttpServer`**: two accreted comment blocks explained the same two lines. Merged into one, keeping the caching caveat and the "getting this wrong is a wrong record, not a missing feature" rationale.
- **`HarnessLauncher` / `DaemonMcpMain`**: four copies of a comment that restated `classpathArgFile`'s own KDoc and then said "see classpathArgFile". Dropped; `DaemonMcpMain` keeps the jail-working-directory note, which is specific to that call site and documented nowhere else.

## Test plan

Run in-session, all passing:

- `:cli:test`, `:mcp:test`, `:daemon:harness:test`, `:daemon:desktop:test`
- `gradle-plugin` `test` + `functionalTest`
- `:samples:cmp:composePreviewRenderAll` — 72 PNGs, end-to-end through `DesktopRenderWorkerPool` (the module whose constructor changed)
- `ktfmtCheckAll` repo-wide

No flaky tests surfaced — every suite passed first run, with no retries.

Text-only PR: no rendered surface changes. The one render-path edit is the removal of an unused constructor parameter, and `composePreviewRenderAll` above confirms the pipeline still produces its full catalog.

---
_Generated by [Claude Code](https://claude.ai/code/session_015uaapXYpRZaq7LSZySDbD1)_