### PR TITLE
fix(deps): take the rest of the minor/patch group, hold coil3 and robolectric

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -147,6 +147,17 @@
       "allowedVersions": "/^2\\.2\\./"
     },
     {
+      "description": "coil3: pin to the 3.5.x line. 3.6.0 depends on `org.jetbrains.compose.foundation:foundation-android:1.12.0`, which resolves `androidx.compose.foundation`/`ui` 1.12.0 — the Compose line this repo deliberately does not sit on (see the compose-multiplatform rule above). coil3 is `compileOnly` in `:renderer-android` but `testImplementation` for that module's own unit tests, so the upgrade lands on a test classpath compiled against `compose-bom-compat` and `FigmaSvgRasterizedTextFieldRenderTest` fails with `AbstractMethodError` (#4503). 3.5.0 resolves foundation 1.11.2 and is green. Bump in lockstep with the Compose floor, not on its own.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchPackageNames": [
+        "io.coil-kt.coil3:{/,}**"
+      ],
+      "matchCurrentValue": "/^3\\.5\\./",
+      "allowedVersions": "/^3\\.5\\./"
+    },
+    {
       "description": "robolectric: released versions only. Robolectric publishes a rolling `4.17-SNAPSHOT` to Sonatype and Renovate ranks it above `4.17-beta-2`, but the build declares no snapshot repository — so the bump resolves nowhere and fails every Android configuration. Betas and RCs are still fair game; only `-SNAPSHOT` is excluded.",
       "matchManagers": [
         "gradle"
@@ -155,6 +166,17 @@
         "org.robolectric:robolectric"
       ],
       "allowedVersions": "!/-SNAPSHOT$/"
+    },
+    {
+      "description": "robolectric: hold at 4.17-beta-2. Under 4.17-beta-4 a pressed ripple stops painting in a held Robolectric session — `LivePressRippleTest.aLiveClickPaintsPressFeedback` sees every post-click frame identical to rest, and `AndroidRippleFrameTest` measures no motion across the filmed press (#4503). Both are pixel oracles over the live lane's press feedback, so this is a product regression in that lane, not a harness detail; `roborazzi` 1.73.0 was bisected out. Raising the line again means re-running those two tests, so it stays manual. Declared after the released-versions-only rule above so this stricter `allowedVersions` wins.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "org.robolectric:robolectric"
+      ],
+      "matchCurrentValue": "/^4\\.17-beta-2$/",
+      "allowedVersions": "/^4\\.17-beta-2$/"
     },
     {
       "description": "Remote Compose, its Wear widget layer and Glance Wear resolve from Google Maven on released alpha coordinates, and the three groups only work together when built against the same `remote-creation*` — `remote-material3` and `androidx.glance.wear:*` name that version in their POMs. Renovate updates one dependency at a time, so an automated bump of any one group produces exactly the skew that has taken CI red before (a `NoClassDefFoundError` inside `RemoteButtonImpl` at render time, a wear pin that did not exist yet). Bump the three refs in gradle/libs.versions.toml as one set after checking the POMs, and re-verify a render, not just a compile.",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,12 +25,20 @@ tapmoc = "0.4.2"
 # above `4.17-beta-2` — but no snapshot repository is declared here (nor should one be, for a
 # reproducible build), so a snapshot pin fails dependency resolution outright. The
 # `org.robolectric:robolectric` rule in `.github/renovate.json` keeps that bump from coming back.
-robolectric = "4.17-beta-4"
+#
+# Held at `4.17-beta-2`. Under `4.17-beta-4` a pressed ripple no longer paints in a held
+# Robolectric session: `LivePressRippleTest.aLiveClickPaintsPressFeedback` sees every post-click
+# frame identical to the resting frame, and `AndroidRippleFrameTest` measures no motion at all
+# across the filmed press. Both are pixel oracles over `RippleOnlySquare`, so this is the live
+# lane's press feedback going dark rather than a test-harness detail — the same symptom #4159
+# existed to fix. Bisected against beta-2/beta-4 with `roborazzi` held at 1.73.0, which is not
+# implicated. Raising this again needs those two tests green, not just a build.
+robolectric = "4.17-beta-2"
 roborazzi = "1.73.0"
 # androidx.tracing — atrace-level sections for the Android daemon's render phases (see
 # `AndroidxTraceSections` in :daemon:android). Version-pinned (not BOM-managed) because the daemon
 # ships it in the standalone lib-daemon-android sidecar where no BOM applies.
-androidx-tracing = "2.0.0"
+androidx-tracing = "2.0.1"
 # androidx.tracing 2.x — the Kotlin Multiplatform rewrite, used by the CMP Remote Compose player
 # stack through `:rc-player-trace`. Pinned separately from `androidx-tracing` above rather than
 # bumping it: 2.x drags `kotlinx-coroutines-core` and `androidx.collection` in, which the daemon's
@@ -38,7 +46,7 @@ androidx-tracing = "2.0.0"
 # atrace-shaped `Trace.beginSection` that 1.3.0 already gives it. The two coordinates never meet on
 # one classpath. Note 2.x publishes only `androidJvm` + `jvm` variants — there is no wasmJs or Apple
 # klib, which is the whole reason `:rc-player-trace` is an `expect`/`actual` facade.
-androidx-tracing-kmp = "2.0.0"
+androidx-tracing-kmp = "2.0.1"
 classgraph = "4.8.194"
 # Stable BOM line — what samples use and what `composePreviewRender` /
 # `Compare previews` is exercised against. Renovate updates this freely;
@@ -96,7 +104,7 @@ compose-multiplatform-forward = "1.12.0-rc01"
 # build.gradle.kts) rather than the repo default 36 — a scoped divergence, like
 # `:samples:design-catalog-remote-m3`. Drop this pin and revert to `libs.compose.material3`
 # once material3 1.5.0 is stable in `compose-bom-stable`.
-compose-material3-catalog = "1.5.0-alpha26"
+compose-material3-catalog = "1.5.0-alpha27"
 # JetBrains Compose Multiplatform material3 tracks its own line, so the explicit coordinate must
 # use this version rather than `compose-multiplatform`. Matched to what `m3-catalog` pins on the
 # 1.11 line, so the largest live-rendered catalog and the host agree on the material3 ABI as well
@@ -117,14 +125,14 @@ activity-compose = "1.13.0"
 # `navigation.*` script-event surface end-to-end. Activity-compose 1.13's
 # transitive `androidx.navigationevent` floor (see CompatRules.kt) means
 # this stays compatible with the renderer's compileOnly stack.
-navigation-compose = "2.9.8"
+navigation-compose = "2.10.0"
 # `androidx.glance:glance-appwidget` — used only by `:samples:android`'s Glance widget
 # preview (`GlanceWidgetPreview` in `AppWidgetPreviews.kt`). Renders a `GlanceAppWidget` to
 # `RemoteViews` via `GlanceAppWidget.compose(...)` and inflates that into the preview surface.
 # 1.1.x is the current stable line; bump when the Glance team ships a 1.2.x with the planned
 # preview-DSL stabilisation.
-glance-appwidget = "1.2.0-rc01"
-wear-compose = "1.7.0-beta01"
+glance-appwidget = "1.2.0"
+wear-compose = "1.7.0-beta02"
 wear-tiles = "1.6.2"
 wear-protolayout = "1.4.2"
 wear-tooling-preview = "1.0.0"
@@ -132,7 +140,7 @@ wear-tooling-preview = "1.0.0"
 # glasses (`androidx.xr.glimmer`). Alpha10+ requires AGP 9.2+ and
 # `compileSdk = 37` (matched by `:samples:xr-glimmer`'s `compileSdk` and our
 # `agp = 9.2.x` toolchain). Alpha13 was published 2026-05-19.
-xr-glimmer = "1.0.0-alpha17"
+xr-glimmer = "1.0.0-alpha18"
 # Jetpack Compose for XR (`androidx.xr.compose`) — the spatial-UI toolkit
 # (`Subspace`, `SpatialPanel`, `Orbiter`, `SpatialElevation`, `SpatialDialog`).
 # AAR metadata declares `minCompileSdk = 36` / `minAgp = 8.9.1`, so it builds on
@@ -306,6 +314,14 @@ jmdns = "3.6.3"
 # against both and pick at runtime. Versions here only bound what the renderer *compiles* against —
 # the consumer's own coil is what runs, and the builder APIs we touch are stable across each major.
 coil2 = "2.7.0"
+# coil3: pinned to the 3.5.x line. 3.6.0 depends on `org.jetbrains.compose.foundation:
+# foundation-android:1.12.0`, which resolves `androidx.compose.foundation`/`ui` 1.12.0 — the same
+# Compose line held out of this repo for `compose-multiplatform` (#4527). coil3 is `compileOnly` in
+# `:renderer-android` but `testImplementation` for its own unit tests, so that upgrade lands
+# directly on a test classpath whose code is compiled against `compose-bom-compat`, and
+# `FigmaSvgRasterizedTextFieldRenderTest` dies with `AbstractMethodError` inside the Compose test
+# rule. 3.5.0 stops at foundation 1.11.2 and is green. Bump this when the repo's Compose floor
+# moves to 1.12, not before; the pin lives in `.github/renovate.json`.
 coil3 = "3.5.0"
 
 [libraries]

--- a/samples/android-alpha/build.gradle.kts
+++ b/samples/android-alpha/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
   // material3 1.5.0-alphaNN's metadata pulls compose-foundation/runtime/ui
   // 1.12.0-alphaNN transitively, so no separate compose-bom application is
   // needed (and would only fight conflict resolution).
-  implementation("androidx.compose.material3:material3:1.5.0-alpha26")
+  implementation("androidx.compose.material3:material3:1.5.0-alpha27")
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)


