### PR TITLE
fix(deploy): hold warmed theme renders on disk by default

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -266,6 +266,42 @@ unavailable. Once resolved it is **pinned for the life of the process**: a later
 does not move it, because live snippet JVMs hold those jars open. Restart the container to compile
 against a newer catalog ABI.
 
+### Warmed theme renders survive a deploy (`SERVE_THEME_CACHE_DIR`)
+
+The server pre-renders every catalog preview under every declared theme while the box is idle, so a
+visitor's theme selection is instant rather than a cold render. On `preview.coo.ee` that is 18,604
+renders, and it takes the better part of a day of quiet to fill.
+
+**That work is held on disk by default**, on the dedicated `preview_theme_cache` volume:
+
+```
+SERVE_THEME_CACHE_DIR=/theme-cache        # the default; `none` for a memory-only cache
+SERVE_THEME_CACHE_MAX_BYTES=4294967296    # 4 GiB — see below for where that comes from
+```
+
+The default was `none` — memory-only — and while it was, **theme optimization could not finish**.
+Without a disk tier the warmed renders live only in the serve process's heap, so every container
+recreation starts the pass again from zero, and the rolling update is a container recreation.
+Measured across one morning: 1,502 of 18,604 entries after a 40-hour uptime, then 0 an hour later,
+then 0 again — three releases, three resets. A pass that needs a day to complete cannot outrun a
+deploy cadence measured in hours. The in-memory tier is deliberately a 128 MB window onto a
+generation several times that size, so it was never going to hold the whole answer by itself.
+
+Sizing: a fully warmed set measures **~0.93 GiB** here — 1,503 cached renders occupied 76.8 MiB,
+i.e. ~52 KiB/entry, across 18,604 declared targets. The 4 GiB cap is ~4x headroom for superseded
+generations awaiting their sweep, and is deliberately below the server's own 8 GB default because
+the catalog blob pool on the same disk really does sit at its full 8 GB.
+
+Staleness is handled rather than assumed away. A generation is keyed by a fingerprint of everything
+that decides the pixels; because an input nobody thought of could still escape it, the server
+re-renders a sample of the adopted entries at startup and discards the entire generation on any
+mismatch, so a fingerprint miss costs a re-render rather than serving wrong pixels.
+
+Read `themeCache` on [`/status.json`](https://preview.coo.ee/status.json) to confirm it is on — it
+is `null` when there is no disk tier, and each catalog's `renderCache.persisted` is `null` beside
+it. `renderCache.persistenceOff` names the reason when a catalog fell back to memory-only for some
+*other* cause (an unreadable launch descriptor, a fingerprint it could not compute).
+
 ### Letting visitors pick the catalog
 
 `SERVE_PLAYGROUND=1` adds a **Catalog** selector to the editor, offering every catalog this box

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -181,17 +181,32 @@ services:
       SERVE_CATALOG_FEED_IDLE: "${SERVE_CATALOG_FEED_IDLE:-}"
       # Warmed theme renders (the per-catalog theme cache) survive container recreation, which is
       # what the rolling update below performs — so a restart no longer discards hours of background
-      # warming. Set SERVE_THEME_CACHE_DIR=/theme-cache in .env to turn it on; it lands on the
-      # dedicated `preview_theme_cache` volume mounted below.
+      # warming. Points at the dedicated `preview_theme_cache` volume mounted below; set
+      # SERVE_THEME_CACHE_DIR=none in .env to go back to a memory-only cache.
       #
-      # Defaults to `none` — OFF — deliberately, on two counts. An unset value would derive a
-      # directory beside catalogs.json, which here is the durable `preview_config` volume, quietly
-      # growing an up-to-8-GB cache on the volume holding the operator's configuration. And the
-      # reuse rules are new: a generation is keyed by a fingerprint of everything that decides the
-      # pixels, and an input that fingerprint misses would serve stale renders, so the conservative
-      # first-release posture is opt-in.
-      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-none}"
-      SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-}"
+      # **This defaulted to `none` — OFF — and that made theme optimization unable to finish.**
+      # Without a disk tier the warmed renders live only in the serve process's heap, so every
+      # deploy starts the whole pass again from zero. Measured on preview.coo.ee: 1,502 of 18,604
+      # entries after a 40-hour uptime on 1.35.0, then 0 again an hour later on 1.36.0, and 0 again
+      # on 1.37.0 — three releases in one morning, three resets. A pass that needs a day of quiet to
+      # complete cannot survive a deploy cadence measured in hours, and the memory tier is by design
+      # a 128 MB window onto a generation several times that size, so it was never going to hold the
+      # answer on its own.
+      #
+      # The two original reasons for opting in are both addressed rather than dismissed. An unset
+      # value would derive a directory beside catalogs.json — the durable `preview_config` volume,
+      # holding the operator's own configuration — so this names the dedicated volume explicitly
+      # instead. And a generation is keyed by a fingerprint of everything that decides the pixels,
+      # which an input nobody thought of could still miss: that is what the startup verification
+      # pass covers, re-rendering a sample of adopted entries and discarding the whole generation on
+      # any mismatch (CatalogThemeCache.verifySample), so stale pixels are caught rather than
+      # served.
+      SERVE_THEME_CACHE_DIR: "${SERVE_THEME_CACHE_DIR:-/theme-cache}"
+      # 4 GiB, not the server's own 8 GB default. A fully warmed set measures ~0.93 GiB here (1,503
+      # cached renders occupied 76.8 MiB, i.e. ~52 KiB/entry, across 18,604 declared targets), so
+      # this is roughly 4x headroom for superseded generations awaiting their sweep — while leaving
+      # the box's disk to the catalog blob pool beside it, which really does sit at its full 8 GB.
+      SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-4294967296}"
       # The heavy bytes a catalog FETCHES (as opposed to the pixels it renders): each live
       # catalog's executable liveBundle — ~100 MB — its per-preview split bundles, and the
       # externalised font/resource pool. Held content-addressed, so a rolled replica reads them
