### PR TITLE
feat(parity): export the alpha normalisation for consumers that decode elsewhere

### DIFF
--- a/scripts/design-artifacts/known-differences.test.mjs
+++ b/scripts/design-artifacts/known-differences.test.mjs
@@ -43,7 +43,7 @@ import { createHash } from "node:crypto";
 import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { MAX_CONFORMING_HEADER_BYTES, decodePng, padPngTo } from "./png-lite.mjs";
+import { MAX_CONFORMING_HEADER_BYTES, decodePng, normaliseAlpha, padPngTo } from "./png-lite.mjs";
 // The writer, for the handful of tests that need bytes rather than a committed fixture. It lives
 // outside `png-lite.mjs` because that module has no compressor — see its header.
 import { encodePng } from "./png-write.mjs";
@@ -798,6 +798,31 @@ test("the memory ceiling is a different cap from the pixel one, both ways round"
   // The ceiling is not a function of the total alone — the same pixel count peaks differently
   // depending on how it is distributed, which is the whole of the transient term.
   assert.ok(peakRasterBytes(67_108_864, 8_388_608) < peakRasterBytes(67_108_864, 33_554_432));
+});
+
+test("the alpha normalisation is reachable by a consumer that decoded elsewhere", () => {
+  // The rule `png-lite.mjs` states is about "every raster that reaches a comparison, not only
+  // decoded PNGs" — a canonical raster lifted off a canvas, or read with whatever PNG library a
+  // consumer already depends on, has to land on the same grid or the same unchanged bytes compare
+  // unequal across two engines. It was private, so the only way to obey it was to reimplement it,
+  // which is the divergence the contract exists to prevent. This asserts it is exported and is the
+  // function the rule describes, over the case that actually bites: a straight-alpha colour that is
+  // not itself a premultiplied bucket's representative.
+  const pixels = new Uint8Array([200, 200, 200, 128, 10, 20, 30, 0, 77, 88, 99, 255]);
+  normaliseAlpha(pixels);
+  // 200 at alpha 128 premultiplies to 100 and comes back as 199 — one off, and the whole point.
+  assert.deepEqual([...pixels.subarray(0, 4)], [199, 199, 199, 128]);
+  // Alpha 0 keeps nothing: the premultiply destroyed every channel, so zero is the only answer both
+  // engines can agree on.
+  assert.deepEqual([...pixels.subarray(4, 8)], [0, 0, 0, 0]);
+  // Alpha 255 is the identity, skipped rather than computed.
+  assert.deepEqual([...pixels.subarray(8, 12)], [77, 88, 99, 255]);
+
+  // Idempotent, which is what lets a consumer apply it without knowing whether the decoder already
+  // did: `N(N(c)) = N(c)`.
+  const twice = Uint8Array.from(pixels);
+  normaliseAlpha(twice);
+  assert.deepEqual([...twice], [...pixels]);
 });
 
 test("a decoded pixel is the one spelling a premultiplied canvas hands back", () => {

--- a/scripts/design-artifacts/png-lite.mjs
+++ b/scripts/design-artifacts/png-lite.mjs
@@ -596,8 +596,19 @@ export function decodePng(bytes) {
  * be recovered from it — so it normalises to zero RGB, as it did when that was the only case
  * handled here. Alpha `255` is the identity and is skipped rather than computed, because it is
  * almost every pixel this contract sees.
+ *
+ * **Exported because the rule above is not only about PNGs this module decoded.** A consumer that
+ * obtains its rasters another way — a browser lifting them off a canvas, an offline runner decoding
+ * with whatever PNG library it already depends on — still has to put them on this grid before they
+ * reach a comparison, or the same unchanged bytes compare unequal across the two. `design-parity`
+ * was doing exactly that: its conformance suite decodes through {@link decodePng} and passes the
+ * partial-alpha cases, while its production path reads with `pngjs` and handed the raw bytes
+ * straight to the evaluation. A one-pixel file of colour `200` at alpha `128` arrives as `200` on
+ * one path and `199` on the other, which is `candidate-changed` on a candidate that never changed.
+ * Keeping this private left every such consumer with a second implementation to write, which is the
+ * divergence the contract exists to prevent.
  */
-function normaliseAlpha(pixels) {
+export function normaliseAlpha(pixels) {
   for (let d = 0; d < pixels.length; d += 4) {
     const a = pixels[d + 3];
     if (a === 255) continue;


### PR DESCRIPTION
Found by Codex review on yschimke/design-parity#394, and the module already says this should be public.

## The rule, and who it binds

`png-lite.mjs`'s KDoc on `normaliseAlpha` states it in its own words:

> **So it must be applied to every raster that reaches a comparison, not only to decoded PNGs.** A canonical raster the browser lifted off a canvas has already been through `host(·)`; the same raster read from a file offline has not. Normalising both is what makes them the same pixels.

The function stating that rule was **private**. So the only way for a consumer holding a raster it decoded some other way to obey it was to write a second copy of it — which is precisely the divergence this contract exists to prevent, and the reason the rule is defined once at all.

## What that cost, concretely

`design-parity` was in exactly that position and could not tell. Its conformance suite decodes through `decodePng` and passes the partial-alpha cases; its production path (`visual.ts`) reads with `pngjs` and hands the raw bytes straight to `evaluateKnownDifferenceComparison` → `canonicalRaster`. One decode is normalised, the other is not:

```
PNG.sync.read  (live path): [ 200, 200, 200, 128 ]
decodePng      (contract) : [ 199, 199, 199, 128 ]
same bytes? false
```

Colour `200` at alpha `128` premultiplies to `100` and comes back as `199`. So a candidate whose bytes never changed compares unequal against its accepted crop — `candidate-changed`, `invalidated` — decided by which decoder happened to read the file rather than by anything in the render. And the conformance suite passing is what made it invisible: the fixtures exercise the normalised path, so the case that reaches production was never covered.

## The change

One word, plus the KDoc paragraph explaining why the export exists so it doesn't get taken away again.

`export function normaliseAlpha(pixels)`.

## Test plan

- `known-differences.test.mjs` 226/226 (225 before), `known-difference-score.test.mjs` 22/22, `check-serve-seam: OK — 151 crossing symbol(s)`.
- New test `the alpha normalisation is reachable by a consumer that decoded elsewhere` pins four things: the value at the case that actually bites (`200 @ 128 → 199`), the alpha-`0` end (nothing survives the premultiply, so zero RGB is the only answer two engines can agree on), the alpha-`255` identity, and **idempotence** — `N(N(c)) = N(c)` is what lets a consumer apply it without having to know whether its decoder already did, which is the exact position `design-parity` is in.
- The committed browser bundles are byte-identical, so no rebuild is in the diff: the function was already bundled and reachable, and adding `export` does not change esbuild's output for it. Verified by running `npm run build` and getting a clean `git status`.
- The existing whole-domain property test (`a decoded pixel is the one spelling a premultiplied canvas hands back`) is untouched — this changes visibility, not arithmetic.

## Downstream

yschimke/design-parity#394 uses it to normalise the live rasters at the acceptance boundary, with a test at the production entry point rather than only in the conformance suite.

Text-only evidence: this changes what a module exports, not how anything is drawn.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_