### PR TITLE
fix(build): stop publishing the vendored RC embedded player to Central

### DIFF
--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -147,32 +147,28 @@ private fun Project.configureAndroidLibraryPublication() {
  * nothing at configuration time) and it names the line a human has to edit.
  */
 private fun Project.rejectSnapshotDependenciesInPom() {
-  // `api`/`implementation`/`runtimeOnly` are what vanniktech maps into the POM's compile and
-  // runtime scopes; the `release*` variants are AGP's per-variant buckets for the single published
-  // Android variant.
-  val pomScopes =
-    setOf(
-      "api",
-      "implementation",
-      "runtimeOnly",
-      "releaseApi",
-      "releaseImplementation",
-      "releaseRuntimeOnly",
-    )
   afterEvaluate {
     val offenders =
       configurations
-        .filter { it.name in pomScopes }
+        .filter { isPomVisibleConfiguration(it.name) }
         .flatMap { configuration ->
-          configuration.dependencies.withType(ExternalModuleDependency::class.java).mapNotNull {
-            dependency ->
-            dependency.version
-              ?.takeIf { it.endsWith("-SNAPSHOT") }
-              ?.let { version ->
-                "  ${configuration.name}(\"${dependency.group}:${dependency.name}:$version\")"
+          // Constraints as well as dependencies: Gradle serializes an `api`/`implementation`
+          // constraint into the POM's `dependencyManagement`, so a constraint pinning a SNAPSHOT
+          // puts that coordinate in the uploaded POM just as a dependency does.
+          val declared =
+            configuration.dependencies
+              .withType(ExternalModuleDependency::class.java)
+              .map { Triple(it.group, it.name, it.version) } +
+              configuration.dependencyConstraints.map {
+                Triple(it.group, it.name, it.version)
               }
+          declared.mapNotNull { (group, name, version) ->
+            version
+              ?.takeIf { it.endsWith("-SNAPSHOT") }
+              ?.let { "  ${configuration.name}(\"$group:$name:$it\")" }
           }
         }
+        .distinct()
         .sorted()
     if (offenders.isNotEmpty()) {
       error(
@@ -191,6 +187,33 @@ private fun Project.rejectSnapshotDependenciesInPom() {
       )
     }
   }
+}
+
+/**
+ * The declaration buckets whose contents Gradle writes into a published POM.
+ *
+ * Matched by *suffix* rather than by an explicit list of names, because the same four kinds are
+ * prefixed differently per plugin: plain `api` for a JVM library, `releaseApi` for the single
+ * Android variant vanniktech publishes, and `commonMainApi` / `jvmMainImplementation` for the
+ * Kotlin Multiplatform modules (`:rc-player-runtime`, `:rc-player-compose`, …) whose source-set
+ * dependencies land in their per-target publications. An explicit list silently stopped covering
+ * whichever convention was added last, which is exactly the hole this guard exists to close.
+ *
+ * `compileOnlyApi` is in — unlike `compileOnly`, it *is* published, in compile scope. Test and
+ * test-fixture source sets are out: nothing they declare reaches a POM. So are the non-published
+ * Android variants, since only `release` is published and a debug-only SNAPSHOT is legitimate.
+ */
+private val POM_SCOPE_KINDS = listOf("compileOnlyApi", "implementation", "runtimeOnly", "api")
+
+private fun isPomVisibleConfiguration(name: String): Boolean {
+  val kind =
+    POM_SCOPE_KINDS.firstOrNull {
+      name == it || name.endsWith(it.replaceFirstChar(Char::uppercaseChar))
+    } ?: return false
+  val prefix = name.dropLast(kind.length)
+  return !prefix.contains("test", ignoreCase = true) &&
+    !prefix.contains("fixtures", ignoreCase = true) &&
+    !prefix.startsWith("debug")
 }
 
 private fun Project.nextPatchSnapshotVersion(): String {

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -8,6 +8,7 @@ import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.configure
@@ -47,6 +48,7 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
         ?: project.nextPatchSnapshotVersion()
 
     project.configureAndroidLibraryPublication()
+    project.rejectSnapshotDependenciesInPom()
 
     project.afterEvaluate {
       val artifactId =
@@ -119,6 +121,73 @@ private fun Project.configureAndroidLibraryPublication() {
           sourcesJar = SourcesJar.Sources(),
           variant = "release",
         )
+      )
+    }
+  }
+}
+
+/**
+ * Fail the build if a module that publishes to Maven Central declares a `-SNAPSHOT` dependency in a
+ * scope that reaches its POM.
+ *
+ * Central does not warn about this, it *rejects the whole deployment*: "Dependencies to SNAPSHOT
+ * versions not allowed for dependency: <coordinates>". Because every publishable module deploys in
+ * one bundle, a single offender fails `publish-gradle-plugin` for the entire release — and
+ * `finalize-release` then leaves the GitHub Release as an un-drafted draft, so the CLI tarball
+ * consumers download 404s and nothing of that version ships at all. 1.34.0 and 1.35.0 were stranded
+ * exactly this way after `:third-party-rc-embedded-player` re-applied `composeai.maven-publishing`
+ * while `api`-exposing `androidx.compose.remote:*:1.0.0-SNAPSHOT` (#4490).
+ *
+ * The check runs on every build, not only releases: the mistake is a *declaration*, so catching it
+ * on the PR that makes it is the whole point. Only POM-visible scopes are inspected — `compileOnly`
+ * and `testImplementation` never reach the POM, which is how `:runtimes:wear-preview` and
+ * `:data-remotecompose-connector` legitimately compile against the same androidx.dev snapshots.
+ *
+ * Declarations rather than a resolved graph, deliberately: this needs no resolution (so it costs
+ * nothing at configuration time) and it names the line a human has to edit.
+ */
+private fun Project.rejectSnapshotDependenciesInPom() {
+  // `api`/`implementation`/`runtimeOnly` are what vanniktech maps into the POM's compile and
+  // runtime scopes; the `release*` variants are AGP's per-variant buckets for the single published
+  // Android variant.
+  val pomScopes =
+    setOf(
+      "api",
+      "implementation",
+      "runtimeOnly",
+      "releaseApi",
+      "releaseImplementation",
+      "releaseRuntimeOnly",
+    )
+  afterEvaluate {
+    val offenders =
+      configurations
+        .filter { it.name in pomScopes }
+        .flatMap { configuration ->
+          configuration.dependencies.withType(ExternalModuleDependency::class.java).mapNotNull {
+            dependency ->
+            dependency.version
+              ?.takeIf { it.endsWith("-SNAPSHOT") }
+              ?.let { version ->
+                "  ${configuration.name}(\"${dependency.group}:${dependency.name}:$version\")"
+              }
+          }
+        }
+        .sorted()
+    if (offenders.isNotEmpty()) {
+      error(
+        buildString {
+          appendLine(
+            "$path publishes to Maven Central but declares SNAPSHOT dependencies that would " +
+              "reach its POM:"
+          )
+          offenders.forEach(::appendLine)
+          append(
+            "Central rejects the whole deployment for these, which strands every artifact of the " +
+              "release. Either pin them to a released version, move them to compileOnly, or stop " +
+              "applying composeai.maven-publishing to this module."
+          )
+        }
       )
     }
   }

--- a/third_party/rc-embedded-player/build.gradle.kts
+++ b/third_party/rc-embedded-player/build.gradle.kts
@@ -39,31 +39,38 @@
 
 plugins {
   id("composeai.base-conventions")
-  // Published for TESTING only — see `composeAiMavenPublishing` below. This is the repo's pinned,
-  // locally patched AndroidX player, not a supported API. Publishing it lets consumers and parity
-  // jobs select the vendored implementation independently from the newer embedded player now
-  // shipped inside androidx.dev's `remote-player-compose` snapshot.
-  id("composeai.maven-publishing")
+  // NOT PUBLISHED, and it must stay that way. Applying `composeai.maven-publishing` joins the root
+  // `publishAndReleaseToMavenCentral` aggregation — and this module exposes
+  // `libs.compose.remote.core`
+  // and `libs.compose.remote.player.core` through `api`. Those sit at `1.0.0-SNAPSHOT` on
+  // androidx.dev, so the release POM requires `androidx.compose.remote:*:1.0.0-SNAPSHOT`:
+  // coordinates
+  // a consumer cannot resolve (the androidx.dev repository is declared in this project's
+  // `settings.gradle.kts` and cannot be inherited), absent from Google Maven and Central, and
+  // eventually swept from androidx.dev altogether. Central does not merely warn about this — it
+  // rejects the whole deployment with "Dependencies to SNAPSHOT versions not allowed", which fails
+  // `publish-gradle-plugin` and leaves the GitHub Release stranded as a draft, so EVERY artifact of
+  // that version goes unshipped. That is what stranded 1.34.0 and 1.35.0 after #4490 re-applied
+  // this
+  // plugin. A published artifact nobody can resolve is worse than no artifact; a published artifact
+  // that blocks the whole release is worse still.
+  //
+  // Unpublishing rather than pinning, because there is nothing to pin to — the upstream player
+  // ships
+  // only as androidx.dev snapshots — and because nothing consumes the coordinates: every user in
+  // this
+  // repo (`:samples:remotecompose`, `:samples:design-catalog-remote-m3`,
+  // `:data-remotecompose-connector`,
+  // and the JVM sibling via `:cli`) depends on the PROJECT, and the rc-compare lanes drive it
+  // through
+  // `./gradlew :third-party-rc-embedded-player:testDebugUnitTest`, not a coordinate.
+  //
+  // `composeai.maven-publishing` also applied `composeai.android-conventions`, so that is named
+  // directly.
+  id("composeai.android-conventions")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
-}
-
-// Deliberately published under the compose-ai-tools group, not `androidx.*`: this is the vendored
-// and locally patched implementation. Its public API exposes AndroidX Remote Compose snapshot
-// types, so consumers must also use the matching androidx.dev repository/build recorded by this
-// release. The coordinate is intended for player experiments and parity testing, not as a stable
-// library API.
-composeAiMavenPublishing {
-  coordinates(
-    artifactId = "third-party-rc-embedded-player",
-    displayName = "Compose Preview — AndroidX Embedded Player (vendored, Android)",
-    description =
-      "Vendored and locally patched Android implementation of AndroidX's experimental Compose " +
-        "embedded Remote Compose player. Published for parity testing alongside the upstream " +
-        "androidx.dev implementation; not a supported API.",
-  )
-  inceptionYear.set("2026")
 }
 
 android {


### PR DESCRIPTION
## Why

Every release since 1.33.0 has failed to ship. `v1.34.0` and `v1.35.0` exist as git tags and as **un-published draft** GitHub Releases, and neither reached Maven Central — `preview-annotations` on Central still tops out at 1.33.0.

The single cause is one POM. `:third-party-rc-embedded-player` `api`-exposes `androidx.compose.remote:remote-core` and `remote-player-core`, which sit at `1.0.0-SNAPSHOT` on androidx.dev. #4490 re-applied `composeai.maven-publishing` to that module, undoing the deliberate un-publishing whose comment had spelled out exactly why it could not be published. Central does not warn about a SNAPSHOT dependency — it rejects the whole deployment:

```
Deployment a24a9751-… failed validation:
Publication pkg:maven/ee.schimke.composeai/third-party-rc-embedded-player@1.35.0:
  * Dependencies to SNAPSHOT versions not allowed for dependency: androidx.compose.remote:remote-core
  * Dependencies to SNAPSHOT versions not allowed for dependency: androidx.compose.remote:remote-player-core
  * Dependencies to SNAPSHOT versions not allowed for dependency: androidx.compose.remote:remote-player-compose
  * Dependencies to SNAPSHOT versions not allowed for dependency: androidx.compose.remote:remote-creation-compose
```

Because every publishable module deploys in one bundle, that one POM fails `publish-gradle-plugin` for the entire release; `finalize-release` requires `needs.release.result == 'success'`, so it skips and the Release stays a draft. A draft Release serves no downloads, so `.github/actions/apply`'s CLI tarball 404s for those versions — which is what is failing [yschimke/m3-catalog#192](https://github.com/yschimke/m3-catalog/pull/192), and why 1.33.0 was reverted there in [yschimke/m3-catalog#193](https://github.com/yschimke/m3-catalog/pull/193).

## What changed

- **`third_party/rc-embedded-player/build.gradle.kts`** — drop `composeai.maven-publishing` (naming `composeai.android-conventions` directly, as before #4490) and the `composeAiMavenPublishing { … }` block. Un-publish rather than pin: there is nothing to pin to, since the upstream player ships only as androidx.dev snapshots. Nothing consumes the coordinate either — `:samples:remotecompose`, `:samples:design-catalog-remote-m3`, `:data-remotecompose-connector` and the JVM sibling via `:cli` all depend on the *project*, and the rc-compare lanes drive it through `:third-party-rc-embedded-player:testDebugUnitTest`. The restored comment now records the release-stranding consequence, not just the unresolvable-POM one.
- **`ComposeAiMavenPublishingPlugin`** — a guard, so this cannot regress a third time. Any module applying the publishing convention now fails configuration if it declares a `-SNAPSHOT` dependency in a POM-visible scope (`api`, `implementation`, `runtimeOnly`, and their `release*` variants). It reads declarations rather than a resolved graph, so it costs nothing at configuration time and names the line a human has to edit. `compileOnly` and test scopes are untouched — that is how `:runtimes:wear-preview` and `:data-remotecompose-connector` legitimately compile against the same androidx.dev snapshots.

## Test plan

- `./gradlew -p build-logic compileKotlin` — passes.
- `./gradlew projects` — configures every project with no new failure, so the guard has no false positives across the modules that publish.
- Negative test: re-applying `composeai.maven-publishing` to the module locally makes `./gradlew :third-party-rc-embedded-player:tasks` fail at configuration, naming exactly the four dependencies Central rejected:
  ```
  :third-party-rc-embedded-player publishes to Maven Central but declares SNAPSHOT
  dependencies that would reach its POM:
    api("androidx.compose.remote:remote-core:1.0.0-SNAPSHOT")
    api("androidx.compose.remote:remote-player-core:1.0.0-SNAPSHOT")
    implementation("androidx.compose.remote:remote-creation-compose:1.0.0-SNAPSHOT")
    implementation("androidx.compose.remote:remote-player-compose:1.0.0-SNAPSHOT")
  ```
- `./gradlew ktfmtFormatAll` — leaves no diff.

No visual surface changes, so no render evidence applies.

## Follow-up not in this PR

Landing this fixes the *next* release. It does not retroactively ship 1.33.0–1.35.0: those drafts stay drafts, and 1.34.0/1.35.0 never reached Central at all, so they cannot honestly be un-drafted.

1.33.0 is the interesting one — it *is* fully on Maven Central (its `publish-gradle-plugin` predates #4490), yet its Release is still a draft too, so m3-catalog#192 hits the same 404. If that draft turns out to carry the five assets `finalize-release` requires, publishing it (`gh release edit v1.33.0 --draft=false --latest`) would unblock m3-catalog#192 immediately. I have not verified its asset list from here, and un-drafting is a deliberate manual call in any case, so this PR does not touch it.