### PR TITLE
fix(serve): retry a catalog revision whose optional assets could not be fetched

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.CatalogBlobPool
 import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.CatalogRefreshResult
+import ee.schimke.composeai.cli.serve.CatalogReloadOutcome
 import ee.schimke.composeai.cli.serve.CatalogThemeCache
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.FileOptimizerHostCoordinator
@@ -3559,7 +3560,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
               is ServeCatalogStore.Result.Ok -> {
                 if (config.listed) registeredCatalogs += r.system
                 else registeredUnlistedCatalogs += r.system
-                loaded += r.system
+                // Seeded as a settled head only when the read was complete: a catalog that came up
+                // serving but could not fetch an optional artifact *right now* must be re-read on
+                // the first tick, not treated as current until someone publishes again.
+                if (!r.incomplete) loaded += r.system
                 System.err.println(
                   "serve: catalog ${r.system} → ${r.previewCount} preview(s), trust=${r.trust} " +
                     "(/${r.system}/${if (config.listed) "" else ", unlisted"})"
@@ -3771,12 +3775,14 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           }
         }
         if (result == null) {
-          false
+          CatalogReloadOutcome.FAILED
         } else if (result is ServeCatalogStore.Result.Failed) {
           System.err.println("serve: catalog $system refresh failed: ${result.reason}")
-          false
+          CatalogReloadOutcome.FAILED
+        } else if (result is ServeCatalogStore.Result.Ok && result.incomplete) {
+          CatalogReloadOutcome.INCOMPLETE
         } else {
-          true
+          CatalogReloadOutcome.COMPLETE
         }
       },
       intervalMillis = catalogRefreshSeconds * 1000,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -4,7 +4,6 @@ import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.CatalogBlobPool
 import ee.schimke.composeai.cli.serve.CatalogLoadTracker
 import ee.schimke.composeai.cli.serve.CatalogRefreshResult
-import ee.schimke.composeai.cli.serve.CatalogReloadOutcome
 import ee.schimke.composeai.cli.serve.CatalogThemeCache
 import ee.schimke.composeai.cli.serve.DaemonStartupLog
 import ee.schimke.composeai.cli.serve.FileOptimizerHostCoordinator
@@ -3774,16 +3773,12 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
             result
           }
         }
-        if (result == null) {
-          CatalogReloadOutcome.FAILED
-        } else if (result is ServeCatalogStore.Result.Failed) {
+        // Handed back as-is: what a result means for the recorded head is the refresher's to
+        // decide, and saying it twice is how the two would drift.
+        if (result is ServeCatalogStore.Result.Failed) {
           System.err.println("serve: catalog $system refresh failed: ${result.reason}")
-          CatalogReloadOutcome.FAILED
-        } else if (result is ServeCatalogStore.Result.Ok && result.incomplete) {
-          CatalogReloadOutcome.INCOMPLETE
-        } else {
-          CatalogReloadOutcome.COMPLETE
         }
+        result
       },
       intervalMillis = catalogRefreshSeconds * 1000,
     )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -3626,6 +3626,10 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         maxImages = catalogMaxImages,
         blobs = catalogBlobPool,
         serverSideRenderEnabled = allowRenderTrusted,
+        // The vector fills and the rc-compare pull run after the catalog is published, so a
+        // throttle there lands after the head was recorded. Un-settle the revision so the next
+        // poll re-reads it, exactly as a trust revocation and a retirement do.
+        onPostPublishIncomplete = { system -> activeRefresher?.forgetHeads(listOf(system)) },
         registerWasm = { system, wasmDir ->
           // A local `--wasm-dir` is the operator's explicit override, so a published app never
           // displaces it — including on a later branch refresh, which re-runs this callback.
@@ -3726,6 +3730,11 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
           // `--wasm-dir` the operator configured, which isn't the catalog's to remove.
           if (system !in localWasm) wasmCatalogs.remove(system)
         }
+        // And forget its branch head, for the reason a trust revocation does: the poller
+        // short-circuits on an unchanged SHA, so a system retired and later republished at the
+        // same commit would keep the head recorded from before it was retired — and the republished
+        // copy would never be re-read, however it loaded.
+        activeRefresher?.forgetHeads(listOf(system))
       },
     )
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -81,6 +81,23 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
       }
     }
 
+  /**
+   * Reads that ended in a **"right now"** failure — throttled, unavailable, or no answer at all.
+   *
+   * Counted here rather than tracked per load because every lane already reaches the network
+   * through one seam, worker pools included, and a flag threaded through those pools would have to
+   * be. A caller that wants "did anything fail transiently while I was working" reads this before
+   * and after and compares.
+   *
+   * `NotFound` is deliberately absent: the branch answering "there is no such file" is an answer,
+   * and the one outcome a caller may treat as permanent. Everything counted here is a statement
+   * about now, so asking again could answer differently — which is the whole point of asking.
+   *
+   * A failure the transport's own retry rescued is not counted: the stats record one read by how it
+   * *ended*, so this reads as "failures we could not ride out".
+   */
+  fun transientFailures(): Long = synchronized(lock) { throttled + unavailable + transport }
+
   /** A snapshot for `/status.json`, or null when nothing has been read yet. */
   fun snapshot(): BranchFetchSnapshot? =
     synchronized(lock) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -81,23 +81,6 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
       }
     }
 
-  /**
-   * Reads that ended in a **"right now"** failure — throttled, unavailable, or no answer at all.
-   *
-   * Counted here rather than tracked per load because every lane already reaches the network
-   * through one seam, worker pools included, and a flag threaded through those pools would have to
-   * be. A caller that wants "did anything fail transiently while I was working" reads this before
-   * and after and compares.
-   *
-   * `NotFound` is deliberately absent: the branch answering "there is no such file" is an answer,
-   * and the one outcome a caller may treat as permanent. Everything counted here is a statement
-   * about now, so asking again could answer differently — which is the whole point of asking.
-   *
-   * A failure the transport's own retry rescued is not counted: the stats record one read by how it
-   * *ended*, so this reads as "failures we could not ride out".
-   */
-  fun transientFailures(): Long = synchronized(lock) { throttled + unavailable + transport }
-
   /** A snapshot for `/status.json`, or null when nothing has been read yet. */
   fun snapshot(): BranchFetchSnapshot? =
     synchronized(lock) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -55,6 +55,21 @@ internal class ServeCatalogRefresher(
   data class Entry(val system: String, val repo: String, val branch: String)
 
   private val lastHead = ConcurrentHashMap<String, String>()
+
+  /**
+   * Systems whose revision has been declared unsettled since their head was last considered.
+   *
+   * A *pending* mark rather than only a removal, because an invalidation can arrive before there is
+   * anything to remove. The post-publish lanes run on their own executor, so a throttled vector
+   * fill for one catalog lands while the startup loader is still working through the others — and
+   * [seedInitialHeads] runs only once every load has finished. Removing a head that is not there
+   * yet is a no-op, and the seed that follows would record the very revision the lane was reporting
+   * as incomplete. The same window exists on the poller between [checkOne] handing off to `reload`
+   * and recording the head afterwards.
+   *
+   * So a mark is left instead, and both places that would record a head consume it first.
+   */
+  private val unsettled = ConcurrentHashMap.newKeySet<String>()
   private val exec: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
     Thread(r, "serve-catalog-refresh").apply { isDaemon = true }
   }