### PR DESCRIPTION
Supersedes #4503. That PR is red for **two independent reasons** — one in its own diff, one it inherits from `main` — so pinning the group entry alone would not have made it green.

## 1. coil3 3.6.0 raises the Compose floor (in #4503's diff)

`io.coil-kt.coil3:coil-compose-core-android:3.6.0` depends on `org.jetbrains.compose.foundation:foundation-android:1.12.0`, which resolves `androidx.compose.foundation` / `androidx.compose.ui` **1.12.0** — the same Compose line #4527 held `compose-multiplatform` off. 3.5.0 stops at foundation 1.11.2.

coil3 is `compileOnly` in `:renderer-android`, but `testImplementation` for that module's own unit tests, so the upgrade lands directly on a test classpath whose code is compiled against `compose-bom-compat`:

```
FigmaSvgRasterizedTextFieldRenderTest > a value flattened into the field raster is not also drawn as live text FAILED
    java.lang.AbstractMethodError at FigmaSvgRasterizedTextFieldRenderTest.kt:119
```

Reproduced and attributed locally, same tree, only the coil3 ref moving:

| coil3 | `:renderer-android:testDebugUnitTest --tests *FigmaSvgRasterizedTextFieldRenderTest*` |
|---|---|
| 3.6.0 | `AbstractMethodError` → BUILD FAILED |
| 3.5.0 | BUILD SUCCESSFUL |

