### PR TITLE
refactor(daemon-client): lift the daemon JSON-RPC client out of :mcp

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -125,6 +125,7 @@
       "preview-server/gradle.properties",
       "scripts/check-preview-server-contracts.sh",
       "daemon/core/**",
+      "daemon/client/**",
       "api/preview-data-api/**",
       "common/io/**",
       "render-session/**",
@@ -133,6 +134,7 @@
       "data/remotecompose/core/**",
       "data/theme/core/**",
       "data/render/core/**",
+      "data/pseudolocale/core/**",
       "mcp/**",
       "renderers/xr-client/**",
       "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -252,6 +252,9 @@ dependencies {
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.
   implementation(project(":mcp"))
+  // Used directly by `DaemonSmokeCheck` (the spawn port + subprocess factory). Available
+  // transitively through `:mcp`, but declared because this module compiles against it.
+  implementation(project(":daemon-client"))
   // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
   // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
   implementation(project(":daemon:core"))

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheck.kt
@@ -1,10 +1,10 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.SubprocessDaemonClientFactory
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.io.SystemFileSystem
-import ee.schimke.composeai.mcp.DaemonClientFactory
-import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
-import ee.schimke.composeai.mcp.WorkspaceId
 import java.io.File
 import okio.FileSystem
 import okio.Path.Companion.toPath

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheckTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonSmokeCheckTest.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.mcp.DaemonClient
-import ee.schimke.composeai.mcp.DaemonClientFactory
-import ee.schimke.composeai.mcp.DaemonSpawn
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.DaemonSpawn
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException

