### PR TITLE
chore: drop the sticky release-as key now that v1.36.0 has published

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,6 @@
   "packages": {
     ".": {
       "package-name": "compose-ai-tools",
-      "release-as": "1.36.0",
       "include-component-in-tag": false,
       "draft": true,
       "extra-files": [


### PR DESCRIPTION
The cleanup #4537 promised. One line removed, exactly the inverse of what `6a80699c` added.

```diff
       "package-name": "compose-ai-tools",
-      "release-as": "1.36.0",
       "include-component-in-tag": false,
```

## It did its job, and now it has to go

`release-as` is **not consumed by the release it forces**. Left in place, the next release PR proposes 1.36.0 again, the tag already exists, and the release wedges. `docs/RELEASING.md` records this having happened twice — once via a `1.0.0` pin, once via a `0.7.0` override that outlived its release. This PR is what stops it being a third.

Verified the override actually worked before removing it, rather than assuming:

| | |
| --- | --- |
| #4500 final title | `chore(main): release 1.36.0` (was `chore(main): release 2.0.0`) |
| merged | 2026-08-27T08:06:58Z |
| tag | `v1.36.0` present |
| release | `v1.36.0`, draft — same as `v1.35.0` / `v1.34.0`, i.e. the configured `"draft": true` |

`jq .` clean.

## Why it took three PRs to force one version

Recorded here because the mechanism `docs/RELEASING.md` recommends cannot work in this repo, and the two failures were both **silent** — merged, green, no effect:

| PR | Payload location | Outcome |
| --- | --- | --- |
| #4532 | PR body | Ruleset allows only `squash`; repo sets `squash_merge_commit_message: BLANK`, so the body is discarded. Commit `0a073692` landed with an empty body. |
| #4533 | Commit message, **empty commit** | Squashing an empty diff produces no commit at all — GitHub recorded `merge_commit_sha` as the pre-existing `0a073692`. Enabling rebase would not have helped: git drops empty commits by default. |
| #4537 | **File content** | Worked. Squash preserves the diff. |

The lesson is narrow and worth keeping: under `squash` + `BLANK`, the only thing that reliably reaches `main` is a **file change**. Anything carried in a commit message or PR description is discarded.

## Follow-ups this exposed

Both docs are actively misleading and cost three round-trips:

- **`CLAUDE.md`** says PRs are "squash-merged from the **PR title + PR body**". The body is discarded. Its instruction to scrub `Co-authored-by:` from PR *descriptions* is therefore moot — a description cannot reach `main`.
- **`docs/RELEASING.md`** recommends the `Release-As:` footer as the preferred mechanism, which this repo's squash-only ruleset makes unreachable. It should recommend the config key *plus a mandatory cleanup PR*, and say why the footer does not work here.

Happy to fix both in a follow-up if you want them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_