### PR TITLE
fix(daemon): seed a held Android session's knobs from the spec it was given

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/HeldNamedOverrides.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/HeldNamedOverrides.kt
@@ -1,0 +1,66 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+
+/**
+ * Wire codec for the `previewOverride*` knob seeds a held (interactive / live) Android session
+ * carries across the Robolectric sandbox boundary — `PreviewOverrides.namedOverrides` in, the same
+ * map out, with only `java.lang.String`s in between.
+ *
+ * **Why strings.** The bridge command
+ * ([ee.schimke.composeai.daemon.bridge.InteractiveCommand.Start]) may reference only `java.*` types
+ * (see `DaemonHostBridge`'s file KDoc), and [PreviewOverrideValue] is in the instrumented
+ * `ee.schimke.composeai` namespace: the sandbox re-loads it, so a host-side instance that did cross
+ * would not satisfy the sandbox controller's `as? IntValue` reads. [encode] runs host-side,
+ * [decode] runs inside the sandbox, and the values the controller compares against are minted by
+ * the classloader that reads them.
+ *
+ * The encoding is the same `<kind>:<raw>` shape the rest of the stack already speaks — the wire
+ * spellings are [PreviewOverrideValue]'s own `@SerialName`s (`string` / `int` / `float` / `bool` /
+ * `color`), and the raw half is the value's `toString`-equivalent text. A value whose raw half no
+ * longer parses to its kind is dropped rather than guessed, which leaves the author default in
+ * place — the same answer the type-strict host gives a mismatched seed.
+ */
+internal object HeldNamedOverrides {
+
+  /** Host-side: `seedKey → "<kind>:<raw>"`, ready to ride `InteractiveCommand.Start`. */
+  fun encode(seeds: Map<String, PreviewOverrideValue>?): Map<String, String> {
+    if (seeds.isNullOrEmpty()) return emptyMap()
+    val out = LinkedHashMap<String, String>(seeds.size)
+    for ((key, value) in seeds) {
+      out[key] =
+        when (value) {
+          is PreviewOverrideValue.StringValue -> "string:${value.value}"
+          is PreviewOverrideValue.IntValue -> "int:${value.value}"
+          is PreviewOverrideValue.FloatValue -> "float:${value.value}"
+          is PreviewOverrideValue.BooleanValue -> "bool:${value.value}"
+          is PreviewOverrideValue.ColorValue -> "color:${value.argb}"
+        }
+    }
+    return out
+  }
+
+  /** Sandbox-side: back to the typed bag the `previewOverride*` reads resolve against. */
+  fun decode(encoded: Map<String, String>?): Map<String, PreviewOverrideValue>? {
+    if (encoded.isNullOrEmpty()) return null
+    val out = LinkedHashMap<String, PreviewOverrideValue>(encoded.size)
+    for ((key, wire) in encoded) {
+      val separator = wire.indexOf(':')
+      if (separator <= 0) continue
+      val raw = wire.substring(separator + 1)
+      val value =
+        when (wire.substring(0, separator)) {
+          // An empty string is a real value here (a cleared label, a variant seeded to ""), which
+          // is why only the non-string kinds parse-or-drop.
+          "string" -> PreviewOverrideValue.StringValue(raw)
+          "int" -> raw.toIntOrNull()?.let { PreviewOverrideValue.IntValue(it) }
+          "float" -> raw.toFloatOrNull()?.let { PreviewOverrideValue.FloatValue(it) }
+          "bool" -> PreviewOverrideValue.BooleanValue(raw.equals("true", ignoreCase = true))
+          "color" -> PreviewOverrideValue.ColorValue(raw)
+          else -> null
+        } ?: continue
+      out[key] = value
+    }
+    return out.ifEmpty { null }
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1663,6 +1663,12 @@ open class RobolectricHost(
         // get threaded across the sandbox boundary (see the field's doc on
         // `InteractiveCommand.Start`).
         touchOverlay = spec.overrides?.touchOverlay,
+        // …and the author-declared knob seeds, encoded as strings for the same boundary reason
+        // (see `InteractiveCommand.Start.namedOverrides`). `applyOverrides` has already layered the
+        // live bag over the preview's own `@OverrideVariant` seed, so this is the value the held
+        // composition must read — without it every knob composed at its author default and a
+        // seeded variant drew its base state in Live (yschimke/wear-m3-catalog#83).
+        namedOverrides = HeldNamedOverrides.encode(spec.overrides?.namedOverrides),
         // Preview flavour — lets the held-rule loop route tile / notification / Glance previews
         // through their non-composable strategies instead of `getDeclaredComposableMethod`, which
         // those previews never satisfy. Without it the start reply errors and live mode blanks the
@@ -3096,9 +3102,19 @@ open class RobolectricHost(
                         // `ldrtl`), so a live session browsed at `?localeTag=ar-XB` mirrored but
                         // showed plain, un-pseudolocalised strings (#4371). `withPseudolocaleFrom`
                         // ignores every real locale, which the qualifier path already serves.
+                        //
+                        // `namedOverrides` joins them for the plain-Compose knob planner, decoded
+                        // here so the values are the sandbox classloader's own — a host-side
+                        // `PreviewOverrideValue` would fail the controller's typed reads even if it
+                        // crossed. Omitting it planned every held composition with an empty seed,
+                        // so an `@OverrideVariant` cell browsed in Live drew its base state and a
+                        // knob edited in the viewer did nothing (yschimke/wear-m3-catalog#83).
                         val syntheticOverrides =
                           ee.schimke.composeai.daemon.protocol
-                            .PreviewOverrides(touchOverlay = start.touchOverlay)
+                            .PreviewOverrides(
+                              touchOverlay = start.touchOverlay,
+                              namedOverrides = HeldNamedOverrides.decode(start.namedOverrides),
+                            )
                             .withPseudolocaleFrom(start.localeTag)
                         ComposeDataExtensionPipeline.Apply(
                           extensions = engine.previewOverrideExtensions.plan(syntheticOverrides),

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -485,6 +485,25 @@ sealed interface InteractiveCommand {
      * restores the old reflect-the-class behaviour.
      */
     val previewId: String? = null,
+    /**
+     * `spec.overrides.namedOverrides` — the author-declared `previewOverride*` knob seeds — encoded
+     * as `seedKey → "<kind>:<raw>"` strings (see `HeldNamedOverrides`). The held-rule loop decodes
+     * them back into the sandbox's own `PreviewOverrideValue` copies and plans
+     * `PreviewOverridesOverrideExtension` from them, so a live session composes the same values the
+     * one-shot render does.
+     *
+     * Threaded as plain strings rather than the typed bag for the same do-not-acquire bridge reason
+     * as [touchOverlay] and the other `spec.*` fields — and, here, for a second reason:
+     * `PreviewOverrideValue` is re-loaded inside the sandbox, so a host-side instance handed across
+     * would fail the controller's `as? IntValue` reads even if it crossed. Decoding sandbox-side
+     * mints the values from the classloader that reads them.
+     *
+     * Without this the held composition planned its extensions from a synthetic bag carrying only
+     * `touchOverlay` / `localeTag`, so **every** knob fell back to its author default the moment
+     * Live was enabled: an `@OverrideVariant` cell drew its base state
+     * (yschimke/wear-m3-catalog#83), and a knob edited in the viewer's Live lane did nothing.
+     */
+    val namedOverrides: Map<String, String> = emptyMap(),
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveNamedOverrideTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveNamedOverrideTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * A held (live) Android session must compose the `previewOverride*` seeds its spec carries.
+ *
+ * `applyOverrides` already layered the live bag over the preview's own `@OverrideVariant` seed onto
+ * `RenderSpec.overrides` (yschimke/wear-m3-catalog#33), but the held-rule `setContent` planned its
+ * extension chain from a **synthetic** bag carrying only `touchOverlay` / `localeTag` — so
+ * `PreviewOverridesOverrideExtension` was planned with no seed and every knob composed at its
+ * author default. Enabling Live on `buttongroup__ideal__three` drew the two-button base state
+ * instead of the variant's three (yschimke/wear-m3-catalog#83), and editing a knob in the viewer's
+ * Live lane did nothing at all.
+ *
+ * The seeds cross the sandbox boundary as strings ([HeldNamedOverrides]); this is the test that the
+ * whole path — encode, bridge, decode, plan, compose — actually lands on the pixels. It is the
+ * Android counterpart of `:daemon:desktop`'s `OverrideIntegrationTest`, which covers the same
+ * ground on a host with no sandbox to cross.
+ */
+class AndroidInteractiveNamedOverrideTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun seeded_knob_reaches_the_held_composition() {
+    val outputDir = tempFolder.newFolder("interactive-named-override-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = PREVIEW_ID,
+          classLoader = AndroidInteractiveNamedOverrideTest::class.java.classLoader!!,
+          overrides =
+            PreviewOverrides(
+              namedOverrides = mapOf("fill" to PreviewOverrideValue.ColorValue(SEEDED_FILL_HEX))
+            ),
+        )
+      try {
+        val frame = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("held render must produce a PNG path", frame.pngPath)
+        val img = decode(File(frame.pngPath!!))
+
+        val seeded = pixelMatchPct(img, expectedRgb = SEEDED_FILL_RGB)
+        val authorDefault = pixelMatchPct(img, expectedRgb = DEFAULT_FILL_RGB)
+        assertTrue(
+          "the held composition must fill with the SEEDED colour, not the author default — " +
+            "seeded ${"%.1f".format(seeded * 100)}%, default " +
+            "${"%.1f".format(authorDefault * 100)}%. A default-coloured frame means the seed " +
+            "never reached the sandbox's PreviewOverrideController (see HeldNamedOverrides).",
+          seeded > 0.9 && authorDefault < 0.01,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    when (previewId) {
+      PREVIEW_ID ->
+        RenderSpec(
+          previewId = PREVIEW_ID,
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "OverridableSquare",
+          widthPx = FRAME_PX,
+          heightPx = FRAME_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-named-override",
+        )
+      else -> null
+    }
+  }
+
+  private fun decode(file: File): java.awt.image.BufferedImage {
+    require(file.exists()) { "expected capture at ${file.absolutePath}" }
+    val bytes = file.readBytes()
+    require(bytes.isNotEmpty()) { "capture is empty: ${file.absolutePath}" }
+    return ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+      ?: error("ImageIO refused to decode capture: ${file.absolutePath}")
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int = 16,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        if (
+          abs(((rgb shr 16) and 0xFF) - expR) <= perChannelTolerance &&
+            abs(((rgb shr 8) and 0xFF) - expG) <= perChannelTolerance &&
+            abs((rgb and 0xFF) - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    return matches.toDouble() / (img.width.toLong() * img.height.toLong()).toDouble()
+  }
+
+  private companion object {
+    const val PREVIEW_ID = "android-named-override-interactive"
+    const val FRAME_PX = 64
+
+    /** `RedFixturePreviews.OverridableSquare`'s author default (`Color(0xFFEF5350)`). */
+    const val DEFAULT_FILL_RGB = 0xEF5350
+
+    const val SEEDED_FILL_HEX = "#FF2196F3"
+    const val SEEDED_FILL_RGB = 0x2196F3
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/HeldNamedOverridesTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/HeldNamedOverridesTest.kt
@@ -1,0 +1,74 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The string encoding [HeldNamedOverrides] uses to carry `previewOverride*` seeds across the
+ * Robolectric sandbox boundary for a held (live) session.
+ *
+ * The two halves run on opposite sides of that boundary and never see each other's types, so the
+ * only thing keeping them in agreement is this round trip. A kind that encodes to a spelling
+ * [HeldNamedOverrides.decode] doesn't know drops silently — and a dropped seed is invisible: the
+ * knob simply renders its author default, which is the very shape of yschimke/wear-m3-catalog#83.
+ */
+class HeldNamedOverridesTest {
+
+  @Test
+  fun `every value kind survives the round trip`() {
+    val seeds =
+      mapOf(
+        "label" to PreviewOverrideValue.StringValue("Tap me"),
+        "count" to PreviewOverrideValue.IntValue(3),
+        "weight" to PreviewOverrideValue.FloatValue(1.5f),
+        "split" to PreviewOverrideValue.BooleanValue(true),
+        "fill" to PreviewOverrideValue.ColorValue("#FF2196F3"),
+      )
+
+    assertEquals(seeds, HeldNamedOverrides.decode(HeldNamedOverrides.encode(seeds)))
+  }
+
+  @Test
+  fun `an indexed seed key crosses verbatim`() {
+    val seeds = mapOf("rowLabel[2]" to PreviewOverrideValue.StringValue("third"))
+
+    val encoded = HeldNamedOverrides.encode(seeds)
+    assertEquals(setOf("rowLabel[2]"), encoded.keys)
+    assertEquals(seeds, HeldNamedOverrides.decode(encoded))
+  }
+
+  @Test
+  fun `an empty string seed is a value, not a missing one`() {
+    // Clearing a label is an edit a viewer must be able to express, and an `@OverrideVariant` can
+    // seed one deliberately (`strings = ["label="]`).
+    val seeds = mapOf("label" to PreviewOverrideValue.StringValue(""))
+
+    assertEquals(seeds, HeldNamedOverrides.decode(HeldNamedOverrides.encode(seeds)))
+  }
+
+  @Test
+  fun `a string seed that looks like a typed one keeps its text`() {
+    val seeds = mapOf("label" to PreviewOverrideValue.StringValue("int:3"))
+
+    assertEquals(seeds, HeldNamedOverrides.decode(HeldNamedOverrides.encode(seeds)))
+  }
+
+  @Test
+  fun `no seeds is no bag, so the planner is not handed an empty map`() {
+    assertEquals(emptyMap<String, String>(), HeldNamedOverrides.encode(null))
+    assertEquals(emptyMap<String, String>(), HeldNamedOverrides.encode(emptyMap()))
+    assertNull(HeldNamedOverrides.decode(emptyMap()))
+    assertNull(HeldNamedOverrides.decode(null))
+  }
+
+  @Test
+  fun `a malformed wire value is dropped rather than guessed`() {
+    // The author default is the right answer for a seed that doesn't parse to its kind — the same
+    // one the type-strict host gives. Anything else invents pixels.
+    assertNull(HeldNamedOverrides.decode(mapOf("count" to "int:three")))
+    assertNull(HeldNamedOverrides.decode(mapOf("count" to "3")))
+    assertNull(HeldNamedOverrides.decode(mapOf("count" to "unknown:3")))
+  }
+}


### PR DESCRIPTION
Fixes the live-lane half of [yschimke/wear-m3-catalog#83](https://github.com/yschimke/wear-m3-catalog/issues/83): enabling **Live** on `buttongroup__ideal__three` streams the two-button base row, while the baked PNG for the same preview correctly shows three.

## What was wrong

The Android held/live lane (`RobolectricHost.runHeldInteractiveSession`) plans its extension chain from a **synthetic** overrides bag:

```kotlin
PreviewOverrides(touchOverlay = start.touchOverlay).withPseudolocaleFrom(start.localeTag)
```

`namedOverrides` is not in it, and `InteractiveCommand.Start` never carried it either — so `PreviewOverridesPreviewOverrideExtension` was planned with `seed = null`, `PreviewOverrideController.set(null)` ran, and **every** `previewOverride*` knob composed at its author default the moment Live was enabled. Two symptoms, one cause: an `@OverrideVariant` cell draws its base state, and a knob edited in the viewer's Live lane does nothing.

Everything upstream of that seam is correct and was verified against the published catalog and the live site: the export records `previewId = …ButtonRowGroup_VARIANT_three` with `current = 3`, the bundle sidecar and both `previews.json` carry the `INT:3` seed, the page's control opens on `data-knob-initial="3"`, and `?knob.count=4` re-renders four buttons through the ordinary render lane. #4272 (wear-m3-catalog#33) had already put the seed on `RenderSpec.overrides` via `applyOverrides` — it simply never crossed the sandbox boundary.

Desktop is unaffected: its held session composes through `RenderEngine.render`, which plans from `spec.overrides` directly.

## The fix

`InteractiveCommand.Start.namedOverrides` carries the seeds as `seedKey -> "<kind>:<raw>"` strings (`HeldNamedOverrides`), and the held-rule `setContent` decodes them into the synthetic bag. Strings for two reasons: the bridge package may reference only `java.*` types, and `PreviewOverrideValue` is re-loaded inside the sandbox — a host-side instance would fail the controller's `as? IntValue` reads even if it did cross. Decoding sandbox-side mints the values from the classloader that reads them.

## Test plan

`./gradlew :daemon:android:testDebugUnitTest --tests '*HeldNamedOverridesTest*' --tests '*AndroidInteractiveNamedOverrideTest*'` — **BUILD SUCCESSFUL**.

- `HeldNamedOverridesTest` — round-trips every value kind plus an indexed seed key, pins that an empty string is a value rather than a missing one, and that a malformed wire value is dropped (author default) rather than guessed. The two halves run on opposite sides of the boundary and never see each other's types, so this round trip is the only thing keeping them in agreement.
- `AndroidInteractiveNamedOverrideTest` — acquires a real held session on `OverridableSquare` with a seeded colour knob and asserts the streamed frame is the **seeded** colour (>90% of pixels) and not the author default (<1%). Pre-fix this is the failing case; it fails for exactly the reason the issue describes.

No visual surface changes here — this is daemon plumbing, and the pixels it fixes are the catalog's own (rendered evidence is on the sibling PR in wear-m3-catalog).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVgQFgrGfFXEQcaECtKmPv)_