### PR TITLE
fix(serve): a catalog asset refused by size is too-large, not absent

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -45,6 +45,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
   private var throttled = 0L
   private var unavailable = 0L
   private var transport = 0L
+  private var tooLarge = 0L
   private var lastThrottleAtEpochMillis: Long? = null
   private var lastFailureAtEpochMillis: Long? = null
   private var lastFailureReason: String? = null
@@ -74,8 +75,17 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
         }
         is BranchFetch.Unavailable -> unavailable++
         is BranchFetch.Transport -> transport++
+        is BranchFetch.TooLarge -> tooLarge++
       }
-      if (outcome !is BranchFetch.Ok && outcome !is BranchFetch.NotFound) {
+      // `lastFailure*` describes the **branch host**, which is what an operator reads it for. A
+      // size refusal is a fact about what the catalog published — this server declining to buffer
+      // it — so it belongs with `notFound` rather than beside a throttle or an outage. Counting it
+      // as the last failure would make a large published asset look like the branch misbehaving.
+      if (
+        outcome !is BranchFetch.Ok &&
+          outcome !is BranchFetch.NotFound &&
+          outcome !is BranchFetch.TooLarge
+      ) {
         lastFailureAtEpochMillis = clock()
         lastFailureReason = outcome.summary.take(MAX_REASON_CHARS)
       }
@@ -93,6 +103,7 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
         throttled = throttled,
         unavailable = unavailable,
         transport = transport,
+        tooLarge = tooLarge,
         lastThrottleAtEpochMillis = lastThrottleAtEpochMillis,
         lastFailureAtEpochMillis = lastFailureAtEpochMillis,
         lastFailureReason = lastFailureReason,
@@ -109,8 +120,9 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
  * Delivery-branch read counters on `/status.json` (`branchFetch`).
  *
  * `notFound` is **not** an error: a catalog legitimately declares assets a given revision never
- * published, and the lane is built to answer that cheaply. The three that mean something is wrong
- * with the *branch host* rather than with the catalog are [throttled], [unavailable] and
+ * published, and the lane is built to answer that cheaply. Neither is [tooLarge], which says the
+ * catalog published something past this server's per-asset ceiling. The three that mean something
+ * is wrong with the *branch host* rather than with the catalog are [throttled], [unavailable] and
  * [transport] — those are the ones to alert on.
  */
 @Serializable
@@ -133,6 +145,15 @@ data class BranchFetchSnapshot(
   val unavailable: Long,
   /** Never got an answer: timeout, DNS, TLS, reset. */
   val transport: Long,
+  /**
+   * Bodies past the transport's own per-asset ceiling, refused without being kept.
+   *
+   * Like [notFound] and unlike the three above it, this is a statement about what the *catalog*
+   * published rather than about the branch host being unwell — so it is not something to alert on
+   * by itself. It is worth counting because it is otherwise invisible: the read is not an error,
+   * returns no bytes, and used to be indistinguishable from an asset that was never published.
+   */
+  val tooLarge: Long = 0,
   val lastThrottleAtEpochMillis: Long? = null,
   val lastFailureAtEpochMillis: Long? = null,
   val lastFailureReason: String? = null,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBranchFetch.kt
@@ -61,6 +61,29 @@ sealed interface BranchFetch {
   /** Never got an answer: connect/read timeout, DNS, TLS, reset. */
   data class Transport(val detail: String) : BranchFetch
 
+  /**
+   * The branch served a body past the transport's own ceiling, so nothing was kept.
+   *
+   * **A refusal, not an absence, and that difference is the point.** The size cap used to surface
+   * as a thrown `IllegalArgumentException` from deep inside the reader — not an `IOException`, so
+   * it escaped the transport's own `catch` and reached whichever caller happened to be on the
+   * stack. Callers that wrap their read in `runCatching` turned it into `null`; the several that do
+   * not still see it as an exception out of a function whose whole purpose is to answer with an
+   * outcome. Either way the fact that a file *existed and was too big* was destroyed.
+   *
+   * That mattered in one place with a contract behind it. `compose-preview-known-differences/v1`
+   * distinguishes `document-too-large`/`artifact-too-large` (413) from `artifact-unreadable` (404),
+   * and the staging path stages over-sized files precisely so the reader can answer the first from
+   * a file's length. Above the transport ceiling the file never arrived, so a 413 became a 404: a
+   * different verdict, and one that hides why.
+   *
+   * [limitBytes] is the ceiling that refused it, not the body's size — nothing measured the body,
+   * which is the whole point of stopping.
+   *
+   * Not [isTransient]: asking again will not make the file smaller.
+   */
+  data class TooLarge(val limitBytes: Long) : BranchFetch
+
   /** The bytes, or null for every failure — the shape the pre-existing call sites still want. */
   val bytesOrNull: ByteArray?
     get() = (this as? Ok)?.bytes
@@ -82,6 +105,7 @@ sealed interface BranchFetch {
         is Unavailable ->
           "unavailable ($status)" + (retryAfterSeconds?.let { " (retry after ${it}s)" } ?: "")
         is Transport -> "transport: $detail"
+        is TooLarge -> "too large (over $limitBytes bytes)"
       }
 
   companion object {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2034,6 +2034,14 @@ class ServeCatalogStore(
    * substitute silence — a missing file, which is the *different* verdict `unreadable` — for a
    * refusal the reader already knows how to voice.
    *
+   * **And above the transport's own ceiling, where there is nothing to stage.** That ceiling
+   * ([MAX_FETCH_BYTES], 25 MiB) is far above the contract's, so between the two a file arrives and
+   * is staged whole. Past it the read is refused and no bytes exist — which used to arrive here as
+   * the same `null` a real 404 gives, collapsing `too-large` into `unreadable` at precisely the
+   * sizes where "too large" is least in doubt. [BranchFetch.TooLarge] now carries that refusal, and
+   * a marker is staged whose *length alone* is past the contract ceiling ([writeOversizedMarker]) —
+   * the reader measures it, refuses by size, and the verdict is the one that actually happened.
+   *
    * Each artifact path is checked with the reader's own lexical rule before anything is fetched or
    * written ([ServeKnownDifferences.isLookupPath]), so a path the host would refuse to look up
    * never lands in the staging tree — and, since the rule admits only portable segments, cannot
@@ -2048,13 +2056,57 @@ class ServeCatalogStore(
    * the artifacts stream to disk through the same bounded helper every other bulk lane here uses,
    * so a refresh holds one artifact per worker rather than a whole wave.
    */
+  /**
+   * Leave a file whose **length alone** is past [ceilingBytes], so the reader refuses it by size.
+   *
+   * [ServeKnownDifferences.document] and [ServeKnownDifferences.artifact] both answer `TooLarge`
+   * from `metadata.size`, before a byte is read — deliberately, so measuring a hostile file cannot
+   * exhaust the process. That is exactly the seam a marker needs: the verdict depends on the
+   * length, and on nothing else.
+   *
+   * Written **sparse** — `setLength` reserves the length without allocating blocks on any
+   * filesystem that supports holes — because the honest alternative is not cheap. The pathological
+   * case here is 256 records × 2 artifacts, and 8 MiB of real zeroes each would be 4 GiB of staging
+   * disk written to say "this was too big to fetch". A hole costs the inode. Where the filesystem
+   * has no holes it falls back to allocating, which still writes strictly less than staging the
+   * real file would have: the file that triggered this was over the transport's 25 MiB ceiling, and
+   * the marker is the contract's 8 MiB.
+   *
+   * The bytes are never read, so their content is irrelevant — which is the point. This is not a
+   * counterfeit of the file; it is a record of the refusal, in the one dimension the reader asks
+   * about.
+   */
+  private fun writeOversizedMarker(target: File, ceilingBytes: Long): Boolean = runCatching {
+    target.parentFile?.mkdirs()
+    java.io.RandomAccessFile(target, "rw").use { it.setLength(ceilingBytes + 1) }
+  }
+    .isSuccess
+
   private fun writeKnownDifferences(base: String, staging: File) {
     val dirName = ServeKnownDifferences.DIRECTORY
-    val documentBytes =
-      runCatching {
-        fetchCatalogAsset("$base$dirName/${ServeKnownDifferences.DOCUMENT_FILE}")
-      }
-        .getOrNull() ?: return
+    val documentUrl = "$base$dirName/${ServeKnownDifferences.DOCUMENT_FILE}"
+    val documentOutcome =
+      runCatching { fetchCatalogAssetOutcome(documentUrl) }.getOrNull() ?: return
+
+    // **Above the transport's ceiling the file never arrives, and "never arrived" is not what
+    // happened.** The contract says a document past `maxDocumentBytes` is `document-too-large`/413;
+    // discarding the outcome and keeping only the bytes turned that into a missing file, which the
+    // engine reports as `document-unreadable`/404 — a different verdict, and one that hides why.
+    // The marker restores it: the reader measures the length, refuses by size, and the route serves
+    // the 413 that was always the right answer.
+    if (documentOutcome is BranchFetch.TooLarge) {
+      File(staging, dirName).mkdirs()
+      writeOversizedMarker(
+        File(staging, "$dirName/${ServeKnownDifferences.DOCUMENT_FILE}"),
+        ServeKnownDifferences.MAX_DOCUMENT_BYTES.toLong(),
+      )
+      // No artifacts. A document the reader refuses whole names nothing the engine will read, which
+      // is the same reason [knownDifferenceArtifactPaths] returns none for an over-sized one it
+      // *did* manage to fetch.
+      return
+    }
+
+    val documentBytes = documentOutcome.bytesOrNull ?: return
 
     val artifactRoot = "$dirName/${ServeKnownDifferences.ARTIFACT_DIRECTORY}"
     // **Streamed to disk, never accumulated.** Each worker holds only the artifact it is writing,
@@ -2076,7 +2128,14 @@ class ServeCatalogStore(
     fetchCatalogAssetsToFiles(
       knownDifferenceArtifactPaths(documentBytes).map { path ->
         "$base$artifactRoot/$path" to File(staging, "$artifactRoot/$path")
-      }
+      },
+      // The artifact half of the same distinction. Between the contract's 8 MiB and the transport's
+      // 25 MiB the file arrives and is staged whole, and the reader refuses it from its length.
+      // Above 25 MiB nothing arrives, and without this the record silently becomes
+      // `artifact-unreadable` instead of `artifact-too-large`.
+      onOversized = { target ->
+        writeOversizedMarker(target, ServeKnownDifferences.MAX_ARTIFACT_BYTES.toLong())
+      },
     )
 
     File(staging, dirName).mkdirs()
@@ -3068,9 +3127,14 @@ class ServeCatalogStore(
     }
 
     /**
-     * A single attempt. Only [java.io.IOException] becomes [BranchFetch.Transport]: the size cap in
-     * [readCapped] throws too, and it must keep propagating rather than being retried — the asset
-     * will be exactly as oversized the second time, and the existing call sites already catch it.
+     * A single attempt. Only [java.io.IOException] becomes [BranchFetch.Transport]; the size cap
+     * becomes [BranchFetch.TooLarge], which is not transient, so the retry loop stops on it — the
+     * asset will be exactly as oversized the second time.
+     *
+     * That cap used to *throw* from [readCapped], past this `catch` and out to whichever caller was
+     * on the stack. Making it an outcome is what lets a writer that has a contract about size say
+     * so; every other caller reads [BranchFetch.bytesOrNull] and sees the same `null` it saw when
+     * the exception was swallowed.
      */
     private fun httpFetchOnce(url: String, maxBytes: Long): BranchFetch =
       try {
@@ -3082,7 +3146,8 @@ class ServeCatalogStore(
             )
           } else {
             val body = response.body
-            BranchFetch.Ok(readCapped(body.byteStream(), maxBytes))
+            readCapped(body.byteStream(), maxBytes)?.let { BranchFetch.Ok(it) }
+              ?: BranchFetch.TooLarge(maxBytes)
           }
         }
       } catch (e: java.io.IOException) {
@@ -3111,7 +3176,18 @@ class ServeCatalogStore(
         BranchFetch.Transport(e::class.simpleName ?: "IOException")
       }
 
-    private fun readCapped(input: InputStream, max: Long): ByteArray {
+    /**
+     * Read at most [max] bytes, or **null** once that is exceeded — stopping there rather than
+     * buffering a deliberately huge response into the server's heap.
+     *
+     * Null rather than a thrown `require`, which is what this did. `IllegalArgumentException` is
+     * not an `IOException`, so it went straight past [httpFetchOnce]'s own `catch` and out of a
+     * function whose entire contract is to answer with a [BranchFetch]. Callers wrapping their read
+     * in `runCatching` silently got `null`; the several that do not got an exception from the
+     * middle of a load. Either way "the file exists and is too big" was destroyed, which is a
+     * verdict `compose-preview-known-differences/v1` requires a consumer to be able to reach.
+     */
+    private fun readCapped(input: InputStream, max: Long): ByteArray? {
       val out = ByteArrayOutputStream()
       val buffer = ByteArray(64 * 1024)
       var total = 0L
@@ -3119,7 +3195,7 @@ class ServeCatalogStore(
         val n = input.read(buffer)
         if (n < 0) break
         total += n
-        require(total <= max) { "catalog file exceeds ${max / (1024 * 1024)}MB" }
+        if (total > max) return null
         out.write(buffer, 0, n)
       }
       return out.toByteArray()
@@ -3350,6 +3426,13 @@ class ServeCatalogStore(
   private fun fetchCatalogAssetsToFiles(
     plan: List<Pair<String, File>>,
     stillWanted: () -> Boolean = { true },
+    /**
+     * What to leave behind when the transport refuses an asset by size, for the one lane whose
+     * contract distinguishes "too large" from "absent". Absent by default: for every other bulk
+     * lane a refused asset really is nothing to serve, and inventing a placeholder would be worse
+     * than the gap.
+     */
+    onOversized: ((File) -> Boolean)? = null,
   ): Set<String> {
     if (plan.isEmpty()) return emptySet()
     val pool =
@@ -3366,7 +3449,13 @@ class ServeCatalogStore(
             val previous = activeFetchScope.get()
             activeFetchScope.set(submitting)
             try {
-              val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return@submit false
+              val outcome = runCatching { fetchCatalogAssetOutcome(url) }.getOrNull()
+              if (outcome is BranchFetch.TooLarge && onOversized != null) {
+                // Re-checked before the write for the same reason the byte path re-checks it.
+                if (!stillWanted()) return@submit false
+                return@submit runCatching { onOversized(target) }.getOrDefault(false)
+              }
+              val bytes = outcome?.bytesOrNull ?: return@submit false
               // Re-checked immediately before the write, not just once per wave: a fetch started
               // for
               // one catalog generation must not land in the directory a refresh has since swapped

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -602,6 +602,113 @@ class ServeCatalogStoreTest {
     assertEquals("button-figma", loaded.issues.single().referenceIds.single())
   }
 
+  /**
+   * Load a catalog whose known-difference document and one artifact answer with [documentOutcome]
+   * and [artifactOutcome].
+   */
+  private fun loadWithKnownDifferenceOutcomes(
+    documentOutcome: (ByteArray) -> BranchFetch,
+    artifactOutcome: BranchFetch,
+  ): ServeHost {
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val document =
+      """
+      {"schema":"compose-preview-known-differences/v1","acceptances":[
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png","acceptedCandidate":"accepted-candidate.png"}]}
+      """
+        .trimIndent()
+        .encodeToByteArray()
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        networkFetch = { url, _ ->
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") ->
+              BranchFetch.Ok(catalog.encodeToByteArray())
+            url.endsWith("/parity/known-differences.json") -> documentOutcome(document)
+            url.endsWith("/parity/known-differences/glyph/mask.png") -> artifactOutcome
+            url.endsWith("/parity/known-differences/glyph/accepted-candidate.png") ->
+              BranchFetch.Ok("accepted".encodeToByteArray())
+            url.endsWith(".png") -> BranchFetch.Ok(png())
+            else -> BranchFetch.NotFound
+          }
+        },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    return registered.getValue("compose-m3")
+  }
+
+  @Test
+  fun `an artifact past the transport ceiling is too large, not missing`() {
+    // The contract distinguishes `artifact-too-large` (413) from `artifact-unreadable` (404), and
+    // the staging path stages over-sized files precisely so the reader can answer the first from a
+    // file's length. Above the transport's own ceiling nothing arrives — and that used to reach the
+    // stager as the same `null` a real 404 gives, so the verdict silently became the second one at
+    // exactly the sizes where "too large" is least in doubt.
+    val host =
+      loadWithKnownDifferenceOutcomes(
+        documentOutcome = { BranchFetch.Ok(it) },
+        artifactOutcome = BranchFetch.TooLarge(25L * 1024 * 1024),
+      )
+
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") is ServeKnownDifferences.Artifact.TooLarge,
+      "a size refusal must reach the engine as too-large, not as a missing file",
+    )
+    // The record's other artifact is untouched: the refusal is per-file, not a reason to abandon
+    // the record or the refresh.
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/accepted-candidate.png")
+        is ServeKnownDifferences.Artifact.Bytes
+    )
+  }
+
+  @Test
+  fun `an artifact the branch really lacks stays unreadable`() {
+    // The other half, and the reason this cannot simply mark everything that fails: a 404 is a
+    // genuine absence and `artifact-unreadable` is the correct verdict for it. Marking it would
+    // manufacture a 413 for a file the producer never published.
+    val host =
+      loadWithKnownDifferenceOutcomes(
+        documentOutcome = { BranchFetch.Ok(it) },
+        artifactOutcome = BranchFetch.NotFound,
+      )
+
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") is ServeKnownDifferences.Artifact.Unreadable,
+      "an absent artifact must stay unreadable",
+    )
+  }
+
+  @Test
+  fun `a document past the transport ceiling is too large, and names no artifacts`() {
+    val host =
+      loadWithKnownDifferenceOutcomes(
+        documentOutcome = { BranchFetch.TooLarge(25L * 1024 * 1024) },
+        artifactOutcome = BranchFetch.Ok("mask".encodeToByteArray()),
+      )
+
+    assertTrue(
+      host.knownDifferences() is ServeKnownDifferences.Document.TooLarge,
+      "a document refused by size must reach the engine as too-large",
+    )
+    // A document the reader refuses whole names nothing the engine will read, so no artifact was
+    // staged for it — the same reasoning that makes an over-sized *fetched* document contribute no
+    // paths.
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") !is ServeKnownDifferences.Artifact.Bytes,
+      "artifacts were staged for a document the engine refuses whole",
+    )
+  }
+
   @Test
   fun `catalog stages the published known differences, document and artifacts`() {
     // The failure this guards is silent: `knownDifferences()` reads the staging tree, so a document


### PR DESCRIPTION
Closes #4521.

## The lost verdict

`fetchCatalogAsset` is `cachedBranchRead(url).bytesOrNull` — it keeps the bytes and discards the outcome. Two events collapsed into one answer:

| what happened | what the writer saw | what the catalog served |
|---|---|---|
| the producer publishes no such file (a real 404) | `null` | nothing — correct |
| the body exceeds `MAX_FETCH_BYTES` (25 MiB) | `null` | nothing — **a lost verdict** |

`compose-preview-known-differences/v1` distinguishes these: `document-too-large`/`artifact-too-large` is 413, `artifact-unreadable` is 404. #4515 stages over-sized files precisely so `ServeKnownDifferences` can answer `TooLarge` from their length — but only up to the transport's own ceiling. Above it the file never arrived, so the verdict silently became `unreadable` at exactly the sizes where "too large" is least in doubt.

## A second problem found on the way

The cap was enforced with `require(total <= max)` inside `readCapped`. `IllegalArgumentException` is **not** an `IOException`, so it went straight past `httpFetchOnce`'s own `catch` — out of a function whose entire contract is to answer with a `BranchFetch`.

Callers wrapping their read in `runCatching` silently got `null`. The several that do not (`catalog.json`, the revision preview index, the tag index, …) got an exception from the middle of a load. The comment above `httpFetchOnce` documented this as intentional — "the existing call sites already catch it" — which was true of some of them.

It is now `BranchFetch.TooLarge(limitBytes)`: not transient, so the retry loop stops on it (the asset will be exactly as oversized the second time), and `bytesOrNull` is still `null`, so every existing caller behaves exactly as it did when the exception was being swallowed.

## Staging the refusal

Both readers answer `TooLarge` from `metadata.size`, before a byte is read — deliberately, so measuring a hostile file cannot exhaust the process. That is exactly the seam a marker needs: **the verdict depends on the length and on nothing else.**

So the known-differences stager consults the outcome and leaves a file whose length alone is past the contract ceiling. The reader measures it, refuses by size, and the route serves the 413 that was always the right answer.

Written **sparse** (`RandomAccessFile.setLength`), because the honest alternative is not cheap: the pathological case is 256 records × 2 artifacts, and 8 MiB of real zeroes each would be 4 GiB of staging disk written to say "this was too big to fetch". Where the filesystem has no holes it falls back to allocating — still strictly less than staging the real file would have, since the file that triggered this was over 25 MiB and the marker is 8 MiB.

The bytes are never read, so their content is irrelevant. This is not a counterfeit of the file; it is a record of the refusal, in the one dimension the reader asks about.

**Scoped to the one writer whose contract distinguishes the two.** `onOversized` defaults to absent, so every other bulk lane is unchanged — for them a refused asset really is nothing to serve, and inventing a placeholder would be worse than the gap.

## Telemetry

`branchFetch.tooLarge` on `/status.json`. It is grouped with `notFound` rather than with `throttled`/`unavailable`/`transport`, and deliberately excluded from `lastFailureReason`: a size refusal is a fact about what the *catalog* published, not about the branch host being unwell. Counting it as the last failure would make a large published asset look like an outage.

## Tests

Three, using the existing outcome-shaped `networkFetch` seam (no new seam — the constructor already argues against a parallel outcome-only one, and the bytes-shaped `fetch` cannot express this):

- `an artifact past the transport ceiling is too large, not missing` — and the record's *other* artifact still arrives, so the refusal is per-file;
- `an artifact the branch really lacks stays unreadable` — the control. A 404 is a genuine absence and marking it would manufacture a 413 for a file the producer never published;
- `a document past the transport ceiling is too large, and names no artifacts`.

The first and third were verified to fail with the staging behaviour reverted (the `TooLarge` outcome left in place, so only the marker paths were removed); the control correctly still passed.

- `:cli:test` — **3173 tests, all passing**
- `check-serve-seam` — `OK — 151 crossing symbol(s)`

The exhaustive `when` in `BranchFetchStats` caught the one place a new `BranchFetch` case had to be handled, which is the value of that type being sealed.

## Unrelated flake found while running the suite

One full-suite run failed with a `ConcurrentModificationException` in `live bundles use the larger dedicated download envelope` — a test that records fetch limits into a plain `linkedMapOf` written from the concurrent fetch pool. It is the test's own bookkeeping, not a product defect, and does not reproduce in isolation. Filed as #4556 rather than fixed here; the suite is green on this branch.

Non-visual (serve-path plumbing), so no rendered before/after applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_