### PR TITLE
refactor(mcp): narrow the daemon client factory port off RegisteredProject

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.mcp.DaemonClientFactory
-import ee.schimke.composeai.mcp.RegisteredProject
 import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
 import ee.schimke.composeai.mcp.WorkspaceId
 import java.io.File
@@ -69,8 +68,8 @@ internal fun daemonDescriptorFile(projectDir: File, modulePath: String): File {
  * Run the smoke test for one module. Returns a [DaemonSmokeOutcome] describing the result.
  *
  * [factory] defaults to the production subprocess factory; tests inject an in-memory factory.
- * [workspaceName] is the project's root name (used for the synthesised [WorkspaceId] passed to the
- * factory — production daemons don't care, but the [RegisteredProject] type wants something).
+ * [workspaceName] is the project's root name, used to derive the [WorkspaceId] the factory names
+ * the daemon by.
  */
 internal fun runDaemonSmokeTest(
   projectDir: File,
@@ -95,17 +94,9 @@ internal fun runDaemonSmokeTest(
   if (!descriptor.enabled) return DaemonSmokeOutcome.DescriptorDisabled(descriptorFile)
 
   val canonicalRoot = runCatching { projectDir.canonicalFile }.getOrDefault(projectDir.absoluteFile)
-  val project =
-    RegisteredProject(
-      workspaceId = WorkspaceId.derive(workspaceName, canonicalRoot),
-      rootProjectName = workspaceName,
-      path = canonicalRoot,
-      knownModules = mutableListOf(),
-    )
-
   val spawn =
     try {
-      factory.spawn(project, descriptor)
+      factory.spawn(WorkspaceId.derive(workspaceName, canonicalRoot), descriptor)
     } catch (e: Exception) {
       return DaemonSmokeOutcome.SpawnFailed(reason = e.message ?: e.javaClass.simpleName)
     }
@@ -115,7 +106,7 @@ internal fun runDaemonSmokeTest(
   return try {
     val result =
       client.initialize(
-        workspaceRoot = project.path.absolutePath,
+        workspaceRoot = canonicalRoot.absolutePath,
         moduleId = descriptor.modulePath,
         moduleProjectDir = descriptor.workingDirectory,
       )

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -172,7 +172,7 @@ object DaemonMcpMain {
  * into a [DaemonClient]. Mirrors `RealDesktopHarnessLauncher` from `:daemon:harness`.
  */
 class SubprocessDaemonClientFactory : DaemonClientFactory {
-  override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+  override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     require(descriptor.enabled) {
       "daemon disabled for ${descriptor.modulePath} — set composePreview { daemon { enabled = true } }"
     }
@@ -204,9 +204,9 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
         .redirectOutput(ProcessBuilder.Redirect.PIPE)
         .redirectError(ProcessBuilder.Redirect.PIPE)
         .start()
-    forwardStderr(process, "${project.workspaceId}/${descriptor.modulePath}")
+    forwardStderr(process, "$workspaceId/${descriptor.modulePath}")
     descriptor.hardTtlSeconds?.let { ttl ->
-      armHardTtl(process, ttl, "${project.workspaceId}/${descriptor.modulePath}")
+      armHardTtl(process, ttl, "$workspaceId/${descriptor.modulePath}")
     }
     return SubprocessDaemonSpawn(process)
   }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -207,7 +207,7 @@ class DaemonSupervisor(
     // before `daemonFor` returns. With sandboxCount > 1 the daemon's per-sandbox bootstrap is
     // sequenced internally (RobolectricHost.start), so the wall-clock here is roughly
     // (1 + replicasPerDaemon) × per-sandbox-boot.
-    val spawn = clientFactory.spawn(project, descriptor)
+    val spawn = clientFactory.spawn(project.workspaceId, descriptor)
     spawn.client(
       onNotification = { method, params ->
         router.dispatch(supervised, method, params)
@@ -688,9 +688,17 @@ fun interface DescriptorProvider {
  * tests inject an in-memory factory that wires the [DaemonClient] to a fake daemon over piped
  * streams. The factory returns a [DaemonSpawn] that owns the underlying resource (subprocess or
  * coroutine).
+ *
+ * [workspaceId] identifies which workspace the daemon serves; with
+ * [DaemonLaunchDescriptor.modulePath] it names the daemon in logs and keys test doubles. It is
+ * deliberately *not* a [RegisteredProject]: that type carries the MCP supervisor's own registry
+ * ([RegisteredProject.knownModules], [RegisteredProject.daemons]), and naming it here would put the
+ * supervision model in the signature of every consumer that only wants to start a daemon —
+ * including the render-session library, which built a throwaway [RegisteredProject] purely to
+ * satisfy this parameter. Spawning needs the identity, not the registry.
  */
 fun interface DaemonClientFactory {
-  fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn
+  fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn
 }
 
 /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpLiveCapabilityTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpLiveCapabilityTest.kt
@@ -161,7 +161,7 @@ class DaemonMcpLiveCapabilityTest {
 private class JsonRpcDaemonClientFactory(private val pngFile: File) : DaemonClientFactory {
   val hosts = java.util.concurrent.CopyOnWriteArrayList<CapabilityRenderHost>()
 
-  override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+  override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     val host = CapabilityRenderHost(pngFile)
     hosts += host
     return JsonRpcDaemonSpawn(host)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -795,11 +795,11 @@ class FakeDaemonClientFactory : DaemonClientFactory {
    */
   @Volatile var daemonConfigurer: (FakeDaemon) -> Unit = {}
 
-  override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+  override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     val daemon = FakeDaemon()
     runCatching { daemonConfigurer(daemon) }
     synchronized(this) {
-      daemons[project.workspaceId to descriptor.modulePath] = daemon
+      daemons[workspaceId to descriptor.modulePath] = daemon
       spawnHistory.add(daemon)
       spawnDescriptors.add(descriptor)
     }

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -5,7 +5,6 @@ import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.mcp.DaemonClient
 import ee.schimke.composeai.mcp.DaemonClientFactory
-import ee.schimke.composeai.mcp.RegisteredProject
 import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
 import ee.schimke.composeai.mcp.WorkspaceId
 import ee.schimke.composeai.render.session.RenderSession
@@ -185,17 +184,9 @@ object SubprocessRenderSessions : RenderSessionFactory {
     shutdownTimeout: Duration?,
     factory: DaemonClientFactory,
   ): RenderSession {
-    val project =
-      RegisteredProject(
-        workspaceId = WorkspaceId.derive(workspaceName, canonicalRoot),
-        rootProjectName = workspaceName,
-        path = canonicalRoot,
-        knownModules = mutableListOf(),
-      )
-
     val spawn =
       try {
-        factory.spawn(project, descriptor)
+        factory.spawn(WorkspaceId.derive(workspaceName, canonicalRoot), descriptor)
       } catch (e: Exception) {
         throw RenderSessionException(
           "Failed to spawn daemon subprocess for ${descriptor.modulePath}: " +


### PR DESCRIPTION
Preparation for #3824 item 3 — lifting the daemon client out of `:mcp` into its own published module, the last leak the contract probe records. This is the narrowing that has to happen *first*; the module move follows in a separate PR.

## The coupling

`DaemonClientFactory.spawn` took a `RegisteredProject`:

```kotlin
data class RegisteredProject(
  val workspaceId: WorkspaceId,
  val rootProjectName: String,
  val path: File,
  val knownModules: MutableList<String>,
  val daemons: ConcurrentHashMap<String, SupervisedDaemon> = ConcurrentHashMap(),
)
```

That is the MCP supervisor's own registry — a mutable module list and a map of `SupervisedDaemon`. Naming it in the factory signature put the whole supervision model in front of every consumer that only wants to start a daemon.

Two of those consumers live outside `:mcp`, and both paid for it by fabricating one. `SubprocessRenderSession` and `DaemonSmokeCheck` each built a four-field `RegisteredProject` — empty module list, untouched daemon map — purely to satisfy the parameter. The CLI's KDoc said so in as many words:

> [workspaceName] is the project's root name (used for the synthesised [WorkspaceId] passed to the factory — production daemons don't care, but the [RegisteredProject] type wants something).

That parenthetical is now gone along with the thing it was apologising for.

## Why narrowing before moving

Doing this first is the point rather than a tidy-up. Moving the factory while it still named `RegisteredProject` would have dragged `SupervisedDaemon` and the supervision model into a module whose entire purpose is to not be MCP — the same mistake #4524 existed to correct, where a port typed in the renderer's own types would have left the renderer client on every consumer's classpath.

## What it costs

Nothing measurable. I checked what the production implementation actually reads from the parameter before removing it: `project.workspaceId`, twice, both times to build a log label.

```
forwardStderr(process, "$workspaceId/${descriptor.modulePath}")
armHardTtl(process, ttl, "$workspaceId/${descriptor.modulePath}")
```

No other field is touched — not `knownModules`, not `daemons`, not `path`, not `rootProjectName`. So `spawn` now takes `WorkspaceId`, and `RegisteredProject` is confined to `:mcp`, verified by grep.

`DaemonSmokeCheck` had one other use, `project.path.absolutePath` for `workspaceRoot`; it already held that value as `canonicalRoot` and now uses it directly.

## Test plan

- `:mcp:test` — full suite, green
- `:cli:test` — full suite, green
- `:render-session-subprocess:test`, `:render-session-embedded-desktop:compileKotlin`
- `ktfmtCheck` on the touched modules (the pre-commit hook caught two KDoc lines; formatted)

The `DaemonClientFactory { _, _ -> … }` lambda doubles in `DaemonSmokeCheckTest` needed no source change; the two `override fun spawn` implementations (`FakeDaemonClientFactory`, `JsonRpcDaemonClientFactory`) did.

Non-visual change (build wiring and a signature), so no rendered evidence applies.

## Two findings worth recording

**A pre-existing failure, not from this change.** `NonGradleContractTest > synthesised descriptor drives a real render via RenderSession` fails in my sandbox — a real daemon not emitting `renderFinished` for a CMP animated preview within 60s. I checked it against a worktree at the merge-base rather than assuming: it fails identically there, same message, and genuinely ran rather than self-skipping (`tests="1" skipped="0" failures="1"`). Pre-existing on `main` in this environment.

**A stale build-cache entry can hide an ABI change.** Three `DaemonSmokeCheckTest` cases first failed with `AbstractMethodError` naming the new `spawn(WorkspaceId, …)`. That was not a source defect. `javap -v` showed the compiled test's `LambdaMetafactory` call site still typed `(RegisteredProject, DaemonLaunchDescriptor)DaemonSpawn`, while the only `DaemonClientFactory.class` on disk had the new signature — and the class file's mtime was *later* than the interface's, so "not recompiled" was ruled out too. With `org.gradle.caching=true`, a cache restore writes a fresh timestamp over stale content; `--no-build-cache --rerun-tasks` produced the correct descriptor and the tests pass.

Worth flagging because the compile succeeds either way: a cached test-compile output can silently disagree with a changed `fun interface` ABI and only surface at runtime. CI builds fresh, so it should not appear there — but a contributor changing a SAM interface locally may hit it and reasonably conclude their change is broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_