## 2. robolectric 4.17-beta-4 puts out the ripple (already on `main`)

This one is **not** #4503's. It landed with #4527 this morning and reproduces on a clean `origin/main` checkout. Under `4.17-beta-4` a pressed ripple never paints in a held Robolectric session:

```
AndroidRippleFrameTest > pressedRippleKeepsAnimatingAcrossHeldFrames FAILED
    java.lang.AssertionError at AndroidRippleFrameTest.kt:121
LivePressRippleTest > aLiveClickPaintsPressFeedback FAILED
    java.lang.AssertionError at LivePressRippleTest.kt:92
```

Both are pixel oracles over `RippleOnlySquare`, whose click handler is inert — press feedback is the only thing that can move a pixel. `LivePressRippleTest` sees every post-click frame identical to rest; `AndroidRippleFrameTest` measures no motion across the filmed press. That is the live lane's press feedback going dark, the symptom #4159 existed to fix, not a harness detail.

Bisected locally on `origin/main`:

| robolectric | roborazzi | both ripple tests |
|---|---|---|
| 4.17-beta-4 | 1.73.0 | FAILED (2/2) |
| 4.17-beta-2 | 1.72.0 | SUCCESSFUL |
| 4.17-beta-2 | **1.73.0** | SUCCESSFUL |

So `roborazzi` 1.73.0 is innocent and stays; `robolectric` goes back to `4.17-beta-2` and is pinned there.

## What lands

`androidx-tracing` + `androidx-tracing-kmp` 2.0.1, `compose-material3-catalog` 1.5.0-alpha27 (with the matching explicit coord in `samples/android-alpha`), `navigation-compose` 2.10.0, `glance-appwidget` 1.2.0, `wear-compose` 1.7.0-beta02, `xr-glimmer` 1.0.0-alpha18. Those were all green on #4503's own run.

Two new `.github/renovate.json` rules, both with `matchCurrentValue` so they self-scope to the lines the repo actually sits on, and both recording what has to be re-verified before the line moves: `io.coil-kt.coil3**` → `3.5.x`, `org.robolectric:robolectric` → `4.17-beta-2` (declared after the existing released-versions-only rule so the stricter `allowedVersions` wins).

## Test plan

Run in-session with the Android SDK installed (`install.sh --android-sdk`), JDK 17 toolchain:

- `./gradlew :renderer-android:testDebugUnitTest :daemon:android:testDebugUnitTest --tests "*AndroidRippleFrameTest*" --tests "*LivePressRippleTest*" --tests "*FigmaSvg*"` on this branch — **BUILD SUCCESSFUL**. These are exactly the three tests red on #4503.
- Each attribution above was measured by moving one ref at a time in an otherwise identical tree; the tables are those runs.
- `jq . .github/renovate.json` — valid.

Non-visual change (dependency pins + Renovate config), so no render evidence applies.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MWVnexf5beL5fafzTYFdPz)_