### PR TITLE
feat(serve): copy the producer's artifact list instead of deriving one

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2123,7 +2123,7 @@ class ServeCatalogStore(
     // guards each write, so one unwriteable artifact is an artifact the engine calls unreadable
     // rather than a reason to abandon the refresh.
     fetchCatalogAssetsToFiles(
-      knownDifferenceArtifactPaths(documentBytes).map { path ->
+      knownDifferenceArtifactPlan(base, documentBytes).map { path ->
         "$base$artifactRoot/$path" to File(staging, "$artifactRoot/$path")
       },
       // An artifact the transport refuses by size gets the same marker treatment the document does,
@@ -2158,8 +2158,77 @@ class ServeCatalogStore(
     .getOrDefault(false)
 
   /**
+   * Which artifact files to fetch: **the producer's list when it publishes one**, and only
+   * otherwise the paths derived from the document.
+   *
+   * The published index ([ServeKnownDifferences.ARTIFACT_INDEX_FILE]) is written by the producer
+   * that wrote the files, so it is the one source that cannot be wrong about what exists.
+   * Preferring it retires the derivation below along with every rule the derivation had to mirror —
+   * including the ones nobody has thought of yet.
+   *
+   * **A fetch plan, not an authority.** Three things follow, and all three are deliberate:
+   * - every path still goes through [ServeKnownDifferences.isLookupPath] before it is fetched or
+   *   written. A producer naming `../../secrets.png` in its index gets exactly the refusal it gets
+   *   for naming it in the document. The index changes *where the list comes from*, never what this
+   *   host will look up.
+   * - a list that disagrees with the document is not an error to report. The document remains the
+   *   contract: a file the index omits is not staged and evaluates as `artifact-unreadable`, which
+   *   is already the verdict for a file a producer forgot to commit.
+   * - the index is not consulted for whether the *document* is readable. It says what to copy, and
+   *   a host that let it decide that would have swapped one derivation for another.
+   *
+   * **Absent means "this producer does not publish one", not "there is nothing".** So a catalog
+   * published before the index existed falls back to the derivation and behaves exactly as it did —
+   * which is what makes this purely additive. An index that parses and names nothing is a different
+   * answer: an empty list, honoured as one.
+   */
+  private fun knownDifferenceArtifactPlan(base: String, documentBytes: ByteArray): List<String> =
+    publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
+
+  /**
+   * The producer's artifact list, or null when this catalog publishes none.
+   *
+   * Fail-soft in the direction that costs least: anything unparseable, wrongly-schema'd or
+   * wrongly-shaped is null, so the caller derives the list as it always did rather than staging
+   * nothing. The alternative — treating a malformed index as an empty list — would let one bad file
+   * silently strip every record of its artifacts, which is the changed-verdict failure this whole
+   * change exists to remove.
+   *
+   * Bounded by the document ceiling. The index is a list of paths for a document that may name at
+   * most [ServeKnownDifferences.MAX_ACCEPTANCES] records, so it has no business being larger than
+   * the document itself, and a host must not read an unbounded file to find out how much to read.
+   */
+  private fun publishedArtifactIndex(base: String): List<String>? {
+    val dirName = ServeKnownDifferences.DIRECTORY
+    val url = "$base$dirName/${ServeKnownDifferences.ARTIFACT_INDEX_FILE}"
+    val bytes = runCatching { fetchCatalogAsset(url) }.getOrNull() ?: return null
+    if (bytes.size > ServeKnownDifferences.MAX_DOCUMENT_BYTES) return null
+    val parsed =
+      runCatching { json.parseToJsonElement(bytes.decodeToString()) }.getOrNull() as? JsonObject
+        ?: return null
+    val schema = (parsed["schema"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+    if (schema != ServeKnownDifferences.ARTIFACT_INDEX_SCHEMA) return null
+    val artifacts = parsed["artifacts"] as? JsonArray ?: return null
+    if (artifacts.size > MAX_INDEXED_ARTIFACTS) return null
+
+    val paths = LinkedHashSet<String>()
+    for (entry in artifacts) {
+      val path = (entry as? JsonPrimitive)?.takeIf { it.isString }?.content ?: continue
+      // The reader's own lexical rule, applied to the producer's list exactly as it is applied to
+      // the document's. A list is a convenience, not a licence.
+      if (ServeKnownDifferences.isLookupPath(path)) paths += path
+    }
+    return paths.toList()
+  }
+
+  /**
    * The `<id>/<file>` paths a known-difference document names — none, when the engine will reject
    * the document whole.
+   *
+   * **The fallback, not the plan.** A producer that publishes an artifact index makes all of this
+   * unnecessary; see [knownDifferenceArtifactPlan]. This remains for catalogs published before the
+   * index existed, and it is worth keeping exactly as conservative as it is, because those catalogs
+   * are the ones with nobody left to fix them.
    *
    * Two questions, and only the second is lenient.
    *
@@ -2226,8 +2295,14 @@ class ServeCatalogStore(
    *
    * What their absence costs is a wasted fetch, bounded by the ceiling a fully-populated *valid*
    * document already permits — 256 × 2 × 8 MiB is what the contract allows and what the engine
-   * genuinely reads. Issue #4520 closes the waste properly, by having the producer publish the
-   * artifact list it already knows so nothing here has to derive one.
+   * genuinely reads.
+   *
+   * That cost is now avoided rather than mitigated: a producer publishing an artifact index is
+   * copied from rather than interpreted, and this whole path is skipped. What is left here runs
+   * only for catalogs published before the index existed — which is why nothing was added to it,
+   * and why the three families of refusal above stay deliberately unmirrored. Growing this to close
+   * the remaining waste would be building the third implementation on the one path that no longer
+   * needs to exist.
    */
   private fun rejectsWholeDocument(document: JsonObject, acceptances: JsonArray): Boolean {
     // The schema and the shape. `acceptances` is already known to be an array by the caller.
@@ -3066,6 +3141,17 @@ class ServeCatalogStore(
     internal const val GENERATION_DIR_PREFIX = "g"
 
     internal const val STAGING_DIR = ".staging"
+
+    /**
+     * How many entries a published artifact index may name before it is ignored.
+     *
+     * The contract's own ceiling: at most [ServeKnownDifferences.MAX_ACCEPTANCES] records, each
+     * naming a `mask` and an `acceptedCandidate`. A producer is free to publish siblings a record
+     * does not name — the consumer decides which matter — so this is not a statement about what is
+     * legal, only a bound on how long a *fetch plan* this host will act on before deciding the file
+     * is not one.
+     */
+    private const val MAX_INDEXED_ARTIFACTS = ServeKnownDifferences.MAX_ACCEPTANCES * 2
 
     /**
      * Cap on a delivery branch's commit feed ([fetchRevisions]). Deliberately far smaller than a

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeKnownDifferences.kt
@@ -67,6 +67,26 @@ object ServeKnownDifferences {
   const val ARTIFACT_DIRECTORY = "known-differences"
 
   /**
+   * The producer's own list of the artifacts it published, beside the document.
+   *
+   * Written by `@design-parity/catalog-export`, which knows exactly which files it wrote. It exists
+   * so the staging path can *copy a list* rather than interpret the contract to derive one — see
+   * [ServeCatalogStore.knownDifferenceArtifactPaths] for what deriving it costs.
+   *
+   * A **sibling** of the document rather than `known-differences/index.json`, because a record `id`
+   * is a portable segment and `index.json` is one: a record so named owns the directory
+   * `known-differences/index.json/`, which an index file of that name could not coexist with.
+   *
+   * Not part of `compose-preview-known-differences/v1` and not read by any engine. It is a
+   * transport convenience between a producer and a host, which is why a catalog without it still
+   * works.
+   */
+  const val ARTIFACT_INDEX_FILE = "known-differences-index.json"
+
+  /** The index's schema token; a document declaring another is ignored rather than guessed at. */
+  const val ARTIFACT_INDEX_SCHEMA = "compose-preview-known-difference-artifacts/v1"
+
+  /**
    * The document's schema token, mirrored for the same one job the record cap is: the staging path
    * has to know whether the engine will read *anything* before it fetches a document's artifacts,
    * and a document declaring another schema is one the engine refuses whole.

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -602,6 +602,175 @@ class ServeCatalogStoreTest {
     assertEquals("button-figma", loaded.issues.single().referenceIds.single())
   }
 
+  /**
+   * A document the derivation refuses **whole** — an unknown document-level member. Using it is
+   * what makes "the index was copied" distinguishable from "the list was re-derived": if the
+   * artifacts arrive, only the index can have named them.
+   */
+  private val DERIVATION_REJECTS =
+    """
+    {"schema":"compose-preview-known-differences/v1","note":"unknown member","acceptances":[
+      {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+       "mask":"mask.png","acceptedCandidate":"accepted-candidate.png"}]}
+    """
+      .trimIndent()
+
+  /**
+   * The same records in a document the derivation happily reads, for the mirror-image assertion.
+   */
+  private val DERIVATION_ACCEPTS =
+    """
+    {"schema":"compose-preview-known-differences/v1","acceptances":[
+      {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+       "mask":"mask.png","acceptedCandidate":"accepted-candidate.png"}]}
+    """
+      .trimIndent()
+
+  /**
+   * Load a catalog whose known-difference document names two artifacts for `glyph`, with [index]
+   * served (or not) as the published artifact list.
+   */
+  private fun loadWithArtifactIndex(
+    index: String?,
+    document: String = DERIVATION_REJECTS,
+  ): Pair<ServeHost, List<String>> {
+    val catalog =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "components":[{"componentId":"Button/Filled","images":[{"path":"images/button.png"}]}]}
+      """
+        .trimIndent()
+    val requested = CopyOnWriteArrayList<String>()
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { TrustStore.EMPTY },
+        fetch = { url ->
+          requested += url
+          when {
+            url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> catalog.encodeToByteArray()
+            url.endsWith("/parity/known-differences-index.json") -> index?.encodeToByteArray()
+            url.endsWith("/parity/known-differences.json") -> document.encodeToByteArray()
+            url.contains("/parity/known-differences/") -> "artifact".encodeToByteArray()
+            url.endsWith("/images/button.png") -> png()
+            else -> null
+          }
+        },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+    return registered.getValue("compose-m3") to requested.toList()
+  }
+
+  @Test
+  fun `a published artifact index is copied, not derived from the contract`() {
+    // The point of the index. Deriving the fetch list from the document means mirroring every
+    // pre-read refusal the engine has, and a mirror that drifts stricter starves a legal record of
+    // its artifacts. The producer wrote the files; it can simply say which.
+    //
+    // The document here carries an unknown member, which the derivation refuses whole — so if the
+    // artifacts arrive, the list came from the index and nothing re-derived it.
+    val (host, requested) =
+      loadWithArtifactIndex(
+        """
+        {"schema":"compose-preview-known-difference-artifacts/v1",
+         "artifacts":["glyph/mask.png","glyph/accepted-candidate.png"]}
+        """
+          .trimIndent()
+      )
+
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") is ServeKnownDifferences.Artifact.Bytes,
+      "the index's artifacts were not staged: $requested",
+    )
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/accepted-candidate.png")
+        is ServeKnownDifferences.Artifact.Bytes
+    )
+    // The document still reaches the host verbatim — the index says what to copy, never what the
+    // engine may read.
+    assertTrue(host.knownDifferences() is ServeKnownDifferences.Document.Text)
+  }
+
+  @Test
+  fun `a catalog without an index still derives the list`() {
+    // Purely additive: a catalog published before the index existed behaves exactly as it did. The
+    // same document, no index — and the derivation refuses it whole, so nothing is staged.
+    val (host, _) = loadWithArtifactIndex(null)
+
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") !is ServeKnownDifferences.Artifact.Bytes,
+      "the derivation must still refuse a document it rejects whole",
+    )
+  }
+
+  @Test
+  fun `without an index, that same document derives its artifacts`() {
+    // The other half of the empty-index test: it only means something if this document really does
+    // produce a fetch when the list is derived.
+    val (_, requested) = loadWithArtifactIndex(index = null, document = DERIVATION_ACCEPTS)
+
+    assertTrue(
+      requested.any { it.endsWith("/parity/known-differences/glyph/mask.png") },
+      "the derivation fetched nothing, so the empty-index test proves nothing: $requested",
+    )
+  }
+
+  @Test
+  fun `an index cannot name a path the reader would refuse to look up`() {
+    // A fetch plan, not a licence. The producer's list goes through exactly the lexical rule the
+    // document's paths do, so an index is never a way around it.
+    val (_, requested) =
+      loadWithArtifactIndex(
+        """
+        {"schema":"compose-preview-known-difference-artifacts/v1",
+         "artifacts":["glyph/mask.png","../../secrets.png","glyph/../../escape.png"]}
+        """
+          .trimIndent()
+      )
+
+    assertTrue(
+      requested.none { it.contains("secrets.png") || it.contains("escape.png") },
+      "a traversal path from the index was fetched: $requested",
+    )
+    assertTrue(requested.any { it.endsWith("glyph/mask.png") }, "the legal path was skipped")
+  }
+
+  @Test
+  fun `a malformed index falls back to deriving rather than staging nothing`() {
+    // The fail-soft direction matters. Treating an unreadable index as an empty list would let one
+    // bad file silently strip every record of its artifacts — the changed-verdict failure the whole
+    // change exists to remove. So a wrong schema means "this producer published no usable index".
+    val (host, _) =
+      loadWithArtifactIndex("""{"schema":"something-else/v1","artifacts":["glyph/mask.png"]}""")
+
+    // Falls back to the derivation, which refuses this document whole — the same answer a catalog
+    // with no index at all gets.
+    assertTrue(
+      host.knownDifferenceArtifact("glyph/mask.png") !is ServeKnownDifferences.Artifact.Bytes
+    )
+  }
+
+  @Test
+  fun `an index that names nothing stages nothing`() {
+    // An empty list is a statement, not an absence: the producer published an index and carried no
+    // artifacts. Falling back to the derivation here would make a producer that says "nothing"
+    // indistinguishable from one that says nothing at all.
+    // The document here is one the derivation *accepts* and would derive two artifacts from, so a
+    // fallback is visible: if anything under the artifact root is fetched, the empty list was
+    // treated as an absence.
+    val (_, requested) =
+      loadWithArtifactIndex(
+        """{"schema":"compose-preview-known-difference-artifacts/v1","artifacts":[]}""",
+        document = DERIVATION_ACCEPTS,
+      )
+
+    assertTrue(
+      requested.none { it.contains("/parity/known-differences/") },
+      "an empty index must not fall back to the derivation: $requested",
+    )
+  }
+
   @Test
   fun `catalog stages the published known differences, document and artifacts`() {
     // The failure this guards is silent: `knownDifferences()` reads the staging tree, so a document


### PR DESCRIPTION
Closes #4520 — consumer half. The producer is yschimke/design-parity#401, **merged**, which publishes the list.

> Rebased onto `main` and retargeted: this was stacked on #4559, which is now closed as superseded by #4552. The size-refusal tests that came along with that stack were dropped here — `main` already covers them.

## Why

`writeKnownDifferences` has to know which artifact files to fetch from a delivery branch. The only place that information existed was **inside the known-difference document**, so the stager read it — and the moment it did, it inherited a question it has no business answering: *will the engine actually read this record?*

Every pre-read refusal the engine has then became a rule to mirror. Review found six of them, arriving one at a time in different shapes. Items 1–3 are properties of the *file*, which a fetch planner legitimately has to know, and are mirrored. Items 4–6 are per-record verdicts — `documentTextRefusal`, `isSafeId`, and 44 lines of `schemaReasons`. Mirroring those makes this a **third implementation** of `compose-preview-known-differences/v1` with no conformance suite behind it, and the failure direction is the bad one: a mirror that drifts *stricter* anywhere starves a legal record of its artifacts and turns it into `artifact-unreadable` — a changed verdict on a legal record.

The producer already knows the answer exactly: it wrote the files.

## What

When the catalog publishes `parity/known-differences-index.json`, the stager copies that list and **the derivation is not consulted at all**. That closes all six findings at once, including the ones nobody has thought of yet.

Three properties, all deliberate:

- **A fetch plan, not an authority.** Every path still goes through `ServeKnownDifferences.isLookupPath` before it is fetched or written. A producer naming `../../secrets.png` in its index gets exactly the refusal it gets for naming it in the document. The index changes *where the list comes from*, never what this host will look up.
- **The document remains the contract.** A list that disagrees with it is not an error to report: a file the index omits is not staged and evaluates as `artifact-unreadable`, already the verdict for a file a producer forgot to commit.
- **The index never decides readability.** It says what to copy. A host that let it decide whether the *document* is readable would have swapped one derivation for another.

## Purely additive

An absent index means "this producer does not publish one", so a catalog published before the index existed falls back to the derivation and behaves exactly as it did.

A **malformed** one falls back too — wrong schema, unparseable, wrong shape, or past the bounds. The alternative, treating it as an empty list, would let one bad file silently strip every record of its artifacts, which is the changed-verdict failure this whole change exists to remove.

An index that parses and names **nothing** is a different answer: an empty list, honoured as one. Otherwise a producer that says "nothing" is indistinguishable from one that says nothing at all.

## The derivation stays, and stays as it is

`knownDifferenceArtifactPaths` and `rejectsWholeDocument` remain for pre-index catalogs, re-documented as the fallback. Nothing was added to them, and the three families of refusal they deliberately do not mirror stay unmirrored — growing them to close the remaining waste would be building the third implementation on the one path that no longer needs to exist.

## Tests

Six new. The pivotal trick: the shared fixture serves a document with an **unknown document-level member**, which the derivation refuses whole. If the artifacts arrive, only the index can have named them.

- `a published artifact index is copied, not derived from the contract`
- `a catalog without an index still derives the list` — the additive control
- `an index cannot name a path the reader would refuse to look up` — `../../secrets.png` and `glyph/../../escape.png` are never fetched, the legal sibling still is
- `a malformed index falls back to deriving rather than staging nothing`
- `an index that names nothing stages nothing`
- `without an index, that same document derives its artifacts`

That last one exists because the first version of the empty-index test **passed either way** — its document was one the derivation rejected anyway, so it proved nothing. It now uses a document the derivation accepts and would fetch from, and this test pins that premise so the assertion cannot quietly become vacuous.

Verified to bite: removing the index preference fails tests 1 and 3; making an empty index fall back fails test 5.

- `:cli:test` — all passing
- `check-serve-seam` — `OK — 151 crossing symbol(s)`

Non-visual (staging plumbing), so no rendered before/after applies.