### PR TITLE
fix(serve): move the in-browser Wasm registration onto the publishing generation

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -3632,12 +3632,26 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
         onPostPublishIncomplete = { system -> activeRefresher?.forgetHeads(listOf(system)) },
         registerWasm = { system, wasmDir ->
           // A local `--wasm-dir` is the operator's explicit override, so a published app never
-          // displaces it — including on a later branch refresh, which re-runs this callback.
+          // displaces it — including on a later branch refresh, which re-runs this callback, and
+          // including the withdrawal below.
           if (system !in localWasm) {
-            wasm[system] = wasmDir
-            System.err.println(
-              "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
-            )
+            if (wasmDir == null) {
+              // This generation carries no usable app. Withdrawn rather than left pointing at the
+              // outgoing generation's copy, which is readable until the next sweep: the toggle
+              // would otherwise run the previous catalog's code, then 404.
+              if (wasm.remove(system) != null) {
+                System.err.println(
+                  "serve: catalog $system no longer carries an in-browser Wasm app"
+                )
+              }
+            } else {
+              val fresh = wasm.put(system, wasmDir) == null
+              if (fresh) {
+                System.err.println(
+                  "serve: catalog $system carries an in-browser Wasm app (/wasm/$system/)"
+                )
+              }
+            }
           }
         },
         buildTrustedBundle = {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -86,12 +86,21 @@ class ServeCatalogStore(
   private val networkProbe: (url: String) -> BranchFetch = ::httpProbeOutcome,
   private val maxImages: Int = DEFAULT_MAX_IMAGES,
   /**
-   * Called when the catalog declares an in-browser Wasm app (`webRender` in `catalog.json`) and its
-   * files were fetched: the system id → the local directory the app was written to. The server then
-   * serves it at `/wasm/<system>/`, so the **CMP-Wasm tier rides the same trusted branch as the
-   * catalog** — a deployed public server needs no local `--wasm-dir` build, just `--catalogs`.
+   * Called when a catalog publishes: the system id → the local directory its in-browser Wasm app
+   * (`webRender` in `catalog.json`) was written to, or **null when this generation has no usable
+   * app**. The server then serves it at `/wasm/<system>/`, so the **CMP-Wasm tier rides the same
+   * trusted branch as the catalog** — a deployed public server needs no local `--wasm-dir` build,
+   * just `--catalogs`.
+   *
+   * Null is not the same as not calling this at all, and the difference is why it is invoked on
+   * every publish. A refreshed catalog that dropped its `webRender`, or whose app failed to fetch,
+   * leaves the previous generation's app on disk and readable — generation directories outlive
+   * their host by a refresh — so a registration nobody withdrew would keep the viewer's "Run in
+   * browser" toggle serving the *old* catalog's code beside the new catalog's pages, until the
+   * sweep turned the same toggle into 404s. So the registration moves with the generation: it is
+   * made at the moment the new host is published, and null withdraws it.
    */
-  private val registerWasm: (system: String, dir: File) -> Unit = { _, _ -> },
+  private val registerWasm: (system: String, dir: File?) -> Unit = { _, _ -> },
   /**
    * Invoked when a **post-publish** lane finished with a transient failure of its own.
    *
@@ -802,7 +811,10 @@ class ServeCatalogStore(
     // dir. Best-effort — a fetch failure just leaves the catalog without the in-browser tier (the
     // PNG + data tiers still serve). The file list is enumerated by the trusted catalog, not the
     // client, and each file is path-contained + size-capped like the images.
-    val wasmRegistered = fetchWasmApp(catalog.webRender, base, dir, safe)
+    // Fetched here, registered at publication ([publishGeneration]) — the tier belongs to this
+    // generation, and nothing may point at it while the previous host is still the registered one.
+    val wasmDir = fetchWasmApp(catalog.webRender, base, dir, safe)
+    val wasmRegistered = wasmDir != null
 
     val verdict =
       if (trust().trustsBranch(repo, branch))
@@ -1075,7 +1087,7 @@ class ServeCatalogStore(
               { bakedFallback(emptyList(), deferredIds.toList()) },
             )
         ) {
-          publishGeneration(safe, dir)
+          publishGeneration(safe, dir, wasmDir)
           return Result.Ok(
             safe,
             count + deferredIds.size + failedIds.size,
@@ -1159,7 +1171,7 @@ class ServeCatalogStore(
                   perPreviewBundle,
                 )
             ) {
-              publishGeneration(safe, dir)
+              publishGeneration(safe, dir, wasmDir)
               return Result.Ok(
                 safe,
                 count + deferredIds.size + failedIds.size,
@@ -1206,7 +1218,7 @@ class ServeCatalogStore(
           { bakedFallback(emptyList(), deferredIds.toList()) },
         )
     ) {
-      publishGeneration(safe, dir)
+      publishGeneration(safe, dir, wasmDir)
       return Result.Ok(
         safe,
         count + deferredIds.size + failedIds.size,
@@ -1250,7 +1262,7 @@ class ServeCatalogStore(
         )
     // Same reasoning as the degradation: a session with no live lane lists no live-only previews.
     val host = bakedFallback(degradations, emptyList())
-    publishGeneration(safe, dir)
+    publishGeneration(safe, dir, wasmDir)
     register(safe, host)
     return Result.Ok(
       safe,
@@ -1267,15 +1279,16 @@ class ServeCatalogStore(
    * to the declared `path`, rejected on traversal, and size-capped by [fetch]. Needs at least an
    * `index.html` to be usable. No-op for a null / non-`compose-wasm` descriptor.
    *
-   * Returns true iff the in-browser Wasm tier was actually registered — the caller uses this to
-   * decide whether the session still has a live (in-browser) lane, so it must NOT record a
-   * baked-only degradation even when there's no server-side `liveBundle`. A declared-but-incomplete
-   * app (any fetch/traversal failure) returns false, leaving the session genuinely snapshot-only.
+   * Returns the app's directory iff the in-browser Wasm tier is usable — the caller registers it
+   * with the generation it belongs to (see [registerWasm]) and uses it to decide whether the
+   * session still has a live (in-browser) lane, so it must NOT record a baked-only degradation even
+   * when there's no server-side `liveBundle`. A declared-but-incomplete app (any fetch/traversal
+   * failure) returns null, leaving the session genuinely snapshot-only.
    */
-  private fun fetchWasmApp(render: WebRender?, base: String, dir: File, system: String): Boolean {
-    if (render == null || render.kind != WEB_RENDER_COMPOSE_WASM) return false
+  private fun fetchWasmApp(render: WebRender?, base: String, dir: File, system: String): File? {
+    if (render == null || render.kind != WEB_RENDER_COMPOSE_WASM) return null
     val prefix = render.path.trim('/')
-    if (prefix.isEmpty() || render.files.isEmpty()) return false
+    if (prefix.isEmpty() || render.files.isEmpty()) return null
     val wasmDir = File(dir, WEB_WASM_DIR)
     // **Fail closed, all-or-nothing.** Register the app only if *every* declared file is fetched
     // and
@@ -1283,10 +1296,10 @@ class ServeCatalogStore(
     // traversal/escaping entry, or a list longer than the cap) would make the viewer advertise "Run
     // in browser (Wasm)" only for the iframe to 404 its module/wasm fetches. The file list is the
     // trusted catalog's complete manifest, so any missing/invalid entry means "don't offer it".
-    fun fail(reason: String): Boolean {
+    fun fail(reason: String): File? {
       wasmDir.deleteRecursively()
       System.err.println("serve: $system web/wasm/ incomplete ($reason) — in-browser tier disabled")
-      return false
+      return null
     }
     if (render.files.size > MAX_WASM_FILES) return fail("more than $MAX_WASM_FILES files declared")
     val wasmRoot = wasmDir.canonicalFile.toPath()
@@ -1302,8 +1315,7 @@ class ServeCatalogStore(
       target.writeBytes(bytes)
     }
     if (!File(wasmDir, "index.html").isFile) return fail("no index.html")
-    registerWasm(system, wasmDir)
-    return true
+    return wasmDir
   }
 
   /**
@@ -3240,8 +3252,12 @@ class ServeCatalogStore(
    * did this load hand over?", and a generation marked live by a load that then returned without
    * registering would be swept while the host that owns it is still serving.
    */
-  private fun publishGeneration(safe: String, dir: File) {
+  private fun publishGeneration(safe: String, dir: File, wasmDir: File?) {
     liveDirs[safe] = dir
+    // Always, including with null: an in-browser app registered by an earlier generation outlives
+    // its host on disk, so a publish that carries none has to withdraw it rather than simply not
+    // replace it. See [registerWasm].
+    registerWasm(safe, wasmDir)
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -137,7 +137,7 @@ class ServeCatalogStoreTest {
       register = { n, h -> registered[n] = h },
       trust = { trust },
       fetch = fetch,
-      registerWasm = { s, d -> registeredWasm[s] = d },
+      registerWasm = { s, d -> if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d },
       maxImages = maxImages,
       figmaExecutor = figmaExecutor,
     )
@@ -1558,7 +1558,9 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = { TrustStore.EMPTY },
         fetch = fetch,
-        registerWasm = { s, d -> registeredWasm[s] = d },
+        registerWasm = { s, d ->
+          if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d
+        },
       )
     assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok, "first load succeeds")
     val png =
@@ -1686,7 +1688,9 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = { TrustStore.EMPTY },
         fetch = fetch,
-        registerWasm = { s, d -> registeredWasm[s] = d },
+        registerWasm = { s, d ->
+          if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d
+        },
       )
     assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
 
@@ -1917,7 +1921,9 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = { TrustStore.EMPTY },
         fetch = fetch,
-        registerWasm = { s, d -> registeredWasm[s] = d },
+        registerWasm = { s, d ->
+          if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d
+        },
       )
     assertTrue(store.load("meshcore-mobile") is ServeCatalogStore.Result.Ok)
 
@@ -3067,6 +3073,55 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a refresh that drops the wasm app withdraws its registration`() {
+    // Generation directories outlive their host by one refresh, so an app the previous generation
+    // registered stays readable after the new host publishes. A registration nobody withdrew would
+    // keep the viewer's "Run in browser" toggle serving the OLD catalog's code beside the new
+    // catalog's pages — and then, once the sweep took that directory, 404 on the same toggle. So
+    // the registration moves with the generation, in both directions.
+    val withWasm = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
+    val withoutWasm =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3","components":[
+        {"componentId":"Button/Filled","images":[
+          {"path":"images/button-filled/ideal__default__dark.png","theme":"dark"}]}]}
+      """
+        .trimIndent()
+    var catalog = withWasm
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.toByteArray()
+            url.endsWith(".png") -> png()
+            url.contains("/web/wasm/") -> "x".toByteArray()
+            else -> null
+          }
+        },
+        registerWasm = { s, d ->
+          if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d
+        },
+      )
+
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(registeredWasm.containsKey("compose-m3"), "the first generation carries an app")
+
+    catalog = withoutWasm
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    assertTrue(
+      registeredWasm.isEmpty(),
+      "a generation with no app must not leave the previous one's registered",
+    )
+    assertEquals(
+      listOf(ServeDegradation.CATALOG_BAKED_ONLY),
+      registered.getValue("compose-m3").degradations.map { it.code },
+    )
+  }
+
+  @Test
   fun `a webRender with a failed required-file fetch registers nothing (fail closed)`() {
     val catalog = wasmCatalog("\"index.html\",\"composeApp.wasm\",\"skiko.wasm\"")
     // composeApp.wasm 404s → the app is incomplete → don't advertise a tier whose iframe would 404.
@@ -3091,7 +3146,9 @@ class ServeCatalogStoreTest {
         register = { n, h -> registered[n] = h },
         trust = { TrustStore.EMPTY },
         fetch = wasmFetcher(catalog),
-        registerWasm = { s, d -> registeredWasm[s] = d },
+        registerWasm = { s, d ->
+          if (d == null) registeredWasm.remove(s) else registeredWasm[s] = d
+        },
       )
       .load("compose-m3")
     assertTrue(registeredWasm.isEmpty(), "malformed manifest must not register")


### PR DESCRIPTION
Follow-up to #4552, from the Codex review it drew after it had already merged.

## The gap

A generation directory now outlives its host by one refresh — that is the grace period #4552 introduced deliberately. `fetchWasmApp` registered `/wasm/<system>/` eagerly, right after the swap, and had no way to *withdraw* a registration. So a refreshed catalog that dropped its `webRender`, or whose app failed to fetch, never called `registerWasm` at all and left the live map pointing at `g<n-1>/web/wasm`:

- while that directory survives, the viewer's "Run in browser" toggle serves the **previous** catalog's code beside the new catalog's pages — the exact host/files split #4552 exists to close, one map entry over;
- once the next sweep takes the directory, the same toggle 404s, permanently, because nothing ever removes the entry.

Before #4552 this was self-limiting: the shared directory was deleted at the swap, so a stale entry became 404s immediately rather than serving old code. The generation directories make the stale-but-readable window real, so the registration has to move with the generation.

## The change

- `fetchWasmApp` returns the app's directory (or null) instead of registering; the caller keeps using it for the "is there still a live lane?" decision, so the baked-only degradation is unchanged.
- `registerWasm` becomes `(system, dir: File?) -> Unit` and is invoked from `publishGeneration` — the same place the new generation becomes live — on **every** publish. Null withdraws the registration.
- `ServeCommand` removes the map entry on null and only logs on a transition, so a refresh no longer prints the "carries an in-browser Wasm app" line every tick. The local `--wasm-dir` override still wins in both directions: a published app never displaces it, and a withdrawal never removes it.

## Test plan

`./gradlew :cli:test :cli:ktfmtCheck` — green. New test `a refresh that drops the wasm app withdraws its registration`: a first load registers the app, a second load of a catalog without `webRender` leaves nothing registered and the session reports `catalog-baked-only`. The existing fail-closed and traversal tests still pin that an incomplete app registers nothing.

Non-visual (serve-side registration plumbing), so no rendered before/after applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKVvJfax7Xpi6E4NR9GBVN)_