### PR TITLE
fix(serve): keep one challenger at the optimizer door so parked catalogs rotate

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -295,24 +295,37 @@ class ServeBackgroundWork(
   }
 
   /**
-   * Lanes nothing is holding right now — how many parked catalogs it is worth making resident
-   * again, and no more.
+   * How many parked catalogs it is worth making resident again — the lanes nothing is holding,
+   * **plus one challenger**.
    *
    * [ServeSessionRegistry.resumeIdleOptimizers] reads this because resuming costs a cold Android
-   * daemon (34-68s) and roughly a gigabyte for as long as it stays up. Resuming a catalog that then
-   * queues behind two others pays that price to sit at the door, which is the residency this whole
-   * change exists to stop paying.
+   * daemon (34-68s) and roughly a gigabyte for as long as it stays up, so it must not resume a
+   * catalog that would merely stand at the door. But bounding it at the *free* lanes alone starves
+   * every catalog that is not already resident: a pass returns its lane on a slice boundary and
+   * re-queues immediately (see `ServeCatalogLiveHost.startThemeOptimization`), so on a box with
+   * more unfinished catalogs than lanes every later sweep reads zero free lanes and the parked ones
+   * wait for an incumbent to *finish* — hours, for a 10,440-target catalog.
    *
-   * Advisory, deliberately unsynchronized: an admission landing in the same instant makes this one
-   * too high and the resumed pass simply queues, which is the ordinary case anyway.
+   * [PLUS_ONE_CHALLENGER] is what makes the rotation reach them. Admission's fairness
+   * ([acquireOptimizerLane]) orders catalogs **at the door** by who has gone longest without a
+   * lane, so a parked catalog wins its turn the moment it is standing there — but it has to be
+   * standing there. Keeping exactly one challenger queued hands it the next lane release ahead of
+   * the incumbent that just ran; the displaced incumbent then goes idle and is suspended in its
+   * turn. One extra resident buys a rotation whose period is the idle window rather than a
+   * catalog's whole backlog.
+   *
+   * Advisory, and deliberately tolerant of races: an admission landing in the same instant makes
+   * this read one too high and the resumed pass simply queues, which is what a challenger does
+   * anyway.
    */