@@ -72,7 +87,10 @@ internal class ServeCatalogRefresher(
    */
   fun seedInitialHeads(systems: Set<String> = entries().mapTo(linkedSetOf()) { it.system }) {
     for (e in entries()) {
-      if (e.system in systems) {
+      // `unsettled` is consumed either way: the mark answers "since the head was last considered",
+      // and this is that consideration.
+      val invalidated = unsettled.remove(e.system)
+      if (e.system in systems && !invalidated) {
         headResolver(e.repo, e.branch)?.let { lastHead[e.system] = it }
       }
     }
@@ -88,7 +106,10 @@ internal class ServeCatalogRefresher(
    * indefinitely.
    */
   fun forgetHeads(systems: Collection<String>) {
-    for (system in systems) lastHead.remove(system)
+    for (system in systems) {
+      unsettled += system
+      lastHead.remove(system)
+    }
   }
 
   /** Start the daemon poller. Idempotent-safe to call once after [seedInitialHeads]. */
@@ -138,6 +159,9 @@ internal class ServeCatalogRefresher(
     onLog(
       "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
     )
+    // Cleared before the reload, not after: a mark left *during* it belongs to this attempt, and
+    // this is what closes the window between the load returning and the head being recorded.
+    unsettled.remove(e.system)
     val loaded =
       runCatching { reload(e.system, e.repo) }.getOrNull() as? ServeCatalogStore.Result.Ok
     if (loaded == null) {
@@ -148,7 +172,9 @@ internal class ServeCatalogRefresher(
     // registered either way — it genuinely IS this revision, which is why both arms report
     // `UPDATED`. What an incomplete read withholds is the recorded head, so the next tick re-reads
     // what the branch would not give us this time instead of short-circuiting on an unmoved sha.
-    if (loaded.incomplete) {
+    // A post-publish lane that failed while this reload ran counts the same as the load itself
+    // coming back incomplete — the revision is serving and it is not settled.
+    if (loaded.incomplete || unsettled.remove(e.system)) {
       onLog(
         "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
           "fetched — will re-read next tick"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -14,30 +14,6 @@ enum class CatalogRefreshResult {
 }
 
 /**
- * How one re-fetch ended, from the refresher's point of view.
- *
- * Three outcomes rather than two, because "the catalog is now serving" and "this revision is
- * settled" are different questions and a boolean can only answer one of them.
- */
-enum class CatalogReloadOutcome {
-  /** Registered, and everything it went looking for was answered. The head can be recorded. */
-  COMPLETE,
-
-  /**
-   * Registered — and something optional could not be fetched *right now*.
-   *
-   * The catalog serves; it is simply missing an artifact whose absence is ours rather than the
-   * producer's. Recording the head here is what used to make that permanent: the revision would
-   * read as current and never be re-read, so one throttled request cost a catalog its parity issue
-   * index, or its whole acceptance surface, until someone published again.
-   */
-  INCOMPLETE,
-
-  /** Not registered. The previous copy keeps serving and the head stays put. */
-  FAILED,
-}
-
-/**
  * Keeps a running `serve` fresh against routinely-changing catalog branches.
  *
  * `serve --catalogs <system>` fetches each system's `design-artifacts/<system>` branch — its
@@ -58,16 +34,18 @@ enum class CatalogReloadOutcome {
  * @param entries the catalog branches to watch: `system` id + owning `repo` + full `branch` ref.
  *   Evaluated per pass rather than captured, because the catalog set is runtime config: a catalog
  *   published through the admin API starts being polled on the next tick, and a retired one stops.
- * @param reload re-fetch + re-register one system; the `store.load(system, sourceRepo = repo)`
- *   seam. Its [CatalogReloadOutcome] decides whether the head is recorded: anything but
- *   [CatalogReloadOutcome.COMPLETE] leaves it, so the next tick re-reads the unchanged branch.
+ * @param reload re-fetch + re-register one system — the `store.load(system, sourceRepo = repo)`
+ *   seam — handing back whatever the store said, or null when there was nothing to load. What that
+ *   result *means* for the recorded head is decided here, in [checkOne], rather than by the caller:
+ *   a load that registered but could not read everything is serving and not settled, and only one
+ *   of those two facts belongs to the caller.
  * @param headResolver resolve a branch's head commit sha (or null when it can't be determined).
  *   Defaults to [gitLsRemoteHead]; injected so tests drive change detection without a network.
  * @param intervalMillis poll cadence; the first tick fires one interval after [start].
  */
 internal class ServeCatalogRefresher(
   private val entries: () -> List<Entry>,
-  private val reload: (system: String, repo: String) -> CatalogReloadOutcome,
+  private val reload: (system: String, repo: String) -> ServeCatalogStore.Result?,
   private val intervalMillis: Long,
   private val headResolver: (repo: String, branch: String) -> String? = ::gitLsRemoteHead,
   private val onLog: (String) -> Unit = { System.err.println(it) },
@@ -160,29 +138,26 @@ internal class ServeCatalogRefresher(
     onLog(
       "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
     )
-    return when (
-      runCatching { reload(e.system, e.repo) }.getOrDefault(CatalogReloadOutcome.FAILED)
-    ) {
-      // Only record the head when the read was complete, so anything else retries next tick.
-      CatalogReloadOutcome.COMPLETE -> {
-        lastHead[e.system] = head
-        onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
-        CatalogRefreshResult.UPDATED
-      }
-      // Serving, but not settled: the catalog IS the new revision, so this is `UPDATED` — the head
-      // is withheld only so the next tick re-reads what the branch would not give us this time.
-      CatalogReloadOutcome.INCOMPLETE -> {
-        onLog(
-          "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
-            "fetched — will re-read next tick"
-        )
-        CatalogRefreshResult.UPDATED
-      }
-      CatalogReloadOutcome.FAILED -> {
-        onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
-        CatalogRefreshResult.FAILED
-      }
+    val loaded =
+      runCatching { reload(e.system, e.repo) }.getOrNull() as? ServeCatalogStore.Result.Ok
+    if (loaded == null) {
+      onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
+      return CatalogRefreshResult.FAILED
     }
+    // **Serving and settled are two answers, and only the first is the caller's.** The catalog is
+    // registered either way — it genuinely IS this revision, which is why both arms report
+    // `UPDATED`. What an incomplete read withholds is the recorded head, so the next tick re-reads
+    // what the branch would not give us this time instead of short-circuiting on an unmoved sha.
+    if (loaded.incomplete) {
+      onLog(
+        "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
+          "fetched — will re-read next tick"
+      )
+      return CatalogRefreshResult.UPDATED
+    }
+    lastHead[e.system] = head
+    onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
+    return CatalogRefreshResult.UPDATED
   }
 
   override fun close() {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -57,19 +57,23 @@ internal class ServeCatalogRefresher(
   private val lastHead = ConcurrentHashMap<String, String>()
 
   /**
-   * Systems whose revision has been declared unsettled since their head was last considered.
+   * How many times each system has been declared unsettled — monotonic, never consumed.
    *
-   * A *pending* mark rather than only a removal, because an invalidation can arrive before there is
-   * anything to remove. The post-publish lanes run on their own executor, so a throttled vector
-   * fill for one catalog lands while the startup loader is still working through the others — and
-   * [seedInitialHeads] runs only once every load has finished. Removing a head that is not there
-   * yet is a no-op, and the seed that follows would record the very revision the lane was reporting
-   * as incomplete. The same window exists on the poller between [checkOne] handing off to `reload`
-   * and recording the head afterwards.
+   * A *count* rather than a pending flag, because the question a head-recorder has to answer is not
+   * "is there an invalidation outstanding?" but "did one arrive since I started reading?". Those
+   * differ, and the difference is the whole bug: the post-publish lanes run on their own executor
+   * and [seedInitialHeads] only runs once every startup load has finished, so an invalidation for
+   * one catalog lands while another is still loading. Removing a head that is not there yet is a
+   * no-op; a flag consumed *before* the branch-head resolution that follows is consumed before the
+   * window it was meant to cover. Both lose the invalidation, and the seed then records exactly the
+   * revision the lane was reporting as incomplete.
    *
-   * So a mark is left instead, and both places that would record a head consume it first.
+   * So a recorder takes a [invalidationMark] before it starts and hands it back to [recordHead],
+   * which writes only if the count still matches. Reads and writes of the count happen inside
+   * [lastHead]'s per-key `compute` lock, so the check and the write are one step rather than two
+   * with a window between them — see [recordHead].
    */
-  private val unsettled = ConcurrentHashMap.newKeySet<String>()
+  private val invalidations = ConcurrentHashMap<String, Long>()
   private val exec: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor { r ->
     Thread(r, "serve-catalog-refresh").apply { isDaemon = true }
   }
@@ -87,12 +91,15 @@ internal class ServeCatalogRefresher(
    */
   fun seedInitialHeads(systems: Set<String> = entries().mapTo(linkedSetOf()) { it.system }) {
     for (e in entries()) {
-      // `unsettled` is consumed either way: the mark answers "since the head was last considered",
-      // and this is that consideration.
-      val invalidated = unsettled.remove(e.system)
-      if (e.system in systems && !invalidated) {
-        headResolver(e.repo, e.branch)?.let { lastHead[e.system] = it }
-      }
+      if (e.system !in systems) continue
+      val head = headResolver(e.repo, e.branch) ?: continue
+      // The mark is `0`, not the current count: what this seed vouches for is the **boot load**,
+      // which finished before this method was even called, so *any* invalidation reported since the
+      // process started necessarily postdates it. That covers both windows at once — a lane that
+      // reported while the startup loader was still working through the other catalogs, and one
+      // that reported while this loop was blocked in `git ls-remote`, which is the widest window
+      // in this class.
+      recordHead(e.system, head, mark = 0L)
     }
   }
 
@@ -107,8 +114,33 @@ internal class ServeCatalogRefresher(
    */
   fun forgetHeads(systems: Collection<String>) {
     for (system in systems) {
-      unsettled += system
-      lastHead.remove(system)
+      // Inside `compute` so the bump and the removal are one step, and so they cannot interleave
+      // with a [recordHead] for the same system: that is what makes "did one arrive since I
+      // started?" answerable without a window. Returning null removes the entry.
+      lastHead.compute(system) { _, _ ->
+        invalidations.merge(system, 1L, Long::plus)
+        null
+      }
+    }
+  }
+
+  /**
+   * The invalidation count to hand back to [recordHead] once the work being vouched for is done.
+   */
+  private fun invalidationMark(system: String): Long = invalidations[system] ?: 0L
+
+  /**
+   * Record [head] for [system] — settling that revision — unless [forgetHeads] ran for it since
+   * [mark] was taken, in which case the invalidation wins and the head stays absent.
+   *
+   * The check and the write are one `compute` on [lastHead], against which [forgetHeads] also
+   * computes. Two statements would leave a window between them, which is the same shape of bug one
+   * level in: an invalidation landing there would be read as "none since I started" and then
+   * overwritten by the very head it was rejecting.
+   */
+  private fun recordHead(system: String, head: String, mark: Long) {
+    lastHead.compute(system) { _, current ->
+      if (invalidationMark(system) == mark) head else current
     }
   }
 
@@ -159,9 +191,10 @@ internal class ServeCatalogRefresher(
     onLog(
       "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
     )
-    // Cleared before the reload, not after: a mark left *during* it belongs to this attempt, and
-    // this is what closes the window between the load returning and the head being recorded.
-    unsettled.remove(e.system)
+    // Taken before the reload: an invalidation arriving *during* it belongs to this attempt, and
+    // making the head write conditional on the mark is what closes the window between the load
+    // returning and the head being recorded.
+    val mark = invalidationMark(e.system)
     val loaded =
       runCatching { reload(e.system, e.repo) }.getOrNull() as? ServeCatalogStore.Result.Ok
     if (loaded == null) {
@@ -174,15 +207,22 @@ internal class ServeCatalogRefresher(
     // what the branch would not give us this time instead of short-circuiting on an unmoved sha.
     // A post-publish lane that failed while this reload ran counts the same as the load itself
     // coming back incomplete — the revision is serving and it is not settled.
-    if (loaded.incomplete || unsettled.remove(e.system)) {
+    if (loaded.incomplete) {
       onLog(
         "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
           "fetched — will re-read next tick"
       )
       return CatalogRefreshResult.UPDATED
     }
-    lastHead[e.system] = head
-    onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
+    // A post-publish lane that failed while this reload ran counts the same, and says so by having
+    // bumped the mark — [recordHead] then leaves the head absent and the next tick re-reads.
+    recordHead(e.system, head, mark)
+    onLog(
+      if (lastHead[e.system] == head) "serve: catalog ${e.system} refreshed to ${head.take(7)}"
+      else
+        "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
+          "fetched — will re-read next tick"
+    )
     return CatalogRefreshResult.UPDATED
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -179,7 +179,9 @@ internal class ServeCatalogRefresher(
   fun refresh(system: String, force: Boolean = false): CatalogRefreshResult {
     val entry =
       entries().firstOrNull { it.system == system } ?: return CatalogRefreshResult.NOT_FOUND
-    if (force) lastHead.remove(system)
+    // [forgetHeads] rather than a bare removal, for the reason its own doc gives: the mark is what
+    // stops a concurrent seed re-recording the head this operator just asked to be re-read.
+    if (force) forgetHeads(listOf(system))
     return checkOne(entry)
   }
 
@@ -208,6 +210,13 @@ internal class ServeCatalogRefresher(
     // A post-publish lane that failed while this reload ran counts the same as the load itself
     // coming back incomplete — the revision is serving and it is not settled.
     if (loaded.incomplete) {
+      // Recorded as an invalidation, not merely left unrecorded. `refresh()` is reachable before
+      // [seedInitialHeads] runs — the route is live while the startup loader is still working
+      // through the other catalogs — so a catalog that booted complete, was refreshed
+      // incompletely, and is therefore still in the loader's `loaded` set would otherwise be
+      // settled by the seed at exactly the sha this read could not finish. Withholding a head only
+      // outlives the operation that withheld it if something says so.
+      forgetHeads(listOf(e.system))
       onLog(
         "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
           "fetched — will re-read next tick"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresher.kt
@@ -14,6 +14,30 @@ enum class CatalogRefreshResult {
 }
 
 /**
+ * How one re-fetch ended, from the refresher's point of view.
+ *
+ * Three outcomes rather than two, because "the catalog is now serving" and "this revision is
+ * settled" are different questions and a boolean can only answer one of them.
+ */
+enum class CatalogReloadOutcome {
+  /** Registered, and everything it went looking for was answered. The head can be recorded. */
+  COMPLETE,
+
+  /**
+   * Registered — and something optional could not be fetched *right now*.
+   *
+   * The catalog serves; it is simply missing an artifact whose absence is ours rather than the
+   * producer's. Recording the head here is what used to make that permanent: the revision would
+   * read as current and never be re-read, so one throttled request cost a catalog its parity issue
+   * index, or its whole acceptance surface, until someone published again.
+   */
+  INCOMPLETE,
+
+  /** Not registered. The previous copy keeps serving and the head stays put. */
+  FAILED,
+}
+
+/**
  * Keeps a running `serve` fresh against routinely-changing catalog branches.
  *
  * `serve --catalogs <system>` fetches each system's `design-artifacts/<system>` branch — its
@@ -35,15 +59,15 @@ enum class CatalogRefreshResult {
  *   Evaluated per pass rather than captured, because the catalog set is runtime config: a catalog
  *   published through the admin API starts being polled on the next tick, and a retired one stops.
  * @param reload re-fetch + re-register one system; the `store.load(system, sourceRepo = repo)`
- *   seam. Its boolean result is whether the reload succeeded (a failure keeps the old head so the
- *   next tick retries).
+ *   seam. Its [CatalogReloadOutcome] decides whether the head is recorded: anything but
+ *   [CatalogReloadOutcome.COMPLETE] leaves it, so the next tick re-reads the unchanged branch.
  * @param headResolver resolve a branch's head commit sha (or null when it can't be determined).
  *   Defaults to [gitLsRemoteHead]; injected so tests drive change detection without a network.
  * @param intervalMillis poll cadence; the first tick fires one interval after [start].
  */
 internal class ServeCatalogRefresher(
   private val entries: () -> List<Entry>,
-  private val reload: (system: String, repo: String) -> Boolean,
+  private val reload: (system: String, repo: String) -> CatalogReloadOutcome,
   private val intervalMillis: Long,
   private val headResolver: (repo: String, branch: String) -> String? = ::gitLsRemoteHead,
   private val onLog: (String) -> Unit = { System.err.println(it) },
@@ -58,11 +82,15 @@ internal class ServeCatalogRefresher(
   }
 
   /**
-   * Record the current head for catalogs that loaded successfully at boot, so their first tick only
-   * reloads after a branch move. [systems] deliberately excludes startup failures: leaving their
-   * head absent makes the first tick retry the unchanged branch, then every later tick until it
-   * succeeds. Previously every configured head was seeded, permanently suppressing retries for an
-   * initial fetch/parse failure until someone happened to publish a new commit.
+   * Record the current head for catalogs that loaded **completely** at boot, so their first tick
+   * only reloads after a branch move. [systems] deliberately excludes startup failures: leaving
+   * their head absent makes the first tick retry the unchanged branch, then every later tick until
+   * it succeeds. Previously every configured head was seeded, permanently suppressing retries for
+   * an initial fetch/parse failure until someone happened to publish a new commit.
+   *
+   * It excludes an *incomplete* load for the same reason. A catalog that came up serving but could
+   * not fetch, say, its issue index because the branch host throttled us is not a settled revision
+   * — and seeding it would make that one throttled request permanent for the life of the process.
    */
   fun seedInitialHeads(systems: Set<String> = entries().mapTo(linkedSetOf()) { it.system }) {
     for (e in entries()) {
@@ -132,14 +160,28 @@ internal class ServeCatalogRefresher(
     onLog(
       "serve: catalog ${e.system} (${e.branch}) moved ${prev?.take(7) ?: "?"}→${head.take(7)} — re-fetching"
     )
-    if (runCatching { reload(e.system, e.repo) }.getOrDefault(false)) {
-      // Only advance the recorded head on success, so a failed reload retries next tick.
-      lastHead[e.system] = head
-      onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
-      return CatalogRefreshResult.UPDATED
-    } else {
-      onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
-      return CatalogRefreshResult.FAILED
+    return when (
+      runCatching { reload(e.system, e.repo) }.getOrDefault(CatalogReloadOutcome.FAILED)
+    ) {
+      // Only record the head when the read was complete, so anything else retries next tick.
+      CatalogReloadOutcome.COMPLETE -> {
+        lastHead[e.system] = head
+        onLog("serve: catalog ${e.system} refreshed to ${head.take(7)}")
+        CatalogRefreshResult.UPDATED
+      }
+      // Serving, but not settled: the catalog IS the new revision, so this is `UPDATED` — the head
+      // is withheld only so the next tick re-reads what the branch would not give us this time.
+      CatalogReloadOutcome.INCOMPLETE -> {
+        onLog(
+          "serve: catalog ${e.system} refreshed to ${head.take(7)}, but some assets could not be " +
+            "fetched — will re-read next tick"
+        )
+        CatalogRefreshResult.UPDATED
+      }
+      CatalogReloadOutcome.FAILED -> {
+        onLog("serve: catalog ${e.system} refresh failed — keeping the current copy, will retry")
+        CatalogRefreshResult.FAILED
+      }
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -101,10 +101,11 @@ class ServeCatalogStore(
    * so — the caller wires it to `ServeCatalogRefresher.forgetHeads`, which un-settles the revision
    * so the next tick re-reads it.
    *
-   * After the fact rather than before, and deliberately: there is a small window between the load
-   * returning and the head being recorded in which an invalidation would be a no-op, but these
-   * lanes are doing network I/O and finish far later than that. The cost of losing that race is one
-   * missed retry, which is exactly the status quo this exists to improve on.
+   * After the fact rather than before, which used to leave a window: an invalidation arriving
+   * between the load returning and the head being recorded — or before the startup loader seeded
+   * any head at all — had nothing to remove. `ServeCatalogRefresher` closes it by leaving a
+   * *pending* mark rather than only removing a head, and consuming that mark everywhere it would
+   * otherwise record one.
    */
   private val onPostPublishIncomplete: (system: String) -> Unit = {},
   private val serverSideRenderEnabled: Boolean = false,
@@ -360,7 +361,17 @@ class ServeCatalogStore(
    * own `design-artifacts/<system>` branch). Null ⇒ the store's [repo] / [branchPrefix]. The
    * branch-trust verdict is computed against whichever repo actually served the catalog.
    */
-  fun load(system: String, sourceRepo: String? = null, sourceBranchPrefix: String? = null): Result {
+  fun load(system: String, sourceRepo: String? = null, sourceBranchPrefix: String? = null): Result =
+    inFetchScope {
+      load(system, sourceRepo, sourceBranchPrefix, it)
+    }
+
+  private fun load(
+    system: String,
+    sourceRepo: String?,
+    sourceBranchPrefix: String?,
+    scope: FetchScope,
+  ): Result {
     val safe = ServeBundleStore.sanitizeName(system) ?: return Result.Failed(system, "invalid name")
     // Bumped per load so a background pass started for an earlier generation of this catalog stops
     // instead of writing its vectors into the refreshed one.
@@ -368,11 +379,6 @@ class ServeCatalogStore(
     val repo = sourceRepo?.takeIf { it.isNotBlank() } ?: this.repo
     val branchPrefix = sourceBranchPrefix?.takeIf { it.isNotBlank() } ?: this.branchPrefix
     val branch = "$branchPrefix$system"
-
-    // Read now so every `Result.Ok` below can say whether anything failed *transiently* while this
-    // load ran — see [Result.Ok.incomplete]. Counted rather than threaded, because the asset lanes
-    // fetch on worker pools and a flag would have to be handed to each of them.
-    val transientFailuresBefore = branchFetchStats.transientFailures()
 
     // The branch's publish history, read BEFORE anything else — because its head decides what the
     // rest of this load reads. Its tail is what a visitor can pin back to. Best-effort: an empty
@@ -1055,7 +1061,7 @@ class ServeCatalogStore(
             count + deferredIds.size + failedIds.size,
             "${BundleVerifier.summary(verdict)} (${prepared.size} live module bundles)",
             failedIds.size,
-            incomplete = fetchedIncompletely(transientFailuresBefore),
+            incomplete = scope.sawTransientFailure,
           )
         }
         if (liveBundleFallback == null) {
@@ -1138,7 +1144,7 @@ class ServeCatalogStore(
                 count + deferredIds.size + failedIds.size,
                 "${BundleVerifier.summary(verdict)} (live bundle)",
                 failedIds.size,
-                incomplete = fetchedIncompletely(transientFailuresBefore),
+                incomplete = scope.sawTransientFailure,
               )
             }
             // Declared + fetched + rehydrated, but the builder didn't stand a daemon up — most
@@ -1184,7 +1190,7 @@ class ServeCatalogStore(
         count + deferredIds.size + failedIds.size,
         "${BundleVerifier.summary(verdict)} (live)",
         failedIds.size,
-        incomplete = fetchedIncompletely(transientFailuresBefore),
+        incomplete = scope.sawTransientFailure,
       )
     }
 
@@ -1228,7 +1234,7 @@ class ServeCatalogStore(
       host.previews.size,
       BundleVerifier.summary(verdict),
       failedIds.size,
-      incomplete = fetchedIncompletely(transientFailuresBefore),
+      incomplete = scope.sawTransientFailure,
     )
   }
 
@@ -1848,13 +1854,16 @@ class ServeCatalogStore(
   ) {
     figmaExecutor.execute {
       if (generations[system] != generation) return@execute
-      val before = branchFetchStats.transientFailures()
-      runCatching {
-        fetchFigmaSvgs(slugs, variantPaths, base, dir) { generations[system] == generation }
+      // Its own scope: this lane runs after the result was handed back, so it reports its own
+      // incompleteness rather than being counted into anyone else's load.
+      val incomplete = inFetchScope { scope ->
+        runCatching {
+          fetchFigmaSvgs(slugs, variantPaths, base, dir) { generations[system] == generation }
+        }
+          .onFailure { System.err.println("serve: catalog $system figma vectors: ${it.message}") }
+        scope.sawTransientFailure
       }
-        .onFailure { System.err.println("serve: catalog $system figma vectors: ${it.message}") }
-      // This lane runs after the result was handed back, so it reports its own incompleteness.
-      if (fetchedIncompletely(before)) onPostPublishIncomplete(system)
+      if (incomplete) onPostPublishIncomplete(system)
     }
   }
 
@@ -1868,11 +1877,13 @@ class ServeCatalogStore(
     if (!ServeRcCompare.stagesFor(alias)) return
     figmaExecutor.execute {
       if (generations[system] != generation) return@execute
-      val before = branchFetchStats.transientFailures()
-      runCatching { fetchRcCompare(alias, base, dir) { generations[system] == generation } }
-        .onFailure { System.err.println("serve: catalog $system rc-compare: ${it.message}") }
-      // Post-publish like the vector fills beside it — see [onPostPublishIncomplete].
-      if (fetchedIncompletely(before)) onPostPublishIncomplete(system)
+      // Post-publish and self-reporting, like the vector fills beside it.
+      val incomplete = inFetchScope { scope ->
+        runCatching { fetchRcCompare(alias, base, dir) { generations[system] == generation } }
+          .onFailure { System.err.println("serve: catalog $system rc-compare: ${it.message}") }
+        scope.sawTransientFailure
+      }
+      if (incomplete) onPostPublishIncomplete(system)
     }
   }
 
@@ -3147,23 +3158,55 @@ class ServeCatalogStore(
 
   /** [networkFetch] with its outcome counted. Every network read in this store goes through it. */
   private fun branchRead(url: String, maxBytes: Long): BranchFetch =
-    networkFetch(url, maxBytes).also(branchFetchStats::record)
+    networkFetch(url, maxBytes).also {
+      branchFetchStats.record(it)
+      // Attributed to whatever operation issued it; a read outside one belongs to nobody.
+      if (it.isTransient) activeFetchScope.get()?.recordTransient()
+    }
 
   /** [networkProbe] with its outcome counted; true only when the branch actually has the file. */
   private fun branchProbe(url: String): Boolean =
     networkProbe(url).also(branchFetchStats::record) is BranchFetch.Ok
 
   /**
-   * Whether anything failed transiently since [before] — the value [Result.Ok.incomplete] carries.
+   * One operation's tally of reads that ended in a **"right now"** failure — throttled, the branch
+   * host unwell, or no answer at all.
    *
-   * A counter comparison rather than a flag, for the reason the counter exists: every lane reaches
-   * the network through one seam, and several of them fetch on worker pools. Two concurrent loads
-   * of *different* systems can therefore make each other look incomplete. That costs one extra
-   * re-read of an unchanged branch and nothing else, which is the right way to be wrong here — the
-   * failure it exists to prevent is a catalog going quiet until someone publishes again.
+   * Scoped to the operation rather than counted store-wide, and the difference is not academic.
+   * `fetchCatalogAsset` also serves *request-time* lazy reads — a baked PNG, a motion capture, a
+   * pinned revision — which run continuously on a busy server. A shared total would let a client
+   * retrying an unavailable asset mark an otherwise complete catalog revision incomplete, forcing a
+   * full re-read every polling interval: more traffic at exactly the moment the branch host is
+   * already unhealthy, which is a feedback loop rather than one wasted request.
    */
-  private fun fetchedIncompletely(before: Long): Boolean =
-    branchFetchStats.transientFailures() > before
+  private class FetchScope {
+    private val transient = java.util.concurrent.atomic.AtomicLong()
+
+    fun recordTransient() {
+      transient.incrementAndGet()
+    }
+
+    val sawTransientFailure: Boolean
+      get() = transient.get() > 0
+  }
+
+  /**
+   * The scope reads on this thread belong to, or null for a read that belongs to no operation — a
+   * request-time lazy fetch, which is nobody's load.
+   */
+  private val activeFetchScope = ThreadLocal<FetchScope?>()
+
+  /** Run [body] with a fresh scope installed, restoring whatever was there before. */
+  private fun <T> inFetchScope(body: (FetchScope) -> T): T {
+    val scope = FetchScope()
+    val previous = activeFetchScope.get()
+    activeFetchScope.set(scope)
+    return try {
+      body(scope)
+    } finally {
+      activeFetchScope.set(previous)
+    }
+  }
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? = cachedBranchRead(url).bytesOrNull
@@ -3275,20 +3318,31 @@ class ServeCatalogStore(
         Thread(r, "serve-catalog-fetch").apply { isDaemon = true }
       }
     return try {
+      // The scope these reads belong to is the caller's, and a `ThreadLocal` set here is invisible
+      // to the workers — so it is captured at submission and re-established inside each task.
+      val submitting = activeFetchScope.get()
       val inFlight = plan.map { (url, target) ->
         url to
           pool.submit<Boolean> {
-            val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
-            // Re-checked immediately before the write, not just once per wave: a fetch started for
-            // one catalog generation must not land in the directory a refresh has since swapped in.
-            // Checking only between waves leaves every worker in the current wave free to write
-            // after the swap, and nothing then removes what they wrote.
-            if (!stillWanted()) return@submit false
-            runCatching {
-              target.parentFile?.mkdirs()
-              target.writeBytes(bytes)
+            val previous = activeFetchScope.get()
+            activeFetchScope.set(submitting)
+            try {
+              val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
+              // Re-checked immediately before the write, not just once per wave: a fetch started
+              // for
+              // one catalog generation must not land in the directory a refresh has since swapped
+              // in.
+              // Checking only between waves leaves every worker in the current wave free to write
+              // after the swap, and nothing then removes what they wrote.
+              if (!stillWanted()) return@submit false
+              runCatching {
+                target.parentFile?.mkdirs()
+                target.writeBytes(bytes)
+              }
+                .isSuccess
+            } finally {
+              activeFetchScope.set(previous)
             }
-              .isSuccess
           }
       }
       buildSet {
@@ -3312,9 +3366,19 @@ class ServeCatalogStore(
       Executors.newFixedThreadPool(minOf(ASSET_FETCH_CONCURRENCY, distinct.size)) { r ->
         Thread(r, "serve-catalog-fetch").apply { isDaemon = true }
       }
+    val submitting = activeFetchScope.get()
     return try {
       val inFlight = distinct.map { url ->
-        url to pool.submit<ByteArray?> { runCatching { fetchCatalogAsset(url) }.getOrNull() }
+        url to
+          pool.submit<ByteArray?> {
+            val previous = activeFetchScope.get()
+            activeFetchScope.set(submitting)
+            try {
+              runCatching { fetchCatalogAsset(url) }.getOrNull()
+            } finally {
+              activeFetchScope.set(previous)
+            }
+          }
       }
       buildMap {
         for ((url, future) in inFlight) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1863,7 +1863,10 @@ class ServeCatalogStore(
           .onFailure { System.err.println("serve: catalog $system figma vectors: ${it.message}") }
         scope.sawTransientFailure
       }
-      if (incomplete) onPostPublishIncomplete(system)
+      // Re-checked, not just checked on entry: a newer load of this system can finish while this
+      // lane is still reading, and un-settling a revision this work was never about would cost the
+      // fresh one a needless full reload. The new revision reports its own incompleteness.
+      if (incomplete && generations[system] == generation) onPostPublishIncomplete(system)
     }
   }
 
@@ -1883,7 +1886,10 @@ class ServeCatalogStore(
           .onFailure { System.err.println("serve: catalog $system rc-compare: ${it.message}") }
         scope.sawTransientFailure
       }
-      if (incomplete) onPostPublishIncomplete(system)
+      // Re-checked, not just checked on entry: a newer load of this system can finish while this
+      // lane is still reading, and un-settling a revision this work was never about would cost the
+      // fresh one a needless full reload. The new revision reports its own incompleteness.
+      if (incomplete && generations[system] == generation) onPostPublishIncomplete(system)
     }
   }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -316,6 +316,21 @@ class ServeCatalogStore(
       val previewCount: Int,
       val trust: String,
       val failedRenderCount: Int = 0,
+      /**
+       * Some optional artifact could not be fetched **right now** — throttled, the branch host
+       * unwell, or no answer at all.
+       *
+       * The catalog is registered and served either way; every writer beside the required ones is
+       * fail-soft by design, and a catalog missing its activity feed is far better than no catalog.
+       * What this says is that the absence is not the producer's: asking again could answer
+       * differently, so the caller must not record this revision as settled.
+       *
+       * Without it a single throttled request drops that catalog's parity issue index — or its
+       * whole acceptance surface — until the branch head next moves, with nothing anywhere
+       * reporting it. See `ServeCatalogRefresher.checkOne`, which is what declines to advance the
+       * recorded head, and `seedInitialHeads`, which does the same at startup.
+       */
+      val incomplete: Boolean = false,
     ) : Result
 
     data class Failed(val system: String, val reason: String) : Result
@@ -338,6 +353,11 @@ class ServeCatalogStore(
     val repo = sourceRepo?.takeIf { it.isNotBlank() } ?: this.repo
     val branchPrefix = sourceBranchPrefix?.takeIf { it.isNotBlank() } ?: this.branchPrefix
     val branch = "$branchPrefix$system"
+
+    // Read now so every `Result.Ok` below can say whether anything failed *transiently* while this
+    // load ran — see [Result.Ok.incomplete]. Counted rather than threaded, because the asset lanes
+    // fetch on worker pools and a flag would have to be handed to each of them.
+    val transientFailuresBefore = branchFetchStats.transientFailures()
 
     // The branch's publish history, read BEFORE anything else — because its head decides what the
     // rest of this load reads. Its tail is what a visitor can pin back to. Best-effort: an empty
@@ -1020,6 +1040,7 @@ class ServeCatalogStore(
             count + deferredIds.size + failedIds.size,
             "${BundleVerifier.summary(verdict)} (${prepared.size} live module bundles)",
             failedIds.size,
+            incomplete = fetchedIncompletely(transientFailuresBefore),
           )
         }
         if (liveBundleFallback == null) {
@@ -1102,6 +1123,7 @@ class ServeCatalogStore(
                 count + deferredIds.size + failedIds.size,
                 "${BundleVerifier.summary(verdict)} (live bundle)",
                 failedIds.size,
+                incomplete = fetchedIncompletely(transientFailuresBefore),
               )
             }
             // Declared + fetched + rehydrated, but the builder didn't stand a daemon up — most
@@ -1147,6 +1169,7 @@ class ServeCatalogStore(
         count + deferredIds.size + failedIds.size,
         "${BundleVerifier.summary(verdict)} (live)",
         failedIds.size,
+        incomplete = fetchedIncompletely(transientFailuresBefore),
       )
     }
 
@@ -1185,7 +1208,13 @@ class ServeCatalogStore(
     // Same reasoning as the degradation: a session with no live lane lists no live-only previews.
     val host = bakedFallback(degradations, emptyList())
     register(safe, host)
-    return Result.Ok(safe, host.previews.size, BundleVerifier.summary(verdict), failedIds.size)
+    return Result.Ok(
+      safe,
+      host.previews.size,
+      BundleVerifier.summary(verdict),
+      failedIds.size,
+      incomplete = fetchedIncompletely(transientFailuresBefore),
+    )
   }
 
   /**
@@ -3102,6 +3131,18 @@ class ServeCatalogStore(
   /** [networkProbe] with its outcome counted; true only when the branch actually has the file. */
   private fun branchProbe(url: String): Boolean =
     networkProbe(url).also(branchFetchStats::record) is BranchFetch.Ok
+
+  /**
+   * Whether anything failed transiently since [before] — the value [Result.Ok.incomplete] carries.
+   *
+   * A counter comparison rather than a flag, for the reason the counter exists: every lane reaches
+   * the network through one seam, and several of them fetch on worker pools. Two concurrent loads
+   * of *different* systems can therefore make each other look incomplete. That costs one extra
+   * re-read of an unchanged branch and nothing else, which is the right way to be wrong here — the
+   * failure it exists to prevent is a catalog going quiet until someone publishes again.
+   */
+  private fun fetchedIncompletely(before: Long): Boolean =
+    branchFetchStats.transientFailures() > before
 
   /** Fetch an ordinary catalog asset using the existing tight per-file envelope. */
   private fun fetchCatalogAsset(url: String): ByteArray? = cachedBranchRead(url).bytesOrNull

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -92,6 +92,21 @@ class ServeCatalogStore(
    * catalog** — a deployed public server needs no local `--wasm-dir` build, just `--catalogs`.
    */
   private val registerWasm: (system: String, dir: File) -> Unit = { _, _ -> },
+  /**
+   * Invoked when a **post-publish** lane finished with a transient failure of its own.
+   *
+   * [Result.Ok.incomplete] can only speak for what the load itself read: the vector fills and the
+   * rc-compare pull run on [figmaExecutor] *after* the catalog is published, so a throttle there
+   * lands long after the result was handed back and the branch head recorded. This is how they say
+   * so — the caller wires it to `ServeCatalogRefresher.forgetHeads`, which un-settles the revision
+   * so the next tick re-reads it.
+   *
+   * After the fact rather than before, and deliberately: there is a small window between the load
+   * returning and the head being recorded in which an invalidation would be a no-op, but these
+   * lanes are doing network I/O and finish far later than that. The cost of losing that race is one
+   * missed retry, which is exactly the status quo this exists to improve on.
+   */
+  private val onPostPublishIncomplete: (system: String) -> Unit = {},
   private val serverSideRenderEnabled: Boolean = false,
   /**
    * Trusted server-side re-render from a carried **executable bundle** (opt-in,
@@ -1833,10 +1848,13 @@ class ServeCatalogStore(
   ) {
     figmaExecutor.execute {
       if (generations[system] != generation) return@execute
+      val before = branchFetchStats.transientFailures()
       runCatching {
         fetchFigmaSvgs(slugs, variantPaths, base, dir) { generations[system] == generation }
       }
         .onFailure { System.err.println("serve: catalog $system figma vectors: ${it.message}") }
+      // This lane runs after the result was handed back, so it reports its own incompleteness.
+      if (fetchedIncompletely(before)) onPostPublishIncomplete(system)
     }
   }
 
@@ -1850,8 +1868,11 @@ class ServeCatalogStore(
     if (!ServeRcCompare.stagesFor(alias)) return
     figmaExecutor.execute {
       if (generations[system] != generation) return@execute
+      val before = branchFetchStats.transientFailures()
       runCatching { fetchRcCompare(alias, base, dir) { generations[system] == generation } }
         .onFailure { System.err.println("serve: catalog $system rc-compare: ${it.message}") }
+      // Post-publish like the vector fills beside it — see [onPostPublishIncomplete].
+      if (fetchedIncompletely(before)) onPostPublishIncomplete(system)
     }
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -14,6 +14,10 @@ class ServeCatalogRefresherTest {
       branch = "design-artifacts/$system",
     )
 
+  /** What the store hands back for a catalog that registered. */
+  private fun ok(incomplete: Boolean = false) =
+    ServeCatalogStore.Result.Ok("compose-m3", 1, "trusted", incomplete = incomplete)
+
   @Test
   fun `reloads only when the branch head changes`() {
     val head = ConcurrentHashMap(mapOf("compose-m3" to "aaaaaaa"))
@@ -23,7 +27,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { sys, _ ->
           reloads += sys
-          CatalogReloadOutcome.COMPLETE
+          ok()
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head["compose-m3"] },
@@ -49,7 +53,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { system, _ ->
           reloads += system
-          CatalogReloadOutcome.COMPLETE
+          ok()
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head },
@@ -75,7 +79,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          if (succeed) CatalogReloadOutcome.COMPLETE else CatalogReloadOutcome.FAILED
+          if (succeed) ok() else null
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head },
@@ -103,7 +107,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          CatalogReloadOutcome.COMPLETE
+          ok()
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> null },
@@ -124,7 +128,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          CatalogReloadOutcome.COMPLETE
+          ok()
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> "stable-sha" },
@@ -149,8 +153,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry("jetnews"), entry("reply")) },
         reload = { system, _ ->
           if (system == "reply") reloads.incrementAndGet()
-          if (system == "jetnews" || succeed) CatalogReloadOutcome.COMPLETE
-          else CatalogReloadOutcome.FAILED
+          if (system == "jetnews" || succeed) ok() else null
         },
         intervalMillis = 1_000,
         headResolver = { _, branch -> "stable-${branch.substringAfterLast('/')}" },
@@ -179,7 +182,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry("compose-m3"), entry("cadence")) },
         reload = { sys, _ ->
           reloads += sys
-          CatalogReloadOutcome.COMPLETE
+          ok()
         },
         intervalMillis = 1_000,
         headResolver = { _, branch -> heads[branch.substringAfterLast('/')] },
@@ -202,7 +205,7 @@ class ServeCatalogRefresherTest {
     // make that permanent, so one throttled request cost a catalog its issue index, or its whole
     // acceptance surface, until somebody published again.
     val reloads = AtomicInteger(0)
-    var outcome = CatalogReloadOutcome.INCOMPLETE
+    var outcome: ServeCatalogStore.Result? = ok(incomplete = true)
     val r =
       ServeCatalogRefresher(
         entries = { listOf(entry()) },
@@ -222,7 +225,7 @@ class ServeCatalogRefresherTest {
     r.tick()
     assertEquals(2, reloads.get(), "an incomplete revision is re-read on the next tick")
 
-    outcome = CatalogReloadOutcome.COMPLETE
+    outcome = ok()
     r.tick()
     assertEquals(3, reloads.get())
     r.tick()
@@ -237,7 +240,7 @@ class ServeCatalogRefresherTest {
     val r =
       ServeCatalogRefresher(
         entries = { listOf(entry()) },
-        reload = { _, _ -> CatalogReloadOutcome.INCOMPLETE },
+        reload = { _, _ -> ok(incomplete = true) },
         intervalMillis = 1_000,
         headResolver = { _, _ -> "stable-sha" },
         onLog = {},

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ServeCatalogRefresherTest {
 
@@ -275,6 +276,79 @@ class ServeCatalogRefresherTest {
     assertEquals(1, reloads.get(), "the invalidated catalog is re-read despite an unmoved head")
     r.tick()
     assertEquals(1, reloads.get(), "and the complete re-read settles it again")
+    r.close()
+  }
+
+  @Test
+  fun `an invalidation arriving while the seed resolves a head survives it`() {
+    // One level in from the test above: the mark is not lost because it was never left, but because
+    // it was *consumed too early*. `headResolver` is a `git ls-remote` — the widest window in this
+    // class — and a post-publish lane reporting a throttle while the seed is blocked in it must
+    // still beat the head the seed is about to write.
+    val reloads = AtomicInteger(0)
+    var refresher: ServeCatalogRefresher? = null
+    var invalidatedDuringResolve = false
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          ok()
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ ->
+          // Stands in for the lane finishing its network read while we are blocked here.
+          if (!invalidatedDuringResolve) {
+            invalidatedDuringResolve = true
+            refresher!!.forgetHeads(listOf("compose-m3"))
+          }
+          "stable-sha"
+        },
+        onLog = {},
+      )
+    refresher = r
+
+    r.seedInitialHeads()
+    assertTrue(invalidatedDuringResolve, "the invalidation really did land mid-resolve")
+
+    r.tick()
+    assertEquals(1, reloads.get(), "the head resolved mid-invalidation was not recorded")
+    r.tick()
+    assertEquals(1, reloads.get(), "and the complete re-read settles it")
+    r.close()
+  }
+
+  @Test
+  fun `an invalidation arriving while a reload runs is not overwritten by its head`() {
+    // The same window on the poller. The load comes back complete — it read everything it needed —
+    // but a post-publish lane for the same revision failed while it ran, so the head must not be
+    // recorded even though nothing about the load itself was incomplete.
+    val reloads = AtomicInteger(0)
+    var refresher: ServeCatalogRefresher? = null
+    var invalidatedDuringReload = false
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          if (!invalidatedDuringReload) {
+            invalidatedDuringReload = true
+            refresher!!.forgetHeads(listOf("compose-m3"))
+          }
+          ok()
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+    refresher = r
+
+    r.tick()
+    assertEquals(1, reloads.get())
+    r.tick()
+    assertEquals(2, reloads.get(), "the head was withheld, so the unmoved branch is re-read")
+    r.tick()
+    assertEquals(2, reloads.get(), "the second, uninvalidated reload settles it")
     r.close()
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -248,4 +248,33 @@ class ServeCatalogRefresherTest {
     assertEquals(CatalogRefreshResult.UPDATED, r.refresh("compose-m3"))
     r.close()
   }
+
+  @Test
+  fun `an invalidation arriving before the startup seed survives it`() {
+    // The post-publish lanes run on their own executor while the startup loader is still working
+    // through the other catalogs, and `seedInitialHeads` only runs once every load has finished.
+    // So the invalidation lands on an empty head map — nothing to forget — and the seed that
+    // follows would record exactly the revision the lane just said it could not finish reading.
+    val reloads = AtomicInteger(0)
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          ok()
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+    // A vector fill for this catalog was throttled while the startup loader was still going.
+    r.forgetHeads(listOf("compose-m3"))
+    r.seedInitialHeads()
+
+    r.tick()
+    assertEquals(1, reloads.get(), "the invalidated catalog is re-read despite an unmoved head")
+    r.tick()
+    assertEquals(1, reloads.get(), "and the complete re-read settles it again")
+    r.close()
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -23,7 +23,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { sys, _ ->
           reloads += sys
-          true
+          CatalogReloadOutcome.COMPLETE
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head["compose-m3"] },
@@ -49,7 +49,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { system, _ ->
           reloads += system
-          true
+          CatalogReloadOutcome.COMPLETE
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head },
@@ -75,7 +75,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          succeed
+          if (succeed) CatalogReloadOutcome.COMPLETE else CatalogReloadOutcome.FAILED
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> head },
@@ -103,7 +103,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          true
+          CatalogReloadOutcome.COMPLETE
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> null },
@@ -124,7 +124,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry()) },
         reload = { _, _ ->
           reloads.incrementAndGet()
-          true
+          CatalogReloadOutcome.COMPLETE
         },
         intervalMillis = 1_000,
         headResolver = { _, _ -> "stable-sha" },
@@ -149,7 +149,8 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry("jetnews"), entry("reply")) },
         reload = { system, _ ->
           if (system == "reply") reloads.incrementAndGet()
-          system == "jetnews" || succeed
+          if (system == "jetnews" || succeed) CatalogReloadOutcome.COMPLETE
+          else CatalogReloadOutcome.FAILED
         },
         intervalMillis = 1_000,
         headResolver = { _, branch -> "stable-${branch.substringAfterLast('/')}" },
@@ -178,7 +179,7 @@ class ServeCatalogRefresherTest {
         entries = { listOf(entry("compose-m3"), entry("cadence")) },
         reload = { sys, _ ->
           reloads += sys
-          true
+          CatalogReloadOutcome.COMPLETE
         },
         intervalMillis = 1_000,
         headResolver = { _, branch -> heads[branch.substringAfterLast('/')] },
@@ -191,6 +192,57 @@ class ServeCatalogRefresherTest {
     heads["cadence"] = "c2"
     r.tick()
     assertEquals(listOf("cadence"), reloads, "only the changed catalog reloads")
+    r.close()
+  }
+
+  @Test
+  fun `an incomplete reload keeps being retried until it comes back complete`() {
+    // The catalog IS the new revision — it registered and it is serving. What it is not is settled:
+    // something optional could not be fetched *right now*. Recording the head here is what used to
+    // make that permanent, so one throttled request cost a catalog its issue index, or its whole
+    // acceptance surface, until somebody published again.
+    val reloads = AtomicInteger(0)
+    var outcome = CatalogReloadOutcome.INCOMPLETE
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          outcome
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+    // Not seeded: this stands in for a branch that moved and was then read incompletely.
+    r.tick()
+    assertEquals(1, reloads.get())
+    // The head has not moved, and an unchanged head normally short-circuits — but the revision was
+    // never recorded, so it is re-read.
+    r.tick()
+    assertEquals(2, reloads.get(), "an incomplete revision is re-read on the next tick")
+
+    outcome = CatalogReloadOutcome.COMPLETE
+    r.tick()
+    assertEquals(3, reloads.get())
+    r.tick()
+    assertEquals(3, reloads.get(), "once complete, the unchanged head short-circuits again")
+    r.close()
+  }
+
+  @Test
+  fun `an incomplete reload still reports that the catalog was updated`() {
+    // It withholds the head, not the truth: the catalog really is the newer revision, and a manual
+    // refresh that answered FAILED would tell an operator their catalog had not moved when it had.
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ -> CatalogReloadOutcome.INCOMPLETE },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+    assertEquals(CatalogRefreshResult.UPDATED, r.refresh("compose-m3"))
     r.close()
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogRefresherTest.kt
@@ -351,4 +351,45 @@ class ServeCatalogRefresherTest {
     assertEquals(2, reloads.get(), "the second, uninvalidated reload settles it")
     r.close()
   }
+
+  @Test
+  fun `an incomplete refresh before the startup seed is not settled by it`() {
+    // The admin refresh route is live while `InitialCatalogLoader` is still working through the
+    // other catalogs, and the seed only runs once they all finish. So a catalog that booted
+    // complete — and is therefore still in the loader's `loaded` set — can be refreshed
+    // incompletely in between. Withholding the head is not enough on its own: the seed that
+    // follows vouches for the boot load and would record exactly the sha this refresh could not
+    // finish reading.
+    val reloads = AtomicInteger(0)
+    var outcome: ServeCatalogStore.Result? = ok(incomplete = true)
+    val r =
+      ServeCatalogRefresher(
+        entries = { listOf(entry()) },
+        reload = { _, _ ->
+          reloads.incrementAndGet()
+          outcome
+        },
+        intervalMillis = 1_000,
+        headResolver = { _, _ -> "stable-sha" },
+        onLog = {},
+      )
+
+    assertEquals(CatalogRefreshResult.UPDATED, r.refresh("compose-m3"))
+    assertEquals(1, reloads.get())
+
+    // The startup loader finishes and seeds the catalog it saw load completely at boot.
+    r.seedInitialHeads()
+
+    r.tick()
+    assertEquals(2, reloads.get(), "the incomplete refresh outlives the seed and is re-read")
+    r.tick()
+    assertEquals(3, reloads.get(), "still unsettled — an incomplete re-read withholds the head too")
+
+    outcome = ok()
+    r.tick()
+    assertEquals(4, reloads.get())
+    r.tick()
+    assertEquals(4, reloads.get(), "and a complete read settles it, so the head short-circuits")
+    r.close()
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -984,6 +984,61 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a throttled post-publish vector fill un-settles the revision`() {
+    // `incomplete` can only speak for what the load itself read. The vector fills run on
+    // `figmaExecutor` AFTER the catalog is published, so a throttle there lands once the result has
+    // been handed back and the branch head recorded — and without this the missing vectors would
+    // wait for the next commit, which is the permanence this whole change exists to end.
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png",
+         "figma":{"nodeId":"1:2"}}]}]}
+      """
+        .trimIndent()
+    val unsettled = CopyOnWriteArrayList<String>()
+    val deferred = mutableListOf<Runnable>()
+    // The publish path itself takes one or two vectors inline (see `scheduleFigmaSvgFetch`) and
+    // leaves the rest to the deferred lane. Throttling only after the load has returned is what
+    // isolates the case under test: a failure the load could not possibly have counted.
+    var published = false
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        // Deferred, so the load returns before the lane runs — which is the whole point.
+        figmaExecutor = java.util.concurrent.Executor { deferred += it },
+        onPostPublishIncomplete = { unsettled += it },
+        networkFetch = { url, _ ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith(".png") -> BranchFetch.Ok(png())
+            url.endsWith(".svg") ->
+              if (published) BranchFetch.Throttled(retryAfterSeconds = 5)
+              else BranchFetch.Ok("<svg/>".encodeToByteArray())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    val result = store.load("compose-m3") as ServeCatalogStore.Result.Ok
+    // The load itself read everything it needed: the vectors are not its business.
+    assertTrue(!result.incomplete, "the publish path itself was complete")
+    assertEquals(emptyList(), unsettled.toList(), "nothing is reported before the lane runs")
+
+    published = true
+    deferred.forEach { it.run() }
+
+    assertEquals(
+      listOf("compose-m3"),
+      unsettled.toList(),
+      "a throttled vector fill must un-settle the revision so the next tick re-reads it",
+    )
+  }
+
+  @Test
   fun `an over-sized artifact is staged, so the reader can refuse it as too large`() {
     // Dropping it would leave a missing file, and a missing file is `artifact-unreadable`/404 — a
     // different verdict from the contract's `artifact-too-large`/413, and one that hides why.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -925,6 +925,64 @@ class ServeCatalogStoreTest {
     )
   }
 
+  /** A catalog whose only optional extra is its parity issue index, fetched through one seam. */
+  private fun loadWithIssueIndexOutcome(
+    issues: BranchFetch
+  ): Pair<ServeCatalogStore.Result, List<String>> {
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val asked = CopyOnWriteArrayList<String>()
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, _ ->
+          asked += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith("/parity/issues.json") -> issues
+            url.endsWith(".png") -> BranchFetch.Ok(png())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+    return store.load("compose-m3") to asked.toList()
+  }
+
+  @Test
+  fun `a throttled optional asset leaves the load incomplete`() {
+    // The load succeeds — every writer beside the required ones is fail-soft, and a catalog missing
+    // its issue index is far better than no catalog. What it must NOT do is look settled: the
+    // absence is ours, not the producer's, so `incomplete` is what stops the refresher recording
+    // this revision as current and never re-reading it.
+    val (result, asked) = loadWithIssueIndexOutcome(BranchFetch.Throttled(retryAfterSeconds = 5))
+    assertTrue(asked.any { it.endsWith("/parity/issues.json") }, "the index was asked for: $asked")
+    val ok = result as ServeCatalogStore.Result.Ok
+    assertTrue(ok.incomplete, "a throttled optional asset must not read as a settled revision")
+  }
+
+  @Test
+  fun `an optional asset the branch does not have leaves the load complete`() {
+    // The other half, and the one that must not regress into needless re-reads: `404` is an answer.
+    // Most catalogs publish no issue index at all, so treating absence as incomplete would put
+    // every one of them into a permanent re-read loop.
+    val (result, _) = loadWithIssueIndexOutcome(BranchFetch.NotFound)
+    val ok = result as ServeCatalogStore.Result.Ok
+    assertTrue(!ok.incomplete, "a genuinely absent optional asset is a settled answer")
+  }
+
+  @Test
+  fun `a transport failure on an optional asset leaves the load incomplete`() {
+    val (result, _) = loadWithIssueIndexOutcome(BranchFetch.Transport("SocketTimeoutException"))
+    assertTrue((result as ServeCatalogStore.Result.Ok).incomplete)
+  }
+
   @Test
   fun `an over-sized artifact is staged, so the reader can refuse it as too large`() {
     // Dropping it would leave a missing file, and a missing file is `artifact-unreadable`/404 — a

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1091,6 +1091,69 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a superseded post-publish lane does not un-settle the revision that replaced it`() {
+    // The lane checks the generation on entry, but it does network I/O afterwards — so a refresh
+    // can land a whole new revision while it is still reading. The entry check cannot see that;
+    // reporting anyway un-settles the *fresh* revision over a throttle belonging to the one it
+    // replaced, costing it a needless full reload. The new revision reports for itself.
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png",
+         "figma":{"nodeId":"1:2"}}]}]}
+      """
+        .trimIndent()
+    val unsettled = CopyOnWriteArrayList<String>()
+    val deferred = mutableListOf<Runnable>()
+    lateinit var store: ServeCatalogStore
+    // 0: first load. 1: the stale lane is reading. 2: the superseding load is running inside it.
+    var phase = 0
+    var superseded = false
+    store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        figmaExecutor = java.util.concurrent.Executor { deferred += it },
+        onPostPublishIncomplete = { unsettled += it },
+        networkFetch = { url, _ ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith(".png") -> BranchFetch.Ok(png())
+            url.endsWith(".svg") ->
+              if (phase != 1) BranchFetch.Ok("<svg/>".encodeToByteArray())
+              else {
+                // Mid-read, a refresh lands a whole new revision under a new generation — the
+                // thing the lane's entry check ran too early to see.
+                if (!superseded) {
+                  superseded = true
+                  phase = 2
+                  store.load("compose-m3")
+                  phase = 1
+                }
+                BranchFetch.Throttled(retryAfterSeconds = 5)
+              }
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    store.load("compose-m3")
+    val stale = deferred.toList()
+    deferred.clear()
+
+    phase = 1
+    stale.forEach { it.run() }
+    assertTrue(superseded, "a newer revision really did land while the stale lane was reading")
+    assertEquals(
+      emptyList(),
+      unsettled.toList(),
+      "a lane whose revision has been superseded must not un-settle the one that replaced it",
+    )
+  }
+
+  @Test
   fun `an over-sized artifact is staged, so the reader can refuse it as too large`() {
     // Dropping it would leave a missing file, and a missing file is `artifact-unreadable`/404 — a
     // different verdict from the contract's `artifact-too-large`/413, and one that hides why.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -984,6 +984,58 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a transient failure on a request-time read does not un-settle a concurrent load`() {
+    // `incomplete` speaks for the operation that issued the read, not for the store. Lazy
+    // request-time reads — a capture somebody opened, a pinned asset — run continuously against
+    // the same branch host, so a store-wide signal would let one reader retrying an unavailable
+    // capture keep every complete revision unsettled and force a full reload every polling
+    // interval. That is traffic amplification precisely while the host is unwell, which is the
+    // condition the mechanism exists to survive.
+    val requested = CopyOnWriteArrayList<String>()
+    var host: ServeBundleHost? = null
+    val watched = java.util.concurrent.atomic.AtomicBoolean(false)
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, _ ->
+          requested += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> {
+              // Once the host exists, drive one lazy capture read from a thread that is inside no
+              // load at all, and let it finish before this load continues.
+              val h = host
+              if (h != null && watched.compareAndSet(false, true)) {
+                val t = Thread { h.motionBytes("switch-on__ideal__default__dark", ".apng") }
+                t.start()
+                t.join()
+              }
+              BranchFetch.Ok(motionCatalogJson.toByteArray())
+            }
+            url.endsWith(".png") -> BranchFetch.Ok(png())
+            // The capture is the unwell asset. It is never staged at registration, so only the
+            // request-time read below ever touches it.
+            url.endsWith(".apng") -> BranchFetch.Throttled(retryAfterSeconds = 5)
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    assertTrue((store.load("compose-m3") as ServeCatalogStore.Result.Ok).incomplete.not())
+    host = registered.getValue("compose-m3")
+
+    val second = store.load("compose-m3") as ServeCatalogStore.Result.Ok
+    assertTrue(watched.get(), "the request-time read ran during the second load")
+    assertTrue(requested.any { it.endsWith(".apng") }, "and it really was throttled: $requested")
+    assertFalse(
+      second.incomplete,
+      "a throttled read issued outside this load must not un-settle the revision it loaded",
+    )
+    assertNull(host.motionBytes("switch-on__ideal__default__dark", ".apng"))
+  }
+
+  @Test
   fun `a throttled post-publish vector fill un-settles the revision`() {
     // `incomplete` can only speak for what the load itself read. The vector fills run on
     // `figmaExecutor` AFTER the catalog is published, so a throttle there lands once the result has


### PR DESCRIPTION
Closes the first and sharpest half of #4521 — the part that turned a momentary failure into a permanent one.

## The bug

`fetchCatalogAsset` is `cachedBranchRead(url).bytesOrNull`: it discards the `BranchFetch` outcome and keeps the bytes. So two different events reached every fail-soft writer as one `null`:

| what happened | what the writer saw | what the catalog served |
| --- | --- | --- |
| the producer publishes no such file (`404`) | `null` | nothing — correct |
| throttled, or the branch host unwell, after the transport's own retries | `null` | nothing — **until the branch head next moved** |

The load still returned `Result.Ok`, so `ServeCatalogRefresher` recorded the head and the revision became *settled* — `head == lastHead` short-circuits every later tick. One throttled request therefore cost that catalog its parity issue index, its activity feed, its design pages, or its whole acceptance surface, for as long as nobody published, with nothing anywhere reporting it. `writeParityActivity`, `writeParityIssues`, `writeDesignPages`, `writeTagIndex`, the rc-compare summary and `writeKnownDifferences` all shared it, and every catalog on preview.coo.ee met it on every refresh tick.

## The fix

`Result.Ok` gains `incomplete` — "something optional could not be fetched **right now**". `ServeCatalogRefresher.checkOne` then separates two questions a boolean could not answer at once:

- **is the catalog serving?** Yes, either way. It registers as before; a catalog missing its activity feed is far better than no catalog, and `refresh()` still answers `UPDATED` because it genuinely *is* the newer revision. Answering `FAILED` would tell an operator their catalog had not moved when it had.
- **is this revision settled?** Only when the read was complete. Otherwise the head is withheld and the next tick re-reads the unchanged branch.

`seedInitialHeads` excludes an incomplete startup load for exactly the reason it already excluded a failed one — otherwise one throttled request at boot is permanent for the life of the process.

The reload seam hands back `ServeCatalogStore.Result?` and the refresher classifies it, rather than the CLI deciding. See **the seam gate** below — that shape was arrived at the hard way, and it is the better layering.

## Three judgement calls worth surfacing

**Scoped to the operation, not to the store.** Reads are attributed to a per-operation `FetchScope` carried on a `ThreadLocal` and installed on worker-pool threads for the duration of a submitted task; `branchRead` — the one seam every network read here goes through — records a transient outcome against whatever scope is active, and a read issued inside no operation belongs to nobody.

An earlier revision of this PR instead compared a store-wide `BranchFetchStats` counter before and after the load, on the argument that the only false positive was two concurrent loads making each other look incomplete, costing one extra re-read. That argument was wrong, and review caught it: request-time lazy reads (baked PNGs, motion captures, pinned revisions) run continuously and are driven by client traffic, so a reader retrying an unavailable asset could keep complete revisions unsettled and force a full reload every polling interval — traffic amplification against a branch host precisely while it is unhealthy, which is the condition the mechanism exists to survive.

**Recording a head is conditional, and atomic against invalidation.** The post-publish lanes (Figma vectors, rc-compare) run on their own executor *after* the load has returned, so they self-report through `onPostPublishIncomplete` → `forgetHeads`. Removing a head is not enough on its own, because the head may not be there yet: `seedInitialHeads` runs only once every startup load has finished, so an invalidation for one catalog lands while another is still loading, forgets nothing, and the seed then records the very revision the lane was reporting as incomplete.

The refresher therefore keeps a monotonic per-system invalidation **count**. A recorder takes a mark before it starts reading and hands it back to `recordHead`, which writes the head only if the count still matches — so the question answered is "did an invalidation arrive since I started?", not "is one outstanding?". Both `forgetHeads` and `recordHead` do their work inside `lastHead.compute(system)`, serialising on the map's per-key lock: check-then-write as two statements would only move the window, not close it. `seedInitialHeads` passes a mark of `0`, because what it vouches for is the boot load, which finished before it was called — any invalidation since process start necessarily postdates it.

The invariant that falls out of it, and that the last round of review pinned down: **withholding a head only outlives the operation that withheld it if something says so.** So every path that declines to settle a revision *invalidates* rather than merely not recording — the incomplete arm of `checkOne` included, since the admin refresh route is live before the seed runs.

**`NotFound` is deliberately not transient.** The branch saying "there is no such file" is an answer, and the one outcome a caller may treat as permanent. Most catalogs publish no issue index at all, so counting absence as incomplete would put every one of them into a permanent re-read loop — trading a rare silent failure for a constant pointless one.

## The seam gate caught a real design mistake

The first push introduced `CatalogReloadOutcome` as a new enum in `serve`, returned by the reload lambda built in `ServeCommand.kt`. `Actions Script Tests` failed:

```
main — NEW coupling (serveInternalsUsedByCli):
    + serve.CatalogReloadOutcome
        cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
```

`scripts/serve-seam-allowlist.json` is a debt register for the preview-server split (#3824) whose entries "only ever come off", and `ServeCommand.kt` is named in it as the long tail the split wants reduced. Adding a symbol to it to make my own change compile would have been exactly backwards, so I removed the crossing instead: the seam now returns `ServeCatalogStore.Result?` — already a listed crossing — and the refresher decides what it means. Fewer public symbols, and the classification lives with the thing that acts on it.

`python3 scripts/check-serve-seam.py` → `OK — 151 crossing symbol(s), all on the allowlist`, and its own 45 tests pass, where the first head failed two.

## What this does not close

#4521's second half: threading the outcome through so a **size refusal** (a body over `MAX_FETCH_BYTES`) stops being indistinguishable from a 404. That one costs a *verdict* rather than availability — `document-too-large`/413 degrading to absent — and wants the per-writer judgement this change deliberately avoids. The issue is retitled and rescoped to just that.

## Test plan

`./gradlew :cli:test` green in full; `./gradlew ktfmtFormat`; `python3 scripts/check-serve-seam.py` OK; `python3 scripts/test_check_serve_seam.py` 45/45.

What the load reports:
- `a throttled optional asset leaves the load incomplete` — drives the outcome-shaped `networkFetch` seam so the issue index comes back `Throttled`, asserts the index *was* asked for and the load reports `incomplete`.
- `a transport failure on an optional asset leaves the load incomplete`.
- `an optional asset the branch does not have leaves the load complete` — the regression guard for the `NotFound` decision above.
- `a transient failure on a request-time read does not un-settle a concurrent load` — drives a lazy capture read from a thread inside no load, mid-load, and asserts the load comes back complete.

What the post-publish lanes report:
- `a throttled post-publish vector fill un-settles the revision` — throttles only once the load has returned, isolating the failure the load could not have counted.
- `a superseded post-publish lane does not un-settle the revision that replaced it` — the superseding load fires from *inside* the stale lane's read, which is the only arrangement that reaches the case.

What the refresher does with it:
- `an incomplete reload keeps being retried until it comes back complete` — an unchanged head is re-read tick after tick while incomplete, and short-circuits again once complete.
- `an incomplete reload still reports that the catalog was updated`.
- `an invalidation arriving before the startup seed survives it`.
- `an invalidation arriving while the seed resolves a head survives it` — `forgetHeads` fires from inside `headResolver`, the widest window here.
- `an invalidation arriving while a reload runs is not overwritten by its head` — the reload returns *complete*; the head is still withheld.
- `an incomplete refresh before the startup seed is not settled by it` — the admin route reached before the seed, which is what forces the incomplete arm to invalidate rather than just decline to record.

Every test added in rounds 2–4 was verified to fail against the code it pins by temporarily reverting that fix. That is not ceremony: the first version of the superseded-lane test passed with the fix reverted, because the stale lane returned at its entry check and never reached the case at all.

Text-only evidence: this changes when a catalog is re-read, not how anything is drawn.