### PR TITLE
feat(contracts): enforce explicit API and gate the ABI on eight contract modules

### DIFF
--- a/api/preview-data-api/api/preview-data-api.api
+++ b/api/preview-data-api/api/preview-data-api.api
@@ -1,0 +1,1389 @@
+public final class ee/schimke/composeai/cli/A11yWireFormatKt {
+	public static final field A11Y_PAYLOAD_SCHEMA_V1 Ljava/lang/String;
+	public static final field A11Y_REPORT_STATUS_ATF_UNAVAILABLE Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityEntry {
+	public static final field Companion Lee/schimke/composeai/cli/AccessibilityEntry$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityEntry;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotatedPath ()Ljava/lang/String;
+	public final fun getFindings ()Ljava/util/List;
+	public final fun getNodes ()Ljava/util/List;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/AccessibilityEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityFinding {
+	public static final field Companion Lee/schimke/composeai/cli/AccessibilityFinding$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityFinding;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityFinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityFinding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getViewDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/AccessibilityFinding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityFinding$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityFinding;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityFinding;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityFinding$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityNode {
+	public static final field Companion Lee/schimke/composeai/cli/AccessibilityNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMerged ()Z
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getStates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/AccessibilityNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityReport {
+	public static final field Companion Lee/schimke/composeai/cli/AccessibilityReport$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)Lee/schimke/composeai/cli/AccessibilityReport;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityReport;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityReport;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPartial ()Z
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/AccessibilityReport$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityReport$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityReport;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityReport;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/AccessibilityReport$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/Capture {
+	public static final field Companion Lee/schimke/composeai/cli/Capture$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Lee/schimke/composeai/cli/ScrollCapture;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component7 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component8 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component9 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/cli/Capture;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/Capture;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/cli/Capture;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getFocus ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getFocusGif ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getGestureHint ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getHover ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getOptional ()Z
+	public final fun getRenderOutput ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
+	public final fun getSettle ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/Capture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/Capture$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/Capture;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/Capture;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/Capture$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CaptureGutterDp {
+	public static final field Companion Lee/schimke/composeai/cli/CaptureGutterDp$Companion;
+	public fun <init> ()V
+	public fun <init> (IIII)V
+	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/cli/CaptureGutterDp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CaptureGutterDp;IIIIILjava/lang/Object;)Lee/schimke/composeai/cli/CaptureGutterDp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getEnd ()I
+	public final fun getHorizontal ()I
+	public final fun getStart ()I
+	public final fun getTop ()I
+	public final fun getVertical ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/CaptureGutterDp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/CaptureGutterDp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CaptureGutterDp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CaptureGutterDp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CaptureGutterDp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CaptureResult {
+	public static final field Companion Lee/schimke/composeai/cli/CaptureResult$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Lee/schimke/composeai/cli/ScrollCapture;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CaptureResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CaptureResult;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CaptureResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getChanged ()Ljava/lang/Boolean;
+	public final fun getOptional ()Z
+	public final fun getParameterLabel ()Ljava/lang/String;
+	public final fun getParameterRowId ()Ljava/lang/String;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
+	public final fun getSha256 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/CaptureResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/CaptureResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CaptureResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CaptureResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CaptureResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CatalogEntry {
+	public static final field Companion Lee/schimke/composeai/cli/CatalogEntry$Companion;
+	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/cli/CatalogRole;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CatalogEntry;Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CatalogEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaption ()Ljava/lang/String;
+	public final fun getComponentId ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getKitAxis ()Ljava/lang/String;
+	public final fun getKitValue ()Ljava/lang/String;
+	public final fun getMotionPreview ()Ljava/lang/String;
+	public final fun getNoReference ()Ljava/lang/String;
+	public final fun getParallel ()Ljava/lang/String;
+	public final fun getPerBreakpoint ()Z
+	public final fun getProps ()Ljava/util/List;
+	public final fun getReference ()Ljava/lang/String;
+	public final fun getReferenceContentsOnly ()Z
+	public final fun getReferenceSet ()Ljava/lang/String;
+	public final fun getRole ()Lee/schimke/composeai/cli/CatalogRole;
+	public final fun getSection ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/CatalogEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/CatalogEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CatalogEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CatalogEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CatalogEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CatalogRole : java/lang/Enum {
+	public static final field COMPONENT Lee/schimke/composeai/cli/CatalogRole;
+	public static final field Companion Lee/schimke/composeai/cli/CatalogRole$Companion;
+	public static final field VARIANT Lee/schimke/composeai/cli/CatalogRole;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogRole;
+	public static fun values ()[Lee/schimke/composeai/cli/CatalogRole;
+}
+
+public final class ee/schimke/composeai/cli/CatalogRole$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CatalogVariantProp {
+	public static final field Companion Lee/schimke/composeai/cli/CatalogVariantProp$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogVariantProp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CatalogVariantProp;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CatalogVariantProp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/CatalogVariantProp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/CatalogVariantProp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CatalogVariantProp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CatalogVariantProp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/CatalogVariantProp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/ExtensionPayload {
+	public static final field Companion Lee/schimke/composeai/cli/ExtensionPayload$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/cli/ExtensionPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/ExtensionPayload;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/cli/ExtensionPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPayload ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/ExtensionPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/ExtensionPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/ExtensionPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/ExtensionPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/ExtensionPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewDataProduct {
+	public static final field Companion Lee/schimke/composeai/cli/PreviewDataProduct$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lee/schimke/composeai/cli/ScrollCapture;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;)Lee/schimke/composeai/cli/PreviewDataProduct;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewDataProduct;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewDataProduct;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getMediaTypes ()Ljava/util/List;
+	public final fun getOutput ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/PreviewDataProduct$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewDataProduct$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewDataProduct;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewDataProduct;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewDataProduct$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewInfo {
+	public static final field Companion Lee/schimke/composeai/cli/PreviewInfo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Lee/schimke/composeai/cli/PreviewParams;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lee/schimke/composeai/cli/CatalogEntry;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZ)Lee/schimke/composeai/cli/PreviewInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBodyLine ()Ljava/lang/Integer;
+	public final fun getCaptures ()Ljava/util/List;
+	public final fun getCatalog ()Lee/schimke/composeai/cli/CatalogEntry;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getFixedTheme ()Z
+	public final fun getFunctionName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIncludeInA11y ()Z
+	public final fun getParams ()Lee/schimke/composeai/cli/PreviewParams;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/PreviewInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewManifest {
+	public static final field Companion Lee/schimke/composeai/cli/PreviewManifest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lee/schimke/composeai/cli/PreviewManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewManifest;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataExtensionReports ()Ljava/util/Map;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getReportsView ()Ljava/util/Map;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/PreviewManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewParams {
+	public static final field Companion Lee/schimke/composeai/cli/PreviewParams$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/lang/Float;
+	public final fun component12 ()F
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()J
+	public final fun component16 ()I
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()I
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Lee/schimke/composeai/cli/CaptureGutterDp;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;)Lee/schimke/composeai/cli/PreviewParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()J
+	public final fun getCaptureGutter ()Lee/schimke/composeai/cli/CaptureGutterDp;
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFontScale ()F
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getHeightDp ()Ljava/lang/Integer;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLocale ()Ljava/lang/String;
+	public final fun getMaxHeightPx ()Ljava/lang/Integer;
+	public final fun getMaxWidthPx ()Ljava/lang/Integer;
+	public final fun getMinHeightPx ()Ljava/lang/Integer;
+	public final fun getMinWidthPx ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPreviewParameterLimit ()I
+	public final fun getPreviewParameterProviderClassName ()Ljava/lang/String;
+	public final fun getShowBackground ()Z
+	public final fun getShowSystemUi ()Z
+	public final fun getUiMode ()I
+	public final fun getWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxHeightDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapperClassName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/PreviewParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewResult {
+	public static final field Companion Lee/schimke/composeai/cli/PreviewResult$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/cli/PreviewParams;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lee/schimke/composeai/cli/PreviewResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptures ()Ljava/util/List;
+	public final fun getChanged ()Ljava/lang/Boolean;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getDataExtensions ()Ljava/util/Map;
+	public final fun getFunctionName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getParams ()Lee/schimke/composeai/cli/PreviewParams;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getProjectDirectory ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/PreviewResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/PreviewResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/ScrollCapture {
+	public static final field Companion Lee/schimke/composeai/cli/ScrollCapture$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)Lee/schimke/composeai/cli/ScrollCapture;
+	public static synthetic fun copy$default (Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/cli/ScrollCapture;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAtEnd ()Z
+	public final fun getAxis ()Ljava/lang/String;
+	public final fun getMaxScrollPx ()I
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getReachedPx ()Ljava/lang/Integer;
+	public final fun getReduceMotion ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/cli/ScrollCapture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/cli/ScrollCapture$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/ScrollCapture;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/ScrollCapture;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/ScrollCapture$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/cli/TalkBackOverlayFrames {
+	public static final field DEFAULT_DWELL_MS J
+	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackOverlayFrames;
+	public final fun focusedStopForFrame (IIIJ)I
+	public static synthetic fun focusedStopForFrame$default (Lee/schimke/composeai/cli/TalkBackOverlayFrames;IIIJILjava/lang/Object;)I
+	public final fun totalFrames (IIJ)I
+	public static synthetic fun totalFrames$default (Lee/schimke/composeai/cli/TalkBackOverlayFrames;IIJILjava/lang/Object;)I
+}
+
+public final class ee/schimke/composeai/cli/TalkBackTraversal {
+	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackTraversal;
+	public final fun focusStops (Ljava/util/List;)Ljava/util/List;
+	public final fun next (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
+	public final fun previous (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
+}
+
+public final class ee/schimke/composeai/cli/TalkBackUtterance {
+	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackUtterance;
+	public final fun compose (Lee/schimke/composeai/cli/AccessibilityNode;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/designpages/DesignPage {
+	public static final field Companion Lee/schimke/composeai/designpages/DesignPage$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageFrame;Lee/schimke/composeai/designpages/PageImage;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageFrame;Lee/schimke/composeai/designpages/PageImage;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/designpages/PageFrame;
+	public final fun component5 ()Lee/schimke/composeai/designpages/PageImage;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageFrame;Lee/schimke/composeai/designpages/PageImage;Ljava/util/List;Z)Lee/schimke/composeai/designpages/DesignPage;
+	public static synthetic fun copy$default (Lee/schimke/composeai/designpages/DesignPage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageFrame;Lee/schimke/composeai/designpages/PageImage;Ljava/util/List;ZILjava/lang/Object;)Lee/schimke/composeai/designpages/DesignPage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoverageGaps ()Ljava/util/List;
+	public final fun getCoverageTotal ()I
+	public final fun getFrame ()Lee/schimke/composeai/designpages/PageFrame;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Lee/schimke/composeai/designpages/PageImage;
+	public final fun getInventory ()Z
+	public final fun getLinked ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getNodes ()Ljava/util/List;
+	public final fun getUnlinked ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/designpages/DesignPage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/designpages/DesignPage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/designpages/DesignPage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/designpages/DesignPage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/DesignPage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/DesignPagesKt {
+	public static final field DESIGN_PAGES_VERSION I
+	public static final fun getDesignPagesJson ()Lkotlinx/serialization/json/Json;
+	public static final fun supportsDesignPagesVersion (I)Z
+}
+
+public final class ee/schimke/composeai/designpages/DesignPagesManifest {
+	public static final field Companion Lee/schimke/composeai/designpages/DesignPagesManifest$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/designpages/DesignPagesManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/designpages/DesignPagesManifest;ILjava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/designpages/DesignPagesManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileKey ()Ljava/lang/String;
+	public final fun getPages ()Ljava/util/List;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getVersion ()I
+	public fun hashCode ()I
+	public final fun isSupported ()Z
+	public final fun refFor (Lee/schimke/composeai/designpages/PageNode;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/designpages/DesignPagesManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/designpages/DesignPagesManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/designpages/DesignPagesManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/designpages/DesignPagesManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/DesignPagesManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageFrame {
+	public static final field Companion Lee/schimke/composeai/designpages/PageFrame$Companion;
+	public fun <init> (DD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun copy (DD)Lee/schimke/composeai/designpages/PageFrame;
+	public static synthetic fun copy$default (Lee/schimke/composeai/designpages/PageFrame;DDILjava/lang/Object;)Lee/schimke/composeai/designpages/PageFrame;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()D
+	public final fun getWidth ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/designpages/PageFrame$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/designpages/PageFrame$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/designpages/PageFrame;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/designpages/PageFrame;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageFrame$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageImage {
+	public static final field Companion Lee/schimke/composeai/designpages/PageImage$Companion;
+	public static final field SVG Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/designpages/PageImage;
+	public static synthetic fun copy$default (Lee/schimke/composeai/designpages/PageImage;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/designpages/PageImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/designpages/PageImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/designpages/PageImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/designpages/PageImage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/designpages/PageImage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageImage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageNode {
+	public static final field Companion Lee/schimke/composeai/designpages/PageNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageNodeLink;Lee/schimke/composeai/designpages/PageNodeConfidence;ZLjava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageNodeLink;Lee/schimke/composeai/designpages/PageNodeConfidence;ZLjava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/designpages/PageNodeLink;
+	public final fun component8 ()Lee/schimke/composeai/designpages/PageNodeConfidence;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageNodeLink;Lee/schimke/composeai/designpages/PageNodeConfidence;ZLjava/lang/String;ZZ)Lee/schimke/composeai/designpages/PageNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/designpages/PageNode;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageNodeLink;Lee/schimke/composeai/designpages/PageNodeConfidence;ZLjava/lang/String;ZZILjava/lang/Object;)Lee/schimke/composeai/designpages/PageNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCell ()Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getConfidence ()Lee/schimke/composeai/designpages/PageNodeConfidence;
+	public final fun getContainer ()Z
+	public final fun getDepth ()I
+	public final fun getInventory ()Z
+	public final fun getLink ()Lee/schimke/composeai/designpages/PageNodeLink;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRenderablePreviewId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isComponent ()Z
+	public final fun isContainer ()Z
+	public final fun isPlacement ()Z
+	public final fun isPrivate ()Z
+	public final fun isRenderable ()Z
+	public final fun isUnlinked ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/designpages/PageNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/designpages/PageNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/designpages/PageNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/designpages/PageNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageNodeConfidence : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/designpages/PageNodeConfidence$Companion;
+	public static final field HIGH Lee/schimke/composeai/designpages/PageNodeConfidence;
+	public static final field LOW Lee/schimke/composeai/designpages/PageNodeConfidence;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/designpages/PageNodeConfidence;
+	public static fun values ()[Lee/schimke/composeai/designpages/PageNodeConfidence;
+}
+
+public final class ee/schimke/composeai/designpages/PageNodeConfidence$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/designpages/PageNodeLink : java/lang/Enum {
+	public static final field CODE_CONNECT Lee/schimke/composeai/designpages/PageNodeLink;
+	public static final field CONVENTION Lee/schimke/composeai/designpages/PageNodeLink;
+	public static final field Companion Lee/schimke/composeai/designpages/PageNodeLink$Companion;
+	public static final field MANIFEST Lee/schimke/composeai/designpages/PageNodeLink;
+	public static final field UNLINKED Lee/schimke/composeai/designpages/PageNodeLink;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/designpages/PageNodeLink;
+	public static fun values ()[Lee/schimke/composeai/designpages/PageNodeLink;
+}
+
+public final class ee/schimke/composeai/designpages/PageNodeLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/OrbitCamera {
+	public static final field Companion Lee/schimke/composeai/xr/OrbitCamera$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/xr/Vec3;DDD)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/xr/Vec3;DDDILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/xr/Vec3;
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/xr/Vec3;DDD)Lee/schimke/composeai/xr/OrbitCamera;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/OrbitCamera;Ljava/lang/String;Lee/schimke/composeai/xr/Vec3;DDDILjava/lang/Object;)Lee/schimke/composeai/xr/OrbitCamera;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDistance ()D
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPitchDeg ()D
+	public final fun getTarget ()Lee/schimke/composeai/xr/Vec3;
+	public final fun getYawDeg ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/OrbitCamera$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/OrbitCamera$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/OrbitCamera;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/OrbitCamera;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/OrbitCamera$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/OrbiterAffordance {
+	public static final field Companion Lee/schimke/composeai/xr/OrbiterAffordance$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun component5 ()Lee/schimke/composeai/xr/SizeDp;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;)Lee/schimke/composeai/xr/OrbiterAffordance;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/OrbiterAffordance;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/xr/OrbiterAffordance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEdge ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getPoseInRoot ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun getSizeDp ()Lee/schimke/composeai/xr/SizeDp;
+	public final fun getTexture ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/OrbiterAffordance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/OrbiterAffordance$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/OrbiterAffordance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/OrbiterAffordance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/OrbiterAffordance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/Quat {
+	public static final field Companion Lee/schimke/composeai/xr/Quat$Companion;
+	public fun <init> (DDDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun copy (DDDD)Lee/schimke/composeai/xr/Quat;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/Quat;DDDDILjava/lang/Object;)Lee/schimke/composeai/xr/Quat;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getW ()D
+	public final fun getX ()D
+	public final fun getY ()D
+	public final fun getZ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/Quat$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/Quat$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/Quat;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/Quat;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/Quat$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/Size3dDp {
+	public static final field Companion Lee/schimke/composeai/xr/Size3dDp$Companion;
+	public fun <init> (III)V
+	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lee/schimke/composeai/xr/Size3dDp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/Size3dDp;IIIILjava/lang/Object;)Lee/schimke/composeai/xr/Size3dDp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDepth ()I
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/Size3dDp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/Size3dDp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/Size3dDp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/Size3dDp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/Size3dDp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SizeDp {
+	public static final field Companion Lee/schimke/composeai/xr/SizeDp$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/xr/SizeDp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SizeDp;IIILjava/lang/Object;)Lee/schimke/composeai/xr/SizeDp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SizeDp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SizeDp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SizeDp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SizeDp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SizeDp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialEnvironment {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialEnvironment$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;)Lee/schimke/composeai/xr/SpatialEnvironment;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialEnvironment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialEnvironment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor ()Ljava/lang/String;
+	public final fun getFloor ()Ljava/lang/String;
+	public final fun getGlow ()Ljava/lang/Double;
+	public final fun getHorizon ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPreset ()Ljava/lang/String;
+	public final fun getSky ()Ljava/lang/String;
+	public final fun getTexture ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialEnvironment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialEnvironment$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialEnvironment;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialEnvironment;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialEnvironment$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialPanel {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialPanel$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun component4 ()Lee/schimke/composeai/xr/SizeDp;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/xr/SpatialPanel;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialPanel;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/SizeDp;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialPanel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getPoseInRoot ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun getSizeDp ()Lee/schimke/composeai/xr/SizeDp;
+	public final fun getTexture ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialPanel$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialPanel$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialPanel;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialPanel;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialPanel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialPose {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialPose$Companion;
+	public fun <init> (Lee/schimke/composeai/xr/Vec3;Lee/schimke/composeai/xr/Quat;)V
+	public final fun component1 ()Lee/schimke/composeai/xr/Vec3;
+	public final fun component2 ()Lee/schimke/composeai/xr/Quat;
+	public final fun copy (Lee/schimke/composeai/xr/Vec3;Lee/schimke/composeai/xr/Quat;)Lee/schimke/composeai/xr/SpatialPose;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/Vec3;Lee/schimke/composeai/xr/Quat;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialPose;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRotation ()Lee/schimke/composeai/xr/Quat;
+	public final fun getTranslation ()Lee/schimke/composeai/xr/Vec3;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialPose$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialPose$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialPose;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialPose;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialPose$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialScene {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialScene$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/OrbitCamera;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/xr/SpatialEnvironment;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/OrbitCamera;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/xr/SpatialEnvironment;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/xr/OrbitCamera;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lee/schimke/composeai/xr/SpatialEnvironment;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/OrbitCamera;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/xr/SpatialEnvironment;)Lee/schimke/composeai/xr/SpatialScene;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialScene;ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/OrbitCamera;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/xr/SpatialEnvironment;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialScene;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCamera ()Lee/schimke/composeai/xr/OrbitCamera;
+	public final fun getEnvironment ()Lee/schimke/composeai/xr/SpatialEnvironment;
+	public final fun getOrbiters ()Ljava/util/List;
+	public final fun getPanels ()Ljava/util/List;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getUnits ()Ljava/lang/String;
+	public final fun getVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialScene$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialScene$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialScene;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialScene;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialScene$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSceneKt {
+	public static final field SPATIAL_SCENE_VERSION I
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsKind {
+	public static final field BOX Ljava/lang/String;
+	public static final field COLUMN Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialSemanticsKind;
+	public static final field ORBITER Ljava/lang/String;
+	public static final field PANEL Ljava/lang/String;
+	public static final field ROW Ljava/lang/String;
+	public static final field SUBSPACE_ROOT Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsNode {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialSemanticsNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/Size3dDp;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/Size3dDp;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun component5 ()Lee/schimke/composeai/xr/Size3dDp;
+	public final fun component6 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/Size3dDp;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/util/List;)Lee/schimke/composeai/xr/SpatialSemanticsNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialSemanticsNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialPose;Lee/schimke/composeai/xr/Size3dDp;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialSemanticsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getPanelContent ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun getPoseInRoot ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun getSizeDp ()Lee/schimke/composeai/xr/Size3dDp;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialSemanticsNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialSemanticsNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialSemanticsNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialSemanticsNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsTree {
+	public static final field Companion Lee/schimke/composeai/xr/SpatialSemanticsTree$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialSemanticsNode;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialSemanticsNode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/xr/SpatialSemanticsNode;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialSemanticsNode;)Lee/schimke/composeai/xr/SpatialSemanticsTree;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/SpatialSemanticsTree;ILjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/xr/SpatialSemanticsNode;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialSemanticsTree;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRoot ()Lee/schimke/composeai/xr/SpatialSemanticsNode;
+	public final fun getUnits ()Ljava/lang/String;
+	public final fun getVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/SpatialSemanticsTree$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialSemanticsTree$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/SpatialSemanticsTree;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/SpatialSemanticsTree;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsTree$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsTreeKt {
+	public static final field SPATIAL_SEMANTICS_TREE_VERSION I
+}
+
+public final class ee/schimke/composeai/xr/SpatialSemanticsTrees {
+	public static final field INSTANCE Lee/schimke/composeai/xr/SpatialSemanticsTrees;
+	public final fun identityPose ()Lee/schimke/composeai/xr/SpatialPose;
+	public final fun singlePanel (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/xr/Size3dDp;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/xr/SpatialSemanticsTree;
+	public static synthetic fun singlePanel$default (Lee/schimke/composeai/xr/SpatialSemanticsTrees;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/xr/Size3dDp;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/xr/SpatialSemanticsTree;
+	public final fun subspaceRoot (Ljava/util/List;)Lee/schimke/composeai/xr/SpatialSemanticsNode;
+}
+
+public final class ee/schimke/composeai/xr/Vec3 {
+	public static final field Companion Lee/schimke/composeai/xr/Vec3$Companion;
+	public fun <init> (DDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun copy (DDD)Lee/schimke/composeai/xr/Vec3;
+	public static synthetic fun copy$default (Lee/schimke/composeai/xr/Vec3;DDDILjava/lang/Object;)Lee/schimke/composeai/xr/Vec3;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getX ()D
+	public final fun getY ()D
+	public final fun getZ ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/xr/Vec3$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/xr/Vec3$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/xr/Vec3;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/xr/Vec3;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/xr/Vec3$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/api/preview-data-api/build.gradle.kts
+++ b/api/preview-data-api/build.gradle.kts
@@ -55,3 +55,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :preview-data-api:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/A11yWireFormat.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/A11yWireFormat.kt
@@ -28,7 +28,7 @@ import kotlinx.serialization.Serializable
 // ---------------------------------------------------------------------------
 
 @Serializable
-data class AccessibilityFinding(
+public data class AccessibilityFinding(
   val level: String,
   val type: String,
   val message: String,
@@ -45,7 +45,7 @@ data class AccessibilityFinding(
  * `ee.schimke.composeai.cli.*` types rather than depending on the Android `:data-a11y-core`.
  */
 @Serializable
-data class AccessibilityNode(
+public data class AccessibilityNode(
   /**
    * What a screen reader announces: the node's own contentDescription / text, or the copy rolled up
    * from the descendants a focus stop merges (issue #4253). Empty only when nothing under the stop
@@ -76,7 +76,7 @@ data class AccessibilityNode(
 )
 
 @Serializable
-data class AccessibilityEntry(
+public data class AccessibilityEntry(
   val previewId: String,
   val findings: List<AccessibilityFinding>,
   /**
@@ -89,7 +89,7 @@ data class AccessibilityEntry(
 )
 
 @Serializable
-data class AccessibilityReport(
+public data class AccessibilityReport(
   val module: String,
   val entries: List<AccessibilityEntry>,
   /**
@@ -125,11 +125,11 @@ data class AccessibilityReport(
  * Lives in `:preview-data-api` (not `:cli`) so external consumers (contrib scripting, third-party
  * tooling) can pin to it without taking a CLI dependency.
  */
-const val A11Y_PAYLOAD_SCHEMA_V1: String = "compose-preview-data-a11y/v1"
+public const val A11Y_PAYLOAD_SCHEMA_V1: String = "compose-preview-data-a11y/v1"
 
 /**
  * Value emitted in [AccessibilityReport.status] when ATF data could not be produced for any preview
  * in the module (daemon classpath issue, render-session open failed, every per-preview fetch
  * errored). The python helper and PR-comment renderer check for this string verbatim.
  */
-const val A11Y_REPORT_STATUS_ATF_UNAVAILABLE: String = "atf-unavailable"
+public const val A11Y_REPORT_STATUS_ATF_UNAVAILABLE: String = "atf-unavailable"

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/PreviewData.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.JsonElement
 
 /** On-disk shape mirrors gradle-plugin/PreviewData.kt (parsed with ignoreUnknownKeys). */
 @Serializable
-data class PreviewParams(
+public data class PreviewParams(
   val name: String? = null,
   val device: String? = null,
   val widthDp: Int? = null,
@@ -93,7 +93,7 @@ data class PreviewParams(
  * left/right.
  */
 @Serializable
-data class CaptureGutterDp(
+public data class CaptureGutterDp(
   val start: Int = 0,
   val top: Int = 0,
   val end: Int = 0,
@@ -113,7 +113,7 @@ data class CaptureGutterDp(
  * string-typed mirror so unknown future modes/axes round-trip cleanly through the CLI.
  */
 @Serializable
-data class ScrollCapture(
+public data class ScrollCapture(
   val mode: String,
   val axis: String = "VERTICAL",
   val maxScrollPx: Int = 0,
@@ -123,7 +123,7 @@ data class ScrollCapture(
 )
 
 @Serializable
-data class Capture(
+public data class Capture(
   val advanceTimeMillis: Long? = null,
   val scroll: ScrollCapture? = null,
   val renderOutput: String = "",
@@ -160,7 +160,7 @@ data class Capture(
    * new primary parameter preserves *source* compatibility only, while appending it still changes
    * the JVM constructor descriptor and its default-argument bridge.
    */
-  constructor(
+  public constructor(
     advanceTimeMillis: Long? = null,
     scroll: ScrollCapture? = null,
     renderOutput: String = "",
@@ -188,7 +188,7 @@ data class Capture(
  * caller (the field itself is nullable on [PreviewInfo]).
  */
 @Serializable
-enum class CatalogRole {
+public enum class CatalogRole {
   COMPONENT,
   VARIANT,
 }
@@ -196,7 +196,7 @@ enum class CatalogRole {
 /**
  * One `key=value` content/i18n/a11y axis of a [CatalogRole.VARIANT]. Mirrors `CatalogVariantProp`.
  */
-@Serializable data class CatalogVariantProp(val key: String, val value: String)
+public @Serializable data class CatalogVariantProp(val key: String, val value: String)
 
 /**
  * Design-catalog identity a preview carries via `@CatalogComponent` / `@CatalogVariant`. Mirrors
@@ -206,7 +206,7 @@ enum class CatalogRole {
  * previews.
  */
 @Serializable
-data class CatalogEntry(
+public data class CatalogEntry(
   val role: CatalogRole,
   val componentId: String,
   val group: String? = null,
@@ -259,7 +259,7 @@ data class CatalogEntry(
    * against the previous artifact would fail with `NoSuchMethodError` without this overload. Same
    * policy as [PreviewResult]'s pre-`projectDirectory` constructor below.
    */
-  constructor(
+  public constructor(
     role: CatalogRole,
     componentId: String,
     group: String? = null,
@@ -294,7 +294,7 @@ data class CatalogEntry(
   )
 
   /** As above, for consumers compiled after [kitValue] but before [motionPreview]. */
-  constructor(
+  public constructor(
     role: CatalogRole,
     componentId: String,
     group: String? = null,
@@ -331,7 +331,7 @@ data class CatalogEntry(
 }
 
 @Serializable
-data class PreviewInfo(
+public data class PreviewInfo(
   val id: String,
   val functionName: String,
   val className: String,
@@ -367,7 +367,7 @@ data class PreviewInfo(
 )
 
 @Serializable
-data class PreviewDataProduct(
+public data class PreviewDataProduct(
   val kind: String,
   val output: String = "",
   val mediaTypes: List<String> = emptyList(),
@@ -376,7 +376,7 @@ data class PreviewDataProduct(
 )
 
 @Serializable
-data class PreviewManifest(
+public data class PreviewManifest(
   val module: String,
   val variant: String,
   val previews: List<PreviewInfo>,
@@ -408,7 +408,7 @@ data class PreviewManifest(
  * fan-out produces N entries — one row per capture filename on disk.
  */
 @Serializable
-data class CaptureResult(
+public data class CaptureResult(
   val advanceTimeMillis: Long? = null,
   val scroll: ScrollCapture? = null,
   val pngPath: String? = null,
@@ -445,7 +445,7 @@ data class CaptureResult(
  * The [schema] string identifies the payload's shape so consumers can detect a version bump (e.g.
  * `"compose-preview-data-a11y/v1"`); pinned strings, never regex-matched.
  */
-@Serializable data class ExtensionPayload(val schema: String, val payload: JsonElement)
+public @Serializable data class ExtensionPayload(val schema: String, val payload: JsonElement)
 
 /**
  * CLI output DTO — enriches manifest entries with runtime data agents need.
@@ -456,7 +456,7 @@ data class CaptureResult(
  * `compose-preview-data-a11y/v1` payload body).
  */
 @Serializable
-data class PreviewResult(
+public data class PreviewResult(
   val id: String,
   val module: String,
   /** Gradle's resolved project directory; never reconstruct this from [module]. */
@@ -493,7 +493,7 @@ data class PreviewResult(
    * added. A default on the new primary parameter preserves source compatibility only; this
    * overload preserves the old JVM constructor descriptor and its default-argument bridge.
    */
-  constructor(
+  public constructor(
     id: String,
     module: String,
     functionName: String,

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/TalkBack.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/cli/TalkBack.kt
@@ -9,10 +9,10 @@ package ee.schimke.composeai.cli
  * lock-step by identical unit-test suites pinning the same expected strings / boundaries on both
  * sides. See the a11y-core originals for the full rationale.
  */
-object TalkBackUtterance {
+public object TalkBackUtterance {
 
   /** The single "what TalkBack speaks" string for [node]: `label, role, state…, usage-hint`. */
-  fun compose(node: AccessibilityNode): String {
+  public fun compose(node: AccessibilityNode): String {
     val checkable = node.states.any { it == CHECKED || it == UNCHECKED }
     val disabled = node.states.any { it == DISABLED }
 
@@ -58,14 +58,14 @@ object TalkBackUtterance {
 }
 
 /** JVM mirror of `:data-a11y-core`'s `TalkBackTraversal` (focus-stop walk). */
-object TalkBackTraversal {
+public object TalkBackTraversal {
 
   /** The focus stops in TalkBack traversal order — the merged nodes, in extraction order. */
-  fun focusStops(nodes: List<AccessibilityNode>): List<AccessibilityNode> = nodes.filter {
+  public fun focusStops(nodes: List<AccessibilityNode>): List<AccessibilityNode> = nodes.filter {
     it.merged
   }
 
-  fun next(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+  public fun next(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
     val stops = focusStops(nodes)
     if (stops.isEmpty()) return null
     val idx = indexOfRef(stops, currentRef)
@@ -73,7 +73,7 @@ object TalkBackTraversal {
     return stops.getOrNull(idx + 1)
   }
 
-  fun previous(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
+  public fun previous(nodes: List<AccessibilityNode>, currentRef: String?): AccessibilityNode? {
     val stops = focusStops(nodes)
     if (stops.isEmpty()) return null
     val idx = indexOfRef(stops, currentRef)
@@ -88,11 +88,11 @@ object TalkBackTraversal {
 }
 
 /** JVM mirror of `:data-a11y-core`'s `TalkBackOverlayFrames` (frame index → focus stop). */
-object TalkBackOverlayFrames {
+public object TalkBackOverlayFrames {
 
-  const val DEFAULT_DWELL_MS: Long = 900L
+  public const val DEFAULT_DWELL_MS: Long = 900L
 
-  fun focusedStopForFrame(
+  public fun focusedStopForFrame(
     frameIndex: Int,
     fps: Int,
     stopCount: Int,
@@ -105,7 +105,7 @@ object TalkBackOverlayFrames {
     return stop.coerceIn(0, stopCount - 1)
   }
 
-  fun totalFrames(fps: Int, stopCount: Int, dwellMs: Long = DEFAULT_DWELL_MS): Int {
+  public fun totalFrames(fps: Int, stopCount: Int, dwellMs: Long = DEFAULT_DWELL_MS): Int {
     if (stopCount <= 0 || fps <= 0 || dwellMs <= 0L) return 0
     val durationMs = stopCount.toLong() * dwellMs
     return (durationMs * fps / 1000L).toInt() + 1

--- a/common/io/api/common-io.api
+++ b/common/io/api/common-io.api
@@ -1,0 +1,16 @@
+public final class ee/schimke/composeai/io/FileSystemsKt {
+	public static final field LEGACY_HISTORY_DIRNAME Ljava/lang/String;
+	public static final fun composeAiCacheDir (Ljava/lang/String;)Ljava/io/File;
+	public static final fun composeAiGitRefCacheDir (Ljava/io/File;)Ljava/io/File;
+	public static final fun composeAiHistoryDir (Ljava/io/File;Ljava/io/File;)Ljava/io/File;
+	public static final fun composeAiHistoryModuleSegment (Ljava/io/File;Ljava/io/File;)Ljava/lang/String;
+	public static final fun composeAiHistoryWorkspaceSlug (Ljava/io/File;)Ljava/lang/String;
+	public static final fun getSystemFileSystem ()Lokio/FileSystem;
+	public static final fun getTemporaryDirectory ()Lokio/Path;
+}
+
+public final class ee/schimke/composeai/io/JvmClasspathArgKt {
+	public static final fun classpathArgFile (Ljava/util/List;Ljava/io/File;)Ljava/lang/String;
+	public static synthetic fun classpathArgFile$default (Ljava/util/List;Ljava/io/File;ILjava/lang/Object;)Ljava/lang/String;
+}
+

--- a/common/io/build.gradle.kts
+++ b/common/io/build.gradle.kts
@@ -34,3 +34,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :common-io:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/FileSystems.kt
@@ -21,10 +21,10 @@ import okio.Path
  * artifact) and exercise the IO entirely in memory. The composition roots (`main` entry points) are
  * the one place that legitimately names this constant.
  */
-val SystemFileSystem: FileSystem = FileSystem.SYSTEM
+public val SystemFileSystem: FileSystem = FileSystem.SYSTEM
 
 /** Okio's process-temp directory, e.g. `$TMPDIR`. */
-val TemporaryDirectory: Path = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
+public val TemporaryDirectory: Path = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
 
 /**
  * Root of compose-ai-tools' user-level cache, following the XDG Base Directory spec:
@@ -40,7 +40,7 @@ val TemporaryDirectory: Path = FileSystem.SYSTEM_TEMPORARY_DIRECTORY
  * weight, italic)` or a dependency keyed by Maven coordinate is identical regardless of which
  * project asked for it, so one cache serves them all.
  */
-fun composeAiCacheDir(subdir: String): File {
+public fun composeAiCacheDir(subdir: String): File {
   val xdg = System.getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
   val base =
     if (xdg != null) File(xdg, "composeai")
@@ -49,7 +49,7 @@ fun composeAiCacheDir(subdir: String): File {
 }
 
 /** Directory name of the legacy in-tree history archive, kept for backwards compatibility. */
-const val LEGACY_HISTORY_DIRNAME: String = ".compose-preview-history"
+public const val LEGACY_HISTORY_DIRNAME: String = ".compose-preview-history"
 
 /**
  * Where a module's render history lives:
@@ -75,7 +75,7 @@ const val LEGACY_HISTORY_DIRNAME: String = ".compose-preview-history"
  * [composeAiHistoryWorkspaceSlug] documents the slug contract those mirror; `HistoryPathsTest` and
  * its TS counterpart pin the same vectors on both sides.
  */
-fun composeAiHistoryDir(workspaceRoot: File, projectDir: File): File {
+public fun composeAiHistoryDir(workspaceRoot: File, projectDir: File): File {
   val legacy = File(projectDir, LEGACY_HISTORY_DIRNAME)
   if (legacy.isDirectory) return legacy
   return File(
@@ -94,7 +94,7 @@ fun composeAiHistoryDir(workspaceRoot: File, projectDir: File): File {
  * inside it instead; this is only the standalone fallback, which previously landed in the repo
  * working tree.
  */
-fun composeAiGitRefCacheDir(repoRoot: File): File =
+public fun composeAiGitRefCacheDir(repoRoot: File): File =
   File(
     File(composeAiCacheDir("history"), composeAiHistoryWorkspaceSlug(repoRoot)),
     ".git-ref-cache",
@@ -110,7 +110,7 @@ fun composeAiGitRefCacheDir(repoRoot: File): File =
  * extension each learn the workspace root by a different route and only the unresolved form is
  * reliably identical across all three.
  */
-fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
+public fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
   val normalised = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
   val digest =
     java.security.MessageDigest.getInstance("SHA-256")
@@ -133,7 +133,7 @@ fun composeAiHistoryWorkspaceSlug(workspaceRoot: File): String {
  * directory would mix their entries and prune state, and let matching preview ids overwrite each
  * other. Segments that need no rewriting (the overwhelming majority) stay plain and readable.
  */
-fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String {
+public fun composeAiHistoryModuleSegment(workspaceRoot: File, projectDir: File): String {
   val root = workspaceRoot.absolutePath.replace('\\', '/').trimEnd('/')
   val module = projectDir.absolutePath.replace('\\', '/').trimEnd('/')
   if (module == root) return "_root"

--- a/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
+++ b/common/io/src/main/kotlin/ee/schimke/composeai/io/JvmClasspathArg.kt
@@ -38,7 +38,7 @@ private val ARGFILE_CHARSET: Charset = runCatching {
  * @return the `@<file>` token to splice into the command **in place of** `-cp`/`-classpath` + the
  *   joined classpath. The file is registered for deletion on exit.
  */
-fun classpathArgFile(classpath: List<String>, directory: File? = null): String {
+public fun classpathArgFile(classpath: List<String>, directory: File? = null): String {
   require(classpath.isNotEmpty()) { "classpath must not be empty" }
   val joined = classpath.joinToString(File.pathSeparator)
   val file = File.createTempFile("composeai-cp", ".args", directory)

--- a/data/preview-overrides/core/api/data-preview-overrides-core.api
+++ b/data/preview-overrides/core/api/data-preview-overrides-core.api
@@ -1,0 +1,371 @@
+public final class ee/schimke/composeai/data/overrides/OverrideSeed {
+	public static final field Companion Lee/schimke/composeai/data/overrides/OverrideSeed$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/data/overrides/OverrideSeedKind;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/data/overrides/OverrideSeedKind;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/data/overrides/OverrideSeedKind;Ljava/lang/String;)Lee/schimke/composeai/data/overrides/OverrideSeed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/OverrideSeed;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/data/overrides/OverrideSeedKind;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/OverrideSeed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()Ljava/lang/Integer;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getKind ()Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public final fun getRaw ()Ljava/lang/String;
+	public final fun getSeedKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun toValueOrNull ()Lee/schimke/composeai/data/overrides/PreviewOverrideValue;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/OverrideSeed$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/OverrideSeed$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/OverrideSeed;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/OverrideSeed;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideSeed$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideSeedKind : java/lang/Enum {
+	public static final field BOOLEAN Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static final field COLOR Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static final field Companion Lee/schimke/composeai/data/overrides/OverrideSeedKind$Companion;
+	public static final field FLOAT Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static final field INT Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static final field STRING Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+	public static fun values ()[Lee/schimke/composeai/data/overrides/OverrideSeedKind;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideSeedKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideVariantInteraction : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/data/overrides/OverrideVariantInteraction$Companion;
+	public static final field Focused Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public static final field Hovered Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public static final field Pressed Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public static fun values ()[Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideVariantInteraction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideVariantSpec {
+	public static final field Companion Lee/schimke/composeai/data/overrides/OverrideVariantSpec$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;ILjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;ILjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/OverrideVariantSpec;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInteraction ()Lee/schimke/composeai/data/overrides/OverrideVariantInteraction;
+	public final fun getInteractionIndex ()I
+	public final fun getKitAxis ()Ljava/lang/String;
+	public final fun getKitValue ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSeeds ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun toNamedOverrides ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/OverrideVariantSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/OverrideVariantSpec$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/OverrideVariantSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideDeclaration {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Ljava/lang/Integer;Ljava/util/List;ZLjava/util/List;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Ljava/lang/Integer;Ljava/util/List;ZLjava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/data/overrides/PreviewOverrideValue;
+	public final fun component5 ()Lee/schimke/composeai/data/overrides/PreviewOverrideValue;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Ljava/lang/Integer;Ljava/util/List;ZLjava/util/List;Z)Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Ljava/lang/Integer;Ljava/util/List;ZLjava/util/List;ZILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrent ()Lee/schimke/composeai/data/overrides/PreviewOverrideValue;
+	public final fun getDefault ()Lee/schimke/composeai/data/overrides/PreviewOverrideValue;
+	public final fun getGoogleFonts ()Z
+	public final fun getIndex ()Ljava/lang/Integer;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getOptionsExhaustive ()Z
+	public final fun getSeedKey ()Ljava/lang/String;
+	public final fun getSuggestions ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideOption {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideOption$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/overrides/PreviewOverrideOption;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideOption;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideOption$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideOption$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideOption;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideOption;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideOption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideType {
+	public static final field BOOL Ljava/lang/String;
+	public static final field COLOR Ljava/lang/String;
+	public static final field FLOAT Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideType;
+	public static final field INT Ljava/lang/String;
+	public static final field STRING Ljava/lang/String;
+}
+
+public abstract class ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lee/schimke/composeai/data/overrides/PreviewOverrideValue;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue : ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue;ZILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$BooleanValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue : ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgb ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$ColorValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue : ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue$Companion;
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue;FILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$FloatValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue : ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue;IILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$IntValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue : ee/schimke/composeai/data/overrides/PreviewOverrideValue {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverrideValue$StringValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverridesPayload {
+	public static final field Companion Lee/schimke/composeai/data/overrides/PreviewOverridesPayload$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/data/overrides/PreviewOverridesPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/overrides/PreviewOverridesPayload;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/overrides/PreviewOverridesPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeclarations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/overrides/PreviewOverridesPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverridesPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/overrides/PreviewOverridesPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/overrides/PreviewOverridesPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverridesPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/overrides/PreviewOverridesProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/overrides/PreviewOverridesProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+

--- a/data/preview-overrides/core/build.gradle.kts
+++ b/data/preview-overrides/core/build.gradle.kts
@@ -37,3 +37,24 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew
+  // :data-preview-overrides-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/OverrideVariant.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
  * [PreviewOverrideValue] is reconstructed here, once, for every render backend.
  */
 @Serializable
-enum class OverrideSeedKind {
+public enum class OverrideSeedKind {
   STRING,
   BOOLEAN,
   INT,
@@ -29,7 +29,7 @@ enum class OverrideSeedKind {
  * wire-compatible copy because it must stay off this runtime's classpath.
  */
 @Serializable
-data class OverrideSeed(
+public data class OverrideSeed(
   val key: String,
   val index: Int? = null,
   val kind: OverrideSeedKind,
@@ -40,7 +40,7 @@ data class OverrideSeed(
     get() = if (index == null) key else "$key[$index]"
 
   /** Typed value for this seed, or `null` when [raw] doesn't parse to [kind]. */
-  fun toValueOrNull(): PreviewOverrideValue? =
+  public fun toValueOrNull(): PreviewOverrideValue? =
     when (kind) {
       OverrideSeedKind.STRING -> PreviewOverrideValue.StringValue(raw)
       OverrideSeedKind.BOOLEAN ->
@@ -60,7 +60,7 @@ data class OverrideSeed(
  * onto the capture. [name] is the `_VARIANT_<name>` render-output tag and catalog `state`.
  */
 @Serializable
-data class OverrideVariantSpec(
+public data class OverrideVariantSpec(
   val name: String,
   val seeds: List<OverrideSeed> = emptyList(),
   val interaction: OverrideVariantInteraction? = null,
@@ -76,7 +76,7 @@ data class OverrideVariantSpec(
    * seeds are dropped; an all-unparseable variant yields an empty map (callers treat empty as "no
    * seed").
    */
-  fun toNamedOverrides(): Map<String, PreviewOverrideValue> {
+  public fun toNamedOverrides(): Map<String, PreviewOverrideValue> {
     val out = LinkedHashMap<String, PreviewOverrideValue>()
     for (seed in seeds) {
       val value = seed.toValueOrNull() ?: continue
@@ -87,7 +87,7 @@ data class OverrideVariantSpec(
 }
 
 @Serializable
-enum class OverrideVariantInteraction {
+public enum class OverrideVariantInteraction {
   Hovered,
   Focused,
   Pressed,

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideModels.kt
@@ -7,9 +7,9 @@ import kotlinx.serialization.Serializable
  * (as `RemoteComposeProduct` is) so the bundle producer and MCP clients can depend on the payload
  * schema without pulling in the connector, Compose, or any backend.
  */
-object PreviewOverridesProduct {
-  const val KIND: String = "compose/overrides"
-  const val SCHEMA_VERSION: Int = 1
+public object PreviewOverridesProduct {
+  public const val KIND: String = "compose/overrides"
+  public const val SCHEMA_VERSION: Int = 1
 }
 
 /**
@@ -18,12 +18,12 @@ object PreviewOverridesProduct {
  * tolerates a future type it doesn't recognise. Matches the [PreviewOverrideValue] variants the
  * runtime emits.
  */
-object PreviewOverrideType {
-  const val STRING: String = "string"
-  const val INT: String = "int"
-  const val FLOAT: String = "float"
-  const val BOOL: String = "bool"
-  const val COLOR: String = "color"
+public object PreviewOverrideType {
+  public const val STRING: String = "string"
+  public const val INT: String = "int"
+  public const val FLOAT: String = "float"
+  public const val BOOL: String = "bool"
+  public const val COLOR: String = "color"
 }
 
 /**
@@ -34,7 +34,7 @@ object PreviewOverrideType {
  * size axis seeds `xs` and reads "Extra small", a pseudo-locale is `en-XA` and reads "Accented
  * (pseudo)".
  */
-@Serializable data class PreviewOverrideOption(val value: String, val label: String = value)
+public @Serializable data class PreviewOverrideOption(val value: String, val label: String = value)
 
 /**
  * One author-declared editable knob a preview exposes through a `previewOverride*` lookup.
@@ -52,7 +52,7 @@ object PreviewOverrideType {
  * `repeat(n)`.
  */
 @Serializable
-data class PreviewOverrideDeclaration(
+public data class PreviewOverrideDeclaration(
   /**
    * Author-chosen key, e.g. `"label"` or `"rowCount"`. Stable across renders for the same call
    * site.
@@ -124,4 +124,6 @@ data class PreviewOverrideDeclaration(
  * latest render, in declaration order.
  */
 @Serializable
-data class PreviewOverridesPayload(val declarations: List<PreviewOverrideDeclaration> = emptyList())
+public data class PreviewOverridesPayload(
+  val declarations: List<PreviewOverrideDeclaration> = emptyList()
+)

--- a/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideValue.kt
+++ b/data/preview-overrides/core/src/main/kotlin/ee/schimke/composeai/data/overrides/PreviewOverrideValue.kt
@@ -26,23 +26,24 @@ import kotlinx.serialization.json.JsonClassDiscriminator
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @JsonClassDiscriminator("kind")
-sealed class PreviewOverrideValue {
+public sealed class PreviewOverrideValue {
   @Serializable
   @SerialName("string")
-  data class StringValue(val value: String) : PreviewOverrideValue()
+  public data class StringValue(val value: String) : PreviewOverrideValue()
 
-  @Serializable @SerialName("int") data class IntValue(val value: Int) : PreviewOverrideValue()
+  public @Serializable @SerialName("int") data class IntValue(val value: Int) :
+    PreviewOverrideValue()
 
   @Serializable
   @SerialName("float")
-  data class FloatValue(val value: Float) : PreviewOverrideValue()
+  public data class FloatValue(val value: Float) : PreviewOverrideValue()
 
   @Serializable
   @SerialName("bool")
-  data class BooleanValue(val value: Boolean) : PreviewOverrideValue()
+  public data class BooleanValue(val value: Boolean) : PreviewOverrideValue()
 
   /** Color as `#AARRGGBB`. The runtime helper parses it back to a Compose `Color`. */
   @Serializable
   @SerialName("color")
-  data class ColorValue(val argb: String) : PreviewOverrideValue()
+  public data class ColorValue(val argb: String) : PreviewOverrideValue()
 }

--- a/data/pseudolocale/core/api/data-pseudolocale-core.api
+++ b/data/pseudolocale/core/api/data-pseudolocale-core.api
@@ -1,0 +1,35 @@
+public final class ee/schimke/composeai/data/pseudolocale/LocaleDirection {
+	public static final field INSTANCE Lee/schimke/composeai/data/pseudolocale/LocaleDirection;
+	public final fun isRtl (Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/data/pseudolocale/Pseudolocale : java/lang/Enum {
+	public static final field ACCENT Lee/schimke/composeai/data/pseudolocale/Pseudolocale;
+	public static final field BIDI Lee/schimke/composeai/data/pseudolocale/Pseudolocale;
+	public static final field Companion Lee/schimke/composeai/data/pseudolocale/Pseudolocale$Companion;
+	public final fun getBaseTag ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getTag ()Ljava/lang/String;
+	public final fun isRtl ()Z
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/pseudolocale/Pseudolocale;
+	public static fun values ()[Lee/schimke/composeai/data/pseudolocale/Pseudolocale;
+}
+
+public final class ee/schimke/composeai/data/pseudolocale/Pseudolocale$Companion {
+	public final fun fromTag (Ljava/lang/String;)Lee/schimke/composeai/data/pseudolocale/Pseudolocale;
+}
+
+public final class ee/schimke/composeai/data/pseudolocale/Pseudolocalizer {
+	public static final field INSTANCE Lee/schimke/composeai/data/pseudolocale/Pseudolocalizer;
+	public final fun accent (Ljava/lang/CharSequence;)Ljava/lang/String;
+	public final fun bidi (Ljava/lang/CharSequence;)Ljava/lang/String;
+	public final fun transform (Ljava/lang/String;Lee/schimke/composeai/data/pseudolocale/Pseudolocale;)Ljava/lang/String;
+	public final fun transformWithIndices (Ljava/lang/String;Lee/schimke/composeai/data/pseudolocale/Pseudolocale;)Lee/schimke/composeai/data/pseudolocale/Pseudolocalizer$TransformResult;
+}
+
+public final class ee/schimke/composeai/data/pseudolocale/Pseudolocalizer$TransformResult {
+	public fun <init> (Ljava/lang/String;[I)V
+	public final fun getIndexMap ()[I
+	public final fun getText ()Ljava/lang/String;
+}
+

--- a/data/pseudolocale/core/build.gradle.kts
+++ b/data/pseudolocale/core/build.gradle.kts
@@ -15,3 +15,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :data-pseudolocale-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirection.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/LocaleDirection.kt
@@ -18,7 +18,7 @@ package ee.schimke.composeai.data.pseudolocale
  * `az-Arab` (Azerbaijani in Arabic script) is RTL despite `az`. Language is the fallback for the
  * common `ar` / `he-IL` shape where no script is written down.
  */
-object LocaleDirection {
+public object LocaleDirection {
   private val RTL_LANGUAGES =
     setOf(
       "ar", // Arabic
@@ -56,7 +56,7 @@ object LocaleDirection {
    * True when [tag] is written right-to-left — by its explicit script subtag when it carries one,
    * otherwise by its primary language subtag.
    */
-  fun isRtl(tag: String?): Boolean {
+  public fun isRtl(tag: String?): Boolean {
     if (tag.isNullOrBlank()) return false
     val subtags = tag.replace('_', '-').split('-').filter { it.isNotEmpty() }
     val language = subtags.firstOrNull()?.lowercase() ?: return false

--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocale.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocale.kt
@@ -14,17 +14,21 @@ package ee.schimke.composeai.data.pseudolocale
  * finds `values/` strings; the pseudolocalisation happens in [Pseudolocalizer] applied to whatever
  * the default locale resolved to.
  */
-enum class Pseudolocale(val tag: String, val baseTag: String, val isRtl: Boolean) {
+public enum class Pseudolocale(
+  public val tag: String,
+  public val baseTag: String,
+  public val isRtl: Boolean,
+) {
   ACCENT(tag = "en-XA", baseTag = "en", isRtl = false),
   BIDI(tag = "ar-XB", baseTag = "en", isRtl = true);
 
-  companion object {
+  public companion object {
     /**
      * Recognise pseudolocale BCP-47 tags. Case-insensitive match, accepts `_` separators alongside
      * `-`. Returns `null` for any other tag — the renderer falls through to its standard locale
      * qualifier path.
      */
-    fun fromTag(tag: String?): Pseudolocale? {
+    public fun fromTag(tag: String?): Pseudolocale? {
       if (tag.isNullOrBlank()) return null
       val normalized = tag.replace('_', '-').lowercase()
       return entries.firstOrNull { it.tag.lowercase() == normalized }

--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
@@ -18,7 +18,7 @@ package ee.schimke.composeai.data.pseudolocale
  *   `LayoutDirection.Rtl` is what actually flips layouts; the bidi marks are belt-and- braces for
  *   code paths that bypass `LocalLayoutDirection`.
  */
-object Pseudolocalizer {
+public object Pseudolocalizer {
   /**
    * Pseudolocalised text plus the input-to-output index map needed to remap span ranges over the
    * original [input] onto the transformed [text].
@@ -34,15 +34,16 @@ object Pseudolocalizer {
    * before transformation and any preview using bold / annotation / URLSpan resources would render
    * unstyled — see `PseudolocaleResources` in `:data-pseudolocale-connector`.
    */
-  class TransformResult(val text: String, val indexMap: IntArray)
+  public class TransformResult(public val text: String, public val indexMap: IntArray)
 
-  fun accent(input: CharSequence): String = transform(input.toString(), Pseudolocale.ACCENT)
+  public fun accent(input: CharSequence): String = transform(input.toString(), Pseudolocale.ACCENT)
 
-  fun bidi(input: CharSequence): String = transform(input.toString(), Pseudolocale.BIDI)
+  public fun bidi(input: CharSequence): String = transform(input.toString(), Pseudolocale.BIDI)
 
-  fun transform(input: String, mode: Pseudolocale): String = transformWithIndices(input, mode).text
+  public fun transform(input: String, mode: Pseudolocale): String =
+    transformWithIndices(input, mode).text
 
-  fun transformWithIndices(input: String, mode: Pseudolocale): TransformResult =
+  public fun transformWithIndices(input: String, mode: Pseudolocale): TransformResult =
     when (mode) {
       Pseudolocale.ACCENT -> accentWithIndices(input)
       Pseudolocale.BIDI -> bidiWithIndices(input)

--- a/data/remotecompose/core/api/data-remotecompose-core.api
+++ b/data/remotecompose/core/api/data-remotecompose-core.api
@@ -1,0 +1,133 @@
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload {
+	public static final field Companion Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeclarations ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload {
+	public static final field Companion Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDocumentBase64 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDocumentPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDocumentProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposeDocumentProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration {
+	public static final field Companion Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;)Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;ILjava/lang/Object;)Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeKnobDeclaration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposePayload {
+	public static final field Companion Lee/schimke/composeai/data/remotecompose/RemoteComposePayload$Companion;
+	public static final field HOST_ACTION_BUFFER_SIZE I
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/List;)Lee/schimke/composeai/data/remotecompose/RemoteComposePayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/remotecompose/RemoteComposePayload;Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/remotecompose/RemoteComposePayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeclarations ()Ljava/util/List;
+	public final fun getHostActions ()Ljava/util/List;
+	public final fun getNamedValues ()Ljava/util/Map;
+	public final fun getProfile ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/remotecompose/RemoteComposePayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposePayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/remotecompose/RemoteComposePayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/remotecompose/RemoteComposePayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposePayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/remotecompose/RemoteComposeProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/remotecompose/RemoteComposeProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+

--- a/data/remotecompose/core/build.gradle.kts
+++ b/data/remotecompose/core/build.gradle.kts
@@ -26,3 +26,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :data-remotecompose-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -12,13 +12,13 @@ import kotlinx.serialization.Serializable
  * `androidx.compose.remote.*` artifacts. Mirrors `Material3PermissionsProduct` /
  * `Material3KeyboardProduct`.
  */
-object RemoteComposeProduct {
-  const val KIND: String = "compose/remotecompose"
+public object RemoteComposeProduct {
+  public const val KIND: String = "compose/remotecompose"
   // v2 adds [RemoteComposePayload.declarations] — the auto-captured set of editable named-value
   // knobs a preview declared this render, so the viewer can render a control per knob instead of
   // relying on a hand-authored sidecar. Additive + defaulted, so a v1 reader that ignores the field
   // still decodes a v2 payload.
-  const val SCHEMA_VERSION: Int = 2
+  public const val SCHEMA_VERSION: Int = 2
 }
 
 /**
@@ -33,9 +33,9 @@ object RemoteComposeProduct {
  * Kept in this alpha-free core module (beside [RemoteComposeProduct]) so a client can depend on the
  * payload schema without the daemon-side registry or the `androidx.compose.remote.*` artifacts.
  */
-object RemoteComposeDocumentProduct {
-  const val KIND: String = "compose/remotecompose-doc"
-  const val SCHEMA_VERSION: Int = 1
+public object RemoteComposeDocumentProduct {
+  public const val KIND: String = "compose/remotecompose-doc"
+  public const val SCHEMA_VERSION: Int = 1
 }
 
 /**
@@ -44,7 +44,7 @@ object RemoteComposeDocumentProduct {
  * JSON, so the raw bytes ride as text). [documentBase64] decodes to the exact `.rc` byte stream the
  * vendored player consumes — the same bytes a bundle's `ir/<id>.rc` sidecar would carry.
  */
-@Serializable data class RemoteComposeDocumentPayload(val documentBase64: String)
+public @Serializable data class RemoteComposeDocumentPayload(val documentBase64: String)
 
 /**
  * One editable Remote Compose named-value knob a preview declared during its render — the auto-
@@ -61,7 +61,7 @@ object RemoteComposeDocumentProduct {
  * writes an edit back through the `remoteCompose` override facet.
  */
 @Serializable
-data class RemoteComposeKnobDeclaration(val name: String, val default: RemoteNamedValue)
+public data class RemoteComposeKnobDeclaration(val name: String, val default: RemoteNamedValue)
 
 /**
  * Bundle-sidecar shape for a preview's declared Remote Compose knobs — the payload of the
@@ -73,7 +73,7 @@ data class RemoteComposeKnobDeclaration(val name: String, val default: RemoteNam
  * carries only the editable surface, not the effective values / host actions / profile.
  */
 @Serializable
-data class RemoteComposeDeclarationsPayload(
+public data class RemoteComposeDeclarationsPayload(
   val declarations: List<RemoteComposeKnobDeclaration> = emptyList()
 )
 
@@ -100,19 +100,19 @@ data class RemoteComposeDeclarationsPayload(
  *   (name + author default + kind).
  */
 @Serializable
-data class RemoteComposePayload(
+public data class RemoteComposePayload(
   val namedValues: Map<String, RemoteNamedValue> = emptyMap(),
   val hostActions: List<RemoteHostAction> = emptyList(),
   val profile: RemoteComposeProfile? = null,
   val declarations: List<RemoteComposeKnobDeclaration> = emptyList(),
 ) {
-  companion object {
+  public companion object {
     /**
      * Cap for the in-memory host-action ring buffer. Picked so a busy panel session can keep ~5
      * seconds of typical agent-driven events without unbounded growth; downstream consumers that
      * need older events should subscribe to `data/subscribe(kind=compose/remotecompose)` and
      * accumulate themselves.
      */
-    const val HOST_ACTION_BUFFER_SIZE: Int = 256
+    public const val HOST_ACTION_BUFFER_SIZE: Int = 256
   }
 }

--- a/data/theme/core/api/data-theme-core.api
+++ b/data/theme/core/api/data-theme-core.api
@@ -1,0 +1,276 @@
+public final class ee/schimke/composeai/data/theme/Material3ThemeProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/Material3ThemeProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/theme/NodeThemeFacts {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Ljava/lang/String;)Lee/schimke/composeai/data/theme/NodeThemeFacts;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/NodeThemeFacts;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/NodeThemeFacts;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()Ljava/lang/String;
+	public final fun getForegroundColor ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getShape ()Ljava/lang/String;
+	public final fun getTextStyle ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/theme/ResolvedThemeTokens {
+	public static final field Companion Lee/schimke/composeai/data/theme/ResolvedThemeTokens$Companion;
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lee/schimke/composeai/data/theme/ResolvedThemeTokens;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ResolvedThemeTokens;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ResolvedThemeTokens;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorScheme ()Ljava/util/Map;
+	public final fun getShapes ()Ljava/util/Map;
+	public final fun getTypography ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ResolvedThemeTokens$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ResolvedThemeTokens$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ResolvedThemeTokens;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ResolvedThemeTokens;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ResolvedThemeTokens$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeConsumer {
+	public static final field Companion Lee/schimke/composeai/data/theme/ThemeConsumer$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/theme/ThemeConsumer;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ThemeConsumer;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ThemeConsumer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getTokens ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ThemeConsumer$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeConsumer$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ThemeConsumer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ThemeConsumer;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeConsumer$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeConsumerAttribution {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeConsumerAttribution;
+	public final fun attribute (Ljava/util/List;Lee/schimke/composeai/data/theme/ResolvedThemeTokens;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeDelta {
+	public static final field Companion Lee/schimke/composeai/data/theme/ThemeDelta$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/data/theme/ThemeDelta;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ThemeDelta;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ThemeDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorScheme ()Ljava/util/List;
+	public final fun getSchema ()Ljava/lang/String;
+	public final fun getShapes ()Ljava/util/List;
+	public final fun getTypography ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ThemeDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeDelta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ThemeDelta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ThemeDelta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeDiff {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeDiff;
+	public final fun diff (Lee/schimke/composeai/data/theme/ThemePayload;Lee/schimke/composeai/data/theme/ThemePayload;)Lee/schimke/composeai/data/theme/ThemeDelta;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeDiffProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeDiffProduct;
+	public static final field SCHEMA Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemePayload {
+	public static final field Companion Lee/schimke/composeai/data/theme/ThemePayload$Companion;
+	public fun <init> (Lee/schimke/composeai/data/theme/ResolvedThemeTokens;Ljava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/data/theme/ResolvedThemeTokens;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/data/theme/ResolvedThemeTokens;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lee/schimke/composeai/data/theme/ResolvedThemeTokens;Ljava/util/List;)Lee/schimke/composeai/data/theme/ThemePayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ThemePayload;Lee/schimke/composeai/data/theme/ResolvedThemeTokens;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ThemePayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConsumers ()Ljava/util/List;
+	public final fun getResolvedTokens ()Lee/schimke/composeai/data/theme/ResolvedThemeTokens;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ThemePayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemePayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ThemePayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ThemePayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemePayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeTokenChange {
+	public static final field Companion Lee/schimke/composeai/data/theme/ThemeTokenChange$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/theme/ThemeTokenChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ThemeTokenChange;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ThemeTokenChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ThemeTokenChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeTokenChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ThemeTokenChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ThemeTokenChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeTokenChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeTypographyChange {
+	public static final field Companion Lee/schimke/composeai/data/theme/ThemeTypographyChange$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Lee/schimke/composeai/data/theme/TypographyToken;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Lee/schimke/composeai/data/theme/TypographyToken;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public final fun component3 ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Lee/schimke/composeai/data/theme/TypographyToken;)Lee/schimke/composeai/data/theme/ThemeTypographyChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/ThemeTypographyChange;Ljava/lang/String;Lee/schimke/composeai/data/theme/TypographyToken;Lee/schimke/composeai/data/theme/TypographyToken;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/ThemeTypographyChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public final fun getTo ()Lee/schimke/composeai/data/theme/TypographyToken;
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/ThemeTypographyChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/ThemeTypographyChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/ThemeTypographyChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/ThemeTypographyChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/ThemeTypographyChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/TypographyToken {
+	public static final field Companion Lee/schimke/composeai/data/theme/TypographyToken$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Float;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Float;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)Lee/schimke/composeai/data/theme/TypographyToken;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/theme/TypographyToken;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/theme/TypographyToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontFamily ()Ljava/lang/String;
+	public final fun getFontSize ()Ljava/lang/Float;
+	public final fun getFontSizeUnit ()Ljava/lang/String;
+	public final fun getFontStyle ()Ljava/lang/String;
+	public final fun getFontWeight ()Ljava/lang/String;
+	public final fun getLetterSpacing ()Ljava/lang/Float;
+	public final fun getLetterSpacingUnit ()Ljava/lang/String;
+	public final fun getLineHeight ()Ljava/lang/Float;
+	public final fun getLineHeightUnit ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/theme/TypographyToken$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/theme/TypographyToken$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/theme/TypographyToken;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/theme/TypographyToken;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/theme/TypographyToken$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/data/theme/core/build.gradle.kts
+++ b/data/theme/core/build.gradle.kts
@@ -18,3 +18,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :data-theme-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/Material3ThemeModels.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/Material3ThemeModels.kt
@@ -7,34 +7,34 @@ import kotlinx.serialization.Serializable
  * MCP clients and other connectors can depend on the payload schema without pulling in the
  * daemon-side registry or Compose runtime.
  */
-object Material3ThemeProduct {
-  const val KIND: String = "compose/theme"
+public object Material3ThemeProduct {
+  public const val KIND: String = "compose/theme"
 
   /**
    * v2 populates [ThemePayload.consumers] (node → tokens read) via resolved-value attribution; v1
    * shipped resolved tokens only and left `consumers` empty (#449, #1847). The payload shape is
    * unchanged — v1 readers see a populated list where they previously saw `[]`.
    */
-  const val SCHEMA_VERSION: Int = 2
+  public const val SCHEMA_VERSION: Int = 2
 }
 
 @Serializable
-data class ThemePayload(
+public data class ThemePayload(
   val resolvedTokens: ResolvedThemeTokens,
   val consumers: List<ThemeConsumer> = emptyList(),
 )
 
 @Serializable
-data class ResolvedThemeTokens(
+public data class ResolvedThemeTokens(
   val colorScheme: Map<String, String>,
   val typography: Map<String, TypographyToken>,
   val shapes: Map<String, String>,
 )
 
-@Serializable data class ThemeConsumer(val nodeId: String, val tokens: List<String>)
+public @Serializable data class ThemeConsumer(val nodeId: String, val tokens: List<String>)
 
 @Serializable
-data class TypographyToken(
+public data class TypographyToken(
   val fontFamily: String? = null,
   val fontSize: Float? = null,
   val fontSizeUnit: String? = null,

--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttribution.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeConsumerAttribution.kt
@@ -9,7 +9,7 @@ package ee.schimke.composeai.data.theme
  * `#AARRGGBB` strings matching [ResolvedThemeTokens.colorScheme] values; [textStyle] is the node's
  * resolved typography token (or `null` for a non-text node).
  */
-data class NodeThemeFacts(
+public data class NodeThemeFacts(
   val nodeId: String,
   val foregroundColor: String? = null,
   val backgroundColor: String? = null,
@@ -45,8 +45,11 @@ data class NodeThemeFacts(
  * A node is only emitted as a [ThemeConsumer] when it read at least one token — nodes that hardcode
  * non-theme values produce no entry.
  */
-object ThemeConsumerAttribution {
-  fun attribute(nodes: List<NodeThemeFacts>, resolved: ResolvedThemeTokens): List<ThemeConsumer> {
+public object ThemeConsumerAttribution {
+  public fun attribute(
+    nodes: List<NodeThemeFacts>,
+    resolved: ResolvedThemeTokens,
+  ): List<ThemeConsumer> {
     if (nodes.isEmpty()) return emptyList()
     val rolesByColor: Map<String, List<String>> =
       buildMap<String, MutableList<String>> {

--- a/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeDiff.kt
+++ b/data/theme/core/src/main/kotlin/ee/schimke/composeai/data/theme/ThemeDiff.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
-object ThemeDiffProduct {
-  const val SCHEMA: String = "compose-theme-diff/v1"
+public object ThemeDiffProduct {
+  public const val SCHEMA: String = "compose-theme-diff/v1"
 }
 
 /**
@@ -21,9 +21,9 @@ object ThemeDiffProduct {
  * [ThemePayload.consumers] (node → token attribution) is deliberately ignored, the way
  * `SemanticsDiff` ignores volatile bounds.
  */
-object ThemeDiff {
+public object ThemeDiff {
 
-  fun diff(base: ThemePayload, head: ThemePayload): ThemeDelta {
+  public fun diff(base: ThemePayload, head: ThemePayload): ThemeDelta {
     val b = base.resolvedTokens
     val h = head.resolvedTokens
     return ThemeDelta(
@@ -55,10 +55,14 @@ object ThemeDiff {
 }
 
 @Serializable
-data class ThemeTokenChange(val token: String, val from: String? = null, val to: String? = null)
+public data class ThemeTokenChange(
+  val token: String,
+  val from: String? = null,
+  val to: String? = null,
+)
 
 @Serializable
-data class ThemeTypographyChange(
+public data class ThemeTypographyChange(
   val token: String,
   val from: TypographyToken? = null,
   val to: TypographyToken? = null,
@@ -66,7 +70,7 @@ data class ThemeTypographyChange(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class ThemeDelta(
+public data class ThemeDelta(
   // `@EncodeDefault` so the versioned schema discriminator rides every wire surface even under
   // `encodeDefaults = false` (the daemon's `history/diff mode=data` result), matching the
   // `SemanticsDelta` contract.

--- a/render-session/api/api/render-session-api.api
+++ b/render-session/api/api/render-session-api.api
@@ -1,0 +1,141 @@
+public final class ee/schimke/composeai/render/session/DataProductException : ee/schimke/composeai/render/session/RenderSessionException {
+	public static final field BUDGET_EXCEEDED I
+	public static final field Companion Lee/schimke/composeai/render/session/DataProductException$Companion;
+	public static final field FETCH_FAILED I
+	public static final field NOT_AVAILABLE I
+	public static final field UNKNOWN I
+	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCode ()I
+	public final fun getData ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getWireMessage ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/render/session/DataProductException$Companion {
+}
+
+public abstract interface class ee/schimke/composeai/render/session/NotificationListener {
+	public abstract fun onNotification (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+}
+
+public abstract interface class ee/schimke/composeai/render/session/RenderSession : java/lang/AutoCloseable {
+	public abstract fun close ()V
+	public abstract fun disableExtensions-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public static synthetic fun disableExtensions-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public abstract fun enableExtensions-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public static synthetic fun enableExtensions-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public abstract fun fetchData-9VgGkz4 (Ljava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;J)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public static synthetic fun fetchData-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public abstract fun fileChanged (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;)V
+	public static synthetic fun fileChanged$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;ILjava/lang/Object;)V
+	public abstract fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public abstract fun getInitializeResult ()Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public abstract fun getModulePath ()Ljava/lang/String;
+	public abstract fun getWorkspaceRoot ()Ljava/lang/String;
+	public abstract fun historyDiff-Wn2Vu4Y (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;J)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public static synthetic fun historyDiff-Wn2Vu4Y$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public abstract fun historyList-HG0u8IE (Lee/schimke/composeai/daemon/protocol/HistoryListParams;J)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public static synthetic fun historyList-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Lee/schimke/composeai/daemon/protocol/HistoryListParams;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public abstract fun historyRead-SxA4cEA (Ljava/lang/String;ZJ)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public static synthetic fun historyRead-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;ZJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public fun interactiveInput (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun interactiveInput$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public abstract fun listExtensions-LRDsOJo (J)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public static synthetic fun listExtensions-LRDsOJo$default (Lee/schimke/composeai/render/session/RenderSession;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public abstract fun onNotification (Lee/schimke/composeai/render/session/NotificationListener;)Ljava/lang/AutoCloseable;
+	public abstract fun recordingEncode-SxA4cEA (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;J)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public static synthetic fun recordingEncode-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public abstract fun recordingScript (Ljava/lang/String;Ljava/util/List;)V
+	public abstract fun recordingStart-9VgGkz4 (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public static synthetic fun recordingStart-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public abstract fun recordingStop-HG0u8IE (Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public static synthetic fun recordingStop-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public abstract fun renderNow-9VgGkz4 (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public static synthetic fun renderNow-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public abstract fun setFocus (Ljava/util/List;)V
+	public abstract fun setVisible (Ljava/util/List;)V
+	public fun streamStart-9VgGkz4 (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public static synthetic fun streamStart-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public fun streamStop (Ljava/lang/String;)V
+	public fun streamVisibility (Ljava/lang/String;ZLjava/lang/Integer;)V
+	public static synthetic fun streamVisibility$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;ZLjava/lang/Integer;ILjava/lang/Object;)V
+	public abstract fun subscribeData-Wn2Vu4Y (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun subscribeData-Wn2Vu4Y$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public abstract fun unsubscribeData-SxA4cEA (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun unsubscribeData-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+}
+
+public final class ee/schimke/composeai/render/session/RenderSession$DefaultImpls {
+	public static synthetic fun disableExtensions-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public static synthetic fun enableExtensions-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public static synthetic fun fetchData-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public static synthetic fun fileChanged$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;ILjava/lang/Object;)V
+	public static synthetic fun historyDiff-Wn2Vu4Y$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public static synthetic fun historyList-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Lee/schimke/composeai/daemon/protocol/HistoryListParams;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public static synthetic fun historyRead-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;ZJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public static fun interactiveInput (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun interactiveInput$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun listExtensions-LRDsOJo$default (Lee/schimke/composeai/render/session/RenderSession;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public static synthetic fun recordingEncode-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public static synthetic fun recordingStart-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public static synthetic fun recordingStop-HG0u8IE$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public static synthetic fun renderNow-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public static fun streamStart-9VgGkz4 (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public static synthetic fun streamStart-9VgGkz4$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public static fun streamStop (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;)V
+	public static fun streamVisibility (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;ZLjava/lang/Integer;)V
+	public static synthetic fun streamVisibility$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;ZLjava/lang/Integer;ILjava/lang/Object;)V
+	public static synthetic fun subscribeData-Wn2Vu4Y$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun unsubscribeData-SxA4cEA$default (Lee/schimke/composeai/render/session/RenderSession;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+}
+
+public final class ee/schimke/composeai/render/session/RenderSessionBackend : java/lang/Enum {
+	public static final field Embedded Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public static final field Subprocess Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public static fun values ()[Lee/schimke/composeai/render/session/RenderSessionBackend;
+}
+
+public final class ee/schimke/composeai/render/session/RenderSessionConfig {
+	public static final field Companion Lee/schimke/composeai/render/session/RenderSessionConfig$Companion;
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/Map;Lkotlin/jvm/functions/Function1;JLkotlin/time/Duration;Lkotlin/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/Map;Lkotlin/jvm/functions/Function1;JLkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()Ljava/io/File;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lkotlin/jvm/functions/Function1;
+	public final fun component7-UwyO8pc ()J
+	public final fun component8-FghU774 ()Lkotlin/time/Duration;
+	public final fun component9-FghU774 ()Lkotlin/time/Duration;
+	public final fun copy-B2U8IQ0 (Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/Map;Lkotlin/jvm/functions/Function1;JLkotlin/time/Duration;Lkotlin/time/Duration;)Lee/schimke/composeai/render/session/RenderSessionConfig;
+	public static synthetic fun copy-B2U8IQ0$default (Lee/schimke/composeai/render/session/RenderSessionConfig;Ljava/io/File;Ljava/io/File;Ljava/lang/String;ZLjava/util/Map;Lkotlin/jvm/functions/Function1;JLkotlin/time/Duration;Lkotlin/time/Duration;ILjava/lang/Object;)Lee/schimke/composeai/render/session/RenderSessionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescriptorPath ()Ljava/io/File;
+	public final fun getForceEnabled ()Z
+	public final fun getInitializeTimeout-UwyO8pc ()J
+	public final fun getLogSink ()Lkotlin/jvm/functions/Function1;
+	public final fun getMaxRenderTime-FghU774 ()Lkotlin/time/Duration;
+	public final fun getShutdownTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getSystemPropertyOverrides ()Ljava/util/Map;
+	public final fun getWorkspaceName ()Ljava/lang/String;
+	public final fun getWorkspaceRoot ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/render/session/RenderSessionConfig$Companion {
+}
+
+public class ee/schimke/composeai/render/session/RenderSessionException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract interface class ee/schimke/composeai/render/session/RenderSessionFactory {
+	public abstract fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public abstract fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;)Lee/schimke/composeai/render/session/RenderSession;
+}
+

--- a/render-session/api/build.gradle.kts
+++ b/render-session/api/build.gradle.kts
@@ -41,3 +41,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :render-session-api:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
@@ -62,18 +62,18 @@ import kotlinx.serialization.json.JsonObject
  * protocol failure. Wire-level data-product errors (`DataProductUnknown`,
  * `DataProductNotAvailable`, etc.) are surfaced as [DataProductException].
  */
-interface RenderSession : AutoCloseable {
+public interface RenderSession : AutoCloseable {
   /** Absolute path to the workspace root the session was opened against. */
-  val workspaceRoot: String
+  public val workspaceRoot: String
 
   /** Gradle path of the target module (e.g. `:samples:android`). */
-  val modulePath: String
+  public val modulePath: String
 
   /** Result of the initialize handshake. Surfaces daemon version, capabilities, and PID. */
-  val initializeResult: InitializeResult
+  public val initializeResult: InitializeResult
 
   /** Backend that hosts this session — informational; behaviour is identical across backends. */
-  val backendKind: RenderSessionBackend
+  public val backendKind: RenderSessionBackend
 
   // ---------------------------------------------------------------------------
   // Editor-state notifications. None of these return data; they update the
@@ -82,16 +82,16 @@ interface RenderSession : AutoCloseable {
   // ---------------------------------------------------------------------------
 
   /** Set the most-recently-visible preview ids. Drives sticky subscription liveness. */
-  fun setVisible(previewIds: List<String>)
+  public fun setVisible(previewIds: List<String>)
 
   /** Set the most-recently-focused preview ids. Drives focus-aware rendering. */
-  fun setFocus(previewIds: List<String>)
+  public fun setFocus(previewIds: List<String>)
 
   /**
    * Notify the session of a source / classpath change so it can invalidate caches, swap user
    * classloaders, and (depending on backend) trigger incremental discovery.
    */
-  fun fileChanged(
+  public fun fileChanged(
     path: String,
     kind: FileKind = FileKind.SOURCE,
     changeType: ChangeType = ChangeType.MODIFIED,
@@ -108,7 +108,7 @@ interface RenderSession : AutoCloseable {
    * unchanged results without re-running compose. Pass [PreviewOverrides] to drive
    * device/locale/inspection-mode tweaks per render without mutating the on-disk preview spec.
    */
-  fun renderNow(
+  public fun renderNow(
     previewIds: List<String>,
     tier: RenderTier = RenderTier.FULL,
     reason: String? = null,
@@ -129,7 +129,7 @@ interface RenderSession : AutoCloseable {
    *
    * @throws DataProductException on wire-level data-product errors.
    */
-  fun fetchData(
+  public fun fetchData(
     previewId: String,
     kind: String,
     inline: Boolean = false,
@@ -142,7 +142,7 @@ interface RenderSession : AutoCloseable {
    * while visible" — when the preview leaves the most recent [setVisible] set the backend drops the
    * subscription automatically. Re-subscribe when it returns to view.
    */
-  fun subscribeData(
+  public fun subscribeData(
     previewId: String,
     kind: String,
     params: JsonElement? = null,
@@ -150,7 +150,7 @@ interface RenderSession : AutoCloseable {
   ): DataSubscribeResult
 
   /** Unsubscribe. See [subscribeData]. */
-  fun unsubscribeData(
+  public fun unsubscribeData(
     previewId: String,
     kind: String,
     timeout: Duration = 15.seconds,
@@ -161,13 +161,19 @@ interface RenderSession : AutoCloseable {
   // ---------------------------------------------------------------------------
 
   /** Enumerate the extensions advertised by the backend. */
-  fun listExtensions(timeout: Duration = 15.seconds): ExtensionsListResult
+  public fun listExtensions(timeout: Duration = 15.seconds): ExtensionsListResult
 
   /** Enable specific extension contributions on this session. */
-  fun enableExtensions(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsEnableResult
+  public fun enableExtensions(
+    ids: List<String>,
+    timeout: Duration = 15.seconds,
+  ): ExtensionsEnableResult
 
   /** Disable specific extension contributions on this session. */
-  fun disableExtensions(ids: List<String>, timeout: Duration = 15.seconds): ExtensionsDisableResult
+  public fun disableExtensions(
+    ids: List<String>,
+    timeout: Duration = 15.seconds,
+  ): ExtensionsDisableResult
 
   // ---------------------------------------------------------------------------
   // History — per-render archive surface. Optional on every backend; backends
@@ -176,20 +182,20 @@ interface RenderSession : AutoCloseable {
   // ---------------------------------------------------------------------------
 
   /** List archived render entries. Pass [HistoryListParams] to filter by preview id / time. */
-  fun historyList(
+  public fun historyList(
     params: HistoryListParams = HistoryListParams(),
     timeout: Duration = 30.seconds,
   ): HistoryListResult
 
   /** Read one archived entry. Set [inline] = `true` to receive base64 PNG bytes inline. */
-  fun historyRead(
+  public fun historyRead(
     entryId: String,
     inline: Boolean = false,
     timeout: Duration = 30.seconds,
   ): HistoryReadResultDto
 
   /** Diff two archived entries. */
-  fun historyDiff(
+  public fun historyDiff(
     fromId: String,
     toId: String,
     mode: HistoryDiffMode = HistoryDiffMode.METADATA,
@@ -201,7 +207,7 @@ interface RenderSession : AutoCloseable {
   // ---------------------------------------------------------------------------
 
   /** Start a recording session against one preview. Returns the daemon-allocated recording id. */
-  fun recordingStart(
+  public fun recordingStart(
     previewId: String,
     fps: Int? = null,
     scale: Float? = null,
@@ -210,13 +216,13 @@ interface RenderSession : AutoCloseable {
   ): RecordingStartResult
 
   /** Send recording-script events (fire-and-forget notification). */
-  fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>)
+  public fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>)
 
   /** Stop recording — blocks until the daemon's playback loop finishes writing frames. */
-  fun recordingStop(recordingId: String, timeout: Duration = 5.minutes): RecordingStopResult
+  public fun recordingStop(recordingId: String, timeout: Duration = 5.minutes): RecordingStopResult
 
   /** Encode a stopped recording into a single file (APNG by default). */
-  fun recordingEncode(
+  public fun recordingEncode(
     recordingId: String,
     format: RecordingFormat = RecordingFormat.APNG,
     timeout: Duration = 60.seconds,
@@ -234,7 +240,7 @@ interface RenderSession : AutoCloseable {
    * failure) and fall back to [renderNow]-per-frame. Only the subprocess/daemon backend overrides
    * this.
    */
-  fun streamStart(
+  public fun streamStart(
     previewId: String,
     codec: StreamCodec? = null,
     maxFps: Int? = null,
@@ -243,7 +249,7 @@ interface RenderSession : AutoCloseable {
   ): StreamStartResult = throw UnsupportedOperationException("streaming not supported")
 
   /** Stop a held stream (daemon `stream/stop`, fire-and-forget). Default throws. */
-  fun streamStop(frameStreamId: String): Unit =
+  public fun streamStop(frameStreamId: String): Unit =
     throw UnsupportedOperationException("streaming not supported")
 
   /**
@@ -252,14 +258,14 @@ interface RenderSession : AutoCloseable {
    * [fps] (daemon default: 1) for both emission *and* rendering, and the first frame after it flips
    * back to visible is flagged as a keyframe. Default throws.
    */
-  fun streamVisibility(frameStreamId: String, visible: Boolean, fps: Int? = null): Unit =
+  public fun streamVisibility(frameStreamId: String, visible: Boolean, fps: Int? = null): Unit =
     throw UnsupportedOperationException("streaming not supported")
 
   /**
    * Dispatch an input event into a held stream's live composition (daemon `interactive/input`,
    * fire-and-forget); the resulting frame arrives as a `streamFrame`. Default throws.
    */
-  fun interactiveInput(
+  public fun interactiveInput(
     frameStreamId: String,
     kind: InteractiveInputKind,
     pixelX: Int? = null,
@@ -280,7 +286,7 @@ interface RenderSession : AutoCloseable {
    * — typical use is `session.onNotification { … }.use { runRenders() }` so the subscription is
    * scoped to one block. Handlers must not block; offload to a worker if real work is needed.
    */
-  fun onNotification(listener: NotificationListener): AutoCloseable
+  public fun onNotification(listener: NotificationListener): AutoCloseable
 
   /**
    * Close the session. Idempotent. After close, every other method throws [IllegalStateException].
@@ -300,12 +306,12 @@ interface RenderSession : AutoCloseable {
  * session.onNotification { method, _ -> println("[notif] $method") }
  * ```
  */
-fun interface NotificationListener {
-  fun onNotification(method: String, params: JsonObject?)
+public fun interface NotificationListener {
+  public fun onNotification(method: String, params: JsonObject?)
 }
 
 /** Backend hosting a [RenderSession]. Informational; behaviour is identical across backends. */
-enum class RenderSessionBackend {
+public enum class RenderSessionBackend {
   /** Daemon JVM spawned as a subprocess, driven over JSON-RPC. The default. */
   Subprocess,
 
@@ -322,7 +328,7 @@ enum class RenderSessionBackend {
  * underlying [cause] (e.g. an `IOException` from the transport, a `JsonRpcException` from the
  * protocol layer) where one exists.
  */
-open class RenderSessionException(message: String, cause: Throwable? = null) :
+public open class RenderSessionException(message: String, cause: Throwable? = null) :
   RuntimeException(message, cause)
 
 /**
@@ -330,16 +336,16 @@ open class RenderSessionException(message: String, cause: Throwable? = null) :
  * JSON-RPC error code (`-32020`..`-32023`); [wireMessage] is the daemon's human-readable message;
  * [data] is the optional structured payload some errors carry.
  */
-class DataProductException(
-  val code: Int,
-  val wireMessage: String,
-  val data: JsonObject?,
+public class DataProductException(
+  public val code: Int,
+  public val wireMessage: String,
+  public val data: JsonObject?,
   cause: Throwable? = null,
 ) : RenderSessionException("data/fetch wire error $code: $wireMessage", cause) {
-  companion object {
-    const val UNKNOWN: Int = -32020
-    const val NOT_AVAILABLE: Int = -32021
-    const val FETCH_FAILED: Int = -32022
-    const val BUDGET_EXCEEDED: Int = -32023
+  public companion object {
+    public const val UNKNOWN: Int = -32020
+    public const val NOT_AVAILABLE: Int = -32021
+    public const val FETCH_FAILED: Int = -32022
+    public const val BUDGET_EXCEEDED: Int = -32023
   }
 }

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSessionFactory.kt
@@ -21,15 +21,15 @@ import kotlin.time.Duration.Companion.seconds
  * session.use { … }
  * ```
  */
-interface RenderSessionFactory {
+public interface RenderSessionFactory {
   /** Backend this factory produces. */
-  val backendKind: RenderSessionBackend
+  public val backendKind: RenderSessionBackend
 
   /**
    * Open and initialize a session. Throws [RenderSessionException] (or subclass) on transport /
    * descriptor / handshake failure — callers don't observe an un-initialized session.
    */
-  fun open(config: RenderSessionConfig): RenderSession
+  public fun open(config: RenderSessionConfig): RenderSession
 }
 
 /**
@@ -37,7 +37,7 @@ interface RenderSessionFactory {
  * subprocess JVM args overrides) live on per-backend extensions; this base record holds the minimum
  * every backend needs.
  */
-data class RenderSessionConfig(
+public data class RenderSessionConfig(
   /**
    * Path to the daemon launch descriptor written by the gradle plugin's `composePreviewDaemonStart`
    * task. Lives at `<projectDir>/build/compose-previews/daemon-launch.json`. Required even for the
@@ -88,7 +88,7 @@ data class RenderSessionConfig(
    */
   val shutdownTimeout: Duration? = null,
 ) {
-  companion object {
+  public companion object {
     private fun inferWorkspaceRoot(descriptorPath: File): File =
       descriptorPath.parentFile?.parentFile?.parentFile ?: descriptorPath.absoluteFile
   }

--- a/render-session/subprocess/api/render-session-subprocess.api
+++ b/render-session/subprocess/api/render-session-subprocess.api
@@ -1,0 +1,50 @@
+public final class ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession : ee/schimke/composeai/render/session/RenderSession {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InitializeResult;Lee/schimke/composeai/render/session/RenderSessionBackend;Lee/schimke/composeai/daemon/client/DaemonClient;Lee/schimke/composeai/render/session/subprocess/NotificationFanout;Lkotlin/jvm/functions/Function0;)V
+	public fun close ()V
+	public fun disableExtensions-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public fun enableExtensions-HG0u8IE (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public fun fetchData-9VgGkz4 (Ljava/lang/String;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;J)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public fun fileChanged (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;)V
+	public fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public fun getInitializeResult ()Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public fun getModulePath ()Ljava/lang/String;
+	public fun getWorkspaceRoot ()Ljava/lang/String;
+	public fun historyDiff-Wn2Vu4Y (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;J)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public fun historyList-HG0u8IE (Lee/schimke/composeai/daemon/protocol/HistoryListParams;J)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public fun historyRead-SxA4cEA (Ljava/lang/String;ZJ)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public fun interactiveInput (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun listExtensions-LRDsOJo (J)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public fun onNotification (Lee/schimke/composeai/render/session/NotificationListener;)Ljava/lang/AutoCloseable;
+	public fun recordingEncode-SxA4cEA (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;J)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public fun recordingScript (Ljava/lang/String;Ljava/util/List;)V
+	public fun recordingStart-9VgGkz4 (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public fun recordingStop-HG0u8IE (Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public fun renderNow-9VgGkz4 (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public fun setFocus (Ljava/util/List;)V
+	public fun setVisible (Ljava/util/List;)V
+	public fun streamStart-9VgGkz4 (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;J)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public fun streamStop (Ljava/lang/String;)V
+	public fun streamVisibility (Ljava/lang/String;ZLjava/lang/Integer;)V
+	public fun subscribeData-Wn2Vu4Y (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public fun unsubscribeData-SxA4cEA (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+}
+
+public final class ee/schimke/composeai/render/session/subprocess/NotificationFanout {
+	public fun <init> ()V
+	public final fun clear ()V
+	public final fun dispatch (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun register (Lee/schimke/composeai/render/session/NotificationListener;)Ljava/lang/AutoCloseable;
+}
+
+public final class ee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions : ee/schimke/composeai/render/session/RenderSessionFactory {
+	public static final field INSTANCE Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;
+	public final fun descriptorFile (Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
+	public fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
+	public final fun getFileSystem ()Lokio/FileSystem;
+	public fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;)Lee/schimke/composeai/render/session/RenderSession;
+	public final fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
+	public final fun openBundleDaemon-w3P_Jxs (Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
+	public static synthetic fun openBundleDaemon-w3P_Jxs$default (Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;ILjava/lang/Object;)Lee/schimke/composeai/render/session/RenderSession;
+	public final fun setFileSystem (Lokio/FileSystem;)V
+}
+

--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -59,3 +59,24 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew
+  // :render-session-subprocess:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/DaemonClientRenderSession.kt
@@ -55,7 +55,7 @@ import kotlinx.serialization.json.JsonObject
  * Pre-1.0 surface. The public constructor lets new backends construct one without owning a copy of
  * the ~150 LOC of pass-through delegate methods.
  */
-class DaemonClientRenderSession(
+public class DaemonClientRenderSession(
   override val workspaceRoot: String,
   override val modulePath: String,
   override val initializeResult: InitializeResult,
@@ -293,19 +293,19 @@ class DaemonClientRenderSession(
  * (which delegates to [register]). Lifetime is the owner's: `clear()` on teardown so stale handles
  * to `close()` are harmless after the underlying daemon goes away.
  */
-class NotificationFanout {
+public class NotificationFanout {
   private val listeners = CopyOnWriteArraySet<NotificationListener>()
 
-  fun register(listener: NotificationListener): AutoCloseable {
+  public fun register(listener: NotificationListener): AutoCloseable {
     listeners.add(listener)
     return AutoCloseable { listeners.remove(listener) }
   }
 
-  fun dispatch(method: String, params: JsonObject?) {
+  public fun dispatch(method: String, params: JsonObject?) {
     for (l in listeners) runCatching { l.onNotification(method, params) }
   }
 
-  fun clear() {
+  public fun clear() {
     listeners.clear()
   }
 }

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -26,10 +26,10 @@ import okio.Path.Companion.toPath
  * [RenderSessionConfig.descriptorPath] — the heavy lifting (subprocess fork, JSON-RPC handshake)
  * happens before the factory returns, so consumers never see an un-initialized session.
  */
-object SubprocessRenderSessions : RenderSessionFactory {
+public object SubprocessRenderSessions : RenderSessionFactory {
   override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
-  var fileSystem: FileSystem = SystemFileSystem
+  public var fileSystem: FileSystem = SystemFileSystem
 
   override fun open(config: RenderSessionConfig): RenderSession =
     open(config = config, factory = SubprocessDaemonClientFactory())
@@ -38,7 +38,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
    * Open a session, injecting a custom [DaemonClientFactory]. Test scaffolding pairs an in-memory
    * factory with a fake daemon; production callers stick with the default factory in [open].
    */
-  fun open(config: RenderSessionConfig, factory: DaemonClientFactory): RenderSession {
+  public fun open(config: RenderSessionConfig, factory: DaemonClientFactory): RenderSession {
     val descriptorFile = config.descriptorPath
     if (!descriptorFile.isFile) {
       throw RenderSessionException(
@@ -118,7 +118,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
    * @param hardTtlSeconds optional wall-clock deadline after which the spawner force-kills the JVM.
    *   Set for a sandboxed playground snippet; null for an ordinary bundle daemon.
    */
-  fun openBundleDaemon(
+  public fun openBundleDaemon(
     daemonClasspath: List<String>,
     classesDir: File,
     previewsJson: File,
@@ -249,7 +249,7 @@ object SubprocessRenderSessions : RenderSessionFactory {
    * conventional `<projectDir>/<modulePath-derived>/build/compose-previews/daemon-launch.json`
    * layout. Convenience wrapper for callers that don't already have the descriptor path.
    */
-  fun descriptorFile(projectDir: File, modulePath: String): File {
+  public fun descriptorFile(projectDir: File, modulePath: String): File {
     val moduleDir =
       if (modulePath.isBlank() || modulePath == ":") projectDir
       else File(projectDir, modulePath.trimStart(':').replace(':', '/'))


### PR DESCRIPTION
#3824 preparation item 6, continuing from #4558. Eight of the remaining eleven published contracts now state their API surface and record it.

`common-io` · `preview-data-api` · `data-theme-core` · `data-pseudolocale-core` · `data-remotecompose-core` · `data-preview-overrides-core` · `render-session-api` · `render-session-subprocess`

**166 declarations annotated**, matching the pre-measured count exactly. Per module: `explicitApi()`, `abiValidation()`, the `check` → `checkKotlinAbi` wiring KGP does not add itself, and a committed dump.

| Module | ABI dump |
| --- | ---: |
| `api/preview-data-api` | 1389 |
| `data/preview-overrides/core` | 371 |
| `data/theme/core` | 276 |
| `render-session/api` | 141 |
| `data/remotecompose/core` | 133 |
| `render-session/subprocess` | 50 |
| `data/pseudolocale/core` | 35 |
| `common/io` | 16 |

`:preview-data-api` is worth noting: 1389 lines of recorded surface from just 33 annotated declarations — few types, very wide. Exactly where an unrecorded ABI change would otherwise pass unnoticed.

## Every annotation is `public`, deliberately

This is the opposite judgement to #4558 and the reason these two PRs are separate.

`:daemon-client` had **never been published** (`v1.36.0` was tagged before #4547 added it), so narrowing a declaration to `internal` was free — I checked each one, and nothing needed it.

These eight are all **in released artifacts**. Every implicitly-public declaration is therefore *already in a shipped ABI*, and marking one `internal` now would be a breaking change for consumers. So this pass **records** the existing surface rather than deciding it. Narrowing any of it is a separate, deliberate call that costs a major version.

Each module's build comment states which regime applies, so a later reader doesn't have to infer it from the git history.

## Verifying the gate is not decorative

Falsified on **`:render-session-api`** — a module *not* exercised in #4558, rather than re-testing the one already known to work:

```
EXIT WITH EXTRA PUBLIC FN: 1     BUILD FAILED
EXIT AFTER RESTORE:        0     BUILD SUCCESSFUL
```

The `check` → `checkKotlinAbi` wiring is the load-bearing half. Without it the gate is configured and never runs — a green build that proves nothing.

## Two sites needed hand-fixing

`Pseudolocale` and `TransformResult` take **constructor `val` parameters**, where the compiler reports the parameter's column rather than the line start. A line-prefixing pass cannot touch them, so the automated sweep stalled at "2 errors, 0 applied" rather than converging — which is how I found them. Same shape as `DataProductWireException` in #4558.

## Test plan

- `check` green on seven of eight modules (includes `checkKotlinAbi`)
- `ktfmtFormat` applied; dumps regenerated afterwards
- ABI gate falsified on `:render-session-api`, then restored
- All eight compile clean under `explicitApi()` — 0 remaining errors

Non-visual change (visibility modifiers and build wiring), so no rendered evidence applies.

## One known-failing check, verified pre-existing

`:render-session-subprocess:check` fails `NonGradleContractTest > synthesised descriptor drives a real render via RenderSession` — a real daemon not emitting `renderFinished` within 60s. Confirmed earlier today against a worktree at the merge-base: it fails identically there, with the same message, and genuinely runs rather than self-skipping. Not caused by this change.

Also expect the usual inherited red from `main`'s three timing tests (`AndroidRippleFrameTest:121`, `LivePressRippleTest:92`, `ServeStatusLiveFramesTest:127`) — the failing subset varies per run, which is what establishes they are load-dependent. Analysis and a proposed patch in #4547.

## Remaining for item 6

`daemon/core` (776 — 55% of the original total, the protocol surface, its own PR), then `data/render/core` (230) + `data/layoutinspector/core` (181).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_