-  fun optimizerLanesFree(): Int =
+  fun optimizerResumeSlots(): Int =
     if (optimizersPaused()) 0
     else
       admissionLock.run {
         lock()
         try {
-          (optimizerLanes - optimizerLanesInUse - optimizerQueue.size).coerceAtLeast(0)
+          (optimizerLanes + PLUS_ONE_CHALLENGER - optimizerLanesInUse - optimizerQueue.size)
+            .coerceAtLeast(0)
         } finally {
           unlock()
         }
@@ -464,6 +477,12 @@ class ServeBackgroundWork(
      * another's renders without recreating the free-for-all.
      */
     const val DEFAULT_MAX_CONCURRENT_OPTIMIZERS: Int = 2
+
+    /**
+     * The one queued challenger [optimizerResumeSlots] keeps beyond the lanes themselves, so a
+     * parked catalog can actually win a turn instead of waiting for an incumbent to finish.
+     */
+    const val PLUS_ONE_CHALLENGER: Int = 1
 
     const val HOST_COORDINATION_RETRY_MILLIS: Long = 100L
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistry.kt
@@ -121,6 +121,16 @@ class ServeSessionRegistry(
      * session momentarily runs two daemon subprocesses and overshoots the live-seat/memory budget.
      * Closing under the lock used to serialise this implicitly.
      */
+    /**
+     * When [suspendIdle] released this session's host, or null while it is resident.
+     *
+     * The rotation key for [resumeIdleOptimizers], and deliberately not [lastAccess]: a catalog
+     * suspended in the very sweep that then resumes is the one with the OLDEST `lastAccess`, so
+     * ordering on that resurrected whatever had just been parked and left the genuinely long-parked
+     * catalogs exactly where they were. Suspension order is least-recently-parked-first, which is
+     * the round-robin the fair admission rule already assumes.
+     */
+    @Volatile var suspendedAt: Long? = null,
     @Volatile var closing: Boolean = false,
   ) {
     /** Every open holder, of either kind — the residency question. */
@@ -590,6 +600,7 @@ class ServeSessionRegistry(
           }
           entry.host = null
           entry.startedAt = null
+          entry.suspendedAt = now
           entry.closing = true
           detached += Triple(id, entry, host)
         }
@@ -641,11 +652,17 @@ class ServeSessionRegistry(
    * a visitor's presence heartbeat drives, so on a box nobody is browsing the parked catalogs would
    * simply stop. This is the heartbeat they would otherwise never get.
    *
-   * Bounded by [ServeBackgroundWork.optimizerLanesFree] because resuming is not free: it costs a
+   * Bounded by [ServeBackgroundWork.optimizerResumeSlots] because resuming is not free: it costs a
    * cold Android daemon (34-68s) and holds roughly a gigabyte for as long as the host stays up.
-   * Resuming a catalog that then queues behind two others pays that price to stand at the door,
-   * which is exactly the residency suspension reclaims. One per sweep, longest-parked first, so the
-   * rotation is the same fair one admission uses.
+   * That budget is the free lanes **plus one challenger**: bounding it at the free lanes alone
+   * starves every catalog that is not already resident, because a pass re-queues the instant its
+   * slice ends, so every later sweep reads zero and the parked ones wait for an incumbent to
+   * *finish* — hours, for a 10,440-target catalog. The extra slot puts the longest-parked catalog
+   * at the door, where admission's own fairness hands it the next lane ahead of the incumbent that
+   * just ran, and the displaced incumbent is suspended in its turn.
+   *
+   * Longest-parked first by [Entry.suspendedAt] — not by `lastAccess`, which would resurrect
+   * whatever the same sweep had just suspended.
    *
    * **Only on a quiet server.** A resume is background work like the renders it leads to, and a
    * cold start landing while someone is browsing competes with them for the seat budget.
@@ -657,11 +674,15 @@ class ServeSessionRegistry(
       val candidates =
         sessions.values
           .filter { it.host == null && !it.closing && optimizerUnfinished(it.state) }
-          .sortedBy { it.lastAccess }
+          // Longest-parked first — see [Entry.suspendedAt] for why this is not `lastAccess`.
+          .sortedBy { it.suspendedAt ?: Long.MIN_VALUE }
       val resumed = mutableListOf<ServeHost>()
-      var lanes = candidates.firstOrNull()?.state?.backgroundWork?.optimizerLanesFree() ?: 0
+      // Read once, from any candidate: every catalog on a server shares the one process-wide
+      // [ServeBackgroundWork], and re-reading it per entry would let a resume this loop just made
+      // widen its own budget.
+      var slots = candidates.firstOrNull()?.state?.backgroundWork?.optimizerResumeSlots() ?: 0
       for (entry in candidates) {
-        if (lanes <= 0) break
+        if (slots <= 0) break
         val host = liveHost(entry) ?: continue
         // The session's own idle clock, NOT `lastActivity`: that one is the whole-server quiet
         // gate the optimizer reads, and stamping it here would have the resume report the server
@@ -669,9 +690,10 @@ class ServeSessionRegistry(
         // `idleTimeoutMillis` before [suspendIdle] looks at it again, which is the slice it needs
         // to win a lane and render.
         entry.lastAccess = clock()
+        entry.suspendedAt = null
         runCatching { entry.state?.backgroundWork?.recordOptimizerHostResumed() }
         resumed += host
-        lanes--
+        slots--
       }
       resumed
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSessionRegistryTest.kt
@@ -532,13 +532,69 @@ class ServeSessionRegistryTest {
         // No lane to give: resuming here would pay a cold daemon to stand at the door, which is
         // the residency the suspension just reclaimed.
         work.pauseOptimizers(10_000, "test")
-        assertEquals(0, work.optimizerLanesFree())
+        assertEquals(0, work.optimizerResumeSlots())
         assertEquals(0, registry.resumeIdleOptimizers(), "no lane free, so nothing is resumed")
 
         work.resumeOptimizers()
         val openedBefore = opener.opened.get()
         assertEquals(1, registry.resumeIdleOptimizers(), "only the unfinished catalog comes back")
         assertEquals(openedBefore + 1, opener.opened.get())
+      }
+  }
+
+  @Test
+  fun `parked catalogs rotate rather than waiting for an incumbent to finish`() {
+    val clock = AtomicLong(0)
+    // One lane, so without the challenger slot the single incumbent would hold it indefinitely: a
+    // pass re-queues the instant its slice ends, and `lanes - inUse - queued` then reads zero on
+    // every later sweep, leaving the parked catalogs to wait for someone to FINISH. That is the
+    // starvation the +1 exists to break.
+    val work = ServeBackgroundWork(maxConcurrentOptimizers = 1, clock = clock::get)
+    val reopened = java.util.Collections.synchronizedList(mutableListOf<String>())
+    val opener = Opener()
+    val recording: (ServeSessionState) -> ServeRenderHost? = { state ->
+      reopened += state.label
+      opener(state)
+    }
+    val ids = listOf("alpha", "beta", "gamma")
+    ServeSessionRegistry(
+        open = recording,
+        idleTimeoutMillis = 100,
+        reaperIntervalMillis = 0,
+        clock = clock::get,
+      )
+      .use { registry ->
+        ids.forEach { id ->
+          val cache = CatalogThemeCache().apply { configureTargets(listOf("$id|dark")) }
+          registry.register(
+            id,
+            stateFor(id).copy(catalogThemeCache = cache, backgroundWork = work),
+            host = opener(stateFor(id)),
+          )
+        }
+        clock.set(1_000)
+        assertEquals(3, registry.suspendIdle(), "all three park while none holds a lane")
+
+        // One lane and nothing queued: the budget is 1 + 1 = 2 — the lane, plus a challenger
+        // standing at the door so admission's fairness has someone to hand the next lane to.
+        assertEquals(2, work.optimizerResumeSlots())
+        reopened.clear()
+        assertEquals(2, registry.resumeIdleOptimizers(), "a lane holder AND a challenger come back")
+        val firstRound = reopened.toList()
+        assertEquals(2, firstRound.size)
+
+        // The third is not stranded. Park the two that just ran and sweep again: ordering is by
+        // suspension time, so the catalog that has been parked since the first sweep is taken
+        // first and the pair that just ran is NOT resurrected ahead of it.
+        clock.set(2_000)
+        assertEquals(2, registry.suspendIdle())
+        reopened.clear()
+        assertTrue(registry.resumeIdleOptimizers() > 0)
+        assertEquals(
+          ids.single { it !in firstRound },
+          reopened.first(),
+          "the rotation reaches the catalog that has waited longest, not the one just parked",
+        )
       }
   }
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -919,10 +919,21 @@ When enabled, it yields twice over — both learned from `preview.coo.ee`:
   `keepLiveWarm()`, which a presence heartbeat drives, so suspending an unfinished catalog on a box
   nobody is browsing would simply stop it. `ServeSessionRegistry.resumeIdleOptimizers()` runs after
   each suspend/reap sweep and brings back the longest-parked unfinished catalog — only while the
-  server is quiet, and only as many as `ServeBackgroundWork.optimizerLanesFree()` says can take a
-  lane now. Resuming costs a cold Android daemon (34-68s) and about a gigabyte for as long as the
-  host stays up, so resuming a catalog that would then queue behind two others pays that price to
-  stand at the door. `themeOptimizer.hostSuspensions` / `hostResumes` on `/status.json` report the
+  server is quiet, and only as many as `ServeBackgroundWork.optimizerResumeSlots()` allows, since
+  resuming costs a cold Android daemon (34-68s) and about a gigabyte for as long as the host stays
+  up.
+- **That budget is the free lanes plus one challenger, and the rotation depends on the plus one.**
+  Bounding resumption at the *free* lanes alone starves every catalog that is not already resident:
+  a pass returns its lane on a slice boundary and re-queues immediately, so every later sweep reads
+  zero free lanes and the parked catalogs wait for an incumbent to **finish** — hours, for the
+  10,440-target `m3-catalog`, and possibly never. Admission's fairness orders catalogs *at the
+  door* by who has gone longest without a lane, which only helps a catalog that is standing there,
+  so one challenger is kept queued: it wins the next lane release ahead of the incumbent that just
+  ran, and that incumbent is then suspended in its turn. The rotation period becomes the idle
+  window rather than a catalog's whole backlog, at the cost of one extra resident daemon.
+  Candidates are ordered by **when they were suspended**, not by `lastAccess` — a catalog parked by
+  the very sweep that then resumes has the oldest `lastAccess` of all, so ordering on that would
+  resurrect whatever had just been parked and leave the long-parked ones where they were. `themeOptimizer.hostSuspensions` / `hostResumes` on `/status.json` report the
   two sides: suspensions stuck at 0 with more unfinished catalogs than `lanes` means the residency
   rule is not firing, and resumes far outrunning `admissions` means catalogs are paying cold starts
   to queue rather than to render.


### PR DESCRIPTION
Follow-up to #4536, which auto-merged on its first commit before this fix reached the head. **`main` currently carries the starvation bug this corrects**, so this is worth landing promptly rather than batching.

## What is wrong on `main` right now

#4536 made a parked optimizer pass suspendable — its daemon is reclaimed while it waits — and added `ServeSessionRegistry.resumeIdleOptimizers()` to bring parked catalogs back. That resumer is bounded by the *free* optimizer lanes, and that bound does not work:

A pass returns its lane on a slice boundary and re-queues immediately (`ServeCatalogLiveHost.startThemeOptimization`). So `lanes - inUse - queued` reads **zero on every sweep after the first**, and a parked catalog waits not for an incumbent to *yield* but for one to **finish**. For the 10,440-target `m3-catalog` that is hours, and on a box that never fully drains, never. Whichever two catalogs happen to be resident when the others park keep both lanes indefinitely.

That is a regression against the pre-#4536 behaviour for the catalogs that need the time most: previously all nine unfinished catalogs stayed resident and rotated fairly (expensively, which is what #4536 fixed); now they rotate only if they win the initial draw.

Caught by the Codex review bot on #4536 ([thread](https://github.com/yschimke/compose-ai-tools/pull/4536#discussion_r3869768128)).

## The fix

**Free lanes plus one challenger** — `optimizerLanesFree()` becomes `optimizerResumeSlots()`, returning `lanes + PLUS_ONE_CHALLENGER - inUse - queued`.

Rather than forcing a handoff from the resume side, this lets the existing fairness rule do the work. `acquireOptimizerLane` already orders catalogs by who has gone longest without a lane — but it only ever ordered catalogs **at the door**, and a parked catalog is not standing there. Keeping exactly one queued challenger hands it the next lane release ahead of the incumbent that just ran; the displaced incumbent then goes idle and is suspended in its turn. The rotation period becomes the idle window rather than a catalog's whole backlog, at the cost of one extra resident daemon.

**A second bug in the same function**, which the review did not name: candidates were ordered by `lastAccess`. A catalog parked by the very sweep that then calls `resumeIdleOptimizers()` has the *oldest* `lastAccess` on the box — so it would be resurrected immediately while the genuinely long-parked catalogs stayed put, burning a cold Android start (34–68s) per cycle to make no progress. Ordering is now by a new `Entry.suspendedAt` stamp, cleared on resume: least-recently-parked first, which is the round-robin the fair admission rule already assumes.

## Test plan

- New `ServeSessionRegistryTest` › *parked catalogs rotate rather than waiting for an incumbent to finish* — one lane, three unfinished catalogs. Asserts the budget is `1 + 1 = 2`, that a lane holder **and** a challenger come back, and that the next sweep reaches the third catalog rather than resurrecting the pair that just ran. This test fails on `main` today.
- Existing *a fully optimized or lane-starved catalog is not resumed* updated for the renamed accessor; the paused-gate case still returns 0 slots.
- `./gradlew :cli:test` — full module suite green on this base.
- `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` — clean.

Not visually verified: no rendered surface — this is background-work admission and daemon residency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_