### PR TITLE
fix(deps): take the gradle minor/patch group, hold compose-multiplatform at 1.11.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,7 +102,7 @@
       "allowedVersions": "/^1\\.13\\./"
     },
     {
-      "description": "compose-multiplatform: pin to the 1.10.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers. 1.11.0 ships ABI-breaking changes (non-Android `Shader` becomes a Compose wrapper type, `NativePaint`/`NativeCanvas` typealiases deprecated, `Paint.asFrameworkPaint`/`Canvas.nativeCanvas` replaced) and bumps the required Kotlin language/API to 2.2 — raising the floor is a manual decision. Keep `samples/cmp-shared`'s explicit `ui-tooling-preview` coord in lockstep so the plugin's compose-runtime compatibility check stays happy.",
+      "description": "compose-multiplatform: pin to the 1.11.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers, and the ref is also a CEILING on every catalog the serve host renders live (docs/RENDERER_COMPATIBILITY.md). 1.12.0 needs a coordinated move, not a minor/patch bump: its `androidx.compose.*` AARs declare `minCompileSdk = 37` (the repo default is 36), skiko 0.150.1 deletes the mutating `org.jetbrains.skia.Path` API our `conicTo` seams call, and `compose-multiplatform-material3` + `compottie` have to move with it. See gradle/libs.versions.toml — raising the floor is a manual decision. Keep `samples/cmp-shared`'s explicit `ui-tooling-preview` coord in lockstep so the plugin's compose-runtime compatibility check stays happy.",
       "matchManagers": [
         "gradle"
       ],
@@ -110,8 +110,8 @@
         "org.jetbrains.compose",
         "org.jetbrains.compose{/,}**"
       ],
-      "matchCurrentValue": "/^1\\.10\\./",
-      "allowedVersions": "/^1\\.10\\./"
+      "matchCurrentValue": "/^1\\.11\\./",
+      "allowedVersions": "/^1\\.11\\./"
     },
     {
       "description": "org.slf4j:slf4j-nop: track gradle-tooling-api's bundled slf4j-api. Tooling API declares `slf4j-api {strictly <X>}` and bumping `-nop` past that drags in a newer `slf4j-api` that can't reconcile with the strict constraint. The matching `-nop` version moves whenever the Tooling-API release ships a newer slf4j-api floor — bump this pin in lockstep then.",
@@ -125,15 +125,15 @@
       "allowedVersions": "/^2\\.0\\.17$/"
     },
     {
-      "description": "compottie: pin to the 2.1.x line. `:lottie-preview-runtime` is built against JetBrains Compose foundation 1.10.1 (matching `compose-multiplatform = 1.10.x`); compottie 2.2.x targets foundation 1.11.0 and drags a newer Compose onto the renderer classpath — the skew `docs/RENDERER_COMPATIBILITY.md` warns about. Bump only in lockstep with `compose-multiplatform`; see gradle/libs.versions.toml.",
+      "description": "compottie: pin to the 2.2.x line. `:lottie-preview-runtime` is built against JetBrains Compose foundation 1.11.0 (matching `compose-multiplatform = 1.11.x`); a compottie line built against a newer foundation drags a newer Compose onto the renderer classpath — the skew `docs/RENDERER_COMPATIBILITY.md` warns about. Bump only in lockstep with `compose-multiplatform`; see gradle/libs.versions.toml.",
       "matchManagers": [
         "gradle"
       ],
       "matchDepNames": [
         "io.github.alexzhirkevich:compottie"
       ],
-      "matchCurrentValue": "/^2\\.1\\./",
-      "allowedVersions": "/^2\\.1\\./"
+      "matchCurrentValue": "/^2\\.2\\./",
+      "allowedVersions": "/^2\\.2\\./"
     },
     {
       "description": "robolectric: released versions only. Robolectric publishes a rolling `4.17-SNAPSHOT` to Sonatype and Renovate ranks it above `4.17-beta-2`, but the build declares no snapshot repository — so the bump resolves nowhere and fails every Android configuration. Betas and RCs are still fair game; only `-SNAPSHOT` is excluded.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -102,7 +102,7 @@
       "allowedVersions": "/^1\\.13\\./"
     },
     {
-      "description": "compose-multiplatform: pin to the 1.11.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers, and the ref is also a CEILING on every catalog the serve host renders live (docs/RENDERER_COMPATIBILITY.md). 1.12.0 needs a coordinated move, not a minor/patch bump: its `androidx.compose.*` AARs declare `minCompileSdk = 37` (the repo default is 36), skiko 0.150.1 deletes the mutating `org.jetbrains.skia.Path` API our `conicTo` seams call, and `compose-multiplatform-material3` + `compottie` have to move with it. See gradle/libs.versions.toml — raising the floor is a manual decision. Keep `samples/cmp-shared`'s explicit `ui-tooling-preview` coord in lockstep so the plugin's compose-runtime compatibility check stays happy.",
+      "description": "compose-multiplatform: pin to the 1.11.x line. `:data-render-compose` exposes `org.jetbrains.compose.{runtime,ui}` as `api` on a published artifact, so the Compose Multiplatform version is part of the supported-minimum floor for consumers, and the ref is also a CEILING on every catalog the serve host renders live (docs/RENDERER_COMPATIBILITY.md). 1.12.0 needs a coordinated move, not a minor/patch bump: its `androidx.compose.*` AARs declare `minCompileSdk = 37` (the repo default is 36), skiko 0.150.1 deletes the mutating `org.jetbrains.skia.Path` API our `conicTo` seams call, and `compose-multiplatform-material3` + `compottie` have to move with it. See gradle/libs.versions.toml — raising the floor is a manual decision. `matchCurrentValue` scopes this to the refs that are actually on 1.11.x; the explicit `ui-tooling-preview:1.10.3` coords in the cmp samples are held on their own line by the rule below.",
       "matchManagers": [
         "gradle"
       ],
@@ -112,6 +112,17 @@
       ],
       "matchCurrentValue": "/^1\\.11\\./",
       "allowedVersions": "/^1\\.11\\./"