--- a/daemon/client/build.gradle.kts
+++ b/daemon/client/build.gradle.kts
@@ -1,0 +1,48 @@
+// JVM client for the preview daemon's JSON-RPC-over-stdio protocol.
+//
+// `DaemonClient` speaks the Content-Length-framed wire format from PROTOCOL.md; the
+// `DaemonClientFactory` port spawns a daemon and hands back a `DaemonSpawn` that owns it, with
+// `SubprocessDaemonClientFactory` as the production implementation (forks a JVM per launch
+// descriptor). Test doubles implement the same port over piped streams.
+//
+// This module exists because these types used to live in `:mcp`. Consuming the render-session
+// library therefore dragged an MCP server onto the classpath — the last leak the preview-server
+// contract probe recorded (#3824 preparation item 3). Nothing here knows about MCP: no tools, no
+// resources, no supervisor. `:mcp` now depends on this module rather than owning it.
+//
+// The package is `ee.schimke.composeai.daemon.client`, deliberately not the old
+// `ee.schimke.composeai.mcp`. Two published artifacts sharing one package is a split package, which
+// breaks JPMS and OSGi consumers and confuses everyone else. Per docs/API_STABILITY.md § 1 the
+// published surface of `:mcp` is its MCP tool names and input schemas — its Kotlin types are
+// internal and may move — so the rename needs no compatibility shim.
+
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+  // Protocol message types (`RenderNowParams`, `InitializeResult`, `PreviewOverrides`, …) and
+  // `DaemonLaunchDescriptor` are all over this module's public surface, so `api` rather than
+  // `implementation`: a consumer resolving from POM metadata must see them to compile.
+  api(project(":daemon:core"))
+  // `classpathArgFile` — writes the daemon's @argfile so the argv survives Windows length limits.
+  implementation(project(":common-io"))
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "daemon-client",
+    displayName = "Compose Preview — Daemon Client",
+    description =
+      "JVM client for the compose-preview daemon's JSON-RPC-over-stdio protocol: the wire client, " +
+        "the spawn port, and the subprocess implementation that forks a daemon JVM.",
+  )
+  inceptionYear.set("2026")
+}

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClient.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClient.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.daemon.client
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClientFactory.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClientFactory.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.daemon.client
+
+import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Pluggable spawn — production [SubprocessDaemonClientFactory] forks a JVM via [ProcessBuilder];
+ * tests inject an in-memory factory that wires the [DaemonClient] to a fake daemon over piped
+ * streams. The factory returns a [DaemonSpawn] that owns the underlying resource (subprocess or
+ * coroutine).
+ *
+ * [workspaceId] identifies which workspace the daemon serves; with
+ * [DaemonLaunchDescriptor.modulePath] it names the daemon in logs and keys test doubles. It is
+ * deliberately *not* `:mcp`'s `RegisteredProject`: that type carries the MCP supervisor's own
+ * registry (a mutable module list and a map of supervised daemons), and naming it here would put
+ * the supervision model in the signature of every consumer that only wants to start a daemon —
+ * including the render-session library, which built a throwaway one purely to satisfy this
+ * parameter. Spawning needs the identity, not the registry. Narrowing it is what made this module
+ * extractable at all (#4528).
+ */
+fun interface DaemonClientFactory {
+  fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn
+}
+
+/**
+ * Owns the resources behind a single live [DaemonClient]: the subprocess (in production) or the
+ * fake daemon side of a piped pair (in tests). The owner calls [client] once after spawn to wire
+ * the notification + close handlers.
+ */
+interface DaemonSpawn {
+  val client: DaemonClient
+
+  /**
+   * Wires the owner's notification + close handlers onto the underlying [client]. Called exactly
+   * once by `DaemonSupervisor.spawn` before any traffic flows. Implementations typically delay
+   * creating the [client] until this call so the handlers are baked in from the first frame.
+   */
+  fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient
+
+  fun shutdown()
+
+  /**
+   * Shuts down within [timeout] when the owner has a stricter lifecycle budget. Implementations
+   * that do not own a subprocess retain their ordinary shutdown behaviour.
+   */
+  fun shutdown(timeout: Duration) = shutdown()
+}

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonClientFactory.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonClientFactory.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.daemon.client
+
+import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.io.classpathArgFile
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Production [DaemonClientFactory]: forks a JVM per [DaemonLaunchDescriptor] and pipes its stdio
+ * into a [DaemonClient]. Mirrors `RealDesktopHarnessLauncher` from `:daemon:harness`.
+ */
+class SubprocessDaemonClientFactory : DaemonClientFactory {
+  override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+    require(descriptor.enabled) {
+      "daemon disabled for ${descriptor.modulePath} — set composePreview { daemon { enabled = true } }"
+    }
+    val javaBin =
+      descriptor.javaLauncher ?: File(System.getProperty("java.home"), "bin/java").absolutePath
+    val command =
+      buildList<String> {
+        // The optional OS jail (playground per-session sandbox). Empty for every ordinary daemon,
+        // so the launched argv is byte-identical to the pre-sandbox one.
+        addAll(descriptor.jailCommand)
+        add(javaBin)
+        addAll(descriptor.jvmArgs)
+        descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
+        // Inside a jail the parent's temp dir may not exist (bwrap mounts its own /tmp), so the
+        // argfile goes in the one directory both sides can see: the daemon's working directory.
+        add(
+          classpathArgFile(
+            descriptor.classpath,
+            File(descriptor.workingDirectory).takeIf { descriptor.jailCommand.isNotEmpty() },
+          )
+        )
+        add(descriptor.mainClass)
+      }
+    val process =
+      ProcessBuilder(command)
+        .directory(File(descriptor.workingDirectory))
+        .redirectErrorStream(false)
+        .redirectInput(ProcessBuilder.Redirect.PIPE)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    forwardStderr(process, "$workspaceId/${descriptor.modulePath}")
+    descriptor.hardTtlSeconds?.let { ttl ->
+      armHardTtl(process, ttl, "$workspaceId/${descriptor.modulePath}")
+    }
+    return SubprocessDaemonSpawn(process)
+  }
+
+  /**
+   * The hard wall-clock TTL: a daemon thread that force-kills the JVM at the deadline regardless of
+   * what it is doing. Cooperative shutdown is not enough for a sandboxed playground session — a
+   * snippet can spin a tight loop that never services a JSON-RPC `shutdown` — so the parent shoots
+   * it. A process that exits on its own first makes this a no-op.
+   */
+  private fun armHardTtl(process: Process, ttlSeconds: Long, tag: String) {
+    Thread(
+        {
+          if (!process.waitFor(ttlSeconds, TimeUnit.SECONDS)) {
+            System.err.println("[daemon $tag] hard TTL of ${ttlSeconds}s reached — killing sandbox")
+            process.destroyForcibly()
+          }
+        },
+        "daemon-hard-ttl-$tag",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
+  private fun forwardStderr(process: Process, tag: String) {
+    Thread(
+        {
+          process.errorStream.bufferedReader().useLines { lines ->
+            lines.forEach { System.err.println("[daemon $tag] $it") }
+          }
+        },
+        "daemon-stderr-$tag",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+}
+
+internal class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn {
+  private lateinit var _client: DaemonClient
+
+  override val client: DaemonClient
+    get() = _client
+
+  override fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient {
+    _client =
+      DaemonClient(
+        input = process.inputStream,
+        output = process.outputStream,
+        onNotification = onNotification,
+        onClose = onClose,
+      )
+    return _client
+  }
+
+  override fun shutdown() {
+    runCatching { _client.shutdownAndExit() }
+    if (!process.waitFor(15, TimeUnit.SECONDS)) {
+      process.destroy()
+      if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+    runCatching { _client.close() }
+  }
+
+  override fun shutdown(timeout: Duration) {
+    require(!timeout.isNegative()) { "shutdown timeout must not be negative" }
+    val deadlineNanos = System.nanoTime() + timeout.inWholeNanoseconds
+
+    runCatching { _client.shutdownAndExit(timeout) }
+    waitForUntil(deadlineNanos)
+
+    if (process.isAlive) {
+      process.destroy()
+      waitForUntil(deadlineNanos)
+      if (process.isAlive) process.destroyForcibly()
+    }
+    runCatching { _client.close() }
+  }
+
+  private fun waitForUntil(deadlineNanos: Long) {
+    if (!process.isAlive) return
+    val remainingMillis = (deadlineNanos - System.nanoTime()).coerceAtLeast(0L) / 1_000_000L
+    if (remainingMillis > 0L) process.waitFor(remainingMillis, TimeUnit.MILLISECONDS)
+  }
+}

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/WorkspaceId.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/WorkspaceId.kt
@@ -1,0 +1,43 @@
+package ee.schimke.composeai.daemon.client
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Stable id derived from a workspace's canonical absolute path. Two worktrees of the same repo
+ * (different paths, same `rootProject.name`) get distinct ids by construction — see
+ * docs/daemon/MCP.md and the chat thread leading up to this PR.
+ *
+ * Format: `<rootProjectName>-<8-char-hash>`. The hash is **always** present (not just on
+ * collisions) so the id encodes path identity unconditionally.
+ */
+data class WorkspaceId(val value: String) {
+  init {
+    require(value.isNotBlank()) { "WorkspaceId.value must not be blank" }
+    require(!value.contains('/')) { "WorkspaceId.value must not contain '/' (got '$value')" }
+  }
+
+  override fun toString(): String = value
+
+  companion object {
+    /**
+     * Builds a deterministic id from [rootProjectName] + the canonical absolute form of [path].
+     * Symlink aliases of the same physical path collapse to one id; distinct worktrees stay
+     * distinct.
+     */
+    fun derive(rootProjectName: String, path: File): WorkspaceId {
+      require(rootProjectName.isNotBlank()) { "rootProjectName must not be blank" }
+      val canonical = runCatching { path.canonicalFile }.getOrDefault(path.absoluteFile)
+      val hash = sha256Hex(canonical.absolutePath).take(SHORT_HASH_CHARS)
+      val sanitisedName = rootProjectName.replace(Regex("[^A-Za-z0-9_.-]"), "-")
+      return WorkspaceId("$sanitisedName-$hash")
+    }
+
+    private const val SHORT_HASH_CHARS = 8
+
+    private fun sha256Hex(s: String): String {
+      val bytes = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+      return bytes.joinToString("") { "%02x".format(it) }
+    }
+  }
+}

--- a/daemon/client/src/test/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonSpawnTest.kt
+++ b/daemon/client/src/test/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonSpawnTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.mcp
+package ee.schimke.composeai.daemon.client
 
 import com.google.common.truth.Truth.assertThat
 import java.io.ByteArrayInputStream

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -57,6 +57,10 @@ dependencies {
   // only and consumers resolving from POM metadata fail to compile against the MCP APIs.
   api(project(":daemon:core"))
   api(project(":render-session-api"))
+  // The daemon JSON-RPC client, lifted out of this module (#3824 item 3). `api` because it is on
+  // this module's public surface — `SupervisedDaemon.client` is a `DaemonClient`, and
+  // `DaemonSupervisor` takes a `DaemonClientFactory`.
+  api(project(":daemon-client"))
   // Semantics diff engine + payload model for the `diff_semantics` tool (issue #1785).
   implementation(project(":data-layoutinspector-core"))
 

--- a/mcp/scripts/README.md
+++ b/mcp/scripts/README.md
@@ -31,14 +31,16 @@ Asserts `before == revert` (byte-equal) and `before != after`.
 sed -i 's/"enabled": false/"enabled": true/' \
   samples/cmp/build/compose-previews/daemon-launch.json
 
-# 3. Build the mcp + daemon-core jars.
-./gradlew :mcp:jar :daemon:core:jar
+# 3. Build the mcp + daemon-core + daemon-client jars.
+./gradlew :mcp:jar :daemon:core:jar :daemon-client:jar
 
 # 4. Build a runtime classpath. Adjust paths to match your gradle cache layout.
 VERSION=$(grep -m1 -oP '"\.":\s*"\K[^"]+' .release-please-manifest.json)
 NEXT="${VERSION%.*}.$((${VERSION##*.} + 1))"
 CP="$(pwd)/mcp/build/libs/mcp-${NEXT}-SNAPSHOT.jar"
 CP="$CP:$(pwd)/daemon/core/build/libs/core-${NEXT}-SNAPSHOT.jar"
+# `DaemonMcpMain` constructs `SubprocessDaemonClientFactory`, which lives here since #3824 item 3.
+CP="$CP:$(pwd)/daemon/client/build/libs/daemon-client-${NEXT}-SNAPSHOT.jar"
 for jar in \
     "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.3.20/"*"/kotlin-stdlib-2.3.20.jar" \
     "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.10.2/"*"/kotlinx-coroutines-core-jvm-1.10.2.jar" \

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClientRenderSession.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClientRenderSession.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DataProductWireException
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -1,12 +1,8 @@
 package ee.schimke.composeai.mcp
 
-import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
-import ee.schimke.composeai.io.classpathArgFile
+import ee.schimke.composeai.daemon.client.SubprocessDaemonClientFactory
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Entry point for the standalone MCP server. Stdio transport in v0; remote / HTTP transports are a
@@ -164,134 +160,5 @@ object DaemonMcpMain {
       return DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON
     }
     return parsed
-  }
-}
-
-/**
- * Production [DaemonClientFactory]: forks a JVM per [DaemonLaunchDescriptor] and pipes its stdio
- * into a [DaemonClient]. Mirrors `RealDesktopHarnessLauncher` from `:daemon:harness`.
- */
-class SubprocessDaemonClientFactory : DaemonClientFactory {
-  override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
-    require(descriptor.enabled) {
-      "daemon disabled for ${descriptor.modulePath} — set composePreview { daemon { enabled = true } }"
-    }
-    val javaBin =
-      descriptor.javaLauncher ?: File(System.getProperty("java.home"), "bin/java").absolutePath
-    val command =
-      buildList<String> {
-        // The optional OS jail (playground per-session sandbox). Empty for every ordinary daemon,
-        // so the launched argv is byte-identical to the pre-sandbox one.
-        addAll(descriptor.jailCommand)
-        add(javaBin)
-        addAll(descriptor.jvmArgs)
-        descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
-        // Inside a jail the parent's temp dir may not exist (bwrap mounts its own /tmp), so the
-        // argfile goes in the one directory both sides can see: the daemon's working directory.
-        add(
-          classpathArgFile(
-            descriptor.classpath,
-            File(descriptor.workingDirectory).takeIf { descriptor.jailCommand.isNotEmpty() },
-          )
-        )
-        add(descriptor.mainClass)
-      }
-    val process =
-      ProcessBuilder(command)
-        .directory(File(descriptor.workingDirectory))
-        .redirectErrorStream(false)
-        .redirectInput(ProcessBuilder.Redirect.PIPE)
-        .redirectOutput(ProcessBuilder.Redirect.PIPE)
-        .redirectError(ProcessBuilder.Redirect.PIPE)
-        .start()
-    forwardStderr(process, "$workspaceId/${descriptor.modulePath}")
-    descriptor.hardTtlSeconds?.let { ttl ->
-      armHardTtl(process, ttl, "$workspaceId/${descriptor.modulePath}")
-    }
-    return SubprocessDaemonSpawn(process)
-  }
-
-  /**
-   * The hard wall-clock TTL: a daemon thread that force-kills the JVM at the deadline regardless of
-   * what it is doing. Cooperative shutdown is not enough for a sandboxed playground session — a
-   * snippet can spin a tight loop that never services a JSON-RPC `shutdown` — so the parent shoots
-   * it. A process that exits on its own first makes this a no-op.
-   */
-  private fun armHardTtl(process: Process, ttlSeconds: Long, tag: String) {
-    Thread(
-        {
-          if (!process.waitFor(ttlSeconds, TimeUnit.SECONDS)) {
-            System.err.println("[daemon $tag] hard TTL of ${ttlSeconds}s reached — killing sandbox")
-            process.destroyForcibly()
-          }
-        },
-        "daemon-hard-ttl-$tag",
-      )
-      .apply { isDaemon = true }
-      .start()
-  }
-
-  private fun forwardStderr(process: Process, tag: String) {
-    Thread(
-        {
-          process.errorStream.bufferedReader().useLines { lines ->
-            lines.forEach { System.err.println("[daemon $tag] $it") }
-          }
-        },
-        "mcp-daemon-stderr-$tag",
-      )
-      .apply { isDaemon = true }
-      .start()
-  }
-}
-
-internal class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn {
-  private lateinit var _client: DaemonClient
-
-  override val client: DaemonClient
-    get() = _client
-
-  override fun client(
-    onNotification: (method: String, params: JsonObject?) -> Unit,
-    onClose: () -> Unit,
-  ): DaemonClient {
-    _client =
-      DaemonClient(
-        input = process.inputStream,
-        output = process.outputStream,
-        onNotification = onNotification,
-        onClose = onClose,
-      )
-    return _client
-  }
-
-  override fun shutdown() {
-    runCatching { _client.shutdownAndExit() }
-    if (!process.waitFor(15, TimeUnit.SECONDS)) {
-      process.destroy()
-      if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
-    }
-    runCatching { _client.close() }
-  }
-
-  override fun shutdown(timeout: Duration) {
-    require(!timeout.isNegative()) { "shutdown timeout must not be negative" }
-    val deadlineNanos = System.nanoTime() + timeout.inWholeNanoseconds
-
-    runCatching { _client.shutdownAndExit(timeout) }
-    waitForUntil(deadlineNanos)
-
-    if (process.isAlive) {
-      process.destroy()
-      waitForUntil(deadlineNanos)
-      if (process.isAlive) process.destroyForcibly()
-    }
-    runCatching { _client.close() }
-  }
-
-  private fun waitForUntil(deadlineNanos: Long) {
-    if (!process.isAlive) return
-    val remainingMillis = (deadlineNanos - System.nanoTime()).coerceAtLeast(0L) / 1_000_000L
-    if (remainingMillis > 0L) process.waitFor(remainingMillis, TimeUnit.MILLISECONDS)
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.RecordingTestGenerator
+import ee.schimke.composeai.daemon.client.DataProductWireException
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.daemon.protocol.AmbientOverride
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -1,12 +1,15 @@
 package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.DaemonSpawn
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.daemon.protocol.BackendKind
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.time.Duration
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -681,51 +684,6 @@ fun interface DescriptorProvider {
       return index
     }
   }
-}
-
-/**
- * Pluggable spawn — production [SubprocessDaemonClientFactory] forks a JVM via [ProcessBuilder];
- * tests inject an in-memory factory that wires the [DaemonClient] to a fake daemon over piped
- * streams. The factory returns a [DaemonSpawn] that owns the underlying resource (subprocess or
- * coroutine).
- *
- * [workspaceId] identifies which workspace the daemon serves; with
- * [DaemonLaunchDescriptor.modulePath] it names the daemon in logs and keys test doubles. It is
- * deliberately *not* a [RegisteredProject]: that type carries the MCP supervisor's own registry
- * ([RegisteredProject.knownModules], [RegisteredProject.daemons]), and naming it here would put the
- * supervision model in the signature of every consumer that only wants to start a daemon —
- * including the render-session library, which built a throwaway [RegisteredProject] purely to
- * satisfy this parameter. Spawning needs the identity, not the registry.
- */
-fun interface DaemonClientFactory {
-  fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn
-}
-
-/**
- * Owns the resources behind a single live [DaemonClient]: the subprocess (in production) or the
- * fake daemon side of a piped pair (in tests). The supervisor calls [client] once after spawn to
- * wire the notification + close handlers.
- */
-interface DaemonSpawn {
-  val client: DaemonClient
-
-  /**
-   * Wires the supervisor's notification + close handlers onto the underlying [client]. Called
-   * exactly once by [DaemonSupervisor.spawn] before any traffic flows. Implementations typically
-   * delay creating the [client] until this call so the handlers are baked in from the first frame.
-   */
-  fun client(
-    onNotification: (method: String, params: JsonObject?) -> Unit,
-    onClose: () -> Unit,
-  ): DaemonClient
-
-  fun shutdown()
-
-  /**
-   * Shuts down within [timeout] when the owner has a stricter lifecycle budget. Implementations
-   * that do not own a subprocess retain their ordinary shutdown behaviour.
-   */
-  fun shutdown(timeout: Duration) = shutdown()
 }
 
 // -----------------------------------------------------------------------------

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
@@ -1,46 +1,6 @@
 package ee.schimke.composeai.mcp
 
-import java.io.File
-import java.security.MessageDigest
-
-/**
- * Stable id derived from a workspace's canonical absolute path. Two worktrees of the same repo
- * (different paths, same `rootProject.name`) get distinct ids by construction — see
- * docs/daemon/MCP.md and the chat thread leading up to this PR.
- *
- * Format: `<rootProjectName>-<8-char-hash>`. The hash is **always** present (not just on
- * collisions) so the id encodes path identity unconditionally.
- */
-data class WorkspaceId(val value: String) {
-  init {
-    require(value.isNotBlank()) { "WorkspaceId.value must not be blank" }
-    require(!value.contains('/')) { "WorkspaceId.value must not contain '/' (got '$value')" }
-  }
-
-  override fun toString(): String = value
-
-  companion object {
-    /**
-     * Builds a deterministic id from [rootProjectName] + the canonical absolute form of [path].
-     * Symlink aliases of the same physical path collapse to one id; distinct worktrees stay
-     * distinct.
-     */
-    fun derive(rootProjectName: String, path: File): WorkspaceId {
-      require(rootProjectName.isNotBlank()) { "rootProjectName must not be blank" }
-      val canonical = runCatching { path.canonicalFile }.getOrDefault(path.absoluteFile)
-      val hash = sha256Hex(canonical.absolutePath).take(SHORT_HASH_CHARS)
-      val sanitisedName = rootProjectName.replace(Regex("[^A-Za-z0-9_.-]"), "-")
-      return WorkspaceId("$sanitisedName-$hash")
-    }
-
-    private const val SHORT_HASH_CHARS = 8
-
-    private fun sha256Hex(s: String): String {
-      val bytes = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
-      return bytes.joinToString("") { "%02x".format(it) }
-    }
-  }
-}
+import ee.schimke.composeai.daemon.client.WorkspaceId
 
 /**
  * Parsed `compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>` URI. The three-segment

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpLiveCapabilityTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpLiveCapabilityTest.kt
@@ -6,6 +6,10 @@ import ee.schimke.composeai.daemon.JsonRpcServer
 import ee.schimke.composeai.daemon.RenderHost
 import ee.schimke.composeai.daemon.RenderRequest
 import ee.schimke.composeai.daemon.RenderResult
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.DaemonSpawn
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.daemon.protocol.BackendKind
 import java.io.File
 import java.io.InputStream

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
 import java.io.InputStream

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import org.junit.Test

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -1,6 +1,10 @@
 package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.DaemonSpawn
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.Manifest

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/PreviewResourceTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/PreviewResourceTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import java.io.File
 import java.security.MessageDigest
 import java.util.Base64

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/StorybookMcpTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/StorybookMcpTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.mcp
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
 import org.junit.Test
 

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -45,6 +45,7 @@ val INTERNAL_GROUP = "ee.schimke.composeai"
 val contracts =
   listOf(
     "daemon-core",
+    "daemon-client",
     "preview-data-api",
     "render-session-api",
     "render-session-subprocess",
@@ -74,16 +75,19 @@ dependencies {
  * server. Each is a preparation item in `docs/design/PREVIEW_SERVER_SPLIT.md`, and each must
  * eventually leave this list — the check fails when a recorded leak is GONE as well as when a new
  * one appears, so the list cannot rot into a permanent exemption.
+ *
+ * **Empty, as of #3824 preparation item 3.** The last entry was `mcp`, reached because
+ * `:render-session-subprocess` built its transport on `:mcp`'s `DaemonClient` /
+ * `SubprocessDaemonClientFactory` — so consuming the render-session library dragged an MCP server
+ * onto the classpath. Those types now live in `:daemon-client`, which is a contract rather than a
+ * leak: the server legitimately needs a daemon client, it just must not need an MCP server to get
+ * one.
+ *
+ * Keep it empty. An addition here is a regression, not a TODO — the extracted server's dependency
+ * floor is now exactly [contracts], and anything else on the graph should fail the build until it
+ * is either promoted to a contract with a reason or removed.
  */
-val contractLeaks =
-  mapOf(
-    "mcp" to
-      "`:render-session-subprocess` implements its transport on `:mcp`'s `DaemonClient` / " +
-        "`SubprocessDaemonClientFactory`, so consuming the render-session library drags an MCP " +
-        "server onto the classpath. #3824 preparation item 3: lift the daemon client out of " +
-        "`:mcp` into its own published module. (`DaemonLaunchDescriptor`, the one MCP type " +
-        "`serve` imported directly, has already moved to `:daemon:core`.)"
-  )
+val contractLeaks = emptyMap<String, String>()
 
 abstract class CheckContractSurface : DefaultTask() {
   /** Artifact names (no group, no version) the server is allowed to resolve. */

--- a/render-session/embedded-desktop/build.gradle.kts
+++ b/render-session/embedded-desktop/build.gradle.kts
@@ -45,7 +45,9 @@ dependencies {
   implementation(project(":render-session-subprocess"))
   implementation(project(":daemon:desktop"))
   implementation(project(":daemon:core"))
-  implementation(project(":mcp"))
+  // Only ever needed `DaemonClient` from here — this was `:mcp` until #3824 item 3 lifted the
+  // transport into its own module, so an embedded render session no longer resolves an MCP server.
+  implementation(project(":daemon-client"))
   implementation(libs.kotlinx.serialization.json)
 
   testImplementation(libs.junit)

--- a/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
+++ b/render-session/embedded-desktop/src/main/kotlin/ee/schimke/composeai/render/session/embedded/EmbeddedDesktopRenderSession.kt
@@ -1,10 +1,10 @@
 package ee.schimke.composeai.render.session.embedded
 
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.DaemonClient
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.runDaemon
 import ee.schimke.composeai.io.SystemFileSystem
-import ee.schimke.composeai.mcp.DaemonClient
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import ee.schimke.composeai.render.session.RenderSessionConfig

--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -20,9 +20,14 @@ dependencies {
   api(project(":render-session-api"))
   implementation(project(":common-io"))
 
-  // Existing JSON-RPC client + subprocess spawn infrastructure. Public surface here is the
-  // `RenderSession` contract; `:mcp` types stay internal to this module.
-  implementation(project(":mcp"))
+  // JSON-RPC client + subprocess spawn infrastructure. Public surface here is the `RenderSession`
+  // contract; the client types stay internal to this module.
+  //
+  // This used to be `implementation(project(":mcp"))`, which is what made consuming the
+  // render-session library drag an MCP server onto the classpath — the last leak the preview-server
+  // contract probe recorded. #3824 item 3 lifted the transport into `:daemon-client`; nothing here
+  // needed the MCP server, only the wire client.
+  implementation(project(":daemon-client"))
   implementation(project(":daemon:core"))
   implementation(libs.kotlinx.serialization.json)
 

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.render.session.subprocess
 
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DataProductWireException
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
@@ -24,8 +26,6 @@ import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamStartResult
-import ee.schimke.composeai.mcp.DaemonClient
-import ee.schimke.composeai.mcp.DataProductWireException
 import ee.schimke.composeai.render.session.DataProductException
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -1,12 +1,12 @@
 package ee.schimke.composeai.render.session.subprocess
 
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
+import ee.schimke.composeai.daemon.client.DaemonClient
+import ee.schimke.composeai.daemon.client.DaemonClientFactory
+import ee.schimke.composeai.daemon.client.SubprocessDaemonClientFactory
+import ee.schimke.composeai.daemon.client.WorkspaceId
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.io.SystemFileSystem
-import ee.schimke.composeai.mcp.DaemonClient
-import ee.schimke.composeai.mcp.DaemonClientFactory
-import ee.schimke.composeai.mcp.SubprocessDaemonClientFactory
-import ee.schimke.composeai.mcp.WorkspaceId
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend
 import ee.schimke.composeai.render.session.RenderSessionConfig

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -31,6 +31,7 @@ PROBE_VERSION="0.0.0-contract-probe-SNAPSHOT"
 # because a contract that isn't published simply won't resolve.
 CONTRACT_PROJECTS=(
   ":daemon:core"
+  ":daemon-client"
   ":preview-data-api"
   ":render-session-api"
   ":render-session-subprocess"
@@ -48,10 +49,15 @@ CONTRACT_PROJECTS=(
 # leaks" table in docs/design/PREVIEW_SERVER_SPLIT.md. They are listed separately from the contracts
 # so this file says out loud what `checkContractSurface` enforces: contracts stay, leaks go.
 #
-#   :mcp                  reached through :render-session-subprocess's transport
-LEAK_PROJECTS=(
-  ":mcp"
-)
+# EMPTY as of #3824 preparation item 3. The last entry was `:mcp`, reached through
+# `:render-session-subprocess`'s transport; those types now live in `:daemon-client`, which is a
+# contract above rather than a leak here.
+#
+# Note this list is what gets PUBLISHED to Maven Local alongside the contracts, which is why an
+# emptied entry matters beyond bookkeeping: while `:mcp` was still listed, the probe resolved
+# against a copy this script had just installed, so it could have reported the leak gone while a
+# real edge survived. Verify a removal with the artifact deleted from ~/.m2 first.
+LEAK_PROJECTS=()
 
 skip_publish=0
 for arg in "$@"; do

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -757,6 +757,13 @@ include(":daemon:bta-host")
 // Same lifecycle as `:daemon:bta-host`; remove together with it.
 include(":daemon:bta-host-fixture")
 
+// JSON-RPC client for the preview daemon, published so the render-session library can drive a
+// daemon without dragging the MCP server onto the classpath. Lifted out of `:mcp` for exactly that
+// reason — #3824 preparation item 3, the last leak the contract probe recorded.
+include(":daemon-client")
+
+project(":daemon-client").projectDir = file("daemon/client")
+
 include(":mcp")
 
 // Public render-session library. `:render-session-api` is the pure-interface surface every


### PR DESCRIPTION
#3824 preparation item 3, and the last entry on the recorded-leaks table.

```
checkContractSurface: 12 contracts resolved, 0 known leak(s) still to remove
```

## The leak

`:render-session-subprocess` built its transport on `:mcp`'s `DaemonClient` / `SubprocessDaemonClientFactory`, so **consuming the render-session library dragged an MCP server onto the classpath** — tools, resources, supervisor and all. `:render-session-embedded-desktop` did the same for `DaemonClient` alone.

Nothing about driving a daemon needs an MCP server. Seven types now live in a new published module, `:daemon-client`:

| Type | Was in |
| --- | --- |
| `DaemonClient`, `DataProductWireException` | `DaemonClient.kt` (whole file, `git mv` so history follows) |
| `DaemonClientFactory`, `DaemonSpawn` | `DaemonSupervisor.kt` |
| `SubprocessDaemonClientFactory`, `SubprocessDaemonSpawn` | `DaemonMcpMain.kt` |
| `WorkspaceId` | `PreviewResource.kt` |

`:mcp` now depends on the module it used to own. Both render-session modules depend on `:daemon-client` instead of `:mcp`, which is the leak closing.

## Why the narrowing had to land first (#4528)

`DaemonClientFactory.spawn` used to take a `RegisteredProject` — the MCP supervisor's own registry, carrying `knownModules` and a `ConcurrentHashMap<String, SupervisedDaemon>`. Moving the factory while it still named that type would have hauled the supervision model into a module whose entire purpose is to *not* be MCP. That is the same mistake #4524 existed to correct, one layer up.

#4528 narrowed it to `WorkspaceId` first — after checking that the production implementation read exactly one field, twice, for a log label. This PR is the move that narrowing made possible.

## Two things I changed my mind about mid-way

**`DaemonLaunchDescriptorCompat.kt` stays in `:mcp`.** My plan had it moving. It is a deprecated typealias whose only job is keeping an external `import ee.schimke.composeai.mcp.DaemonLaunchDescriptor` compiling; relocating it to the new package would have silently destroyed the one thing it does. Its two mentions of `DaemonClientFactory` are KDoc prose, so it needs no import.

**`SubprocessDaemonSpawnTest` moves too.** `SubprocessDaemonSpawn` is `internal`, so its test could not see it from `:mcp` any more. Moving the type without the test would have compiled and quietly lost the coverage.

## The package rename, and why no shim

New package is `ee.schimke.composeai.daemon.client`, deliberately not the old `ee.schimke.composeai.mcp`. Two published artifacts sharing one package is a split package — it breaks JPMS and OSGi consumers and confuses everyone else.

No compatibility shim, and that is checked rather than assumed: [`docs/API_STABILITY.md`](docs/API_STABILITY.md) § 1 states the published surface of `:mcp` is its MCP tool names and input schemas — its Kotlin types are internal and may move.

## Verification

The probe number above is the load-bearing one, and it was run **with the `mcp` and `daemon-client` artifacts deleted from `~/.m2` first**. That matters: `LEAK_PROJECTS` is what the driver *publishes* to Maven Local, so while `:mcp` sat in that list the probe resolved against a copy the script had just installed and could have reported the leak gone while a real edge survived. That weakness is now recorded in a comment in the script itself.

The check also fails when a recorded leak *stops* resolving, so `contractLeaks` and `LEAK_PROJECTS` had to be emptied in the same change — the ratchet works in both directions.

- `:daemon-client:test`, `:mcp:test`, `:cli:test` — green (`--no-build-cache`)
- `./scripts/check-preview-server-contracts.sh` — 12 contracts, 0 leaks, clean `~/.m2`
- Rebased onto `ff5ecd26`; the upstream `data-pseudolocale-core` contract added since I started is in the count above, and the probe was re-run after the rebase rather than before it

Non-visual change (module boundaries and build wiring), so no rendered evidence applies.

## Expect two inherited red checks

`main` is currently red, and this PR will show it. `Module Unit Tests` and `Build CLI` fail on `b78dfef6` and later with three timing tests — `AndroidRippleFrameTest:121`, `LivePressRippleTest:92` (`:daemon:android`), and `ServeStatusLiveFramesTest:127` (`:cli`). Same tests, same line numbers, same counts as here. They are animation-frame and socket-poll deadlines, the same class as the `pollUntil` bound fixed in #4528, and none of them is reachable from this diff. Worth fixing on their own branch; flagged in #4540 too.

## What is left of #3824

Items 2 (rest of the daemon-launch schema consolidation), 5 (bundle format), 6 (ABI validation), 7 (server extraction), 8 (allowlist on resolved identities).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_