### PR TITLE
fix(serve): give each catalog load its own generation directory, and keep a size refusal a size refusal

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -45,6 +45,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
   private var throttled = 0L
   private var unavailable = 0L
   private var transport = 0L
+  private var tooLarge = 0L
   private var lastThrottleAtEpochMillis: Long? = null
   private var lastFailureAtEpochMillis: Long? = null
   private var lastFailureReason: String? = null
@@ -74,6 +75,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
         }
         is BranchFetch.Unavailable -> unavailable++
         is BranchFetch.Transport -> transport++
+        is BranchFetch.TooLarge -> tooLarge++
       }
       if (outcome !is BranchFetch.Ok && outcome !is BranchFetch.NotFound) {
         lastFailureAtEpochMillis = clock()
@@ -93,6 +95,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
         throttled = throttled,
         unavailable = unavailable,
         transport = transport,
+        tooLarge = tooLarge,
         lastThrottleAtEpochMillis = lastThrottleAtEpochMillis,
         lastFailureAtEpochMillis = lastFailureAtEpochMillis,
         lastFailureReason = lastFailureReason,
@@ -133,6 +136,15 @@ data class BranchFetchSnapshot(
   val unavailable: Long,
   /** Never got an answer: timeout, DNS, TLS, reset. */
   val transport: Long,
+  /**
+   * Reads the branch answered with a body past the envelope the read was given.
+   *
+   * Not a fault of the branch host the way [throttled] and [unavailable] are — the file arrived, it
+   * is simply bigger than this server will carry — but worth its own number rather than being
+   * folded into [notFound]: an operator looking at a catalog that serves nothing wants "the
+   * producer published something we refuse" separated from "the producer published nothing".
+   */
+  val tooLarge: Long = 0,
   val lastThrottleAtEpochMillis: Long? = null,
   val lastFailureAtEpochMillis: Long? = null,
   val lastFailureReason: String? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -61,6 +61,24 @@ sealed interface BranchFetch {
   /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
   data class Transport(val detail: String) : BranchFetch
 
+  /**
+   * The branch has the file and it is **past the envelope this read was given** — the body outgrew
+   * [limitBytes] before it was fully read, so no bytes are handed back.
+   *
+   * A distinct case rather than a `null`, because "there is no such file" and "the file is bigger
+   * than we will carry" are opposite facts about the branch, and one writer at least has a contract
+   * that must tell them apart: `compose-preview-known-differences/v1` answers `too-large`/413 for
+   * an over-sized document or artifact and `unreadable`/404 for an absent one. Collapsed into
+   * [NotFound] — which is what discarding the outcome does — an asset refused by size is reported
+   * as one the producer never published, which is both a different verdict and one that hides why.
+   *
+   * Not transient: the file will be exactly as oversized on the next attempt, so there is nothing
+   * to retry. Not permanent-cacheable either, in the sense [NotFound] is — the branch ref may
+   * publish a smaller file tomorrow — but every caller that memoises does so on a pinned `(commit,
+   * path)`, where the size is as immutable as the bytes.
+   */
+  data class TooLarge(val limitBytes: Long) : BranchFetch
+
   /** The bytes, or null for every failure — the shape the pre-existing call sites still want. */
   val bytesOrNull: ByteArray?
     get() = (this as? Ok)?.bytes
@@ -82,6 +100,7 @@ sealed interface BranchFetch {
         is Unavailable ->
           "unavailable ($status)" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
         is Transport -> "transport: $detail"
+        is TooLarge -> "too large (over $limitBytes bytes)"
       }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -434,9 +434,29 @@ class ServeCatalogStore(
     // below run *after* the swap and are all fail-soft (they disable their tier or fall back to the
     // baked host), so they never leave the catalog broken — only the image fetch is a hard failure,
     // and that's what staging protects.
-    val dir = File(root, safe)
-    val staging = File(root, "$safe.staging")
+    //
+    // **The live directory is generation-scoped**, `<root>/<system>/g<n>`, and a load never writes
+    // into the one that is currently registered. The host and the bytes it reads lazily
+    // (`knownDifferenceArtifact`, rasters, preview PNGs) therefore change together: the previous
+    // generation keeps serving, from its own untouched files, until the new host is registered — at
+    // which point both switch at once. Replacing a shared `<root>/<system>` in place is what made
+    // the two divisible, and the gap was not small: everything between the swap and the
+    // registration (the Wasm app, the vectors, the live bundles) is network work, and a read that
+    // landed in it served the new generation's pixels beside the old generation's metadata, with
+    // nothing to notice.
+    //
+    // Retirement is deferred to the *next* load's sweep rather than done here, which gives every
+    // in-flight request against the outgoing host a full refresh interval to finish reading. See
+    // [retireStaleGenerations].
+    val systemRoot = File(root, safe)
+    val dir = File(systemRoot, "$GENERATION_DIR_PREFIX$generation")
+    val staging = File(systemRoot, STAGING_DIR)
+    retireStaleGenerations(safe, systemRoot, keep = setOf(dir.name, staging.name))
     staging.deleteRecursively()
+    // Only ever a leftover: the counter climbs within a process, so this name cannot be the live
+    // generation — but it can be one a previous process left behind, and the rename below needs the
+    // path free.
+    dir.deleteRecursively()
     val previewsDir = File(staging, "previews")
     val previewsRoot = previewsDir.canonicalFile.toPath()
     var count = 0
@@ -767,10 +787,9 @@ class ServeCatalogStore(
     writeDesignPages(base, staging)
     writeKnownDifferences(base, staging)
 
-    // The staged catalog is usable — atomically replace the live dir with it. The delete + rename
-    // is near-instant (same filesystem), so the window where `dir` is absent is microseconds, not
-    // the multi-second fetch above. From here everything operates on the fresh `dir` as before.
-    dir.deleteRecursively()
+    // The staged catalog is usable — move it into place as this load's generation. Nothing serves
+    // from `dir` yet (no host names it until [publishGeneration] below), so this is a rename onto a
+    // free path rather than a mutation of what the registered host is reading.
     if (!staging.renameTo(dir)) {
       // Cross-device or a racing reader held a handle — copy then drop the staging dir.
       staging.copyRecursively(dir, overwrite = true)
@@ -1056,6 +1075,7 @@ class ServeCatalogStore(
               { bakedFallback(emptyList(), deferredIds.toList()) },
             )
         ) {
+          publishGeneration(safe, dir)
           return Result.Ok(
             safe,
             count + deferredIds.size + failedIds.size,
@@ -1139,6 +1159,7 @@ class ServeCatalogStore(
                   perPreviewBundle,
                 )
             ) {
+              publishGeneration(safe, dir)
               return Result.Ok(
                 safe,
                 count + deferredIds.size + failedIds.size,
@@ -1185,6 +1206,7 @@ class ServeCatalogStore(
           { bakedFallback(emptyList(), deferredIds.toList()) },
         )
     ) {
+      publishGeneration(safe, dir)
       return Result.Ok(
         safe,
         count + deferredIds.size + failedIds.size,
@@ -1228,6 +1250,7 @@ class ServeCatalogStore(
         )
     // Same reasoning as the degradation: a session with no live lane lists no live-only previews.
     val host = bakedFallback(degradations, emptyList())
+    publishGeneration(safe, dir)
     register(safe, host)
     return Result.Ok(
       safe,
@@ -2050,11 +2073,25 @@ class ServeCatalogStore(
    */
   private fun writeKnownDifferences(base: String, staging: File) {
     val dirName = ServeKnownDifferences.DIRECTORY
-    val documentBytes =
+    val documentFile = File(staging, "$dirName/${ServeKnownDifferences.DOCUMENT_FILE}")
+    val documentOutcome =
       runCatching {
-        fetchCatalogAsset("$base$dirName/${ServeKnownDifferences.DOCUMENT_FILE}")
+        fetchCatalogAssetOutcome("$base$dirName/${ServeKnownDifferences.DOCUMENT_FILE}")
       }
         .getOrNull() ?: return
+    // The transport's own ceiling is far above the contract's, so a document it refuses by size is
+    // one the reader would refuse anyway — but it would refuse it as *absent*, because a fetch that
+    // brings back no bytes and a branch that published no file are the same `null`. Staging a
+    // marker past the contract's ceiling restores the verdict the producer earned: the reader
+    // measures the file, answers `TooLarge`, the route serves 413 and the engine says
+    // `document-too-large` rather than `document-unreadable`. Nothing reads the marker's bytes —
+    // [ServeKnownDifferences.document] refuses from the length before opening it — so it is a
+    // length, not a payload.
+    if (documentOutcome is BranchFetch.TooLarge) {
+      stageOversizeMarker(documentFile, ServeKnownDifferences.MAX_DOCUMENT_BYTES + 1L)
+      return
+    }
+    val documentBytes = documentOutcome.bytesOrNull ?: return
 
     val artifactRoot = "$dirName/${ServeKnownDifferences.ARTIFACT_DIRECTORY}"
     // **Streamed to disk, never accumulated.** Each worker holds only the artifact it is writing,
@@ -2076,12 +2113,37 @@ class ServeCatalogStore(
     fetchCatalogAssetsToFiles(
       knownDifferenceArtifactPaths(documentBytes).map { path ->
         "$base$artifactRoot/$path" to File(staging, "$artifactRoot/$path")
-      }
+      },
+      // An artifact the transport refuses by size gets the same marker treatment the document does,
+      // for the same reason and against the artifact ceiling: `artifact-too-large`/413 is the
+      // verdict the contract names, and dropping the file would leave `artifact-unreadable`/404 —
+      // the answer that means the producer published nothing.
+      oversizeMarkerBytes = ServeKnownDifferences.MAX_ARTIFACT_BYTES + 1L,
     )
 
     File(staging, dirName).mkdirs()
-    File(staging, "$dirName/${ServeKnownDifferences.DOCUMENT_FILE}").writeBytes(documentBytes)
+    documentFile.writeBytes(documentBytes)
   }
+
+  /**
+   * Write a placeholder of exactly [length] bytes, for an asset the transport refused by size.
+   *
+   * Set rather than written: [java.io.RandomAccessFile.setLength] extends the file without
+   * producing its bytes, which every filesystem this runs on stores as a hole. The point is the
+   * size — the readers this exists for ([ServeKnownDifferences.document],
+   * [ServeKnownDifferences.artifact]) answer `TooLarge` from the metadata and never open the file —
+   * so materialising 8 MiB of zeroes to say "too big" would be the ceiling defeated by the code
+   * enforcing it.
+   *
+   * Fail-soft like every writer around it: a marker that cannot be written leaves the asset absent,
+   * which is what it was before.
+   */
+  private fun stageOversizeMarker(target: File, length: Long): Boolean = runCatching {
+    target.parentFile?.mkdirs()
+    java.io.RandomAccessFile(target, "rw").use { it.setLength(length) }
+    true
+  }
+    .getOrDefault(false)
 
   /**
    * The `<id>/<file>` paths a known-difference document names — none, when the engine will reject
@@ -2980,6 +3042,20 @@ class ServeCatalogStore(
     private const val MAX_FETCH_BYTES = 25L * 1024 * 1024 // 25 MB per catalog asset
 
     /**
+     * A catalog's live directories are `<root>/<system>/g<generation>`; the staging tree it is
+     * assembled in is `<root>/<system>/.staging`.
+     *
+     * Nested under the system rather than named as siblings (`<system>.g3`) because a system id may
+     * itself contain a dot — `ServeBundleStore.sanitizeName` admits one — so a sibling naming
+     * scheme would let a system called `m3.g3` collide with a generation of one called `m3`. Under
+     * the system's own directory the namespace is this store's alone, which also makes the sweep a
+     * listing rather than a prefix match.
+     */
+    internal const val GENERATION_DIR_PREFIX = "g"
+
+    internal const val STAGING_DIR = ".staging"
+
+    /**
      * Cap on a delivery branch's commit feed ([fetchRevisions]). Deliberately far smaller than a
      * catalog asset: the feed is ~20 commit entries and measures in tens of kilobytes. A body that
      * doesn't fit here is not one worth scanning.
@@ -3068,9 +3144,15 @@ class ServeCatalogStore(
     }
 
     /**
-     * A single attempt. Only [java.io.IOException] becomes [BranchFetch.Transport]: the size cap in
-     * [readCapped] throws too, and it must keep propagating rather than being retried — the asset
-     * will be exactly as oversized the second time, and the existing call sites already catch it.
+     * A single attempt. Only [java.io.IOException] becomes [BranchFetch.Transport]; a body that
+     * outgrows the envelope becomes [BranchFetch.TooLarge], which is not retried — the asset will
+     * be exactly as oversized the second time.
+     *
+     * The size refusal is an *outcome* rather than a thrown exception because it is a fact about
+     * the branch that one writer has to act on: known differences answers `too-large`/413 for an
+     * asset past the contract's ceiling and `unreadable`/404 for an absent one, and a throw that
+     * every call site catches into `null` erases exactly that distinction. Callers that only ever
+     * wanted bytes are unaffected — [BranchFetch.bytesOrNull] is null either way.
      */
     private fun httpFetchOnce(url: String, maxBytes: Long): BranchFetch =
       try {
@@ -3082,7 +3164,8 @@ class ServeCatalogStore(
             )
           } else {
             val body = response.body
-            BranchFetch.Ok(readCapped(body.byteStream(), maxBytes))
+            readCapped(body.byteStream(), maxBytes)?.let { BranchFetch.Ok(it) }
+              ?: BranchFetch.TooLarge(maxBytes)
           }
         }
       } catch (e: java.io.IOException) {
@@ -3111,7 +3194,15 @@ class ServeCatalogStore(
         BranchFetch.Transport(e::class.simpleName ?: "IOException")
       }
 
-    private fun readCapped(input: InputStream, max: Long): ByteArray {
+    /**
+     * The body, or null once it has read past [max] — the caller turns that into
+     * [BranchFetch.TooLarge].
+     *
+     * Abandons the read at the ceiling rather than counting to the end: the point of the cap is
+     * that an over-sized body is never held, and knowing the exact length of one we are refusing
+     * anyway would cost the whole download to learn.
+     */
+    private fun readCapped(input: InputStream, max: Long): ByteArray? {
       val out = ByteArrayOutputStream()
       val buffer = ByteArray(64 * 1024)
       var total = 0L
@@ -3119,7 +3210,7 @@ class ServeCatalogStore(
         val n = input.read(buffer)
         if (n < 0) break
         total += n
-        require(total <= max) { "catalog file exceeds ${max / (1024 * 1024)}MB" }
+        if (total > max) return null
         out.write(buffer, 0, n)
       }
       return out.toByteArray()
@@ -3128,6 +3219,50 @@ class ServeCatalogStore(
 
   /** Current generation per system; see [scheduleFigmaSvgFetch]. */
   private val generations = ConcurrentHashMap<String, Int>()
+
+  /**
+   * The generation directory each system's **registered** host reads from.
+   *
+   * Written only where a host is published, never where one is built: a load that stages a
+   * generation and then fails to stand a session up leaves the previous entry in place, because the
+   * previous host is still the one serving.
+   */
+  private val liveDirs = ConcurrentHashMap<String, File>()
+
+  /** Where [system]'s registered host reads its bytes from, or null if it has never published. */
+  fun liveDir(system: String): File? = ServeBundleStore.sanitizeName(system)?.let { liveDirs[it] }
+
+  /**
+   * Record [dir] as [safe]'s live generation, at the moment the host reading it is registered.
+   *
+   * Called at every point a load publishes a session — the baked registration and each of the three
+   * live-lane builders — because "which files is the current host reading?" is exactly "which host
+   * did this load hand over?", and a generation marked live by a load that then returned without
+   * registering would be swept while the host that owns it is still serving.
+   */
+  private fun publishGeneration(safe: String, dir: File) {
+    liveDirs[safe] = dir
+  }
+
+  /**
+   * Delete every generation directory of [safe] except the live one and the names in [keep].
+   *
+   * Run at the **start** of a load rather than after the swap, and that is the whole of the grace
+   * period: a request that began against the outgoing host has until the next refresh tick —
+   * minutes — to finish reading, where retiring at the swap would pull the files out from under a
+   * read already in flight. Nothing here is load-bearing for correctness; a directory this misses
+   * is disk, not a wrong answer, and the next sweep takes it.
+   *
+   * The previous process's leftovers are swept by the same rule: on a fresh start nothing is live,
+   * so every generation on disk is stale by definition.
+   */
+  private fun retireStaleGenerations(safe: String, systemRoot: File, keep: Set<String>) {
+    val live = liveDirs[safe]?.name
+    for (child in systemRoot.listFiles().orEmpty()) {
+      if (child.name == live || child.name in keep) continue
+      runCatching { child.deleteRecursively() }
+    }
+  }
 
   /**
    * The delivery branch's published revisions, newest first — its commit history, read from the
@@ -3350,6 +3485,13 @@ class ServeCatalogStore(
   private fun fetchCatalogAssetsToFiles(
     plan: List<Pair<String, File>>,
     stillWanted: () -> Boolean = { true },
+    /**
+     * When set, an asset the transport refuses by size is staged as a marker of this many bytes
+     * instead of being skipped — see [stageOversizeMarker]. Only a lane whose reader distinguishes
+     * "too large" from "absent" passes it; for everything else a size refusal really is nothing to
+     * serve, and a marker would invent a file the branch never published.
+     */
+    oversizeMarkerBytes: Long? = null,
   ): Set<String> {
     if (plan.isEmpty()) return emptySet()
     val pool =
@@ -3366,13 +3508,19 @@ class ServeCatalogStore(
             val previous = activeFetchScope.get()
             activeFetchScope.set(submitting)
             try {
-              val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
+              val outcome =
+                runCatching { fetchCatalogAssetOutcome(url) }.getOrNull() ?: return@submit false
               // Re-checked immediately before the write, not just once per wave: a fetch started
               // for
               // one catalog generation must not land in the directory a refresh has since swapped
               // in.
               // Checking only between waves leaves every worker in the current wave free to write
               // after the swap, and nothing then removes what they wrote.
+              if (outcome is BranchFetch.TooLarge && oversizeMarkerBytes != null) {
+                if (!stillWanted()) return@submit false
+                return@submit stageOversizeMarker(target, oversizeMarkerBytes)
+              }
+              val bytes = outcome.bytesOrNull ?: return@submit false
               if (!stillWanted()) return@submit false
               runCatching {
                 target.parentFile?.mkdirs()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -767,6 +767,218 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a document the transport refuses by size still reaches the reader as too-large`() {
+    // #4521. The transport's envelope (25 MiB) sits far above the contract's document ceiling
+    // (1 MiB), so a document big enough to be refused *by the transport* is one the reader would
+    // refuse anyway — but it would refuse it as absent, because a read that brings back no bytes
+    // and a branch that published no file were the same `null`. `too-large`/413 and
+    // `unreadable`/404 are different verdicts, and the second one hides why.
+    //
+    // The marker is a length, not a payload: the reader answers from the file's metadata and never
+    // opens it, so nothing here materialises the megabytes it stands for.
+    val root = tempRoot()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, maxBytes ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith("/parity/known-differences.json") -> BranchFetch.TooLarge(maxBytes)
+            url.endsWith("/images/button.png") -> BranchFetch.Ok(png())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(
+      registered.getValue("compose-m3").knownDifferences()
+        is ServeKnownDifferences.Document.TooLarge,
+      "a size refusal must not read as a document the producer never published",
+    )
+    assertTrue(
+      File(store.liveDir("compose-m3")!!, "parity/known-differences.json").length() >
+        ServeKnownDifferences.MAX_DOCUMENT_BYTES,
+      "the marker's length alone is what the reader refuses from",
+    )
+  }
+
+  @Test
+  fun `an artifact the transport refuses by size still reaches the reader as too-large`() {
+    // The artifact half of #4521, and the half that costs something in practice: a mask past the
+    // transport's envelope was staged as nothing at all, so the engine reached
+    // `artifact-unreadable` — "the producer published no such file" — for a file the producer did
+    // publish and this server declined to carry.
+    val root = tempRoot()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val document =
+      """{"schema":"${ServeKnownDifferences.SCHEMA}","acceptances":[
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png"}]}"""
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, maxBytes ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith("/parity/known-differences.json") ->
+              BranchFetch.Ok(document.encodeToByteArray())
+            url.endsWith("/parity/known-differences/glyph/mask.png") ->
+              BranchFetch.TooLarge(maxBytes)
+            url.endsWith("/images/button.png") -> BranchFetch.Ok(png())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    val host = registered.getValue("compose-m3")
+    assertTrue(
+      host.knownDifferences() is ServeKnownDifferences.Document.Text,
+      "the document itself was readable",
+    )
+    assertEquals(
+      ServeKnownDifferences.Artifact.TooLarge,
+      host.knownDifferenceArtifact("glyph/mask.png"),
+    )
+  }
+
+  @Test
+  fun `an absent artifact stays absent — the marker is only for a size refusal`() {
+    // The other side of the same seam, and the reason the marker is opt-in per lane: a 404 must
+    // keep answering `unreadable`. A stager that invented a file for every failure would trade one
+    // collapsed verdict for the opposite one.
+    val root = tempRoot()
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val document =
+      """{"schema":"${ServeKnownDifferences.SCHEMA}","acceptances":[
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png"}]}"""
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, _ ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith("/parity/known-differences.json") ->
+              BranchFetch.Ok(document.encodeToByteArray())
+            url.endsWith("/images/button.png") -> BranchFetch.Ok(png())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertEquals(
+      ServeKnownDifferences.Artifact.Unreadable,
+      registered.getValue("compose-m3").knownDifferenceArtifact("glyph/mask.png"),
+    )
+  }
+
+  @Test
+  fun `a refreshing catalog never serves one host against another generation's files`() {
+    // #4522. The live directory is generation-scoped, so a refresh assembles `g<n+1>` while the
+    // registered host keeps reading `g<n>`. What this pins is the property the shared directory
+    // could not have: at every moment between the swap and the new registration, the host that is
+    // serving reads the files it was built for.
+    //
+    // Read through the outgoing host itself, since that is the thing the old shape got wrong: it
+    // kept serving from a directory whose files a later load had already replaced, so a lazily-read
+    // artifact came back as the new generation's bytes under the old generation's metadata.
+    val root = tempRoot()
+    val catalog = { marker: String ->
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","title":"$marker",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    }
+    val document = { marker: String ->
+      """{"schema":"${ServeKnownDifferences.SCHEMA}","acceptances":[
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/$marker",
+         "mask":"mask.png"}]}"""
+    }
+    var generation = "1"
+    val store =
+      ServeCatalogStore(
+        root = root,
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              catalog(generation).encodeToByteArray()
+            url.endsWith("/parity/known-differences.json") ->
+              document(generation).encodeToByteArray()
+            url.endsWith("/parity/known-differences/glyph/mask.png") ->
+              "mask-$generation".encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    val firstHost = registered.getValue("compose-m3")
+    val firstDir = store.liveDir("compose-m3")!!
+
+    generation = "2"
+    // The second load's staged files land in their own generation directory; the first host's
+    // remain exactly where they were until the new host takes over.
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    val secondDir = store.liveDir("compose-m3")!!
+    assertFalse(firstDir == secondDir, "a load publishes a new generation directory")
+    assertTrue(firstDir.isDirectory, "the outgoing generation survives its successor's load")
+
+    // The first host still reads its own generation's bytes, not the second's.
+    assertEquals(
+      "mask-1",
+      (firstHost.knownDifferenceArtifact("glyph/mask.png") as ServeKnownDifferences.Artifact.Bytes)
+        .bytes
+        .decodeToString(),
+    )
+    // And the new host reads the new ones.
+    assertEquals(
+      "mask-2",
+      (registered.getValue("compose-m3").knownDifferenceArtifact("glyph/mask.png")
+          as ServeKnownDifferences.Artifact.Bytes)
+        .bytes
+        .decodeToString(),
+    )
+
+    // A third load retires the first generation: the grace period is one refresh, not forever.
+    generation = "3"
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertFalse(firstDir.exists(), "the generation two loads back is swept")
+    assertTrue(secondDir.isDirectory, "the generation one load back is still readable")
+  }
+
+  @Test
   fun `a document the engine refuses whole names nothing to fetch`() {
     // Every one of these is a rejection of the *file*: the engine reaches it before `readArtifact`
     // is called once, and the result carries no `statuses` at all. So a stager that read the fetch
@@ -1349,7 +1561,8 @@ class ServeCatalogStoreTest {
         registerWasm = { s, d -> registeredWasm[s] = d },
       )
     assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok, "first load succeeds")
-    val png = File(root, "compose-m3/previews/button-filled__ideal__default__dark.png")
+    val png =
+      File(store.liveDir("compose-m3")!!, "previews/button-filled__ideal__default__dark.png")
     assertTrue(png.isFile, "the first load writes the preview PNG on disk")
 
     // Re-load with every image (transiently) unavailable — parseable catalog.json, zero images.
@@ -1359,7 +1572,10 @@ class ServeCatalogStoreTest {
       "a catalog with no usable images fails the re-load",
     )
     assertTrue(png.isFile, "the previously-served catalog is left intact on a failed re-load")
-    assertFalse(File(root, "compose-m3.staging").exists(), "the staging dir is cleaned up")
+    assertFalse(
+      File(root, "compose-m3/${ServeCatalogStore.STAGING_DIR}").exists(),
+      "the staging dir is cleaned up",
+    )
   }
 
   @Test
@@ -1476,7 +1692,8 @@ class ServeCatalogStoreTest {
 
     // The manifest is written into the served previews dir, with null keys omitted (all present
     // here).
-    val manifest = File(root, "compose-m3/previews/${ServeCatalogStore.VARIANTS_FILE}")
+    val manifest =
+      File(store.liveDir("compose-m3")!!, "previews/${ServeCatalogStore.VARIANTS_FILE}")
     assertTrue(manifest.isFile, "variants.json is written")
     val text = manifest.readText()
     assertTrue(
@@ -1641,7 +1858,8 @@ class ServeCatalogStoreTest {
     val preview = registered.getValue("reply").previews.single()
     assertEquals(expected, preview.props)
 
-    val manifest = File(root, "reply/previews/${ServeCatalogStore.VARIANTS_FILE}").readText()
+    val manifest =
+      File(store.liveDir("reply")!!, "previews/${ServeCatalogStore.VARIANTS_FILE}").readText()
     assertEquals(
       expected,
       Json.parseToJsonElement(manifest)
@@ -1705,7 +1923,8 @@ class ServeCatalogStoreTest {
 
     // variants.json carries the section/group/order the tabbed landing keys off (state/theme
     // absent).
-    val manifest = File(root, "meshcore-mobile/previews/${ServeCatalogStore.VARIANTS_FILE}")
+    val manifest =
+      File(store.liveDir("meshcore-mobile")!!, "previews/${ServeCatalogStore.VARIANTS_FILE}")
     val text = manifest.readText()
     assertTrue(
       text.contains("\"section\":\"Themes\"") && text.contains("\"group\":\"Foundation\""),
@@ -1899,7 +2118,7 @@ class ServeCatalogStoreTest {
     )
     assertContentEquals(
       rcBytes,
-      File(root, "remote-m3/ir/remote__ideal__default.rc").readBytes(),
+      File(store.liveDir("remote-m3")!!, "ir/remote__ideal__default.rc").readBytes(),
       "the IR-backed preview remains available for browser-side replay",
     )
   }
@@ -2013,7 +2232,7 @@ class ServeCatalogStoreTest {
 
     // On disk: the daemon-keyed entry landed re-keyed to the catalog id, beside `previews/`.
     assertTrue(
-      File(root, "compose-m3/ir/button-filled__ideal__default__dark.rc").isFile,
+      File(store.liveDir("compose-m3")!!, "ir/button-filled__ideal__default__dark.rc").isFile,
       "ir/<catalog-id>.rc materialised",
     )
     val host = registered.getValue("compose-m3")
@@ -2876,7 +3095,10 @@ class ServeCatalogStoreTest {
       )
       .load("compose-m3")
     assertTrue(registeredWasm.isEmpty(), "malformed manifest must not register")
-    assertTrue(!File(root, "compose-m3/escape.html").exists(), "traversal write rejected")
+    assertTrue(
+      root.walkTopDown().none { it.name == "escape.html" },
+      "traversal write rejected anywhere under the catalog root",
+    )
   }
 
   @Test

--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -1163,7 +1163,16 @@ canonical plane — a preview render is hundreds of pixels a side, not thousands
 `ServeCatalogStore.fetchCatalogAsset` caps every fetched catalog asset at `MAX_FETCH_BYTES` — 25 MB
 — so a noisy `accepted-candidate.png` that is comfortably inside 8192 px and 128 megapixels can
 still be evaluated offline, where it is read off disk, and refused on the serving host, where the
-fetch never completes and becomes `artifact-unreadable`. Dimensions do not bound file size: PNG
+fetch never completes. That refusal used to arrive as `artifact-unreadable`, because a fetch that
+brings back no bytes and a branch that published no file were the same `null` — the transport kept
+the bytes and discarded the outcome. It no longer does: `BranchFetch.TooLarge` is its own outcome
+(#4521), and the known-differences staging lane turns one into a marker file whose *length alone* is
+past the contract's ceiling, so the reader answers `artifact-too-large` from the metadata, the route
+serves 413, and the engine reports the verdict the producer actually earned. The marker is a length,
+not a payload — nothing allocates the megabytes it stands for, and nothing reads them, because both
+`ServeKnownDifferences.document` and `.artifact` refuse from the file's size before opening it.
+Only this lane opts in: for every other writer a size refusal genuinely is nothing to serve, and a
+marker there would invent a file the branch never published. Dimensions do not bound file size: PNG
 compression varies by orders of magnitude with content, and an acceptance's rasters are exactly the
 noisy sub-regions that compress worst. So `v1` caps each artifact at **8 MiB encoded**, checked from
 the artifact's length, which the reader reports alongside the prefix it serves (measuring the prefix

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -3265,13 +3265,36 @@ repo they had never heard of, which is the opposite of the rule and reads as "no
 contributor read a signed-out Live lane as a broken preview). The playground's own refusal still
 names the repo, because there the access genuinely is the bar.
 
+### A refresh never serves one host against another generation's files
+
+A load stages its catalog into `<root>/<system>/.staging` and, when the tree is usable, moves it to
+`<root>/<system>/g<n>` — a directory **no registered host is reading**. The session built from it is
+registered at the end of the load; only then does `g<n>` become the live generation, and the previous
+one keeps serving, from its own untouched files, until that moment.
+
+That is a property the older shape could not have. It renamed the staged tree over one shared
+`<root>/<system>`, and the registration of the host built for it came *later* — after the Wasm app,
+the baked vectors, the live bundles, all of which are network work measured in seconds. Everything
+read lazily from the bundle directory was exposed in that gap: `knownDifferenceArtifact`, design
+reference rasters, preview PNGs. Hash-guarded content degraded to a refusal that self-healed on the
+next tick, which is late rather than wrong; un-hashed content — a preview PNG, a raster — was served
+as the new generation's pixels beside the old generation's metadata, with nothing to notice
+([#4522](https://github.com/yschimke/compose-ai-tools/issues/4522)).
+
+Generations are retired by the sweep at the **start** of the next load rather than at the swap, so a
+request already reading the outgoing host has a full refresh interval to finish. Nothing there is
+load-bearing for correctness: a directory a sweep misses costs disk, and the following sweep takes
+it. On a fresh process nothing is live, so every generation left on disk by the previous one is stale
+by definition and swept on the first load.
+
 ### Fetched catalog bytes outlive the container (`--catalog-cache-dir`)
 
 `serve --catalogs` fetches each system's delivery branch into a directory the server creates with
 `createTempDirectory`, so everything a catalog pulled is discarded when the container is recreated —
 which on this image is what every rolled release performs. It is not only restarts: a catalog load
-deletes the live per-system directory before renaming its staging over it, so **each reload throws
-the previous generation away too**, including bytes the new revision never changed.
+publishes into a fresh per-system generation directory and the sweep at the *next* load retires the
+one before it, so **each reload throws an earlier generation away too**, including bytes the new
+revision never changed.
 
 For most of what a catalog fetches that costs little, because the baked PNGs are already lazy — a
 grid fills them through the ordinary request path. The exception is the executable tier: each live


### PR DESCRIPTION
Two holes in `ServeCatalogStore`'s storage model.

## #4522 — a refreshing catalog served one host against another generation's files

`load` renamed its staging tree over the shared `<root>/<system>` directory and only registered the host built for it *afterwards*, with the Wasm app, the baked vectors and the live bundles — all network work — in between. Between the swap and the registration the **old** host was still the registered one, reading a directory that already held the **new** generation's files. Hash-guarded content (known-difference masks, accepted candidates) degraded to a refusal that self-heals on the next tick; preview PNGs and design-reference rasters have no such guard and were served as the new generation's pixels beside the old generation's metadata.

Option (1) from the issue, not (2): the live directory is now **generation-scoped**, `<root>/<system>/g<n>`, and a load never writes into the one that is registered.

- A load stages into `<root>/<system>/.staging` and moves it to `g<n>` — a path no host is reading — so the swap stops being a mutation of shared state.
- `publishGeneration` records the new directory as live at each of the four points a load actually registers a session (the baked registration and the three live-lane builders), so a load that stages a generation and then fails to stand a session up leaves the previous one live, because the previous host is still serving.
- Retirement is deferred to the sweep at the **start** of the next load, giving a request already reading the outgoing host a full refresh interval to finish. Nothing there is load-bearing: a directory a sweep misses costs disk, not a wrong answer. On a fresh process nothing is live, so the previous process's generations are stale by definition and swept on the first load.

## #4521 — a size refusal was indistinguishable from an unpublished asset

`readCapped` threw and every call site caught it into `null` — which is also what a 404 answers. A known-difference document or artifact past the transport's 25 MiB envelope therefore reached the engine as `document-unreadable` / `artifact-unreadable`: the verdict that means *the producer published nothing*, where `compose-preview-known-differences/v1` calls for `too-large`/413.

Option (1) from the issue, scoped to the one writer whose contract distinguishes the two:

- The transport answers `BranchFetch.TooLarge(limitBytes)` instead of throwing — not transient (the file will be exactly as oversized next time), and counted on `/status.json` as `branchFetch.tooLarge` beside `notFound`.
- `writeKnownDifferences` consults the outcome and stages a **marker whose length alone** is past the contract's ceiling. The reader (`ServeKnownDifferences.document` / `.artifact`) already refuses from the file's size before opening it, so `RandomAccessFile.setLength` is enough — nothing allocates the megabytes the marker stands for.
- Opt-in per lane (`fetchCatalogAssetsToFiles(oversizeMarkerBytes = …)`): for every other writer a size refusal really is nothing to serve, and a marker would invent a file the branch never published.

## Test plan

`./gradlew :cli:test :cli:ktfmtCheck` — green (81 tests in `ServeCatalogStoreTest`, four of them new):

- `a refreshing catalog never serves one host against another generation's files` — the outgoing host still reads its own generation's artifact bytes after a second load has published, the new host reads the new ones, and a third load retires the first generation.
- `a document the transport refuses by size still reaches the reader as too-large` — and the staged marker's length is past `MAX_DOCUMENT_BYTES`.
- `an artifact the transport refuses by size still reaches the reader as too-large`.
- `an absent artifact stays absent — the marker is only for a size refusal` — a 404 keeps answering `Unreadable`.

Non-visual change (serve-side storage model and transport plumbing), so no rendered before/after applies.

Closes #4522
Closes #4521

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKVvJfax7Xpi6E4NR9GBVN)_