@@ -265,9 +280,9 @@ services:
       # The same volume carries producers.json (the trust store) for the same reasons.
       - preview_config:/config
       # Warmed theme renders, on a volume of their OWN — never on preview_config, which is where
-      # the catalog set and trust store live and must not be crowded out by an up-to-8-GB render
-      # cache. Mounted unconditionally so turning the cache on is a one-line .env change
-      # (SERVE_THEME_CACHE_DIR=/theme-cache); while it stays `none` the volume is simply empty.
+      # the catalog set and trust store live and must not be crowded out by the render cache. This
+      # is what SERVE_THEME_CACHE_DIR points at by default, and what lets a deploy keep the hours of
+      # background warming it would otherwise discard.
       - preview_theme_cache:/theme-cache
       # Fetched catalog bytes, on a volume of their OWN for the same reason the theme cache got
       # one: preview_config holds the catalog set and the trust store and must not be crowded out


### PR DESCRIPTION
Found while watching #4536 / #4541 land on `preview.coo.ee`. Those two fixed the *throughput* of theme optimization; this fixes the fact that its output was being thrown away.

## The observation

`/status.json` reports `themeCache: null` and, per catalog, `renderCache.persisted: null` with `persistenceOff: null` — the code path where no `ThemeCacheStore` was configured at all. That is true on 1.35.0, 1.36.0 and 1.37.0 alike, so it is long-standing rather than a regression from either fix.

The cause is one line: `deploy/image/docker-compose.yml` defaults `SERVE_THEME_CACHE_DIR` to `none`. The `preview_theme_cache` volume it would use is already mounted and sitting empty.

## Why it matters

Without a disk tier the warmed renders live only in the serve process's heap, so **every container recreation starts the pass again from zero** — and the rolling update is a container recreation. Measured across one morning on the public box:

| version | uptime | entries cached |
|---|---|---|
| 1.35.0 | 40h | 1,502 / 18,604 |
| 1.36.0 | 1.6h | 1,198 |
| 1.37.0 | 5min | **0** |

Three releases, three resets. A pass that needs the better part of a day of quiet cannot outrun a deploy cadence measured in hours, and the in-memory tier is deliberately a 128 MB window onto a generation several times that size — it was never going to hold the whole answer by itself. (This also explains the 1,502 → 1,198 drop, which otherwise looks like the optimizer going backwards.)

## The change

`SERVE_THEME_CACHE_DIR` now defaults to `/theme-cache`, the dedicated volume already mounted for it. `SERVE_THEME_CACHE_DIR=none` in `.env` restores the memory-only behaviour.

**The two reasons the knob shipped opt-in are addressed, not dropped.**

- *An unset value would derive a directory beside `catalogs.json`* — the durable `preview_config` volume holding the operator's own configuration, quietly growing a multi-GB cache on it. So this names the dedicated volume explicitly rather than leaving the value unset.
- *A generation is keyed by a fingerprint that could miss an input, and stale pixels are worse than a re-render.* That is exactly what `CatalogThemeCache.verifySample` covers: on adoption it re-renders a sample of the persisted entries against the current renderer and discards the whole generation on any mismatch, with the adopted entries withheld from the read path until the check settles. A fingerprint miss costs a re-render, not wrong pixels served as ground truth.

**Sizing: 4 GiB, not the server's own 8 GB default.** A fully warmed set measures **~0.93 GiB** here — 1,503 cached renders occupied 76.8 MiB (~52 KiB/entry) across 18,604 declared targets. 4 GiB is ~4x headroom for superseded generations awaiting their sweep, while leaving the disk to the catalog blob pool beside it, which really does sit at its full 8 GB (`catalogCache.bytes` 8.00 GiB of 8.00 GiB).

**Documented.** The knob existed only as a compose comment — not in the README at all — which is part of why it was never turned on. The README now covers what it does, the sizing arithmetic, the staleness handling, and how to confirm from `/status.json` that the disk tier is actually live (`themeCache` non-null; `renderCache.persistenceOff` names the reason when a single catalog falls back for some other cause).

## Effect on an existing box

`setup.sh` never writes `SERVE_THEME_CACHE_DIR` into `.env` and the README never mentioned it, so a deployed box almost certainly has no line for it and picks up the new default on the next roll — no env migration needed. An operator who *has* pinned a value keeps it, since the compose interpolation only supplies a default.

## Test plan

- All eight `deploy/image/test-*.sh` guards pass, including `test-compose-env-passthrough.sh` (both `SERVE_THEME_CACHE_DIR` and `SERVE_THEME_CACHE_MAX_BYTES` remain forwarded to the container) and `test-env-migrations.sh`.
- `docker-compose.yml` parses, resolves to `${SERVE_THEME_CACHE_DIR:-/theme-cache}` / `${SERVE_THEME_CACHE_MAX_BYTES:-4294967296}`, and still mounts `preview_theme_cache:/theme-cache`.
- The image runs as root (no `USER` in the Dockerfile), so the fresh volume needs no ownership handling.

Not visually verified: deployment configuration and documentation, no rendered surface.

**After this rolls**, `themeCache` on `/status.json` should be non-null and the entries count should survive the next deploy instead of returning to 0 — that is the check that says it worked.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_