### PR TITLE
test(vscode): make scenario E artifact cleanup deterministic and self-describing

### DIFF
--- a/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2eInteractive.test.ts
@@ -1419,17 +1419,33 @@ describeE2E("Compose Preview interactive scenarios (real Gradle)", function () {
                 ),
                 ":samples:cmp cleanup render",
             );
+            const missingOldRenderOutputs = () =>
+                oldRenderOutputs.filter((p) => !fs.existsSync(p));
+            const survivingNewRenderOutputs = () =>
+                newRenderOutputs.filter((p) => fs.existsSync(p));
             await waitFor(
-                "batch artifacts after reverting the rename",
+                "original render PNG(s) restored after reverting the rename",
                 budgetWithin(deadlineAt, PANEL_UPDATE_BUDGET_MS),
                 500,
                 () =>
-                    oldRenderOutputs.every((p) => fs.existsSync(p)) &&
-                    newRenderOutputs.every((p) => !fs.existsSync(p))
-                        ? true
-                        : undefined,
-                describeCmpPanelState,
+                    missingOldRenderOutputs().length === 0 ? true : undefined,
+                () =>
+                    [
+                        describeCmpPanelState(),
+                        `original PNG(s) still missing: ${missingOldRenderOutputs().join(", ") || "<none>"}`,
+                        `renamed PNG(s) still present: ${survivingNewRenderOutputs().join(", ") || "<none>"}`,
+                    ].join("\n  "),
             );
+            // Restoring the original PNGs is the renderer's job and is waited on
+            // above. Pruning the renamed one is not: the cleanup render carries a
+            // filter built from the reverted preview set, which no longer names
+            // the renamed id, so its PNG can outlive the render that would have
+            // pruned it. Delete the leftovers directly — this block exists to
+            // stop a focused E run corrupting the artifacts later scenarios read,
+            // not to assert filtered pruning.
+            for (const stale of survivingNewRenderOutputs()) {
+                fs.rmSync(stale, { force: true });
+            }
         } catch (cleanupError) {
             if (!renamePhaseError) throw cleanupError;
             console.error(


### PR DESCRIPTION
## Summary

Follow-up to #4499, which merged while `VS Code Extension E2E (interactive-e-g)` was red on its head ([run 32930391430](https://github.com/yschimke/compose-ai-tools/actions/runs/32930391430/job/98061426450)): scenario E timed out after 180s on `batch artifacts after reverting the rename` — the cleanup step #4499 added. The same job passed on that PR's first commit, so the step is timing-sensitive rather than plainly broken.

Two problems with the step as merged:

- **It could not say what it saw.** One combined `waitFor` covered both halves of the condition (original PNGs restored *and* renamed PNG gone), so the timeout message named neither. The wait now covers only the renderer's half and its `describeState` lists the original PNGs still missing and the renamed PNGs still present, so the next occurrence identifies itself.
- **Pruning the renamed PNG was left to a filtered batch render.** The cleanup render carries a filter built from the reverted preview set, which need not name the renamed id, so its PNG can outlive the render that would have pruned it. The leftovers are now deleted directly — this block exists to stop a focused E run corrupting the artifacts later scenarios read, not to assert filtered pruning (invariants E2–E4 earlier in the scenario still assert the rename-time pruning, untouched).

This does not by itself prove the CI failure fixed: if the half that timed out was the renderer failing to restore the original PNGs, the wait still fails — but it now says so precisely, which the merged version did not.

## Test plan

- `npm run format:check` and `npm run compile:host` in `vscode-extension/` — both green.
- `VS Code Extension E2E (interactive-e-g)` on this PR exercises the changed path; the scenario is real-Gradle e2e and cannot be run in this environment.

Text-only change to an e2e test's cleanup path — no rendered surface is affected, so there is no before/after visual evidence to embed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URury2HDiw9t4NBeECU4jo

---
_Generated by [Claude Code](https://claude.ai/code/session_01URury2HDiw9t4NBeECU4jo)_