### PR TITLE
fix(ci): schedule the contract probe on the pseudolocale module's own sources

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -133,6 +133,7 @@
       "data/remotecompose/core/**",
       "data/theme/core/**",
       "data/render/core/**",
+      "data/pseudolocale/core/**",
       "mcp/**",
       "renderers/xr-client/**",
       "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"


### PR DESCRIPTION
`main` is red on **Actions Script Tests** since #4542, and this is the one line that fixes it.

## What broke

Three lists name the preview-server contracts, and #4542 updated two of them:

1. `contracts` in `preview-server/contract-probe/build.gradle.kts` — what the probe compiles against ✅
2. `CONTRACT_PROJECTS` in `scripts/check-preview-server-contracts.sh` — what gets published so the probe can resolve ✅
3. `groups.preview_server_contracts` in `.github/ci/ci-paths.json` — **what decides the job runs at all** ❌

`.github/ci/test_path_scope.py::test_every_contract_project_reaches_the_probe_job` exists precisely to catch that third omission, and it did — just after the merge rather than before it, because the earlier failure it reported was the *second* list and I fixed only that one:

```
AssertionError: Lists differ: [':data-pseudolocale-core (data/pseudolocale/core)'] != []
  contract project(s) whose sources do not schedule preview-server-contracts:
  :data-pseudolocale-core (data/pseudolocale/core)
```

The consequence beyond the red check: an edit to `data/pseudolocale/core` would not schedule the probe that now resolves it as a published artifact — the check that would notice a contract going unpublishable would be the check that never ran.

## Test plan

- `python3 .github/ci/test_path_scope.py` — 19 tests, green (was 1 failure).
- `python3 scripts/check-serve-seam.py` and `python3 scripts/test_check_serve_seam.py` — still green, unchanged by this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsmPLYypi1uq79yUPvcDwz)_