### PR TITLE
fix(parity): mirror JavaScript's blank-id test, not the JVM's

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2112,9 +2112,47 @@ class ServeCatalogStore(
     return false
   }
 
-  /** A record's `id` as the engine keys it: a non-blank string, or nothing. */
+  /**
+   * A record's `id` as the engine keys it: a string that is not blank *to JavaScript*, or nothing.
+   */
   private fun recordId(fields: JsonObject): String? =
-    (fields["id"] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+    (fields["id"] as? JsonPrimitive)
+      ?.takeIf { it.isString }
+      ?.content
+      ?.takeIf { !isEcmaScriptBlank(it) }
+
+  /**
+   * Whether `String.prototype.trim()` would empty this string — the engine's own test for an
+   * unkeyable id, spelled out rather than borrowed from the JVM.
+   *
+   * `String.isBlank()` is the obvious Kotlin answer and it is the wrong one, in the direction this
+   * mirror must never be wrong in. It delegates to `Character.isWhitespace`, which counts the four
+   * separators U+001C..U+001F and U+0085 as whitespace; ECMAScript's `TrimString` does not. So an
+   * id of a single U+001C is *keyable* to the engine — the record fails on its own as `id-not-safe`
+   * while every other record in the document is read normally — and would have rejected the whole
+   * document here, skipping the artifacts of every legal record beside it and turning them into
+   * `artifact-unreadable`. That is a changed verdict on legal records, which is the one failure
+   * direction [rejectsWholeDocument] exists to avoid.
+   *
+   * (It differs the other way too — `Character.isWhitespace` excludes the non-breaking U+00A0,
+   * U+2007, U+202F and U+FEFF that `trim()` removes — but that direction only costs a fetch.)
+   *
+   * The set is `WhiteSpace` ∪ `LineTerminator` from the specification: the three format controls
+   * below, the four line terminators, the Unicode `Zs` category, and the byte-order mark.
+   */
+  private fun isEcmaScriptBlank(value: String): Boolean = value.all {
+    when (it) {
+      '\u0009',
+      '\u000B',
+      '\u000C',
+      '\uFEFF' -> true
+      '\u000A',
+      '\u000D',
+      '\u2028',
+      '\u2029' -> true
+      else -> Character.getType(it) == Character.SPACE_SEPARATOR.toInt()
+    }
+  }
 
   /**
    * Stage the published design-parity activity feed, if the catalog has one.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -833,6 +833,99 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `an id blank only to the JVM does not cost the other records their artifacts`() {
+    // The mirror's one forbidden direction: claiming a rejection the engine would not make starves
+    // legal records of their artifacts and turns them into `artifact-unreadable`.
+    //
+    // `String.isBlank()` delegates to `Character.isWhitespace`, which counts U+001C..U+001F as
+    // whitespace; ECMAScript's `trim()` does not. So this id is keyable to the engine — that record
+    // fails on its own as `id-not-safe` while the rest of the document is read normally — and using
+    // the JVM's definition here would have rejected the whole document and skipped `glyph`'s
+    // artifacts along with it.
+    val root = tempRoot()
+    val requested = CopyOnWriteArrayList<String>()
+    val document =
+      """{"schema":"${ServeKnownDifferences.SCHEMA}","acceptances":[
+        {"id":"\u001C","mask":"m.png"},
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png"}]}"""
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          requested += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              """
+              {"schema":"design-parity-catalog/v1","system":"compose-m3",
+               "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+              """
+                .trimIndent()
+                .encodeToByteArray()
+            url.endsWith("/parity/known-differences.json") -> document.encodeToByteArray()
+            url.endsWith("/parity/known-differences/glyph/mask.png") -> "mask".encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(
+      requested.any { it.endsWith("/parity/known-differences/glyph/mask.png") },
+      "the legal record's artifact was skipped: $requested",
+    )
+    assertTrue(
+      registered.getValue("compose-m3").knownDifferenceArtifact("glyph/mask.png")
+        is ServeKnownDifferences.Artifact.Bytes
+    )
+  }
+
+  @Test
+  fun `an id blank to JavaScript still rejects the document`() {
+    // The other side of the same definition: `trim()` removes the non-breaking U+00A0, which
+    // `Character.isWhitespace` does not. The engine calls this id unkeyable and rejects the
+    // document, so nothing here is worth fetching for.
+    val root = tempRoot()
+    val requested = CopyOnWriteArrayList<String>()
+    val document =
+      """{"schema":"${ServeKnownDifferences.SCHEMA}","acceptances":[
+        {"id":"\u00A0","mask":"m.png"},
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png"}]}"""
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          requested += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              """
+              {"schema":"design-parity-catalog/v1","system":"compose-m3",
+               "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+              """
+                .trimIndent()
+                .encodeToByteArray()
+            url.endsWith("/parity/known-differences.json") -> document.encodeToByteArray()
+            url.contains("/parity/known-differences/") -> "mask".encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(
+      requested.none { it.contains("/parity/known-differences/") },
+      "artifacts were fetched for a document the engine refuses whole: $requested",
+    )
+  }
+
+  @Test
   fun `an over-sized artifact is staged, so the reader can refuse it as too large`() {
     // Dropping it would leave a missing file, and a missing file is `artifact-unreadable`/404 — a
     // different verdict from the contract's `artifact-too-large`/413, and one that hides why.


### PR DESCRIPTION
Follow-up to #4515, which merged while this was being written. Found by Codex on that PR's last review round.

`rejectsWholeDocument` mirrors the engine's document-level rejections so a fetch planner knows when the engine will read nothing. Its KDoc states the one direction it must never be wrong in:

> claiming a rejection the engine would not make starves legal records of their artifacts and turns them into `artifact-unreadable`

It was wrong in exactly that direction.

## The mismatch

`String.isBlank()` delegates to `Character.isWhitespace`, which counts the four separators **U+001C..U+001F** and **U+0085** as whitespace. ECMAScript's `TrimString` does not:

| char | `trim()` empties it | `Character.isWhitespace` |
| --- | --- | --- |
| U+001C..U+001F | **no** | **yes** |
| U+0085 (NEL) | **no** | **yes** |
| U+00A0, U+2007, U+202F | yes | **no** |
| U+FEFF | yes | **no** |

So a record with an id of a single U+001C is **keyable to the engine**: `identityFailures` lets it through, `preflightRecord` refuses that one record as `id-not-safe`, and every other record in the document is read normally. The stager called it unkeyable, rejected the whole document, and skipped the artifacts of every legal record beside it — turning them into `artifact-unreadable`. A changed verdict on legal records, from one control character in one id.

The disagreement runs the other way too — `trim()` removes the non-breaking U+00A0, U+2007, U+202F and U+FEFF that `Character.isWhitespace` does not — but that direction only costs a fetch, so it was never the dangerous half.

## The fix

The set is spelled out from the specification rather than borrowed from either language: `WhiteSpace` ∪ `LineTerminator` — the three format controls (U+0009, U+000B, U+000C), the four line terminators (U+000A, U+000D, U+2028, U+2029), the Unicode `Zs` category via `Character.getType`, and the byte-order mark.

Borrowing a host's definition is what caused this; the KDoc says so in place, so the next reader doesn't reach for `isBlank()` again.

## Test plan

Two tests, one per direction, both in `ServeCatalogStoreTest`:

- `an id blank only to the JVM does not cost the other records their artifacts` — a document pairing a U+001C id with a legal `glyph` record asserts `glyph`'s mask **is** fetched and reaches the host. **Verified this fails on the pre-fix code**, so it pins the bug rather than merely passing.
- `an id blank to JavaScript still rejects the document` — a U+00A0 id must reject, so nothing is fetched.

`./gradlew :cli:test` green in full on `main` at `b2163c6`; `./gradlew ktfmtFormat`.

Text-only evidence: this changes which bytes a serving host fetches, not how anything is drawn.

## Also on that review round

Two other findings, neither needing code here:

- **Transient artifact-fetch failures collapse to a missing file**, and `lastHead` then advances so the revision is never retried. Same root as the document case — tracked in #4521, which covers every writer in the store rather than this one.
- **The artifact accessor stays directory-backed** across a refresh's swap window. Bounded to refusals (the hash gates turn changed bytes into `plane-changed` / `candidate-changed`, missing bytes into `artifact-unreadable`), never a false accept. The real fix is generation-scoped directories — #4522.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_