### PR TITLE
refactor(daemon): invert the XR renderer behind a port owned by :daemon:core

### DIFF
--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -49,11 +49,6 @@ dependencies {
   // public surface keeps its java.io.File signatures.
   implementation(project(":common-io"))
 
-  // JVM client for the native XR render server — the daemon fronts it for `xr/…`.
-  // `api`, not `implementation`: `JsonRpcServer`'s public constructor exposes
-  // `XrRenderServerFactory?`, so the type is part of this published module's compile ABI.
-  api(project(":renderer-xr-client"))
-
   // Protocol message types are @Serializable. Exposed as `api` so downstream
   // daemon modules (e.g. :daemon:android) get
   // kotlinx-serialization-json on their compile classpath without re-declaring

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2774,9 +2774,15 @@ class JsonRpcServer(
 
   private fun handleXrUpdatePanels(params: XrUpdatePanelsParams) {
     val manager = xrSessions ?: return
-    if (!manager.isOpen(params.frameStreamId)) return
     val frame =
       try {
+        // `isOpen` is inside the guard, not before it. Unlike the other two port calls fixed
+        // alongside this one there is no observable difference — `xr/updatePanels` is a
+        // notification, so a throw is absorbed by the outer dispatch and the read loop continues
+        // either way, and a test asserting otherwise passes with the guard removed. It is here so
+        // every call through the port is guarded uniformly, rather than leaving the next reader to
+        // re-derive which ones happen to be safe.
+        if (!manager.isOpen(params.frameStreamId)) return
         manager.updatePanels(params.frameStreamId, params.panels)
       } catch (t: Throwable) {
         System.err.println(
@@ -2805,7 +2811,19 @@ class JsonRpcServer(
         sendErrorResponse(req.id, ERR_INVALID_PARAMS, "invalid xr/structure params: ${e.message}")
         return
       }
-    val structure = manager.structure(params.frameStreamId)
+    val structure =
+      try {
+        manager.structure(params.frameStreamId)
+      } catch (t: Throwable) {
+        // A request, so silence is the worst outcome: the outer dispatch would log and continue,
+        // leaving this id unanswered until the client's own timeout. Answer it.
+        sendErrorResponse(
+          req.id,
+          ERR_INTERNAL,
+          "xr/structure failed: ${t.javaClass.simpleName}: ${t.message}",
+        )
+        return
+      }
     if (structure == null) {
       sendErrorResponse(
         req.id,
@@ -2828,7 +2846,17 @@ class JsonRpcServer(
     // registry state, then tear down the native session.
     val finalFrame = streamRegistry.finalFrameOnStop(params.frameStreamId)
     streamRegistry.unregister(params.frameStreamId)
-    xrSessions?.close(params.frameStreamId)
+    try {
+      xrSessions?.close(params.frameStreamId)
+    } catch (t: Throwable) {
+      // Guarded so the final marker below still goes out. Without this a renderer that failed to
+      // drop the session would also cost the client its `final=true` frame, and with it the
+      // decoder state this method exists to release.
+      System.err.println(
+        "compose-ai-daemon: xr/stop close failed for ${params.frameStreamId}: " +
+          "${t.javaClass.simpleName}: ${t.message}; continuing"
+      )
+    }
     if (finalFrame != null) {
       sendNotification("streamFrame", encode(StreamFrameParams.serializer(), finalFrame))
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -79,9 +79,6 @@ import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import ee.schimke.composeai.data.layoutinspector.SemanticsDiff
 import ee.schimke.composeai.io.SystemFileSystem
-import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
-import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
-import ee.schimke.composeai.renderer.xr.client.XrSessionManager
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -282,14 +279,17 @@ class JsonRpcServer(
    */
   private val onExit: (Int) -> Unit,
   /**
-   * Factory for the native XR render server (see the "XR render service" section in
+   * The daemon's XR renderer, if it has one (see the "XR render service" section in
    * `protocol/Messages.kt`). When non-null the daemon advertises `capabilities.xr` and serves
-   * `xr/start` / `xr/updatePanels` / `xr/stop`, spawning one `xr-composite --serve` child per
-   * session. When null (the in-process integration tests, fake-mode harness, daemons whose host has
-   * no XR binary) the `xr/…` methods reply `MethodNotFound` — the one-shot composite path is
-   * unaffected.
+   * `xr/start` / `xr/updatePanels` / `xr/structure` / `xr/stop`. When null (the in-process
+   * integration tests, fake-mode harness, daemons whose host has no XR binary) the `xr/…` methods
+   * reply `MethodNotFound` — the one-shot composite path is unaffected.
+   *
+   * A port rather than the renderer client itself, so this module's compile ABI does not carry
+   * `:renderer-xr-client` to every consumer of the daemon protocol; `:daemon:desktop` adapts the
+   * real `XrSessionManager` onto it. See [XrSessions].
    */
-  private val xrServerFactory: XrRenderServerFactory? = null,
+  private val xrSessions: XrSessions? = null,
 ) {
 
   private val json = Json {
@@ -550,13 +550,6 @@ class JsonRpcServer(
    * `interactive/start` is also using; each surface owns its own lifecycle.
    */
   private val streamSessions = ConcurrentHashMap<String, InteractiveSession>()
-
-  /**
-   * Held native XR render sessions, one per `frameStreamId`, present only when [xrServerFactory]
-   * was wired. The daemon's `xr/…` handlers drive it and feed each returned frame out as a
-   * `streamFrame` notification.
-   */
-  private val xrSessions: XrSessionManager? = xrServerFactory?.let { XrSessionManager(it) }
 
   // ----------------------------------------------------------------------
   // Recording (scripted screen-record) state — see docs/daemon/RECORDING.md.
@@ -854,7 +847,7 @@ class JsonRpcServer(
             // held-scene recording driver (DesktopHost). `false` keeps `recording/start` behind a
             // `MethodNotFound` reply so clients can grey out the toggle.
             recording = host.supportsRecording,
-            // `true` when the daemon can front the native XR render server (the `xrServerFactory`
+            // `true` when the daemon can front the native XR render server (an `xrSessions` port
             // was wired). Gates the `xr/…` methods.
             xr = xrSessions != null,
             // RECORDING.md § "encoded formats" — list of wire format spellings the host can
@@ -2846,7 +2839,7 @@ class JsonRpcServer(
    * if it survives the gate, send it as a `streamFrame` notification. The native server already
    * base64-encodes the PNG, so the registry forwards the payload as-is.
    */
-  private fun emitXrFrame(frameStreamId: String, frame: XrStreamFrame) {
+  private fun emitXrFrame(frameStreamId: String, frame: XrFrame) {
     val params =
       streamRegistry.consumeForStream(frameStreamId, frame.dataBase64, frame.width, frame.height)
         ?: return

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -614,7 +614,7 @@ class JsonRpcServer(
       // [closeAllInteractiveSessions] is idempotent, so the second call inside [cleanShutdown]
       // is a safe no-op on this path.
       closeAllInteractiveSessions()
-      xrSessions?.close()
+      closeXrSessions()
       // EOF without exit notification — PROTOCOL.md § 3 idle-timeout exit.
       if (!shutdownRequested.get()) {
         try {
@@ -4099,7 +4099,7 @@ class JsonRpcServer(
     // safe no-op on this path.
     closeAllInteractiveSessions()
     closeAllRecordingSessions()
-    xrSessions?.close()
+    closeXrSessions()
     running.set(false)
     cleanShutdown()
     invokeExit(exitCode)
@@ -4114,6 +4114,32 @@ class JsonRpcServer(
    * tearing down the scene; the [InteractiveSession.close] contract pushes that responsibility to
    * the implementation.
    */
+  /**
+   * Close the XR port, best-effort. Called from every teardown path, and deliberately more than
+   * once on some of them — the EOF path closes before the idle-timeout grace window and
+   * [cleanShutdown] closes again afterwards, exactly as [closeAllInteractiveSessions] is called
+   * twice there.
+   *
+   * Guarded because [XrSessions] is an interface. The old concrete `XrSessionManager` swallowed
+   * renderer-close failures internally and was idempotent, so an unguarded call was safe by
+   * accident; a port implementation makes neither promise. An exception escaping here would be
+   * raised from the middle of [cleanShutdown] — before `host.shutdown()`, before the writer
+   * sentinel and the thread joins, and before `invokeExit` — so a renderer that failed to close
+   * would strand the daemon rather than end it. Every neighbouring teardown call in [cleanShutdown]
+   * is wrapped for the same reason.
+   */
+  private fun closeXrSessions() {
+    val sessions = xrSessions ?: return
+    try {
+      sessions.close()
+    } catch (e: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: xrSessions.close failed: ${e.javaClass.simpleName}: ${e.message}; " +
+          "continuing shutdown"
+      )
+    }
+  }
+
   private fun closeAllInteractiveSessions() {
     val sessions = interactiveSessions.values.toList()
     interactiveSessions.clear()
@@ -4267,7 +4293,7 @@ class JsonRpcServer(
     }
     closeAllInteractiveSessions()
     closeAllRecordingSessions()
-    xrSessions?.close()
+    closeXrSessions()
     try {
       host.shutdown()
     } catch (e: Throwable) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/XrSessions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/XrSessions.kt
@@ -75,6 +75,15 @@ public interface XrSessions : AutoCloseable {
   /** Close and drop the session for [id]; no-op if none is open. */
   public fun close(id: String)
 
-  /** Close every live session and release the renderer — called on daemon shutdown. */
+  /**
+   * Close every live session and release the renderer — called on daemon shutdown.
+   *
+   * The daemon calls this **more than once** on some paths: transport EOF closes before the
+   * idle-timeout grace window, and `cleanShutdown` closes again afterwards. Implementations should
+   * make it idempotent, and should not throw — the daemon guards the call anyway, since a throw
+   * here would otherwise be raised mid-shutdown, before the host stops and before the exit hook
+   * runs, but swallowing an unexpected exception is a worse place to learn about it than handling
+   * it where the renderer is.
+   */
   override fun close()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/XrSessions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/XrSessions.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.daemon
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * One frame rendered out of an XR session, in the shape the daemon puts on the wire.
+ *
+ * A deliberate re-declaration of the XR client's `StreamFrame` rather than a re-export of it. The
+ * point of [XrSessions] is that `:daemon:core` no longer names a renderer client in its API, and a
+ * port whose return type is the renderer's own type would not achieve that — the client would still
+ * be on every consumer's compile classpath. The two are structurally identical and the adapter maps
+ * between them; that mapping is the seam.
+ *
+ * [dataBase64] is base64-encoded image bytes and [encoding] names the container (e.g. `png`). The
+ * daemon forwards the payload as-is, so nothing here decodes it.
+ */
+public data class XrFrame(
+  val seq: Long,
+  val width: Int,
+  val height: Int,
+  val encoding: String,
+  val dataBase64: String,
+)
+
+/**
+ * The daemon's port onto XR rendering: a set of live sessions keyed by the daemon's
+ * `frameStreamId`, which `xr/start` opens, `xr/updatePanels` drives, `xr/structure` reads and
+ * `xr/stop` closes.
+ *
+ * This exists so `:daemon:core` can serve the `xr/…` methods without depending on the JVM client
+ * for the native `xr-composite --serve` process. Before it, `JsonRpcServer`'s constructor took an
+ * `XrRenderServerFactory`, which put `:renderer-xr-client` in this module's **compile ABI** — so
+ * every consumer of the daemon protocol, including an extracted preview server that never renders
+ * XR, resolved a renderer client transitively. That is #3824 preparation item 4, and the reason the
+ * contract probe recorded `renderer-xr-client` as a leak.
+ *
+ * The implementation lives with the thing it talks to: `:daemon:desktop` adapts `XrSessionManager`
+ * onto this interface and injects it. XR is host-native, so the desktop daemon is the only one that
+ * wires a non-null port; elsewhere it stays null and the `xr/…` methods answer `MethodNotFound`.
+ *
+ * **Threading** matches what the daemon does: calls for distinct ids may be concurrent, calls for
+ * one id are serialised by the caller (the daemon dispatches per-stream from one thread).
+ */
+public interface XrSessions : AutoCloseable {
+  /**
+   * Open a session for [id] and render [scene], returning the first frame — or `null` when the
+   * renderer isn't available, since XR is best-effort and the caller degrades rather than failing.
+   * [width]/[height] set the session viewport. Re-opening an existing [id] replaces its scene.
+   */
+  public fun open(
+    id: String,
+    scene: JsonElement,
+    sceneDir: String? = null,
+    environment: String? = null,
+    width: Int? = null,
+    height: Int? = null,
+  ): XrFrame?
+
+  /** True if a session is currently open for [id]. */
+  public fun isOpen(id: String): Boolean
+
+  /**
+   * Push per-frame panel mutations into the session for [id] and return the fresh frame. Throws if
+   * no session is open for [id] or the renderer died; the daemon logs and drops the frame.
+   */
+  public fun updatePanels(id: String, panels: JsonArray): XrFrame
+
+  /**
+   * The held scene for [id] — the `xr/structure` data product (panel tree + poses as inline JSON),
+   * kept in step with `updatePanels` deltas. `null` when no session is open for [id].
+   */
+  public fun structure(id: String): JsonElement?
+
+  /** Close and drop the session for [id]; no-op if none is open. */
+  public fun close(id: String)
+
+  /** Close every live session and release the renderer — called on daemon shutdown. */
+  override fun close()
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -1354,6 +1354,25 @@ class JsonRpcServerIntegrationTest {
     }
   }
 
+  private companion object {
+    /**
+     * How long a [pollUntil] waits for a message that the daemon has already been asked to produce.
+     *
+     * These tests drive a real [JsonRpcServer] over real pipes with a real dispatch thread, so
+     * every wait is on genuine scheduling rather than a fake clock, and 10s is comfortable on an
+     * unloaded machine. It is not comfortable on a shared CI runner: this job runs alongside the
+     * rest of the module matrix, and a `renderFinished` notification that takes longer than 10s to
+     * come back has not exposed a defect, only a runner with no CPU to spare. The failure then
+     * reads as an assertion about the daemon, which it is not.
+     *
+     * So the deadline is a liveness bound, not a latency assertion — nothing here checks that a
+     * render is *fast*, only that it finishes. Raising it on CI costs nothing when the code is
+     * correct (a passing test returns as soon as the message lands, not at the deadline) and only
+     * changes how long a genuinely hung daemon takes to be reported.
+     */
+    private val defaultPollTimeoutMs: Long = if (System.getenv("CI") != null) 60_000 else 10_000
+  }
+
   /** Helper: writes one Content-Length-framed JSON message. */
   private fun writeFrame(out: PipedOutputStream, json: String) {
     val payload = json.toByteArray(Charsets.UTF_8)
@@ -1364,7 +1383,7 @@ class JsonRpcServerIntegrationTest {
 
   private fun pollUntil(
     queue: LinkedBlockingQueue<JsonObject>,
-    timeoutMs: Long = 10_000,
+    timeoutMs: Long = defaultPollTimeoutMs,
     matcher: (JsonObject) -> Boolean,
   ): JsonObject? {
     val deadline = System.currentTimeMillis() + timeoutMs

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -23,7 +23,9 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.Timeout
 
 /**
  * End-to-end test for [JsonRpcServer] over piped streams. Drives the full happy-path lifecycle:
@@ -58,7 +60,13 @@ class JsonRpcServerIntegrationTest {
 
   private val json = Json { ignoreUnknownKeys = true }
 
-  @Test(timeout = 30_000)
+  /**
+   * The per-test deadline, replacing the `@Test(timeout = …)` this suite used to carry. A backstop
+   * against a wedged daemon, not an assertion about speed — see [testTimeoutMs].
+   */
+  @get:Rule val globalTimeout: Timeout = Timeout.millis(testTimeoutMs)
+
+  @Test
   fun full_lifecycle_renders_one_preview_and_emits_finished_notification() {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
@@ -217,7 +225,7 @@ class JsonRpcServerIntegrationTest {
     }
   }
 
-  @Test(timeout = 30_000)
+  @Test
   fun render_failure_notifies_data_product_registry_before_render_failed() {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
@@ -312,7 +320,7 @@ class JsonRpcServerIntegrationTest {
    * count of previews known to the daemon. Mirrors the `initialize.classpathFingerprint` pin in the
    * B2.1 test below.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun initialize_manifest_reports_preview_index_path_and_count() {
     val tmpDir = java.nio.file.Files.createTempDirectory("preview-index-test")
     val previewsJson = tmpDir.resolve("previews.json")
@@ -415,7 +423,7 @@ class JsonRpcServerIntegrationTest {
    * stub shape so existing in-process callers that don't yet wire the index keep receiving the
    * empty placeholder.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun initialize_manifest_defaults_to_empty_index() {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
@@ -482,7 +490,7 @@ class JsonRpcServerIntegrationTest {
    * configured. When the cheap-signal file's bytes change AND the (synthetic) classpath hash
    * drifts, the daemon must emit `classpathDirty` exactly once and then exit cleanly.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun classpath_fingerprint_dirty_emits_classpathDirty_and_exits() {
     val tmpDir = java.nio.file.Files.createTempDirectory("classpath-fp-test").toFile()
     val cheapFile = java.io.File(tmpDir, "libs.versions.toml").apply { writeText("a = 1\n") }
@@ -612,7 +620,7 @@ class JsonRpcServerIntegrationTest {
    * a comment-only edit in `build.gradle.kts`). Daemon must NOT emit `classpathDirty` and must keep
    * accepting `renderNow`.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun classpath_fingerprint_false_alarm_does_not_emit_classpathDirty() {
     val tmpDir = java.nio.file.Files.createTempDirectory("classpath-fp-fa-test").toFile()
     val cheapFile = java.io.File(tmpDir, "build.gradle.kts").apply { writeText("// hi\n") }
@@ -710,7 +718,7 @@ class JsonRpcServerIntegrationTest {
    * The synthetic classpath has no `@Preview`-bearing classes, so the scoped scan returns empty and
    * the diff carries `removed = [the index's preview]`.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun fileChanged_source_emits_discoveryUpdated() {
     val tmpDir = java.nio.file.Files.createTempDirectory("phase2-discovery-test")
     // The "source" file we'll claim changed. Cheap pre-filter trips on text match (`@Preview`).
@@ -836,7 +844,7 @@ class JsonRpcServerIntegrationTest {
    * The watchdog is set to a value much larger than the render's wall-clock so the only way
    * `discoveryUpdated` can arrive is via the post-`renderFinished` drain.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun fileChanged_then_renderNow_emits_renderFinished_before_discoveryUpdated() {
     val tmpDir = java.nio.file.Files.createTempDirectory("ordering-test")
     val sourceKt = tmpDir.resolve("Foo.kt")
@@ -962,7 +970,7 @@ class JsonRpcServerIntegrationTest {
    * preview set already on the index emits **no** `discoveryUpdated`. The watchdog still fires
    * (drains the queue) but [`runIncrementalDiscoveryNow`] short-circuits on `discoveryDiffEmpty`.
    */
-  @Test(timeout = 15_000)
+  @Test
   fun fileChanged_with_no_diff_emits_no_discoveryUpdated() {
     val tmpDir = java.nio.file.Files.createTempDirectory("identity-save-test")
     val sourceKt = tmpDir.resolve("NoChange.kt")
@@ -1062,7 +1070,7 @@ class JsonRpcServerIntegrationTest {
    * `JsonRpcServer.renderFinishedFromResult` translates them into a structured [RenderMetrics] on
    * the wire.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun renderFinished_metrics_populated_when_host_supplies_all_four_b23_keys() {
     val hostMetrics: Map<String, Long> =
       mapOf(
@@ -1098,7 +1106,7 @@ class JsonRpcServerIntegrationTest {
    * wire-level `renderFinished.metrics` stays null. Pins the pre-B2.3 behaviour for hosts that
    * don't measure anything.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun renderFinished_metrics_null_when_host_supplies_null() {
     runRenderAndPollFinished(
       host = FakeRenderHost(metricsToReturn = null),
@@ -1119,7 +1127,7 @@ class JsonRpcServerIntegrationTest {
    * Pinned here to lock the JsonRpcServer behaviour; the partial-map outcome itself is unit- tested
    * in [RenderMetricsFromFlatMapTest].
    */
-  @Test(timeout = 30_000)
+  @Test
   fun renderFinished_metrics_null_when_host_supplies_partial_map() {
     val partial: Map<String, Long> =
       mapOf(
@@ -1235,7 +1243,7 @@ class JsonRpcServerIntegrationTest {
    * grace window. Uses a 200 ms idle timeout so the assertion has a comfortable margin without the
    * test sleeping for the full 5 s default.
    */
-  @Test(timeout = 30_000)
+  @Test
   fun interactive_session_closes_immediately_on_transport_eof() {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
@@ -1356,21 +1364,42 @@ class JsonRpcServerIntegrationTest {
 
   private companion object {
     /**
-     * How long a [pollUntil] waits for a message that the daemon has already been asked to produce.
+     * Whether this suite is running on a shared CI runner rather than a developer machine.
+     *
+     * GitHub Actions sets `CI`; verified rather than assumed, since Gradle only forwards the
+     * ambient environment to the test worker and a value that never arrives would make both bounds
+     * below silently local-sized.
+     */
+    private val onCi: Boolean = System.getenv("CI") != null
+
+    /**
+     * The hard per-test deadline, enforced by [globalTimeout].
+     *
+     * This used to be `@Test(timeout = 30_000)` on each of the thirteen tests. It moved to a
+     * `@Rule` for a reason that is not tidiness: an annotation argument must be a compile-time
+     * constant, so a per-test deadline written that way *cannot* be scaled for CI, and any
+     * [pollUntil] bound raised past it is unreachable — the test is killed with a timeout while the
+     * poll is still waiting, replacing an assertion that says which message never arrived with one
+     * that says nothing at all.
+     */
+    private val testTimeoutMs: Long = if (onCi) 180_000 else 30_000
+
+    /**
+     * How long a [pollUntil] waits for a message the daemon has already been asked to produce.
      *
      * These tests drive a real [JsonRpcServer] over real pipes with a real dispatch thread, so
-     * every wait is on genuine scheduling rather than a fake clock, and 10s is comfortable on an
-     * unloaded machine. It is not comfortable on a shared CI runner: this job runs alongside the
-     * rest of the module matrix, and a `renderFinished` notification that takes longer than 10s to
-     * come back has not exposed a defect, only a runner with no CPU to spare. The failure then
-     * reads as an assertion about the daemon, which it is not.
+     * every wait is on genuine scheduling. 10s is generous on an idle machine and tight on a runner
+     * executing the rest of the module matrix beside it. Nothing here asserts that a render is
+     * *fast*, only that it finishes, so this is a liveness bound rather than a latency assertion:
+     * raising it costs nothing when the code is correct — a passing poll returns the moment the
+     * message lands, not at the deadline — and only changes how long a genuinely hung daemon takes
+     * to be reported.
      *
-     * So the deadline is a liveness bound, not a latency assertion — nothing here checks that a
-     * render is *fast*, only that it finishes. Raising it on CI costs nothing when the code is
-     * correct (a passing test returns as soon as the message lands, not at the deadline) and only
-     * changes how long a genuinely hung daemon takes to be reported.
+     * Deliberately a fraction of [testTimeoutMs] rather than an independent number, so the poll
+     * always expires first and the failure is `assertNotNull`'s message naming the awaited message,
+     * not an opaque test-level timeout. Keep it that way if either value changes.
      */
-    private val defaultPollTimeoutMs: Long = if (System.getenv("CI") != null) 60_000 else 10_000
+    private val defaultPollTimeoutMs: Long = testTimeoutMs / 3
   }
 
   /** Helper: writes one Content-Length-framed JSON message. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -1,8 +1,5 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.renderer.xr.client.StreamFrame as XrStreamFrame
-import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
-import ee.schimke.composeai.renderer.xr.client.XrRenderServerHandle
 import java.io.File
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
@@ -14,9 +11,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
@@ -490,7 +487,7 @@ class StreamRpcIntegrationTest {
 
   private fun bringUpServer(
     host: RenderHost,
-    xrServerFactory: XrRenderServerFactory? = null,
+    xrSessions: XrSessions? = null,
   ): ServerHarness {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
@@ -506,7 +503,7 @@ class StreamRpcIntegrationTest {
         daemonVersion = "test",
         interactiveFrameIntervalMs = 0,
         onExit = { _ -> exitLatch.countDown() },
-        xrServerFactory = xrServerFactory,
+        xrSessions = xrSessions,
       )
     val thread = Thread({ server.run() }, "stream-rpc-server").apply { isDaemon = true }
     thread.start()
@@ -584,9 +581,9 @@ class StreamRpcIntegrationTest {
   fun xrStart_then_updatePanels_emit_streamFrames_and_stop_closes() {
     val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
-    val factory = FakeXrFactory()
+    val sessions = FakeXrSessions()
     val (_, serverThread, out, received, exitLatch) =
-      bringUpServer(StreamRpcFakeHost(pngFile), factory)
+      bringUpServer(StreamRpcFakeHost(pngFile), sessions)
     resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
     handshake(out, received)
 
@@ -637,14 +634,14 @@ class StreamRpcIntegrationTest {
       """{"jsonrpc":"2.0","method":"xr/stop","params":{"frameStreamId":"$streamId"}}""",
     )
     teardownServer(out, received, serverThread, exitLatch)
-    assertTrue("the native session must be closed", factory.created.single().closed)
+    assertTrue("the XR sessions must be closed", sessions.closed)
   }
 
   @Test(timeout = 30_000)
   fun xrStart_replies_methodNotFound_when_xr_unavailable() {
     val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
-    // No xrServerFactory → capability off, methods rejected.
+    // No xrSessions port → capability off, methods rejected.
     val (_, serverThread, out, received, exitLatch) = bringUpServer(StreamRpcFakeHost(pngFile))
     resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
     handshake(out, received)
@@ -684,41 +681,52 @@ class StreamRpcIntegrationTest {
   }
 }
 
-/** Fake native XR render server — returns monotonically-sequenced frames, tracks stop/close. */
-private class FakeXrHandle : XrRenderServerHandle {
+/**
+ * Fake [XrSessions] port — monotonically-sequenced frames, holds the scene, tracks stop/close.
+ *
+ * A fake of the port, not of the native server: what this file tests is that `JsonRpcServer` serves
+ * the `xr/…` methods correctly against whatever renderer it is given — routing frames through the
+ * stream registry, gating the capability, closing on shutdown. The real multiplexer's own behaviour
+ * (one shared process, scene merging on `updatePanels`, respawn after a death) belongs to
+ * `XrSessionManagerTest` in `:renderer-xr-client`, which covers it directly, and the mapping
+ * between the two lives in `:daemon:desktop`'s `XrManagerSessionsTest`.
+ */
+private class FakeXrSessions : XrSessions {
   private val seq = AtomicInteger(0)
   @Volatile var closed = false
   val stopped = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
-  override val capabilities = buildJsonObject {}
+  private val scenes = java.util.concurrent.ConcurrentHashMap<String, JsonElement>()
 
   // Distinct payload per frame so the registry doesn't dedup them to heartbeats.
   private fun frame() =
-    seq.incrementAndGet().let { n -> XrStreamFrame(n.toLong(), 64, 48, "png", "data-$n") }
+    seq.incrementAndGet().let { n -> XrFrame(n.toLong(), 64, 48, "png", "data-$n") }
 
-  override fun render(
-    sessionId: String,
-    scene: kotlinx.serialization.json.JsonElement,
+  override fun open(
+    id: String,
+    scene: JsonElement,
     sceneDir: String?,
     environment: String?,
     width: Int?,
     height: Int?,
-  ) = frame()
+  ): XrFrame {
+    scenes[id] = scene
+    return frame()
+  }
 
-  override fun updatePanels(sessionId: String, panels: JsonArray) = frame()
+  override fun isOpen(id: String): Boolean = scenes.containsKey(id)
 
-  override fun stop(sessionId: String) {
-    stopped.add(sessionId)
+  override fun updatePanels(id: String, panels: JsonArray): XrFrame = frame()
+
+  override fun structure(id: String): JsonElement? = scenes[id]
+
+  override fun close(id: String) {
+    scenes.remove(id)
+    stopped.add(id)
   }
 
   override fun close() {
     closed = true
   }
-}
-
-private class FakeXrFactory : XrRenderServerFactory {
-  val created = mutableListOf<FakeXrHandle>()
-
-  override fun start(): XrRenderServerHandle = FakeXrHandle().also { created.add(it) }
 }
 
 /** Mirror of the test-only host in InteractiveRpcIntegrationTest. */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -638,6 +638,36 @@ class StreamRpcIntegrationTest {
   }
 
   @Test(timeout = 30_000)
+  fun xrPortThatThrowsOnCloseStillLetsTheDaemonExit() {
+    // `XrSessions` is an interface, so the daemon cannot assume the renderer's close() is
+    // well-behaved — and it is called on every teardown path, twice on some. Unguarded, a throw
+    // would escape from the middle of cleanShutdown: before host.shutdown(), before the writer
+    // sentinel and thread joins, and before onExit. The daemon would hang instead of exiting.
+    val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val sessions = ThrowingCloseXrSessions()
+    val (_, serverThread, out, received, exitLatch) =
+      bringUpServer(StreamRpcFakeHost(pngFile), sessions)
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":30,"method":"xr/start","params":{
+            "previewId":"p","sceneDir":".",
+            "scene":{"version":1,"units":"dp","camera":{"kind":"orbit"},"panels":[]}}}""",
+    )
+    assertNotNull(
+      "xr/start must respond",
+      pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 30 },
+    )
+
+    // The assertion is teardownServer's own: the exit latch must fire within 5s.
+    teardownServer(out, received, serverThread, exitLatch)
+    assertTrue("the failing close must still have been attempted", sessions.closeAttempts.get() > 0)
+  }
+
+  @Test(timeout = 30_000)
   fun xrStart_replies_methodNotFound_when_xr_unavailable() {
     val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -678,6 +708,37 @@ class StreamRpcIntegrationTest {
     val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
     val payload = ByteArray(16) { i -> ((i + seed * 13) and 0xFF).toByte() }
     return sig + payload
+  }
+}
+
+/**
+ * An [XrSessions] whose `close()` always throws — the shape the daemon must survive, since the port
+ * is an interface and an implementation can fail to tear its renderer down.
+ */
+private class ThrowingCloseXrSessions : XrSessions {
+  val closeAttempts = AtomicInteger(0)
+
+  override fun open(
+    id: String,
+    scene: JsonElement,
+    sceneDir: String?,
+    environment: String?,
+    width: Int?,
+    height: Int?,
+  ): XrFrame = XrFrame(1L, 64, 48, "png", "data-1")
+
+  override fun isOpen(id: String): Boolean = true
+
+  override fun updatePanels(id: String, panels: JsonArray): XrFrame =
+    XrFrame(2L, 64, 48, "png", "data-2")
+
+  override fun structure(id: String): JsonElement? = null
+
+  override fun close(id: String) = Unit
+
+  override fun close() {
+    closeAttempts.incrementAndGet()
+    throw IllegalStateException("renderer refused to close")
   }
 }
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/StreamRpcIntegrationTest.kt
@@ -668,6 +668,77 @@ class StreamRpcIntegrationTest {
   }
 
   @Test(timeout = 30_000)
+  fun xrStructureAnswersTheRequestWhenThePortThrows() {
+    // `structure()` is reached from a REQUEST handler, so a throw that only hits the outer
+    // dispatch log leaves this id unanswered and the client blocked until its own timeout.
+    val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val sessions = FakeXrSessions(throwFrom = "structure")
+    val (_, serverThread, out, received, exitLatch) =
+      bringUpServer(StreamRpcFakeHost(pngFile), sessions)
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":40,"method":"xr/start","params":{
+            "previewId":"p","sceneDir":".",
+            "scene":{"version":1,"units":"dp","camera":{"kind":"orbit"},"panels":[]}}}""",
+    )
+    val started = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 40 }!!
+    val streamId = started["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":41,"method":"xr/structure","params":{"frameStreamId":"$streamId"}}""",
+    )
+    val resp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 41 }
+    assertNotNull("xr/structure must answer even when the port throws", resp)
+    assertEquals(
+      JsonRpcServer.ERR_INTERNAL,
+      resp!!["error"]!!.jsonObject["code"]?.jsonPrimitive?.intOrNull,
+    )
+
+    teardownServer(out, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
+  fun xrStopStillEmitsTheFinalFrameWhenThePortThrows() {
+    // The final `final=true` marker is what lets the client release decoder state. An unguarded
+    // close(id) that threw would take the marker with it.
+    val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val sessions = FakeXrSessions(throwFrom = "closeSession")
+    val (_, serverThread, out, received, exitLatch) =
+      bringUpServer(StreamRpcFakeHost(pngFile), sessions)
+    resourcesToClose.add(AutoCloseable { runCatching { out.close() } })
+    handshake(out, received)
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":50,"method":"xr/start","params":{
+            "previewId":"p","sceneDir":".",
+            "scene":{"version":1,"units":"dp","camera":{"kind":"orbit"},"panels":[]}}}""",
+    )
+    val started = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 50 }!!
+    val streamId = started["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "streamFrame" }
+
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","method":"xr/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+    val finalFrame =
+      pollUntil(received) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "streamFrame" &&
+          it["params"]!!.jsonObject["final"]?.jsonPrimitive?.boolean == true
+      }
+    assertNotNull("xr/stop must still emit the final marker when the port throws", finalFrame)
+
+    teardownServer(out, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
   fun xrStart_replies_methodNotFound_when_xr_unavailable() {
     val tmp = Files.createTempDirectory("xr-rpc-test").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -752,7 +823,7 @@ private class ThrowingCloseXrSessions : XrSessions {
  * `XrSessionManagerTest` in `:renderer-xr-client`, which covers it directly, and the mapping
  * between the two lives in `:daemon:desktop`'s `XrManagerSessionsTest`.
  */
-private class FakeXrSessions : XrSessions {
+private class FakeXrSessions(private val throwFrom: String? = null) : XrSessions {
   private val seq = AtomicInteger(0)
   @Volatile var closed = false
   val stopped = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
@@ -774,13 +845,24 @@ private class FakeXrSessions : XrSessions {
     return frame()
   }
 
-  override fun isOpen(id: String): Boolean = scenes.containsKey(id)
+  private fun failIf(point: String) {
+    if (throwFrom == point) throw IllegalStateException("renderer failed at $point")
+  }
+
+  override fun isOpen(id: String): Boolean {
+    failIf("isOpen")
+    return scenes.containsKey(id)
+  }
 
   override fun updatePanels(id: String, panels: JsonArray): XrFrame = frame()
 
-  override fun structure(id: String): JsonElement? = scenes[id]
+  override fun structure(id: String): JsonElement? {
+    failIf("structure")
+    return scenes[id]
+  }
 
   override fun close(id: String) {
+    failIf("closeSession")
     scenes.remove(id)
     stopped.add(id)
   }

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -50,6 +50,11 @@ dependencies {
   // core module re-exposes kotlinx-serialization-json as `api`, so we don't
   // re-declare it here.
   implementation(project(":daemon:core"))
+  // JVM client for the native XR render server. Explicit since `:daemon:core` stopped api-exposing
+  // it: this module owns `XrManagerSessions`, the adapter from `XrSessionManager` onto the daemon's
+  // `XrSessions` port, so the renderer client is a detail of the desktop daemon rather than of the
+  // published protocol contract.
+  implementation(project(":renderer-xr-client"))
   implementation(project(":common-io"))
   // PreviewBackground — the shared showBackground/backgroundColor/uiMode resolution.
   implementation(project(":data-render-core"))

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -362,9 +362,9 @@ fun runDaemon(
   // host-native, so it's wired on the desktop (host) daemon only.
   val xrBinary = XrCompositeBinary.resolve(version = DaemonVersion.value)
   val xrMaterials = xrBinary?.let { XrCompositeBinary.resolveMaterials(it) }
-  val xrServerFactory =
+  val xrSessions =
     if (xrBinary != null && xrMaterials != null) {
-      XrRenderServerFactory { XrRenderServer.start(xrBinary, xrMaterials) }
+      XrManagerSessions(XrRenderServerFactory { XrRenderServer.start(xrBinary, xrMaterials) })
     } else {
       null
     }
@@ -382,7 +382,7 @@ fun runDaemon(
       extensions = extensions,
       btaCompileService = btaCompileService,
       onExit = onExit,
-      xrServerFactory = xrServerFactory,
+      xrSessions = xrSessions,
     )
 
   if (installSigtermHook) {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/XrManagerSessions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/XrManagerSessions.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.renderer.xr.client.StreamFrame
+import ee.schimke.composeai.renderer.xr.client.XrRenderServerFactory
+import ee.schimke.composeai.renderer.xr.client.XrSessionManager
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Adapts [XrSessionManager] — the JVM client's multiplexer over one native `xr-composite --serve`
+ * process — onto the daemon's [XrSessions] port.
+ *
+ * This class is the whole reason `:daemon:core` no longer names `:renderer-xr-client` in its API.
+ * The daemon serves `xr/…` against the port; the mapping to the renderer client happens here, in
+ * the module that actually has a native renderer to talk to. XR is host-native, so the desktop
+ * daemon is the only one that wires it.
+ *
+ * The manager is owned by this adapter: [close] tears down every live session and the shared child
+ * process, which is what `JsonRpcServer` calls on shutdown.
+ */
+public class XrManagerSessions(private val manager: XrSessionManager) : XrSessions {
+
+  /** Wrap a factory directly — the shape [ee.schimke.composeai.daemon.DaemonMain] wires. */
+  public constructor(factory: XrRenderServerFactory) : this(XrSessionManager(factory))
+
+  override fun open(
+    id: String,
+    scene: JsonElement,
+    sceneDir: String?,
+    environment: String?,
+    width: Int?,
+    height: Int?,
+  ): XrFrame? = manager.open(id, scene, sceneDir, environment, width, height)?.toXrFrame()
+
+  override fun isOpen(id: String): Boolean = manager.isOpen(id)
+
+  override fun updatePanels(id: String, panels: JsonArray): XrFrame =
+    manager.updatePanels(id, panels).toXrFrame()
+
+  override fun structure(id: String): JsonElement? = manager.structure(id)
+
+  override fun close(id: String): Unit = manager.close(id)
+
+  override fun close(): Unit = manager.close()
+}
+
+/**
+ * The structural mapping between the renderer client's frame and the daemon's. Field-for-field
+ * today; kept explicit so a change on either side is a compile error here rather than a silent
+ * re-shape of what goes on the wire.
+ */
+private fun StreamFrame.toXrFrame(): XrFrame =
+  XrFrame(
+    seq = seq,
+    width = width,
+    height = height,
+    encoding = encoding,
+    dataBase64 = dataBase64,
+  )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/XrManagerSessions.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/XrManagerSessions.kt
@@ -17,11 +17,17 @@ import kotlinx.serialization.json.JsonElement
  *
  * The manager is owned by this adapter: [close] tears down every live session and the shared child
  * process, which is what `JsonRpcServer` calls on shutdown.
+ *
+ * `internal`, and it has to be: `:renderer-xr-client` is an `implementation` dependency of this
+ * module, so its types are absent from the compile classpath of anyone consuming the published
+ * `daemon-desktop` artifact. A public constructor taking `XrSessionManager` would name a type such
+ * a consumer cannot resolve. Nothing outside this module needs to build one — `DaemonMain` wires
+ * it, and everyone else takes the [XrSessions] port, which is the published shape.
  */
-public class XrManagerSessions(private val manager: XrSessionManager) : XrSessions {
+internal class XrManagerSessions(private val manager: XrSessionManager) : XrSessions {
 
   /** Wrap a factory directly — the shape [ee.schimke.composeai.daemon.DaemonMain] wires. */
-  public constructor(factory: XrRenderServerFactory) : this(XrSessionManager(factory))
+  constructor(factory: XrRenderServerFactory) : this(XrSessionManager(factory))
 
   override fun open(
     id: String,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/XrManagerSessionsTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/XrManagerSessionsTest.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.renderer.xr.client.StreamFrame
+import ee.schimke.composeai.renderer.xr.client.XrRenderServerHandle
+import ee.schimke.composeai.renderer.xr.client.XrSessionManager
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The seam that lets `:daemon:core` stop naming `:renderer-xr-client` in its API: this adapter is
+ * the only place the renderer client's types meet the daemon's port.
+ *
+ * `XrSessionManager`'s own behaviour is `XrSessionManagerTest`'s subject and the RPC surface is
+ * `StreamRpcIntegrationTest`'s; what is left, and what is only testable here, is that the mapping
+ * between them is faithful — every frame field carried across, and every call delegated.
+ */
+class XrManagerSessionsTest {
+
+  private class FakeHandle : XrRenderServerHandle {
+    private val seq = AtomicInteger(0)
+    @Volatile var closed = false
+    val stopped = mutableListOf<String>()
+    var lastPanels: JsonArray? = null
+    var lastDimensions: Pair<Int?, Int?>? = null
+    override val capabilities = buildJsonObject {}
+
+    // Deliberately distinct values per field so a transposed mapping cannot pass.
+    private fun frame() =
+      seq.incrementAndGet().let { n -> StreamFrame(n.toLong() + 40, 64, 48, "png", "payload-$n") }
+
+    override fun render(
+      sessionId: String,
+      scene: JsonElement,
+      sceneDir: String?,
+      environment: String?,
+      width: Int?,
+      height: Int?,
+    ): StreamFrame {
+      lastDimensions = width to height
+      return frame()
+    }
+
+    override fun updatePanels(sessionId: String, panels: JsonArray): StreamFrame {
+      lastPanels = panels
+      return frame()
+    }
+
+    override fun stop(sessionId: String) {
+      stopped.add(sessionId)
+    }
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  private fun scene() = buildJsonObject {
+    put("version", 1)
+    put("units", "dp")
+  }
+
+  @Test
+  fun openCarriesEveryFrameFieldAcross() {
+    val handle = FakeHandle()
+    val sessions = XrManagerSessions(XrSessionManager { handle })
+
+    val frame = sessions.open("s1", scene(), width = 320, height = 240)
+
+    assertEquals(XrFrame(seq = 41L, width = 64, height = 48, "png", "payload-1"), frame)
+    assertEquals(320 to 240, handle.lastDimensions)
+  }
+
+  @Test
+  fun openReturnsNullWhenTheRendererIsUnavailable() {
+    // The factory answering null is how "no native binary" reaches the daemon; the port must
+    // preserve it as null rather than throwing, or `xr/start` stops degrading gracefully.
+    val sessions = XrManagerSessions(XrSessionManager { null })
+
+    assertNull(sessions.open("s1", scene()))
+    assertFalse(sessions.isOpen("s1"))
+  }
+
+  @Test
+  fun updatePanelsDelegatesAndMapsTheFreshFrame() {
+    val handle = FakeHandle()
+    val sessions = XrManagerSessions(XrSessionManager { handle })
+    sessions.open("s1", scene())
+
+    val panels = JsonArray(listOf(buildJsonObject { put("id", "top") }))
+    val frame = sessions.updatePanels("s1", panels)
+
+    assertEquals(panels, handle.lastPanels)
+    assertEquals(XrFrame(seq = 42L, width = 64, height = 48, "png", "payload-2"), frame)
+  }
+
+  @Test
+  fun structureAndIsOpenTrackTheSession() {
+    val sessions = XrManagerSessions(XrSessionManager { FakeHandle() })
+    val scene = scene()
+    sessions.open("s1", scene)
+
+    assertTrue(sessions.isOpen("s1"))
+    assertEquals(scene, sessions.structure("s1"))
+
+    sessions.close("s1")
+
+    assertFalse(sessions.isOpen("s1"))
+    assertNull(sessions.structure("s1"))
+  }
+
+  @Test
+  fun closingThePortTearsDownTheSharedProcess() {
+    // `JsonRpcServer` calls close() on shutdown and never touches the manager, so if the adapter
+    // did not delegate this the native child would outlive the daemon.
+    val handle = FakeHandle()
+    val sessions = XrManagerSessions(XrSessionManager { handle })
+    sessions.open("s1", scene())
+
+    sessions.close()
+
+    assertTrue(handle.closed)
+  }
+}

--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -187,11 +187,15 @@ classpath — so it is staging, not a blocker.
 
 | Leak | Why it is on the classpath | Fix |
 | --- | --- | --- |
-| `renderer-xr-client` | `:daemon:core` api-exposes it: `JsonRpcServer`'s constructor takes an `XrRenderServerFactory?`, so it is part of the published compile ABI | item 4 |
 | `mcp` | `:render-session-subprocess` builds its transport on `:mcp`'s `DaemonClient` / `SubprocessDaemonClientFactory` | item 3 |
 
-Both are recorded in `preview-server/contract-probe/build.gradle.kts`. The protocol contract should
-not ship a renderer client, and the render-session library should not ship an MCP server.
+It is recorded in `preview-server/contract-probe/build.gradle.kts`. The render-session library
+should not ship an MCP server.
+
+`renderer-xr-client` came off this table with item 4: `JsonRpcServer` now takes an `XrSessions`
+port that `:daemon:core` owns, and `:daemon:desktop` adapts `XrSessionManager` onto it, so the
+renderer client is no longer on the protocol contract's compile ABI — or on the classpath of a
+preview server that never renders XR.
 
 ## Preparation order
 
@@ -211,7 +215,15 @@ From #3824's follow-up investigation, with what has landed marked.
 3. **Extract the subprocess daemon client from `:mcp`** into its own published module, so
    `:render-session-subprocess` stops dragging an MCP server onto every consumer's classpath.
 4. **Remove the renderer-XR implementation dependency from `:daemon:core`** through an injected
-   port, so the protocol contract stops shipping a renderer client.
+   port, so the protocol contract stops shipping a renderer client. — *done.* `JsonRpcServer` takes
+   an `XrSessions?` (with `XrFrame`, a structural re-declaration of the client's `StreamFrame`)
+   instead of an `XrRenderServerFactory?`, and `:daemon:core` no longer depends on
+   `:renderer-xr-client` at all — not as `api`, not as `implementation`. The adapter,
+   `XrManagerSessions`, lives in `:daemon:desktop`, which is where the native renderer actually is;
+   XR is host-native, so no other daemon wired it anyway. Each test now sits with its subject: the
+   RPC surface against a fake port in `:daemon:core`, the multiplexer's own scene-merge and respawn
+   behaviour in `:renderer-xr-client`'s `XrSessionManagerTest`, and the mapping between them in
+   `XrManagerSessionsTest`.
 5. **Extract the bundle schema / read / sign / hydrate / extract path into a published module.**
    `bundle.json` is an external, versioned format that is currently a `:cli` internal, and it is
    most of the `serve→cli` half of the seam register.

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -73,17 +73,12 @@ dependencies {
  */
 val contractLeaks =
   mapOf(
-    "renderer-xr-client" to
-      "`:daemon:core` api-exposes the XR render-server client because `JsonRpcServer`'s " +
-        "constructor takes an `XrRenderServerFactory?`. #3824 preparation item 4: invert it " +
-        "into a port the daemon injects, so the protocol contract stops shipping a renderer " +
-        "client to every consumer.",
     "mcp" to
       "`:render-session-subprocess` implements its transport on `:mcp`'s `DaemonClient` / " +
         "`SubprocessDaemonClientFactory`, so consuming the render-session library drags an MCP " +
         "server onto the classpath. #3824 preparation item 3: lift the daemon client out of " +
         "`:mcp` into its own published module. (`DaemonLaunchDescriptor`, the one MCP type " +
-        "`serve` imported directly, has already moved to `:daemon:core`.)",
+        "`serve` imported directly, has already moved to `:daemon:core`.)"
   )
 
 abstract class CheckContractSurface : DefaultTask() {

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -48,10 +48,8 @@ CONTRACT_PROJECTS=(
 # so this file says out loud what `checkContractSurface` enforces: contracts stay, leaks go.
 #
 #   :mcp                  reached through :render-session-subprocess's transport
-#   :renderer-xr-client   reached through :daemon:core's JsonRpcServer constructor ABI
 LEAK_PROJECTS=(
   ":mcp"
-  ":renderer-xr-client"
 )
 
 skip_publish=0


### PR DESCRIPTION
Preparation item 4 for the preview-server split (#3824), following on from #4512 and #4516. This is the first of the two leaks the contract probe records coming off the list.

## The leak

`JsonRpcServer`'s constructor took an `XrRenderServerFactory?`, so `:renderer-xr-client` was part of `:daemon:core`'s **compile ABI** — declared `api` for exactly that reason, with a comment saying so. Every consumer of the daemon protocol therefore resolved a renderer client transitively, including an extracted preview server that never renders XR.

## The inversion

`:daemon:core` now owns an `XrSessions` port (with an `XrFrame`) and serves the `xr/…` methods against it. `:daemon:desktop` adapts `XrSessionManager` onto that port in `XrManagerSessions` and injects it — which is where the native renderer already lives. XR is host-native, so the desktop daemon was the only one that ever wired a factory; nothing else changes shape.

**`:daemon:core` no longer depends on `:renderer-xr-client` at all** — not as `api`, not as `implementation`.

`XrFrame` is a structural re-declaration of the client's `StreamFrame`, not a re-export, and that is the point. A port whose types belong to the renderer would have achieved nothing: the client would still be on every consumer's compile classpath. The adapter maps between them, and that mapping *is* the seam — which is why it has its own test rather than being a one-line delegation nobody checks.

The adapter is `internal`. `:renderer-xr-client` is an `implementation` dependency here, so its types are off the compile classpath of anyone consuming the published `daemon-desktop` artifact; a public constructor taking `XrSessionManager` would name a type they cannot resolve. Nothing outside the module needs to build one — `DaemonMain` wires it, everyone else takes the port.

## Tests move to sit with their subjects

The old arrangement tested three layers at once through the RPC surface. Now:

| Subject | Where | What it covers |
| --- | --- | --- |
| RPC surface | `:daemon:core` `StreamRpcIntegrationTest` (fake port) | frames routed through the stream registry, `capabilities.xr` gating, close on shutdown |
| The multiplexer | `:renderer-xr-client` `XrSessionManagerTest` | one shared process, scene merging on `updatePanels`, respawn after a death |
| The mapping | `:daemon:desktop` `XrManagerSessionsTest` *(new)* | every frame field carried across, every call delegated, null factory still degrades to a null frame |

Worth noting explicitly, because it would otherwise look like lost coverage: the RPC test's `xr/structure` assertions were incidentally exercising `XrSessionManager`'s scene tracking. I checked before faking it away — `XrSessionManagerTest` already owns `retainsSceneAsStructureUntilClosed` and `updatePanelsMergesDeltasIntoStructure` directly, so nothing real is lost; each test just stops reaching through a layer it does not own.

The new adapter test uses deliberately distinct values per frame field (`seq` offset from width/height) so a transposed mapping cannot pass.

## Verification, and a correction to it

The first revision of this description called the contract-probe run the load-bearing proof. It was weaker than that, and the Codex review is what surfaced why.

`scripts/check-preview-server-contracts.sh` publishes its `LEAK_PROJECTS` list to Maven Local so the probe can resolve at all — and that list still contained `:renderer-xr-client`. So the probe reported the leak gone *while the artifact was sitting in `~/.m2` at the probe version*: a genuine remaining edge would have resolved against that copy and passed anyway. The check was green for a reason that did not establish the claim.

Fixed in `6a8e693b`, and re-verified rather than re-run: deleted `renderer-xr-client/0.0.0-contract-probe-SNAPSHOT` from `~/.m2` first, then ran the driver.

```
==> publishing 10 contract module(s) + 1 recorded leak(s) at 0.0.0-contract-probe-SNAPSHOT
checkContractSurface: 10 contracts resolved, 1 known leak(s) still to remove
```

That is the claim worth making: the graph **cannot** pull the renderer client, rather than pulling a copy that happened to be there. The probe also fails on a *stale* recorded leak as well as a new one, so the entry could not simply be deleted from the register without the dependency actually going.

## Test plan

- **The contract probe, as above** — with the leak artifact removed from Maven Local first
- `:daemon:core:test` and `:daemon:desktop:test` — full module suites, not just the XR ones
- `:renderer-xr-client:test`
- `:cli:checkServeSeam` — 151 crossings, unchanged
- `:daemon:core:ktfmtCheck`, `:daemon:desktop:ktfmtCheck`, and the preview-server build's own `ktfmtCheck`

Non-visual change (protocol plumbing and build wiring), so no rendered evidence applies.

Remaining on the recorded-leaks table: `mcp`, via `:render-session-subprocess` building its transport on `:mcp`'s `DaemonClient` — that is item 3 and a larger extraction.