+    },
+    {
+      "description": "org.jetbrains.compose.ui:ui-tooling-preview (explicit coords in `samples/cmp-shared` and `samples/cmp-android-only`): pin to the 1.10.x line. These two modules declare the JetBrains-relocated androidx artifact by hand — it ships `androidx.compose.ui.tooling.preview.Preview` on every target, which is the FQN `DiscoverPreviewsTask` scans for, whereas the CMP-bundled `compose.components.uiToolingPreview` republishes the annotation under `org.jetbrains.compose.ui.tooling.preview` and discovery does not recognise it. The explicit coords were renamed in the 1.10 line and are not reliably published to every mirror above it, so they deliberately do NOT track `compose-multiplatform`. Held here because the rule above is scoped by `matchCurrentValue` to the 1.11.x refs and no longer covers them; without this the generic minor/patch group would drift these to a line the preview-discovery contract has not been validated against. See each module's build.gradle.kts.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "org.jetbrains.compose.ui:ui-tooling-preview"
+      ],
+      "matchCurrentValue": "/^1\\.10\\./",
+      "allowedVersions": "/^1\\.10\\./"
     },
     {
       "description": "org.slf4j:slf4j-nop: track gradle-tooling-api's bundled slf4j-api. Tooling API declares `slf4j-api {strictly <X>}` and bumping `-nop` past that drags in a newer `slf4j-api` that can't reconcile with the strict constraint. The matching `-nop` version moves whenever the Tooling-API release ships a newer slf4j-api floor — bump this pin in lockstep then.",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,20 @@ compose-bom-compat = "2025.11.01"
 # on 1.10.3 (skiko 0.9.37.4, whose native exports no `PathBuilder_*` symbol at all). Bumping this
 # ref is therefore a SERVE-HOST RELEASE concern, not just a build-hygiene one — see
 # `docs/RENDERER_COMPATIBILITY.md`.
-compose-multiplatform = "1.12.0"
+#
+# HELD AT 1.11.1 — 1.12.0 is not a minor/patch bump this ref can take on its own (#4503):
+#   * `androidx.compose.*:1.12.0` AAR metadata declares `minCompileSdk = 37`, so every Android
+#     module on the conventions default (`compileSdk = 36`) fails `checkAarMetadata` — the bump is
+#     a repo-wide platform move, not a version-ref edit.
+#   * skiko 0.150.1 (what 1.12.0 resolves) REMOVES the mutating `org.jetbrains.skia.Path` API that
+#     m144 had only deprecated at `DeprecationLevel.ERROR`. `Path.conicTo` is gone, which breaks
+#     `PathConic.{jvm,wasm,ios}.kt` and the vendored `FloatsToPath.kt`; the replacement
+#     (`PathBuilder`) is build-then-`snapshot()`, so those seams have to be restructured.
+#   * `compose-multiplatform-material3` (1.11.0-alpha07) and `compottie` (built against foundation
+#     1.11.0) move in lockstep with this ref — see their comments below.
+# The Renovate rule for `org.jetbrains.compose**` in `.github/renovate.json` now tracks the 1.11.x
+# line so the group stops re-proposing this; moving to 1.12 is a deliberate, coordinated change.
+compose-multiplatform = "1.11.1"
 # Consumer runtime used by renderer forward-compatibility tests. Keep this on the newest CMP line
 # that catalogs are expected to adopt; it intentionally does not affect production compilation.
 compose-multiplatform-forward = "1.12.0-rc01"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,15 +18,15 @@ kotlin = "2.4.10"
 # `configureKotlinCompatibility(...)`; remove the flag (and bump this to
 # `2.1.x`) when the removal lands and we're ready to drop 2.0.x consumers.
 kotlinCoreLibraries = "2.0.21"
-agp = "9.3.1"
+agp = "9.3.2"
 ktfmt = "0.27.0"
 tapmoc = "0.4.2"
 # Released versions only. Robolectric publishes `4.17-SNAPSHOT` to Sonatype, and Renovate ranks it
 # above `4.17-beta-2` — but no snapshot repository is declared here (nor should one be, for a
 # reproducible build), so a snapshot pin fails dependency resolution outright. The
 # `org.robolectric:robolectric` rule in `.github/renovate.json` keeps that bump from coming back.
-robolectric = "4.17-beta-2"
-roborazzi = "1.72.0"
+robolectric = "4.17-beta-4"
+roborazzi = "1.73.0"
 # androidx.tracing — atrace-level sections for the Android daemon's render phases (see
 # `AndroidxTraceSections` in :daemon:android). Version-pinned (not BOM-managed) because the daemon
 # ships it in the standalone lib-daemon-android sidecar where no BOM applies.
@@ -39,7 +39,7 @@ androidx-tracing = "2.0.0"
 # one classpath. Note 2.x publishes only `androidJvm` + `jvm` variants — there is no wasmJs or Apple
 # klib, which is the whole reason `:rc-player-trace` is an `expect`/`actual` facade.
 androidx-tracing-kmp = "2.0.0"
-classgraph = "4.8.192"
+classgraph = "4.8.194"
 # Stable BOM line — what samples use and what `composePreviewRender` /
 # `Compare previews` is exercised against. Renovate updates this freely;
 # the variant below (`compose-bom-compat`) is the older line that
@@ -66,7 +66,7 @@ compose-bom-compat = "2025.11.01"
 # on 1.10.3 (skiko 0.9.37.4, whose native exports no `PathBuilder_*` symbol at all). Bumping this
 # ref is therefore a SERVE-HOST RELEASE concern, not just a build-hygiene one — see
 # `docs/RENDERER_COMPATIBILITY.md`.
-compose-multiplatform = "1.11.1"
+compose-multiplatform = "1.12.0"
 # Consumer runtime used by renderer forward-compatibility tests. Keep this on the newest CMP line
 # that catalogs are expected to adopt; it intentionally does not affect production compilation.
 compose-multiplatform-forward = "1.12.0-rc01"


### PR DESCRIPTION
Supersedes #4503, which is red across ~10 jobs. Every failure traces to one entry in that group: `compose-multiplatform` 1.11.1 → 1.12.0. This PR takes the rest of the group and holds that ref.

## Why 1.12.0 can't ride the minor/patch group

- **`minCompileSdk = 37`.** `androidx.compose.*:1.12.0` AAR metadata requires compileSdk 37; the conventions default is 36, so `checkAarMetadata` fails on every Android module that isn't already an explicit 37 override (`Build plugin + CLI`, run 32931346601). Moving the default is a repo-wide platform change.
- **skiko 0.150.1 deletes the mutating `Path` API.** CMP 1.12.0 resolves skiko 0.150.1, which *removes* what m144 had only deprecated at `DeprecationLevel.ERROR`. `Unresolved reference 'conicTo'` in `PathConic.wasm.kt` and the vendored `third_party/rc-embedded-player-jvm/.../FloatsToPath.kt`. The `@Suppress("DEPRECATION_ERROR")` seams those files carry can't be re-pointed — `PathBuilder` is build-then-`snapshot()`, the opposite of the `expect fun Path.conicToSkia(...)` contract that mutates its receiver, so all four call sites need restructuring.
- **`ExperimentalAnimatableApi` is gone**, breaking `RcBoundsAnimation.kt`.
- **It's a serve-host release decision.** `gradle/libs.versions.toml` already documents this ref as a *ceiling* on every catalog the host renders live (#3447, `docs/RENDERER_COMPATIBILITY.md`), and `compose-multiplatform-material3` (1.11.0-alpha07) + `compottie` (built against foundation 1.11.0) move in lockstep with it.

## Why Renovate proposed it at all

Two pins had gone stale. The `org.jetbrains.compose**` rule matched `matchCurrentValue: /^1\.10\./` and the compottie rule `/^2\.1\./` — but the refs were manually moved to 1.11.1 and 2.2.4, so neither rule applied any more and the group was free to sweep the ref. Both now track the lines the repo actually sits on (1.11.x / 2.2.x), with the 1.12 blockers written into the descriptions. `matchCurrentValue` keeps the pin self-scoping: `compose-multiplatform-forward` (1.12.0-rc01) is untouched.

## What lands

`agp` 9.3.1 → 9.3.2, `robolectric` 4.17-beta-2 → 4.17-beta-4, `roborazzi` 1.72.0 → 1.73.0, `classgraph` 4.8.192 → 4.8.194. `compose-multiplatform` stays 1.11.1.

## Test plan

- `./gradlew :rc-player-compose:compileKotlinWasmJs :rc-player-compose:compileKotlinJvm :third-party-rc-embedded-player-jvm:compileKotlin` — BUILD SUCCESSFUL. These are exactly the two tasks that failed on #4503's `Build CLI` job.
- `jq . .github/renovate.json` — valid.
- Android `checkAarMetadata` can't run here (no SDK in this container); it's covered by the Android jobs in CI, which were the ones red on #4503.

Non-visual change (dependency pins + Renovate config), so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf536k5GJY7P6GM6wVeEMR)_