### PR TITLE
feat(daemon-client): enforce explicit API and gate the published ABI

### DIFF
--- a/daemon/client/api/daemon-client.api
+++ b/daemon/client/api/daemon-client.api
@@ -1,0 +1,100 @@
+public final class ee/schimke/composeai/daemon/client/DaemonClient : java/io/Closeable {
+	public fun <init> (Ljava/io/InputStream;Ljava/io/OutputStream;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/io/InputStream;Ljava/io/OutputStream;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun dataFetch-9VgGkz4 (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ZJ)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public static synthetic fun dataFetch-9VgGkz4$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ZJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public final fun dataSubscribe-SxA4cEA (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun dataSubscribe-SxA4cEA$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public final fun dataUnsubscribe-SxA4cEA (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun dataUnsubscribe-SxA4cEA$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public final fun extensionsDisable-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public static synthetic fun extensionsDisable-HG0u8IE$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public final fun extensionsEnable-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public static synthetic fun extensionsEnable-HG0u8IE$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public final fun extensionsList-LRDsOJo (J)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public static synthetic fun extensionsList-LRDsOJo$default (Lee/schimke/composeai/daemon/client/DaemonClient;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public final fun fileChanged (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;)V
+	public static synthetic fun fileChanged$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;ILjava/lang/Object;)V
+	public final fun historyDiff-Wn2Vu4Y (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;J)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public static synthetic fun historyDiff-Wn2Vu4Y$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public final fun historyList-HG0u8IE (Lee/schimke/composeai/daemon/protocol/HistoryListParams;J)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public static synthetic fun historyList-HG0u8IE$default (Lee/schimke/composeai/daemon/client/DaemonClient;Lee/schimke/composeai/daemon/protocol/HistoryListParams;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public final fun historyRead-SxA4cEA (Ljava/lang/String;ZJ)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public static synthetic fun historyRead-SxA4cEA$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;ZJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public final fun initialize-B8UsjHI (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Ljava/util/List;Ljava/lang/Long;J)Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public static synthetic fun initialize-B8UsjHI$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Ljava/util/List;Ljava/lang/Long;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public final fun interactiveInput (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun interactiveInput$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun recordingEncode-SxA4cEA (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;J)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public static synthetic fun recordingEncode-SxA4cEA$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public final fun recordingScript (Ljava/lang/String;Ljava/util/List;)V
+	public final fun recordingStart-9VgGkz4 (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public static synthetic fun recordingStart-9VgGkz4$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public final fun recordingStop-HG0u8IE (Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public static synthetic fun recordingStop-HG0u8IE$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public final fun renderNow-9VgGkz4 (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public static synthetic fun renderNow-9VgGkz4$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public final fun setFocus (Ljava/util/List;)V
+	public final fun setVisible (Ljava/util/List;)V
+	public final fun shutdownAndExit-LRDsOJo (J)V
+	public static synthetic fun shutdownAndExit-LRDsOJo$default (Lee/schimke/composeai/daemon/client/DaemonClient;JILjava/lang/Object;)V
+	public final fun streamStart-9VgGkz4 (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public static synthetic fun streamStart-9VgGkz4$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public final fun streamStop (Ljava/lang/String;)V
+	public final fun streamVisibility (Ljava/lang/String;ZLjava/lang/Integer;)V
+	public static synthetic fun streamVisibility$default (Lee/schimke/composeai/daemon/client/DaemonClient;Ljava/lang/String;ZLjava/lang/Integer;ILjava/lang/Object;)V
+}
+
+public abstract interface class ee/schimke/composeai/daemon/client/DaemonClientFactory {
+	public abstract fun spawn (Lee/schimke/composeai/daemon/client/WorkspaceId;Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;)Lee/schimke/composeai/daemon/client/DaemonSpawn;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/client/DaemonSpawn {
+	public abstract fun client (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;)Lee/schimke/composeai/daemon/client/DaemonClient;
+	public abstract fun getClient ()Lee/schimke/composeai/daemon/client/DaemonClient;
+	public abstract fun shutdown ()V
+	public fun shutdown-LRDsOJo (J)V
+}
+
+public final class ee/schimke/composeai/daemon/client/DaemonSpawn$DefaultImpls {
+	public static fun shutdown-LRDsOJo (Lee/schimke/composeai/daemon/client/DaemonSpawn;J)V
+}
+
+public final class ee/schimke/composeai/daemon/client/DataProductWireException : java/lang/RuntimeException {
+	public static final field BUDGET_EXCEEDED I
+	public static final field Companion Lee/schimke/composeai/daemon/client/DataProductWireException$Companion;
+	public static final field FETCH_FAILED I
+	public static final field NOT_AVAILABLE I
+	public static final field UNKNOWN I
+	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun getCode ()I
+	public final fun getData ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getWireMessage ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/client/DataProductWireException$Companion {
+	public final fun from (Lkotlinx/serialization/json/JsonObject;)Lee/schimke/composeai/daemon/client/DataProductWireException;
+}
+
+public final class ee/schimke/composeai/daemon/client/SubprocessDaemonClientFactory : ee/schimke/composeai/daemon/client/DaemonClientFactory {
+	public fun <init> ()V
+	public fun spawn (Lee/schimke/composeai/daemon/client/WorkspaceId;Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;)Lee/schimke/composeai/daemon/client/DaemonSpawn;
+}
+
+public final class ee/schimke/composeai/daemon/client/WorkspaceId {
+	public static final field Companion Lee/schimke/composeai/daemon/client/WorkspaceId$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/client/WorkspaceId;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/client/WorkspaceId;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/client/WorkspaceId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/client/WorkspaceId$Companion {
+	public final fun derive (Ljava/lang/String;Ljava/io/File;)Lee/schimke/composeai/daemon/client/WorkspaceId;
+}
+

--- a/daemon/client/build.gradle.kts
+++ b/daemon/client/build.gradle.kts
@@ -23,6 +23,25 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
 }
 
+kotlin {
+  // `explicitApi()` — every declaration here must state its visibility, and every public one must
+  // state its return type. This module is a published contract an extracted preview server compiles
+  // against across a repo boundary (#3824), so an implicitly-public declaration is an API decision
+  // nobody made. The compiler now asks. See docs/API_STABILITY.md and #3824 preparation item 6.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*`. `checkKotlinAbi` diffs the module's real public ABI
+  // against the committed dump in `api/`, so a change to the published surface shows up as a diff
+  // in review rather than as a downstream break. Ships in the Kotlin Gradle plugin itself (still
+  // `@ExperimentalAbiValidation` at 2.4), so no extra plugin on the classpath. Regenerate with
+  // `./gradlew :daemon-client:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }
+
 dependencies {
   // Protocol message types (`RenderNowParams`, `InitializeResult`, `PreviewOverrides`, …) and
   // `DaemonLaunchDescriptor` are all over this module's public surface, so `api` rather than

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClient.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClient.kt
@@ -80,7 +80,7 @@ import kotlinx.serialization.json.long
  *    → list_changed; `classpathDirty` → respawn) so we don't need the predicate-poll API the
  *    harness uses for assertions.
  */
-class DaemonClient(
+public class DaemonClient(
   private val input: InputStream,
   private val output: OutputStream,
   /** Notification sink. Called from the reader thread; handlers must not block. */
@@ -101,7 +101,7 @@ class DaemonClient(
     }
 
   /** Drives `initialize` + `initialized`. Returns the daemon's [InitializeResult]. */
-  fun initialize(
+  public fun initialize(
     workspaceRoot: String,
     moduleId: String,
     moduleProjectDir: String,
@@ -144,23 +144,23 @@ class DaemonClient(
     return result
   }
 
-  fun setVisible(ids: List<String>) =
+  public fun setVisible(ids: List<String>): Unit =
     sendNotification(
       "setVisible",
       json.encodeToJsonElement(SetVisibleParams.serializer(), SetVisibleParams(ids = ids)),
     )
 
-  fun setFocus(ids: List<String>) =
+  public fun setFocus(ids: List<String>): Unit =
     sendNotification(
       "setFocus",
       json.encodeToJsonElement(SetFocusParams.serializer(), SetFocusParams(ids = ids)),
     )
 
-  fun fileChanged(
+  public fun fileChanged(
     path: String,
     kind: FileKind = FileKind.SOURCE,
     changeType: ChangeType = ChangeType.MODIFIED,
-  ) =
+  ): Unit =
     sendNotification(
       "fileChanged",
       json.encodeToJsonElement(
@@ -170,7 +170,7 @@ class DaemonClient(
     )
 
   /** Drives `renderNow` for the given preview ids at the given [tier]. */
-  fun renderNow(
+  public fun renderNow(
     previews: List<String>,
     tier: RenderTier = RenderTier.FULL,
     reason: String? = null,
@@ -199,7 +199,7 @@ class DaemonClient(
   // ---------------------------------------------------------------------------
 
   /** Drives `history/list`. Default no-filter call returns recent entries across all previews. */
-  fun historyList(
+  public fun historyList(
     params: HistoryListParams = HistoryListParams(),
     timeout: Duration = 30.seconds,
   ): HistoryListResult {
@@ -218,7 +218,7 @@ class DaemonClient(
   }
 
   /** Drives `history/read`. With [inline] = true the daemon returns base64 PNG bytes inline. */
-  fun historyRead(
+  public fun historyRead(
     entryId: String,
     inline: Boolean = false,
     timeout: Duration = 30.seconds,
@@ -239,7 +239,7 @@ class DaemonClient(
   }
 
   /** Drives `history/diff` (metadata mode by default). */
-  fun historyDiff(
+  public fun historyDiff(
     fromId: String,
     toId: String,
     mode: HistoryDiffMode = HistoryDiffMode.METADATA,
@@ -276,7 +276,7 @@ class DaemonClient(
    * the tool result so the agent sees the exact wire-error name (`DataProductUnknown`,
    * `DataProductNotAvailable`, `DataProductFetchFailed`, `DataProductBudgetExceeded`).
    */
-  fun dataFetch(
+  public fun dataFetch(
     previewId: String,
     kind: String,
     params: kotlinx.serialization.json.JsonElement? = null,
@@ -306,14 +306,14 @@ class DaemonClient(
    * — the daemon drops them automatically when the preview leaves the most recent `setVisible` set
    * (see DATA-PRODUCTS.md). Re-subscribe when the preview returns to view.
    */
-  fun dataSubscribe(
+  public fun dataSubscribe(
     previewId: String,
     kind: String,
     timeout: Duration = 15.seconds,
   ): DataSubscribeResult = dataSubOrUnsub("data/subscribe", previewId, kind, timeout)
 
   /** Drives `data/unsubscribe`. See [dataSubscribe]. */
-  fun dataUnsubscribe(
+  public fun dataUnsubscribe(
     previewId: String,
     kind: String,
     timeout: Duration = 15.seconds,
@@ -327,7 +327,7 @@ class DaemonClient(
   // requirements). Disabling them on shutdown is unnecessary — the daemon dies with the spawn.
   // ---------------------------------------------------------------------------
 
-  fun extensionsList(timeout: Duration = 15.seconds): ExtensionsListResult {
+  public fun extensionsList(timeout: Duration = 15.seconds): ExtensionsListResult {
     val id = nextId.getAndIncrement()
     val request =
       JsonRpcRequest(id = id, method = "extensions/list", params = JsonObject(emptyMap()))
@@ -336,7 +336,10 @@ class DaemonClient(
     return json.decodeFromJsonElement(ExtensionsListResult.serializer(), resultElem)
   }
 
-  fun extensionsEnable(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsEnableResult {
+  public fun extensionsEnable(
+    ids: List<String>,
+    timeout: Duration = 15.seconds,
+  ): ExtensionsEnableResult {
     val id = nextId.getAndIncrement()
     val params = ExtensionsEnableParams(ids = ids)
     val request =
@@ -350,7 +353,7 @@ class DaemonClient(
     return json.decodeFromJsonElement(ExtensionsEnableResult.serializer(), resultElem)
   }
 
-  fun extensionsDisable(
+  public fun extensionsDisable(
     ids: List<String>,
     timeout: Duration = 15.seconds,
   ): ExtensionsDisableResult {
@@ -401,7 +404,7 @@ class DaemonClient(
   // ---------------------------------------------------------------------------
 
   /** Drives `recording/start`. Returns the daemon-allocated `recordingId`. */
-  fun recordingStart(
+  public fun recordingStart(
     previewId: String,
     fps: Int? = null,
     scale: Float? = null,
@@ -428,7 +431,7 @@ class DaemonClient(
   }
 
   /** Drives `recording/script` (notification — no response). */
-  fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+  public fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>): Unit =
     sendNotification(
       "recording/script",
       json.encodeToJsonElement(
@@ -438,7 +441,10 @@ class DaemonClient(
     )
 
   /** Drives `recording/stop`. Blocks until the daemon's playback loop finishes writing frames. */
-  fun recordingStop(recordingId: String, timeout: Duration = 5.minutes): RecordingStopResult {
+  public fun recordingStop(
+    recordingId: String,
+    timeout: Duration = 5.minutes,
+  ): RecordingStopResult {
     val id = nextId.getAndIncrement()
     val params = RecordingStopParams(recordingId = recordingId)
     val request =
@@ -458,7 +464,7 @@ class DaemonClient(
   }
 
   /** Drives `recording/encode`. Returns `{ videoPath, mimeType, sizeBytes }`. */
-  fun recordingEncode(
+  public fun recordingEncode(
     recordingId: String,
     format: RecordingFormat = RecordingFormat.APNG,
     timeout: Duration = 60.seconds,
@@ -488,7 +494,7 @@ class DaemonClient(
    * [sendAndAwait] / the error branch) when the daemon doesn't implement streaming — callers fall
    * back to per-frame renders.
    */
-  fun streamStart(
+  public fun streamStart(
     previewId: String,
     codec: StreamCodec? = null,
     maxFps: Int? = null,
@@ -520,7 +526,7 @@ class DaemonClient(
   }
 
   /** Drives `stream/stop` (notification — no response). Tears down the held stream. */
-  fun streamStop(frameStreamId: String) =
+  public fun streamStop(frameStreamId: String): Unit =
     sendNotification(
       "stream/stop",
       json.encodeToJsonElement(StreamStopParams.serializer(), StreamStopParams(frameStreamId)),
@@ -532,7 +538,7 @@ class DaemonClient(
    * rate and — since the daemon's frame loop reads the same gate — the render rate behind it. [fps]
    * overrides the throttled rate; the daemon's default is 1 fps.
    */
-  fun streamVisibility(frameStreamId: String, visible: Boolean, fps: Int? = null) =
+  public fun streamVisibility(frameStreamId: String, visible: Boolean, fps: Int? = null): Unit =
     sendNotification(
       "stream/visibility",
       json.encodeToJsonElement(
@@ -546,7 +552,7 @@ class DaemonClient(
    * [frameStreamId]; the daemon dispatches the input into the live composition and emits the
    * resulting `streamFrame`.
    */
-  fun interactiveInput(
+  public fun interactiveInput(
     frameStreamId: String,
     kind: InteractiveInputKind,
     pixelX: Int? = null,
@@ -556,7 +562,7 @@ class DaemonClient(
     keyCode: String? = null,
     text: String? = null,
     pointerType: String? = null,
-  ) =
+  ): Unit =
     sendNotification(
       "interactive/input",
       json.encodeToJsonElement(
@@ -579,7 +585,7 @@ class DaemonClient(
    * Sends `shutdown` (drains in-flight renders) then `exit`. Does not wait for process exit — the
    * [DaemonSpawn] owner does that.
    */
-  fun shutdownAndExit(timeout: Duration = 15.seconds) {
+  public fun shutdownAndExit(timeout: Duration = 15.seconds) {
     if (closed.get()) return
     runCatching {
       val id = nextId.getAndIncrement()
@@ -702,16 +708,19 @@ class DaemonClient(
  * `-32023` DataProductBudgetExceeded. Callers (notably `DaemonMcpServer.toolGetPreviewData`) use
  * [code] to decide whether to retry — `DataProductNotAvailable` is the auto-render trigger.
  */
-class DataProductWireException(val code: Int, val wireMessage: String, val data: JsonObject?) :
-  RuntimeException("data/fetch wire error $code: $wireMessage") {
-  companion object {
-    const val UNKNOWN = -32020
-    const val NOT_AVAILABLE = -32021
-    const val FETCH_FAILED = -32022
-    const val BUDGET_EXCEEDED = -32023
+public class DataProductWireException(
+  public val code: Int,
+  public val wireMessage: String,
+  public val data: JsonObject?,
+) : RuntimeException("data/fetch wire error $code: $wireMessage") {
+  public companion object {
+    public const val UNKNOWN: Int = -32020
+    public const val NOT_AVAILABLE: Int = -32021
+    public const val FETCH_FAILED: Int = -32022
+    public const val BUDGET_EXCEEDED: Int = -32023
 
     /** Extracts the JSON-RPC error payload into a [DataProductWireException]. */
-    fun from(errorElem: JsonObject): DataProductWireException =
+    public fun from(errorElem: JsonObject): DataProductWireException =
       DataProductWireException(
         code = errorElem["code"]?.jsonPrimitive?.long?.toInt() ?: 0,
         wireMessage = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: errorElem.toString(),

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClientFactory.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/DaemonClientFactory.kt
@@ -19,8 +19,8 @@ import kotlinx.serialization.json.JsonObject
  * parameter. Spawning needs the identity, not the registry. Narrowing it is what made this module
  * extractable at all (#4528).
  */
-fun interface DaemonClientFactory {
-  fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn
+public fun interface DaemonClientFactory {
+  public fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn
 }
 
 /**
@@ -28,24 +28,24 @@ fun interface DaemonClientFactory {
  * fake daemon side of a piped pair (in tests). The owner calls [client] once after spawn to wire
  * the notification + close handlers.
  */
-interface DaemonSpawn {
-  val client: DaemonClient
+public interface DaemonSpawn {
+  public val client: DaemonClient
 
   /**
    * Wires the owner's notification + close handlers onto the underlying [client]. Called exactly
    * once by `DaemonSupervisor.spawn` before any traffic flows. Implementations typically delay
    * creating the [client] until this call so the handlers are baked in from the first frame.
    */
-  fun client(
+  public fun client(
     onNotification: (method: String, params: JsonObject?) -> Unit,
     onClose: () -> Unit,
   ): DaemonClient
 
-  fun shutdown()
+  public fun shutdown()
 
   /**
    * Shuts down within [timeout] when the owner has a stricter lifecycle budget. Implementations
    * that do not own a subprocess retain their ordinary shutdown behaviour.
    */
-  fun shutdown(timeout: Duration) = shutdown()
+  public fun shutdown(timeout: Duration): Unit = shutdown()
 }

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonClientFactory.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/SubprocessDaemonClientFactory.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.JsonObject
  * Production [DaemonClientFactory]: forks a JVM per [DaemonLaunchDescriptor] and pipes its stdio
  * into a [DaemonClient]. Mirrors `RealDesktopHarnessLauncher` from `:daemon:harness`.
  */
-class SubprocessDaemonClientFactory : DaemonClientFactory {
+public class SubprocessDaemonClientFactory : DaemonClientFactory {
   override fun spawn(workspaceId: WorkspaceId, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     require(descriptor.enabled) {
       "daemon disabled for ${descriptor.modulePath} — set composePreview { daemon { enabled = true } }"

--- a/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/WorkspaceId.kt
+++ b/daemon/client/src/main/kotlin/ee/schimke/composeai/daemon/client/WorkspaceId.kt
@@ -11,7 +11,7 @@ import java.security.MessageDigest
  * Format: `<rootProjectName>-<8-char-hash>`. The hash is **always** present (not just on
  * collisions) so the id encodes path identity unconditionally.
  */
-data class WorkspaceId(val value: String) {
+public data class WorkspaceId(val value: String) {
   init {
     require(value.isNotBlank()) { "WorkspaceId.value must not be blank" }
     require(!value.contains('/')) { "WorkspaceId.value must not contain '/' (got '$value')" }
@@ -19,13 +19,13 @@ data class WorkspaceId(val value: String) {
 
   override fun toString(): String = value
 
-  companion object {
+  public companion object {
     /**
      * Builds a deterministic id from [rootProjectName] + the canonical absolute form of [path].
      * Symlink aliases of the same physical path collapse to one id; distinct worktrees stay
      * distinct.
      */
-    fun derive(rootProjectName: String, path: File): WorkspaceId {
+    public fun derive(rootProjectName: String, path: File): WorkspaceId {
       require(rootProjectName.isNotBlank()) { "rootProjectName must not be blank" }
       val canonical = runCatching { path.canonicalFile }.getOrDefault(path.absoluteFile)
       val hash = sha256Hex(canonical.absolutePath).take(SHORT_HASH_CHARS)


### PR DESCRIPTION
#3824 preparation item 6, first of the contract modules. A change to a contract's published surface should be a diff in review, not a break downstream.

Follows the `:rc-player-*` precedent exactly — those took the gate first, their build comment noting it was ahead of *"a repo-wide rollout"*. This starts that rollout.

| | |
| --- | --- |
| `explicitApi()` | every declaration states visibility; every public one states its return type |
| `abiValidation()` | Kotlin's own ABI validation — ships in the Kotlin Gradle plugin, no extra plugin on the classpath |
| `check` → `checkKotlinAbi` | **KGP does not wire this itself.** Without the explicit `dependsOn`, the gate exists and never runs |
| `api/daemon-client.api` | the committed dump, 100 lines |

## The narrowing window, and what was in it

57 declarations needed annotating. Before marking them all `public` I checked whether any should be `internal` instead — and there is an asymmetry across the twelve contracts worth stating, because it decides how the rest of item 6 should be sequenced:

- **The eleven already-published contracts**: every implicitly-public declaration is *already in a shipped ABI*. Marking one `internal` now is a breaking change. `explicitApi()` there is largely mechanical.
- **`:daemon-client`**: never published. `v1.36.0` was tagged at `b78dfef6`; #4547 added this module afterwards at `4c29764f`, and the tag's `settings.gradle.kts` has zero mentions of it. Narrowing was free — and only until the next release cuts it into the published surface.

So this was the one module where the decision was genuinely open, which is why it went first.

**Nothing needed narrowing.** Every method has callers outside the module — between 2 and 130 call sites each:

```
initialize 130   renderNow 52   shutdownAndExit 36   setVisible 12
fileChanged 9    dataFetch 9    setFocus 7           historyList 7
extensionsEnable 6 … streamStart 2   extensionsDisable 2
```

That is a result rather than an assumption, and a reassuring one: it says #4547 cut the module at the right boundary and brought nothing accidental across. If some method had had zero external callers, this PR would have made it `internal` for free; none did.

## Verifying the gate is not decorative

I have shipped a "robustness" fix before whose raised bound was unreachable, so it silently did nothing (#4528, caught in review). So I forced this one to fail rather than trusting a green build:

```
probe method inserted: 1
EXIT CODE WITH EXTRA PUBLIC METHOD: 1
BUILD FAILED in 849ms
```

Adding one public method makes `checkKotlinAbi` fail; removing it passes again. A gate never seen to fail has not been verified.

## What the 57 were

45 visibility, 12 return type. The return-type ones are all expression-bodied `sendNotification(...)` senders (`Unit`), the four `const val` error codes (`Int`), and `DaemonSpawn.shutdown(timeout)`. `DataProductWireException`'s constructor `val`s became explicit `public val`s, which reflowed the constructor — hence the ktfmt pass, after which the dump was regenerated and came back identical at 100 lines, confirming it records ABI rather than source layout.

## Test plan

- `:daemon-client:check` — green, and now includes `checkKotlinAbi`
- `:daemon-client:ktfmtCheck` — green
- ABI gate falsified as above, then restored

Non-visual change (build wiring and visibility modifiers), so no rendered evidence applies.

## Remaining for item 6

Verified counts, `--rerun-tasks` so nothing is skipped as up-to-date:

| Module | Declarations |
| --- | ---: |
| `daemon/core` | 776 |
| `data/render/core` | 230 |
| `data/layoutinspector/core` | 181 |
| `render-session/api` | 45 |
| `api/preview-data-api` | 33 |
| `data/preview-overrides/core` | 24 |
| `data/theme/core` | 17 |
| `data/pseudolocale/core` | 16 |
| `data/remotecompose/core` | 12 |
| `render-session/subprocess` | 10 |
| `common/io` | 9 |

`:daemon:core` alone is 55% of the remaining work and is the protocol surface an extracted server compiles against, so it wants its own PR. The eight small modules (166 total) fit comfortably in one.

## Expect inherited red checks

`main` is red on three timing tests — `AndroidRippleFrameTest:121`, `LivePressRippleTest:92` (`:daemon:android`), `ServeStatusLiveFramesTest:127` (`:cli`). The failing subset varies per run, which is what confirms they are load-dependent rather than caused by any diff. Details and a proposed patch in #4547.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_