### PR TITLE
chore: force the next release to 1.36.0 via release-as (TEMPORARY — must be reverted after release)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "packages": {
     ".": {
       "package-name": "compose-ai-tools",
+      "release-as": "1.36.0",
       "include-component-in-tag": false,
       "draft": true,
       "extra-files": [


### PR DESCRIPTION
> [!WARNING]
> **This key is sticky and must be deleted in the first PR after v1.36.0 publishes.**
> Left in place, every later release PR re-proposes 1.36.0, the tag already exists, and the release wedges. `docs/RELEASING.md` records this having bitten the repo twice — once via a `1.0.0` pin, once via a `0.7.0` override that outlived its release.

One line:

```json
".": {
  "package-name": "compose-ai-tools",
  "release-as": "1.36.0",
```

## Why not the `Release-As:` footer that RELEASING.md recommends

Because it cannot reach `main` in this repo. That took two merged no-ops to establish, and both are worth recording so nobody retries them:

| PR | Where the trailer went | Result |
| --- | --- | --- |
| #4532 | PR **body** | Ruleset allows only `squash`, and the repo sets `squash_merge_commit_message: BLANK`, so the body is discarded. Commit `0a073692` landed with an empty body. |
| #4533 | Commit **message** | That commit had **no file changes**. Squashing an empty diff produces no commit — GitHub recorded #4533's `merge_commit_sha` as the pre-existing `0a073692`, and `main` was unchanged. |

Both PRs merged cleanly and changed nothing, which is the worst failure mode: green, closed, no effect. Enabling rebase merges would not have rescued #4533 either — git drops empty commits by default.

A config key is the only mechanism whose effect survives, because it lives in **file content** rather than in a commit message, and file content is exactly what squash preserves.

## Why 1.36.0 and not 2.0.0

The pending major comes solely from `feat(parity)!: make the portable kernel the live scorer` (#4518). The `!` is the whole cause — `docs/RELEASING.md` calls this out as *"the single most likely way to cut an unintended major"*.

Its diff is confined to the parity scorer (`cli/serve-web/src/scorer/*`), its serve endpoints, and docs. There is no `BREAKING CHANGE:` footer, and nothing moves in the published Gradle plugin, CLI or library APIs. It rebaselines parity **scores** — worth announcing, and worth re-checking acceptances over — but that is not a break in the published surface.

## After merging

1. Wait for the `release-please` run; confirm #4500 re-titles itself to `chore(main): release 1.36.0`.
2. Merge #4500 and let v1.36.0 publish.
3. **Delete the `release-as` key.** I will open that PR automatically once the release publishes; if you get there first, it is a one-line revert of this commit.

## Follow-ups this exposed

Two docs are actively misleading and cost this round-trip:

- `CLAUDE.md` says PRs are "squash-merged from the **PR title + PR body**". The body is discarded (`squash_merge_commit_message: BLANK`). As a side effect its instruction to scrub `Co-authored-by:` from PR *descriptions* is moot — a description cannot reach `main` at all.
- `docs/RELEASING.md` recommends the `Release-As:` footer as the preferred mechanism, which this repo's squash-only ruleset makes unreachable. It should recommend the config key plus a mandatory cleanup PR, and say why.

Happy to fix both in a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_