### PR TITLE
feat(serve): let a deployment name its background render lane

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -155,6 +155,7 @@ internal object CliFlagValidation {
             "--bundles",
             "--catalog-branch-prefix",
             "--catalog-feed-cache",
+            "--background-renders",
             "--catalog-cache-dir",
             "--catalog-cache-max-bytes",
             "--theme-cache-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -124,6 +124,7 @@ internal object CliFlags {
       "--catalog-max-images",
       "--catalog-feed-idle-timeout",
       "--catalog-feed-cache",
+      "--background-renders",
       "--catalog-cache-dir",
       "--catalog-cache-max-bytes",
       "--theme-cache-dir",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -149,6 +149,24 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
   private val liveSeats: Int = args.flagValue("--live-seats")?.toIntOrNull()?.coerceAtLeast(0) ?: 0
 
   /**
+   * Background renders admitted at once, server-wide, when the operator names it — otherwise
+   * [ServeBackgroundWork.renderLaneFor] derives one from the seat budget.
+   *
+   * The derivation clamps at [ServeBackgroundWork.MAX_DERIVED_CONCURRENT_RENDERS] (3), and that
+   * ceiling is reached at a seat budget of 8 — so on a box with more seats than that the lane stops
+   * widening while everything else does, and there was no way to say otherwise short of rebuilding
+   * the image: `composeai.serve.backgroundRenders` is a system property, and the prebuilt image
+   * bakes JAVA_TOOL_OPTIONS into its own ENV. Measured on preview.coo.ee, whose container is
+   * allowed 24 GB: the seat budget went 8 → 12 and the background lane stayed 3.
+   *
+   * Deliberately un-clamped. The derivation is conservative because it is guessing; an operator
+   * naming a number has looked at their own box, and the seat budget still bounds how many daemons
+   * those renders can actually occupy.
+   */
+  private val backgroundRenders: Int? =
+    args.flagValue("--background-renders")?.toIntOrNull()?.takeIf { it >= 1 }
+
+  /**
    * The one live-seat budget for this server, shared by the HTTP stream lane and by every catalog
    * daemon pool. Built here rather than inside [ServeHttpServer] so the pools — which are
    * constructed while catalogs load, before the server exists — charge the same budget. Two
@@ -905,7 +923,8 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
   private val backgroundWork by lazy {
     val pressureSampler = LinuxHostResourceSampler()
     ServeBackgroundWork(
-      maxConcurrentRenders = ServeBackgroundWork.renderLaneFor(liveSeatLimiter),
+      maxConcurrentRenders =
+        backgroundRenders ?: ServeBackgroundWork.renderLaneFor(liveSeatLimiter),
       hostCoordinator =
         optimizerCoordinationDirectory?.let {
           FileOptimizerHostCoordinator(
@@ -4828,6 +4847,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
                           ${ThemeCacheStore.DEFAULT_MAX_BYTES / (1024L * 1024 * 1024)} GB). Superseded
                           generations are reclaimed; generations still in use are never evicted, so
                           exceeding this is reported rather than acted on.
+        --background-renders <n>
+                          Background (theme-optimizer) renders admitted at once, server-wide.
+                          Defaults to a value derived from --live-seats, which clamps at
+                          ${ServeBackgroundWork.MAX_DERIVED_CONCURRENT_RENDERS} — a ceiling reached
+                          at 8 seats, so a bigger box stops widening this lane while everything else
+                          scales. Name it explicitly to go past that; the seat budget still bounds
+                          how many daemons the renders can occupy.
         --theme-optimizer-coordination-dir <dir>
                           Shared directory used to coordinate background optimizer lanes across
                           server replicas. Defaults to optimizer-locks beside --catalogs-file; set

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWorkTest.kt
@@ -171,6 +171,15 @@ class ServeBackgroundWorkTest {
       ServeBackgroundWork.MAX_DERIVED_CONCURRENT_RENDERS,
       ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 64)),
     )
+    // **The cap is reached at eight permits**, which is why `--background-renders` exists. Every
+    // budget from here up derives the same lane, so on a box with more seats than that this lane
+    // stops widening while everything else scales with the budget. Measured on preview.coo.ee,
+    // whose container is allowed 24 GB: the seat budget went 8 -> 12 and the lane stayed 3.
+    assertEquals(
+      ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 8)),
+      ServeBackgroundWork.renderLaneFor(LiveSeatLimiter(totalPermits = 12)),
+      "8 seats already saturates the derivation, so 12 buys nothing without an explicit override",
+    )
   }
 
   @Test

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -266,6 +266,34 @@ unavailable. Once resolved it is **pinned for the life of the process**: a later
 does not move it, because live snippet JVMs hold those jars open. Restart the container to compile
 against a newer catalog ABI.
 
+### Widening the background render lane (`SERVE_BACKGROUND_RENDERS`)
+
+The theme optimizer's renders run in their own server-wide lane, so a visitor's render is never
+queued behind more than a bounded number of background ones. Unset, the server derives that lane
+from `SERVE_LIVE_SEATS`:
+
+```
+(seats − stream reserve) / Android seat weight,  clamped to [1, 3]
+```
+
+**The clamp is reached at 8 seats**, so on a bigger box the lane stops widening while everything
+else scales with the budget. Raising `SERVE_LIVE_SEATS` from 8 to 12 on `preview.coo.ee` — a
+container allowed 24 GB — left the lane at 3, unchanged.
+
+Name it explicitly to go past that:
+
+```
+SERVE_BACKGROUND_RENDERS=5
+```
+
+Deliberately un-clamped: the derivation is conservative because it is guessing, and an operator
+naming a number has looked at their own box. The seat budget still bounds how many daemons those
+renders can actually occupy, so this widens the queue rather than licensing unbounded memory.
+
+Before this existed the knob was reachable only as a system property, and the prebuilt image bakes
+`JAVA_TOOL_OPTIONS` into its own `ENV` — so on this deployment there was no way to set it short of
+rebuilding the image.
+
 ### Warmed theme renders survive a deploy (`SERVE_THEME_CACHE_DIR`)
 
 The server pre-renders every catalog preview under every declared theme while the box is idle, so a

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -122,6 +122,10 @@ services:
       # Where that optional clone lands inside the container. Empty ⇒ /catalog-src.
       SERVE_CATALOG_SOURCE_ROOT: "${SERVE_CATALOG_SOURCE_ROOT:-}"
       SERVE_LIVE_SEATS: "${SERVE_LIVE_SEATS:-}"
+      # Background theme-optimizer renders admitted at once, server-wide. Empty leaves the server's
+      # derivation from the seat budget, which clamps at 3 and reaches that at 8 seats — so raising
+      # SERVE_LIVE_SEATS alone does not widen this lane.
+      SERVE_BACKGROUND_RENDERS: "${SERVE_BACKGROUND_RENDERS:-}"
       # Playground compile lane. Off by default: it runs visitor-supplied Kotlin and needs both a
       # catalog liveBundle classpath plus a sandbox profile on public hosts. Set the bundle path(s)
       # to local files available inside the container, for example a bind mount under /config.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -335,6 +335,13 @@ if [[ -z "${SERVE_LIVE_SEATS:-}" ]]; then
   echo "entrypoint: auto live-seat budget ${SERVE_LIVE_SEATS} (effective mem ${eff_mb} MB)" >&2
 fi
 [[ -n "${SERVE_LIVE_SEATS}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
+# Background (theme-optimizer) renders admitted at once, server-wide. Unset leaves the server's own
+# derivation from the seat budget, which clamps at 3 — a ceiling reached at 8 seats, so a box with
+# more than that stops widening this lane while everything else scales with it. The underlying knob
+# is a system property, and this image bakes JAVA_TOOL_OPTIONS into its own ENV, so without this
+# there was no way to set it short of rebuilding.
+[[ -n "${SERVE_BACKGROUND_RENDERS:-}" ]] &&
+  args+=(--background-renders "${SERVE_BACKGROUND_RENDERS}")
 if [[ "${SERVE_ACCEPT_BUNDLES:-}" == "1" || "${SERVE_ACCEPT_BUNDLES:-}" == "true" ]]; then
   args+=(--accept-bundles)
   [[ -n "${SERVE_ACCEPT_BUNDLES_FROM:-}" ]] &&


### PR DESCRIPTION
Follow-on from #4536 / #4541 / #4550, and from raising `SERVE_LIVE_SEATS` on `preview.coo.ee` and watching it change nothing.

## The derivation saturates at 8 seats

The theme optimizer's renders run in a server-wide lane so a visitor's render is never queued behind more than a bounded number of background ones. `ServeBackgroundWork.renderLaneFor` derives it from the live-seat budget:

```
(seats − STREAM_RESERVE) / ANDROID_LIVE_SEAT_WEIGHT   coerced into [1, MAX_DERIVED_CONCURRENT_RENDERS]
   8 seats → (8−2)/2 = 3 → 3
  12 seats → (12−2)/2 = 5 → 3      ← clamped
```

**Every budget from eight permits up derives the same lane.** So on a bigger box the lane stops widening while everything else scales with the budget. Measured on `preview.coo.ee`, whose container is allowed 24 GB: `SERVE_LIVE_SEATS` went 8 → 12, `daemons.liveSeatsTotal` confirmed 12, and the background lane stayed at 3.

The knob to say otherwise already existed — the system property `composeai.serve.backgroundRenders`, which `renderLaneFor` checks first. It just wasn't reachable on this deployment: the prebuilt image bakes `JAVA_TOOL_OPTIONS` into its own `ENV` and `docker-compose.yml` forwards no override, so setting it meant rebuilding the image.

## The change

`--background-renders <n>` on the CLI, forwarded from `SERVE_BACKGROUND_RENDERS` by the entrypoint, with the usual compose passthrough. Precedence is flag → system property → seat derivation, so nothing that works today changes.

**Deliberately un-clamped**, unlike the derivation. The derivation is conservative because it is guessing from a seat count; an operator naming a number has looked at their own box. And the seat budget still bounds how many daemons those renders can actually occupy — this widens the queue, it does not license unbounded memory.

Also worth knowing when reading the constant: `MAX_DERIVED_CONCURRENT_RENDERS = 3` and the seat auto-derivation's own `[2, 8]` clamp were both calibrated for the 8 GB reference box. `preview.coo.ee` is a container allowed 24 GB, where the entrypoint's derivation computes 19 seats and then clamps to 8. This PR does not touch either default — it makes the one that matters for background throughput nameable, which seems the safer first move than re-tuning ceilings for every deployment at once.

## Test plan

- `ServeBackgroundWorkTest` › *the render lane widens only where a seat budget can refuse the daemons it licenses* — new assertion that 8 and 12 seats derive the **same** lane, so the saturation point that motivates this flag is pinned rather than described in a comment.
- `CliFlagsRegistryTest` and the flag-validation guard both required registering the new flag (`CliFlags.VALUE_FLAGS`, `CliFlagValidation`); caught by running them, and green now.
- `./gradlew :cli:test` — full module suite green.
- All eight `deploy/image/test-*.sh` guards pass, including `test-compose-env-passthrough.sh`, which is what enforces that a variable the entrypoint reads is actually forwarded by compose — the exact failure mode that left `SERVE_PLAYGROUND` inert for its whole life.
- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest`.

Not visually verified: CLI flag, deployment wiring and docs — no rendered surface.

## Using it

```
SERVE_BACKGROUND_RENDERS=5
```

I'd suggest measuring before reaching for it: on `preview.coo.ee` the residency and rotation fixes may already be enough, and a wider lane is more concurrent daemons and so more memory pressure — which the optimizer's own pressure gate would then push back on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_