### PR TITLE
perf(serve): release a parked optimizer's daemon so the pressure gate reopens

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -89,6 +89,8 @@ class ServeBackgroundWork(
   private val optimizerAdmissions = AtomicLong()
   private val optimizerRefusals = AtomicLong()
   private val optimizerAdmissionWaitMillis = AtomicLong()
+  private val optimizerHostSuspensions = AtomicLong()
+  private val optimizerHostResumes = AtomicLong()
   private val optimizerPausedUntil = AtomicLong(Long.MIN_VALUE)
   private val optimizerPauseReason = ConcurrentHashMap<String, String>()
   private val optimizerHostRefusals = AtomicLong()
@@ -292,6 +294,40 @@ class ServeBackgroundWork(
     }
   }
 
+  /**
+   * Lanes nothing is holding right now — how many parked catalogs it is worth making resident
+   * again, and no more.
+   *
+   * [ServeSessionRegistry.resumeIdleOptimizers] reads this because resuming costs a cold Android
+   * daemon (34-68s) and roughly a gigabyte for as long as it stays up. Resuming a catalog that then
+   * queues behind two others pays that price to sit at the door, which is the residency this whole
+   * change exists to stop paying.
+   *
+   * Advisory, deliberately unsynchronized: an admission landing in the same instant makes this one
+   * too high and the resumed pass simply queues, which is the ordinary case anyway.
+   */
+  fun optimizerLanesFree(): Int =
+    if (optimizersPaused()) 0
+    else
+      admissionLock.run {
+        lock()
+        try {
+          (optimizerLanes - optimizerLanesInUse - optimizerQueue.size).coerceAtLeast(0)
+        } finally {
+          unlock()
+        }
+      }
+
+  /** A catalog with optimization left to do had its host released to reclaim its daemon's RAM. */
+  fun recordOptimizerHostSuspended() {
+    optimizerHostSuspensions.incrementAndGet()
+  }
+
+  /** A parked catalog was made resident again so it could take a lane. */
+  fun recordOptimizerHostResumed() {
+    optimizerHostResumes.incrementAndGet()
+  }
+
   private fun releaseOptimizerLane(system: String) {
     admissionLock.lock()
     try {
@@ -383,6 +419,8 @@ class ServeBackgroundWork(
       refusals = optimizerRefusals.get(),
       hostRefusals = optimizerHostRefusals.get(),
       admissionWaitMillis = optimizerAdmissionWaitMillis.get(),
+      hostSuspensions = optimizerHostSuspensions.get(),
+      hostResumes = optimizerHostResumes.get(),
       paused = paused,
       pausedUntilEpochMillis = if (manuallyPaused) until else null,
       pauseReason =
@@ -507,6 +545,19 @@ data class ThemeOptimizerAdmissionSnapshot(
   val refusals: Long,
   val hostRefusals: Long = 0,
   val admissionWaitMillis: Long,
+  /**
+   * Catalogs whose host was released while they still had optimization left, and catalogs made
+   * resident again to take a lane — the residency the pass costs when it is *not* running.
+   *
+   * The pair is the read that was missing while every unfinished catalog stayed resident for the
+   * life of the process: `running`/`waiting` describe passes, and a parked pass looks free there
+   * while its daemon holds ~1.2 GB. A [hostSuspensions] that stays 0 on a box with more unfinished
+   * catalogs than [lanes] means the residency rule is not firing, whatever the memory reading says.
+   * [hostResumes] climbing far faster than [admissions] is the opposite fault: catalogs paying a
+   * cold start to queue rather than to render.
+   */
+  val hostSuspensions: Long = 0,
+  val hostResumes: Long = 0,
   val paused: Boolean,
   val pausedUntilEpochMillis: Long? = null,
   val pauseReason: String? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHost.kt
@@ -290,6 +290,25 @@ class ServeCatalogLiveHost(
    * [verifyPersistedRenders].
    */
   private val persistenceVerified = AtomicBoolean()
+  /**
+   * True only while the pass **holds an optimizer lane**, which is what [backgroundWorkActive] —
+   * and through it [ServeSessionRegistry.suspendIdle] — reads as "this host must stay resident".
+   *
+   * It used to be set for the whole life of the worker, and the worker does not end: on a catalog
+   * with targets left it loops through the quiet gate forever, so the flag was effectively "this
+   * catalog is not fully optimized". That made a catalog's own unfinished optimization the reason
+   * its daemon could never be suspended, and the daemon is the expensive part — an Android lane is
+   * priced at ~1.2 GB in the seat budget. preview.coo.ee reached nine such residents with zero
+   * active streams, `MemAvailable` pinned at 14-21%, and the pressure gate therefore holding: the
+   * optimizer's own residency was what stopped the optimizer running, and the box made progress
+   * only on [OptimizerPressureThresholds.dutyCycleMillis] concessions — 50 of them across 40 hours,
+   * 1,502 of 18,604 entries.
+   *
+   * A pass parked at the gate or queued for a lane needs nothing resident. Its progress lives in
+   * [catalogThemeCache], which is held in [ServeSessionState] precisely so it survives daemon
+   * suspension, and [ServeSessionRegistry.resumeIdleOptimizers] brings the host back when a lane
+   * frees. So the flag covers the slice and nothing more.
+   */
   private val optimizationActive = AtomicBoolean()
   private val warmExecutor by lazy {
     Executors.newSingleThreadExecutor { r ->
@@ -469,6 +488,18 @@ class ServeCatalogLiveHost(
   override val backgroundWorkActive: Boolean
     get() = optimizationActive.get()
 
+  /**
+   * Whether the pass **worker** is alive, as opposed to [backgroundWorkActive], which says only
+   * whether it currently holds a lane.
+   *
+   * The two stopped being the same question when residency was scoped to the lane: a worker parked
+   * at the quiet gate is running and holding nothing. Tests that want "the pass has settled" need
+   * this one — reading the residency flag would let them proceed while the worker was merely
+   * between slices, or before it had taken its first.
+   */
+  internal val optimizationPassRunning: Boolean
+    get() = optimizationStarted.get()
+
   private data class ThemeOptimizationJob(
     val previewId: String,
     val overrides: PreviewOverrides,
@@ -519,7 +550,6 @@ class ServeCatalogLiveHost(
     // heartbeat, so the pass resumes by itself if the breaker closes.
     if (renderBreakerStopsBackgroundWork()) return
     if (!optimizationStarted.compareAndSet(false, true)) return
-    optimizationActive.set(true)
     optimizationExecutor.execute {
       try {
         // Verification does NOT run here, ahead of admission — see the slot below. It renders, and
@@ -561,12 +591,20 @@ class ServeCatalogLiveHost(
           }
           val outcome =
             backgroundWork.withOptimizerSlot(label, optimizerAdmissionWaitMillis) {
-              // Holding the turn established above, so the sample's renders are admitted on
-              // exactly the terms every other background render is. Cheap and once per host: a
-              // no-op when nothing was adopted from disk.
-              if (!persistenceVerified.get()) verifyPersistedRenders(jobs)
-              if (catalogThemeCache.snapshot().fullyOptimized) PassOutcome.FINISHED
-              else runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
+              // The lane, not the worker, is what this host has to be resident for — see
+              // [optimizationActive]. Set inside the slot and cleared on the way out, so the
+              // catalog is suspendable again the instant it re-queues.
+              optimizationActive.set(true)
+              try {
+                // Holding the turn established above, so the sample's renders are admitted on
+                // exactly the terms every other background render is. Cheap and once per host: a
+                // no-op when nothing was adopted from disk.
+                if (!persistenceVerified.get()) verifyPersistedRenders(jobs)
+                if (catalogThemeCache.snapshot().fullyOptimized) PassOutcome.FINISHED
+                else runOptimizerPass(jobs, sliceUntil = clock() + optimizerSliceMillis)
+              } finally {
+                optimizationActive.set(false)
+              }
             }
           if (outcome == null) {
             // Stay in the admission queue without needing a visitor heartbeat to resurrect this
@@ -654,7 +692,14 @@ class ServeCatalogLiveHost(
     optimizationExecutor.execute {
       try {
         backgroundWork.withOptimizerSlot(label, OPTIMIZER_ADMISSION_WAIT_MILLIS) {
-          if (awaitOptimizerTurn()) verifyPersistedRenders(jobs)
+          // Resident for the lane, like the pass proper — this one renders too, and a suspension
+          // landing mid-sample would close the daemon under it.
+          optimizationActive.set(true)
+          try {
+            if (awaitOptimizerTurn()) verifyPersistedRenders(jobs)
+          } finally {
+            optimizationActive.set(false)
+          }
           true
         }
       } finally {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -5431,7 +5431,13 @@ class ServeHttpServer(
             " · duty cycle $cycles" + (pressure.reason?.let { " · $it" } ?: "")
           cycles > 0 -> " · ${countLabel(cycles, "duty cycle")}"
           else -> ""
-        }
+        } +
+          // Residency is the other half of the memory story the gate reads. A box with more
+          // unfinished catalogs than lanes and `0 parked` is one whose daemons are still pinned by
+          // their own backlog — the state that made the reading the gate trips on.
+          if (admission.hostSuspensions > 0 || admission.hostResumes > 0)
+            " · ${admission.hostSuspensions} parked / ${admission.hostResumes} resumed"
+          else ""
       if (admission.paused) {
         return "paused" + (admission.pauseReason?.let { " · $it" } ?: "") + dutyCycles
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -286,6 +286,9 @@ class ServeSessionRegistry(
               runCatching { suspendIdle() }
               runCatching { releaseIdleDaemons() }
               runCatching { reclaimIdleForked() }
+              // After the shedding, not before: the lane a parked catalog is resumed into is
+              // usually the one this sweep's suspensions just freed.
+              runCatching { resumeIdleOptimizers() }
             },
             reaperIntervalMillis,
             reaperIntervalMillis,
@@ -582,6 +585,9 @@ class ServeSessionRegistry(
           // Under the lock, BEFORE the detach: this and `entry.host = null` are one transition,
           // so no reader can catch the session detached with its snapshot not yet published.
           snapshots?.let { runCatching { it.capture(id, host) } }
+          if (optimizerUnfinished(entry.state)) {
+            runCatching { entry.state?.backgroundWork?.recordOptimizerHostSuspended() }
+          }
           entry.host = null
           entry.startedAt = null
           entry.closing = true
@@ -624,6 +630,67 @@ class ServeSessionRegistry(
       if (closed) emptyList() else sessions.values.mapNotNull { it.host }
     }
     return hosts.sumOf { host -> runCatching { host.releaseIdleDaemons(window) }.getOrDefault(0) }
+  }
+
+  /**
+   * Bring back the parked catalog that has waited longest, while a lane is free to give it.
+   *
+   * The counterpart to letting an unfinished optimizer be suspended at all. Its progress survives —
+   * a catalog's rendered PNGs live in [ServeSessionState.catalogThemeCache], which outlives the
+   * host — but nothing would *restart* the pass: re-entry rides on [ServeHost.keepLiveWarm], which
+   * a visitor's presence heartbeat drives, so on a box nobody is browsing the parked catalogs would
+   * simply stop. This is the heartbeat they would otherwise never get.
+   *
+   * Bounded by [ServeBackgroundWork.optimizerLanesFree] because resuming is not free: it costs a
+   * cold Android daemon (34-68s) and holds roughly a gigabyte for as long as the host stays up.
+   * Resuming a catalog that then queues behind two others pays that price to stand at the door,
+   * which is exactly the residency suspension reclaims. One per sweep, longest-parked first, so the
+   * rotation is the same fair one admission uses.
+   *
+   * **Only on a quiet server.** A resume is background work like the renders it leads to, and a
+   * cold start landing while someone is browsing competes with them for the seat budget.
+   */
+  fun resumeIdleOptimizers(): Int {
+    val toWarm = lock.withLock {
+      if (closed) return 0
+      if (idleMillis() == null) return 0
+      val candidates =
+        sessions.values
+          .filter { it.host == null && !it.closing && optimizerUnfinished(it.state) }
+          .sortedBy { it.lastAccess }
+      val resumed = mutableListOf<ServeHost>()
+      var lanes = candidates.firstOrNull()?.state?.backgroundWork?.optimizerLanesFree() ?: 0
+      for (entry in candidates) {
+        if (lanes <= 0) break
+        val host = liveHost(entry) ?: continue
+        // The session's own idle clock, NOT `lastActivity`: that one is the whole-server quiet
+        // gate the optimizer reads, and stamping it here would have the resume report the server
+        // as busy and refuse the very turn it was resumed to take. This one only buys the host
+        // `idleTimeoutMillis` before [suspendIdle] looks at it again, which is the slice it needs
+        // to win a lane and render.
+        entry.lastAccess = clock()
+        runCatching { entry.state?.backgroundWork?.recordOptimizerHostResumed() }
+        resumed += host
+        lanes--
+      }
+      resumed
+    }
+    // Outside the lock: `keepLiveWarm` re-enters the optimization pass, and a pass that starts
+    // synchronously here would hold the registry lock across a daemon warm.
+    toWarm.forEach { runCatching { it.keepLiveWarm() } }
+    return toWarm.size
+  }
+
+  /**
+   * Whether this session is a catalog with theme-optimization targets left to fill.
+   *
+   * Read from [ServeSessionState] rather than from a host, because the whole point is to ask it of
+   * a session whose host is gone. A session with no cache, or one whose optimizer is switched off
+   * (no targets are ever configured, so `total` stays 0), is not a candidate.
+   */
+  private fun optimizerUnfinished(state: ServeSessionState?): Boolean {
+    val snapshot = state?.catalogThemeCache?.snapshot() ?: return false
+    return snapshot.total > 0 && !snapshot.fullyOptimized
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogLiveHostTest.kt
@@ -1259,7 +1259,10 @@ class ServeCatalogLiveHostTest {
     Thread.sleep(50)
     assertEquals(0, firstLive.renderCalls)
     assertEquals("paused", first.themeOptimizationSnapshot()?.state)
-    assertTrue(first.backgroundWorkActive)
+    // Parked at the gate, holding no lane — and therefore NOT keeping its host resident. The
+    // catalog's progress is in the shared cache, not in the daemon, which is what lets the registry
+    // reclaim the daemon's memory while the pass waits.
+    assertFalse(first.backgroundWorkActive, "a parked pass does not pin its daemon")
     idle.set(true)
     awaitOptimization(first)
     first.close()
@@ -1370,10 +1373,10 @@ class ServeCatalogLiveHostTest {
       )
 
     composite.prewarm()
-    // The pass is at the quiet gate, which it now waits out holding NO lane — so what says it has
-    // started is its own worker being active, not an admission. (It used to be `running == 1`;
-    // that assertion was reading the bug where a gated pass sat on a lane the whole time.)
-    awaitOk(5_000) { composite.backgroundWorkActive.takeIf { it } }
+    // The pass is at the quiet gate, which it waits out holding NO lane — and, since residency
+    // follows the lane, not keeping its host resident either. So what says it has started is the
+    // gate wait it is accruing, not an admission and not `backgroundWorkActive`.
+    awaitOk(5_000) { composite.themeOptimizationSnapshot()?.takeIf { it.gateWaitMillis > 0 } }
     assertEquals(
       0,
       backgroundWork.optimizerAdmissionSnapshot().running,
@@ -1829,7 +1832,9 @@ class ServeCatalogLiveHostTest {
     // turn, however long it waits.
     val blocked = host { null }
     blocked.prewarm()
-    awaitOk(5_000) { blocked.backgroundWorkActive.takeIf { it } }
+    // The accruing gate wait, not `backgroundWorkActive`: a pass that holds no lane holds no
+    // residency either, so the flag stays false for exactly as long as this test cares about.
+    awaitOk(5_000) { blocked.themeOptimizationSnapshot()?.takeIf { it.gateWaitMillis > 0 } }
 
     repeat(5) {
       assertEquals(
@@ -1930,9 +1935,60 @@ class ServeCatalogLiveHostTest {
     composite.close()
   }
 
+  /**
+   * The residency rule this whole memory fix rests on.
+   *
+   * `backgroundWorkActive` is what [ServeSessionRegistry.suspendIdle] reads as "this host must stay
+   * resident", and the pass worker does not end while a catalog has targets left — it loops through
+   * the quiet gate forever. Setting the flag for the worker's life therefore meant "not fully
+   * optimized" implied "daemon can never be released", and on the public box nine catalogs held a
+   * ~1.2 GB Android daemon each with no traffic, which is the memory reading the pressure gate then
+   * refused to admit work against.
+   */
+  @Test
+  fun `optimizer residency follows the lane, not the backlog`() {
+    val backgroundWork = ServeBackgroundWork(maxConcurrentOptimizers = 1)
+    val idle = AtomicBoolean()
+    val composite =
+      ServeCatalogLiveHost(
+        alias = mapOf(catalogId to daemonId),
+        live =
+          RecordingHost(
+            previews = listOf(ServePreview(daemonId, daemonId)),
+            tag = "live",
+            declaredThemes = listOf(brandTheme),
+          ),
+        baked = RecordingHost(listOf(ServePreview(catalogId, catalogId)), "baked"),
+        serverIdleMillis = { if (idle.get()) Long.MAX_VALUE else null },
+        themeOptimizationEnabled = true,
+        themeOptimizationIdleMillis = 0,
+        optimizerGateCeilingMillis = 0,
+        backgroundWork = backgroundWork,
+      )
+
+    composite.prewarm()
+    // Targets left and a worker running, but parked at a gate that answers busy: nothing is held.
+    awaitOk(5_000) { composite.themeOptimizationSnapshot()?.takeIf { it.gateWaitMillis > 0 } }
+    assertFalse(
+      composite.backgroundWorkActive,
+      "a catalog with work left but no lane must not pin its daemon",
+    )
+    assertEquals(1, composite.themeOptimizationSnapshot()?.remaining)
+
+    // Let it in: now it is rendering on a lane, and the host has to stay put under it.
+    idle.set(true)
+    assertTrue(awaitOptimization(composite).fullyOptimized)
+    awaitPassIdle(composite)
+    assertFalse(composite.backgroundWorkActive, "and it is released again once the slice ends")
+    composite.close()
+  }
+
   private fun awaitPassIdle(host: ServeCatalogLiveHost) {
+    // The WORKER, not the residency flag. Since residency follows the lane, `backgroundWorkActive`
+    // is false while a worker is parked at the gate and before it takes its first slice — so
+    // reading it here returned the instant the pass was scheduled, ahead of any render.
     repeat(200) {
-      if (!host.backgroundWorkActive) return
+      if (!host.optimizationPassRunning) return
       Thread.sleep(25)
     }
     error("theme optimization pass did not settle: ${host.themeOptimizationSnapshot()}")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -458,6 +458,91 @@ class ServeSessionRegistryTest {
   }
 
   @Test
+  fun `an unfinished optimizer no longer pins its daemon and is resumed when a lane is free`() {
+    val clock = AtomicLong(0)
+    val work = ServeBackgroundWork(clock = clock::get)
+    val cache = CatalogThemeCache().apply { configureTargets(listOf("preview|dark")) }
+    val opener = Opener()
+    ServeSessionRegistry(
+        open = opener,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { registry ->
+        registry.register(
+          "catalog",
+          stateFor("catalog").copy(catalogThemeCache = cache, backgroundWork = work),
+          host = opener(stateFor("catalog")),
+        )
+        clock.set(200)
+        // The pass is parked, not holding a lane: `backgroundWorkActive` is false, so the daemon
+        // is reclaimable even though the catalog has targets left. This is the whole change — the
+        // flag used to stay set for the worker's life and the worker never ends.
+        assertEquals(1, registry.suspendIdle(), "a parked optimizer does not pin its daemon")
+        assertEquals(
+          1,
+          work.optimizerAdmissionSnapshot().hostSuspensions,
+          "the suspension is counted against the optimizer, not lost as an ordinary idle reap",
+        )
+
+        val openedBefore = opener.opened.get()
+        assertEquals(1, registry.resumeIdleOptimizers(), "an unfinished catalog is brought back")
+        assertEquals(openedBefore + 1, opener.opened.get(), "the host was actually reopened")
+        assertEquals(1, work.optimizerAdmissionSnapshot().hostResumes)
+
+        // Resuming stamps the session's own idle clock, not the whole-server one the quiet gate
+        // reads: a resume that reported the box as busy would refuse the turn it exists to take.
+        assertNotNull(registry.idleMillis(), "the resume did not make the server look busy")
+        assertEquals(0, registry.suspendIdle(), "the resumed host gets its idle window to work in")
+      }
+  }
+
+  @Test
+  fun `a fully optimized or lane-starved catalog is not resumed`() {
+    val clock = AtomicLong(0)
+    val work = ServeBackgroundWork(clock = clock::get)
+    val unfinished = CatalogThemeCache().apply { configureTargets(listOf("preview|dark")) }
+    val finished =
+      CatalogThemeCache().apply {
+        configureTargets(listOf("preview|dark"))
+        put("preview|dark", ByteArray(4))
+      }
+    val opener = Opener()
+    ServeSessionRegistry(
+        open = opener,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { registry ->
+        registry.register(
+          "done",
+          stateFor("done").copy(catalogThemeCache = finished, backgroundWork = work),
+          host = opener(stateFor("done")),
+        )
+        registry.register(
+          "todo",
+          stateFor("todo").copy(catalogThemeCache = unfinished, backgroundWork = work),
+          host = opener(stateFor("todo")),
+        )
+        clock.set(200)
+        assertEquals(2, registry.suspendIdle())
+
+        // No lane to give: resuming here would pay a cold daemon to stand at the door, which is
+        // the residency the suspension just reclaimed.
+        work.pauseOptimizers(10_000, "test")
+        assertEquals(0, work.optimizerLanesFree())
+        assertEquals(0, registry.resumeIdleOptimizers(), "no lane free, so nothing is resumed")
+
+        work.resumeOptimizers()
+        val openedBefore = opener.opened.get()
+        assertEquals(1, registry.resumeIdleOptimizers(), "only the unfinished catalog comes back")
+        assertEquals(openedBefore + 1, opener.opened.get())
+      }
+  }
+
+  @Test
   fun `a leased session is not suspended until the lease closes`() {
     val clock = AtomicLong(0)
     ServeSessionRegistry(

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -903,6 +903,29 @@ When enabled, it yields twice over — both learned from `preview.coo.ee`:
   scheduler eventually warmed one non-reapable primary per catalog: the public box reached 17
   resident daemons with no traffic, and that idle RAM kept the pressure gate closed against the
   optimizer that created it.
+- **A catalog is resident for its lane, not for its backlog.** The pass worker does not end while a
+  catalog has targets left — it loops through the quiet gate, takes a slice, re-queues — and the
+  registry refuses to suspend a host whose `backgroundWorkActive` is set. Setting that flag for the
+  worker's whole life therefore made "this catalog is not fully optimized" mean "this catalog's
+  daemon can never be released": the public box carried nine such residents at zero active streams,
+  `MemAvailable` pinned at 14-21%, and the pressure gate consequently holding — so the only progress
+  left was the starvation cap's five-minute concessions (50 of them across a 40-hour uptime,
+  1,502 of 18,604 entries, i.e. roughly a **ten-day** finish). The optimizer's own residency was
+  what stopped the optimizer running. The flag now covers only the slice a pass actually holds a
+  lane for. A parked catalog is suspendable, loses its daemon on the ordinary idle sweep, and its
+  progress is unaffected — the rendered PNGs live in `ServeSessionState.catalogThemeCache`, which
+  is retained across suspend/resume precisely so they survive it.
+- **Parked catalogs are resumed by the reaper, not by a visitor.** Re-entering a pass rides on
+  `keepLiveWarm()`, which a presence heartbeat drives, so suspending an unfinished catalog on a box
+  nobody is browsing would simply stop it. `ServeSessionRegistry.resumeIdleOptimizers()` runs after
+  each suspend/reap sweep and brings back the longest-parked unfinished catalog — only while the
+  server is quiet, and only as many as `ServeBackgroundWork.optimizerLanesFree()` says can take a
+  lane now. Resuming costs a cold Android daemon (34-68s) and about a gigabyte for as long as the
+  host stays up, so resuming a catalog that would then queue behind two others pays that price to
+  stand at the door. `themeOptimizer.hostSuspensions` / `hostResumes` on `/status.json` report the
+  two sides: suspensions stuck at 0 with more unfinished catalogs than `lanes` means the residency
+  rule is not firing, and resumes far outrunning `admissions` means catalogs are paying cold starts
+  to queue rather than to render.
 
 **When it isn't running, `/status` says which gate is holding it.** A pass must clear a quiet gate
 before it starts: the whole server has to have been untouched for


### PR DESCRIPTION
## The measurement

From `https://preview.coo.ee/status.json`, 40 hours into the current uptime:

| reading | value |
| --- | --- |
| theme-optimization entries | **1,502 of 18,604** cached |
| `themeOptimizer.pressure.dutyCycles` | **50** |
| `themeOptimizer.pressure.memoryAvailableFraction` | **0.2116** |
| `themeOptimizer.admissions` / `refusals` | 282 / 1,563 |
| `daemons.running` with `activeStreams: 0` | 14, nine of them up the full 1d 16h |

50 duty cycles across 40 hours is one `dutyCycleMillis` (5 min) concession per ~48 min — roughly a **10% duty ratio**, and the gate's own starvation backstop rather than an open gate. At that rate the remaining 17,102 entries finish in about **ten days**, not 24 hours. Meanwhile a single admitted lane measures **138 entries/min** on `m3-catalog`: the box is not render-bound, it is admission-bound, and admission is bound by a memory reading pinned on the `0.15` stop side.

## The memory the gate was reading was the optimizer's own

`ServeCatalogLiveHost`'s pass worker does not end while its catalog has targets left — it loops through the quiet gate, takes a slice, re-queues. `optimizationActive` was set for that worker's whole life, and `backgroundWorkActive` is exactly what `ServeSessionRegistry.suspendIdle` reads as "this host must stay resident".

So the flag meant *"this catalog is not fully optimized"* and was being used as *"this catalog's daemon may never be released"*. Every catalog the fair scheduler had ever visited kept a resident Android daemon — priced at ~1.2 GB in the seat budget — for the life of the process, with no streams and no traffic. Nine of them on the deployed box. That residency is what held `MemAvailable` at 14–21%, which is what held the pressure gate, which is what stopped the optimizer running. The optimizer's own residency was the thing preventing the optimizer from finishing.

#4498 had already stopped background slices from *warming* a cold primary; it could not reclaim the primaries that foreground traffic or an earlier pass had already started, because nothing was allowed to suspend those hosts.

## The change

**Residency follows the lane, not the backlog.** `optimizationActive` is now set inside the `withOptimizerSlot` block and cleared on the way out. A pass parked at the quiet gate or queued for a lane holds nothing and is suspendable, so its daemon goes on the ordinary idle sweep. No progress is lost: a catalog's rendered PNGs live in `ServeSessionState.catalogThemeCache`, which is retained across suspend/resume precisely so they survive it.

**Parked catalogs are resumed by the reaper, not by a visitor.** Re-entering a pass rides on `keepLiveWarm()`, which a presence heartbeat drives — so suspending an unfinished catalog on a box nobody is browsing would have stopped it for good. `ServeSessionRegistry.resumeIdleOptimizers()` runs after each suspend/reap sweep and brings back the longest-parked unfinished catalog, only while `idleMillis()` says the server is quiet — a cold start landing on a browsing visitor competes with them for the seat budget.

**The resume budget is the free lanes plus one challenger, and the rotation depends on the plus one.** Bounding it at the *free* lanes alone starves every catalog that is not already resident: a pass returns its lane on a slice boundary and re-queues immediately, so every sweep after the first reads zero free lanes and the parked catalogs wait for an incumbent to **finish** — hours for the 10,440-target `m3-catalog`, and in practice never. Admission's fairness (`acquireOptimizerLane`) already orders catalogs by who has gone longest without a lane, but it only ever ordered catalogs *at the door*, and a parked catalog is not standing there. `optimizerResumeSlots()` keeps exactly one challenger queued: it wins the next lane release ahead of the incumbent that just ran, and that incumbent is then suspended in its turn. The rotation period becomes the idle window rather than a catalog's whole backlog, at the cost of one extra resident daemon. (Caught by the Codex review bot on this PR; fixed in 50bc89dc.)

Candidates are ordered by a new `Entry.suspendedAt`, **not** by `lastAccess` — a catalog parked by the very sweep that then resumes has the oldest `lastAccess` on the box, so ordering on that would resurrect whatever had just been parked and leave the long-parked ones untouched. The resume stamps the session's own `lastAccess`, deliberately not the whole-server `lastActivity` the quiet gate reads: a resume that reported the box as busy would refuse the very turn it exists to take.

**It is measurable.** `themeOptimizer.hostSuspensions` / `hostResumes` on `/status.json`, and appended to the status page's **Theme optimiser gate** row as `N parked / M resumed`. Suspensions stuck at 0 on a box with more unfinished catalogs than `lanes` means the residency rule is not firing; resumes far outrunning `admissions` means catalogs are paying cold starts to queue rather than to render. Both are the reads that were missing while every unfinished catalog stayed resident — `running`/`waiting` describe passes, and a parked pass looks free there while its daemon holds a gigabyte.

## Does this reach 24 hours?

Returning ~7 idle Android daemons to the host moves `MemAvailable` clear of the `0.25` resume threshold, so the memory signal stops re-tripping the `0.15` stop side and the gate stops duty-cycling. That takes admission from ~10% duty to the ordinary idle-gate regime. At two lanes and the 138 entries/min already measured in-lane, the 17,102 remaining entries are a few hours of admitted time — inside 24 hours with substantial slack for yielding to traffic. **This is a projection from the deployed readings, not a measurement**: the effect on the real box can only be confirmed from `/status.json` after the roll, and the two new counters are there to confirm it.

One honest cost: a catalog that is suspended and later resumed pays a cold Android start it would not have paid while pinned. The slice is 5 min (`DEFAULT_OPTIMIZER_SLICE_MILLIS`) against a 10-min session idle window and a 10-min reaper interval, so a catalog that re-wins a lane promptly is usually still resident and pays nothing; the tax falls on the tail of the rotation, which is the half that was making no progress at all.

## Test plan

- `ServeSessionRegistryTest`
  - *an unfinished optimizer no longer pins its daemon and is resumed when a lane is free* — a parked pass suspends, is counted as an optimizer suspension, is reopened by `resumeIdleOptimizers()`, and the resume leaves `idleMillis()` non-null so the quiet gate is not lied to.
  - *parked catalogs rotate rather than waiting for an incumbent to finish* — one lane, three unfinished catalogs: the lane holder and a challenger come back, and the third is reached on the next sweep rather than the pair that just ran being resurrected ahead of it.
  - *a fully optimized or lane-starved catalog is not resumed* — a completed catalog is never a candidate, and with no slot free nothing is resumed at all.
- `ServeCatalogLiveHostTest`
  - *optimizer residency follows the lane, not the backlog* — a catalog with targets left but no lane reports `backgroundWorkActive == false`; it goes true on the slice and false again when the slice ends.
  - Three existing assertions were reading the old contract (a gated pass reported as active) and now assert the new one, keying "the pass has started" off the gate wait it accrues. `awaitPassIdle` now waits on the pass *worker* (`optimizationPassRunning`) rather than the residency flag, which since this change goes false between slices.
- `./gradlew :cli:test` — full module suite green.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`.

Not visually verified: this change has no rendered surface — it is background-work admission and daemon residency.