### PR TITLE
feat(daemon-core): enforce explicit API and gate the protocol ABI

### DIFF
--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -1,0 +1,7317 @@
+public final class ee/schimke/composeai/daemon/A11yAssertThreshold : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/A11yAssertThreshold$Companion;
+	public static final field ERRORS Lee/schimke/composeai/daemon/A11yAssertThreshold;
+	public static final field WARNINGS Lee/schimke/composeai/daemon/A11yAssertThreshold;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/A11yAssertThreshold;
+	public static fun values ()[Lee/schimke/composeai/daemon/A11yAssertThreshold;
+}
+
+public final class ee/schimke/composeai/daemon/A11yAssertThreshold$Companion {
+	public final fun parseOrDefault (Ljava/lang/String;)Lee/schimke/composeai/daemon/A11yAssertThreshold;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/AlwaysOnPreviewOverrideExtension {
+}
+
+public final class ee/schimke/composeai/daemon/ApngEncoder {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/ApngEncoder;
+	public final fun encodeFromPngFrames (Ljava/util/List;SSILjava/io/File;Lokio/FileSystem;)V
+	public static synthetic fun encodeFromPngFrames$default (Lee/schimke/composeai/daemon/ApngEncoder;Ljava/util/List;SSILjava/io/File;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+
+public abstract interface class ee/schimke/composeai/daemon/AssertionVerdict {
+}
+
+public final class ee/schimke/composeai/daemon/AssertionVerdict$Failed : ee/schimke/composeai/daemon/AssertionVerdict {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/AssertionVerdict$Failed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/AssertionVerdict$Failed;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/AssertionVerdict$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/AssertionVerdict$Passed : ee/schimke/composeai/daemon/AssertionVerdict {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/AssertionVerdict$Passed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/BundleIrReplayStore {
+	public static final field BUNDLE_MANIFEST_PATH_PROP Ljava/lang/String;
+	public static final field FORMAT_PROTOLAYOUT Ljava/lang/String;
+	public static final field FORMAT_REMOTECOMPOSE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/daemon/BundleIrReplayStore;
+	public static final field IR_DIR_PROP Ljava/lang/String;
+	public final fun loadFrom (Ljava/io/File;Ljava/io/File;Lokio/FileSystem;)Ljava/util/Map;
+	public static synthetic fun loadFrom$default (Lee/schimke/composeai/daemon/BundleIrReplayStore;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/Map;
+	public final fun lookup (Ljava/lang/String;)Lee/schimke/composeai/daemon/BundleIrReplayStore$Entry;
+	public final fun resetForTest ()V
+}
+
+public final class ee/schimke/composeai/daemon/BundleIrReplayStore$Entry {
+	public fun <init> (Ljava/lang/String;[B[B)V
+	public final fun getBytes ()[B
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getResourcesBytes ()[B
+}
+
+public final class ee/schimke/composeai/daemon/CaptureGutterDto {
+	public static final field Companion Lee/schimke/composeai/daemon/CaptureGutterDto$Companion;
+	public fun <init> ()V
+	public fun <init> (IIII)V
+	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/daemon/CaptureGutterDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/CaptureGutterDto;IIIIILjava/lang/Object;)Lee/schimke/composeai/daemon/CaptureGutterDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getEnd ()I
+	public final fun getStart ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/CaptureGutterDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/CaptureGutterDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/CaptureGutterDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/CaptureGutterDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/CaptureGutterDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/ClasspathFingerprint {
+	public static final field CHEAP_SIGNAL_FILES_PROP Ljava/lang/String;
+	public static final field Companion Lee/schimke/composeai/daemon/ClasspathFingerprint$Companion;
+	public static final field SHA_256_HEX_LENGTH I
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun cheapHash ()Ljava/lang/String;
+	public final fun classpathHash ()Ljava/lang/String;
+	public final fun getCheapSignalFiles ()Ljava/util/List;
+	public final fun getClasspathEntries ()Ljava/util/List;
+	public final fun snapshot ()Lee/schimke/composeai/daemon/ClasspathFingerprint$Snapshot;
+}
+
+public final class ee/schimke/composeai/daemon/ClasspathFingerprint$Companion {
+	public final fun parseCheapSignalFilesSysprop (Ljava/lang/String;)Ljava/util/List;
+	public static synthetic fun parseCheapSignalFilesSysprop$default (Lee/schimke/composeai/daemon/ClasspathFingerprint$Companion;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/ClasspathFingerprint$Snapshot {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/ClasspathFingerprint$Snapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/ClasspathFingerprint$Snapshot;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/ClasspathFingerprint$Snapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheapHash ()Ljava/lang/String;
+	public final fun getClasspathHash ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/CompositeDataProductRegistry : ee/schimke/composeai/daemon/DataProductRegistry {
+	public fun <init> (Ljava/util/List;)V
+	public fun attachmentsFor (Ljava/lang/String;Ljava/util/Set;)Ljava/util/List;
+	public fun fetch (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Z)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome;
+	public fun getCapabilities ()Ljava/util/List;
+	public fun isKnown (Ljava/lang/String;)Z
+	public fun onRender (Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/data/render/PreviewContext;)V
+	public fun onRenderFailed (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onSubscribe (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public fun onUnsubscribe (Ljava/lang/String;Ljava/lang/String;)V
+	public fun renderModeFor (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DaemonLaunchDescriptor {
+	public static final field Companion Lee/schimke/composeai/daemon/DaemonLaunchDescriptor$Companion;
+	public static final field SANDBOX_COUNT_PROP Ljava/lang/String;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClasspath ()Ljava/util/List;
+	public final fun getEnabled ()Z
+	public final fun getHardTtlSeconds ()Ljava/lang/Long;
+	public final fun getJailCommand ()Ljava/util/List;
+	public final fun getJavaLauncher ()Ljava/lang/String;
+	public final fun getJvmArgs ()Ljava/util/List;
+	public final fun getMainClass ()Ljava/lang/String;
+	public final fun getManifestPath ()Ljava/lang/String;
+	public final fun getModulePath ()Ljava/lang/String;
+	public final fun getSchemaVersion ()I
+	public final fun getSystemProperties ()Ljava/util/Map;
+	public final fun getVariant ()Ljava/lang/String;
+	public final fun getWorkingDirectory ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun jailed (Ljava/util/List;Ljava/lang/Long;)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+	public fun toString ()Ljava/lang/String;
+	public final fun withSandboxCount (I)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/DaemonLaunchDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/DaemonLaunchDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/DaemonLaunchDescriptor$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/daemon/DaemonLaunchDescriptor;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/DaemonVersion {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/DaemonVersion;
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/DataProductRegistry {
+	public static final field Companion Lee/schimke/composeai/daemon/DataProductRegistry$Companion;
+	public abstract fun attachmentsFor (Ljava/lang/String;Ljava/util/Set;)Ljava/util/List;
+	public abstract fun fetch (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Z)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome;
+	public abstract fun getCapabilities ()Ljava/util/List;
+	public fun isKnown (Ljava/lang/String;)Z
+	public fun onRender (Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/data/render/PreviewContext;)V
+	public fun onRenderFailed (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onSubscribe (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public fun onUnsubscribe (Ljava/lang/String;Ljava/lang/String;)V
+	public fun renderModeFor (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Companion {
+	public final fun getEmpty ()Lee/schimke/composeai/daemon/DataProductRegistry;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$DefaultImpls {
+	public static fun isKnown (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;)Z
+	public static fun onRender (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/data/render/PreviewContext;)V
+	public static fun onRenderFailed (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public static fun onSubscribe (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public static fun onUnsubscribe (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun renderModeFor (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$BudgetExceeded : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$BudgetExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$FetchFailed : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$FetchFailed;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$FetchFailed;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$FetchFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrorKind ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$NotAvailable : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$NotAvailable;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$Ok : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/DataFetchResult;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/DataFetchResult;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$Ok;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$Ok;Lee/schimke/composeai/daemon/protocol/DataFetchResult;ILjava/lang/Object;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResult ()Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$RequiresRerender : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$RequiresRerender;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$RequiresRerender;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$RequiresRerender;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistry$Outcome$Unknown : ee/schimke/composeai/daemon/DataProductRegistry$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/DataProductRegistry$Outcome$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DataProductRegistryKt {
+	public static final fun onRender (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;)V
+	public static final fun onRender (Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+}
+
+public final class ee/schimke/composeai/daemon/DisableOutcome {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/DisableOutcome;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DisableOutcome;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/DisableOutcome;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeactivated ()Ljava/util/List;
+	public final fun getDisabled ()Ljava/util/List;
+	public final fun getNotEnabled ()Ljava/util/List;
+	public final fun getStillActiveAsDependency ()Ljava/util/List;
+	public final fun getUnknown ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/DiscoveryDiff {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()I
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;I)Lee/schimke/composeai/daemon/DiscoveryDiff;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/DiscoveryDiff;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lee/schimke/composeai/daemon/DiscoveryDiff;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getChanged ()Ljava/util/List;
+	public final fun getRemoved ()Ljava/util/List;
+	public final fun getTotalPreviews ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/EnableOutcome {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/EnableOutcome;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/EnableOutcome;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/EnableOutcome;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlreadyEnabled ()Ljava/util/List;
+	public final fun getNewlyEnabled ()Ljava/util/List;
+	public final fun getPulledIn ()Ljava/util/List;
+	public final fun getUnknown ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/EncodedRecording {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/EncodedRecording;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/EncodedRecording;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/EncodedRecording;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getSizeBytes ()J
+	public final fun getVideoPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/Extension {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lee/schimke/composeai/daemon/DataProductRegistry;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/Extension;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/Extension;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/daemon/DataProductRegistry;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/Extension;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataExtensionDescriptors ()Ljava/util/List;
+	public final fun getDataProductCapabilities ()Ljava/util/List;
+	public final fun getDataProductRegistry ()Lee/schimke/composeai/daemon/DataProductRegistry;
+	public final fun getDependencies ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPreviewExtensionDescriptors ()Ljava/util/List;
+	public final fun getPreviewOverrideExtensions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/ExtensionInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/ExtensionInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/ExtensionInfo;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/ExtensionInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActive ()Z
+	public final fun getDataExtensionIds ()Ljava/util/List;
+	public final fun getDataProductKinds ()Ljava/util/List;
+	public final fun getDependencies ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPreviewExtensionIds ()Ljava/util/List;
+	public final fun getPubliclyEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/ExtensionRegistry {
+	public static final field Companion Lee/schimke/composeai/daemon/ExtensionRegistry$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun activeDataProducts ()Lee/schimke/composeai/daemon/DataProductRegistry;
+	public final fun activeIds ()Ljava/util/Set;
+	public final fun activeOverrideExtensions ()Lee/schimke/composeai/daemon/PreviewOverrideExtensions;
+	public final fun all ()Ljava/util/List;
+	public final fun disable (Ljava/lang/Iterable;)Lee/schimke/composeai/daemon/DisableOutcome;
+	public final fun enable (Ljava/lang/Iterable;)Lee/schimke/composeai/daemon/EnableOutcome;
+	public final fun infoList ()Ljava/util/List;
+	public final fun isActive (Ljava/lang/String;)Z
+	public final fun isPubliclyEnabled (Ljava/lang/String;)Z
+	public final fun publicDataExtensionDescriptors ()Ljava/util/List;
+	public final fun publicDataProductCapabilities ()Ljava/util/List;
+	public final fun publicDataProducts ()Lee/schimke/composeai/daemon/DataProductRegistry;
+	public final fun publicIds ()Ljava/util/Set;
+	public final fun publicPreviewExtensionDescriptors ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/ExtensionRegistry$Companion {
+	public final fun getEmpty ()Lee/schimke/composeai/daemon/ExtensionRegistry;
+}
+
+public final class ee/schimke/composeai/daemon/FfmpegEncoder {
+	public static final field ENCODE_TIMEOUT_MS J
+	public static final field INSTANCE Lee/schimke/composeai/daemon/FfmpegEncoder;
+	public final fun available ()Z
+	public final fun encodeFromPngFrames (Ljava/io/File;ILee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;Ljava/io/File;Ljava/io/File;)V
+	public static synthetic fun encodeFromPngFrames$default (Lee/schimke/composeai/daemon/FfmpegEncoder;Ljava/io/File;ILee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice : java/lang/Enum {
+	public static final field MP4 Lee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;
+	public static final field WEBM Lee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;
+	public static fun values ()[Lee/schimke/composeai/daemon/FfmpegEncoder$RecordingFormatChoice;
+}
+
+public abstract class ee/schimke/composeai/daemon/FileBackedDataProductRegistry : ee/schimke/composeai/daemon/DataProductRegistry {
+	public static final field Companion Lee/schimke/composeai/daemon/FileBackedDataProductRegistry$Companion;
+	public fun <init> (Ljava/util/List;Lokio/FileSystem;)V
+	public synthetic fun <init> (Ljava/util/List;Lokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected fun allowInlineUpgrade (Ljava/lang/String;)Z
+	public fun attachmentsFor (Ljava/lang/String;Ljava/util/Set;)Ljava/util/List;
+	protected fun extras (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Ljava/util/List;
+	public fun fetch (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Z)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome;
+	protected abstract fun fileFor (Ljava/lang/String;Ljava/lang/String;)Ljava/io/File;
+	public final fun getCapabilities ()Ljava/util/List;
+	public fun isKnown (Ljava/lang/String;)Z
+	protected fun missingOutcome (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/DataProductRegistry$Outcome;
+	public fun onRender (Ljava/lang/String;Lee/schimke/composeai/daemon/RenderResult;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/data/render/PreviewContext;)V
+	public fun onRenderFailed (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun onSubscribe (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public fun onUnsubscribe (Ljava/lang/String;Ljava/lang/String;)V
+	protected fun readInlinePayload (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lkotlinx/serialization/json/JsonElement;
+	public fun renderModeFor (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/FileBackedDataProductRegistry$Companion {
+}
+
+public final class ee/schimke/composeai/daemon/GifEncoder {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/GifEncoder;
+	public final fun encodeFromPngFrames (Ljava/util/List;ILjava/io/File;)V
+}
+
+public final class ee/schimke/composeai/daemon/HistoryFeature {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/HistoryFeature;
+	public static final field PROP Ljava/lang/String;
+	public static final fun getENABLED ()Z
+}
+
+public final class ee/schimke/composeai/daemon/IncrementalDiscovery {
+	public static final field Companion Lee/schimke/composeai/daemon/IncrementalDiscovery$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun cheapPrefilter (Ljava/nio/file/Path;Lee/schimke/composeai/daemon/PreviewIndex;)Z
+	public final fun scanForFile (Ljava/nio/file/Path;)Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/daemon/IncrementalDiscovery$Companion {
+	public final fun getDEFAULT_PREVIEW_ANNOTATION_FQNS ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents;
+	public static final field KEY_DOWN_EVENT Ljava/lang/String;
+	public static final field KEY_UP_EVENT Ljava/lang/String;
+	public final fun descriptor (Z)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getDescriptors ()Ljava/util/List;
+	public final fun getSupportedDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+}
+
+public final class ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents {
+	public static final field CLICK_EVENT Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/daemon/InputTouchRecordingScriptEvents;
+	public static final field POINTER_DOWN_EVENT Ljava/lang/String;
+	public static final field POINTER_MOVE_EVENT Ljava/lang/String;
+	public static final field POINTER_UP_EVENT Ljava/lang/String;
+	public final fun getDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getDescriptors ()Ljava/util/List;
+	public final fun getWIRED_EVENTS ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/daemon/InteractiveKeyCodes {
+	public static final field A I
+	public static final field ALT_LEFT I
+	public static final field ALT_RIGHT I
+	public static final field APOSTROPHE I
+	public static final field B I
+	public static final field BACKSLASH I
+	public static final field BACKSPACE I
+	public static final field C I
+	public static final field CAPS_LOCK I
+	public static final field COMMA I
+	public static final field CTRL_LEFT I
+	public static final field CTRL_RIGHT I
+	public static final field D I
+	public static final field DIGIT_0 I
+	public static final field DIGIT_1 I
+	public static final field DIGIT_2 I
+	public static final field DIGIT_3 I
+	public static final field DIGIT_4 I
+	public static final field DIGIT_5 I
+	public static final field DIGIT_6 I
+	public static final field DIGIT_7 I
+	public static final field DIGIT_8 I
+	public static final field DIGIT_9 I
+	public static final field DPAD_CENTER I
+	public static final field DPAD_DOWN I
+	public static final field DPAD_LEFT I
+	public static final field DPAD_RIGHT I
+	public static final field DPAD_UP I
+	public static final field E I
+	public static final field END I
+	public static final field ENTER I
+	public static final field EQUALS I
+	public static final field ESCAPE I
+	public static final field F I
+	public static final field F1 I
+	public static final field F10 I
+	public static final field F11 I
+	public static final field F12 I
+	public static final field F2 I
+	public static final field F3 I
+	public static final field F4 I
+	public static final field F5 I
+	public static final field F6 I
+	public static final field F7 I
+	public static final field F8 I
+	public static final field F9 I
+	public static final field FORWARD_DELETE I
+	public static final field G I
+	public static final field GRAVE I
+	public static final field H I
+	public static final field HOME I
+	public static final field I I
+	public static final field INSTANCE Lee/schimke/composeai/daemon/InteractiveKeyCodes;
+	public static final field J I
+	public static final field K I
+	public static final field L I
+	public static final field LEFT_BRACKET I
+	public static final field M I
+	public static final field META_LEFT I
+	public static final field META_RIGHT I
+	public static final field MINUS I
+	public static final field N I
+	public static final field NUMPAD_0 I
+	public static final field NUMPAD_1 I
+	public static final field NUMPAD_2 I
+	public static final field NUMPAD_3 I
+	public static final field NUMPAD_4 I
+	public static final field NUMPAD_5 I
+	public static final field NUMPAD_6 I
+	public static final field NUMPAD_7 I
+	public static final field NUMPAD_8 I
+	public static final field NUMPAD_9 I
+	public static final field NUMPAD_ADD I
+	public static final field NUMPAD_COMMA I
+	public static final field NUMPAD_DIVIDE I
+	public static final field NUMPAD_DOT I
+	public static final field NUMPAD_ENTER I
+	public static final field NUMPAD_EQUALS I
+	public static final field NUMPAD_MULTIPLY I
+	public static final field NUMPAD_SUBTRACT I
+	public static final field NUM_LOCK I
+	public static final field O I
+	public static final field P I
+	public static final field PAGE_DOWN I
+	public static final field PAGE_UP I
+	public static final field PERIOD I
+	public static final field Q I
+	public static final field R I
+	public static final field RIGHT_BRACKET I
+	public static final field S I
+	public static final field SCROLL_LOCK I
+	public static final field SEMICOLON I
+	public static final field SHIFT_LEFT I
+	public static final field SHIFT_RIGHT I
+	public static final field SLASH I
+	public static final field SPACE I
+	public static final field T I
+	public static final field TAB I
+	public static final field U I
+	public static final field V I
+	public static final field W I
+	public static final field X I
+	public static final field Y I
+	public static final field Z I
+	public final fun parse (Ljava/lang/String;)Ljava/lang/Integer;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/InteractiveSession : java/lang/AutoCloseable {
+	public fun captureA11yFindings ()Ljava/util/List;
+	public fun captureProbeSemantics ()Ljava/util/List;
+	public abstract fun close ()V
+	public abstract fun dispatch (Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;)V
+	public fun dispatchLifecycle (Ljava/lang/String;)Z
+	public fun dispatchLottieProgress (F)Z
+	public fun dispatchNavigation (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)Z
+	public static synthetic fun dispatchNavigation$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILjava/lang/Object;)Z
+	public fun dispatchPreviewReload ()Z
+	public fun dispatchRemoteComposeChange (Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;)Z
+	public fun dispatchSemanticsAction (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun dispatchStateRecreate ()Z
+	public fun dispatchStateRestore (Ljava/lang/String;)Z
+	public fun dispatchStateSave (Ljava/lang/String;)Z
+	public fun dispatchUiAutomator (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Z
+	public static synthetic fun dispatchUiAutomator$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Z
+	public fun findUiAutomatorEvidence (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public static synthetic fun findUiAutomatorEvidence$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public abstract fun getPreviewId ()Ljava/lang/String;
+	public fun isClosed ()Z
+	public abstract fun render (JLjava/lang/Long;)Lee/schimke/composeai/daemon/RenderResult;
+	public static synthetic fun render$default (Lee/schimke/composeai/daemon/InteractiveSession;JLjava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderResult;
+}
+
+public final class ee/schimke/composeai/daemon/InteractiveSession$DefaultImpls {
+	public static fun captureA11yFindings (Lee/schimke/composeai/daemon/InteractiveSession;)Ljava/util/List;
+	public static fun captureProbeSemantics (Lee/schimke/composeai/daemon/InteractiveSession;)Ljava/util/List;
+	public static fun dispatchLifecycle (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;)Z
+	public static fun dispatchLottieProgress (Lee/schimke/composeai/daemon/InteractiveSession;F)Z
+	public static fun dispatchNavigation (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)Z
+	public static synthetic fun dispatchNavigation$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILjava/lang/Object;)Z
+	public static fun dispatchPreviewReload (Lee/schimke/composeai/daemon/InteractiveSession;)Z
+	public static fun dispatchRemoteComposeChange (Lee/schimke/composeai/daemon/InteractiveSession;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;)Z
+	public static fun dispatchSemanticsAction (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;)Z
+	public static fun dispatchStateRecreate (Lee/schimke/composeai/daemon/InteractiveSession;)Z
+	public static fun dispatchStateRestore (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;)Z
+	public static fun dispatchStateSave (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;)Z
+	public static fun dispatchUiAutomator (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Z
+	public static synthetic fun dispatchUiAutomator$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Z
+	public static fun findUiAutomatorEvidence (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public static synthetic fun findUiAutomatorEvidence$default (Lee/schimke/composeai/daemon/InteractiveSession;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public static fun isClosed (Lee/schimke/composeai/daemon/InteractiveSession;)Z
+	public static synthetic fun render$default (Lee/schimke/composeai/daemon/InteractiveSession;JLjava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderResult;
+}
+
+public final class ee/schimke/composeai/daemon/JsonRpcServer {
+	public static final field CLASSPATH_DIRTY_GRACE_PROP Ljava/lang/String;
+	public static final field Companion Lee/schimke/composeai/daemon/JsonRpcServer$Companion;
+	public static final field DATA_FETCH_RERENDER_BUDGET_PROP Ljava/lang/String;
+	public static final field DEFAULT_CLASSPATH_DIRTY_GRACE_MS J
+	public static final field DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS J
+	public static final field DEFAULT_DISCOVERY_WATCHDOG_MS J
+	public static final field DEFAULT_IDLE_TIMEOUT_MS J
+	public static final field DEFAULT_RECORDING_FPS I
+	public static final field DEFAULT_RECORDING_SCALE F
+	public static final field DEFAULT_RENDER_TIMEOUT_MS J
+	public static final field DISCOVERY_WATCHDOG_PROP Ljava/lang/String;
+	public static final field ERR_CLASSPATH_DIRTY I
+	public static final field ERR_DATA_PRODUCT_BUDGET_EXCEEDED I
+	public static final field ERR_DATA_PRODUCT_FETCH_FAILED I
+	public static final field ERR_DATA_PRODUCT_NOT_AVAILABLE I
+	public static final field ERR_DATA_PRODUCT_UNKNOWN I
+	public static final field ERR_HISTORY_DIFF_MISMATCH I
+	public static final field ERR_HISTORY_ENTRY_NOT_FOUND I
+	public static final field ERR_HISTORY_PIXEL_NOT_IMPLEMENTED I
+	public static final field ERR_HISTORY_SEMANTICS_NOT_CAPTURED I
+	public static final field ERR_INTERNAL I
+	public static final field ERR_INVALID_PARAMS I
+	public static final field ERR_INVALID_REQUEST I
+	public static final field ERR_METHOD_NOT_FOUND I
+	public static final field ERR_NOT_INITIALIZED I
+	public static final field ERR_PARSE I
+	public static final field HISTORY_DIFF_EXPERIMENTAL_PROP Ljava/lang/String;
+	public static final field IDLE_TIMEOUT_PROP Ljava/lang/String;
+	public static final field INTERACTIVE_BURST_INTERVAL_MS J
+	public static final field INTERACTIVE_BURST_MS J
+	public static final field INTERACTIVE_FRAME_INTERVAL_MS J
+	public static final field INTERACTIVE_IDLE_MAX_INTERVAL_MS J
+	public static final field INTERACTIVE_QUIESCENT_AFTER I
+	public static final field MAX_RECORDING_FPS I
+	public static final field MAX_RECORDING_SCALE F
+	public static final field MIN_RECORDING_FPS I
+	public static final field PROTOCOL_VERSION I
+	public static final field RENDER_TIMEOUT_PROP Ljava/lang/String;
+	public fun <init> (Ljava/io/InputStream;Ljava/io/OutputStream;Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/ClasspathFingerprint;JLee/schimke/composeai/daemon/PreviewIndex;Lee/schimke/composeai/daemon/IncrementalDiscovery;JLee/schimke/composeai/daemon/history/HistoryManager;ZJLee/schimke/composeai/daemon/ExtensionRegistry;JJJJJILee/schimke/composeai/daemon/bta/BtaCompileService;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/daemon/XrSessions;)V
+	public synthetic fun <init> (Ljava/io/InputStream;Ljava/io/OutputStream;Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/ClasspathFingerprint;JLee/schimke/composeai/daemon/PreviewIndex;Lee/schimke/composeai/daemon/IncrementalDiscovery;JLee/schimke/composeai/daemon/history/HistoryManager;ZJLee/schimke/composeai/daemon/ExtensionRegistry;JJJJJILee/schimke/composeai/daemon/bta/BtaCompileService;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/daemon/XrSessions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun run ()V
+}
+
+public final class ee/schimke/composeai/daemon/JsonRpcServer$Companion {
+	public final fun getEXIT_PROCESS ()Lkotlin/jvm/functions/Function1;
+}
+
+public final class ee/schimke/composeai/daemon/KeyboardBandLabels {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/KeyboardBandLabels;
+	public final fun fromAndroidKeycode (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/MergedPreviewOverrides {
+	public fun <init> (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;Z)V
+	public synthetic fun <init> (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun component11 ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun component12 ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun component13 ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun component14 ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun component18 ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun component19 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun component2 ()I
+	public final fun component20 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun component21 ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()Z
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Float;
+	public final fun component7 ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun component8 ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;Z)Lee/schimke/composeai/daemon/MergedPreviewOverrides;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/MergedPreviewOverrides;IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/MergedPreviewOverrides;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmbient ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun getDensity ()F
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFocus ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun getFontScale ()Ljava/lang/Float;
+	public final fun getGestures ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun getHeightPx ()I
+	public final fun getInspectionMode ()Ljava/lang/Boolean;
+	public final fun getKeyboard ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun getLauncherWidget ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun getLocaleTag ()Ljava/lang/String;
+	public final fun getLottie ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun getMaterial3Theme ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun getNamedOverrides ()Ljava/util/Map;
+	public final fun getOrientation ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun getPermissions ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun getRemoteCompose ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun getRotated ()Z
+	public final fun getTalkBack ()Ljava/lang/Boolean;
+	public final fun getTouchOverlay ()Ljava/lang/Boolean;
+	public final fun getUiMode ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun getWallpaper ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun getWidthPx ()I
+	public fun hashCode ()I
+	public final fun toExtensionOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PixelAssertionsKt {
+	public static final fun pixelAssertVerdict ([B[BLee/schimke/composeai/daemon/PixelDiffTolerance;)Lee/schimke/composeai/daemon/AssertionVerdict;
+	public static synthetic fun pixelAssertVerdict$default ([B[BLee/schimke/composeai/daemon/PixelDiffTolerance;ILjava/lang/Object;)Lee/schimke/composeai/daemon/AssertionVerdict;
+}
+
+public final class ee/schimke/composeai/daemon/PixelDiff {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PixelDiff;
+	public final fun compare ([B[BLee/schimke/composeai/daemon/PixelDiffTolerance;)Lee/schimke/composeai/daemon/PixelDiffResult;
+	public static synthetic fun compare$default (Lee/schimke/composeai/daemon/PixelDiff;[B[BLee/schimke/composeai/daemon/PixelDiffTolerance;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PixelDiffResult;
+	public final fun writeDiffArtefacts ([B[BLjava/io/File;Lee/schimke/composeai/daemon/PixelDiffTolerance;Lokio/FileSystem;)V
+	public static synthetic fun writeDiffArtefacts$default (Lee/schimke/composeai/daemon/PixelDiff;[B[BLjava/io/File;Lee/schimke/composeai/daemon/PixelDiffTolerance;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/daemon/PixelDiffResult {
+	public static final field Companion Lee/schimke/composeai/daemon/PixelDiffResult$Companion;
+	public fun <init> (ZIIILjava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (ZIIILjava/lang/String;)Lee/schimke/composeai/daemon/PixelDiffResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PixelDiffResult;ZIIILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PixelDiffResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxDelta ()I
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getOffendingPixelCount ()I
+	public final fun getOk ()Z
+	public final fun getTotalPixels ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PixelDiffResult$Companion {
+	public final fun failure (Ljava/lang/String;)Lee/schimke/composeai/daemon/PixelDiffResult;
+}
+
+public final class ee/schimke/composeai/daemon/PixelDiffTolerance {
+	public static final field Companion Lee/schimke/composeai/daemon/PixelDiffTolerance$Companion;
+	public fun <init> ()V
+	public fun <init> (IDI)V
+	public synthetic fun <init> (IDIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()D
+	public final fun component3 ()I
+	public final fun copy (IDI)Lee/schimke/composeai/daemon/PixelDiffTolerance;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PixelDiffTolerance;IDIILjava/lang/Object;)Lee/schimke/composeai/daemon/PixelDiffTolerance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAbsoluteCap ()I
+	public final fun getAggregateFraction ()D
+	public final fun getPerPixel ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PixelDiffTolerance$Companion {
+	public final fun getDEFAULT ()Lee/schimke/composeai/daemon/PixelDiffTolerance;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewCaptureDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewCaptureDto$Companion;
+	public fun <init> ()V
+	public fun <init> (Lee/schimke/composeai/daemon/ScrollCaptureDto;Lee/schimke/composeai/daemon/SettleCaptureDto;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/ScrollCaptureDto;Lee/schimke/composeai/daemon/SettleCaptureDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public final fun component2 ()Lee/schimke/composeai/daemon/SettleCaptureDto;
+	public final fun copy (Lee/schimke/composeai/daemon/ScrollCaptureDto;Lee/schimke/composeai/daemon/SettleCaptureDto;)Lee/schimke/composeai/daemon/PreviewCaptureDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewCaptureDto;Lee/schimke/composeai/daemon/ScrollCaptureDto;Lee/schimke/composeai/daemon/SettleCaptureDto;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewCaptureDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getScroll ()Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public final fun getSettle ()Lee/schimke/composeai/daemon/SettleCaptureDto;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewCaptureDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewCaptureDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewCaptureDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewCaptureDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewCaptureDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewDataProductDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewDataProductDto$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/ScrollCaptureDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/ScrollCaptureDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/ScrollCaptureDto;)Lee/schimke/composeai/daemon/PreviewDataProductDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewDataProductDto;Ljava/lang/String;Lee/schimke/composeai/daemon/ScrollCaptureDto;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewDataProductDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewDataProductDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewDataProductDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewDataProductDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewDataProductDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewDataProductDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewIndex {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewIndex$Companion;
+	public static final field PREVIEWS_JSON_PATH_PROP Ljava/lang/String;
+	public final fun applyDiff (Lee/schimke/composeai/daemon/DiscoveryDiff;)V
+	public final fun byId (Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public final fun diff (Ljava/util/Set;Ljava/nio/file/Path;)Lee/schimke/composeai/daemon/DiscoveryDiff;
+	public final fun getPath ()Ljava/nio/file/Path;
+	public final fun getSize ()I
+	public final fun ids ()Ljava/util/Set;
+	public final fun rowResolved (Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewIndex$Resolved;
+	public final fun scrollCaptureFor (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public final fun snapshot ()Ljava/util/Map;
+	public final fun staticScrollFor (Ljava/lang/String;)Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public final fun staticSettleFor (Ljava/lang/String;)Lee/schimke/composeai/daemon/SettleCaptureDto;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewIndex$Companion {
+	public final fun empty ()Lee/schimke/composeai/daemon/PreviewIndex;
+	public final fun fromMap (Ljava/nio/file/Path;Ljava/util/Map;)Lee/schimke/composeai/daemon/PreviewIndex;
+	public final fun loadFromFile (Ljava/nio/file/Path;)Lee/schimke/composeai/daemon/PreviewIndex;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewIndex$Resolved {
+	public fun <init> (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewIndex$Resolved;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewIndex$Resolved;Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewIndex$Resolved;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInfo ()Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public final fun getRow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewIndexKt {
+	public static final fun discoveryDiffEmpty (Lee/schimke/composeai/daemon/DiscoveryDiff;)Z
+	public static final fun uiModeIsNight (Ljava/lang/Integer;)Z
+}
+
+public final class ee/schimke/composeai/daemon/PreviewInfoDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewInfoDto$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/daemon/PreviewParamsDto;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/overrides/OverrideVariantSpec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptures ()Ljava/util/List;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMethodName ()Ljava/lang/String;
+	public final fun getOverrides ()Lee/schimke/composeai/data/overrides/OverrideVariantSpec;
+	public final fun getParams ()Lee/schimke/composeai/daemon/PreviewParamsDto;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewInfoDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewInfoDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewInfoDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewOverrideBaseSpec {
+	public fun <init> (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;)V
+	public synthetic fun <init> (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun component11 ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun component12 ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun component13 ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun component14 ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun component18 ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun component19 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun component2 ()I
+	public final fun component20 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun component21 ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Float;
+	public final fun component7 ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun component8 ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;)Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;IIFLjava/lang/String;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmbient ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun getDensity ()F
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFocus ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun getFontScale ()Ljava/lang/Float;
+	public final fun getGestures ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun getHeightPx ()I
+	public final fun getInspectionMode ()Ljava/lang/Boolean;
+	public final fun getKeyboard ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun getLauncherWidget ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun getLocaleTag ()Ljava/lang/String;
+	public final fun getLottie ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun getMaterial3Theme ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun getNamedOverrides ()Ljava/util/Map;
+	public final fun getOrientation ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun getPermissions ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun getRemoteCompose ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun getTalkBack ()Ljava/lang/Boolean;
+	public final fun getTouchOverlay ()Ljava/lang/Boolean;
+	public final fun getUiMode ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun getWallpaper ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun getWidthPx ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewOverrideExtensions {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewOverrideExtensions$Companion;
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExtensions ()Ljava/util/List;
+	public final fun plan (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewOverrideExtensions$Companion {
+	public final fun getEmpty ()Lee/schimke/composeai/daemon/PreviewOverrideExtensions;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewOverrideMergeKt {
+	public static final fun layeredOver (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public static final fun mergePreviewOverrides (Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/MergedPreviewOverrides;
+	public static final fun withCarriedOverrides (Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/PreviewOverrideBaseSpec;
+	public static final fun withPseudolocaleFrom (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public static final fun withSizeBounds (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public static final fun withThemeProvider (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewParameterRow {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewParameterRow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewParameterRow;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewParameterRow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewParamsDto {
+	public static final field Companion Lee/schimke/composeai/daemon/PreviewParamsDto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/daemon/CaptureGutterDto;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/daemon/CaptureGutterDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Long;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/Integer;
+	public final fun component17 ()Lee/schimke/composeai/daemon/CaptureGutterDto;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Float;
+	public final fun component6 ()Ljava/lang/Float;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/daemon/CaptureGutterDto;)Lee/schimke/composeai/daemon/PreviewParamsDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewParamsDto;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/daemon/CaptureGutterDto;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewParamsDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssetPath ()Ljava/lang/String;
+	public final fun getBackgroundColor ()Ljava/lang/Long;
+	public final fun getCaptureGutter ()Lee/schimke/composeai/daemon/CaptureGutterDto;
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFontScale ()Ljava/lang/Float;
+	public final fun getHeightDp ()Ljava/lang/Integer;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLocale ()Ljava/lang/String;
+	public final fun getPreviewParameterLimit ()Ljava/lang/Integer;
+	public final fun getPreviewParameterProviderClassName ()Ljava/lang/String;
+	public final fun getShowBackground ()Ljava/lang/Boolean;
+	public final fun getUiMode ()Ljava/lang/Integer;
+	public final fun getWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxHeightDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapperClassName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/PreviewParamsDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewParamsDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/PreviewParamsDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/PreviewParamsDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewParamsDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewRowAddress {
+	public static final field INDEX_PREFIX Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/daemon/PreviewRowAddress;
+	public final fun indexOf (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun rowId (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun split (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/daemon/PreviewRowAddress$Split;
+}
+
+public final class ee/schimke/composeai/daemon/PreviewRowAddress$Split {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/PreviewRowAddress$Split;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/PreviewRowAddress$Split;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/PreviewRowAddress$Split;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseId ()Ljava/lang/String;
+	public final fun getRow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/ProbeTargetResolution {
+}
+
+public final class ee/schimke/composeai/daemon/ProbeTargetResolution$Matched : ee/schimke/composeai/daemon/ProbeTargetResolution {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/ProbeTargetResolution$Matched;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/ProbeTargetResolution$Matched;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/ProbeTargetResolution$Matched;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/ProbeTargetResolution$Unsupported : ee/schimke/composeai/daemon/ProbeTargetResolution {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/ProbeTargetResolution$Unsupported;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/ProbeTargetResolution$Unsupported;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/ProbeTargetResolution$Unsupported;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingAssertionsKt {
+	public static final fun evaluateA11yAssertion (Ljava/util/List;Lee/schimke/composeai/daemon/A11yAssertThreshold;)Lee/schimke/composeai/daemon/AssertionVerdict;
+	public static final fun evaluateTextEqualsAssertion (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/AssertionVerdict;
+	public static final fun evaluateVisibilityAssertion (ZILjava/lang/String;)Lee/schimke/composeai/daemon/AssertionVerdict;
+	public static final fun resolvedNodeText (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RecordingDispatchContext {
+	public abstract fun getTMs ()J
+	public abstract fun getTNanos ()J
+}
+
+public final class ee/schimke/composeai/daemon/RecordingProbeTargetsKt {
+	public static final fun effectiveText (Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;)Ljava/lang/String;
+	public static final fun resolveProbeTarget (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;)Lee/schimke/composeai/daemon/ProbeTargetResolution;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingResult {
+	public fun <init> (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/RecordingResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RecordingResult;IJLjava/lang/String;IILjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapturedScript ()Ljava/util/List;
+	public final fun getDurationMs ()J
+	public final fun getFrameCount ()I
+	public final fun getFrameHeightPx ()I
+	public final fun getFrameWidthPx ()I
+	public final fun getFramesDir ()Ljava/lang/String;
+	public final fun getScriptEvents ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RecordingScriptDispatchObserver {
+	public abstract fun beforeDispatch (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Lee/schimke/composeai/daemon/RecordingDispatchContext;)V
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RecordingScriptEventHandler {
+	public abstract fun apply (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Lee/schimke/composeai/daemon/RecordingDispatchContext;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry {
+	public fun <init> (Ljava/util/Map;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun dispatch (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Lee/schimke/composeai/daemon/RecordingDispatchContext;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public final fun knownKinds ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryKt {
+	public static final fun appliedEvidence (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static synthetic fun appliedEvidence$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static final fun failedEvidence (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static synthetic fun failedEvidence$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static final fun unsupportedEvidence (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static synthetic fun unsupportedEvidence$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RecordingSession : java/lang/AutoCloseable {
+	public abstract fun close ()V
+	public abstract fun encode (Lee/schimke/composeai/daemon/protocol/RecordingFormat;)Lee/schimke/composeai/daemon/EncodedRecording;
+	public abstract fun getFps ()I
+	public abstract fun getLive ()Z
+	public abstract fun getPreviewId ()Ljava/lang/String;
+	public abstract fun getRecordingId ()Ljava/lang/String;
+	public abstract fun getScale ()F
+	public abstract fun postInput (Lee/schimke/composeai/daemon/protocol/RecordingInputParams;)V
+	public abstract fun postScript (Ljava/util/List;)V
+	public abstract fun stop ()Lee/schimke/composeai/daemon/RecordingResult;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingSessionKt {
+	public static final fun getINTERACTIVE_INPUT_KIND_BY_WIRE_NAME ()Ljava/util/Map;
+	public static final fun toInteractiveInputKindOrNull (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final fun wireName (Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingTestGenerator {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/RecordingTestGenerator;
+	public final fun defaultSpec (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;
+	public static synthetic fun defaultSpec$default (Lee/schimke/composeai/daemon/RecordingTestGenerator;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;
+	public final fun generate (Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;)Ljava/lang/String;
+	public final fun stepsOf (Ljava/util/List;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingTestGenerator$Spec {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Spec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getComposableInvocation ()Ljava/lang/String;
+	public final fun getMethodName ()Ljava/lang/String;
+	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getSteps ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RecordingTestGenerator$Step {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;ZLjava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;ZLjava/util/List;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Step;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RecordingTestGenerator$Step;Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;ZLjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingTestGenerator$Step;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplied ()Z
+	public final fun getEvent ()Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;
+	public final fun getProbeSemantics ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RenderErrorClassifier {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/RenderErrorClassifier;
+	public final fun classify (Ljava/lang/Throwable;)Lee/schimke/composeai/daemon/RenderErrorClassifier$Classification;
+}
+
+public final class ee/schimke/composeai/daemon/RenderErrorClassifier$Classification {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;)Lee/schimke/composeai/daemon/RenderErrorClassifier$Classification;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RenderErrorClassifier$Classification;Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderErrorClassifier$Classification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public final fun getSuggestion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RenderHost {
+	public static final field Companion Lee/schimke/composeai/daemon/RenderHost$Companion;
+	public fun acquireInteractiveSession (Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/InteractiveSession;
+	public static synthetic fun acquireInteractiveSession$default (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/daemon/InteractiveSession;
+	public fun acquireRecordingSession (Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;IFLee/schimke/composeai/daemon/protocol/PreviewOverrides;Z)Lee/schimke/composeai/daemon/RecordingSession;
+	public static synthetic fun acquireRecordingSession$default (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;IFLee/schimke/composeai/daemon/protocol/PreviewOverrides;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingSession;
+	public fun getAndroidSdk ()Ljava/lang/Integer;
+	public fun getBackendKind ()Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public fun getSupportedInteractiveControlKinds ()Ljava/util/Set;
+	public fun getSupportedOverrides ()Ljava/util/Set;
+	public fun getSupportedRecordingFormats ()Ljava/util/List;
+	public fun getSupportsInteractive ()Z
+	public fun getSupportsRecording ()Z
+	public fun getUserClassloaderHolder ()Lee/schimke/composeai/daemon/UserClassLoaderHolder;
+	public fun previewParameterRows (Ljava/lang/String;)Ljava/util/List;
+	public fun recordingScriptEventDescriptors ()Ljava/util/List;
+	public abstract fun shutdown (J)V
+	public static synthetic fun shutdown$default (Lee/schimke/composeai/daemon/RenderHost;JILjava/lang/Object;)V
+	public abstract fun start ()V
+	public abstract fun submit (Lee/schimke/composeai/daemon/RenderRequest;J)Lee/schimke/composeai/daemon/RenderResult;
+	public static synthetic fun submit$default (Lee/schimke/composeai/daemon/RenderHost;Lee/schimke/composeai/daemon/RenderRequest;JILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderResult;
+	public fun swapUserClassLoaders ()V
+}
+
+public final class ee/schimke/composeai/daemon/RenderHost$Companion {
+	public final fun nextRequestId ()J
+}
+
+public final class ee/schimke/composeai/daemon/RenderHost$DefaultImpls {
+	public static fun acquireInteractiveSession (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/InteractiveSession;
+	public static synthetic fun acquireInteractiveSession$default (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/ClassLoader;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function0;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/daemon/InteractiveSession;
+	public static fun acquireRecordingSession (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;IFLee/schimke/composeai/daemon/protocol/PreviewOverrides;Z)Lee/schimke/composeai/daemon/RecordingSession;
+	public static synthetic fun acquireRecordingSession$default (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;IFLee/schimke/composeai/daemon/protocol/PreviewOverrides;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/RecordingSession;
+	public static fun getAndroidSdk (Lee/schimke/composeai/daemon/RenderHost;)Ljava/lang/Integer;
+	public static fun getBackendKind (Lee/schimke/composeai/daemon/RenderHost;)Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public static fun getSupportedInteractiveControlKinds (Lee/schimke/composeai/daemon/RenderHost;)Ljava/util/Set;
+	public static fun getSupportedOverrides (Lee/schimke/composeai/daemon/RenderHost;)Ljava/util/Set;
+	public static fun getSupportedRecordingFormats (Lee/schimke/composeai/daemon/RenderHost;)Ljava/util/List;
+	public static fun getSupportsInteractive (Lee/schimke/composeai/daemon/RenderHost;)Z
+	public static fun getSupportsRecording (Lee/schimke/composeai/daemon/RenderHost;)Z
+	public static fun getUserClassloaderHolder (Lee/schimke/composeai/daemon/RenderHost;)Lee/schimke/composeai/daemon/UserClassLoaderHolder;
+	public static fun previewParameterRows (Lee/schimke/composeai/daemon/RenderHost;Ljava/lang/String;)Ljava/util/List;
+	public static fun recordingScriptEventDescriptors (Lee/schimke/composeai/daemon/RenderHost;)Ljava/util/List;
+	public static synthetic fun shutdown$default (Lee/schimke/composeai/daemon/RenderHost;JILjava/lang/Object;)V
+	public static synthetic fun submit$default (Lee/schimke/composeai/daemon/RenderHost;Lee/schimke/composeai/daemon/RenderRequest;JILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderResult;
+	public static fun swapUserClassLoaders (Lee/schimke/composeai/daemon/RenderHost;)V
+}
+
+public abstract interface class ee/schimke/composeai/daemon/RenderRequest {
+}
+
+public final class ee/schimke/composeai/daemon/RenderRequest$ParameterRows : ee/schimke/composeai/daemon/RenderRequest {
+	public fun <init> ()V
+	public fun <init> (JLjava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lee/schimke/composeai/daemon/RenderRequest$ParameterRows;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RenderRequest$ParameterRows;JLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderRequest$ParameterRows;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getPayload ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RenderRequest$Render : ee/schimke/composeai/daemon/RenderRequest {
+	public fun <init> ()V
+	public fun <init> (JLjava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;)Lee/schimke/composeai/daemon/RenderRequest$Render;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RenderRequest$Render;JLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderRequest$Render;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getPayload ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RenderRequest$Shutdown : ee/schimke/composeai/daemon/RenderRequest {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/RenderRequest$Shutdown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/RenderResult {
+	public fun <init> (JILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/render/PreviewContext;Ljava/lang/String;Lee/schimke/composeai/data/render/RenderTrace;)V
+	public synthetic fun <init> (JILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/render/PreviewContext;Ljava/lang/String;Lee/schimke/composeai/data/render/RenderTrace;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lee/schimke/composeai/data/render/PreviewContext;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lee/schimke/composeai/data/render/RenderTrace;
+	public final fun copy (JILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/render/PreviewContext;Ljava/lang/String;Lee/schimke/composeai/data/render/RenderTrace;)Lee/schimke/composeai/daemon/RenderResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/RenderResult;JILjava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/render/PreviewContext;Ljava/lang/String;Lee/schimke/composeai/data/render/RenderTrace;ILjava/lang/Object;)Lee/schimke/composeai/daemon/RenderResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassLoaderHashCode ()I
+	public final fun getClassLoaderName ()Ljava/lang/String;
+	public final fun getId ()J
+	public final fun getMetrics ()Ljava/util/Map;
+	public final fun getOutputBaseName ()Ljava/lang/String;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getPreviewContext ()Lee/schimke/composeai/data/render/PreviewContext;
+	public final fun getTrace ()Lee/schimke/composeai/data/render/RenderTrace;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/SandboxLifecycleStats {
+	public fun <init> ()V
+	public fun <init> (J)V
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun ageMs ()J
+	public final fun bumpRenderCount ()J
+	public final fun renders ()J
+	public final fun reset ()V
+}
+
+public final class ee/schimke/composeai/daemon/SandboxMeasurement {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/SandboxMeasurement;
+	public final fun collect (Lee/schimke/composeai/daemon/SandboxLifecycleStats;J)Ljava/util/Map;
+}
+
+public final class ee/schimke/composeai/daemon/ScrollCaptureDto {
+	public static final field Companion Lee/schimke/composeai/daemon/ScrollCaptureDto$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IZI)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IZI)Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/ScrollCaptureDto;Ljava/lang/String;Ljava/lang/String;IZIILjava/lang/Object;)Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAxis ()Ljava/lang/String;
+	public final fun getFrameIntervalMs ()I
+	public final fun getMaxScrollPx ()I
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getReduceMotion ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/ScrollCaptureDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/ScrollCaptureDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/ScrollCaptureDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/ScrollCaptureDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/ScrollCaptureDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/SemanticsTargetUnresolvedException : java/lang/RuntimeException {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Ljava/lang/String;)V
+	public final fun getReason ()Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+}
+
+public final class ee/schimke/composeai/daemon/SettleCaptureDto {
+	public static final field Companion Lee/schimke/composeai/daemon/SettleCaptureDto$Companion;
+	public fun <init> ()V
+	public fun <init> (II)V
+	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/daemon/SettleCaptureDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/SettleCaptureDto;IIILjava/lang/Object;)Lee/schimke/composeai/daemon/SettleCaptureDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAfterMs ()I
+	public final fun getMaxMs ()I
+	public final fun getWindowMs ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/SettleCaptureDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/SettleCaptureDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/SettleCaptureDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/SettleCaptureDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/SettleCaptureDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/SimpleRecordingDispatchContext : ee/schimke/composeai/daemon/RecordingDispatchContext {
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lee/schimke/composeai/daemon/SimpleRecordingDispatchContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/SimpleRecordingDispatchContext;JJILjava/lang/Object;)Lee/schimke/composeai/daemon/SimpleRecordingDispatchContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getTMs ()J
+	public fun getTNanos ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/StartupTimings {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/StartupTimings;
+	public static final field QUIET_PROP Ljava/lang/String;
+	public final fun elapsedMs ()J
+	public final fun getJvmStartMs ()J
+	public final fun mark (Ljava/lang/String;)V
+	public final fun marks ()Ljava/util/List;
+	public final fun summary ()V
+}
+
+public final class ee/schimke/composeai/daemon/StartupTimings$Mark {
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/StartupTimings$Mark;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/StartupTimings$Mark;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/StartupTimings$Mark;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElapsedMs ()J
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getThread ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/UserClassLoaderHolder {
+	public static final field Companion Lee/schimke/composeai/daemon/UserClassLoaderHolder$Companion;
+	public static final field USER_CLASS_DIRS_PROP Ljava/lang/String;
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun currentChildLoader ()Ljava/net/URLClassLoader;
+	public final fun liveLoaderCount ()I
+	public final fun swap ()V
+	public final fun urls ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/UserClassLoaderHolder$Companion {
+	public final fun classFileFingerprint (Ljava/lang/ClassLoader;Ljava/lang/String;)Ljava/lang/String;
+	public final fun urlsFromSysprop ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/XrFrame {
+	public fun <init> (JIILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (JIILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/XrFrame;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/XrFrame;JIILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/XrFrame;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataBase64 ()Ljava/lang/String;
+	public final fun getEncoding ()Ljava/lang/String;
+	public final fun getHeight ()I
+	public final fun getSeq ()J
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/XrSessions : java/lang/AutoCloseable {
+	public abstract fun close ()V
+	public abstract fun close (Ljava/lang/String;)V
+	public abstract fun isOpen (Ljava/lang/String;)Z
+	public abstract fun open (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/daemon/XrFrame;
+	public static synthetic fun open$default (Lee/schimke/composeai/daemon/XrSessions;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/daemon/XrFrame;
+	public abstract fun structure (Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
+	public abstract fun updatePanels (Ljava/lang/String;Lkotlinx/serialization/json/JsonArray;)Lee/schimke/composeai/daemon/XrFrame;
+}
+
+public final class ee/schimke/composeai/daemon/XrSessions$DefaultImpls {
+	public static synthetic fun open$default (Lee/schimke/composeai/daemon/XrSessions;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/daemon/XrFrame;
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaBenchMain {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaCompileDiagnosticException : java/lang/RuntimeException {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getErrors ()Ljava/util/List;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/bta/BtaCompileService {
+	public abstract fun compile (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome;
+}
+
+public abstract class ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome {
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$CompileError : ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$CompileError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$CompileError;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$CompileError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrors ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Fallback : ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Fallback;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Fallback;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Fallback;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Ok : ee/schimke/composeai/daemon/bta/BtaCompileService$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome$Ok;
+}
+
+public final class ee/schimke/composeai/daemon/bta/BtaCompileSession {
+	public fun <init> (Ljava/util/List;Ljava/nio/file/Path;Ljava/lang/String;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/nio/file/Path;Ljava/lang/String;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun compile (Ljava/util/List;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;)Ljava/util/List;
+	public static synthetic fun compile$default (Lee/schimke/composeai/daemon/bta/BtaCompileSession;Ljava/util/List;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;ILjava/lang/Object;)Ljava/util/List;
+	public final fun compileIncremental (Ljava/util/List;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Lorg/jetbrains/kotlin/buildtools/api/SourcesChanges;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;Ljava/nio/file/Path;)Ljava/util/List;
+	public static synthetic fun compileIncremental$default (Lee/schimke/composeai/daemon/bta/BtaCompileSession;Ljava/util/List;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Lorg/jetbrains/kotlin/buildtools/api/SourcesChanges;Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;Ljava/nio/file/Path;ILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/daemon/bta/DefaultBtaCompileService : ee/schimke/composeai/daemon/bta/BtaCompileService {
+	public static final field Companion Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService$Companion;
+	public static final field SYSPROP_COMPILER_PLUGINS Ljava/lang/String;
+	public static final field SYSPROP_COMPILE_CLASSPATH Ljava/lang/String;
+	public static final field SYSPROP_IC_WORKING_DIR Ljava/lang/String;
+	public static final field SYSPROP_IMPL_CLASSPATH Ljava/lang/String;
+	public static final field SYSPROP_INELIGIBILITY_REASON Ljava/lang/String;
+	public static final field SYSPROP_MODULE_NAME Ljava/lang/String;
+	public static final field SYSPROP_OUTPUT_DIR Ljava/lang/String;
+	public fun <init> (Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService$CompileBackend;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService$CompileBackend;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun compile (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;)Lee/schimke/composeai/daemon/bta/BtaCompileService$Outcome;
+}
+
+public final class ee/schimke/composeai/daemon/bta/DefaultBtaCompileService$Companion {
+	public final fun forSession (Lee/schimke/composeai/daemon/bta/BtaCompileSession;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService;
+	public static synthetic fun forSession$default (Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService$Companion;Lee/schimke/composeai/daemon/bta/BtaCompileSession;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService;
+	public final fun fromSysprops (Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService;
+	public static synthetic fun fromSysprops$default (Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/daemon/bta/DefaultBtaCompileService;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/bta/DefaultBtaCompileService$CompileBackend {
+	public abstract fun compile (Ljava/util/List;Lorg/jetbrains/kotlin/buildtools/api/SourcesChanges;)V
+}
+
+public final class ee/schimke/composeai/daemon/bta/DiagnosticCollector : org/jetbrains/kotlin/buildtools/api/KotlinLogger {
+	public fun <init> ()V
+	public fun <init> (Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;)V
+	public synthetic fun <init> (Lorg/jetbrains/kotlin/buildtools/api/KotlinLogger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun debug (Ljava/lang/String;)V
+	public fun error (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun getErrors ()Ljava/util/List;
+	public fun info (Ljava/lang/String;)V
+	public fun isDebugEnabled ()Z
+	public fun lifecycle (Ljava/lang/String;)V
+	public fun warn (Ljava/lang/String;)V
+	public fun warn (Ljava/lang/String;Ljava/lang/Throwable;)V
+}
+
+public final class ee/schimke/composeai/daemon/devices/DeviceDimensions {
+	public static final field DEFAULT_DENSITY F
+	public static final field INSTANCE Lee/schimke/composeai/daemon/devices/DeviceDimensions;
+	public final fun getDEFAULT ()Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+	public final fun getDEFAULT_WEAR ()Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+	public final fun getKNOWN_DEVICE_IDS ()Ljava/util/Set;
+	public final fun resolve (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+	public static synthetic fun resolve$default (Lee/schimke/composeai/daemon/devices/DeviceDimensions;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+}
+
+public final class ee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec {
+	public fun <init> (IIFZ)V
+	public synthetic fun <init> (IIFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()F
+	public final fun component4 ()Z
+	public final fun copy (IIFZ)Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;IIFZILjava/lang/Object;)Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public final fun getHeightDp ()I
+	public final fun getWidthDp ()I
+	public fun hashCode ()I
+	public final fun isRound ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/devices/DeviceDimensionsKt {
+	public static final fun frameDpOverriddenBy (Lee/schimke/composeai/daemon/devices/DeviceDimensions$DeviceSpec;Ljava/lang/Integer;Ljava/lang/Integer;)Lkotlin/Pair;
+}
+
+public final class ee/schimke/composeai/daemon/devices/FrameOrientation {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/devices/FrameOrientation;
+	public final fun orientedPx (IILee/schimke/composeai/daemon/protocol/Orientation;)Lkotlin/Pair;
+	public final fun orientedPx (IILjava/lang/String;)Lkotlin/Pair;
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/Orientation;
+}
+
+public final class ee/schimke/composeai/daemon/forensics/ClassloaderForensics {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/forensics/ClassloaderForensics;
+	public final fun capture (Ljava/util/List;Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;Ljava/lang/String;Ljava/io/File;)V
+	public final fun capture (Ljava/util/List;Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;Ljava/lang/String;Ljava/io/File;Lokio/FileSystem;)V
+	public final fun capture (Ljava/util/List;Ljava/lang/String;Ljava/io/File;)V
+	public static synthetic fun capture$default (Lee/schimke/composeai/daemon/forensics/ClassloaderForensics;Ljava/util/List;Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;Ljava/lang/String;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)V
+	public final fun diff (Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;)V
+	public static synthetic fun diff$default (Lee/schimke/composeai/daemon/forensics/ClassloaderForensics;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot {
+	public static final field Companion Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot$Companion;
+	public fun <init> (ILjava/lang/String;FLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (ILjava/lang/String;FLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (ILjava/lang/String;FLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;ILjava/lang/String;FLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiLevel ()I
+	public final fun getApplicationClassName ()Ljava/lang/String;
+	public final fun getDoNotAcquirePackages ()Ljava/util/List;
+	public final fun getDoNotInstrumentPackages ()Ljava/util/List;
+	public final fun getFontScale ()F
+	public final fun getGraphicsMode ()Ljava/lang/String;
+	public final fun getInstrumentedPackages ()Ljava/util/List;
+	public final fun getInstrumentingClassLoaderIdentity ()Ljava/lang/String;
+	public final fun getLooperMode ()Ljava/lang/String;
+	public final fun getQualifiers ()Ljava/lang/String;
+	public final fun getSandboxAgeMs ()Ljava/lang/Long;
+	public final fun getSandboxFactoryClassName ()Ljava/lang/String;
+	public final fun getSandboxRenderCount ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/forensics/RobolectricConfigSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yDelta {
+	public static final field Companion Lee/schimke/composeai/daemon/history/A11yDelta$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/history/A11yDelta;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/A11yDelta;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/A11yDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getChanged ()Ljava/util/List;
+	public final fun getRemoved ()Ljava/util/List;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/A11yDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yDelta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/A11yDelta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/A11yDelta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yDiff {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yDiff;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yDiffProduct {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yDiffProduct;
+	public static final field SCHEMA Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFieldChange {
+	public static final field Companion Lee/schimke/composeai/daemon/history/A11yFieldChange$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/A11yFieldChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/A11yFieldChange;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/A11yFieldChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getField ()Ljava/lang/String;
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/A11yFieldChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yFieldChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/A11yFieldChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/A11yFieldChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFieldChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFindingChange {
+	public static final field Companion Lee/schimke/composeai/daemon/history/A11yFindingChange$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/history/A11yFindingChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/A11yFindingChange;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/A11yFindingChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChanges ()Ljava/util/List;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/A11yFindingChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yFindingChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/A11yFindingChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/A11yFindingChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFindingChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFindingSummary {
+	public static final field Companion Lee/schimke/composeai/daemon/history/A11yFindingSummary$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/A11yFindingSummary;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/A11yFindingSummary;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/A11yFindingSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/A11yFindingSummary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/A11yFindingSummary$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/A11yFindingSummary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/A11yFindingSummary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/A11yFindingSummary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitInfo {
+	public static final field Companion Lee/schimke/composeai/daemon/history/GitInfo$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/GitInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/GitInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/GitInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getDirty ()Ljava/lang/Boolean;
+	public final fun getRemote ()Ljava/lang/String;
+	public final fun getShortCommit ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/GitInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/GitInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/GitInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/GitInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitProvenance {
+	public static final field CACHE_TTL_PROP Ljava/lang/String;
+	public static final field Companion Lee/schimke/composeai/daemon/history/GitProvenance$Companion;
+	public static final field DEFAULT_CACHE_TTL_MS J
+	public static final field ENV_AGENT_ID Ljava/lang/String;
+	public static final field ENV_WORKTREE_ID Ljava/lang/String;
+	public fun <init> (Ljava/nio/file/Path;Ljava/util/Map;JLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/util/Map;JLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun snapshot ()Lkotlin/Pair;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitProvenance$Companion {
+}
+
+public final class ee/schimke/composeai/daemon/history/GitRefHistorySource : ee/schimke/composeai/daemon/history/HistorySource {
+	public static final field Companion Lee/schimke/composeai/daemon/history/GitRefHistorySource$Companion;
+	public static final field DEBOUNCE_PROP Ljava/lang/String;
+	public static final field DEFAULT_DEBOUNCE_MS J
+	public static final field DEFAULT_REMOTE Ljava/lang/String;
+	public static final field GIT_REF_HISTORY_PROP Ljava/lang/String;
+	public static final field LEGACY_INDEX_FILENAME Ljava/lang/String;
+	public static final field MANIFEST_FILENAME Ljava/lang/String;
+	public static final field MAX_PUSH_ATTEMPTS I
+	public static final field MAX_TIMELINE_DEPTH I
+	public static final field PUBLISH_POLICY_PROP Ljava/lang/String;
+	public static final field RENDER_FILENAME Ljava/lang/String;
+	public static final field REPORTING_BRANCH_FORMAT_VERSION I
+	public static final field SYNC_MODE_PROP Ljava/lang/String;
+	public fun <init> (Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;JLee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;Ljava/lang/String;Ljava/nio/file/Path;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Ljava/lang/String;JLee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun close ()V
+	public final fun flushPending ()V
+	public fun getId ()Ljava/lang/String;
+	public fun getKind ()Ljava/lang/String;
+	public fun list (Lee/schimke/composeai/daemon/history/HistoryFilter;)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public fun prune (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Z)Lee/schimke/composeai/daemon/history/PruneResult;
+	public fun read (Ljava/lang/String;Z)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public fun supportsWrites ()Z
+	public fun write (Lee/schimke/composeai/daemon/history/HistoryEntry;[B)Lee/schimke/composeai/daemon/history/WriteResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitRefHistorySource$Companion {
+	public final fun defaultCacheDir (Ljava/nio/file/Path;)Ljava/nio/file/Path;
+	public final fun defaultRepoCacheDir (Ljava/nio/file/Path;)Ljava/nio/file/Path;
+	public final fun parseDebounceSysprop (Ljava/lang/String;)J
+	public static synthetic fun parseDebounceSysprop$default (Lee/schimke/composeai/daemon/history/GitRefHistorySource$Companion;Ljava/lang/String;ILjava/lang/Object;)J
+	public final fun parsePublishPolicySysprop (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+	public static synthetic fun parsePublishPolicySysprop$default (Lee/schimke/composeai/daemon/history/GitRefHistorySource$Companion;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+	public final fun parseRefsSysprop (Ljava/lang/String;)Ljava/util/List;
+	public static synthetic fun parseRefsSysprop$default (Lee/schimke/composeai/daemon/history/GitRefHistorySource$Companion;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
+	public final fun parseSyncModeSysprop (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+	public static synthetic fun parseSyncModeSysprop$default (Lee/schimke/composeai/daemon/history/GitRefHistorySource$Companion;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy : java/lang/Enum {
+	public static final field ALL Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+	public static final field CLEAN_ON_BRANCH Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+	public static fun values ()[Lee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;
+}
+
+public final class ee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode : java/lang/Enum {
+	public static final field READ_ONLY Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+	public static final field WRITE_LOCAL Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+	public static final field WRITE_PUSH Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+	public static fun values ()[Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDataDelta {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistoryDataDelta$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/A11yDelta;Lee/schimke/composeai/data/theme/ThemeDelta;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/A11yDelta;Lee/schimke/composeai/data/theme/ThemeDelta;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public final fun component3 ()Lee/schimke/composeai/daemon/history/A11yDelta;
+	public final fun component4 ()Lee/schimke/composeai/data/theme/ThemeDelta;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/A11yDelta;Lee/schimke/composeai/data/theme/ThemeDelta;)Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryDataDelta;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/A11yDelta;Lee/schimke/composeai/data/theme/ThemeDelta;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getA11y ()Lee/schimke/composeai/daemon/history/A11yDelta;
+	public final fun getSchema ()Ljava/lang/String;
+	public final fun getSemantics ()Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public final fun getTheme ()Lee/schimke/composeai/data/theme/ThemeDelta;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/HistoryDataDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryDataDelta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/HistoryDataDelta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDataDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDataDiff {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryDataDiff;
+	public final fun diff (Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/HistoryEntry;Lkotlinx/serialization/json/Json;)Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public static synthetic fun diff$default (Lee/schimke/composeai/daemon/history/HistoryDataDiff;Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/HistoryEntry;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDataDiffProduct {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryDataDiffProduct;
+	public static final field SCHEMA Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDelta {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistoryDelta$Companion;
+	public fun <init> (ZLjava/lang/Long;Ljava/lang/Double;)V
+	public synthetic fun <init> (ZLjava/lang/Long;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun copy (ZLjava/lang/Long;Ljava/lang/Double;)Lee/schimke/composeai/daemon/history/HistoryDelta;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryDelta;ZLjava/lang/Long;Ljava/lang/Double;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiffPx ()Ljava/lang/Long;
+	public final fun getPngHashChanged ()Z
+	public final fun getSsim ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/HistoryDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryDelta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/HistoryDelta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/HistoryDelta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryDiffArtifacts {
+	public static final field DIFFS_DIR_NAME Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryDiffArtifacts;
+	public final fun fileName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun referencesEntry (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun sanitiseId (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryEntry {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistoryEntry$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/history/HistorySourceInfo;Lee/schimke/composeai/daemon/history/WorktreeInfo;Lee/schimke/composeai/daemon/history/GitInfo;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;Lee/schimke/composeai/daemon/history/HistoryDelta;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/history/HistorySourceInfo;Lee/schimke/composeai/daemon/history/WorktreeInfo;Lee/schimke/composeai/daemon/history/GitInfo;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;Lee/schimke/composeai/daemon/history/HistoryDelta;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component11 ()Lee/schimke/composeai/daemon/history/HistorySourceInfo;
+	public final fun component12 ()Lee/schimke/composeai/daemon/history/WorktreeInfo;
+	public final fun component13 ()Lee/schimke/composeai/daemon/history/GitInfo;
+	public final fun component14 ()J
+	public final fun component15 ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public final fun component16 ()Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Lee/schimke/composeai/daemon/history/HistoryDelta;
+	public final fun component19 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component21 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component22 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component23 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/history/HistorySourceInfo;Lee/schimke/composeai/daemon/history/WorktreeInfo;Lee/schimke/composeai/daemon/history/GitInfo;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;Lee/schimke/composeai/daemon/history/HistoryDelta;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryEntry;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/history/HistorySourceInfo;Lee/schimke/composeai/daemon/history/WorktreeInfo;Lee/schimke/composeai/daemon/history/GitInfo;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;Lee/schimke/composeai/daemon/history/HistoryDelta;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getA11yAtf ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getA11yHierarchy ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getA11yTouchTargets ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getDeltaFromPrevious ()Lee/schimke/composeai/daemon/history/HistoryDelta;
+	public final fun getGit ()Lee/schimke/composeai/daemon/history/GitInfo;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMetrics ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPngHash ()Ljava/lang/String;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getPngSize ()J
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getPreviewMetadata ()Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public final fun getPreviousId ()Ljava/lang/String;
+	public final fun getProducer ()Ljava/lang/String;
+	public final fun getRenderTookMs ()J
+	public final fun getSemantics ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSource ()Lee/schimke/composeai/daemon/history/HistorySourceInfo;
+	public final fun getTheme ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getTimestamp ()Ljava/lang/String;
+	public final fun getTrigger ()Ljava/lang/String;
+	public final fun getTriggerDetail ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getWorktree ()Lee/schimke/composeai/daemon/history/WorktreeInfo;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/HistoryEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/HistoryEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryFilter {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/HistoryFilter;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryFilter;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryFilter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgentId ()Ljava/lang/String;
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getBranchPattern ()Ljava/lang/String;
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getSince ()Ljava/lang/String;
+	public final fun getSourceId ()Ljava/lang/String;
+	public final fun getSourceKind ()Ljava/lang/String;
+	public final fun getUntil ()Ljava/lang/String;
+	public final fun getWorktreePath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryImageDiff {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistoryImageDiff;
+	public final fun diff ([B[B)Lee/schimke/composeai/daemon/history/HistoryImageDiff$Result;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryImageDiff$Result {
+	public fun <init> (JD[B)V
+	public final fun component1 ()J
+	public final fun component2 ()D
+	public final fun component3 ()[B
+	public final fun copy (JD[B)Lee/schimke/composeai/daemon/history/HistoryImageDiff$Result;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryImageDiff$Result;JD[BILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryImageDiff$Result;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiffPx ()J
+	public final fun getMarkedPng ()[B
+	public final fun getSsim ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryImageDiff$UndecodableImageException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryListPage {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;Ljava/lang/String;I)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryListPage;Ljava/util/List;Ljava/lang/String;IILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getNextCursor ()Ljava/lang/String;
+	public final fun getTotalCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryManager {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistoryManager$Companion;
+	public static final field DEFAULT_INITIAL_DELAY_MS J
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun closeSources ()V
+	public final fun configurePruneConfig (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;)V
+	public final fun getPruneConfig ()Lee/schimke/composeai/daemon/history/HistoryPruneConfig;
+	public final fun isEnabled ()Z
+	public final fun list (Lee/schimke/composeai/daemon/history/HistoryFilter;)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public final fun pruneNow (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;ZLee/schimke/composeai/daemon/history/PruneReason;)Lee/schimke/composeai/daemon/history/PruneAggregateResult;
+	public static synthetic fun pruneNow$default (Lee/schimke/composeai/daemon/history/HistoryManager;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;ZLee/schimke/composeai/daemon/history/PruneReason;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneAggregateResult;
+	public final fun read (Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public static synthetic fun read$default (Lee/schimke/composeai/daemon/history/HistoryManager;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public final fun recordRender (Ljava/lang/String;[BLjava/lang/String;Lkotlinx/serialization/json/JsonElement;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/time/Instant;)Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public static synthetic fun recordRender$default (Lee/schimke/composeai/daemon/history/HistoryManager;Ljava/lang/String;[BLjava/lang/String;Lkotlinx/serialization/json/JsonElement;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/time/Instant;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public final fun setPruneListener (Lkotlin/jvm/functions/Function1;)V
+	public final fun startAutoPrune (J)V
+	public static synthetic fun startAutoPrune$default (Lee/schimke/composeai/daemon/history/HistoryManager;JILjava/lang/Object;)V
+	public final fun stopAutoPrune ()V
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryManager$Companion {
+	public final fun forLocalFs (Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;)Lee/schimke/composeai/daemon/history/HistoryManager;
+	public static synthetic fun forLocalFs$default (Lee/schimke/composeai/daemon/history/HistoryManager$Companion;Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryManager;
+	public final fun forLocalFsAndGitRefs (Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Ljava/util/List;Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;JLee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;)Lee/schimke/composeai/daemon/history/HistoryManager;
+	public static synthetic fun forLocalFsAndGitRefs$default (Lee/schimke/composeai/daemon/history/HistoryManager$Companion;Ljava/nio/file/Path;Ljava/lang/String;Lee/schimke/composeai/daemon/history/GitProvenance;Ljava/util/List;Lee/schimke/composeai/daemon/history/GitRefHistorySource$SyncMode;Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;JLee/schimke/composeai/daemon/history/GitRefHistorySource$PublishPolicy;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryManager;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryPruneConfig {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistoryPruneConfig$Companion;
+	public static final field PROP_AUTO_PRUNE_INTERVAL_MS Ljava/lang/String;
+	public static final field PROP_MAX_AGE_DAYS Ljava/lang/String;
+	public static final field PROP_MAX_ENTRIES Ljava/lang/String;
+	public static final field PROP_MAX_TOTAL_SIZE_BYTES Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (IIJJ)V
+	public synthetic fun <init> (IIJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (IIJJ)Lee/schimke/composeai/daemon/history/HistoryPruneConfig;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;IIJJILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryPruneConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoPruneIntervalMs ()J
+	public final fun getMaxAgeDays ()I
+	public final fun getMaxEntriesPerPreview ()I
+	public final fun getMaxTotalSizeBytes ()J
+	public fun hashCode ()I
+	public final fun isAllOff ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryPruneConfig$Companion {
+	public final fun fromSysprops (Lkotlin/jvm/functions/Function1;)Lee/schimke/composeai/daemon/history/HistoryPruneConfig;
+	public static synthetic fun fromSysprops$default (Lee/schimke/composeai/daemon/history/HistoryPruneConfig$Companion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryPruneConfig;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistoryReadResult {
+	public fun <init> (Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;[B)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;[BILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public final fun component2 ()Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()[B
+	public final fun copy (Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;[B)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistoryReadResult;Lee/schimke/composeai/daemon/history/HistoryEntry;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;[BILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntry ()Lee/schimke/composeai/daemon/history/HistoryEntry;
+	public final fun getPngBytes ()[B
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getPreviewMetadata ()Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/history/HistorySource {
+	public fun close ()V
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getKind ()Ljava/lang/String;
+	public abstract fun list (Lee/schimke/composeai/daemon/history/HistoryFilter;)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public fun prune (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Z)Lee/schimke/composeai/daemon/history/PruneResult;
+	public static synthetic fun prune$default (Lee/schimke/composeai/daemon/history/HistorySource;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneResult;
+	public abstract fun read (Ljava/lang/String;Z)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public static synthetic fun read$default (Lee/schimke/composeai/daemon/history/HistorySource;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public abstract fun supportsWrites ()Z
+	public abstract fun write (Lee/schimke/composeai/daemon/history/HistoryEntry;[B)Lee/schimke/composeai/daemon/history/WriteResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistorySource$DefaultImpls {
+	public static fun close (Lee/schimke/composeai/daemon/history/HistorySource;)V
+	public static fun prune (Lee/schimke/composeai/daemon/history/HistorySource;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Z)Lee/schimke/composeai/daemon/history/PruneResult;
+	public static synthetic fun prune$default (Lee/schimke/composeai/daemon/history/HistorySource;Lee/schimke/composeai/daemon/history/HistoryPruneConfig;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneResult;
+	public static synthetic fun read$default (Lee/schimke/composeai/daemon/history/HistorySource;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistorySourceInfo {
+	public static final field Companion Lee/schimke/composeai/daemon/history/HistorySourceInfo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/HistorySourceInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/HistorySourceInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/HistorySourceInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/HistorySourceInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/HistorySourceInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/HistorySourceInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/HistorySourceInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/HistorySourceInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/LocalFsHistorySource : ee/schimke/composeai/daemon/history/HistorySource {
+	public static final field Companion Lee/schimke/composeai/daemon/history/LocalFsHistorySource$Companion;
+	public static final field DEFAULT_LIMIT I
+	public static final field INDEX_FILENAME Ljava/lang/String;
+	public static final field MAX_LIMIT I
+	public fun <init> (Ljava/nio/file/Path;)V
+	public fun close ()V
+	public fun getId ()Ljava/lang/String;
+	public fun getKind ()Ljava/lang/String;
+	public fun list (Lee/schimke/composeai/daemon/history/HistoryFilter;)Lee/schimke/composeai/daemon/history/HistoryListPage;
+	public fun prune (Lee/schimke/composeai/daemon/history/HistoryPruneConfig;Z)Lee/schimke/composeai/daemon/history/PruneResult;
+	public fun read (Ljava/lang/String;Z)Lee/schimke/composeai/daemon/history/HistoryReadResult;
+	public fun supportsWrites ()Z
+	public fun write (Lee/schimke/composeai/daemon/history/HistoryEntry;[B)Lee/schimke/composeai/daemon/history/WriteResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/LocalFsHistorySource$Companion {
+	public final fun sha256Hex ([B)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/PreviewMetadataSnapshot {
+	public static final field Companion Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfig ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/PreviewMetadataSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/PreviewMetadataSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/PreviewMetadataSnapshot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneAggregateResult {
+	public static final field Companion Lee/schimke/composeai/daemon/history/PruneAggregateResult$Companion;
+	public fun <init> (Ljava/util/List;JLjava/util/Map;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;JLjava/util/Map;)Lee/schimke/composeai/daemon/history/PruneAggregateResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/PruneAggregateResult;Ljava/util/List;JLjava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneAggregateResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getRemovedEntryIds ()Ljava/util/List;
+	public final fun getSourceResults ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneAggregateResult$Companion {
+	public final fun getEMPTY ()Lee/schimke/composeai/daemon/history/PruneAggregateResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneNotification {
+	public fun <init> (Ljava/util/List;JLee/schimke/composeai/daemon/history/PruneReason;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun component3 ()Lee/schimke/composeai/daemon/history/PruneReason;
+	public final fun copy (Ljava/util/List;JLee/schimke/composeai/daemon/history/PruneReason;)Lee/schimke/composeai/daemon/history/PruneNotification;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/PruneNotification;Ljava/util/List;JLee/schimke/composeai/daemon/history/PruneReason;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneNotification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getReason ()Lee/schimke/composeai/daemon/history/PruneReason;
+	public final fun getRemovedIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneReason : java/lang/Enum {
+	public static final field AUTO Lee/schimke/composeai/daemon/history/PruneReason;
+	public static final field MANUAL Lee/schimke/composeai/daemon/history/PruneReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/PruneReason;
+	public static fun values ()[Lee/schimke/composeai/daemon/history/PruneReason;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneResult {
+	public static final field Companion Lee/schimke/composeai/daemon/history/PruneResult$Companion;
+	public fun <init> (Ljava/util/List;J)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun copy (Ljava/util/List;J)Lee/schimke/composeai/daemon/history/PruneResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/PruneResult;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/history/PruneResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getRemovedEntryIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/history/PruneResult$Companion {
+	public final fun getEMPTY ()Lee/schimke/composeai/daemon/history/PruneResult;
+}
+
+public final class ee/schimke/composeai/daemon/history/ReportingBranchManifest {
+	public static final field Companion Lee/schimke/composeai/daemon/history/ReportingBranchManifest$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/history/ReportingBranchManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/ReportingBranchManifest;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/ReportingBranchManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getFormatVersion ()I
+	public final fun getGeneratedAt ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getSourceBranch ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/ReportingBranchManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/ReportingBranchManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/ReportingBranchManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/ReportingBranchManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/ReportingBranchManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/ReportingBranchPreview {
+	public static final field Companion Lee/schimke/composeai/daemon/history/ReportingBranchPreview$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/history/ReportingBranchPreview;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/ReportingBranchPreview;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/ReportingBranchPreview;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getDir ()Ljava/lang/String;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPngHash ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/ReportingBranchPreview$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/ReportingBranchPreview$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/ReportingBranchPreview;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/ReportingBranchPreview;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/ReportingBranchPreview$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/WorktreeInfo {
+	public static final field Companion Lee/schimke/composeai/daemon/history/WorktreeInfo$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/history/WorktreeInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/history/WorktreeInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/history/WorktreeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgentId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/history/WorktreeInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/history/WorktreeInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/history/WorktreeInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/history/WorktreeInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/WorktreeInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/history/WriteResult : java/lang/Enum {
+	public static final field SKIPPED_DUPLICATE Lee/schimke/composeai/daemon/history/WriteResult;
+	public static final field WRITTEN Lee/schimke/composeai/daemon/history/WriteResult;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/history/WriteResult;
+	public static fun values ()[Lee/schimke/composeai/daemon/history/WriteResult;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/AmbientOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/AmbientOverride$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;)Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBurnInProtectionRequired ()Ljava/lang/Boolean;
+	public final fun getDeviceHasLowBitAmbient ()Ljava/lang/Boolean;
+	public final fun getIdleTimeoutMs ()Ljava/lang/Long;
+	public final fun getState ()Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public final fun getUpdateTimeMillis ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/AmbientOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/AmbientOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/AmbientOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/AmbientOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/AmbientStateOverride : java/lang/Enum {
+	public static final field AMBIENT Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/AmbientStateOverride$Companion;
+	public static final field INACTIVE Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public static final field INTERACTIVE Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/AmbientStateOverride;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/AmbientStateOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/BackendKind : java/lang/Enum {
+	public static final field ANDROID Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/BackendKind$Companion;
+	public static final field DESKTOP Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/BackendKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/BackendKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ChangeType : java/lang/Enum {
+	public static final field CREATED Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ChangeType$Companion;
+	public static final field DELETED Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public static final field MODIFIED Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/ChangeType;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ChangeType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClasspathDirtyParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams;Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChangedPaths ()Ljava/util/List;
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getReason ()Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ClasspathDirtyParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ClasspathDirtyParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClasspathDirtyParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClasspathDirtyReason : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason$Companion;
+	public static final field FILE_CHANGED Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public static final field FINGERPRINT_MISMATCH Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public static final field MANIFEST_MISSING Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/ClasspathDirtyReason;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClasspathDirtyReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClientCapabilities {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ClientCapabilities$Companion;
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lee/schimke/composeai/daemon/protocol/ClientCapabilities;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ClientCapabilities;ZZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ClientCapabilities;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMetrics ()Z
+	public final fun getVisibility ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ClientCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ClientCapabilities$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ClientCapabilities;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ClientCapabilities$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileErrorDetail {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/CompileErrorDetail$Companion;
+	public fun <init> (Ljava/lang/String;IILjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;IILjava/lang/String;)Lee/schimke/composeai/daemon/protocol/CompileErrorDetail;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/CompileErrorDetail;Ljava/lang/String;IILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/CompileErrorDetail;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColumn ()I
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getLine ()I
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/CompileErrorDetail$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/CompileErrorDetail$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/CompileErrorDetail;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/CompileErrorDetail;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileErrorDetail$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileResultKind : java/lang/Enum {
+	public static final field COMPILE_ERROR Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/CompileResultKind$Companion;
+	public static final field FALLBACK Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public static final field OK Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileResultKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileSourcesParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/CompileSourcesParams$Companion;
+	public fun <init> (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;)V
+	public synthetic fun <init> (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/SourceChangeSet;
+	public final fun copy (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;)Lee/schimke/composeai/daemon/protocol/CompileSourcesParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/CompileSourcesParams;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/CompileSourcesParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChanges ()Lee/schimke/composeai/daemon/protocol/SourceChangeSet;
+	public final fun getSources ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/CompileSourcesParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/CompileSourcesParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/CompileSourcesParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/CompileSourcesParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileSourcesParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileSourcesResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/CompileSourcesResult$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/CompileResultKind;Ljava/util/List;J)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/CompileResultKind;Ljava/util/List;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()J
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/CompileResultKind;Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/CompileSourcesResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/CompileSourcesResult;Lee/schimke/composeai/daemon/protocol/CompileResultKind;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/CompileSourcesResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDurationMs ()J
+	public final fun getErrors ()Ljava/util/List;
+	public final fun getResult ()Lee/schimke/composeai/daemon/protocol/CompileResultKind;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/CompileSourcesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/CompileSourcesResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/CompileSourcesResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/CompileSourcesResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/CompileSourcesResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DaemonReadyParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DaemonReadyParams$Companion;
+	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DaemonReadyParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DaemonReadyParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DaemonReadyParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DaemonReadyParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DaemonReadyParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DaemonWarmingParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEtaMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DaemonWarmingParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DaemonWarmingParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DaemonWarmingParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataFetchParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataFetchParams$Companion;
+	public static final field PARAM_FORCE_RERENDER Ljava/lang/String;
+	public static final field PARAM_OVERRIDES Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Z)Lee/schimke/composeai/daemon/protocol/DataFetchParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataFetchParams;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataFetchParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInline ()Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getParams ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataFetchParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataFetchParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataFetchParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataFetchParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataFetchParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataFetchResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataFetchResult$Companion;
+	public fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataFetchResult;Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()Ljava/lang/String;
+	public final fun getExtras ()Ljava/util/List;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPayload ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSchemaVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataFetchResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataFetchResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataFetchResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataFetchResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataFetchResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductAttachment {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataProductAttachment$Companion;
+	public fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/DataProductAttachment;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataProductAttachment;Ljava/lang/String;ILkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataProductAttachment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtras ()Ljava/util/List;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPayload ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSchemaVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataProductAttachment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataProductAttachment$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataProductAttachment;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataProductAttachment;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductAttachment$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductCapability {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataProductCapability$Companion;
+	public fun <init> (Ljava/lang/String;ILee/schimke/composeai/daemon/protocol/DataProductTransport;ZZZLjava/lang/String;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;)V
+	public synthetic fun <init> (Ljava/lang/String;ILee/schimke/composeai/daemon/protocol/DataProductTransport;ZZZLjava/lang/String;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public final fun component2 ()I
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;ILee/schimke/composeai/daemon/protocol/DataProductTransport;ZZZLjava/lang/String;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;)Lee/schimke/composeai/daemon/protocol/DataProductCapability;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataProductCapability;Ljava/lang/String;ILee/schimke/composeai/daemon/protocol/DataProductTransport;ZZZLjava/lang/String;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataProductCapability;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachable ()Z
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getFacets ()Ljava/util/List;
+	public final fun getFetchable ()Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getMediaTypes ()Ljava/util/List;
+	public final fun getRequiresRerender ()Z
+	public final fun getSampling ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public final fun getSchemaVersion ()I
+	public final fun getTransport ()Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataProductCapability$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataProductCapability$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataProductCapability;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataProductCapability;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductCapability$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductExtra {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataProductExtra$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lee/schimke/composeai/daemon/protocol/DataProductExtra;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataProductExtra;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataProductExtra;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSizeBytes ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataProductExtra$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataProductExtra$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataProductExtra;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataProductExtra;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductExtra$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductFacet : java/lang/Enum {
+	public static final field ANIMATION Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field ARTIFACT Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field CHECK Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataProductFacet$Companion;
+	public static final field DIAGNOSTIC Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field IMAGE Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field INTERACTIVE Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field OVERLAY Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field PROFILE Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static final field STRUCTURED Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/DataProductFacet;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductFacet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductTransport : java/lang/Enum {
+	public static final field BOTH Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataProductTransport$Companion;
+	public static final field INLINE Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public static final field PATH Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/DataProductTransport;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataProductTransport$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataSubscribeParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataSubscribeParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/DataSubscribeParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataSubscribeParams;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getParams ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataSubscribeParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataSubscribeParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataSubscribeParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataSubscribeParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataSubscribeParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataSubscribeResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DataSubscribeResult$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOk ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DataSubscribeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DataSubscribeResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DataSubscribeResult$Companion {
+	public final fun getOK ()Lee/schimke/composeai/daemon/protocol/DataSubscribeResult;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DetectLeaks : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DetectLeaks$Companion;
+	public static final field HEAVY Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public static final field LIGHT Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public static final field OFF Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DetectLeaks$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()I
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;I)Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getChanged ()Ljava/util/List;
+	public final fun getRemoved ()Ljava/util/List;
+	public final fun getTotalPreviews ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/DiscoveryUpdatedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionInfoDto {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActive ()Z
+	public final fun getDataExtensionIds ()Ljava/util/List;
+	public final fun getDataProductKinds ()Ljava/util/List;
+	public final fun getDependencies ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPreviewExtensionIds ()Ljava/util/List;
+	public final fun getPubliclyEnabled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionInfoDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionInfoDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionInfoDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsDisableParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionsDisableParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionsDisableParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsDisableParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsDisableResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataExtensions ()Ljava/util/List;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getDeactivated ()Ljava/util/List;
+	public final fun getDisabled ()Ljava/util/List;
+	public final fun getNotEnabled ()Ljava/util/List;
+	public final fun getPreviewExtensions ()Ljava/util/List;
+	public final fun getStillActiveAsDependency ()Ljava/util/List;
+	public final fun getUnknown ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionsDisableResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionsDisableResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsDisableResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsEnableParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionsEnableParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionsEnableParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsEnableParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsEnableResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlreadyEnabled ()Ljava/util/List;
+	public final fun getDataExtensions ()Ljava/util/List;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getNewlyEnabled ()Ljava/util/List;
+	public final fun getPreviewExtensions ()Ljava/util/List;
+	public final fun getPulledIn ()Ljava/util/List;
+	public final fun getUnknown ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionsEnableResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionsEnableResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsEnableResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsListResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ExtensionsListResult$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtensions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ExtensionsListResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ExtensionsListResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ExtensionsListResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ExtensionsListResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FileChangedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/FileChangedParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/FileKind;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;)Lee/schimke/composeai/daemon/protocol/FileChangedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/FileChangedParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/FileKind;Lee/schimke/composeai/daemon/protocol/ChangeType;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/FileChangedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChangeType ()Lee/schimke/composeai/daemon/protocol/ChangeType;
+	public final fun getKind ()Lee/schimke/composeai/daemon/protocol/FileKind;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/FileChangedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/FileChangedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/FileChangedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/FileChangedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FileChangedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FileKind : java/lang/Enum {
+	public static final field CLASSPATH Lee/schimke/composeai/daemon/protocol/FileKind;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/FileKind$Companion;
+	public static final field RESOURCE Lee/schimke/composeai/daemon/protocol/FileKind;
+	public static final field SOURCE Lee/schimke/composeai/daemon/protocol/FileKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/FileKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/FileKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FileKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FocusDirection : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/FocusDirection$Companion;
+	public static final field Down Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static final field Left Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static final field Next Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static final field Previous Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static final field Right Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static final field Up Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/FocusDirection;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FocusDirection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FocusOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/FocusOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/FocusDirection;Ljava/lang/Integer;ZZZ)V
+	public synthetic fun <init> (Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/FocusDirection;Ljava/lang/Integer;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/FocusDirection;Ljava/lang/Integer;ZZZ)Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/FocusDirection;Ljava/lang/Integer;ZZZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirection ()Lee/schimke/composeai/daemon/protocol/FocusDirection;
+	public final fun getEnterPlacesFocus ()Z
+	public final fun getOverlay ()Z
+	public final fun getPressed ()Z
+	public final fun getStep ()Ljava/lang/Integer;
+	public final fun getTabIndex ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/FocusOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/FocusOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/FocusOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/FocusOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/GestureKindOverride : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/GestureKindOverride$Companion;
+	public static final field DISMISS Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public static final field PAGE Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public static final field PRIMARY Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public static final field SCROLL Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/GestureKindOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/GestureOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/GestureOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/GestureKindOverride;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/GestureKindOverride;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/GestureKindOverride;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/GestureOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/GestureKindOverride;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getInvoke ()Lee/schimke/composeai/daemon/protocol/GestureKindOverride;
+	public final fun getInvokeLabel ()Ljava/lang/String;
+	public final fun getShowHints ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/GestureOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/GestureOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/GestureOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/GestureOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryAddedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryAddedParams$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/HistoryAddedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryAddedParams;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryAddedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntry ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryAddedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryAddedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryAddedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryAddedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryAddedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffMode : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryDiffMode$Companion;
+	public static final field DATA Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public static final field METADATA Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public static final field PIXEL Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public static final field SEMANTICS Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryDiffParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/HistoryDiffParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryDiffParams;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryDiffParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getMode ()Lee/schimke/composeai/daemon/protocol/HistoryDiffMode;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryDiffParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryDiffParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryDiffParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryDiffParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryDiffResult$Companion;
+	public fun <init> (ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/HistoryDataDelta;)V
+	public synthetic fun <init> (ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/HistoryDataDelta;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public final fun component8 ()Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public final fun copy (ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/HistoryDataDelta;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/Long;Ljava/lang/Double;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Lee/schimke/composeai/daemon/history/HistoryDataDelta;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataDelta ()Lee/schimke/composeai/daemon/history/HistoryDataDelta;
+	public final fun getDiffPngPath ()Ljava/lang/String;
+	public final fun getDiffPx ()Ljava/lang/Long;
+	public final fun getFromMetadata ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getPngHashChanged ()Z
+	public final fun getSemanticsDelta ()Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public final fun getSsim ()Ljava/lang/Double;
+	public final fun getToMetadata ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryDiffResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryDiffResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryDiffResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryDiffResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryListParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryListParams$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/HistoryListParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryListParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryListParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgentId ()Ljava/lang/String;
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getBranchPattern ()Ljava/lang/String;
+	public final fun getCommit ()Ljava/lang/String;
+	public final fun getCursor ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getSince ()Ljava/lang/String;
+	public final fun getSourceId ()Ljava/lang/String;
+	public final fun getSourceKind ()Ljava/lang/String;
+	public final fun getUntil ()Ljava/lang/String;
+	public final fun getWorktreePath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryListParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryListParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryListParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryListParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryListParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryListResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryListResult$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun copy (Ljava/util/List;Ljava/lang/String;I)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryListResult;Ljava/util/List;Ljava/lang/String;IILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getNextCursor ()Ljava/lang/String;
+	public final fun getTotalCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryListResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryListResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryListResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryListResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryListResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneOptions {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;)Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoIntervalMs ()Ljava/lang/Long;
+	public final fun getMaxAgeDays ()Ljava/lang/Integer;
+	public final fun getMaxEntriesPerPreview ()Ljava/lang/Integer;
+	public final fun getMaxTotalSizeBytes ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryPruneOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryPruneParams$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Z)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;Z)Lee/schimke/composeai/daemon/protocol/HistoryPruneParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryPruneParams;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Long;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryPruneParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDryRun ()Z
+	public final fun getMaxAgeDays ()Ljava/lang/Integer;
+	public final fun getMaxEntriesPerPreview ()Ljava/lang/Integer;
+	public final fun getMaxTotalSizeBytes ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryPruneParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryPruneParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryPruneParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryPruneParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryPruneResult$Companion;
+	public fun <init> (Ljava/util/List;JLjava/util/Map;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;JLjava/util/Map;)Lee/schimke/composeai/daemon/protocol/HistoryPruneResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryPruneResult;Ljava/util/List;JLjava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryPruneResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getRemovedEntries ()Ljava/util/List;
+	public final fun getSourceResults ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryPruneResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryPruneResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryPruneResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryPruneResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult$Companion;
+	public fun <init> (Ljava/util/List;J)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun copy (Ljava/util/List;J)Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult;Ljava/util/List;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getRemovedEntryIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPruneSourceResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPrunedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams$Companion;
+	public fun <init> (Ljava/util/List;JLee/schimke/composeai/daemon/protocol/PruneReasonWire;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+	public final fun copy (Ljava/util/List;JLee/schimke/composeai/daemon/protocol/PruneReasonWire;)Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams;Ljava/util/List;JLee/schimke/composeai/daemon/protocol/PruneReasonWire;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFreedBytes ()J
+	public final fun getReason ()Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+	public final fun getRemovedIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryPrunedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryPrunedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryPrunedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryReadParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryReadParams$Companion;
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/HistoryReadParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryReadParams;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryReadParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInline ()Z
+	public final fun getRef ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryReadParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryReadParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryReadParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryReadParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryReadParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryReadResultDto {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto$Companion;
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntry ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getPngBytes ()Ljava/lang/String;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getPreviewMetadata ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/HistoryReadResultDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/HistoryReadResultDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/HistoryReadResultDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InitializeParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InitializeParams$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Lee/schimke/composeai/daemon/protocol/Options;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Lee/schimke/composeai/daemon/protocol/Options;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/ClientCapabilities;
+	public final fun component7 ()Lee/schimke/composeai/daemon/protocol/Options;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Lee/schimke/composeai/daemon/protocol/Options;)Lee/schimke/composeai/daemon/protocol/InitializeParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InitializeParams;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/ClientCapabilities;Lee/schimke/composeai/daemon/protocol/Options;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InitializeParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Lee/schimke/composeai/daemon/protocol/ClientCapabilities;
+	public final fun getClientVersion ()Ljava/lang/String;
+	public final fun getModuleId ()Ljava/lang/String;
+	public final fun getModuleProjectDir ()Ljava/lang/String;
+	public final fun getOptions ()Lee/schimke/composeai/daemon/protocol/Options;
+	public final fun getProtocolVersion ()I
+	public final fun getWorkspaceRoot ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InitializeParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InitializeParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InitializeParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InitializeParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InitializeParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InitializeResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InitializeResult$Companion;
+	public fun <init> (ILjava/lang/String;JLee/schimke/composeai/daemon/protocol/ServerCapabilities;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/Manifest;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/ServerCapabilities;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/Manifest;
+	public final fun copy (ILjava/lang/String;JLee/schimke/composeai/daemon/protocol/ServerCapabilities;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/Manifest;)Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InitializeResult;ILjava/lang/String;JLee/schimke/composeai/daemon/protocol/ServerCapabilities;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/Manifest;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapabilities ()Lee/schimke/composeai/daemon/protocol/ServerCapabilities;
+	public final fun getClasspathFingerprint ()Ljava/lang/String;
+	public final fun getDaemonVersion ()Ljava/lang/String;
+	public final fun getManifest ()Lee/schimke/composeai/daemon/protocol/Manifest;
+	public final fun getPid ()J
+	public final fun getProtocolVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InitializeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InitializeResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InitializeResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InitializeResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InitializeResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveInputKind : java/lang/Enum {
+	public static final field CLICK Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveInputKind$Companion;
+	public static final field KEY_DOWN Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field KEY_UP Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field POINTER_DOWN Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field POINTER_MOVE Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field POINTER_UP Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static final field ROTARY_SCROLL Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveInputKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveInputParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveInputParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Float;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getKeyCode ()Ljava/lang/String;
+	public final fun getKind ()Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public final fun getPixelX ()Ljava/lang/Integer;
+	public final fun getPixelY ()Ljava/lang/Integer;
+	public final fun getPointerId ()Ljava/lang/Integer;
+	public final fun getPointerType ()Ljava/lang/String;
+	public final fun getScrollDeltaY ()Ljava/lang/Float;
+	public final fun getTarget ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveInputParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveInputParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveInputParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveInputParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractivePointerType : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractivePointerType$Companion;
+	public static final field MOUSE Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+	public static final field PEN Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+	public static final field TOUCH Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractivePointerType$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractivePointerType;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams$Companion;
+	public fun <init> (Ljava/lang/String;F)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()F
+	public final fun copy (Ljava/lang/String;F)Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams;Ljava/lang/String;FILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getProgress ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveSetLottieParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;)Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChange ()Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveSetRemoteComposeParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStartParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveStartParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/protocol/InteractiveStartParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveStartParams;Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveStartParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInspectionMode ()Ljava/lang/Boolean;
+	public final fun getOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveStartParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveStartParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveStartParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveStartParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStartParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStartResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveStartResult$Companion;
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractiveStartResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveStartResult;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveStartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFallbackReason ()Ljava/lang/String;
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getHeldSession ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveStartResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveStartResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveStartResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveStartResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStartResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStopParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/InteractiveStopParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/InteractiveStopParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/InteractiveStopParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/InteractiveStopParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/InteractiveStopParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/InteractiveStopParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/InteractiveStopParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/InteractiveStopParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/InteractiveStopParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcError {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/JsonRpcError$Companion;
+	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/JsonRpcError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/JsonRpcError;ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/JsonRpcError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()I
+	public final fun getData ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/JsonRpcError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/JsonRpcError$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/JsonRpcError;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/JsonRpcError;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcError$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcNotification {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/JsonRpcNotification$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/JsonRpcNotification;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/JsonRpcNotification;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/JsonRpcNotification;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getJsonrpc ()Ljava/lang/String;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getParams ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/JsonRpcNotification$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/JsonRpcNotification$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/JsonRpcNotification;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/JsonRpcNotification;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcNotification$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcRequest {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/JsonRpcRequest$Companion;
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/JsonRpcRequest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/JsonRpcRequest;Ljava/lang/String;JLjava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/JsonRpcRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()J
+	public final fun getJsonrpc ()Ljava/lang/String;
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getParams ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/JsonRpcRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/JsonRpcRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/JsonRpcRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/JsonRpcRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcResponse {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/JsonRpcResponse$Companion;
+	public fun <init> (Ljava/lang/String;JLkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/protocol/JsonRpcError;)V
+	public synthetic fun <init> (Ljava/lang/String;JLkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/protocol/JsonRpcError;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/JsonRpcError;
+	public final fun copy (Ljava/lang/String;JLkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/protocol/JsonRpcError;)Lee/schimke/composeai/daemon/protocol/JsonRpcResponse;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/JsonRpcResponse;Ljava/lang/String;JLkotlinx/serialization/json/JsonElement;Lee/schimke/composeai/daemon/protocol/JsonRpcError;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/JsonRpcResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lee/schimke/composeai/daemon/protocol/JsonRpcError;
+	public final fun getId ()J
+	public final fun getJsonrpc ()Ljava/lang/String;
+	public final fun getResult ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/JsonRpcResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/JsonRpcResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/JsonRpcResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/JsonRpcResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/JsonRpcResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/KeyboardOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/KeyboardOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPressedKey ()Ljava/lang/String;
+	public final fun getVisible ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/KeyboardOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/KeyboardOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/KeyboardOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/KnownDevice {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/KnownDevice$Companion;
+	public fun <init> (Ljava/lang/String;IIFZ)V
+	public synthetic fun <init> (Ljava/lang/String;IIFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()F
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;IIFZ)Lee/schimke/composeai/daemon/protocol/KnownDevice;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/KnownDevice;Ljava/lang/String;IIFZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/KnownDevice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public final fun getHeightDp ()I
+	public final fun getId ()Ljava/lang/String;
+	public final fun getWidthDp ()I
+	public fun hashCode ()I
+	public final fun isRound ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/KnownDevice$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/KnownDevice$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/KnownDevice;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/KnownDevice;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/KnownDevice$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherResizeAxes : java/lang/Enum {
+	public static final field BOTH Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes$Companion;
+	public static final field HORIZONTAL Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public static final field NONE Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public static final field VERTICAL Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherResizeAxes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherResizeOrder : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder$Companion;
+	public static final field DIAGONAL Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public static final field HEIGHT_FIRST Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public static final field WIDTH_FIRST Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherResizeOrder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun component5 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/lang/Boolean;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/lang/Boolean;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCellSizeDp ()Ljava/lang/Integer;
+	public final fun getCellSpacingDp ()Ljava/lang/Integer;
+	public final fun getCells ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun getLauncherMode ()Ljava/lang/Boolean;
+	public final fun getMaxCells ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun getMinCells ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun getResizeOrder ()Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/LauncherWidgetOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetPayload {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;IIIILee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;Z)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;IIIILee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public final fun component9 ()Z
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;IIIILee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;Z)Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;IIIILee/schimke/composeai/daemon/protocol/LauncherResizeOrder;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCellSizeDp ()I
+	public final fun getCellSpacingDp ()I
+	public final fun getCells ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public final fun getHeightDp ()I
+	public final fun getLauncherMode ()Z
+	public final fun getResizeAxes ()Lee/schimke/composeai/daemon/protocol/LauncherResizeAxes;
+	public final fun getResizeOrder ()Lee/schimke/composeai/daemon/protocol/LauncherResizeOrder;
+	public final fun getSupportedCells ()Ljava/util/List;
+	public final fun getWidthDp ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/LauncherWidgetPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/LauncherWidgetPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetSize {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;IIILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/LauncherWidgetSize$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/LauncherWidgetSize;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LauncherWidgetSize$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LeakDetectionMode : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LeakDetectionMode$Companion;
+	public static final field HEAVY Lee/schimke/composeai/daemon/protocol/LeakDetectionMode;
+	public static final field LIGHT Lee/schimke/composeai/daemon/protocol/LeakDetectionMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/LeakDetectionMode;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/LeakDetectionMode;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LeakDetectionMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LogLevel : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LogLevel$Companion;
+	public static final field DEBUG Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public static final field ERROR Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public static final field INFO Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public static final field WARN Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/LogLevel;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LogLevel$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LogParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LogParams$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/LogLevel;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/LogLevel;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/LogLevel;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/daemon/protocol/LogParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/LogParams;Lee/schimke/composeai/daemon/protocol/LogLevel;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/LogParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getContext ()Ljava/util/Map;
+	public final fun getLevel ()Lee/schimke/composeai/daemon/protocol/LogLevel;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/LogParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/LogParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/LogParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/LogParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LogParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LottieOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/LottieOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Float;)V
+	public synthetic fun <init> (Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/Float;)Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/lang/Float;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProgress ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/LottieOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/LottieOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/LottieOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/LottieOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Manifest {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/Manifest$Companion;
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lee/schimke/composeai/daemon/protocol/Manifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/Manifest;Ljava/lang/String;IILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/Manifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPreviewCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/Manifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/Manifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/Manifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/Manifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Manifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Material3ThemeOverrides {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorScheme ()Ljava/util/Map;
+	public final fun getShapes ()Ljava/util/Map;
+	public final fun getTypography ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/Material3ThemeOverrides$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Material3ThemeOverrides$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Material3TypographyOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;)Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontSizeSp ()Ljava/lang/Float;
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getItalic ()Ljava/lang/Boolean;
+	public final fun getLetterSpacingSp ()Ljava/lang/Float;
+	public final fun getLineHeightSp ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/Material3TypographyOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/Material3TypographyOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Material3TypographyOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Options {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/Options$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/DetectLeaks;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/DetectLeaks;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/DetectLeaks;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;)Lee/schimke/composeai/daemon/protocol/Options;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/Options;Ljava/lang/Integer;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/DetectLeaks;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachDataProducts ()Ljava/util/List;
+	public final fun getDetectLeaks ()Lee/schimke/composeai/daemon/protocol/DetectLeaks;
+	public final fun getForeground ()Ljava/lang/Boolean;
+	public final fun getHistoryPrune ()Lee/schimke/composeai/daemon/protocol/HistoryPruneOptions;
+	public final fun getMaxHeapMb ()Ljava/lang/Integer;
+	public final fun getMaxRenderMs ()Ljava/lang/Long;
+	public final fun getWarmSpare ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/Options$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/Options$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/Options;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/Options;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Options$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Orientation : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/Orientation$Companion;
+	public static final field LANDSCAPE Lee/schimke/composeai/daemon/protocol/Orientation;
+	public static final field PORTRAIT Lee/schimke/composeai/daemon/protocol/Orientation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/Orientation;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/Orientation;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/Orientation$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride$Companion;
+	public static final field DENIED Lee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride;
+	public static final field GRANTED Lee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PermissionGrantStateOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PermissionsOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PermissionsOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGrants ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/PermissionsOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/PermissionsOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PermissionsOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewOverrides {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PreviewOverrides$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component10 ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun component11 ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Long;
+	public final fun component14 ()Ljava/lang/Long;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Ljava/lang/Boolean;
+	public final fun component18 ()Ljava/lang/Boolean;
+	public final fun component19 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component20 ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun component23 ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun component24 ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun component25 ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun component26 ()Ljava/lang/Boolean;
+	public final fun component27 ()Ljava/lang/Boolean;
+	public final fun component28 ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun component29 ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component30 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun component31 ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun component32 ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun component33 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Float;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/UiMode;Lee/schimke/composeai/daemon/protocol/Orientation;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Lee/schimke/composeai/daemon/protocol/AmbientOverride;Lee/schimke/composeai/daemon/protocol/GestureOverride;Lee/schimke/composeai/daemon/protocol/FocusOverride;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/KeyboardOverride;Lee/schimke/composeai/daemon/protocol/PermissionsOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;Lee/schimke/composeai/daemon/protocol/LottieOverride;Ljava/util/Map;IILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAmbient ()Lee/schimke/composeai/daemon/protocol/AmbientOverride;
+	public final fun getCaptureAdvanceMs ()Ljava/lang/Long;
+	public final fun getClearBackground ()Ljava/lang/Boolean;
+	public final fun getClockEpochMillis ()Ljava/lang/Long;
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFocus ()Lee/schimke/composeai/daemon/protocol/FocusOverride;
+	public final fun getFontScale ()Ljava/lang/Float;
+	public final fun getGestures ()Lee/schimke/composeai/daemon/protocol/GestureOverride;
+	public final fun getHeightPx ()Ljava/lang/Integer;
+	public final fun getInspectionMode ()Ljava/lang/Boolean;
+	public final fun getKeyboard ()Lee/schimke/composeai/daemon/protocol/KeyboardOverride;
+	public final fun getLauncherWidget ()Lee/schimke/composeai/daemon/protocol/LauncherWidgetOverride;
+	public final fun getLocaleTag ()Ljava/lang/String;
+	public final fun getLottie ()Lee/schimke/composeai/daemon/protocol/LottieOverride;
+	public final fun getMaterial3Theme ()Lee/schimke/composeai/daemon/protocol/Material3ThemeOverrides;
+	public final fun getMaxHeightPx ()Ljava/lang/Integer;
+	public final fun getMaxWidthPx ()Ljava/lang/Integer;
+	public final fun getMinHeightPx ()Ljava/lang/Integer;
+	public final fun getMinWidthPx ()Ljava/lang/Integer;
+	public final fun getNamedOverrides ()Ljava/util/Map;
+	public final fun getOrientation ()Lee/schimke/composeai/daemon/protocol/Orientation;
+	public final fun getPermissions ()Lee/schimke/composeai/daemon/protocol/PermissionsOverride;
+	public final fun getPlaceholderActive ()Ljava/lang/Boolean;
+	public final fun getRemoteCompose ()Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public final fun getSlotMode ()Ljava/lang/Boolean;
+	public final fun getSvgBackground ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public final fun getTalkBack ()Ljava/lang/Boolean;
+	public final fun getThemeProvider ()Ljava/lang/String;
+	public final fun getTouchOverlay ()Ljava/lang/Boolean;
+	public final fun getUiMode ()Lee/schimke/composeai/daemon/protocol/UiMode;
+	public final fun getWallpaper ()Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public final fun getWidthPx ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/PreviewOverrides$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/PreviewOverrides$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewOverrides$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowDto {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PreviewRowDto$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PreviewRowDto;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/PreviewRowDto;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/PreviewRowDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIndex ()I
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/PreviewRowDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/PreviewRowDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/PreviewRowDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/PreviewRowDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowsParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PreviewRowsParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PreviewRowsParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/PreviewRowsParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/PreviewRowsParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/PreviewRowsParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/PreviewRowsParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/PreviewRowsParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/PreviewRowsParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowsParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowsResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PreviewRowsResult$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/PreviewRowsResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/PreviewRowsResult;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/PreviewRowsResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/PreviewRowsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/PreviewRowsResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/PreviewRowsResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/PreviewRowsResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PreviewRowsResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PruneReasonWire : java/lang/Enum {
+	public static final field AUTO Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/PruneReasonWire$Companion;
+	public static final field MANUAL Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/PruneReasonWire;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/PruneReasonWire$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingA11yFinding {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingA11yFinding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingA11yFinding;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingA11yFinding$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingEncodeParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingFormat;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormat ()Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public final fun getRecordingId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingEncodeParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingEncodeParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingEncodeParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingEncodeResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getSizeBytes ()J
+	public final fun getVideoPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingEncodeResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingEncodeResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingEncodeResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingFormat : java/lang/Enum {
+	public static final field APNG Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingFormat$Companion;
+	public static final field GIF Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public static final field MP4 Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public static final field WEBM Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RecordingFormat;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingFormat$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getComposableInvocation ()Ljava/lang/String;
+	public final fun getEvents ()Ljava/util/List;
+	public final fun getMethodName ()Ljava/lang/String;
+	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingGenerateTestResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingInputParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingInputParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Float;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingInputParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingInputParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingInputParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyCode ()Ljava/lang/String;
+	public final fun getKind ()Lee/schimke/composeai/daemon/protocol/InteractiveInputKind;
+	public final fun getPixelX ()Ljava/lang/Integer;
+	public final fun getPixelY ()Ljava/lang/Integer;
+	public final fun getPointerId ()Ljava/lang/Integer;
+	public final fun getPointerType ()Ljava/lang/String;
+	public final fun getRecordingId ()Ljava/lang/String;
+	public final fun getScrollDeltaY ()Ljava/lang/Float;
+	public final fun getTarget ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingInputParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingInputParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingInputParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingInputParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingInputParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingProbeNode {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingProbeNode$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClickable ()Z
+	public final fun getContentDescription ()Ljava/lang/String;
+	public final fun getMergedText ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingProbeNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingProbeNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingProbeNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingProbeNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEvent {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent$Companion;
+	public fun <init> (JLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/Float;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component17 ()Ljava/lang/Boolean;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/Float;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;JLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackEdge ()Ljava/lang/String;
+	public final fun getBackProgress ()Ljava/lang/Float;
+	public final fun getCheckpointId ()Ljava/lang/String;
+	public final fun getDeepLinkUri ()Ljava/lang/String;
+	public final fun getInputText ()Ljava/lang/String;
+	public final fun getKeyCode ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLifecycleEvent ()Ljava/lang/String;
+	public final fun getNodeContentDescription ()Ljava/lang/String;
+	public final fun getPixelX ()Ljava/lang/Integer;
+	public final fun getPixelY ()Ljava/lang/Integer;
+	public final fun getPointerId ()Ljava/lang/Integer;
+	public final fun getPointerType ()Ljava/lang/String;
+	public final fun getScrollDeltaY ()Ljava/lang/Float;
+	public final fun getSelector ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getTMs ()J
+	public final fun getTags ()Ljava/util/List;
+	public final fun getTarget ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUseUnmergedTree ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingScriptEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingScriptEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus : java/lang/Enum {
+	public static final field APPLIED Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus$Companion;
+	public static final field FAILED Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public static final field UNSUPPORTED Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEvidence {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence$Companion;
+	public fun <init> (JLjava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Ljava/util/List;)V
+	public synthetic fun <init> (JLjava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public final fun copy (JLjava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;JLjava/lang/String;Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheckpointId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLifecycleEvent ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getProbeSemantics ()Ljava/util/List;
+	public final fun getStatus ()Lee/schimke/composeai/daemon/protocol/RecordingScriptEventStatus;
+	public final fun getTMs ()J
+	public final fun getTags ()Ljava/util/List;
+	public final fun getTargetUnresolvedReason ()Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+	public final fun getUnsupportedReason ()Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingScriptEvidence$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingScriptEvidence;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptEvidence$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingScriptParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RecordingScriptParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingScriptParams;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingScriptParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvents ()Ljava/util/List;
+	public final fun getRecordingId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingScriptParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingScriptParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingScriptParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingScriptParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingScriptParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStartParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingStartParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;Z)Lee/schimke/composeai/daemon/protocol/RecordingStartParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingStartParams;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Float;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStartParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFps ()Ljava/lang/Integer;
+	public final fun getLive ()Z
+	public final fun getOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getScale ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingStartParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingStartParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingStartParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingStartParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStartParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStartResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingStartResult$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingStartResult;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecordingId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingStartResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingStartResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingStartResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingStartResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStartResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStopParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingStopParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RecordingStopParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingStopParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStopParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRecordingId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingStopParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingStopParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingStopParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingStopParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStopParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStopResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RecordingStopResult$Companion;
+	public fun <init> (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (IJLjava/lang/String;IILjava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RecordingStopResult;IJLjava/lang/String;IILjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapturedScript ()Ljava/util/List;
+	public final fun getDurationMs ()J
+	public final fun getFrameCount ()I
+	public final fun getFrameHeightPx ()I
+	public final fun getFrameWidthPx ()I
+	public final fun getFramesDir ()Ljava/lang/String;
+	public final fun getScriptEvents ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RecordingStopResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RecordingStopResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RecordingStopResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RecordingStopResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RecordingStopResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RejectedRender {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RejectedRender$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RejectedRender;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RejectedRender;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RejectedRender;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RejectedRender$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RejectedRender$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RejectedRender;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RejectedRender;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RejectedRender$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class ee/schimke/composeai/daemon/protocol/RemoteComposeChange {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lee/schimke/composeai/daemon/protocol/RemoteComposeChange;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue : ee/schimke/composeai/daemon/protocol/RemoteComposeChange {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getValue ()Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$NamedValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile : ee/schimke/composeai/daemon/protocol/RemoteComposeChange {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile$Companion;
+	public fun <init> ()V
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeChange$Profile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride$Companion;
+	public fun <init> ()V
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;)Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;Ljava/util/Map;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcceptedHostActions ()Ljava/util/List;
+	public final fun getNamedValues ()Ljava/util/Map;
+	public final fun getPlayer ()Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public final fun getProfile ()Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteComposeOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteComposeOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind$Companion;
+	public static final field EMBEDDED Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public static final field VIEW Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposePlayerKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeProfile : java/lang/Enum {
+	public static final field ANDROIDX Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field ANDROIDX7 Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field ANDROIDX8 Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field ANDROIDX9 Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile$Companion;
+	public static final field WEAR_WIDGETS Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field WIDGETS_V6 Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static final field WIDGETS_V7 Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RemoteComposeProfile;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteComposeProfile$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteHostAction {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteHostAction$Companion;
+	public fun <init> (Ljava/lang/String;FJ)V
+	public synthetic fun <init> (Ljava/lang/String;FJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()F
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;FJ)Lee/schimke/composeai/daemon/protocol/RemoteHostAction;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteHostAction;Ljava/lang/String;FJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteHostAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFiredAtMillis ()J
+	public final fun getHandlerId ()F
+	public final fun getPayload ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteHostAction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteHostAction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteHostAction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteHostAction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteHostAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$Companion;
+	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public static final synthetic fun write$Self (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$BooleanValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgb ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$ColorValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue$Companion;
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue;FILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$DpValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue$Companion;
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue;FILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$FloatValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue$Companion;
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue;IILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$IntValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue : ee/schimke/composeai/daemon/protocol/RemoteNamedValue {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RemoteNamedValue$StringValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderError {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderError$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RenderError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderError;Lee/schimke/composeai/daemon/protocol/RenderErrorKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStackTrace ()Ljava/lang/String;
+	public final fun getSuggestion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderError$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderError$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderError;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderError;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderError$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderErrorKind : java/lang/Enum {
+	public static final field CAPTURE Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field CLASSPATH_SKEW Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field COMPILE Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderErrorKind$Companion;
+	public static final field INTERNAL Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field MISSING_COMPOSABLE Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field RUNTIME Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field SDK_MISMATCH Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field TIMEOUT Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field UNKNOWN Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static final field UNSET_PARAMETER Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderErrorKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderErrorKindSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderErrorKindSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderErrorKind;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderErrorKind;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderFailedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderFailedParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RenderError;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RenderError;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RenderError;)Lee/schimke/composeai/daemon/protocol/RenderFailedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderFailedParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/RenderError;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderFailedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Lee/schimke/composeai/daemon/protocol/RenderError;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderFailedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderFailedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderFailedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderFailedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderFailedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderFinishedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderFinishedParams$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Ljava/util/List;Ljava/lang/Boolean;)Lee/schimke/composeai/daemon/protocol/RenderFinishedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderFinishedParams;Ljava/lang/String;Ljava/lang/String;JLee/schimke/composeai/daemon/protocol/RenderMetrics;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderFinishedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMetrics ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getTookMs ()J
+	public final fun getUnchanged ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderFinishedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderFinishedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderFinishedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderFinishedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderFinishedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderMetrics {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderMetrics$Companion;
+	public static final field KEY_HEAP_AFTER_GC_MB Ljava/lang/String;
+	public static final field KEY_NATIVE_HEAP_MB Ljava/lang/String;
+	public static final field KEY_SANDBOX_AGE_MS Ljava/lang/String;
+	public static final field KEY_SANDBOX_AGE_RENDERS Ljava/lang/String;
+	public fun <init> (JJJJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (JJJJ)Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderMetrics;JJJJILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeapAfterGcMb ()J
+	public final fun getNativeHeapMb ()J
+	public final fun getSandboxAgeMs ()J
+	public final fun getSandboxAgeRenders ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderMetrics$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderMetrics$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderMetrics;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderMetrics$Companion {
+	public final fun fromFlatMap (Ljava/util/Map;)Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult {
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$AbsentSource : ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$AbsentSource;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$PartialMap : ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$PartialMap;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$PartialMap;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$PartialMap;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMissingKeys ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$Populated : ee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult {
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/RenderMetrics;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/RenderMetrics;)Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$Populated;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$Populated;Lee/schimke/composeai/daemon/protocol/RenderMetrics;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderMetrics$FromFlatMapResult$Populated;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMetrics ()Lee/schimke/composeai/daemon/protocol/RenderMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderNowParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderNowParams$Companion;
+	public fun <init> (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+	public synthetic fun <init> (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/RenderTier;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun copy (Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/protocol/RenderNowParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderNowParams;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/RenderTier;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderNowParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getTier ()Lee/schimke/composeai/daemon/protocol/RenderTier;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderNowParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderNowParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderNowParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderNowParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderNowParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderNowResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderNowResult$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderNowResult;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQueued ()Ljava/util/List;
+	public final fun getRejected ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderNowResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderNowResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderNowResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderNowResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderNowResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderStartedParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderStartedParams$Companion;
+	public fun <init> (Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun copy (Ljava/lang/String;J)Lee/schimke/composeai/daemon/protocol/RenderStartedParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/RenderStartedParams;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/RenderStartedParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getQueuedMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/RenderStartedParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/RenderStartedParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/RenderStartedParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/RenderStartedParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderStartedParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderTier : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/RenderTier$Companion;
+	public static final field FAST Lee/schimke/composeai/daemon/protocol/RenderTier;
+	public static final field FULL Lee/schimke/composeai/daemon/protocol/RenderTier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/RenderTier;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/RenderTier;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/RenderTier$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SandboxRecycleParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;JJZ)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()Z
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;JJZ)Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams;Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;JJZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgeMs ()J
+	public final fun getReason ()Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public final fun getRenderCount ()J
+	public final fun getWarmSpareReady ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SandboxRecycleParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SandboxRecycleParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SandboxRecycleParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SandboxRecycleReason : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason$Companion;
+	public static final field HEAP_CEILING Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field HEAP_DRIFT Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field HISTOGRAM_DRIFT Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field LEAK_SUSPECTED Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field MANUAL Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field RENDER_COUNT Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static final field RENDER_TIME_DRIFT Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/SandboxRecycleReason;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SandboxRecycleReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsInputTarget {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SemanticsInputTarget$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsInputTarget$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInRoot ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetCandidate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode : java/lang/Enum {
+	public static final field AMBIGUOUS Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode$Companion;
+	public static final field NO_MATCH Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public static final field NO_SEMANTICS_ROOT Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;ILjava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;ILjava/util/List;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;ILjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCandidates ()Ljava/util/List;
+	public final fun getCode ()Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedCode;
+	public final fun getMatchCount ()I
+	public final fun getTarget ()Lee/schimke/composeai/daemon/protocol/SemanticsInputTarget;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ServerCapabilities {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/ServerCapabilities$Companion;
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/BackendKind;Ljava/lang/Integer;Ljava/util/List;)V
+	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/BackendKind;Ljava/lang/Integer;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (ZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/BackendKind;Ljava/lang/Integer;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/ServerCapabilities;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/ServerCapabilities;ZZLjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZZZLjava/util/List;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/daemon/protocol/BackendKind;Ljava/lang/Integer;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/ServerCapabilities;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAndroidSdk ()Ljava/lang/Integer;
+	public final fun getBackend ()Lee/schimke/composeai/daemon/protocol/BackendKind;
+	public final fun getDataExtensions ()Ljava/util/List;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getIncrementalDiscovery ()Z
+	public final fun getInteractive ()Z
+	public final fun getInteractiveControlKinds ()Ljava/util/List;
+	public final fun getKnownDevices ()Ljava/util/List;
+	public final fun getLeakDetection ()Ljava/util/List;
+	public final fun getPreviewExtensions ()Ljava/util/List;
+	public final fun getRecording ()Z
+	public final fun getRecordingFormats ()Ljava/util/List;
+	public final fun getSandboxRecycle ()Z
+	public final fun getSupportedOverrides ()Ljava/util/List;
+	public final fun getXr ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/ServerCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/ServerCapabilities$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/ServerCapabilities;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/ServerCapabilities;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/ServerCapabilities$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SetFocusParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SetFocusParams$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/SetFocusParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SetFocusParams;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SetFocusParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SetFocusParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SetFocusParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SetFocusParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SetFocusParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SetFocusParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SetVisibleParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SetVisibleParams$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/SetVisibleParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SetVisibleParams;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SetVisibleParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SetVisibleParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SetVisibleParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SetVisibleParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SetVisibleParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SetVisibleParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SourceChangeSet {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/SourceChangeSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/daemon/protocol/SourceChangeSet;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/SourceChangeSet;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/SourceChangeSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getModified ()Ljava/util/List;
+	public final fun getRemoved ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/SourceChangeSet$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/SourceChangeSet$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/SourceChangeSet;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/SourceChangeSet;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/SourceChangeSet$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamCodec : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamCodec$Companion;
+	public static final field PNG Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public static final field WEBP Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/StreamCodec;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamCodec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamFrameHeader {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamFrameHeader$Companion;
+	public static final field HEADER_BYTES I
+	public static final field MAGIC B
+	public static final field VERSION B
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/StreamCodec;JJIIZZI)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()I
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/StreamCodec;JJIIZZI)Lee/schimke/composeai/daemon/protocol/StreamFrameHeader;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamFrameHeader;Lee/schimke/composeai/daemon/protocol/StreamCodec;JJIIZZIILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamFrameHeader;
+	public final fun encodeTo ([B)[B
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getFinal ()Z
+	public final fun getHeightPx ()I
+	public final fun getKeyframe ()Z
+	public final fun getPayloadLen ()I
+	public final fun getPtsMillis ()J
+	public final fun getSeq ()J
+	public final fun getWidthPx ()I
+	public fun hashCode ()I
+	public final fun pack ()[B
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamFrameHeader$Companion {
+	public final fun parse ([BI)Lee/schimke/composeai/daemon/protocol/StreamFrameHeader;
+	public static synthetic fun parse$default (Lee/schimke/composeai/daemon/protocol/StreamFrameHeader$Companion;[BIILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamFrameHeader;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamFrameParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamFrameParams$Companion;
+	public fun <init> (Ljava/lang/String;JJIILee/schimke/composeai/daemon/protocol/StreamCodec;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JJIILee/schimke/composeai/daemon/protocol/StreamCodec;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JJIILee/schimke/composeai/daemon/protocol/StreamCodec;ZZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/StreamFrameParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamFrameParams;Ljava/lang/String;JJIILee/schimke/composeai/daemon/protocol/StreamCodec;ZZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamFrameParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getFinal ()Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getHeightPx ()I
+	public final fun getKeyframe ()Z
+	public final fun getPayloadBase64 ()Ljava/lang/String;
+	public final fun getPtsMillis ()J
+	public final fun getSeq ()J
+	public final fun getWidthPx ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/StreamFrameParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/StreamFrameParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/StreamFrameParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/StreamFrameParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamFrameParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStartParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamStartParams$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;)Lee/schimke/composeai/daemon/protocol/StreamStartParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamStartParams;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/PreviewOverrides;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStartParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getHidpi ()Ljava/lang/Boolean;
+	public final fun getInspectionMode ()Ljava/lang/Boolean;
+	public final fun getMaxFps ()Ljava/lang/Integer;
+	public final fun getOverrides ()Lee/schimke/composeai/daemon/protocol/PreviewOverrides;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/StreamStartParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/StreamStartParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/StreamStartParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/StreamStartParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStartParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStartResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamStartResult$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZLjava/lang/String;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamStartResult;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getFallbackReason ()Ljava/lang/String;
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getHeldSession ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/StreamStartResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/StreamStartResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/StreamStartResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/StreamStartResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStartResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStopParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamStopParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/StreamStopParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamStopParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamStopParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/StreamStopParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/StreamStopParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/StreamStopParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/StreamStopParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamStopParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamVisibilityParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams$Companion;
+	public fun <init> (Ljava/lang/String;ZLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/Integer;)Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams;Ljava/lang/String;ZLjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFps ()Ljava/lang/Integer;
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getVisible ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/StreamVisibilityParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/StreamVisibilityParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/StreamVisibilityParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActions ()Ljava/util/List;
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getContentDescription ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason$Companion;
+	public fun <init> (Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;Ljava/lang/String;Ljava/lang/String;ZILee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;)V
+	public synthetic fun <init> (Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;Ljava/lang/String;Ljava/lang/String;ZILee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()I
+	public final fun component6 ()Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;
+	public final fun copy (Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;Ljava/lang/String;Ljava/lang/String;ZILee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;Ljava/lang/String;Ljava/lang/String;ZILee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActionKind ()Ljava/lang/String;
+	public final fun getCode ()Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public final fun getMatchCount ()I
+	public final fun getNearMatch ()Lee/schimke/composeai/daemon/protocol/UiAutomatorNearMatchNode;
+	public final fun getSelectorJson ()Ljava/lang/String;
+	public final fun getUseUnmergedTree ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode : java/lang/Enum {
+	public static final field ACTION_NOT_EXPOSED Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode$Companion;
+	public static final field MISSING_INPUT_TEXT Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field MISSING_SELECTOR Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field MULTIPLE_MATCHES Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field NO_HOST_SUPPORT Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field NO_MATCH Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static final field UNKNOWN_ACTION_KIND Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReasonCode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiMode : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/UiMode$Companion;
+	public static final field DARK Lee/schimke/composeai/daemon/protocol/UiMode;
+	public static final field LIGHT Lee/schimke/composeai/daemon/protocol/UiMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/UiMode;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/UiMode;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/UiMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/WallpaperOverride {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/WallpaperOverride$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;Ljava/lang/Double;)Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/WallpaperOverride;Ljava/lang/String;Ljava/lang/Boolean;Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;Ljava/lang/Double;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContrastLevel ()Ljava/lang/Double;
+	public final fun getPaletteStyle ()Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public final fun getSeedColor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isDark ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/WallpaperOverride$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/WallpaperOverride$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/WallpaperOverride;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/WallpaperOverride;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/WallpaperOverride$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle : java/lang/Enum {
+	public static final field CONTENT Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle$Companion;
+	public static final field EXPRESSIVE Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field FIDELITY Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field FRUIT_SALAD Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field MONOCHROME Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field NEUTRAL Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field RAINBOW Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field TONAL_SPOT Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static final field VIBRANT Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+	public static fun values ()[Lee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/WallpaperPaletteStyle$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStartParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrStartParams$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/StreamCodec;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/StreamCodec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/StreamCodec;)Lee/schimke/composeai/daemon/protocol/XrStartParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrStartParams;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Lee/schimke/composeai/daemon/protocol/StreamCodec;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrStartParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getEnvironment ()Ljava/lang/String;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getMaxFps ()Ljava/lang/Integer;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getScene ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSceneDir ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrStartParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrStartParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrStartParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrStartParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStartParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStartResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrStartResult$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;Z)Lee/schimke/composeai/daemon/protocol/XrStartResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrStartResult;Ljava/lang/String;Lee/schimke/composeai/daemon/protocol/StreamCodec;ZILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrStartResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailable ()Z
+	public final fun getCodec ()Lee/schimke/composeai/daemon/protocol/StreamCodec;
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrStartResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrStartResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrStartResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrStartResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStartResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStopParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrStopParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/XrStopParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrStopParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrStopParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrStopParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrStopParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrStopParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrStopParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStopParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStructureParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrStructureParams$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/daemon/protocol/XrStructureParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrStructureParams;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrStructureParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrStructureParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrStructureParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrStructureParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrStructureParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStructureParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStructureResult {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrStructureResult$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/daemon/protocol/XrStructureResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrStructureResult;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrStructureResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getStructure ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrStructureResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrStructureResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrStructureResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrStructureResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrStructureResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams {
+	public static final field Companion Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonArray;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonArray;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonArray;)Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams;Ljava/lang/String;Lkotlinx/serialization/json/JsonArray;ILjava/lang/Object;)Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameStreamId ()Ljava/lang/String;
+	public final fun getPanels ()Lkotlinx/serialization/json/JsonArray;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/daemon/protocol/XrUpdatePanelsParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -111,3 +111,26 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2025")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This is the JSON-RPC protocol contract an extracted preview server compiles against across a
+  // repo boundary (#3824), and the widest surface of the twelve: 776 declarations. An
+  // implicitly-public declaration here is an API decision nobody made.
+  //
+  // All of it is already in a shipped ABI, so the annotations record the existing surface rather
+  // than changing it — narrowing any of these to `internal` would be a breaking change and is
+  // deliberately not part of this pass. (`:daemon-client` in #4558 was the one module where
+  // narrowing was free, because it had never been published.)
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*`, `:daemon-client` and the eight contracts in #4561.
+  // `checkKotlinAbi` diffs the real public ABI against the committed dump in `api/`, so a change to
+  // the protocol surface is a diff in review rather than a downstream break. Regenerate with
+  // `./gradlew :daemon:core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ApngEncoder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ApngEncoder.kt
@@ -43,7 +43,7 @@ import okio.Path.Companion.toPath
  *
  * **Loop count.** `0` means "infinite" per APNG spec — that's the default.
  */
-object ApngEncoder {
+public object ApngEncoder {
 
   private val PNG_SIGNATURE = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10) // 0x89 PNG\r\n SUB \n
   private const val CHUNK_TYPE_IHDR = "IHDR"
@@ -53,7 +53,7 @@ object ApngEncoder {
   private const val CHUNK_TYPE_FCTL = "fcTL"
   private const val CHUNK_TYPE_FDAT = "fdAT"
 
-  fun encodeFromPngFrames(
+  public fun encodeFromPngFrames(
     frames: List<File>,
     delayNumerator: Short,
     delayDenominator: Short,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/BundleIrReplayStore.kt
@@ -25,23 +25,27 @@ import okio.Path.Companion.toPath
  * so [lookup] is always a cheap no-op there. Format strings are kept in lockstep with `IR_FORMAT_*`
  * in `:gradle-plugin` / `IrSidecarChannel` in `:data-render-core`.
  */
-object BundleIrReplayStore {
+public object BundleIrReplayStore {
 
-  const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
+  public const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
 
-  const val FORMAT_PROTOLAYOUT: String = "protolayout"
+  public const val FORMAT_PROTOLAYOUT: String = "protolayout"
 
   /** One preview's resolved IR. [resourcesBytes] is non-null only for protolayout. */
-  class Entry(val format: String, val bytes: ByteArray, val resourcesBytes: ByteArray?)
+  public class Entry(
+    public val format: String,
+    public val bytes: ByteArray,
+    public val resourcesBytes: ByteArray?,
+  )
 
-  const val BUNDLE_MANIFEST_PATH_PROP: String = "composeai.daemon.bundleManifestPath"
+  public const val BUNDLE_MANIFEST_PATH_PROP: String = "composeai.daemon.bundleManifestPath"
 
-  const val IR_DIR_PROP: String = "composeai.daemon.irDir"
+  public const val IR_DIR_PROP: String = "composeai.daemon.irDir"
 
   @Volatile private var cached: Map<String, Entry>? = null
 
   /** The resolved IR for [previewId], or `null` when this preview isn't IR-backed. */
-  fun lookup(previewId: String?): Entry? {
+  public fun lookup(previewId: String?): Entry? {
     if (previewId == null) return null
     return entries()[previewId]
   }
@@ -49,7 +53,7 @@ object BundleIrReplayStore {
   private fun entries(): Map<String, Entry> = cached ?: load().also { cached = it }
 
   /** Visible for tests — load from explicit paths instead of the system properties. */
-  fun loadFrom(
+  public fun loadFrom(
     bundleManifestFile: File,
     irDir: File,
     fileSystem: FileSystem = SystemFileSystem,
@@ -82,7 +86,7 @@ object BundleIrReplayStore {
   }
 
   /** Test seam — drop the cached map so a follow-up [lookup] reloads from the (new) sysprops. */
-  fun resetForTest() {
+  public fun resetForTest() {
     cached = null
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ClasspathFingerprint.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ClasspathFingerprint.kt
@@ -43,21 +43,21 @@ import java.security.MessageDigest
  * responsible for serialising recomputation; in practice this happens on the single read thread, so
  * no locking is needed.
  */
-class ClasspathFingerprint(
+public class ClasspathFingerprint(
   /**
    * Cheap-signal file set. The daemon recomputes [cheapHash] on every `fileChanged` notification
    * tagged `kind: "classpath"` — so the set should stay small (single-digit files) and stable for
    * the lifetime of the daemon. `libs.versions.toml`, `*.gradle.kts`, `settings.gradle.kts`,
    * `gradle.properties`, `local.properties` per DESIGN § 8.
    */
-  val cheapSignalFiles: List<File>,
+  public val cheapSignalFiles: List<File>,
   /**
    * Authoritative classpath. Hashed over `(absolutePath, length, lastModified)` per entry — bytes
    * are intentionally NOT read (a 200-JAR Compose classpath would cost hundreds of ms per check).
    * The mtime/size pair is sufficient for a build-system-driven classpath: gradle's resolved
    * artefact cache touches the JAR's mtime when the version changes.
    */
-  val classpathEntries: List<File>,
+  public val classpathEntries: List<File>,
 ) {
 
   /**
@@ -65,7 +65,7 @@ class ClasspathFingerprint(
    * (insertion order in the constructor list); a file that doesn't exist contributes its absolute
    * path string only.
    */
-  fun cheapHash(): String {
+  public fun cheapHash(): String {
     val md = MessageDigest.getInstance(SHA_256)
     for (file in cheapSignalFiles) {
       md.update(file.absolutePath.toByteArray(Charsets.UTF_8))
@@ -94,7 +94,7 @@ class ClasspathFingerprint(
    * hash; a JAR being temporarily missing during a Gradle re-resolve would too, but Gradle
    * re-resolves are atomic from the daemon's POV (it doesn't watch them mid-flight).
    */
-  fun classpathHash(): String {
+  public fun classpathHash(): String {
     val md = MessageDigest.getInstance(SHA_256)
     for (file in classpathEntries) {
       md.update(file.absolutePath.toByteArray(Charsets.UTF_8))
@@ -109,21 +109,22 @@ class ClasspathFingerprint(
   }
 
   /** Composite snapshot — the daemon stores this at startup as the reference. */
-  fun snapshot(): Snapshot = Snapshot(cheapHash = cheapHash(), classpathHash = classpathHash())
+  public fun snapshot(): Snapshot =
+    Snapshot(cheapHash = cheapHash(), classpathHash = classpathHash())
 
   /** Pair of hashes recorded at a single point in time. */
-  data class Snapshot(val cheapHash: String, val classpathHash: String)
+  public data class Snapshot(val cheapHash: String, val classpathHash: String)
 
-  companion object {
+  public companion object {
     /**
      * Sysprop the gradle plugin's `composePreviewDaemonStart` task sets to a colon-delimited
      * (`File.pathSeparator`) list of absolute paths in the cheap-signal file set. Read by
      * [parseCheapSignalFilesSysprop] at daemon startup.
      */
-    const val CHEAP_SIGNAL_FILES_PROP: String = "composeai.daemon.cheapSignalFiles"
+    public const val CHEAP_SIGNAL_FILES_PROP: String = "composeai.daemon.cheapSignalFiles"
 
     /** SHA-256 hash size — used by tests to assert hex-string length. */
-    const val SHA_256_HEX_LENGTH: Int = 64
+    public const val SHA_256_HEX_LENGTH: Int = 64
 
     private const val SHA_256: String = "SHA-256"
     private const val BUFFER_SIZE: Int = 64 * 1024
@@ -136,7 +137,7 @@ class ClasspathFingerprint(
      * daemon respawn). That's the pre-B2.1 fallback and it's what the harness's fake-mode scenarios
      * deliberately use so they don't drift on B2.1's Tier-1 logic.
      */
-    fun parseCheapSignalFilesSysprop(
+    public fun parseCheapSignalFilesSysprop(
       value: String? = System.getProperty(CHEAP_SIGNAL_FILES_PROP)
     ): List<File> {
       if (value.isNullOrBlank()) return emptyList()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.render.PreviewContext
 import kotlinx.serialization.json.JsonElement
@@ -10,10 +11,10 @@ import kotlinx.serialization.json.JsonElement
  * Capabilities are concatenated in constructor order; kind routing uses the first registry that
  * advertises the kind.
  */
-class CompositeDataProductRegistry(private val registries: List<DataProductRegistry>) :
+public class CompositeDataProductRegistry(private val registries: List<DataProductRegistry>) :
   DataProductRegistry {
 
-  override val capabilities = registries.flatMap { it.capabilities }
+  override val capabilities: List<DataProductCapability> = registries.flatMap { it.capabilities }
 
   override fun isKnown(kind: String): Boolean = registries.any { it.isKnown(kind) }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonLaunchDescriptor.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonLaunchDescriptor.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.Json
  * side of the boundary first.
  */
 @Serializable
-data class DaemonLaunchDescriptor(
+public data class DaemonLaunchDescriptor(
   val schemaVersion: Int,
   val modulePath: String,
   val variant: String,
@@ -58,7 +58,7 @@ data class DaemonLaunchDescriptor(
 ) {
 
   /** Returns a copy launched behind [command] and force-killed after [hardTtlSeconds]. */
-  fun jailed(command: List<String>, hardTtlSeconds: Long?): DaemonLaunchDescriptor =
+  public fun jailed(command: List<String>, hardTtlSeconds: Long?): DaemonLaunchDescriptor =
     copy(jailCommand = command, hardTtlSeconds = hardTtlSeconds)
 
   /**
@@ -69,7 +69,7 @@ data class DaemonLaunchDescriptor(
    * Idempotent at [count] = 1 (the daemon's default; the sysprop is omitted to keep the disk
    * descriptor trivially diffable across replicas-per-daemon settings of 0).
    */
-  fun withSandboxCount(count: Int): DaemonLaunchDescriptor {
+  public fun withSandboxCount(count: Int): DaemonLaunchDescriptor {
     require(count >= 1) { "sandboxCount must be >= 1, got $count" }
     if (count == 1) return this
     val merged = systemProperties.toMutableMap()
@@ -77,17 +77,17 @@ data class DaemonLaunchDescriptor(
     return copy(systemProperties = merged)
   }
 
-  companion object {
+  public companion object {
     /**
      * Sysprop key the daemon reads to configure
      * [`RobolectricHost.sandboxCount`][ee.schimke.composeai.daemon.RobolectricHost.sandboxCount].
      * Mirrored on the daemon side as a private const in `DaemonMain.kt`; both sides MUST agree.
      */
-    const val SANDBOX_COUNT_PROP: String = "composeai.daemon.sandboxCount"
+    public const val SANDBOX_COUNT_PROP: String = "composeai.daemon.sandboxCount"
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun parse(jsonText: String): DaemonLaunchDescriptor =
+    public fun parse(jsonText: String): DaemonLaunchDescriptor =
       json.decodeFromString(serializer(), jsonText)
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonVersion.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DaemonVersion.kt
@@ -13,8 +13,8 @@ import java.util.Properties
  * baked in is the same one downstream artifacts publish, so embedders can reason about
  * compatibility without a separate compile-time literal.
  */
-object DaemonVersion {
-  val value: String by lazy {
+public object DaemonVersion {
+  public val value: String by lazy {
     val stream =
       DaemonVersion::class
         .java

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -20,19 +20,19 @@ import kotlinx.serialization.json.JsonElement
  * Android-side a11y producer (`renderer-android`) is the first concrete consumer in D2. They
  * register at daemon-main construction time, not here.
  */
-interface DataProductRegistry {
+public interface DataProductRegistry {
   /**
    * Kinds the daemon can produce. Surfaced via `initialize.capabilities.dataProducts` so clients
    * can grey out unavailable panels at handshake time.
    */
-  val capabilities: List<DataProductCapability>
+  public val capabilities: List<DataProductCapability>
 
   /**
    * Fast-path lookup: does the registry know this kind at all? Used by the subscribe path to reject
    * unknown kinds before bookkeeping takes any memory. Default scans [capabilities]; producers with
    * many kinds may override with a hash lookup.
    */
-  fun isKnown(kind: String): Boolean = capabilities.any { it.kind == kind }
+  public fun isKnown(kind: String): Boolean = capabilities.any { it.kind == kind }
 
   /**
    * Pull-on-demand fetch for one `(previewId, kind)` pair against the latest render. The dispatcher
@@ -43,7 +43,7 @@ interface DataProductRegistry {
    * `data/fetch.inline` flag — `true` asks the registry to inline the payload (or `bytes` for blob
    * kinds), `false` lets it return a `path` for cheap local-client read-from-disk.
    */
-  fun fetch(previewId: String, kind: String, params: JsonElement?, inline: Boolean): Outcome
+  public fun fetch(previewId: String, kind: String, params: JsonElement?, inline: Boolean): Outcome
 
   /**
    * Build the attachment list for [previewId]'s pending `renderFinished` across the supplied
@@ -54,7 +54,7 @@ interface DataProductRegistry {
    * Always called *after* the render produced the PNG, so producers can read whatever the renderer
    * wrote to disk during the same pass.
    */
-  fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment>
+  public fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment>
 
   /**
    * Render lifecycle hook. Called after a host returns [result] and before `renderFinished`
@@ -71,7 +71,7 @@ interface DataProductRegistry {
    * method removes the trap; [onRender] extension overloads below keep the narrow call shapes
    * available to callers (tests, mostly) without letting anyone override them.
    */
-  fun onRender(
+  public fun onRender(
     previewId: String,
     result: RenderResult,
     overrides: PreviewOverrides?,
@@ -82,7 +82,7 @@ interface DataProductRegistry {
    * Render failure lifecycle hook. Called before `renderFailed` is emitted so failure-oriented
    * producers can snapshot the throwable for a later `data/fetch`.
    */
-  fun onRenderFailed(previewId: String, cause: Throwable) {}
+  public fun onRenderFailed(previewId: String, cause: Throwable) {}
 
   /**
    * Producer-side subscription lifecycle hook. Called by the dispatcher when a client issues a
@@ -98,14 +98,14 @@ interface DataProductRegistry {
    * Idempotent on the wire: a re-subscribe (same `(previewId, kind)`) calls this again with the
    * latest `params`. Producers that need "reset on re-subscribe" semantics use that as the signal.
    */
-  fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {}
+  public fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {}
 
   /**
    * Producer-side subscription teardown. Fires from `data/unsubscribe`, from a `setVisible` that
    * drops [previewId] (subscriptions are sticky-while-visible per the spec), and from a daemon
    * shutdown. Default no-op; producers with per-subscription state should clear it here.
    */
-  fun onUnsubscribe(previewId: String, kind: String) {}
+  public fun onUnsubscribe(previewId: String, kind: String) {}
 
   /**
    * Renderer-mode tag the dispatcher should stamp into a render when [kind] has at least one sticky
@@ -117,26 +117,26 @@ interface DataProductRegistry {
    * return `null` for kinds whose data is harvested opportunistically without a mode switch. See
    * [JsonRpcServer.subscriptionDrivenRenderMode] for the resolution rule.
    */
-  fun renderModeFor(kind: String): String? = null
+  public fun renderModeFor(kind: String): String? = null
 
   /**
    * Tagged outcome of a [fetch]. The dispatcher maps each case to its wire-error counterpart in
    * `JsonRpcServer.handleDataFetch`.
    */
-  sealed interface Outcome {
-    data class Ok(val result: DataFetchResult) : Outcome
+  public sealed interface Outcome {
+    public data class Ok(val result: DataFetchResult) : Outcome
 
     /** Kind not advertised by this registry → `DataProductUnknown` (-32020). */
-    data object Unknown : Outcome
+    public data object Unknown : Outcome
 
     /** Preview has never rendered → `DataProductNotAvailable` (-32021). */
-    data object NotAvailable : Outcome
+    public data object NotAvailable : Outcome
 
     /** Producer-side failure → `DataProductFetchFailed` (-32022). */
-    data class FetchFailed(val message: String, val errorKind: String? = null) : Outcome
+    public data class FetchFailed(val message: String, val errorKind: String? = null) : Outcome
 
     /** Re-render budget tripped → `DataProductBudgetExceeded` (-32023). */
-    data object BudgetExceeded : Outcome
+    public data object BudgetExceeded : Outcome
 
     /**
      * D3 — the latest pass didn't compute the kind and producing it requires a fresh render in the
@@ -158,17 +158,17 @@ interface DataProductRegistry {
      * share a mode, in which case a follow-up D-step can opportunistically piggy-back fetches
      * against an already-queued re-render.
      */
-    data class RequiresRerender(val mode: String) : Outcome
+    public data class RequiresRerender(val mode: String) : Outcome
   }
 
-  companion object {
+  public companion object {
     /**
      * The pre-D2 default — daemon advertises no kinds, every `data/fetch` returns
      * [Outcome.Unknown], every `data/subscribe` short-circuits to the same. Used by in-process
      * tests, the harness's fake-mode scenarios, and the daemon-main path when no producer has been
      * wired yet (during D1 rollout).
      */
-    val Empty: DataProductRegistry =
+    public val Empty: DataProductRegistry =
       object : DataProductRegistry {
         override val capabilities: List<DataProductCapability> = emptyList()
 
@@ -194,12 +194,12 @@ interface DataProductRegistry {
  * forwarders did before. Kept because most test call sites don't care about overrides or context
  * and reading `onRender(id, result)` at those sites is clearer than four arguments of nulls.
  */
-fun DataProductRegistry.onRender(previewId: String, result: RenderResult) {
+public fun DataProductRegistry.onRender(previewId: String, result: RenderResult) {
   onRender(previewId, result, overrides = null, previewContext = result.previewContext)
 }
 
 /** @see onRender */
-fun DataProductRegistry.onRender(
+public fun DataProductRegistry.onRender(
   previewId: String,
   result: RenderResult,
   overrides: PreviewOverrides?,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/Extension.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/Extension.kt
@@ -31,7 +31,7 @@ import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
  * in `extensions/enable` calls); use a feature-shaped id when one extension carries several kinds
  * or pure metadata.
  */
-data class Extension(
+public data class Extension(
   val id: String,
   val displayName: String = id,
   val dependencies: List<String> = emptyList(),

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/ExtensionRegistry.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.json.JsonElement
  * lock and snapshots into an immutable view. This matches the JSON-RPC server's existing
  * concurrency shape (read thread + worker thread + watcher thread).
  */
-class ExtensionRegistry(extensions: List<Extension>) {
+public class ExtensionRegistry(extensions: List<Extension>) {
   private val byId: Map<String, Extension>
   private val lock = ReentrantReadWriteLock()
   private val publicIds = HashSet<String>()
@@ -69,26 +69,26 @@ class ExtensionRegistry(extensions: List<Extension>) {
   }
 
   /** All registered extensions, in the order they were supplied. */
-  fun all(): List<Extension> = byId.values.toList()
+  public fun all(): List<Extension> = byId.values.toList()
 
   /** True iff [id] was made public via [enable] (and not since [disable]d). */
-  fun isPubliclyEnabled(id: String): Boolean = lock.read { id in publicIds }
+  public fun isPubliclyEnabled(id: String): Boolean = lock.read { id in publicIds }
 
   /** True iff [id] is publicly enabled or pulled in transitively. */
-  fun isActive(id: String): Boolean = lock.read { id in activeIdsCache }
+  public fun isActive(id: String): Boolean = lock.read { id in activeIdsCache }
 
   /** Snapshot of publicly enabled ids. */
-  fun publicIds(): Set<String> = lock.read { publicIds.toSet() }
+  public fun publicIds(): Set<String> = lock.read { publicIds.toSet() }
 
   /** Snapshot of all ids that should run during a render (public + transitive deps). */
-  fun activeIds(): Set<String> = lock.read { activeIdsCache.toSet() }
+  public fun activeIds(): Set<String> = lock.read { activeIdsCache.toSet() }
 
   /**
    * Enable [requested] ids. Unknown ids land in [EnableOutcome.unknown] and the rest are processed.
    * Already-enabled ids are reported separately. Transitive dependencies that come online land in
    * [EnableOutcome.pulledIn].
    */
-  fun enable(requested: Iterable<String>): EnableOutcome {
+  public fun enable(requested: Iterable<String>): EnableOutcome {
     val asked = requested.toSet()
     val unknown = asked.filter { it !in byId }.sorted()
     val known = asked - unknown.toSet()
@@ -113,7 +113,7 @@ class ExtensionRegistry(extensions: List<Extension>) {
    * enabled extension still depends on them land in [DisableOutcome.stillActiveAsDependency] —
    * disabling them publicly is fine, the client just sees the dep didn't fully deactivate.
    */
-  fun disable(requested: Iterable<String>): DisableOutcome {
+  public fun disable(requested: Iterable<String>): DisableOutcome {
     val asked = requested.toSet()
     val unknown = asked.filter { it !in byId }.sorted()
     val known = asked - unknown.toSet()
@@ -149,19 +149,19 @@ class ExtensionRegistry(extensions: List<Extension>) {
   // Wire-facing snapshots — only publicly enabled extensions contribute.
   // -------------------------------------------------------------------------
 
-  fun publicDataProductCapabilities(): List<DataProductCapability> = lock.read {
+  public fun publicDataProductCapabilities(): List<DataProductCapability> = lock.read {
     publicIds.sorted().flatMap { byId.getValue(it).dataProductCapabilities }
   }
 
-  fun publicDataExtensionDescriptors(): List<DataExtensionDescriptor> = lock.read {
+  public fun publicDataExtensionDescriptors(): List<DataExtensionDescriptor> = lock.read {
     publicIds.sorted().flatMap { byId.getValue(it).dataExtensionDescriptors }
   }
 
-  fun publicPreviewExtensionDescriptors(): List<PreviewExtensionDescriptor> = lock.read {
+  public fun publicPreviewExtensionDescriptors(): List<PreviewExtensionDescriptor> = lock.read {
     publicIds.sorted().flatMap { byId.getValue(it).previewExtensionDescriptors }
   }
 
-  fun infoList(): List<ExtensionInfo> = lock.read {
+  public fun infoList(): List<ExtensionInfo> = lock.read {
     byId.values.map { ext ->
       ExtensionInfo(
         id = ext.id,
@@ -191,12 +191,12 @@ class ExtensionRegistry(extensions: List<Extension>) {
   // -------------------------------------------------------------------------
 
   /** Composite over publicly enabled extensions. */
-  fun publicDataProducts(): DataProductRegistry = ScopedDataProducts {
+  public fun publicDataProducts(): DataProductRegistry = ScopedDataProducts {
     lock.read { publicIds.toList() }
   }
 
   /** Composite over publicly enabled or transitively active extensions. */
-  fun activeDataProducts(): DataProductRegistry = ScopedDataProducts {
+  public fun activeDataProducts(): DataProductRegistry = ScopedDataProducts {
     lock.read { activeIdsCache.toList() }
   }
 
@@ -284,7 +284,7 @@ class ExtensionRegistry(extensions: List<Extension>) {
    * render without rebuilding the renderer. Active-as-dependency overrides plan too — the depending
    * extension may need them to wrap the composable correctly.
    */
-  fun activeOverrideExtensions(): PreviewOverrideExtensions {
+  public fun activeOverrideExtensions(): PreviewOverrideExtensions {
     val byOverrideId = HashMap<String, String>() // dataExtensionId -> owning extension id
     for (ext in byId.values) {
       for (over in ext.previewOverrideExtensions) {
@@ -314,8 +314,8 @@ class ExtensionRegistry(extensions: List<Extension>) {
     )
   }
 
-  companion object {
-    val Empty: ExtensionRegistry = ExtensionRegistry(emptyList())
+  public companion object {
+    public val Empty: ExtensionRegistry = ExtensionRegistry(emptyList())
   }
 }
 
@@ -324,7 +324,7 @@ class ExtensionRegistry(extensions: List<Extension>) {
  * lands in exactly one of [newlyEnabled], [alreadyEnabled], or [unknown]. [pulledIn] is additive —
  * dependencies that came online as a side effect.
  */
-data class EnableOutcome(
+public data class EnableOutcome(
   val newlyEnabled: List<String>,
   val pulledIn: List<String>,
   val alreadyEnabled: List<String>,
@@ -337,7 +337,7 @@ data class EnableOutcome(
  * public dependent); [stillActiveAsDependency] are ids that were disabled publicly but remain
  * active because another public extension still depends on them.
  */
-data class DisableOutcome(
+public data class DisableOutcome(
   val disabled: List<String>,
   val deactivated: List<String>,
   val stillActiveAsDependency: List<String>,
@@ -346,7 +346,7 @@ data class DisableOutcome(
 )
 
 /** Per-extension snapshot returned by `extensions/list`. */
-data class ExtensionInfo(
+public data class ExtensionInfo(
   val id: String,
   val displayName: String,
   val dependencies: List<String>,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
  * should still complete within minutes. The subprocess is `destroyForcibly()`'d on timeout to
  * prevent zombies; tests rely on this to keep the JVM clean across encode failures.
  */
-object FfmpegEncoder {
+public object FfmpegEncoder {
 
   /**
    * Encoder timeout in milliseconds. 60 s is generous enough for ~5 s of 30 fps content (libx264
@@ -41,7 +41,7 @@ object FfmpegEncoder {
    * should still complete; if not, surfacing the timeout to the caller as an exception is
    * preferable to leaving a half-written file on disk.
    */
-  const val ENCODE_TIMEOUT_MS: Long = 60_000L
+  public const val ENCODE_TIMEOUT_MS: Long = 60_000L
 
   @Volatile private var detected: Boolean? = null
 
@@ -50,7 +50,7 @@ object FfmpegEncoder {
    * is computed once per JVM. Tests can flip the cache via [resetDetectionForTesting] when they
    * need to exercise the "ffmpeg unavailable" path on a machine where it's installed.
    */
-  fun available(): Boolean {
+  public fun available(): Boolean {
     val cached = detected
     if (cached != null) return cached
     val result =
@@ -87,7 +87,7 @@ object FfmpegEncoder {
    * only meaningful for MP4 / WEBM; APNG / GIF have no audio track, so [DesktopRecordingSession]
    * passes it only down the ffmpeg path.
    */
-  fun encodeFromPngFrames(
+  public fun encodeFromPngFrames(
     framesDir: File,
     fps: Int,
     format: RecordingFormatChoice,
@@ -241,7 +241,7 @@ object FfmpegEncoder {
    * distinct so the encoder body never has to consider the APNG path (handled by [ApngEncoder]
    * inline in [DesktopRecordingSession.encode]).
    */
-  enum class RecordingFormatChoice {
+  public enum class RecordingFormatChoice {
     MP4,
     WEBM,
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FileBackedDataProductRegistry.kt
@@ -44,7 +44,7 @@ import okio.Path.Companion.toPath
  * - Payload synthesis from a sibling kind's file (the strings registry derives from the semantics
  *   file, not its own).
  */
-abstract class FileBackedDataProductRegistry(
+public abstract class FileBackedDataProductRegistry(
   final override val capabilities: List<DataProductCapability>,
   private val fileSystem: FileSystem = SystemFileSystem,
 ) : DataProductRegistry {
@@ -205,7 +205,7 @@ abstract class FileBackedDataProductRegistry(
     }
       .getOrNull() == true
 
-  companion object {
+  public companion object {
     private val DEFAULT_JSON = Json { ignoreUnknownKeys = true }
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/GifEncoder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/GifEncoder.kt
@@ -30,13 +30,13 @@ import javax.imageio.metadata.IIOMetadataNode
  * `java.io.File` boundaries (see docs/AGENTS.md "File/IO goes through Okio … except a hard
  * third-party boundary"). The encoder keeps `File` local to those calls.
  */
-object GifEncoder {
+public object GifEncoder {
 
   /**
    * Encode [frames] (PNG files, contiguous, sharing one size) into a looping GIF at [fps] frames
    * per second, writing to [out]. Throws when [frames] is empty or a frame can't be read.
    */
-  fun encodeFromPngFrames(frames: List<File>, fps: Int, out: File) {
+  public fun encodeFromPngFrames(frames: List<File>, fps: Int, out: File) {
     require(frames.isNotEmpty()) { "GifEncoder: at least one frame required" }
     require(fps in 1..120) { "GifEncoder: fps=$fps out of range [1, 120]" }
     val writer =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryFeature.kt
@@ -22,11 +22,11 @@ package ee.schimke.composeai.daemon
  * out of history recording. `history/diff` carries its own additional experimental gate (see
  * `JsonRpcServer`), so flipping this on does not by itself enable diffing.
  */
-object HistoryFeature {
+public object HistoryFeature {
   /** Override sysprop name; default `true`. */
-  const val PROP: String = "composeai.history.enabled"
+  public const val PROP: String = "composeai.history.enabled"
 
   @JvmStatic
-  val ENABLED: Boolean
+  public val ENABLED: Boolean
     get() = System.getProperty(PROP, "true").toBoolean()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -41,7 +41,7 @@ import java.nio.file.Path
  * during the plugin's full discovery pass) are passed in via [knownPreviewAnnotationFqns] so the
  * cheap pre-filter can also greplace them.
  */
-class IncrementalDiscovery(
+public class IncrementalDiscovery(
   /** The daemon's own classpath — typically `java.class.path` split on the path separator. */
   private val classpath: List<Path>,
   /**
@@ -79,7 +79,7 @@ class IncrementalDiscovery(
    * Fail-safe on I/O errors — returns `true` so a transient read failure can't silently drop a real
    * edit.
    */
-  fun cheapPrefilter(file: Path, currentIndex: PreviewIndex): Boolean {
+  public fun cheapPrefilter(file: Path, currentIndex: PreviewIndex): Boolean {
     // Quick path: file currently contributes previews. The basename match guards against the
     // worst-case "absolute path" → "relative path" mismatch by also accepting suffix matches.
     val pathString = file.toString()
@@ -116,7 +116,7 @@ class IncrementalDiscovery(
    *
    * Fail-safe: returns `emptySet` on any scan failure (and writes a stderr diagnostic).
    */
-  fun scanForFile(file: Path): Set<PreviewInfoDto> {
+  public fun scanForFile(file: Path): Set<PreviewInfoDto> {
     val target = classpathElementForFile(file)
     val scanRoots = scanRootsForTarget(target)
     return try {
@@ -388,13 +388,13 @@ class IncrementalDiscovery(
       }
   }
 
-  companion object {
+  public companion object {
     /**
      * Daemon-side mirror of `:gradle-plugin`'s `DiscoverPreviewsTask.PREVIEW_FQNS`. Sharing would
      * pull `:gradle-plugin` onto the daemon classpath (a layering inversion); duplicating ~3 FQNs
      * is the cheap fix.
      */
-    val DEFAULT_PREVIEW_ANNOTATION_FQNS: Set<String> =
+    public val DEFAULT_PREVIEW_ANNOTATION_FQNS: Set<String> =
       setOf(
         "androidx.compose.ui.tooling.preview.Preview",
         "androidx.compose.desktop.ui.tooling.preview.Preview",

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -14,17 +14,17 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends advertise it
  * from `recordingScriptEventDescriptors()`. Issue #1203 closed the desktop/Android no-op gaps.
  */
-object InputKeyboardRecordingScriptEvents {
+public object InputKeyboardRecordingScriptEvents {
 
-  const val KEY_DOWN_EVENT: String = "input.keyDown"
-  const val KEY_UP_EVENT: String = "input.keyUp"
+  public const val KEY_DOWN_EVENT: String = "input.keyDown"
+  public const val KEY_UP_EVENT: String = "input.keyUp"
 
   /**
    * Build the descriptor with [supported] set on each script event. Hosts call this with `supported
    * = true` once they've wired real dispatch; the pre-#1203 default (`supported = false`) remains
    * available for backends that haven't yet.
    */
-  fun descriptor(supported: Boolean): DataExtensionDescriptor =
+  public fun descriptor(supported: Boolean): DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("input.keyboard"),
       displayName = "Keyboard input",
@@ -53,11 +53,11 @@ object InputKeyboardRecordingScriptEvents {
     )
 
   /** Convenience for hosts whose dispatch path is wired. */
-  val supportedDescriptor: DataExtensionDescriptor = descriptor(supported = true)
+  public val supportedDescriptor: DataExtensionDescriptor = descriptor(supported = true)
 
   /** Legacy const-style alias retained for backends that haven't wired key dispatch yet. */
-  val descriptor: DataExtensionDescriptor = descriptor(supported = false)
+  public val descriptor: DataExtensionDescriptor = descriptor(supported = false)
 
   /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
-  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+  public val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -26,18 +26,18 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
  * trivially additive.
  */
-object InputTouchRecordingScriptEvents {
+public object InputTouchRecordingScriptEvents {
 
-  const val CLICK_EVENT: String = "input.click"
-  const val POINTER_DOWN_EVENT: String = "input.pointerDown"
-  const val POINTER_MOVE_EVENT: String = "input.pointerMove"
-  const val POINTER_UP_EVENT: String = "input.pointerUp"
+  public const val CLICK_EVENT: String = "input.click"
+  public const val POINTER_DOWN_EVENT: String = "input.pointerDown"
+  public const val POINTER_MOVE_EVENT: String = "input.pointerMove"
+  public const val POINTER_UP_EVENT: String = "input.pointerUp"
 
   /** All wired touch event ids. */
-  val WIRED_EVENTS: Set<String> =
+  public val WIRED_EVENTS: Set<String> =
     setOf(CLICK_EVENT, POINTER_DOWN_EVENT, POINTER_MOVE_EVENT, POINTER_UP_EVENT)
 
-  val descriptor: DataExtensionDescriptor =
+  public val descriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("input.touch"),
       displayName = "Touch / pointer input",
@@ -73,5 +73,5 @@ object InputTouchRecordingScriptEvents {
     )
 
   /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
-  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+  public val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodes.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveKeyCodes.kt
@@ -16,129 +16,129 @@ package ee.schimke.composeai.daemon
  *
  * Codes match `android.view.KeyEvent.KEYCODE_*` and are stable Android API integers.
  */
-object InteractiveKeyCodes {
+public object InteractiveKeyCodes {
 
   // Letters (Android KEYCODE_A = 29, KEYCODE_Z = 54).
-  const val A: Int = 29
-  const val B: Int = 30
-  const val C: Int = 31
-  const val D: Int = 32
-  const val E: Int = 33
-  const val F: Int = 34
-  const val G: Int = 35
-  const val H: Int = 36
-  const val I: Int = 37
-  const val J: Int = 38
-  const val K: Int = 39
-  const val L: Int = 40
-  const val M: Int = 41
-  const val N: Int = 42
-  const val O: Int = 43
-  const val P: Int = 44
-  const val Q: Int = 45
-  const val R: Int = 46
-  const val S: Int = 47
-  const val T: Int = 48
-  const val U: Int = 49
-  const val V: Int = 50
-  const val W: Int = 51
-  const val X: Int = 52
-  const val Y: Int = 53
-  const val Z: Int = 54
+  public const val A: Int = 29
+  public const val B: Int = 30
+  public const val C: Int = 31
+  public const val D: Int = 32
+  public const val E: Int = 33
+  public const val F: Int = 34
+  public const val G: Int = 35
+  public const val H: Int = 36
+  public const val I: Int = 37
+  public const val J: Int = 38
+  public const val K: Int = 39
+  public const val L: Int = 40
+  public const val M: Int = 41
+  public const val N: Int = 42
+  public const val O: Int = 43
+  public const val P: Int = 44
+  public const val Q: Int = 45
+  public const val R: Int = 46
+  public const val S: Int = 47
+  public const val T: Int = 48
+  public const val U: Int = 49
+  public const val V: Int = 50
+  public const val W: Int = 51
+  public const val X: Int = 52
+  public const val Y: Int = 53
+  public const val Z: Int = 54
 
   // Digits (KEYCODE_0 = 7, KEYCODE_9 = 16).
-  const val DIGIT_0: Int = 7
-  const val DIGIT_1: Int = 8
-  const val DIGIT_2: Int = 9
-  const val DIGIT_3: Int = 10
-  const val DIGIT_4: Int = 11
-  const val DIGIT_5: Int = 12
-  const val DIGIT_6: Int = 13
-  const val DIGIT_7: Int = 14
-  const val DIGIT_8: Int = 15
-  const val DIGIT_9: Int = 16
+  public const val DIGIT_0: Int = 7
+  public const val DIGIT_1: Int = 8
+  public const val DIGIT_2: Int = 9
+  public const val DIGIT_3: Int = 10
+  public const val DIGIT_4: Int = 11
+  public const val DIGIT_5: Int = 12
+  public const val DIGIT_6: Int = 13
+  public const val DIGIT_7: Int = 14
+  public const val DIGIT_8: Int = 15
+  public const val DIGIT_9: Int = 16
 
   // Whitespace / editing.
-  const val SPACE: Int = 62
-  const val ENTER: Int = 66
-  const val TAB: Int = 61
-  const val BACKSPACE: Int = 67 // KEYCODE_DEL
-  const val FORWARD_DELETE: Int = 112 // KEYCODE_FORWARD_DEL
-  const val ESCAPE: Int = 111
+  public const val SPACE: Int = 62
+  public const val ENTER: Int = 66
+  public const val TAB: Int = 61
+  public const val BACKSPACE: Int = 67 // KEYCODE_DEL
+  public const val FORWARD_DELETE: Int = 112 // KEYCODE_FORWARD_DEL
+  public const val ESCAPE: Int = 111
 
   // Navigation.
-  const val DPAD_LEFT: Int = 21
-  const val DPAD_RIGHT: Int = 22
-  const val DPAD_UP: Int = 19
-  const val DPAD_DOWN: Int = 20
-  const val DPAD_CENTER: Int = 23
-  const val HOME: Int = 122 // KEYCODE_MOVE_HOME
-  const val END: Int = 123 // KEYCODE_MOVE_END
-  const val PAGE_UP: Int = 92
-  const val PAGE_DOWN: Int = 93
+  public const val DPAD_LEFT: Int = 21
+  public const val DPAD_RIGHT: Int = 22
+  public const val DPAD_UP: Int = 19
+  public const val DPAD_DOWN: Int = 20
+  public const val DPAD_CENTER: Int = 23
+  public const val HOME: Int = 122 // KEYCODE_MOVE_HOME
+  public const val END: Int = 123 // KEYCODE_MOVE_END
+  public const val PAGE_UP: Int = 92
+  public const val PAGE_DOWN: Int = 93
 
   // Modifiers.
-  const val SHIFT_LEFT: Int = 59
-  const val SHIFT_RIGHT: Int = 60
-  const val CTRL_LEFT: Int = 113
-  const val CTRL_RIGHT: Int = 114
-  const val ALT_LEFT: Int = 57
-  const val ALT_RIGHT: Int = 58
-  const val META_LEFT: Int = 117
-  const val META_RIGHT: Int = 118
+  public const val SHIFT_LEFT: Int = 59
+  public const val SHIFT_RIGHT: Int = 60
+  public const val CTRL_LEFT: Int = 113
+  public const val CTRL_RIGHT: Int = 114
+  public const val ALT_LEFT: Int = 57
+  public const val ALT_RIGHT: Int = 58
+  public const val META_LEFT: Int = 117
+  public const val META_RIGHT: Int = 118
 
   // Function keys (KEYCODE_F1 = 131 … KEYCODE_F12 = 142).
-  const val F1: Int = 131
-  const val F2: Int = 132
-  const val F3: Int = 133
-  const val F4: Int = 134
-  const val F5: Int = 135
-  const val F6: Int = 136
-  const val F7: Int = 137
-  const val F8: Int = 138
-  const val F9: Int = 139
-  const val F10: Int = 140
-  const val F11: Int = 141
-  const val F12: Int = 142
+  public const val F1: Int = 131
+  public const val F2: Int = 132
+  public const val F3: Int = 133
+  public const val F4: Int = 134
+  public const val F5: Int = 135
+  public const val F6: Int = 136
+  public const val F7: Int = 137
+  public const val F8: Int = 138
+  public const val F9: Int = 139
+  public const val F10: Int = 140
+  public const val F11: Int = 141
+  public const val F12: Int = 142
 
   // Numpad (KEYCODE_NUMPAD_0 = 144 … KEYCODE_NUMPAD_EQUALS = 161).
-  const val NUMPAD_0: Int = 144
-  const val NUMPAD_1: Int = 145
-  const val NUMPAD_2: Int = 146
-  const val NUMPAD_3: Int = 147
-  const val NUMPAD_4: Int = 148
-  const val NUMPAD_5: Int = 149
-  const val NUMPAD_6: Int = 150
-  const val NUMPAD_7: Int = 151
-  const val NUMPAD_8: Int = 152
-  const val NUMPAD_9: Int = 153
-  const val NUMPAD_DIVIDE: Int = 154
-  const val NUMPAD_MULTIPLY: Int = 155
-  const val NUMPAD_SUBTRACT: Int = 156
-  const val NUMPAD_ADD: Int = 157
-  const val NUMPAD_DOT: Int = 158
-  const val NUMPAD_COMMA: Int = 159
-  const val NUMPAD_ENTER: Int = 160
-  const val NUMPAD_EQUALS: Int = 161
+  public const val NUMPAD_0: Int = 144
+  public const val NUMPAD_1: Int = 145
+  public const val NUMPAD_2: Int = 146
+  public const val NUMPAD_3: Int = 147
+  public const val NUMPAD_4: Int = 148
+  public const val NUMPAD_5: Int = 149
+  public const val NUMPAD_6: Int = 150
+  public const val NUMPAD_7: Int = 151
+  public const val NUMPAD_8: Int = 152
+  public const val NUMPAD_9: Int = 153
+  public const val NUMPAD_DIVIDE: Int = 154
+  public const val NUMPAD_MULTIPLY: Int = 155
+  public const val NUMPAD_SUBTRACT: Int = 156
+  public const val NUMPAD_ADD: Int = 157
+  public const val NUMPAD_DOT: Int = 158
+  public const val NUMPAD_COMMA: Int = 159
+  public const val NUMPAD_ENTER: Int = 160
+  public const val NUMPAD_EQUALS: Int = 161
 
   // Punctuation.
-  const val MINUS: Int = 69
-  const val EQUALS: Int = 70
-  const val LEFT_BRACKET: Int = 71
-  const val RIGHT_BRACKET: Int = 72
-  const val BACKSLASH: Int = 73
-  const val SEMICOLON: Int = 74
-  const val APOSTROPHE: Int = 75
-  const val COMMA: Int = 55
-  const val PERIOD: Int = 56
-  const val SLASH: Int = 76
-  const val GRAVE: Int = 68 // KEYCODE_GRAVE — backtick / DOM `Backquote`.
+  public const val MINUS: Int = 69
+  public const val EQUALS: Int = 70
+  public const val LEFT_BRACKET: Int = 71
+  public const val RIGHT_BRACKET: Int = 72
+  public const val BACKSLASH: Int = 73
+  public const val SEMICOLON: Int = 74
+  public const val APOSTROPHE: Int = 75
+  public const val COMMA: Int = 55
+  public const val PERIOD: Int = 56
+  public const val SLASH: Int = 76
+  public const val GRAVE: Int = 68 // KEYCODE_GRAVE — backtick / DOM `Backquote`.
 
   // Locks.
-  const val CAPS_LOCK: Int = 115
-  const val NUM_LOCK: Int = 143
-  const val SCROLL_LOCK: Int = 116
+  public const val CAPS_LOCK: Int = 115
+  public const val NUM_LOCK: Int = 143
+  public const val SCROLL_LOCK: Int = 116
 
   /** Parse the wire spelling. Returns `null` for null / blank / non-numeric input. */
-  fun parse(wire: String?): Int? = wire?.trim()?.toIntOrNull()
+  public fun parse(wire: String?): Int? = wire?.trim()?.toIntOrNull()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -32,10 +32,10 @@ import ee.schimke.composeai.daemon.protocol.RemoteComposeChange
  * tearing down the scene, the same way `RenderHost.shutdown` drains its queue. We never interrupt a
  * render mid-flight.
  */
-interface InteractiveSession : AutoCloseable {
+public interface InteractiveSession : AutoCloseable {
 
   /** The preview id this session is rendering. Frozen at allocation time. */
-  val previewId: String
+  public val previewId: String
 
   /**
    * `true` once the session has been closed — either by explicit [close] or by a host-internal
@@ -48,7 +48,7 @@ interface InteractiveSession : AutoCloseable {
    * behaviour (the worker still cleans up when their `render()` throws — see the catch in
    * `submitInteractiveRenderAsync` — but the loop won't pre-emptively stop).
    */
-  val isClosed: Boolean
+  public val isClosed: Boolean
     get() = false
 
   /**
@@ -62,7 +62,7 @@ interface InteractiveSession : AutoCloseable {
    * coalescing path in [JsonRpcServer.handleInteractiveInput] queue several inputs and dispatch
    * them in a batch followed by a single [render].
    */
-  fun dispatch(input: InteractiveInputParams)
+  public fun dispatch(input: InteractiveInputParams)
 
   /**
    * Push one Remote Compose state edit into the held composition's `RemoteComposeController`
@@ -82,7 +82,7 @@ interface InteractiveSession : AutoCloseable {
    *   `RemoteComposeChangeDetail`. The implementation maps each variant onto the controller's
    *   matching method.
    */
-  fun dispatchRemoteComposeChange(change: RemoteComposeChange): Boolean = false
+  public fun dispatchRemoteComposeChange(change: RemoteComposeChange): Boolean = false
 
   /**
    * Push one Lottie timeline scrub into the held composition without a fresh `renderNow`. The
@@ -101,7 +101,7 @@ interface InteractiveSession : AutoCloseable {
    * @param progress timeline position in `0f..1f` (implementations clamp); mirrors the panel's
    *   `setLottieProgress` value.
    */
-  fun dispatchLottieProgress(progress: Float): Boolean = false
+  public fun dispatchLottieProgress(progress: Float): Boolean = false
 
   /**
    * Accessibility-driven dispatch: resolve a node by its visible content description and invoke the
@@ -126,7 +126,8 @@ interface InteractiveSession : AutoCloseable {
    *   `SemanticsProperties.ContentDescription` — exact match, useUnmergedTree = true so merged
    *   children remain reachable.
    */
-  fun dispatchSemanticsAction(actionKind: String, nodeContentDescription: String): Boolean = false
+  public fun dispatchSemanticsAction(actionKind: String, nodeContentDescription: String): Boolean =
+    false
 
   /**
    * UIAutomator-shaped dispatch: resolve a node by a multi-axis BySelector-style predicate and
@@ -153,7 +154,7 @@ interface InteractiveSession : AutoCloseable {
    * @param inputText payload for `actionKind = "inputText"`; ignored otherwise. Routed through
    *   `SemanticsActions.SetText` (Compose) or `ACTION_SET_TEXT` (View).
    */
-  fun dispatchUiAutomator(
+  public fun dispatchUiAutomator(
     actionKind: String,
     selectorJson: String,
     useUnmergedTree: Boolean = false,
@@ -172,7 +173,7 @@ interface InteractiveSession : AutoCloseable {
    * cleanly degrade to the existing free-form `message` — agents iterating on selectors only see
    * the structured field on backends that wired it up.
    */
-  fun findUiAutomatorEvidence(
+  public fun findUiAutomatorEvidence(
     actionKind: String,
     selectorJson: String,
     useUnmergedTree: Boolean = false,
@@ -190,7 +191,8 @@ interface InteractiveSession : AutoCloseable {
    * Default returns `null` so hosts that can't reach the live tree (or predate probe capture) leave
    * the probe assertion-less and the generator falls back to a stub.
    */
-  fun captureProbeSemantics(): List<ee.schimke.composeai.daemon.protocol.RecordingProbeNode>? = null
+  public fun captureProbeSemantics():
+    List<ee.schimke.composeai.daemon.protocol.RecordingProbeNode>? = null
 
   /**
    * Run the Android Accessibility Test Framework (ATF) against the held composition for an
@@ -203,7 +205,8 @@ interface InteractiveSession : AutoCloseable {
    * hierarchy, and ATF runs only against Android Views) cleanly surface "a11y capture unavailable"
    * — the `assert.a11y` handler then reports unsupported rather than blowing up the session.
    */
-  fun captureA11yFindings(): List<ee.schimke.composeai.daemon.protocol.RecordingA11yFinding>? = null
+  public fun captureA11yFindings():
+    List<ee.schimke.composeai.daemon.protocol.RecordingA11yFinding>? = null
 
   /**
    * Lifecycle dispatch: move the held activity (or per-host equivalent) to the named lifecycle
@@ -225,7 +228,7 @@ interface InteractiveSession : AutoCloseable {
    *   intentionally not part of v1 — moving to `DESTROYED` mid-recording would tear down the
    *   scenario and break subsequent renders; document it as a follow-up if a use case lands.
    */
-  fun dispatchLifecycle(lifecycleEvent: String): Boolean = false
+  public fun dispatchLifecycle(lifecycleEvent: String): Boolean = false
 
   /**
    * Force a fresh composition: tear down the current composition slot and rebuild from scratch
@@ -241,7 +244,7 @@ interface InteractiveSession : AutoCloseable {
    * rebuild invalidates the saveable-state call sites. For "state survives a config-change" audits
    * use [dispatchLifecycle] (`pause` / `resume`) instead.
    */
-  fun dispatchPreviewReload(): Boolean = false
+  public fun dispatchPreviewReload(): Boolean = false
 
   /**
    * Force a Compose-level save+restore round-trip: snapshot `rememberSaveable` state from the
@@ -260,7 +263,7 @@ interface InteractiveSession : AutoCloseable {
    * (`pause` / `resume`) when you want a real Android lifecycle round-trip with the activity
    * intact.
    */
-  fun dispatchStateRecreate(): Boolean = false
+  public fun dispatchStateRecreate(): Boolean = false
 
   /**
    * Capture the current `SaveableStateRegistry` snapshot into a named bundle keyed by
@@ -270,7 +273,7 @@ interface InteractiveSession : AutoCloseable {
    * Returns `true` when the snapshot was stored; `false` when the host doesn't have the bridge
    * wired (DesktopHost today). Multiple saves to the same id overwrite the previous bundle.
    */
-  fun dispatchStateSave(checkpointId: String): Boolean = false
+  public fun dispatchStateSave(checkpointId: String): Boolean = false
 
   /**
    * Look up the bundle stashed by an earlier [dispatchStateSave] with matching [checkpointId] and
@@ -278,7 +281,7 @@ interface InteractiveSession : AutoCloseable {
    * when no checkpoint with that id has been saved (caller surfaces unsupported evidence). Throws
    * when the rebuild itself failed.
    */
-  fun dispatchStateRestore(checkpointId: String): Boolean = false
+  public fun dispatchStateRestore(checkpointId: String): Boolean = false
 
   /**
    * Navigation-driven dispatch: fire a deep-link Intent at the held activity, an instant back
@@ -307,7 +310,7 @@ interface InteractiveSession : AutoCloseable {
    *   (default) or `"right"`. Mapped sandbox-side to
    *   [`androidx.activity.BackEventCompat.EDGE_LEFT`] / `EDGE_RIGHT`.
    */
-  fun dispatchNavigation(
+  public fun dispatchNavigation(
     actionKind: String,
     deepLinkUri: String? = null,
     backProgress: Float? = null,
@@ -326,7 +329,7 @@ interface InteractiveSession : AutoCloseable {
    *   interactive callers leave this null so the backend uses its default settle window; recording
    *   callers can pass frame deltas to keep captured animation time paced to fps.
    */
-  fun render(requestId: Long, advanceTimeMs: Long? = null): RenderResult
+  public fun render(requestId: Long, advanceTimeMs: Long? = null): RenderResult
 
   /**
    * Drains any in-flight render, frees the held scene + its native resources, and removes any

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -138,7 +138,7 @@ import okio.Path.Companion.toPath
  * that materialises the PNG and returns timing/metrics. The render queue plumbing (submit → poll →
  * notify) does not need to change.
  */
-class JsonRpcServer(
+public class JsonRpcServer(
   private val input: InputStream,
   private val output: OutputStream,
   private val host: RenderHost,
@@ -591,7 +591,7 @@ class JsonRpcServer(
    *    1).
    * 2. stdin EOF without `shutdown`+`exit` → waits up to [idleTimeoutMs], then exits with code 1.
    */
-  fun run() {
+  public fun run() {
     StartupTimings.mark("JsonRpcServer.run() entered")
     host.start()
     StartupTimings.mark("host.start() returned (sandbox ready)")
@@ -4392,7 +4392,7 @@ class JsonRpcServer(
     data class Failed(val message: String) : RerenderOutcome
   }
 
-  companion object {
+  public companion object {
     /**
      * PROTOCOL.md § 7. Bumped to 2 when daemons stopped advertising every extension's contributions
      * by default — `initialize.capabilities.{dataProducts,dataExtensions,previewExtensions}` are
@@ -4400,21 +4400,21 @@ class JsonRpcServer(
      * daemon will see empty capability lists and assume nothing is supported; the daemon errors out
      * on `protocolVersion` mismatch so they get a clean handshake failure instead.
      */
-    const val PROTOCOL_VERSION: Int = 2
+    public const val PROTOCOL_VERSION: Int = 2
 
     /**
      * The `onExit` a **real daemon process** wants: end the JVM with the server's exit code. Named
      * rather than inlined at each `DaemonMain` so the process-ending call sites are greppable, and
      * so no in-process caller reaches it by accident (see the `onExit` parameter doc / #3087).
      */
-    val EXIT_PROCESS: (Int) -> Unit = { code -> exitProcess(code) }
+    public val EXIT_PROCESS: (Int) -> Unit = { code -> exitProcess(code) }
 
-    const val IDLE_TIMEOUT_PROP: String = "composeai.daemon.idleTimeoutMs"
-    const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L
+    public const val IDLE_TIMEOUT_PROP: String = "composeai.daemon.idleTimeoutMs"
+    public const val DEFAULT_IDLE_TIMEOUT_MS: Long = 5_000L
 
     /** PROTOCOL.md § 6 — `daemon.classpathDirtyGraceMs`, default 2000ms. */
-    const val CLASSPATH_DIRTY_GRACE_PROP: String = "composeai.daemon.classpathDirtyGraceMs"
-    const val DEFAULT_CLASSPATH_DIRTY_GRACE_MS: Long = 2_000L
+    public const val CLASSPATH_DIRTY_GRACE_PROP: String = "composeai.daemon.classpathDirtyGraceMs"
+    public const val DEFAULT_CLASSPATH_DIRTY_GRACE_MS: Long = 2_000L
 
     /**
      * DATA-PRODUCTS.md § "Re-render semantics" — `daemon.dataFetchRerenderBudgetMs`, default
@@ -4422,8 +4422,9 @@ class JsonRpcServer(
      * override for tests; `JsonRpcServer` constructor param for in-process callers (the in-process
      * integration tests pin it sub-second so the timeout branch is fast).
      */
-    const val DATA_FETCH_RERENDER_BUDGET_PROP: String = "composeai.daemon.dataFetchRerenderBudgetMs"
-    const val DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS: Long = 30_000L
+    public const val DATA_FETCH_RERENDER_BUDGET_PROP: String =
+      "composeai.daemon.dataFetchRerenderBudgetMs"
+    public const val DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS: Long = 30_000L
 
     /**
      * Watchdog window between `fileChanged({kind:source})` and the (deferred) discovery scan. The
@@ -4433,15 +4434,15 @@ class JsonRpcServer(
      * metadata reconcile responsive without racing fast renders. Tests override to a few hundred ms
      * via the sysprop.
      */
-    const val DISCOVERY_WATCHDOG_PROP: String = "composeai.daemon.discoveryWatchdogMs"
-    const val DEFAULT_DISCOVERY_WATCHDOG_MS: Long = 1_500L
+    public const val DISCOVERY_WATCHDOG_PROP: String = "composeai.daemon.discoveryWatchdogMs"
+    public const val DEFAULT_DISCOVERY_WATCHDOG_MS: Long = 1_500L
 
     /**
      * Experimental gate for `history/diff`. See the constructor parameter on [JsonRpcServer] for
      * rationale. TODO(1.1): remove once H5 + the rest of the History roadmap lands and the diff
      * surface is no longer half-finished.
      */
-    const val HISTORY_DIFF_EXPERIMENTAL_PROP: String = "composeai.experimental.historyDiff"
+    public const val HISTORY_DIFF_EXPERIMENTAL_PROP: String = "composeai.experimental.historyDiff"
 
     /**
      * Ceiling on shutdown drain. Renders that take longer than this are still allowed to finish —
@@ -4454,7 +4455,7 @@ class JsonRpcServer(
      * render in a daemon's life (Robolectric cold sandbox bootstrap, ~5–15s) plus a heavy
      * single-render render body. Overridable per-session via `initialize.options.maxRenderMs`.
      */
-    const val DEFAULT_RENDER_TIMEOUT_MS: Long = 5 * 60_000L
+    public const val DEFAULT_RENDER_TIMEOUT_MS: Long = 5 * 60_000L
 
     /**
      * Sysprop override for the initial [renderTimeoutMs]. Set to a positive ms value (e.g.
@@ -4462,19 +4463,19 @@ class JsonRpcServer(
      * debugging-friendly window before the client's `initialize.options.maxRenderMs` lands. Unset /
      * non-positive values keep [DEFAULT_RENDER_TIMEOUT_MS].
      */
-    const val RENDER_TIMEOUT_PROP: String = "composeai.daemon.renderTimeoutMs"
+    public const val RENDER_TIMEOUT_PROP: String = "composeai.daemon.renderTimeoutMs"
 
     /** RECORDING.md — default `recording/start.fps` when the caller doesn't specify one. */
-    const val DEFAULT_RECORDING_FPS: Int = 30
+    public const val DEFAULT_RECORDING_FPS: Int = 30
 
     /** Live interactive preview frame cadence. Conservative to avoid saturating Android renders. */
-    const val INTERACTIVE_FRAME_INTERVAL_MS: Long = 250L
+    public const val INTERACTIVE_FRAME_INTERVAL_MS: Long = 250L
 
     /**
      * Frame cadence while a live preview is settling an input — roughly 60fps, so press feedback
      * that lives and dies inside one idle frame gap gets sampled rather than skipped.
      */
-    const val INTERACTIVE_BURST_INTERVAL_MS: Long = 16L
+    public const val INTERACTIVE_BURST_INTERVAL_MS: Long = 16L
 
     /**
      * How long after an input the burst cadence holds. Long enough for a Material ripple to fade
@@ -4482,7 +4483,7 @@ class JsonRpcServer(
      * top of it, and short enough that a resting preview is back to four frames a second before the
      * next tap.
      */
-    const val INTERACTIVE_BURST_MS: Long = 600L
+    public const val INTERACTIVE_BURST_MS: Long = 600L
 
     /**
      * Ceiling on the idle backoff — how rarely a resting live preview is re-rendered.
@@ -4493,7 +4494,7 @@ class JsonRpcServer(
      * waiting this out, so the only thing a longer gap delays is an animation that started with
      * nobody touching it.
      */
-    const val INTERACTIVE_IDLE_MAX_INTERVAL_MS: Long = 2_000L
+    public const val INTERACTIVE_IDLE_MAX_INTERVAL_MS: Long = 2_000L
 
     /**
      * Byte-identical frames tolerated before the idle backoff starts.
@@ -4503,19 +4504,19 @@ class JsonRpcServer(
      * motion. Three at the idle cadence is ~750ms of nothing moving, which is well past the burst
      * window any input opens.
      */
-    const val INTERACTIVE_QUIESCENT_AFTER: Int = 3
+    public const val INTERACTIVE_QUIESCENT_AFTER: Int = 3
 
     /** RECORDING.md — minimum legal `recording/start.fps`. */
-    const val MIN_RECORDING_FPS: Int = 1
+    public const val MIN_RECORDING_FPS: Int = 1
 
     /** RECORDING.md — maximum legal `recording/start.fps`. Capped to keep frame budgets sane. */
-    const val MAX_RECORDING_FPS: Int = 120
+    public const val MAX_RECORDING_FPS: Int = 120
 
     /** RECORDING.md — default `recording/start.scale` when the caller doesn't specify one. */
-    const val DEFAULT_RECORDING_SCALE: Float = 1.0f
+    public const val DEFAULT_RECORDING_SCALE: Float = 1.0f
 
     /** RECORDING.md — maximum legal `recording/start.scale` (output dimension multiplier). */
-    const val MAX_RECORDING_SCALE: Float = 8.0f
+    public const val MAX_RECORDING_SCALE: Float = 8.0f
 
     private const val DEFAULT_DAEMON_VERSION: String = "0.0.0-dev"
     private const val DEFAULT_HISTORY_DIR: String = ".compose-preview-history"
@@ -4525,25 +4526,25 @@ class JsonRpcServer(
       "history methods are post-1.0 and disabled in this daemon build; tracking for 1.1+"
 
     // JSON-RPC error codes — PROTOCOL.md § 2.
-    const val ERR_PARSE: Int = -32700
-    const val ERR_INVALID_REQUEST: Int = -32600
-    const val ERR_METHOD_NOT_FOUND: Int = -32601
-    const val ERR_INVALID_PARAMS: Int = -32602
-    const val ERR_INTERNAL: Int = -32603
-    const val ERR_NOT_INITIALIZED: Int = -32001
+    public const val ERR_PARSE: Int = -32700
+    public const val ERR_INVALID_REQUEST: Int = -32600
+    public const val ERR_METHOD_NOT_FOUND: Int = -32601
+    public const val ERR_INVALID_PARAMS: Int = -32602
+    public const val ERR_INTERNAL: Int = -32603
+    public const val ERR_NOT_INITIALIZED: Int = -32001
 
     /** PROTOCOL.md § 5 — `renderNow` rejected because the daemon will exit imminently. */
-    const val ERR_CLASSPATH_DIRTY: Int = -32002
+    public const val ERR_CLASSPATH_DIRTY: Int = -32002
 
     /** HISTORY.md § "Error codes" — `history/read` referenced a missing entry id. */
-    const val ERR_HISTORY_ENTRY_NOT_FOUND: Int = -32010
+    public const val ERR_HISTORY_ENTRY_NOT_FOUND: Int = -32010
 
     /**
      * HISTORY.md § "Error codes" — `history/diff` was given two entries from different previews.
      * Reserved in the wire enum even though `history/diff` itself isn't implemented in H1+H2 (lands
      * in H3+); pinned here so the code constant is part of the locked surface.
      */
-    const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
+    public const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
 
     /**
      * HISTORY.md § "Error codes" — formerly returned when `history/diff` was called with `mode =
@@ -4553,7 +4554,7 @@ class JsonRpcServer(
      * special-cased it still compile/resolve it.
      */
     @Deprecated("Pixel mode is implemented (H5); this code is no longer emitted.")
-    const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
+    public const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
 
     /**
      * HISTORY.md § "Error codes" — `history/diff` was called with `mode = semantics` but one of the
@@ -4562,19 +4563,19 @@ class JsonRpcServer(
      * semantics (a stub host, or a render that never had the kind subscribed), so there's nothing
      * to diff against.
      */
-    const val ERR_HISTORY_SEMANTICS_NOT_CAPTURED: Int = -32013
+    public const val ERR_HISTORY_SEMANTICS_NOT_CAPTURED: Int = -32013
 
     /** DATA-PRODUCTS.md § "Error codes" — kind not advertised by the daemon. */
-    const val ERR_DATA_PRODUCT_UNKNOWN: Int = -32020
+    public const val ERR_DATA_PRODUCT_UNKNOWN: Int = -32020
 
     /** DATA-PRODUCTS.md § "Error codes" — preview has never rendered; caller should `renderNow`. */
-    const val ERR_DATA_PRODUCT_NOT_AVAILABLE: Int = -32021
+    public const val ERR_DATA_PRODUCT_NOT_AVAILABLE: Int = -32021
 
     /** DATA-PRODUCTS.md § "Error codes" — re-render or projection failed; details in `data`. */
-    const val ERR_DATA_PRODUCT_FETCH_FAILED: Int = -32022
+    public const val ERR_DATA_PRODUCT_FETCH_FAILED: Int = -32022
 
     /** DATA-PRODUCTS.md § "Error codes" — re-render budget tripped before the payload landed. */
-    const val ERR_DATA_PRODUCT_BUDGET_EXCEEDED: Int = -32023
+    public const val ERR_DATA_PRODUCT_BUDGET_EXCEEDED: Int = -32023
 
     private val SHUTDOWN_SENTINEL = ByteArray(0)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabels.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/KeyboardBandLabels.kt
@@ -15,9 +15,9 @@ package ee.schimke.composeai.daemon
  * Lives on `daemon:core` so both `AndroidInteractiveSession` and `DesktopInteractiveSession` can
  * call into it without either side taking a dep on the other's connector module.
  */
-object KeyboardBandLabels {
+public object KeyboardBandLabels {
 
-  fun fromAndroidKeycode(wire: String?): String? {
+  public fun fromAndroidKeycode(wire: String?): String? {
     val code = InteractiveKeyCodes.parse(wire) ?: return null
     return LABELS[code]
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelAssertions.kt
@@ -17,7 +17,7 @@ package ee.schimke.composeai.daemon
  * itself reports a dimension mismatch (different-sized baseline) as a non-`ok` result, so that path
  * also fails with a clear message.
  */
-fun pixelAssertVerdict(
+public fun pixelAssertVerdict(
   actualPng: ByteArray?,
   baselinePng: ByteArray?,
   tolerance: PixelDiffTolerance = PixelDiffTolerance.DEFAULT,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PixelDiff.kt
@@ -24,14 +24,14 @@ import okio.Path.Companion.toPath
  * Per-scenario tolerance overrides via [PixelDiffTolerance]; callers stay on the defaults until a
  * real PR shows the tolerances need tightening or loosening.
  */
-object PixelDiff {
+public object PixelDiff {
 
   /**
    * Compares two PNGs (decoded via `javax.imageio`) and returns an [PixelDiffResult] indicating
    * whether they match within [tolerance]. Mismatched dimensions are an immediate failure with
    * `offendingPixelCount = -1` to distinguish from a per-pixel miss.
    */
-  fun compare(
+  public fun compare(
     actual: ByteArray,
     expected: ByteArray,
     tolerance: PixelDiffTolerance = PixelDiffTolerance.DEFAULT,
@@ -102,7 +102,7 @@ object PixelDiff {
    * Best-effort: any I/O failure is swallowed (after logging to stderr) so the test's primary
    * failure isn't masked by an artefact-writing exception.
    */
-  fun writeDiffArtefacts(
+  public fun writeDiffArtefacts(
     actual: ByteArray,
     expected: ByteArray,
     outDir: File,
@@ -162,7 +162,7 @@ object PixelDiff {
 }
 
 /** Tolerance struct — see TEST-HARNESS § 11 for the rationale behind each default. */
-data class PixelDiffTolerance(
+public data class PixelDiffTolerance(
   /** Maximum allowed `|Δr| + |Δg| + |Δb|` per pixel before it counts toward the aggregate. */
   val perPixel: Int = 3,
   /** Maximum fraction of pixels that may exceed [perPixel]. 0.5% by default. */
@@ -170,21 +170,21 @@ data class PixelDiffTolerance(
   /** No single pixel may exceed this — catches whole-region colour bleed. */
   val absoluteCap: Int = 50,
 ) {
-  companion object {
-    val DEFAULT = PixelDiffTolerance()
+  public companion object {
+    public val DEFAULT: PixelDiffTolerance = PixelDiffTolerance()
   }
 }
 
 /** Outcome of a [PixelDiff.compare] call. */
-data class PixelDiffResult(
+public data class PixelDiffResult(
   val ok: Boolean,
   val offendingPixelCount: Int,
   val totalPixels: Int,
   val maxDelta: Int,
   val message: String,
 ) {
-  companion object {
-    fun failure(message: String): PixelDiffResult =
+  public companion object {
+    public fun failure(message: String): PixelDiffResult =
       PixelDiffResult(
         ok = false,
         offendingPixelCount = -1,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -42,7 +42,7 @@ import kotlinx.serialization.json.Json
  * `protocolVersion` bump.
  */
 @Serializable
-data class PreviewInfoDto(
+public data class PreviewInfoDto(
   val id: String,
   /** Fully-qualified class containing the `@Preview` function. */
   val className: String,
@@ -125,7 +125,7 @@ data class PreviewInfoDto(
  * daemon-side change.
  */
 @Serializable
-data class PreviewDataProductDto(val kind: String, val scroll: ScrollCaptureDto? = null)
+public data class PreviewDataProductDto(val kind: String, val scroll: ScrollCaptureDto? = null)
 
 /**
  * Daemon-side mirror of the gradle plugin's `Capture` — one planned render of a preview. Only
@@ -134,7 +134,7 @@ data class PreviewDataProductDto(val kind: String, val scroll: ScrollCaptureDto?
  * doesn't produce, and `ignoreUnknownKeys` drops them on parse.
  */
 @Serializable
-data class PreviewCaptureDto(
+public data class PreviewCaptureDto(
   val scroll: ScrollCaptureDto? = null,
   val settle: SettleCaptureDto? = null,
 )
@@ -146,7 +146,7 @@ data class PreviewCaptureDto(
  * publishing.
  */
 @Serializable
-data class SettleCaptureDto(val afterMs: Int = 0, val maxMs: Int = 1000) {
+public data class SettleCaptureDto(val afterMs: Int = 0, val maxMs: Int = 1000) {
   /** The longest virtual-time window this settle can consume, whichever mode it is in. */
   val windowMs: Int
     get() = if (afterMs > 0) afterMs else maxMs
@@ -159,7 +159,7 @@ data class SettleCaptureDto(val afterMs: Int = 0, val maxMs: Int = 1000) {
  * plugin's recorded state.
  */
 @Serializable
-data class ScrollCaptureDto(
+public data class ScrollCaptureDto(
   /**
    * Mirrors the gradle plugin's `ScrollMode` (`END` / `LONG` / `GIF`). String-typed so the daemon
    * doesn't depend on the plugin's enum.
@@ -207,7 +207,7 @@ data class ScrollCaptureDto(
  * today — present here so a future plugin-side addition lands without another DTO bump.
  */
 @Serializable
-data class PreviewParamsDto(
+public data class PreviewParamsDto(
   val widthDp: Int? = null,
   val heightDp: Int? = null,
   /**
@@ -313,14 +313,14 @@ data class PreviewParamsDto(
  * direction), not left/right.
  */
 @Serializable
-data class CaptureGutterDto(
+public data class CaptureGutterDto(
   val start: Int = 0,
   val top: Int = 0,
   val end: Int = 0,
   val bottom: Int = 0,
 ) {
   /** True when no edge carries a gutter — the render then keeps its pre-gutter path verbatim. */
-  fun isEmpty(): Boolean = start == 0 && top == 0 && end == 0 && bottom == 0
+  public fun isEmpty(): Boolean = start == 0 && top == 0 && end == 0 && bottom == 0
 }
 
 /**
@@ -329,7 +329,7 @@ data class CaptureGutterDto(
  * the desktop daemon's `previewIndexBackedSpecResolver` and the daemon-android side can share the
  * decode without re-importing Android's `Configuration` constants on the desktop classpath.
  */
-fun uiModeIsNight(uiMode: Int?): Boolean {
+public fun uiModeIsNight(uiMode: Int?): Boolean {
   if (uiMode == null) return false
   return (uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
 }
@@ -352,7 +352,7 @@ private data class PreviewManifestDto(val previews: List<PreviewInfoDto> = empty
  * scoped to one source file. Mirrors the wire shape of `discoveryUpdated` ([PROTOCOL.md §
  * 6](../../../../../../../docs/daemon/PROTOCOL.md)).
  */
-data class DiscoveryDiff(
+public data class DiscoveryDiff(
   /** Previews present in the new scan but not in the cached index. */
   val added: List<PreviewInfoDto>,
   /**
@@ -367,7 +367,7 @@ data class DiscoveryDiff(
 )
 
 /** True when the diff has no `added`, `removed`, or `changed` entries. */
-fun discoveryDiffEmpty(diff: DiscoveryDiff): Boolean =
+public fun discoveryDiffEmpty(diff: DiscoveryDiff): Boolean =
   diff.added.isEmpty() && diff.removed.isEmpty() && diff.changed.isEmpty()
 
 /**
@@ -385,14 +385,14 @@ fun discoveryDiffEmpty(diff: DiscoveryDiff): Boolean =
  * [PROTOCOL.md § 1](../../../../../../../docs/daemon/PROTOCOL.md)). The daemon should still come up
  * on a corrupt manifest; clients see `previewCount = 0` and can re-trigger discovery.
  */
-class PreviewIndex
+public class PreviewIndex
 internal constructor(
   /**
    * Absolute path to the file the index was loaded from. `null` when the index is the empty
    * placeholder — i.e. no `composeai.daemon.previewsJsonPath` sysprop was set, or the file didn't
    * exist / was malformed.
    */
-  val path: Path?,
+  public val path: Path?,
   initial: Map<String, PreviewInfoDto>,
 ) {
 
@@ -400,12 +400,12 @@ internal constructor(
   private val byId: MutableMap<String, PreviewInfoDto> = LinkedHashMap(initial)
 
   /** Total number of previews known to the daemon. */
-  val size: Int
+  public val size: Int
     get() = lock.read { byId.size }
 
   /** Lookup by `PreviewInfo.id`. `null` if the id is unknown. */
   /** The discovered preview [id] names, or `null`. Exact match only — see [rowResolved]. */
-  fun byId(id: String): PreviewInfoDto? = lock.read { byId[id] }
+  public fun byId(id: String): PreviewInfoDto? = lock.read { byId[id] }
 
   /**
    * [byId], widened to accept a **row-addressed** id (`<baseId>_Dark` / `<baseId>_PARAM_4`,
@@ -423,7 +423,7 @@ internal constructor(
    * silently the wrong state, which is worse than the "unknown previewId" a caller used to get.
    * That is why the row rides out here rather than being folded invisibly into [byId].
    */
-  fun rowResolved(id: String): Resolved? = lock.read {
+  public fun rowResolved(id: String): Resolved? = lock.read {
     byId[id]?.let {
       return@read Resolved(it, null)
     }
@@ -435,7 +435,7 @@ internal constructor(
   }
 
   /** A previewId resolved by [rowResolved]: the entry, and the `@PreviewParameter` row it named. */
-  data class Resolved(val info: PreviewInfoDto, val row: String?)
+  public data class Resolved(val info: PreviewInfoDto, val row: String?)
 
   /**
    * Issue #1528 — resolves the [ScrollCaptureDto] for a given `(previewId, renderMode)` pair so the
@@ -445,7 +445,7 @@ internal constructor(
    * preview has no `dataProducts` entry of that kind (typical for previews without
    * `@ScrollingPreview`).
    */
-  fun scrollCaptureFor(previewId: String, mode: String): ScrollCaptureDto? {
+  public fun scrollCaptureFor(previewId: String, mode: String): ScrollCaptureDto? {
     val kind =
       when (mode) {
         "scroll-long" -> "render/scroll/long"
@@ -484,7 +484,7 @@ internal constructor(
    * carries `@AnimatedPreview` plans a scroll-less GIF capture beside the END one, but that GIF is
    * a separate output rather than a rival static frame.
    */
-  fun staticScrollFor(previewId: String): ScrollCaptureDto? {
+  public fun staticScrollFor(previewId: String): ScrollCaptureDto? {
     // Row-aware for the same reason as [scrollCaptureFor]: without it an `END` static row silently
     // renders at the resting top instead of the scrolled-to-end frame its base asked for.
     val info = rowResolved(previewId)?.info ?: return null
@@ -504,19 +504,19 @@ internal constructor(
    * carries one carries the same one, and a disagreement means the manifest describes something the
    * daemon has no honest single answer for.
    */
-  fun staticSettleFor(previewId: String): SettleCaptureDto? {
+  public fun staticSettleFor(previewId: String): SettleCaptureDto? {
     val info = rowResolved(previewId)?.info ?: return null
     val settles = info.captures.mapNotNull { it.settle }.distinct()
     return settles.singleOrNull()
   }
 
   /** All known preview ids. Phase 2 will diff a fresh scan against this set. */
-  fun ids(): Set<String> = lock.read { byId.keys.toSet() }
+  public fun ids(): Set<String> = lock.read { byId.keys.toSet() }
 
   /**
    * Snapshot of the current `id → PreviewInfoDto` map. Not live; safe to iterate without locking.
    */
-  fun snapshot(): Map<String, PreviewInfoDto> = lock.read { LinkedHashMap(byId) }
+  public fun snapshot(): Map<String, PreviewInfoDto> = lock.read { LinkedHashMap(byId) }
 
   /**
    * Computes a [DiscoveryDiff] for one source file.
@@ -530,7 +530,7 @@ internal constructor(
    *
    * Pure — does NOT mutate the index. Call [applyDiff] separately to commit.
    */
-  fun diff(newScanForFile: Set<PreviewInfoDto>, sourceFile: Path): DiscoveryDiff {
+  public fun diff(newScanForFile: Set<PreviewInfoDto>, sourceFile: Path): DiscoveryDiff {
     val sourceKey = sourceFile.toString()
     return lock.read {
       val newById = newScanForFile.associateBy { it.id }
@@ -575,7 +575,7 @@ internal constructor(
    *
    * Holds the write lock for the duration of the merge.
    */
-  fun applyDiff(diff: DiscoveryDiff) {
+  public fun applyDiff(diff: DiscoveryDiff) {
     lock.write {
       for (id in diff.removed) byId.remove(id)
       for (dto in diff.added) byId[dto.id] = dto
@@ -611,20 +611,20 @@ internal constructor(
     }
   }
 
-  companion object {
+  public companion object {
     /**
      * The empty placeholder. Used when no `composeai.daemon.previewsJsonPath` was supplied — e.g.
      * fake-mode harness scenarios, the in-process integration tests, the pre-B2.2 default. `path =
      * null`, `size = 0`.
      */
-    fun empty(): PreviewIndex = PreviewIndex(path = null, initial = emptyMap())
+    public fun empty(): PreviewIndex = PreviewIndex(path = null, initial = emptyMap())
 
     /**
      * Constructs an index from an in-memory map. Used by the harness's `FakeDaemonMain` to seed a
      * daemon-side index from its own fixture manifest without round-tripping a JSON file. [path]
      * may be null (harness path) or absolute (production / desktop daemon path).
      */
-    fun fromMap(path: Path?, byId: Map<String, PreviewInfoDto>): PreviewIndex =
+    public fun fromMap(path: Path?, byId: Map<String, PreviewInfoDto>): PreviewIndex =
       PreviewIndex(path = path?.toAbsolutePath(), initial = byId)
 
     /**
@@ -632,7 +632,7 @@ internal constructor(
      * array. Returns [empty] (and prints a warn-level diagnostic to stderr) if the file is missing,
      * unreadable, or malformed; never throws.
      */
-    fun loadFromFile(path: Path): PreviewIndex {
+    public fun loadFromFile(path: Path): PreviewIndex {
       val absolute = path.toAbsolutePath()
       if (!Files.exists(absolute)) {
         System.err.println(
@@ -674,7 +674,7 @@ internal constructor(
      * [DaemonClasspathDescriptor.systemProperties]); when unset, the daemon comes up with [empty] —
      * preserves pre-B2.2 in-process / fake-mode behaviour.
      */
-    const val PREVIEWS_JSON_PATH_PROP: String = "composeai.daemon.previewsJsonPath"
+    public const val PREVIEWS_JSON_PATH_PROP: String = "composeai.daemon.previewsJsonPath"
 
     private val JSON: Json = Json {
       ignoreUnknownKeys = true

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideExtensions.kt
@@ -23,7 +23,7 @@ import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
  * the merged [PreviewOverrides] to every registered planner and threads the resulting list through
  * the Compose data-extension pipeline.
  */
-typealias PreviewOverrideExtension = DataExtension<PreviewOverrides>
+public typealias PreviewOverrideExtension = DataExtension<PreviewOverrides>
 
 /**
  * Opt-in marker for a [PreviewOverrideExtension] that must be planned on **every** render,
@@ -46,7 +46,7 @@ typealias PreviewOverrideExtension = DataExtension<PreviewOverrides>
  * shared interactive state (keyboard visibility, permission grants) on an empty bag — running those
  * on every no-override render would reset state a held session still depends on.
  */
-interface AlwaysOnPreviewOverrideExtension
+public interface AlwaysOnPreviewOverrideExtension
 
 /**
  * Aggregator of registered [PreviewOverrideExtension]s, injected into the renderer.
@@ -60,11 +60,11 @@ interface AlwaysOnPreviewOverrideExtension
  * rebuilding the renderer. The default predicate considers every extension active — used by tests
  * and by callers that want the legacy "always on" behaviour.
  */
-class PreviewOverrideExtensions(
-  val extensions: List<PreviewOverrideExtension>,
+public class PreviewOverrideExtensions(
+  public val extensions: List<PreviewOverrideExtension>,
   private val isActive: (PreviewOverrideExtension) -> Boolean = { true },
 ) {
-  fun plan(overrides: PreviewOverrides?): List<PlannedDataExtension> {
+  public fun plan(overrides: PreviewOverrides?): List<PlannedDataExtension> {
     if (extensions.isEmpty()) return emptyList()
     // No override bag on this render: most planners would abstain, so skip them — but the
     // always-on planners (e.g. the named-override host + scope stamper) still have to run. Hand
@@ -79,7 +79,7 @@ class PreviewOverrideExtensions(
     return extensions.mapNotNull { if (isActive(it)) it.plan(overrides) else null }
   }
 
-  companion object {
-    val Empty: PreviewOverrideExtensions = PreviewOverrideExtensions(emptyList())
+  public companion object {
+    public val Empty: PreviewOverrideExtensions = PreviewOverrideExtensions(emptyList())
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -24,7 +24,7 @@ import ee.schimke.composeai.data.overrides.PreviewOverrideValue
  * need to stay identical across hosts. This small DTO lets hosts adapt their local spec into a
  * shared merge function, then copy the merged fields back into their local type.
  */
-data class PreviewOverrideBaseSpec(
+public data class PreviewOverrideBaseSpec(
   val widthPx: Int,
   val heightPx: Int,
   val density: Float,
@@ -49,7 +49,7 @@ data class PreviewOverrideBaseSpec(
   val namedOverrides: Map<String, PreviewOverrideValue>? = null,
 )
 
-data class MergedPreviewOverrides(
+public data class MergedPreviewOverrides(
   val widthPx: Int,
   val heightPx: Int,
   val density: Float,
@@ -98,7 +98,7 @@ data class MergedPreviewOverrides(
    * without this, locale-only overrides ran the qualifier rewrite but never installed the
    * around-composable, leaving strings un-pseudolocalised.
    */
-  fun toExtensionOverrides(): PreviewOverrides? {
+  public fun toExtensionOverrides(): PreviewOverrides? {
     val isPseudolocale = isPseudolocaleTag(localeTag)
     if (
       material3Theme == null &&
@@ -162,7 +162,7 @@ data class MergedPreviewOverrides(
  * Display-geometry fields (`widthPx`, `density`, `uiMode`, …) are deliberately NOT touched: the
  * host resolves those from its own spec, where the discovery-time values already live.
  */
-fun PreviewOverrideBaseSpec.withCarriedOverrides(
+public fun PreviewOverrideBaseSpec.withCarriedOverrides(
   carried: PreviewOverrides?
 ): PreviewOverrideBaseSpec =
   if (carried == null) this
@@ -192,7 +192,7 @@ fun PreviewOverrideBaseSpec.withCarriedOverrides(
  * the default wrapper. Both hosts' `applyOverrides` call this to carry the selection through,
  * mirroring how `clearBackground` is carried onto the held spec. A blank / null FQN is a no-op.
  */
-fun PreviewOverrides?.withThemeProvider(themeProvider: String?): PreviewOverrides? =
+public fun PreviewOverrides?.withThemeProvider(themeProvider: String?): PreviewOverrides? =
   if (themeProvider.isNullOrBlank()) this
   else (this ?: PreviewOverrides()).copy(themeProvider = themeProvider)
 
@@ -205,7 +205,7 @@ fun PreviewOverrides?.withThemeProvider(themeProvider: String?): PreviewOverride
  * wrap. Mirrors [withThemeProvider] and the `clearBackground` carry in each host's
  * `applyOverrides`. A [source] with no bounds set is a no-op.
  */
-fun PreviewOverrides?.withSizeBounds(source: PreviewOverrides?): PreviewOverrides? {
+public fun PreviewOverrides?.withSizeBounds(source: PreviewOverrides?): PreviewOverrides? {
   if (
     source?.minWidthPx == null &&
       source?.minHeightPx == null &&
@@ -249,7 +249,7 @@ fun PreviewOverrides?.withSizeBounds(source: PreviewOverrides?): PreviewOverride
  * Only pseudolocales are folded back: a real locale (`de`, `ar`, `zh-Hant-TW`) has no bag-consuming
  * planner, and restating it would put a tokenised field back in the bag for no reader.
  */
-fun PreviewOverrides?.withPseudolocaleFrom(localeTag: String?): PreviewOverrides? =
+public fun PreviewOverrides?.withPseudolocaleFrom(localeTag: String?): PreviewOverrides? =
   if (!isPseudolocaleTag(localeTag)) this
   else (this ?: PreviewOverrides()).copy(localeTag = localeTag)
 
@@ -285,7 +285,7 @@ private fun isPseudolocaleTag(tag: String?): Boolean {
  * base value. `PreviewOverrideMergeTest.layeredOver…` guards this by asserting an empty overlay
  * over a fully-populated base round-trips to the base unchanged.
  */
-fun PreviewOverrides?.layeredOver(base: PreviewOverrides?): PreviewOverrides? {
+public fun PreviewOverrides?.layeredOver(base: PreviewOverrides?): PreviewOverrides? {
   val over = this ?: return base
   if (base == null) return over
   return PreviewOverrides(
@@ -337,7 +337,7 @@ fun PreviewOverrides?.layeredOver(base: PreviewOverrides?): PreviewOverrides? {
  * pixels from its dp geometry at the effective density, then let explicit pixel dimensions replace
  * either axis.
  */
-fun mergePreviewOverrides(
+public fun mergePreviewOverrides(
   base: PreviewOverrideBaseSpec,
   overrides: PreviewOverrides?,
 ): MergedPreviewOverrides {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewRowAddress.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewRowAddress.kt
@@ -33,13 +33,13 @@ package ee.schimke.composeai.daemon
  * keeps `MyScreenPreview_Light_PARAM_4` addressing row 4 of the `_Light` variant rather than
  * reading `Light_PARAM_4` as a row token of the bare preview.
  */
-object PreviewRowAddress {
+public object PreviewRowAddress {
 
   /** Prefix of the index-addressed row token — `PARAM_4` names provider value 4. */
-  const val INDEX_PREFIX: String = "PARAM_"
+  public const val INDEX_PREFIX: String = "PARAM_"
 
   /** A previewId resolved against the manifest: which entry to render, and which row of it. */
-  data class Split(val baseId: String, val row: String)
+  public data class Split(val baseId: String, val row: String)
 
   /**
    * Resolves [previewId] as `<baseId>_<row>` where `baseId` satisfies [isParameterized], or `null`
@@ -53,7 +53,7 @@ object PreviewRowAddress {
    *
    * Callers check the exact id first; this is the fallback for a miss.
    */
-  fun split(previewId: String, isParameterized: (String) -> Boolean): Split? {
+  public fun split(previewId: String, isParameterized: (String) -> Boolean): Split? {
     var cut = previewId.lastIndexOf('_')
     while (cut > 0) {
       val base = previewId.substring(0, cut)
@@ -65,14 +65,14 @@ object PreviewRowAddress {
   }
 
   /** The addressable id of one row: `<baseId>_<rowToken>`, matching the fan-out's filename stem. */
-  fun rowId(baseId: String, row: String): String = "${baseId}_$row"
+  public fun rowId(baseId: String, row: String): String = "${baseId}_$row"
 
   /**
    * The index a `PARAM_<n>` token names, or `null` for a label token. Blank/negative/overflowing
    * spellings return `null` so they fall through to label matching and fail with the "no row named
    * …" diagnostic rather than an opaque parse error.
    */
-  fun indexOf(row: String): Int? =
+  public fun indexOf(row: String): Int? =
     if (row.startsWith(INDEX_PREFIX))
       row.removePrefix(INDEX_PREFIX).toIntOrNull()?.takeIf { it >= 0 }
     else null

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingAssertions.kt
@@ -15,10 +15,10 @@ import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
  * nodes match. This is deliberately laxer than the tap-dispatch path (which treats an ambiguous
  * match as unresolved): an existence check doesn't need a unique node, it needs a yes/no answer.
  */
-sealed interface AssertionVerdict {
-  data object Passed : AssertionVerdict
+public sealed interface AssertionVerdict {
+  public data object Passed : AssertionVerdict
 
-  data class Failed(val reason: String) : AssertionVerdict
+  public data class Failed(val reason: String) : AssertionVerdict
 }
 
 /**
@@ -26,7 +26,7 @@ sealed interface AssertionVerdict {
  * `assert.notVisible`. [matchCount] is how many semantics nodes the target resolved to (0, 1, or
  * more). [targetLabel] is a human-readable rendering of the target for the failure message.
  */
-fun evaluateVisibilityAssertion(
+public fun evaluateVisibilityAssertion(
   expectVisible: Boolean,
   matchCount: Int,
   targetLabel: String,
@@ -49,7 +49,7 @@ fun evaluateVisibilityAssertion(
  * The target-resolution failure (no match / ambiguous) is handled by the caller before this runs —
  * this is purely the string comparison.
  */
-fun evaluateTextEqualsAssertion(
+public fun evaluateTextEqualsAssertion(
   expected: String,
   actual: String?,
   targetLabel: String,
@@ -73,7 +73,7 @@ fun evaluateTextEqualsAssertion(
  * than `<none>`. Pure (operates on the [ComposeSemanticsNode] model, no scene) so it's
  * unit-testable directly.
  */
-fun resolvedNodeText(node: ComposeSemanticsNode): String? {
+public fun resolvedNodeText(node: ComposeSemanticsNode): String? {
   node.text
     ?.takeIf { it.isNotEmpty() }
     ?.let {
@@ -92,13 +92,13 @@ fun resolvedNodeText(node: ComposeSemanticsNode): String? {
 }
 
 /** Threshold for `assert.a11y`: fail on ATF errors only, or on warnings (and errors) too. */
-enum class A11yAssertThreshold {
+public enum class A11yAssertThreshold {
   ERRORS,
   WARNINGS;
 
-  companion object {
+  public companion object {
     /** Parse the wire token (`errors` / `warnings`, singular accepted); defaults to [ERRORS]. */
-    fun parseOrDefault(token: String?): A11yAssertThreshold =
+    public fun parseOrDefault(token: String?): A11yAssertThreshold =
       when (token?.trim()?.lowercase()) {
         "warnings",
         "warning" -> WARNINGS
@@ -114,7 +114,7 @@ enum class A11yAssertThreshold {
  * [RecordingA11yFinding][ee.schimke.composeai.daemon.protocol.RecordingA11yFinding] projection) so
  * it's unit-testable without standing up a Robolectric scene.
  */
-fun evaluateA11yAssertion(
+public fun evaluateA11yAssertion(
   findings: List<ee.schimke.composeai.daemon.protocol.RecordingA11yFinding>,
   threshold: A11yAssertThreshold,
 ): AssertionVerdict {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingProbeTargets.kt
@@ -35,23 +35,23 @@ import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
  * desktop [resolvedNodeText] preference (own text wins over descendant text) so the two backends
  * answer `role`+`text` and `assert.textEquals` the same way.
  */
-fun RecordingProbeNode.effectiveText(): String? =
+public fun RecordingProbeNode.effectiveText(): String? =
   text?.takeIf { it.isNotEmpty() } ?: mergedText?.takeIf { it.isNotEmpty() }
 
 /** Outcome of resolving a [SemanticsInputTarget] against a flat probe snapshot. */
-sealed interface ProbeTargetResolution {
+public sealed interface ProbeTargetResolution {
   /**
    * The target shape is resolvable against the snapshot; [nodes] is every node that matched (0, 1,
    * or more). A visibility check reads its size; a text check requires exactly one.
    */
-  data class Matched(val nodes: List<RecordingProbeNode>) : ProbeTargetResolution
+  public data class Matched(val nodes: List<RecordingProbeNode>) : ProbeTargetResolution
 
   /**
    * The target can't be resolved against the flat snapshot at all (a `ref` target, or a target with
    * no resolvable field). [reason] is a caller-facing explanation for the failed-assertion
    * evidence.
    */
-  data class Unsupported(val reason: String) : ProbeTargetResolution
+  public data class Unsupported(val reason: String) : ProbeTargetResolution
 }
 
 /**
@@ -60,7 +60,7 @@ sealed interface ProbeTargetResolution {
  * [ProbeTargetResolution.Unsupported] so the caller fails the assertion with a clear message
  * instead of risking a false pass.
  */
-fun resolveProbeTarget(
+public fun resolveProbeTarget(
   nodes: List<RecordingProbeNode>,
   target: SemanticsInputTarget,
 ): ProbeTargetResolution {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -14,17 +14,19 @@ import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
  *
  * Live tick-loop callers reuse the same shape with the wall-clock-anchored virtual nanoTime.
  */
-interface RecordingDispatchContext {
+public interface RecordingDispatchContext {
   /** Virtual nanoTime of the frame this event is dispatched at. */
-  val tNanos: Long
+  public val tNanos: Long
 
   /** Virtual milliseconds (`tNanos / 1_000_000`). */
-  val tMs: Long
+  public val tMs: Long
 }
 
 /** Default value-class implementation — backends can pass an instance per event. */
-data class SimpleRecordingDispatchContext(override val tNanos: Long, override val tMs: Long) :
-  RecordingDispatchContext
+public data class SimpleRecordingDispatchContext(
+  override val tNanos: Long,
+  override val tMs: Long,
+) : RecordingDispatchContext
 
 /**
  * Single-event dispatch interface. One implementation per `(host, event-kind)` pair. The session
@@ -35,8 +37,11 @@ data class SimpleRecordingDispatchContext(override val tNanos: Long, override va
  * never throw — so a malformed event aborts at most a single dispatch slot, not the whole
  * recording. Use [appliedEvidence] / [unsupportedEvidence] to build the result.
  */
-fun interface RecordingScriptEventHandler {
-  fun apply(event: RecordingScriptEvent, ctx: RecordingDispatchContext): RecordingScriptEvidence
+public fun interface RecordingScriptEventHandler {
+  public fun apply(
+    event: RecordingScriptEvent,
+    ctx: RecordingDispatchContext,
+  ): RecordingScriptEvidence
 }
 
 /**
@@ -50,8 +55,8 @@ fun interface RecordingScriptEventHandler {
  * recording session is the source of truth for evidence shape and shouldn't fail because an
  * extension threw.
  */
-fun interface RecordingScriptDispatchObserver {
-  fun beforeDispatch(event: RecordingScriptEvent, ctx: RecordingDispatchContext)
+public fun interface RecordingScriptDispatchObserver {
+  public fun beforeDispatch(event: RecordingScriptEvent, ctx: RecordingDispatchContext)
 }
 
 /**
@@ -67,12 +72,12 @@ fun interface RecordingScriptDispatchObserver {
  * [observers] receive every dispatched event before the handler runs — see
  * [RecordingScriptDispatchObserver] for the contract.
  */
-class RecordingScriptHandlerRegistry(
+public class RecordingScriptHandlerRegistry(
   private val handlers: Map<String, RecordingScriptEventHandler>,
   private val observers: List<RecordingScriptDispatchObserver> = emptyList(),
 ) {
 
-  fun dispatch(
+  public fun dispatch(
     event: RecordingScriptEvent,
     ctx: RecordingDispatchContext,
   ): RecordingScriptEvidence {
@@ -95,7 +100,7 @@ class RecordingScriptHandlerRegistry(
   }
 
   /** Wire-string keys this registry knows about. Useful for tests + capability derivation. */
-  fun knownKinds(): Set<String> = handlers.keys
+  public fun knownKinds(): Set<String> = handlers.keys
 }
 
 /**
@@ -103,7 +108,7 @@ class RecordingScriptHandlerRegistry(
  * `message` field for human-readable trace context. [probeSemantics] carries the host-captured
  * semantics snapshot for a `recording.probe` event (issue #1786); null for every other kind.
  */
-fun appliedEvidence(
+public fun appliedEvidence(
   event: RecordingScriptEvent,
   message: String? = null,
   probeSemantics: List<ee.schimke.composeai.daemon.protocol.RecordingProbeNode>? = null,
@@ -131,7 +136,7 @@ fun appliedEvidence(
  * ref/testTag/role+text dispatch path (issue #1784) — matched-count + candidate nodes. Other event
  * kinds leave both `null`.
  */
-fun unsupportedEvidence(
+public fun unsupportedEvidence(
   event: RecordingScriptEvent,
   message: String,
   unsupportedReason: ee.schimke.composeai.daemon.protocol.UiAutomatorUnsupportedReason? = null,
@@ -158,7 +163,7 @@ fun unsupportedEvidence(
  * [message] states the unmet condition; optional [targetUnresolvedReason] carries the matched-count
  * + candidate nodes so the agent can see what *was* present without re-rendering.
  */
-fun failedEvidence(
+public fun failedEvidence(
   event: RecordingScriptEvent,
   message: String,
   targetUnresolvedReason: ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedReason? =

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -40,19 +40,19 @@ import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
  * 9](../../../../../../docs/daemon/DESIGN.md)). [close] must drain any in-flight render before
  * tearing down the scene, the same way `RenderHost.shutdown` drains its queue.
  */
-interface RecordingSession : AutoCloseable {
+public interface RecordingSession : AutoCloseable {
 
   /** The preview id this session is recording. Frozen at allocation time. */
-  val previewId: String
+  public val previewId: String
 
   /** Opaque session id assigned by [JsonRpcServer] at `recording/start`. Frozen at allocation. */
-  val recordingId: String
+  public val recordingId: String
 
   /** Frame rate of the virtual clock, in frames per second. Frozen at allocation. */
-  val fps: Int
+  public val fps: Int
 
   /** Output-frame size multiplier (≥ 0). Frozen at allocation. */
-  val scale: Float
+  public val scale: Float
 
   /**
    * `true` when this session captures real-time interactions instead of replaying a scripted
@@ -63,14 +63,14 @@ interface RecordingSession : AutoCloseable {
    * `false` (the default) is the scripted path that's been live since v1: post a full timeline via
    * [postScript], then [stop] plays it back at virtual frame time.
    */
-  val live: Boolean
+  public val live: Boolean
 
   /**
    * **Scripted mode only.** Append a batch of events to the virtual timeline. May be called
    * multiple times before [stop]; each call merges and re-sorts by `tMs` so out-of-order client
    * batches still play in order. Throws [IllegalStateException] when [live] is `true`.
    */
-  fun postScript(events: List<RecordingScriptEvent>)
+  public fun postScript(events: List<RecordingScriptEvent>)
 
   /**
    * **Live mode only.** Append one input event to the live tick loop's pending queue. The
@@ -81,7 +81,7 @@ interface RecordingSession : AutoCloseable {
    * Fire-and-forget by design: the daemon's `recording/input` notification handler doesn't wait for
    * the tick to consume the event. Inputs that arrive after [stop] are dropped silently.
    */
-  fun postInput(input: RecordingInputParams)
+  public fun postInput(input: RecordingInputParams)
 
   /**
    * Stop the recording and return its frame metadata. Behaviour differs by mode:
@@ -94,14 +94,14 @@ interface RecordingSession : AutoCloseable {
    * illegal — but the PNGs remain on disk so [encode] can be invoked. Idempotent in the limited
    * sense that a second call returns the same [RecordingResult] without re-rendering.
    */
-  fun stop(): RecordingResult
+  public fun stop(): RecordingResult
 
   /**
    * Encode the on-disk frames produced by [stop] into a single video file. Must be called after
    * [stop] (the implementation throws otherwise). Idempotent: encoding the same format twice
    * returns the same path; encoding different formats writes side-by-side files.
    */
-  fun encode(format: RecordingFormat): EncodedRecording
+  public fun encode(format: RecordingFormat): EncodedRecording
 
   /**
    * Drains any in-flight playback, frees the held scene + native resources, and removes any
@@ -115,7 +115,7 @@ interface RecordingSession : AutoCloseable {
  * Metadata returned by [RecordingSession.stop]. The on-disk PNGs at `<framesDir>/frame-NNNNN.png`
  * outlive the session.
  */
-data class RecordingResult(
+public data class RecordingResult(
   val frameCount: Int,
   val durationMs: Long,
   val framesDir: String,
@@ -131,9 +131,9 @@ data class RecordingResult(
 )
 
 /** Metadata returned by [RecordingSession.encode]. */
-data class EncodedRecording(val videoPath: String, val mimeType: String, val sizeBytes: Long)
+public data class EncodedRecording(val videoPath: String, val mimeType: String, val sizeBytes: Long)
 
-fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
+public fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
   INTERACTIVE_INPUT_KIND_BY_WIRE_NAME[this]
 
 /**
@@ -147,7 +147,7 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
  * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind against
  * the daemon's advertised set — no special-case branch for input kinds anymore.
  */
-val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
+public val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(
     "input.click" to InteractiveInputKind.CLICK,
     "input.pointerDown" to InteractiveInputKind.POINTER_DOWN,
@@ -171,4 +171,5 @@ private val INTERACTIVE_INPUT_KIND_TO_WIRE_NAME: Map<InteractiveInputKind, Strin
 /**
  * Wire-name string for an [InteractiveInputKind] (the reverse of [toInteractiveInputKindOrNull]).
  */
-fun InteractiveInputKind.wireName(): String = INTERACTIVE_INPUT_KIND_TO_WIRE_NAME.getValue(this)
+public fun InteractiveInputKind.wireName(): String =
+  INTERACTIVE_INPUT_KIND_TO_WIRE_NAME.getValue(this)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingTestGenerator.kt
@@ -25,21 +25,21 @@ import ee.schimke.composeai.daemon.protocol.SemanticsInputTarget
  *
  * Pure string generation — no Compose / daemon runtime — so it is golden-testable in isolation.
  */
-object RecordingTestGenerator {
+public object RecordingTestGenerator {
 
   /**
    * One recorded event plus whether the recording reported it as applied (vs `unsupported`).
    * [probeSemantics] is the host-captured semantics snapshot for a `recording.probe` event (null
    * for every other kind, and for probes from daemons that predate the capture).
    */
-  data class Step(
+  public data class Step(
     val event: RecordingScriptEvent,
     val applied: Boolean = true,
     val probeSemantics: List<RecordingProbeNode>? = null,
   )
 
   /** Inputs for one generated test. */
-  data class Spec(
+  public data class Spec(
     /** Generated class name, e.g. `GeneratedTogglePreviewTest`. */
     val className: String,
     /** Generated `@Test` method name, e.g. `togglePreviewInteraction`. */
@@ -52,7 +52,7 @@ object RecordingTestGenerator {
   )
 
   /** Wrap raw events as all-applied steps — for callers without recording evidence. */
-  fun stepsOf(events: List<RecordingScriptEvent>): List<Step> = events.map { Step(it) }
+  public fun stepsOf(events: List<RecordingScriptEvent>): List<Step> = events.map { Step(it) }
 
   /**
    * Build a [Spec] for a recording captured against [previewId] (issue #2047, the record-live
@@ -66,7 +66,7 @@ object RecordingTestGenerator {
    * pin exact names. Events are wrapped as all-applied steps (panel clicks dispatched); callers
    * with per-event evidence build [Step]s themselves and call [generate] directly.
    */
-  fun defaultSpec(
+  public fun defaultSpec(
     previewId: String,
     functionName: String?,
     classFqn: String?,
@@ -102,7 +102,7 @@ object RecordingTestGenerator {
     return trimmed.takeIf { it.isNotBlank() }
   }
 
-  fun generate(spec: Spec): String = buildString {
+  public fun generate(spec: Spec): String = buildString {
     val sortedSteps = spec.steps.sortedBy { it.event.tMs }
     // Probe snapshots opt the assertion finders/imports in; without any, the output stays
     // byte-identical to the pre-#1786-assertions stub form so older recordings are unaffected.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderErrorClassifier.kt
@@ -16,11 +16,11 @@ import ee.schimke.composeai.daemon.protocol.RenderErrorKind
  * fine-grained kind stays additive and decode-safe for old clients (which see it as
  * [RenderErrorKind.UNKNOWN] and fall back to [Classification.suggestion] / the message).
  */
-object RenderErrorClassifier {
+public object RenderErrorClassifier {
 
-  data class Classification(val kind: RenderErrorKind, val suggestion: String? = null)
+  public data class Classification(val kind: RenderErrorKind, val suggestion: String? = null)
 
-  fun classify(cause: Throwable): Classification {
+  public fun classify(cause: Throwable): Classification {
     val diagnostic = buildString {
       var t: Throwable? = cause
       var depth = 0

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -26,14 +26,14 @@ import java.util.concurrent.atomic.AtomicLong
  * returns a [RenderResult]; [JsonRpcServer] already runs each `submit` on a fire-and-forget worker
  * so the JSON-RPC read loop is never blocked.
  */
-interface RenderHost {
+public interface RenderHost {
 
   /**
    * Lifecycle: must be called once before the first [submit]. After this returns the host is alive
    * and ready (though the first [submit] may still pay a cold-start cost, e.g. Robolectric sandbox
    * bootstrap).
    */
-  fun start()
+  public fun start()
 
   /**
    * Submits one render request and blocks until its [RenderResult] is available, or until
@@ -43,7 +43,7 @@ interface RenderHost {
    * @param request must be a [RenderRequest.Render]; the [RenderRequest.Shutdown] poison pill is
    *   implementation-internal and not legal here.
    */
-  fun submit(request: RenderRequest, timeoutMs: Long = 60_000): RenderResult
+  public fun submit(request: RenderRequest, timeoutMs: Long = 60_000): RenderResult
 
   /**
    * Drains in-flight renders cleanly, then stops the render thread. Never aborts a render
@@ -51,7 +51,7 @@ interface RenderHost {
    *
    * @param timeoutMs upper bound for the worker thread to exit after the poison pill is enqueued.
    */
-  fun shutdown(timeoutMs: Long = 30_000)
+  public fun shutdown(timeoutMs: Long = 30_000)
 
   /**
    * The disposable user-class [UserClassLoaderHolder] this host renders against (B2.0 — see
@@ -68,7 +68,7 @@ interface RenderHost {
    * representative holder (slot 0) so callers that only need "is this host classloader-aware?" keep
    * working; callers that mutate state should use [swapUserClassLoaders] for the broadcast.
    */
-  val userClassloaderHolder: UserClassLoaderHolder?
+  public val userClassloaderHolder: UserClassLoaderHolder?
     get() = null
 
   /**
@@ -81,7 +81,7 @@ interface RenderHost {
    * [userClassloaderHolder]?.swap() directly so the broadcast is the same call site for both
    * single-sandbox and pool modes.
    */
-  fun swapUserClassLoaders() {
+  public fun swapUserClassLoaders() {
     userClassloaderHolder?.swap()
   }
 
@@ -96,7 +96,7 @@ interface RenderHost {
    * Implementations MUST keep this in sync with their [acquireInteractiveSession] override —
    * advertising `true` while throwing is a contract violation.
    */
-  val supportsInteractive: Boolean
+  public val supportsInteractive: Boolean
     get() = false
 
   /**
@@ -114,7 +114,7 @@ interface RenderHost {
    * exposes a providable locale list. `orientation` IS advertised on desktop — reduced to a
    * `widthPx ↔ heightPx` swap by `DesktopHost` (issue #1208).
    */
-  val supportedOverrides: Set<String>
+  public val supportedOverrides: Set<String>
     get() = emptySet()
 
   /**
@@ -125,7 +125,7 @@ interface RenderHost {
    * etc. Real backends override: `RobolectricHost` returns `ANDROID`, `DesktopHost` returns
    * `DESKTOP`.
    */
-  val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind?
+  public val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind?
     get() = null
 
   /**
@@ -133,7 +133,7 @@ interface RenderHost {
    * `@Config(sdk = ...)` value so clients can reason about backend compatibility without scraping
    * daemon logs. Non-Android backends return `null`.
    */
-  val androidSdk: Int?
+  public val androidSdk: Int?
     get() = null
 
   /**
@@ -147,7 +147,7 @@ interface RenderHost {
    * etc.) instead of probing each kind. The default empty set is the pre-#1203 contract — clients
    * treat absent and `[]` identically and assume only pointer events are dispatchable.
    */
-  val supportedInteractiveControlKinds: Set<String>
+  public val supportedInteractiveControlKinds: Set<String>
     get() = emptySet()
 
   /**
@@ -183,7 +183,7 @@ interface RenderHost {
    *   auto-close, the JSON-RPC read thread for explicit stop, the JVM shutdown thread for
    *   `cleanShutdown` — so implementations should be cheap and thread-safe.
    */
-  fun acquireInteractiveSession(
+  public fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
     inspectionMode: Boolean? = null,
@@ -210,7 +210,7 @@ interface RenderHost {
    *
    * Implementations MUST keep this in sync with their [acquireRecordingSession] override.
    */
-  val supportsRecording: Boolean
+  public val supportsRecording: Boolean
     get() = false
 
   /**
@@ -223,7 +223,7 @@ interface RenderHost {
    * Default empty list keeps pre-feature hosts (FakeHost, RobolectricHost today) consistent with
    * `supportsRecording = false` — clients see "no formats" and don't offer the toggle.
    */
-  val supportedRecordingFormats: List<String>
+  public val supportedRecordingFormats: List<String>
     get() = emptyList()
 
   /**
@@ -254,7 +254,7 @@ interface RenderHost {
    *   [RecordingSession.postScript] and [RecordingSession.stop] plays it back. See RECORDING.md §
    *   "live mode".
    */
-  fun acquireRecordingSession(
+  public fun acquireRecordingSession(
     previewId: String,
     recordingId: String,
     classLoader: ClassLoader,
@@ -282,7 +282,7 @@ interface RenderHost {
    * dispatch for one of them can flip just its own contribution to `supported = true` without
    * editing the global roadmap list.
    */
-  fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> = emptyList()
+  public fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> = emptyList()
 
   /**
    * The `@PreviewParameter` rows of [previewId] — the ids a client can actually render
@@ -303,13 +303,13 @@ interface RenderHost {
    * (the default) for a host that can't enumerate — [JsonRpcServer] maps those to `InvalidParams`
    * and `MethodNotFound` respectively.
    */
-  fun previewParameterRows(previewId: String): List<PreviewParameterRow> =
+  public fun previewParameterRows(previewId: String): List<PreviewParameterRow> =
     throw UnsupportedOperationException(
       "preview-parameter row enumeration unsupported by " +
         (this::class.simpleName ?: this::class.java.name)
     )
 
-  companion object {
+  public companion object {
     /**
      * Monotonic id source shared across [JsonRpcServer] (which assigns ids to incoming render
      * requests) and any host-side bookkeeping. Stays monotonic across host restarts within a single
@@ -317,14 +317,14 @@ interface RenderHost {
      */
     private val nextId: AtomicLong = AtomicLong(1)
 
-    fun nextRequestId(): Long = nextId.getAndIncrement()
+    public fun nextRequestId(): Long = nextId.getAndIncrement()
   }
 }
 
 /** Request envelope. [Shutdown] is the poison pill; everything else is a [Render]. */
-sealed interface RenderRequest {
+public sealed interface RenderRequest {
 
-  data class Render(
+  public data class Render(
     val id: Long = RenderHost.nextRequestId(),
     /**
      * Free-form payload the stub host doesn't read. Real backends will replace this with a typed
@@ -351,11 +351,13 @@ sealed interface RenderRequest {
    * The reply posted back on the per-id result queue is a `java.util.List<String>` of row labels in
    * provider order, for the same reason.
    */
-  data class ParameterRows(val id: Long = RenderHost.nextRequestId(), val payload: String = "") :
-    RenderRequest
+  public data class ParameterRows(
+    val id: Long = RenderHost.nextRequestId(),
+    val payload: String = "",
+  ) : RenderRequest
 
   /** Singleton poison pill. */
-  data object Shutdown : RenderRequest
+  public data object Shutdown : RenderRequest
 }
 
 /**
@@ -365,7 +367,7 @@ sealed interface RenderRequest {
  * [id] is the addressable previewId — `<baseId>_<label>`, the same stem the fan-out renderer writes
  * to disk — so a client lists rows and renders one without constructing ids itself.
  */
-data class PreviewParameterRow(
+public data class PreviewParameterRow(
   /** Zero-based position in the provider's value sequence. */
   val index: Int,
   /**
@@ -408,7 +410,7 @@ data class PreviewParameterRow(
  * recorder (the harness fake, sandbox-worker replies), which is exactly when `render/trace` falls
  * back to its v1 single-phase shape over `metrics["tookMs"]`.
  */
-data class RenderResult(
+public data class RenderResult(
   val id: Long,
   val classLoaderHashCode: Int,
   val classLoaderName: String,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SandboxLifecycle.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SandboxLifecycle.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicLong
  * desktop / Android backends serialise renders to a single thread, so contention is rare in
  * practice; the [AtomicLong] is cheap insurance for any future host that submits concurrently.
  */
-class SandboxLifecycleStats(
+public class SandboxLifecycleStats(
   /** Host-construction time in nanoseconds. Defaults to [System.nanoTime] at instantiation. */
   startNs: Long = System.nanoTime()
 ) {
@@ -29,19 +29,19 @@ class SandboxLifecycleStats(
   private val renderCount: AtomicLong = AtomicLong(0)
 
   /** Wall-clock since host construction, in milliseconds. */
-  fun ageMs(): Long = (System.nanoTime() - startNs) / 1_000_000L
+  public fun ageMs(): Long = (System.nanoTime() - startNs) / 1_000_000L
 
   /** Number of renders completed against this host so far. */
-  fun renders(): Long = renderCount.get()
+  public fun renders(): Long = renderCount.get()
 
   /** Bumps the render counter. Called from the engine after each render-body returns. */
-  fun bumpRenderCount(): Long = renderCount.incrementAndGet()
+  public fun bumpRenderCount(): Long = renderCount.incrementAndGet()
 
   /**
    * Resets both counters — wired from B2.5's recycle path once that lands. For B2.3 v1 nobody calls
    * this in production; only unit tests use it.
    */
-  fun reset() {
+  public fun reset() {
     startNs = System.nanoTime()
     renderCount.set(0)
   }
@@ -67,7 +67,7 @@ class SandboxLifecycleStats(
  * non-HotSpot JVMs where the cast fails we fall back to 0 with a one-time warn-log; clients see
  * `nativeHeapMb = 0` and that's clearer than a hand-waved heuristic.
  */
-object SandboxMeasurement {
+public object SandboxMeasurement {
 
   private val nonHotSpotWarned = AtomicBoolean(false)
 
@@ -79,7 +79,7 @@ object SandboxMeasurement {
    * The map's keys are pinned constants on [RenderMetrics.Companion] so all consumers
    * (`JsonRpcServer.renderFinishedFromResult`, the soak tests, etc.) agree on the spelling.
    */
-  fun collect(stats: SandboxLifecycleStats, tookMs: Long): Map<String, Long> {
+  public fun collect(stats: SandboxLifecycleStats, tookMs: Long): Map<String, Long> {
     // Run a single GC hint after the render body so post-render heap reflects what survived this
     // render's short-lived allocations. Yes, `System.gc()` is a hint; HotSpot mostly honours it
     // for instrumentation. We don't over-engineer.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SemanticsTargetUnresolvedException.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SemanticsTargetUnresolvedException.kt
@@ -12,7 +12,7 @@ import ee.schimke.composeai.daemon.protocol.SemanticsTargetUnresolvedReason
  * reply crosses the bridge) throw and catch the same type. Pixel dispatches never raise this — a
  * bad pixel just dispatches into empty space.
  */
-class SemanticsTargetUnresolvedException(
-  val reason: SemanticsTargetUnresolvedReason,
+public class SemanticsTargetUnresolvedException(
+  public val reason: SemanticsTargetUnresolvedReason,
   message: String,
 ) : RuntimeException(message)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
@@ -34,18 +34,18 @@ import java.util.concurrent.atomic.AtomicBoolean
  * See [docs/daemon/STARTUP.md](../../../../../../docs/daemon/STARTUP.md) for the analysis of where
  * the time actually goes and the menu of options to attack each stage.
  */
-object StartupTimings {
+public object StartupTimings {
 
-  data class Mark(val elapsedMs: Long, val label: String, val thread: String)
+  public data class Mark(val elapsedMs: Long, val label: String, val thread: String)
 
   /**
    * JVM start instant via [java.lang.management.RuntimeMXBean.getStartTime]. Cheaper to read than
    * `ProcessHandle.current().info().startInstant()` and consistent across threads.
    */
-  val jvmStartMs: Long = ManagementFactory.getRuntimeMXBean().startTime
+  public val jvmStartMs: Long = ManagementFactory.getRuntimeMXBean().startTime
 
   /** Sysprop knob to suppress stderr emission. Marks are still buffered for [summary]. */
-  const val QUIET_PROP: String = "composeai.daemon.startupQuiet"
+  public const val QUIET_PROP: String = "composeai.daemon.startupQuiet"
 
   private val quiet: Boolean
     get() = System.getProperty(QUIET_PROP) == "true"
@@ -53,13 +53,13 @@ object StartupTimings {
   private val buffer = ConcurrentLinkedQueue<Mark>()
   private val summarised = AtomicBoolean(false)
 
-  fun elapsedMs(): Long = System.currentTimeMillis() - jvmStartMs
+  public fun elapsedMs(): Long = System.currentTimeMillis() - jvmStartMs
 
   /**
    * Record a labelled instant on the timeline. Thread-safe. Emits one stderr line unless
    * [QUIET_PROP] is set; always retained for [summary].
    */
-  fun mark(label: String) {
+  public fun mark(label: String) {
     val mark = Mark(elapsedMs(), label, Thread.currentThread().name)
     buffer.add(mark)
     if (!quiet) {
@@ -68,13 +68,13 @@ object StartupTimings {
   }
 
   /** All marks recorded so far, in insertion order. */
-  fun marks(): List<Mark> = buffer.toList()
+  public fun marks(): List<Mark> = buffer.toList()
 
   /**
    * Emit a multi-line summary of the timeline. Idempotent — first caller wins; subsequent calls are
    * no-ops to avoid duplicate output when multiple paths converge on "I'm warm now."
    */
-  fun summary() {
+  public fun summary() {
     if (!summarised.compareAndSet(false, true)) return
     if (quiet) return
     val ms = marks()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -56,7 +56,7 @@ import java.net.URLClassLoader
  *   with the new loader. The Android backend uses it to mirror the loader into
  *   `DaemonHostBridge.currentChildLoader` so the sandbox-side render thread sees the swap.
  */
-class UserClassLoaderHolder(
+public class UserClassLoaderHolder(
   private val urls: List<URL>,
   private val parentSupplier: () -> ClassLoader = {
     Thread.currentThread().contextClassLoader ?: ClassLoader.getSystemClassLoader()
@@ -72,7 +72,7 @@ class UserClassLoaderHolder(
    * Returns the current child [URLClassLoader], allocating it lazily on first read. Subsequent
    * reads return the same instance until [swap] is invoked.
    */
-  fun currentChildLoader(): URLClassLoader =
+  public fun currentChildLoader(): URLClassLoader =
     synchronized(lock) {
       val existing = current
       if (existing != null) return@synchronized existing
@@ -85,7 +85,7 @@ class UserClassLoaderHolder(
    * sandbox/Compose state holding references to user-class-loaded objects is cleared (per-render
    * scoping verified in CLASSLOADER.md § Risks 1).
    */
-  fun swap() {
+  public fun swap() {
     synchronized(lock) {
       current = null
       // Self-diagnostic log — surfaces as `[daemon stderr] [classloader] swap …` in the VS Code
@@ -106,7 +106,7 @@ class UserClassLoaderHolder(
    * Returns the URL list this holder uses. Exposed so backends can construct identically-shaped
    * sibling loaders (e.g. the Robolectric bridge mirror).
    */
-  fun urls(): List<URL> = urls.toList()
+  public fun urls(): List<URL> = urls.toList()
 
   /**
    * Forces 2 GCs and returns the count of allocated child loaders that haven't yet been collected.
@@ -115,7 +115,7 @@ class UserClassLoaderHolder(
    *
    * Used by the soak `WeakReference` probe in the unit test.
    */
-  fun liveLoaderCount(): Int {
+  public fun liveLoaderCount(): Int {
     repeat(2) {
       System.gc()
       // Hint the runtime that finalizers should run; not guaranteed but doesn't hurt.
@@ -200,13 +200,13 @@ class UserClassLoaderHolder(
     }
   }
 
-  companion object {
+  public companion object {
     /**
      * Sysprop name. Colon-delimited (`File.pathSeparator`) absolute paths to user-class directories
      * — the gradle plugin's daemon launch descriptor sets it; both backends' [DaemonMain] reads it
      * and constructs a [UserClassLoaderHolder] with the resolved URLs.
      */
-    const val USER_CLASS_DIRS_PROP: String = "composeai.daemon.userClassDirs"
+    public const val USER_CLASS_DIRS_PROP: String = "composeai.daemon.userClassDirs"
 
     /**
      * Whether [name] must be resolved via the parent loader instead of child-first (used by
@@ -277,7 +277,7 @@ class UserClassLoaderHolder(
      * themselves keep their relative order — important because AGP's main-vs-test classpath
      * ordering carries semantics we don't want to scramble.
      */
-    fun urlsFromSysprop(): List<URL> {
+    public fun urlsFromSysprop(): List<URL> {
       val raw = System.getProperty(USER_CLASS_DIRS_PROP) ?: return emptyList()
       if (raw.isBlank()) return emptyList()
       val files =
@@ -317,7 +317,7 @@ class UserClassLoaderHolder(
      * The SHA is the first 6 bytes of SHA-256 hex (12 chars) — enough to disambiguate consecutive
      * recompiles in a save loop without bloating each log line.
      */
-    fun classFileFingerprint(loader: ClassLoader, className: String): String? {
+    public fun classFileFingerprint(loader: ClassLoader, className: String): String? {
       val resourceName = className.replace('.', '/') + ".class"
       if (loader is URLClassLoader) {
         fingerprintFromUrls(loader.urLs, resourceName)?.let {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaBenchMain.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.buildtools.api.SourcesChanges
  * The driver mutates the edit file in place (the `warm-after-1-line-edit` scenario) and always
  * restores it in a `finally`, so a crash mid-run can't leave the working tree dirty.
  */
-fun main() {
+public fun main() {
   val sysprops: (String) -> String? = System::getProperty
   val config = BenchConfig.fromSysprops(sysprops)
   if (config == null) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileService.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileService.kt
@@ -20,7 +20,7 @@ import java.nio.file.Path
  * `btaCompilerClasspath` is non-null; never reconstructed (daemon recycles on classpath-dirty, Tier
  * 1).
  */
-interface BtaCompileService {
+public interface BtaCompileService {
 
   /**
    * Compile [sources] in-process. Implementations are responsible for translating BTA's
@@ -29,26 +29,26 @@ interface BtaCompileService {
    * NOT throw — the handler treats any thrown exception as "fallback with the exception message as
    * reason" and logs.
    */
-  fun compile(sources: List<Path>, changes: SourceChangeSet?): Outcome
+  public fun compile(sources: List<Path>, changes: SourceChangeSet?): Outcome
 
-  sealed class Outcome {
+  public sealed class Outcome {
     /**
      * Compile succeeded; `.class` files are on disk and the caller should swap the user
      * classloader.
      */
-    object Ok : Outcome()
+    public object Ok : Outcome()
 
     /**
      * BTA returned diagnostics that the editor can render in its existing compile-error banner. The
      * classloader was NOT swapped.
      */
-    data class CompileError(val errors: List<CompileErrorDetail>) : Outcome()
+    public data class CompileError(val errors: List<CompileErrorDetail>) : Outcome()
 
     /**
      * Implementation refused this compile and the caller should retry through stage 1 / 0. Common
      * reasons: KSP/KAPT-tainted classpath, BTA bootstrap failure, transient classpath-dirty between
      * session construction and this call.
      */
-    data class Fallback(val reason: String) : Outcome()
+    public data class Fallback(val reason: String) : Outcome()
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/BtaCompileSession.kt
@@ -54,7 +54,7 @@ import org.jetbrains.kotlin.buildtools.api.jvm.operations.JvmCompilationOperatio
  * worker, not the read loop. The `BtaCompileSession` itself is thread-safe; concurrent compile
  * calls serialize on the underlying `KotlinToolchains.BuildSession` lifecycle.
  */
-class BtaCompileSession(
+public class BtaCompileSession(
   private val implClasspath: List<Path>,
   private val icWorkingDir: Path,
   private val moduleName: String,
@@ -75,7 +75,7 @@ class BtaCompileSession(
    * where IC isn't useful (cold-bootstrap warm-up, parity tests). Production save loops should call
    * [compileIncremental] instead.
    */
-  fun compile(
+  public fun compile(
     sources: List<Path>,
     compileClasspath: List<Path>,
     outputDir: Path,
@@ -109,7 +109,7 @@ class BtaCompileSession(
    * - The BTA IC working directory is [icWorkingDir]/`ic/`; the current API owns any reduced
    *   classpath state inside that directory rather than requiring a separate snapshot path.
    */
-  fun compileIncremental(
+  public fun compileIncremental(
     sources: List<Path>,
     compileClasspath: List<Path>,
     outputDir: Path,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DefaultBtaCompileService.kt
@@ -42,7 +42,7 @@ import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
  * wrapping a [BtaCompileSession]) lets unit tests stub the compile behaviour without dragging in a
  * real BTA classloader — same idea KGP's tests use for their compilation work.
  */
-class DefaultBtaCompileService(
+public class DefaultBtaCompileService(
   /**
    * The actual compile call. Production wiring captures a [BtaCompileSession] + the module's
    * resolved compile classpath + output dir + plugins; tests inject lambdas that model success /
@@ -57,8 +57,8 @@ class DefaultBtaCompileService(
    * Bound compile call — what [DefaultBtaCompileService] actually invokes on each save. Throws on
    * any unrecoverable error; the service maps the throw to [BtaCompileService.Outcome.Fallback].
    */
-  fun interface CompileBackend {
-    fun compile(sources: List<Path>, sourcesChanges: SourcesChanges)
+  public fun interface CompileBackend {
+    public fun compile(sources: List<Path>, sourcesChanges: SourcesChanges)
   }
 
   override fun compile(sources: List<Path>, changes: SourceChangeSet?): BtaCompileService.Outcome {
@@ -89,7 +89,7 @@ class DefaultBtaCompileService(
     }
   }
 
-  companion object {
+  public companion object {
     /**
      * System-property keys the gradle plugin's daemon-bootstrap task populates unconditionally
      * whenever the variant wiring resolved the BTA classpath. Mirror of `BtaCompileConfig` in the
@@ -97,23 +97,24 @@ class DefaultBtaCompileService(
      * `File.pathSeparator`-joined; an unset / empty value means "this part of the config is
      * missing" and [fromSysprops] returns null.
      */
-    const val SYSPROP_IMPL_CLASSPATH: String = "composeai.daemon.bta.implClasspath"
-    const val SYSPROP_COMPILE_CLASSPATH: String = "composeai.daemon.bta.compileClasspath"
-    const val SYSPROP_COMPILER_PLUGINS: String = "composeai.daemon.bta.compilerPlugins"
-    const val SYSPROP_MODULE_NAME: String = "composeai.daemon.bta.moduleName"
-    const val SYSPROP_OUTPUT_DIR: String = "composeai.daemon.bta.outputDir"
-    const val SYSPROP_IC_WORKING_DIR: String = "composeai.daemon.bta.icWorkingDir"
+    public const val SYSPROP_IMPL_CLASSPATH: String = "composeai.daemon.bta.implClasspath"
+    public const val SYSPROP_COMPILE_CLASSPATH: String = "composeai.daemon.bta.compileClasspath"
+    public const val SYSPROP_COMPILER_PLUGINS: String = "composeai.daemon.bta.compilerPlugins"
+    public const val SYSPROP_MODULE_NAME: String = "composeai.daemon.bta.moduleName"
+    public const val SYSPROP_OUTPUT_DIR: String = "composeai.daemon.bta.outputDir"
+    public const val SYSPROP_IC_WORKING_DIR: String = "composeai.daemon.bta.icWorkingDir"
     /**
      * Optional. Non-empty value disables stage 2 for this module with the given reason surfaced
      * verbatim in every `compileSources` result.
      */
-    const val SYSPROP_INELIGIBILITY_REASON: String = "composeai.daemon.bta.ineligibilityReason"
+    public const val SYSPROP_INELIGIBILITY_REASON: String =
+      "composeai.daemon.bta.ineligibilityReason"
 
     /**
      * Production factory — captures the [session] + its per-module compile config in a
      * [CompileBackend] lambda and constructs the service.
      */
-    fun forSession(
+    public fun forSession(
       session: BtaCompileSession,
       compileClasspath: List<Path>,
       outputDir: Path,
@@ -165,7 +166,7 @@ class DefaultBtaCompileService(
      * pass a [Map.get]-shaped lambda so the factory can be exercised without polluting JVM-wide
      * state.
      */
-    fun fromSysprops(
+    public fun fromSysprops(
       sysprops: (String) -> String? = System::getProperty
     ): DefaultBtaCompileService? {
       val implClasspath = sysprops(SYSPROP_IMPL_CLASSPATH).toPathList()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DiagnosticCollector.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/bta/DiagnosticCollector.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.buildtools.api.KotlinLogger
  * provided; null delegate silently drops them. Production wiring passes the daemon's stderr logger
  * as delegate so non-error compiler output still surfaces in daemon logs.
  */
-class DiagnosticCollector(private val delegate: KotlinLogger? = null) : KotlinLogger {
+public class DiagnosticCollector(private val delegate: KotlinLogger? = null) : KotlinLogger {
   private val collected = mutableListOf<CompileErrorDetail>()
 
   /**
@@ -36,7 +36,7 @@ class DiagnosticCollector(private val delegate: KotlinLogger? = null) : KotlinLo
    * concurrently with `error(...)` calls — implementations of `KotlinLogger.error` are invoked
    * serially from the compiler thread.
    */
-  val errors: List<CompileErrorDetail>
+  public val errors: List<CompileErrorDetail>
     get() = collected.toList()
 
   override val isDebugEnabled: Boolean
@@ -103,5 +103,5 @@ class DiagnosticCollector(private val delegate: KotlinLogger? = null) : KotlinLo
  *
  * Internal to the BTA wiring; not part of the JSON-RPC surface or the spike module.
  */
-class BtaCompileDiagnosticException(val errors: List<CompileErrorDetail>) :
+public class BtaCompileDiagnosticException(public val errors: List<CompileErrorDetail>) :
   RuntimeException("BTA compile failed with ${errors.size} diagnostic(s)")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -27,7 +27,7 @@ package ee.schimke.composeai.daemon.devices
  *
  * @see ee.schimke.composeai.plugin.DeviceDimensions
  */
-object DeviceDimensions {
+public object DeviceDimensions {
   /**
    * Per-device geometry resolved from a `@Preview(device = ...)` string.
    *
@@ -35,7 +35,7 @@ object DeviceDimensions {
    * density to populate `RenderSpec.widthPx`/`heightPx`; the Android backend then re-derives the
    * Robolectric `<n>dpi` qualifier from it.
    */
-  data class DeviceSpec(
+  public data class DeviceSpec(
     val widthDp: Int,
     val heightDp: Int,
     val density: Float = DEFAULT_DENSITY,
@@ -46,7 +46,7 @@ object DeviceDimensions {
    * The density Android Studio uses when no device is specified — xxhdpi-ish (420dpi → 2.625x),
    * matching its default phone-class preview.
    */
-  const val DEFAULT_DENSITY: Float = 2.625f
+  public const val DEFAULT_DENSITY: Float = 2.625f
 
   // Source-of-truth for the dp values and densities below: sergio-sastre/ComposablePreviewScanner
   // (Phone.kt / Tablet.kt / Wear.kt / GenericDevices.kt / Desktop.kt / Television.kt /
@@ -128,8 +128,8 @@ object DeviceDimensions {
       "id:xr_device" to DeviceSpec(1280, 1279, 2.0f),
     )
 
-  val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
-  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f, isRound = true)
+  public val DEFAULT: DeviceSpec = DeviceSpec(400, 800, DEFAULT_DENSITY)
+  public val DEFAULT_WEAR: DeviceSpec = DeviceSpec(227, 227, 2.0f, isRound = true)
 
   /**
    * The set of device-id strings the catalog recognises (every key in [KNOWN_DEVICES]). Useful for
@@ -137,7 +137,7 @@ object DeviceDimensions {
    * `renderNow`. The `spec:...` and `name:...` grammars are not enumerable; they're parsed at
    * resolve-time.
    */
-  val KNOWN_DEVICE_IDS: Set<String> = KNOWN_DEVICES.keys
+  public val KNOWN_DEVICE_IDS: Set<String> = KNOWN_DEVICES.keys
 
   /**
    * Resolves a `@Preview(device = ...)` string to a [DeviceSpec]. Mirrors the gradle-plugin's
@@ -154,7 +154,7 @@ object DeviceDimensions {
    * - Any device string containing `wear` (case-insensitive) returns [DEFAULT_WEAR].
    * - Otherwise [DEFAULT] (400×800 dp at xxhdpi).
    */
-  fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
+  public fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
     if (widthDp != null && widthDp > 0 && heightDp != null && heightDp > 0) {
       return DeviceSpec(widthDp, heightDp, DEFAULT_DENSITY)
     }
@@ -233,7 +233,10 @@ object DeviceDimensions {
  * Kept here rather than in either resolver so the four places that make this decision — both
  * daemons' `PreviewManifestEntry.resolved()` and `renderSpecFromInfo()` — cannot drift apart on it.
  */
-fun DeviceDimensions.DeviceSpec.frameDpOverriddenBy(widthDp: Int?, heightDp: Int?): Pair<Int, Int> {
+public fun DeviceDimensions.DeviceSpec.frameDpOverriddenBy(
+  widthDp: Int?,
+  heightDp: Int?,
+): Pair<Int, Int> {
   val w = widthDp?.takeIf { it > 0 }
   val h = heightDp?.takeIf { it > 0 }
   return if (w != null && h != null) w to h else this.widthDp to this.heightDp

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/FrameOrientation.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/FrameOrientation.kt
@@ -30,7 +30,7 @@ import ee.schimke.composeai.daemon.protocol.Orientation
  * axis was given explicitly. [orientedPx] can't see that context; the guard belongs at the call
  * site, next to the override it is guarding.
  */
-object FrameOrientation {
+public object FrameOrientation {
 
   /**
    * [widthPx] and [heightPx] rotated to satisfy [orientation], or unchanged when they already do.
@@ -38,7 +38,7 @@ object FrameOrientation {
    * Pixels rather than dp because every caller has already resolved density by this point, and a
    * swap of the two is density-independent anyway.
    */
-  fun orientedPx(widthPx: Int, heightPx: Int, orientation: Orientation?): Pair<Int, Int> =
+  public fun orientedPx(widthPx: Int, heightPx: Int, orientation: Orientation?): Pair<Int, Int> =
     if (shouldSwap(widthPx, heightPx, orientation)) heightPx to widthPx else widthPx to heightPx
 
   /**
@@ -46,11 +46,11 @@ object FrameOrientation {
    * (`portrait` / `landscape`, case-insensitive). An unrecognised token is treated as absent — the
    * payload parsers already tolerate unknown values rather than failing a render over one.
    */
-  fun orientedPx(widthPx: Int, heightPx: Int, orientation: String?): Pair<Int, Int> =
+  public fun orientedPx(widthPx: Int, heightPx: Int, orientation: String?): Pair<Int, Int> =
     orientedPx(widthPx, heightPx, parse(orientation))
 
   /** The [Orientation] a payload token names, or null when absent, blank, or unrecognised. */
-  fun parse(token: String?): Orientation? =
+  public fun parse(token: String?): Orientation? =
     when (token?.trim()?.lowercase()) {
       "portrait" -> Orientation.PORTRAIT
       "landscape" -> Orientation.LANDSCAPE

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
@@ -43,7 +43,7 @@ import okio.Path.Companion.toPath
  * dump `java.lang.String` always identical; etc.) live in the design doc and are realised by the
  * test bodies.
  */
-object ClassloaderForensics {
+public object ClassloaderForensics {
 
   private val json = Json {
     prettyPrint = true
@@ -83,7 +83,7 @@ object ClassloaderForensics {
    * reflective path.
    */
   @JvmOverloads
-  fun capture(
+  public fun capture(
     surveySet: List<String>,
     robolectricConfig: RobolectricConfigSnapshot? = null,
     contextHint: String,
@@ -123,7 +123,7 @@ object ClassloaderForensics {
    * 4. Robolectric-config field diffs.
    * 5. The remainder (loader-name diffs that don't affect identity, package version diffs).
    */
-  fun diff(
+  public fun diff(
     a: File,
     b: File,
     mdOut: File,
@@ -715,7 +715,7 @@ object ClassloaderForensics {
  * across Robolectric versions are populated best-effort and documented inline in the test.
  */
 @Serializable
-data class RobolectricConfigSnapshot(
+public data class RobolectricConfigSnapshot(
   val apiLevel: Int,
   val qualifiers: String,
   val fontScale: Float,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicReference
  * @param gitRunner runs `git <args>` in a working dir and returns trimmed stdout (or null on
  *   failure); injected in tests to avoid spawning real subprocesses.
  */
-class GitProvenance(
+public class GitProvenance(
   private val workspaceRoot: Path?,
   private val env: Map<String, String> = System.getenv(),
   private val cacheTtlMs: Long = resolveGitProvenanceTtlMs(),
@@ -55,7 +55,7 @@ class GitProvenance(
    * Returns a fresh-or-cached [WorktreeInfo] / [GitInfo] pair. Within [cacheTtlMs] of the previous
    * call the cached value is returned without spawning git; otherwise it re-resolves and re-caches.
    */
-  fun snapshot(): Pair<WorktreeInfo?, GitInfo?> {
+  public fun snapshot(): Pair<WorktreeInfo?, GitInfo?> {
     if (cacheTtlMs > 0L) {
       val hit = snapshotCache.get()
       if (hit != null && nowNanos() - hit.atNanos < cacheTtlMs * NANOS_PER_MS) {
@@ -121,23 +121,23 @@ class GitProvenance(
 
   private data class CachedSnapshot(val atNanos: Long, val value: Pair<WorktreeInfo?, GitInfo?>)
 
-  companion object {
+  public companion object {
     /**
      * Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent
      * attribution".
      */
-    const val ENV_AGENT_ID: String = "COMPOSEAI_AGENT_ID"
+    public const val ENV_AGENT_ID: String = "COMPOSEAI_AGENT_ID"
 
     /**
      * Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs".
      */
-    const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
+    public const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
 
     /** Sysprop overriding the per-render provenance cache TTL (ms). `0` disables caching. */
-    const val CACHE_TTL_PROP: String = "composeai.history.gitProvenanceTtlMs"
+    public const val CACHE_TTL_PROP: String = "composeai.history.gitProvenanceTtlMs"
 
     /** Default cache window — collapses a render burst's repeated provenance fetches into one. */
-    const val DEFAULT_CACHE_TTL_MS: Long = 1000L
+    public const val DEFAULT_CACHE_TTL_MS: Long = 1000L
 
     private const val NANOS_PER_MS: Long = 1_000_000L
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -69,7 +69,7 @@ import kotlinx.serialization.json.JsonElement
  * @param gitExecutable git binary; defaults to `git` on PATH.
  * @param warnEmitter logger for the ref-missing read case.
  */
-class GitRefHistorySource(
+public class GitRefHistorySource(
   private val repoRoot: Path,
   private val ref: String,
   private val syncMode: SyncMode = SyncMode.READ_ONLY,
@@ -277,7 +277,7 @@ class GitRefHistorySource(
    * debounced commit can't break a render). Driven by the debounce timer and by [close] on
    * shutdown.
    */
-  fun flushPending() {
+  public fun flushPending() {
     val batch =
       synchronized(pendingLock) {
         val drained = pending.values.toList()
@@ -904,7 +904,7 @@ class GitRefHistorySource(
     HistoryListPage(entries = emptyList(), nextCursor = null, totalCount = 0)
 
   /** How this source treats the reporting ref. */
-  enum class SyncMode {
+  public enum class SyncMode {
     /** Read the ref, never write. */
     READ_ONLY,
     /** Commit each changed render onto the local ref via git plumbing; no push. */
@@ -921,7 +921,7 @@ class GitRefHistorySource(
    * always records every render (the developer's scratch history); this only gates the *shared*
    * branch so uncommitted / off-branch local states don't pollute it.
    */
-  enum class PublishPolicy {
+  public enum class PublishPolicy {
     /** Record every render (today's behaviour) — no curation. */
     ALL,
     /**
@@ -933,18 +933,18 @@ class GitRefHistorySource(
     CLEAN_ON_BRANCH,
   }
 
-  companion object {
+  public companion object {
     /** Stable filename for the overwritten-per-render PNG on the ref. */
-    const val RENDER_FILENAME: String = "render.png"
+    public const val RENDER_FILENAME: String = "render.png"
 
     /** Current-state pointer at the ref root. docs/daemon/REPORTING-BRANCH.md § manifest.json. */
-    const val MANIFEST_FILENAME: String = "manifest.json"
+    public const val MANIFEST_FILENAME: String = "manifest.json"
 
     /** Aggregate index of the legacy read-only format; read as a fallback for old refs. */
-    const val LEGACY_INDEX_FILENAME: String = "_index.jsonl"
+    public const val LEGACY_INDEX_FILENAME: String = "_index.jsonl"
 
     /** Bumped on incompatible reporting-branch layout changes. */
-    const val REPORTING_BRANCH_FORMAT_VERSION: Int = 1
+    public const val REPORTING_BRANCH_FORMAT_VERSION: Int = 1
 
     /**
      * Depth cap for the commit-walk timeline read (#1868) — the newest N commits of the ref are
@@ -952,16 +952,16 @@ class GitRefHistorySource(
      * older history stays reachable by tightening the `since`/`until` filter against a re-orphaned
      * ref.
      */
-    const val MAX_TIMELINE_DEPTH: Int = 500
+    public const val MAX_TIMELINE_DEPTH: Int = 500
 
     /**
      * Comma/semicolon-separated list of refs (e.g.
      * `refs/heads/preview/main,refs/heads/preview/agent/foo`).
      */
-    const val GIT_REF_HISTORY_PROP: String = "composeai.daemon.gitRefHistory"
+    public const val GIT_REF_HISTORY_PROP: String = "composeai.daemon.gitRefHistory"
 
     /** Sync mode for the reporting refs: `READ_ONLY` (default) or `WRITE_LOCAL`. */
-    const val SYNC_MODE_PROP: String = "composeai.daemon.gitRefHistorySyncMode"
+    public const val SYNC_MODE_PROP: String = "composeai.daemon.gitRefHistorySyncMode"
 
     // Synthetic identity for daemon-authored reporting-branch commits. These are machine-generated
     // history commits in the *consumer's* repo (not this project's git history), so they carry a
@@ -981,13 +981,15 @@ class GitRefHistorySource(
       prettyPrint = true
     }
 
-    fun parseRefsSysprop(
+    public fun parseRefsSysprop(
       propValue: String? = System.getProperty(GIT_REF_HISTORY_PROP)
     ): List<String> =
       propValue?.split(',', ';')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
 
     /** Parses [SYNC_MODE_PROP]; unknown / unset → [SyncMode.READ_ONLY]. */
-    fun parseSyncModeSysprop(propValue: String? = System.getProperty(SYNC_MODE_PROP)): SyncMode =
+    public fun parseSyncModeSysprop(
+      propValue: String? = System.getProperty(SYNC_MODE_PROP)
+    ): SyncMode =
       when (propValue?.trim()?.uppercase()) {
         "WRITE_LOCAL" -> SyncMode.WRITE_LOCAL
         "WRITE_PUSH" -> SyncMode.WRITE_PUSH
@@ -995,31 +997,31 @@ class GitRefHistorySource(
       }
 
     /** Default git remote for `WRITE_PUSH`. Remote-name config is a follow-up. */
-    const val DEFAULT_REMOTE: String = "origin"
+    public const val DEFAULT_REMOTE: String = "origin"
 
     /** Max push attempts before giving up (one initial + retries after fetch–rebase on a race). */
-    const val MAX_PUSH_ATTEMPTS: Int = 5
+    public const val MAX_PUSH_ATTEMPTS: Int = 5
 
     /** Sysprop for the reporting-branch commit debounce window in ms (#1882). */
-    const val DEBOUNCE_PROP: String = "composeai.daemon.gitRefHistoryDebounceMs"
+    public const val DEBOUNCE_PROP: String = "composeai.daemon.gitRefHistoryDebounceMs"
 
     /** Default debounce window (ms): coalesce a render burst into one commit. `0` disables it. */
-    const val DEFAULT_DEBOUNCE_MS: Long = 1_000
+    public const val DEFAULT_DEBOUNCE_MS: Long = 1_000
 
     /** Parses [DEBOUNCE_PROP]; unset → [DEFAULT_DEBOUNCE_MS], unparseable / negative → `0`. */
-    fun parseDebounceSysprop(propValue: String? = System.getProperty(DEBOUNCE_PROP)): Long {
+    public fun parseDebounceSysprop(propValue: String? = System.getProperty(DEBOUNCE_PROP)): Long {
       if (propValue == null) return DEFAULT_DEBOUNCE_MS
       return propValue.trim().toLongOrNull()?.coerceAtLeast(0) ?: 0
     }
 
     /** Sysprop for the reporting-branch publish policy (#1872 curation). */
-    const val PUBLISH_POLICY_PROP: String = "composeai.daemon.gitRefHistoryPublishPolicy"
+    public const val PUBLISH_POLICY_PROP: String = "composeai.daemon.gitRefHistoryPublishPolicy"
 
     /**
      * Parses [PUBLISH_POLICY_PROP]; `all` → [PublishPolicy.ALL], else →
      * [PublishPolicy.CLEAN_ON_BRANCH].
      */
-    fun parsePublishPolicySysprop(
+    public fun parsePublishPolicySysprop(
       propValue: String? = System.getProperty(PUBLISH_POLICY_PROP)
     ): PublishPolicy =
       when (propValue?.trim()?.lowercase()) {
@@ -1027,21 +1029,21 @@ class GitRefHistorySource(
         else -> PublishPolicy.CLEAN_ON_BRANCH
       }
 
-    fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
+    public fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
 
     /**
      * Cache location when no module history directory is configured. Keyed by repo under the
      * user-level cache root — this used to be `<repoRoot>/.compose-preview-history/.git-ref-cache`,
      * i.e. a bare git working area planted in the user's working tree.
      */
-    fun defaultRepoCacheDir(repoRoot: Path): Path =
+    public fun defaultRepoCacheDir(repoRoot: Path): Path =
       composeAiGitRefCacheDir(repoRoot.toFile()).toPath()
   }
 }
 
 /** Current-state manifest written at the reporting ref root. docs/daemon/REPORTING-BRANCH.md. */
 @Serializable
-data class ReportingBranchManifest(
+public data class ReportingBranchManifest(
   val formatVersion: Int = 1,
   val generatedAt: String,
   val commit: String? = null,
@@ -1050,7 +1052,7 @@ data class ReportingBranchManifest(
 )
 
 @Serializable
-data class ReportingBranchPreview(
+public data class ReportingBranchPreview(
   val previewId: String,
   val module: String,
   val dir: String,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDataDiff.kt
@@ -33,11 +33,11 @@ import kotlinx.serialization.json.JsonElement
 // needs are mirrored; `ignoreUnknownKeys` skips the rest.
 // ---------------------------------------------------------------------------
 
-object HistoryDataDiffProduct {
-  const val SCHEMA: String = "history-data-diff/v1"
+public object HistoryDataDiffProduct {
+  public const val SCHEMA: String = "history-data-diff/v1"
 }
 
-object HistoryDataDiff {
+public object HistoryDataDiff {
 
   private val DECODE = Json { ignoreUnknownKeys = true }
 
@@ -46,7 +46,7 @@ object HistoryDataDiff {
    * preview (the caller enforces that). Decoding uses a lenient JSON reader so an older sidecar
    * with extra/renamed fields still diffs on the fields this product cares about.
    */
-  fun diff(from: HistoryEntry, to: HistoryEntry, json: Json = DECODE): HistoryDataDelta {
+  public fun diff(from: HistoryEntry, to: HistoryEntry, json: Json = DECODE): HistoryDataDelta {
     val semantics =
       bothPresent(from.semantics, to.semantics) { base, head ->
         SemanticsDiff.diff(
@@ -90,7 +90,7 @@ object HistoryDataDiff {
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class HistoryDataDelta(
+public data class HistoryDataDelta(
   // `@EncodeDefault` so the versioned schema discriminator rides the wire even under
   // `encodeDefaults = false`, matching the `SemanticsDelta` / `ThemeDelta` contract.
   @EncodeDefault val schema: String = HistoryDataDiffProduct.SCHEMA,
@@ -107,8 +107,8 @@ data class HistoryDataDelta(
 // a11y findings diff (a11y-diff/v1)
 // ---------------------------------------------------------------------------
 
-object A11yDiffProduct {
-  const val SCHEMA: String = "a11y-diff/v1"
+public object A11yDiffProduct {
+  public const val SCHEMA: String = "a11y-diff/v1"
 }
 
 /**
@@ -119,7 +119,7 @@ object A11yDiffProduct {
  * is still deterministic; a copy edit (message text changing on the same ref) then reports as a
  * field change rather than a remove + add.
  */
-object A11yDiff {
+public object A11yDiff {
 
   // `internal` because the parameter types are internal mirrors; the only caller is
   // `HistoryDataDiff` in this module. The result type (`A11yDelta`) is public.
@@ -203,10 +203,14 @@ object A11yDiff {
 }
 
 @Serializable
-data class A11yFieldChange(val field: String, val from: String? = null, val to: String? = null)
+public data class A11yFieldChange(
+  val field: String,
+  val from: String? = null,
+  val to: String? = null,
+)
 
 @Serializable
-data class A11yFindingSummary(
+public data class A11yFindingSummary(
   val ref: String? = null,
   val type: String,
   val level: String,
@@ -215,7 +219,7 @@ data class A11yFindingSummary(
 )
 
 @Serializable
-data class A11yFindingChange(
+public data class A11yFindingChange(
   val ref: String? = null,
   val type: String,
   val changes: List<A11yFieldChange>,
@@ -223,7 +227,7 @@ data class A11yFindingChange(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class A11yDelta(
+public data class A11yDelta(
   @EncodeDefault val schema: String = A11yDiffProduct.SCHEMA,
   val added: List<A11yFindingSummary> = emptyList(),
   val removed: List<A11yFindingSummary> = emptyList(),

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffArtifacts.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffArtifacts.kt
@@ -13,16 +13,16 @@ package ee.schimke.composeai.daemon.history
  * Layout: `<historyDir>/<sanitisedPreviewDir>/.diffs/<fromId>__<toId>.png` (ids sanitised). The
  * `.diffs` subdir is dot-prefixed so the per-preview sidecar resolution never trips over it.
  */
-object HistoryDiffArtifacts {
+public object HistoryDiffArtifacts {
 
   /** Per-preview subdirectory holding marked-diff PNGs. Dot-prefixed so sidecar scans skip it. */
-  const val DIFFS_DIR_NAME: String = ".diffs"
+  public const val DIFFS_DIR_NAME: String = ".diffs"
 
   /** Filesystem-safe form of a history entry id for use in a diff filename. */
-  fun sanitiseId(id: String): String = id.replace(NON_FILENAME, "_")
+  public fun sanitiseId(id: String): String = id.replace(NON_FILENAME, "_")
 
   /** Diff filename for the ordered pair (`from`, `to`): `<from>__<to>.png` (ids sanitised). */
-  fun fileName(fromId: String, toId: String): String =
+  public fun fileName(fromId: String, toId: String): String =
     "${sanitiseId(fromId)}__${sanitiseId(toId)}.png"
 
   /**
@@ -31,7 +31,7 @@ object HistoryDiffArtifacts {
    * pruned when that entry is. Robust against ids that themselves contain `_` (it anchors on the
    * `__` separator's start/end rather than splitting).
    */
-  fun referencesEntry(diffFileName: String, sanitisedEntryId: String): Boolean {
+  public fun referencesEntry(diffFileName: String, sanitisedEntryId: String): Boolean {
     if (!diffFileName.endsWith(".png")) return false
     val stem = diffFileName.removeSuffix(".png")
     return stem.startsWith("${sanitisedEntryId}__") || stem.endsWith("__$sanitisedEntryId")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -50,7 +50,7 @@ import kotlinx.serialization.json.JsonElement
  *   schemas under `schema/`.
  */
 @Serializable
-data class HistoryEntry(
+public data class HistoryEntry(
   val id: String,
   val previewId: String,
   val module: String,
@@ -80,7 +80,7 @@ data class HistoryEntry(
  * Storage-backend identity. `kind` is one of `"fs"`, `"git"`, `"http"` (HISTORY.md § "Wire-format
  * effects"); `id` is the source's stable identifier (e.g. `"fs:/abs/historyDir"`).
  */
-@Serializable data class HistorySourceInfo(val kind: String, val id: String)
+public @Serializable data class HistorySourceInfo(val kind: String, val id: String)
 
 /**
  * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to the
@@ -89,7 +89,7 @@ data class HistoryEntry(
  * produces a valid sidecar.
  */
 @Serializable
-data class WorktreeInfo(
+public data class WorktreeInfo(
   val path: String? = null,
   val id: String? = null,
   val agentId: String? = null,
@@ -97,7 +97,7 @@ data class WorktreeInfo(
 
 /** Git provenance captured per-render. Any subfield may be null when resolution failed. */
 @Serializable
-data class GitInfo(
+public data class GitInfo(
   val branch: String? = null,
   val commit: String? = null,
   val shortCommit: String? = null,
@@ -110,7 +110,7 @@ data class GitInfo(
  * history. The current "live" metadata for a preview lives in the daemon's `PreviewIndex`.
  */
 @Serializable
-data class PreviewMetadataSnapshot(
+public data class PreviewMetadataSnapshot(
   val displayName: String? = null,
   val group: String? = null,
   val sourceFile: String? = null,
@@ -122,7 +122,7 @@ data class PreviewMetadataSnapshot(
  * signal; H5 will populate [diffPx] / [ssim] when pixel mode lands.
  */
 @Serializable
-data class HistoryDelta(
+public data class HistoryDelta(
   val pngHashChanged: Boolean,
   val diffPx: Long? = null,
   val ssim: Double? = null,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryImageDiff.kt
@@ -30,10 +30,10 @@ import kotlin.math.max
  * `diffPx = max(areaFrom, areaTo)`, `ssim = 0.0`, `markedPng = null`. The caller still gets a
  * usable "everything changed" signal.
  */
-object HistoryImageDiff {
+public object HistoryImageDiff {
 
   /** Result of [diff]. [markedPng] is null on dimension mismatch or PNG-encode failure. */
-  data class Result(val diffPx: Long, val ssim: Double, val markedPng: ByteArray?) {
+  public data class Result(val diffPx: Long, val ssim: Double, val markedPng: ByteArray?) {
     // ByteArray needs structural equals/hashCode for the data class to behave in tests/maps.
     override fun equals(other: Any?): Boolean {
       if (this === other) return true
@@ -52,13 +52,13 @@ object HistoryImageDiff {
   }
 
   /** Thrown when a frame's bytes can't be decoded as an image. */
-  class UndecodableImageException(message: String) : Exception(message)
+  public class UndecodableImageException(message: String) : Exception(message)
 
   /**
    * Diffs [fromPng] against [toPng]. Throws [UndecodableImageException] if either side can't be
    * decoded — the caller maps that onto a structured RPC error.
    */
-  fun diff(fromPng: ByteArray, toPng: ByteArray): Result {
+  public fun diff(fromPng: ByteArray, toPng: ByteArray): Result {
     val a =
       decode(fromPng) ?: throw UndecodableImageException("from frame is not a decodable image")
     val b = decode(toPng) ?: throw UndecodableImageException("to frame is not a decodable image")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -37,7 +37,7 @@ import kotlinx.serialization.json.JsonElement
  * @param gitProvenance per-render provenance source. When null (e.g. fake-mode test paths), the
  *   `git` / `worktree` fields land null on entries.
  */
-class HistoryManager(
+public class HistoryManager(
   private val sources: List<HistorySource>,
   private val module: String,
   private val gitProvenance: GitProvenance?,
@@ -59,21 +59,21 @@ class HistoryManager(
 ) {
   private val pruneConfigRef: AtomicReference<HistoryPruneConfig> = AtomicReference(pruneConfig)
 
-  val pruneConfig: HistoryPruneConfig
+  public val pruneConfig: HistoryPruneConfig
     get() = pruneConfigRef.get()
 
   /**
    * Initialize-time override path for clients that cannot set daemon JVM sysprops directly. Must be
    * called before [startAutoPrune] to affect the scheduler interval for this daemon session.
    */
-  fun configurePruneConfig(config: HistoryPruneConfig) {
+  public fun configurePruneConfig(config: HistoryPruneConfig) {
     pruneConfigRef.set(config)
   }
 
   /**
    * True when at least one writable source is configured — i.e. when `recordRender` is meaningful.
    */
-  val isEnabled: Boolean
+  public val isEnabled: Boolean
     get() = sources.any { it.supportsWrites() }
 
   /**
@@ -96,7 +96,7 @@ class HistoryManager(
    * **Failure semantics.** If a source's [HistorySource.write] throws, this method logs to stderr
    * but does NOT propagate — history is observation, the render itself is unaffected.
    */
-  fun recordRender(
+  public fun recordRender(
     previewId: String,
     pngBytes: ByteArray,
     trigger: String,
@@ -218,7 +218,7 @@ class HistoryManager(
    * canonical entry (with `source.kind = "fs"`) is what surfaces; a GitRef-only render still
    * surfaces its `source.kind = "git"` entry.
    */
-  fun list(filter: HistoryFilter): HistoryListPage {
+  public fun list(filter: HistoryFilter): HistoryListPage {
     // H10-read — a `ref` request is served from a single on-demand git-ref source, bypassing the
     // configured sources entirely (the caller wants *that* branch's history, not a merge).
     filter.ref?.let { ref ->
@@ -271,7 +271,7 @@ class HistoryManager(
    * that branch (matching the routing in [list]); otherwise falls through the configured sources in
    * order until a hit.
    */
-  fun read(entryId: String, includeBytes: Boolean, ref: String? = null): HistoryReadResult? {
+  public fun read(entryId: String, includeBytes: Boolean, ref: String? = null): HistoryReadResult? {
     if (ref != null) {
       val source = gitRefSourceFactory?.invoke(ref) ?: return null
       return source.read(entryId, includeBytes = includeBytes)
@@ -305,7 +305,7 @@ class HistoryManager(
    * caller can emit a `historyPruned` JSON-RPC notification. [JsonRpcServer.runHistoryManager]
    * wires this on construction; tests pass a buffer-capturing lambda or leave it null.
    */
-  fun setPruneListener(listener: ((PruneNotification) -> Unit)?) {
+  public fun setPruneListener(listener: ((PruneNotification) -> Unit)?) {
     pruneListener = listener
   }
 
@@ -322,7 +322,7 @@ class HistoryManager(
    * @param reason controls the [PruneNotification.reason] field — `AUTO` for the scheduler,
    *   `MANUAL` for `history/prune`. Null suppresses the listener (used by dry-run probes).
    */
-  fun pruneNow(
+  public fun pruneNow(
     config: HistoryPruneConfig = pruneConfig,
     dryRun: Boolean = false,
     reason: PruneReason? = null,
@@ -388,7 +388,7 @@ class HistoryManager(
    * **Safety.** Reentrancy-guarded — second call with the scheduler already running is a no-op. The
    * scheduler thread is daemonised so the JVM can exit even if [stopAutoPrune] isn't called.
    */
-  fun startAutoPrune(initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS) {
+  public fun startAutoPrune(initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS) {
     val config = pruneConfig
     if (config.isAllOff) return
     if (config.autoPruneIntervalMs <= 0L) return
@@ -428,7 +428,7 @@ class HistoryManager(
    * pass observes the interrupt at its next syscall and exits without leaving the index in a
    * partial state (the rewrite is atomic).
    */
-  fun stopAutoPrune() {
+  public fun stopAutoPrune() {
     autoPruneStopped.set(true)
     val future = autoPruneFuture.getAndSet(null)
     future?.cancel(true)
@@ -447,7 +447,7 @@ class HistoryManager(
    * source whose close throws is logged and skipped. Called from the daemon's shutdown path
    * alongside [stopAutoPrune].
    */
-  fun closeSources() {
+  public fun closeSources() {
     for (source in sources) {
       try {
         source.close()
@@ -460,10 +460,10 @@ class HistoryManager(
     }
   }
 
-  companion object {
+  public companion object {
 
     /** Initial delay for [startAutoPrune] — a few seconds, after the sandbox is up. */
-    const val DEFAULT_INITIAL_DELAY_MS: Long = 5_000L
+    public const val DEFAULT_INITIAL_DELAY_MS: Long = 5_000L
 
     /** `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape. */
     private val TIMESTAMP_FORMAT: DateTimeFormatter =
@@ -473,7 +473,7 @@ class HistoryManager(
      * Builds the default H1 manager wiring — one [LocalFsHistorySource] under [historyDir]. Pass
      * `null` historyDir to get a disabled (`isEnabled = false`) manager.
      */
-    fun forLocalFs(
+    public fun forLocalFs(
       historyDir: java.nio.file.Path?,
       module: String,
       gitProvenance: GitProvenance?,
@@ -500,7 +500,7 @@ class HistoryManager(
      *   production daemon main passes a lambda that posts a warn-level `log` notification; tests
      *   pass a buffer-capturing lambda.
      */
-    fun forLocalFsAndGitRefs(
+    public fun forLocalFsAndGitRefs(
       historyDir: java.nio.file.Path?,
       module: String,
       gitProvenance: GitProvenance?,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
@@ -20,7 +20,7 @@ package ee.schimke.composeai.daemon.history
  * ee.schimke.composeai.daemon.protocol.HistoryPruneParams]); the auto-prune scheduler always uses
  * the configured defaults.
  */
-data class HistoryPruneConfig(
+public data class HistoryPruneConfig(
   val maxEntriesPerPreview: Int = 50,
   val maxAgeDays: Int = 14,
   val maxTotalSizeBytes: Long = 500_000_000L,
@@ -38,17 +38,19 @@ data class HistoryPruneConfig(
         maxTotalSizeBytes <= 0L &&
         autoPruneIntervalMs <= 0L
 
-  companion object {
-    const val PROP_MAX_ENTRIES: String = "composeai.daemon.history.maxEntriesPerPreview"
-    const val PROP_MAX_AGE_DAYS: String = "composeai.daemon.history.maxAgeDays"
-    const val PROP_MAX_TOTAL_SIZE_BYTES: String = "composeai.daemon.history.maxTotalSizeBytes"
-    const val PROP_AUTO_PRUNE_INTERVAL_MS: String = "composeai.daemon.history.autoPruneIntervalMs"
+  public companion object {
+    public const val PROP_MAX_ENTRIES: String = "composeai.daemon.history.maxEntriesPerPreview"
+    public const val PROP_MAX_AGE_DAYS: String = "composeai.daemon.history.maxAgeDays"
+    public const val PROP_MAX_TOTAL_SIZE_BYTES: String =
+      "composeai.daemon.history.maxTotalSizeBytes"
+    public const val PROP_AUTO_PRUNE_INTERVAL_MS: String =
+      "composeai.daemon.history.autoPruneIntervalMs"
 
     /**
      * Builds a config from system properties, falling back to defaults for any unset / unparseable
      * value. Production daemon mains call this; tests construct [HistoryPruneConfig] directly.
      */
-    fun fromSysprops(props: (String) -> String? = System::getProperty): HistoryPruneConfig {
+    public fun fromSysprops(props: (String) -> String? = System::getProperty): HistoryPruneConfig {
       val defaults = HistoryPruneConfig()
       return HistoryPruneConfig(
         maxEntriesPerPreview =
@@ -69,9 +71,9 @@ data class HistoryPruneConfig(
  * actually got deleted — entries that surrendered their sidecar but whose PNG was retained because
  * a surviving sidecar still references it (dedup-by-hash) do NOT contribute to [freedBytes].
  */
-data class PruneResult(val removedEntryIds: List<String>, val freedBytes: Long) {
-  companion object {
-    val EMPTY: PruneResult = PruneResult(emptyList(), 0L)
+public data class PruneResult(val removedEntryIds: List<String>, val freedBytes: Long) {
+  public companion object {
+    public val EMPTY: PruneResult = PruneResult(emptyList(), 0L)
   }
 }
 
@@ -83,13 +85,13 @@ data class PruneResult(val removedEntryIds: List<String>, val freedBytes: Long) 
  * - [sourceResults] — per-source breakdown keyed by [HistorySource.id]. Read-only sources are NOT
  *   listed (they're skipped by the manager).
  */
-data class PruneAggregateResult(
+public data class PruneAggregateResult(
   val removedEntryIds: List<String>,
   val freedBytes: Long,
   val sourceResults: Map<String, PruneResult>,
 ) {
-  companion object {
-    val EMPTY: PruneAggregateResult = PruneAggregateResult(emptyList(), 0L, emptyMap())
+  public companion object {
+    public val EMPTY: PruneAggregateResult = PruneAggregateResult(emptyList(), 0L, emptyMap())
   }
 }
 
@@ -101,13 +103,13 @@ data class PruneAggregateResult(
  *
  * Empty (no-op) passes do NOT emit a notification at all (don't spam clients).
  */
-enum class PruneReason {
+public enum class PruneReason {
   AUTO,
   MANUAL,
 }
 
 /** Internal payload [HistoryManager] hands to its `pruneListener`. */
-data class PruneNotification(
+public data class PruneNotification(
   val removedIds: List<String>,
   val freedBytes: Long,
   val reason: PruneReason,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -16,7 +16,7 @@ package ee.schimke.composeai.daemon.history
  * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the shape
  * lets H9+ multi-source merging plug in without re-shaping the filter.
  */
-data class HistoryFilter(
+public data class HistoryFilter(
   val previewId: String? = null,
   val since: String? = null,
   val until: String? = null,
@@ -45,7 +45,7 @@ data class HistoryFilter(
  * [totalCount] is the count of entries matching the filter BEFORE pagination, so a UI can show
  * "showing 50 of 312".
  */
-data class HistoryListPage(
+public data class HistoryListPage(
   val entries: List<HistoryEntry>,
   val nextCursor: String? = null,
   val totalCount: Int,
@@ -55,7 +55,7 @@ data class HistoryListPage(
  * Result of [HistorySource.read]. [pngPath] is the absolute path to the bytes; [pngBytes] is
  * non-null only when the caller asked for inline bytes (e.g. an MCP client over a remote stdio).
  */
-data class HistoryReadResult(
+public data class HistoryReadResult(
   val entry: HistoryEntry,
   val previewMetadata: PreviewMetadataSnapshot?,
   val pngPath: String,
@@ -98,7 +98,7 @@ data class HistoryReadResult(
  * render is a meaningful event ("we went back to A") and is kept; render history A → A → A skips
  * everything after the first.
  */
-enum class WriteResult {
+public enum class WriteResult {
   WRITTEN,
   SKIPPED_DUPLICATE,
 }
@@ -112,15 +112,15 @@ enum class WriteResult {
  * [HistoryManager.recordRender]; read is paginated; watch is reserved for future phases (a UI
  * doesn't poll, it subscribes to `historyAdded`).
  */
-interface HistorySource {
+public interface HistorySource {
   /** Stable identifier — e.g. `"fs:/abs/historyDir"`, `"git:preview/main"`, `"http:https://…"`. */
-  val id: String
+  public val id: String
 
   /** `kind` from [HistorySourceInfo] — `"fs"`, `"git"`, `"http"`. */
-  val kind: String
+  public val kind: String
 
   /** True when this source can accept [write] calls. FS=true; git/HTTP read-only sources=false. */
-  fun supportsWrites(): Boolean
+  public fun supportsWrites(): Boolean
 
   /**
    * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this source
@@ -134,13 +134,13 @@ interface HistorySource {
    * Failures here must NOT be load-bearing for the render itself — `HistoryManager.recordRender`
    * catches and logs, then continues. The render succeeded; history is observation, not state.
    */
-  fun write(entry: HistoryEntry, png: ByteArray): WriteResult
+  public fun write(entry: HistoryEntry, png: ByteArray): WriteResult
 
   /** Lists history entries newest-first, applying [filter] and paginating. */
-  fun list(filter: HistoryFilter): HistoryListPage
+  public fun list(filter: HistoryFilter): HistoryListPage
 
   /** Reads one entry by id. Returns null when the id isn't present in this source. */
-  fun read(entryId: String, includeBytes: Boolean = false): HistoryReadResult?
+  public fun read(entryId: String, includeBytes: Boolean = false): HistoryReadResult?
 
   /**
    * H4 — applies the pruning policy from [config] to this source's storage. Read-only sources
@@ -161,12 +161,13 @@ interface HistorySource {
    *
    * Each individual knob set to `0` or negative is treated as disabled — that pass is skipped.
    */
-  fun prune(config: HistoryPruneConfig, dryRun: Boolean = false): PruneResult = PruneResult.EMPTY
+  public fun prune(config: HistoryPruneConfig, dryRun: Boolean = false): PruneResult =
+    PruneResult.EMPTY
 
   /**
    * Releases any background resources and flushes pending work on daemon shutdown. Default no-op;
    * `GitRefHistorySource` overrides it to flush a debounced commit batch (#1882) and stop its
    * scheduler so nothing buffered is lost on a clean stop.
    */
-  fun close() {}
+  public fun close() {}
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -61,7 +61,7 @@ import kotlinx.serialization.json.JsonElement
  * model". `index.jsonl` writes use [StandardOpenOption.APPEND] (POSIX `O_APPEND`); PNGs and
  * sidecars use distinct filenames per render so two writes never race on the same file.
  */
-class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
+public class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
 
   /** `fs:<absoluteHistoryDir>` — HISTORY.md § "Built-in sources § LocalFsHistorySource". */
   override val id: String = "fs:${historyDir.toAbsolutePath()}"
@@ -592,12 +592,12 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     return parsed
   }
 
-  companion object {
-    const val INDEX_FILENAME: String = "index.jsonl"
+  public companion object {
+    public const val INDEX_FILENAME: String = "index.jsonl"
     /** Default limit for [HistoryFilter.limit]. Pinned in [HistoryFilters] for shared use. */
-    const val DEFAULT_LIMIT: Int = HistoryFilters.DEFAULT_LIMIT
+    public const val DEFAULT_LIMIT: Int = HistoryFilters.DEFAULT_LIMIT
     /** Hard ceiling for [HistoryFilter.limit]. Pinned in [HistoryFilters] for shared use. */
-    const val MAX_LIMIT: Int = HistoryFilters.MAX_LIMIT
+    public const val MAX_LIMIT: Int = HistoryFilters.MAX_LIMIT
 
     /**
      * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the sidecar
@@ -614,7 +614,7 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     private val ISO_TS: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
     /** SHA-256 hex of [bytes]. */
-    fun sha256Hex(bytes: ByteArray): String {
+    public fun sha256Hex(bytes: ByteArray): String {
       val digest = MessageDigest.getInstance("SHA-256")
       val hash = digest.digest(bytes)
       val sb = StringBuilder(hash.size * 2)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -47,7 +47,7 @@ import kotlinx.serialization.json.JsonElement
 // `encodeDefaults = false`.
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class JsonRpcRequest(
+public data class JsonRpcRequest(
   @EncodeDefault val jsonrpc: String = "2.0",
   val id: Long,
   val method: String,
@@ -56,7 +56,7 @@ data class JsonRpcRequest(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class JsonRpcResponse(
+public data class JsonRpcResponse(
   @EncodeDefault val jsonrpc: String = "2.0",
   val id: Long,
   val result: JsonElement? = null,
@@ -65,21 +65,21 @@ data class JsonRpcResponse(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class JsonRpcNotification(
+public data class JsonRpcNotification(
   @EncodeDefault val jsonrpc: String = "2.0",
   val method: String,
   val params: JsonElement? = null,
 )
 
 @Serializable
-data class JsonRpcError(val code: Int, val message: String, val data: JsonElement? = null)
+public data class JsonRpcError(val code: Int, val message: String, val data: JsonElement? = null)
 
 // =====================================================================
 // 2. initialize (PROTOCOL.md § 3)
 // =====================================================================
 
 @Serializable
-data class InitializeParams(
+public data class InitializeParams(
   val protocolVersion: Int,
   val clientVersion: String,
   val workspaceRoot: String,
@@ -89,10 +89,10 @@ data class InitializeParams(
   val options: Options? = null,
 )
 
-@Serializable data class ClientCapabilities(val visibility: Boolean, val metrics: Boolean)
+public @Serializable data class ClientCapabilities(val visibility: Boolean, val metrics: Boolean)
 
 @Serializable
-data class Options(
+public data class Options(
   val maxHeapMb: Int? = null,
   val warmSpare: Boolean? = null,
   val detectLeaks: DetectLeaks? = null,
@@ -118,7 +118,7 @@ data class Options(
 )
 
 @Serializable
-data class HistoryPruneOptions(
+public data class HistoryPruneOptions(
   val maxEntriesPerPreview: Int? = null,
   val maxAgeDays: Int? = null,
   val maxTotalSizeBytes: Long? = null,
@@ -126,14 +126,14 @@ data class HistoryPruneOptions(
 )
 
 @Serializable
-enum class DetectLeaks {
+public enum class DetectLeaks {
   @SerialName("off") OFF,
   @SerialName("light") LIGHT,
   @SerialName("heavy") HEAVY,
 }
 
 @Serializable
-data class InitializeResult(
+public data class InitializeResult(
   val protocolVersion: Int,
   val daemonVersion: String,
   val pid: Long,
@@ -143,7 +143,7 @@ data class InitializeResult(
 )
 
 @Serializable
-data class ServerCapabilities(
+public data class ServerCapabilities(
   val incrementalDiscovery: Boolean,
   val sandboxRecycle: Boolean,
   // Subset of {"light","heavy"}; empty means leak detection unavailable.
@@ -245,7 +245,7 @@ data class ServerCapabilities(
  * variant is a wire change.
  */
 @Serializable
-enum class BackendKind {
+public enum class BackendKind {
   @SerialName("desktop") DESKTOP,
   @SerialName("android") ANDROID,
 }
@@ -257,7 +257,7 @@ enum class BackendKind {
  * identifies circular Wear-style displays.
  */
 @Serializable
-data class KnownDevice(
+public data class KnownDevice(
   val id: String,
   val widthDp: Int,
   val heightDp: Int,
@@ -274,7 +274,7 @@ data class KnownDevice(
  * `data/fetch` may pay a render cost when the latest pass didn't compute the kind.
  */
 @Serializable
-data class DataProductCapability(
+public data class DataProductCapability(
   val kind: String,
   val schemaVersion: Int,
   val transport: DataProductTransport,
@@ -288,14 +288,14 @@ data class DataProductCapability(
 )
 
 @Serializable
-enum class DataProductTransport {
+public enum class DataProductTransport {
   @SerialName("inline") INLINE,
   @SerialName("path") PATH,
   @SerialName("both") BOTH,
 }
 
 @Serializable
-enum class DataProductFacet {
+public enum class DataProductFacet {
   @SerialName("structured") STRUCTURED,
   @SerialName("artifact") ARTIFACT,
   @SerialName("image") IMAGE,
@@ -308,12 +308,12 @@ enum class DataProductFacet {
 }
 
 @Serializable
-enum class LeakDetectionMode {
+public enum class LeakDetectionMode {
   @SerialName("light") LIGHT,
   @SerialName("heavy") HEAVY,
 }
 
-@Serializable data class Manifest(val path: String, val previewCount: Int)
+public @Serializable data class Manifest(val path: String, val previewCount: Int)
 
 // =====================================================================
 // 2b. extensions/{list,enable,disable} (PROTOCOL.md § 3a)
@@ -325,7 +325,7 @@ enum class LeakDetectionMode {
 // =====================================================================
 
 @Serializable
-data class ExtensionInfoDto(
+public data class ExtensionInfoDto(
   val id: String,
   val displayName: String,
   val dependencies: List<String> = emptyList(),
@@ -336,12 +336,12 @@ data class ExtensionInfoDto(
   val previewExtensionIds: List<String> = emptyList(),
 )
 
-@Serializable data class ExtensionsListResult(val extensions: List<ExtensionInfoDto>)
+public @Serializable data class ExtensionsListResult(val extensions: List<ExtensionInfoDto>)
 
-@Serializable data class ExtensionsEnableParams(val ids: List<String>)
+public @Serializable data class ExtensionsEnableParams(val ids: List<String>)
 
 @Serializable
-data class ExtensionsEnableResult(
+public data class ExtensionsEnableResult(
   val newlyEnabled: List<String> = emptyList(),
   val pulledIn: List<String> = emptyList(),
   val alreadyEnabled: List<String> = emptyList(),
@@ -352,10 +352,10 @@ data class ExtensionsEnableResult(
   val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
 )
 
-@Serializable data class ExtensionsDisableParams(val ids: List<String>)
+public @Serializable data class ExtensionsDisableParams(val ids: List<String>)
 
 @Serializable
-data class ExtensionsDisableResult(
+public data class ExtensionsDisableResult(
   val disabled: List<String> = emptyList(),
   val deactivated: List<String> = emptyList(),
   val stillActiveAsDependency: List<String> = emptyList(),
@@ -370,22 +370,26 @@ data class ExtensionsDisableResult(
 // 3. Client → daemon notifications (PROTOCOL.md § 4)
 // =====================================================================
 
-@Serializable data class SetVisibleParams(val ids: List<String>)
+public @Serializable data class SetVisibleParams(val ids: List<String>)
 
-@Serializable data class SetFocusParams(val ids: List<String>)
-
-@Serializable
-data class FileChangedParams(val path: String, val kind: FileKind, val changeType: ChangeType)
+public @Serializable data class SetFocusParams(val ids: List<String>)
 
 @Serializable
-enum class FileKind {
+public data class FileChangedParams(
+  val path: String,
+  val kind: FileKind,
+  val changeType: ChangeType,
+)
+
+@Serializable
+public enum class FileKind {
   @SerialName("source") SOURCE,
   @SerialName("resource") RESOURCE,
   @SerialName("classpath") CLASSPATH,
 }
 
 @Serializable
-enum class ChangeType {
+public enum class ChangeType {
   @SerialName("modified") MODIFIED,
   @SerialName("created") CREATED,
   @SerialName("deleted") DELETED,
@@ -407,20 +411,23 @@ enum class ChangeType {
  * its on-disk cache. Either form works; `Known` saves BTA a directory scan.
  */
 @Serializable
-data class CompileSourcesParams(val sources: List<String>, val changes: SourceChangeSet? = null)
+public data class CompileSourcesParams(
+  val sources: List<String>,
+  val changes: SourceChangeSet? = null,
+)
 
 /**
  * Editor-supplied dirty set for [CompileSourcesParams]. Translates 1:1 to BTA's
  * `SourcesChanges.Known(modifiedFiles, removedFiles)`.
  */
 @Serializable
-data class SourceChangeSet(
+public data class SourceChangeSet(
   val modified: List<String> = emptyList(),
   val removed: List<String> = emptyList(),
 )
 
 @Serializable
-data class CompileSourcesResult(
+public data class CompileSourcesResult(
   val result: CompileResultKind,
   /** Populated when [result] = `compileError`. Empty otherwise. */
   val errors: List<CompileErrorDetail> = emptyList(),
@@ -429,7 +436,7 @@ data class CompileSourcesResult(
 )
 
 @Serializable
-enum class CompileResultKind {
+public enum class CompileResultKind {
   @SerialName("ok") OK,
 
   /**
@@ -447,14 +454,19 @@ enum class CompileResultKind {
 }
 
 @Serializable
-data class CompileErrorDetail(val file: String, val line: Int, val column: Int, val message: String)
+public data class CompileErrorDetail(
+  val file: String,
+  val line: Int,
+  val column: Int,
+  val message: String,
+)
 
 // =====================================================================
 // 4. Client → daemon requests (PROTOCOL.md § 5)
 // =====================================================================
 
 @Serializable
-data class RenderNowParams(
+public data class RenderNowParams(
   val previews: List<String>,
   val tier: RenderTier,
   val reason: String? = null,
@@ -474,7 +486,7 @@ data class RenderNowParams(
  * PROTOCOL.md § 5 ("renderNow.overrides").
  */
 @Serializable
-data class PreviewOverrides(
+public data class PreviewOverrides(
   /** Sandbox width in pixels. Mirrors `@Preview(widthDp=…)` × density. A *fixed* frame. */
   val widthPx: Int? = null,
   /** Sandbox height in pixels. A *fixed* frame. */
@@ -792,7 +804,7 @@ data class PreviewOverrides(
  * path yet and ignores the field.
  */
 @Serializable
-data class LottieOverride(
+public data class LottieOverride(
   /**
    * Timeline position in `0f..1f` (`0f` = first frame, `1f` = last). Coerced into range by the
    * runtime. Null leaves the composable's authored `progress` untouched — so an override carrying
@@ -813,14 +825,14 @@ data class LottieOverride(
  * preview JAR carries.
  */
 @Serializable
-data class PermissionsOverride(
+public data class PermissionsOverride(
   /** Permission name -> grant state. Keys are `Manifest.permission.*` constant strings. */
   val grants: Map<String, PermissionGrantStateOverride> = emptyMap()
 )
 
 /** Wire spelling for [PermissionsOverride.grants] values. */
 @Serializable
-enum class PermissionGrantStateOverride {
+public enum class PermissionGrantStateOverride {
   @SerialName("granted") GRANTED,
   @SerialName("denied") DENIED,
 }
@@ -842,7 +854,7 @@ enum class PermissionGrantStateOverride {
  *   `"sym"`.
  */
 @Serializable
-data class KeyboardOverride(val visible: Boolean? = null, val pressedKey: String? = null)
+public data class KeyboardOverride(val visible: Boolean? = null, val pressedKey: String? = null)
 
 /**
  * Focus / keyboard-traversal override for previews. Drives the connector-side
@@ -865,7 +877,7 @@ data class KeyboardOverride(val visible: Boolean? = null, val pressedKey: String
  * `ee.schimke.composeai.daemon.FocusOverlay.apply` when set.
  */
 @Serializable
-data class FocusOverride(
+public data class FocusOverride(
   val tabIndex: Int? = null,
   val direction: FocusDirection? = null,
   val step: Int? = null,
@@ -893,7 +905,7 @@ data class FocusOverride(
  * focus connector's `toCompose` adapter maps each value to the upstream constant at render time.
  */
 @Serializable
-enum class FocusDirection {
+public enum class FocusDirection {
   Next,
   Previous,
   Up,
@@ -913,7 +925,7 @@ enum class FocusDirection {
  * accessibility contrast control (`-1.0` → reduced, `0.0` → default, `0.5` → medium, `1.0` → high).
  */
 @Serializable
-data class WallpaperOverride(
+public data class WallpaperOverride(
   /** Seed color as `#RRGGBB` or `#AARRGGBB`. */
   val seedColor: String,
   /** When non-null, forces the dark variant of the derived scheme. */
@@ -949,7 +961,7 @@ data class WallpaperOverride(
  * requested state after [idleTimeoutMs] of further inactivity.
  */
 @Serializable
-data class AmbientOverride(
+public data class AmbientOverride(
   /** Requested ambient state. */
   val state: AmbientStateOverride,
   /**
@@ -982,7 +994,7 @@ data class AmbientOverride(
 
 /** Wire spelling for [AmbientOverride.state]. */
 @Serializable
-enum class AmbientStateOverride {
+public enum class AmbientStateOverride {
   @SerialName("interactive") INTERACTIVE,
   @SerialName("ambient") AMBIENT,
   @SerialName("inactive") INACTIVE,
@@ -1006,7 +1018,7 @@ enum class AmbientStateOverride {
  * previewed tree (the "disabled gesture" screen). Null falls back to `true`.
  */
 @Serializable
-data class GestureOverride(
+public data class GestureOverride(
   /** Mirrors `LocalOneHandedGestureEnabled`. Null falls back to `true` (recognition enabled). */
   val enabled: Boolean? = null,
   /** Force-show the gesture hints for this render (immediate mode). Null falls back to `false`. */
@@ -1022,7 +1034,7 @@ data class GestureOverride(
 
 /** Wire spelling for [GestureOverride.invoke] and the connector's registered-gesture kinds. */
 @Serializable
-enum class GestureKindOverride {
+public enum class GestureKindOverride {
   @SerialName("primary") PRIMARY,
   @SerialName("dismiss") DISMISS,
   @SerialName("scroll") SCROLL,
@@ -1030,7 +1042,7 @@ enum class GestureKindOverride {
 }
 
 @Serializable
-enum class WallpaperPaletteStyle {
+public enum class WallpaperPaletteStyle {
   @SerialName("tonalSpot") TONAL_SPOT,
   @SerialName("neutral") NEUTRAL,
   @SerialName("vibrant") VIBRANT,
@@ -1063,7 +1075,7 @@ enum class WallpaperPaletteStyle {
  * Android-only — the desktop backend has no Remote Compose runtime and ignores this field.
  */
 @Serializable
-data class RemoteComposeOverride(
+public data class RemoteComposeOverride(
   val profile: RemoteComposeProfile? = null,
   val namedValues: Map<String, RemoteNamedValue> = emptyMap(),
   val acceptedHostActions: List<String>? = null,
@@ -1095,7 +1107,7 @@ data class RemoteComposeOverride(
  * way `:daemon:android` gates the whole Remote Compose extension.
  */
 @Serializable
-enum class RemoteComposePlayerKind {
+public enum class RemoteComposePlayerKind {
   @SerialName("view") VIEW,
   @SerialName("embedded") EMBEDDED,
 }
@@ -1119,7 +1131,7 @@ enum class RemoteComposePlayerKind {
  *   face hosts).
  */
 @Serializable
-enum class RemoteComposeProfile {
+public enum class RemoteComposeProfile {
   @SerialName("androidx") ANDROIDX,
   @SerialName("androidx7") ANDROIDX7,
   @SerialName("androidx8") ANDROIDX8,
@@ -1141,27 +1153,31 @@ enum class RemoteComposeProfile {
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @kotlinx.serialization.json.JsonClassDiscriminator("kind")
-sealed class RemoteNamedValue {
+public sealed class RemoteNamedValue {
   /** Single-precision float. Matches `Float.rf` / `RemoteFloat`. */
-  @Serializable @SerialName("float") data class FloatValue(val value: Float) : RemoteNamedValue()
+  public @Serializable @SerialName("float") data class FloatValue(val value: Float) :
+    RemoteNamedValue()
 
   /**
    * Density-independent pixel measurement. Carries the raw dp value; the connector wraps with
    * `.rdp` at bind time so user code can read it as a `RemoteFloat` representing the dp.
    */
-  @Serializable @SerialName("dp") data class DpValue(val value: Float) : RemoteNamedValue()
+  public @Serializable @SerialName("dp") data class DpValue(val value: Float) : RemoteNamedValue()
 
   /** 32-bit integer. Matches `Int.rint` / `RemoteInt`. */
-  @Serializable @SerialName("int") data class IntValue(val value: Int) : RemoteNamedValue()
+  public @Serializable @SerialName("int") data class IntValue(val value: Int) : RemoteNamedValue()
 
   /** UTF-8 string. Matches `String.rs` / `RemoteString`. */
-  @Serializable @SerialName("string") data class StringValue(val value: String) : RemoteNamedValue()
+  public @Serializable @SerialName("string") data class StringValue(val value: String) :
+    RemoteNamedValue()
 
   /** Boolean flag. Matches `Boolean.rb` / `RemoteBoolean`. */
-  @Serializable @SerialName("bool") data class BooleanValue(val value: Boolean) : RemoteNamedValue()
+  public @Serializable @SerialName("bool") data class BooleanValue(val value: Boolean) :
+    RemoteNamedValue()
 
   /** Color as `#AARRGGBB`. Matches `RemoteColor(Color(...))`. */
-  @Serializable @SerialName("color") data class ColorValue(val argb: String) : RemoteNamedValue()
+  public @Serializable @SerialName("color") data class ColorValue(val argb: String) :
+    RemoteNamedValue()
 }
 
 /**
@@ -1174,7 +1190,11 @@ sealed class RemoteNamedValue {
  * downstream consumers can order events without needing the remote runtime's own clock model.
  */
 @Serializable
-data class RemoteHostAction(val payload: String, val handlerId: Float, val firedAtMillis: Long = 0L)
+public data class RemoteHostAction(
+  val payload: String,
+  val handlerId: Float,
+  val firedAtMillis: Long = 0L,
+)
 
 /**
  * Whole-cell size on a launcher's grid, expressed as integer cell counts.
@@ -1185,7 +1205,7 @@ data class RemoteHostAction(val payload: String, val handlerId: Float, val fired
  * up to the configured floor.
  */
 @Serializable
-data class LauncherWidgetSize(val width: Int, val height: Int) {
+public data class LauncherWidgetSize(val width: Int, val height: Int) {
   init {
     require(width >= 0) { "LauncherWidgetSize.width must be >= 0, was $width" }
     require(height >= 0) { "LauncherWidgetSize.height must be >= 0, was $height" }
@@ -1205,7 +1225,7 @@ data class LauncherWidgetSize(val width: Int, val height: Int) {
  * intermediate frames it emits between source and target.
  */
 @Serializable
-enum class LauncherResizeOrder {
+public enum class LauncherResizeOrder {
   @SerialName("diagonal") DIAGONAL,
   @SerialName("widthFirst") WIDTH_FIRST,
   @SerialName("heightFirst") HEIGHT_FIRST,
@@ -1247,7 +1267,7 @@ enum class LauncherResizeOrder {
  *   (`widthPx`/`heightPx` or `device`); the chrome fills whatever canvas the render is given.
  */
 @Serializable
-data class LauncherWidgetOverride(
+public data class LauncherWidgetOverride(
   val cells: LauncherWidgetSize,
   val cellSizeDp: Int? = null,
   val cellSpacingDp: Int? = null,
@@ -1271,7 +1291,7 @@ data class LauncherWidgetOverride(
  * resolved end-state the renderer rendered.
  */
 @Serializable
-data class LauncherWidgetPayload(
+public data class LauncherWidgetPayload(
   /** Resolved (post-clamp) cell count the renderer applied. */
   val cells: LauncherWidgetSize,
   /** Resolved per-cell edge length in dp. */
@@ -1331,7 +1351,7 @@ data class LauncherWidgetPayload(
  * can lock the axes the widget doesn't support.
  */
 @Serializable
-enum class LauncherResizeAxes {
+public enum class LauncherResizeAxes {
   @SerialName("none") NONE,
   @SerialName("horizontal") HORIZONTAL,
   @SerialName("vertical") VERTICAL,
@@ -1339,7 +1359,7 @@ enum class LauncherResizeAxes {
 }
 
 @Serializable
-data class Material3ThemeOverrides(
+public data class Material3ThemeOverrides(
   /** Material 3 color role -> `#RRGGBB` or `#AARRGGBB`. */
   val colorScheme: Map<String, String> = emptyMap(),
   /** Material 3 text style name -> partial text-style override. */
@@ -1349,7 +1369,7 @@ data class Material3ThemeOverrides(
 )
 
 @Serializable
-data class Material3TypographyOverride(
+public data class Material3TypographyOverride(
   val fontSizeSp: Float? = null,
   val lineHeightSp: Float? = null,
   val letterSpacingSp: Float? = null,
@@ -1358,27 +1378,27 @@ data class Material3TypographyOverride(
 )
 
 @Serializable
-enum class UiMode {
+public enum class UiMode {
   @SerialName("light") LIGHT,
   @SerialName("dark") DARK,
 }
 
 @Serializable
-enum class Orientation {
+public enum class Orientation {
   @SerialName("portrait") PORTRAIT,
   @SerialName("landscape") LANDSCAPE,
 }
 
 @Serializable
-enum class RenderTier {
+public enum class RenderTier {
   @SerialName("fast") FAST,
   @SerialName("full") FULL,
 }
 
 @Serializable
-data class RenderNowResult(val queued: List<String>, val rejected: List<RejectedRender>)
+public data class RenderNowResult(val queued: List<String>, val rejected: List<RejectedRender>)
 
-@Serializable data class RejectedRender(val id: String, val reason: String)
+public @Serializable data class RejectedRender(val id: String, val reason: String)
 
 // ---------------------------------------------------------------------------
 // `preview/rows` — enumerate a `@PreviewParameter` provider's rows (issue #3749).
@@ -1389,17 +1409,20 @@ data class RenderNowResult(val queued: List<String>, val rejected: List<Rejected
 // past the end and read the error. This is the direct answer.
 // ---------------------------------------------------------------------------
 
-@Serializable data class PreviewRowsParams(val previewId: String)
+public @Serializable data class PreviewRowsParams(val previewId: String)
 
 /**
  * [rows] is empty for an ordinary preview — the daemon answers that from discovery metadata alone,
  * without touching a classloader or (on Android) the render sandbox. Empty means "render the bare
  * id"; it is not an error.
  */
-@Serializable data class PreviewRowsResult(val previewId: String, val rows: List<PreviewRowDto>)
+public @Serializable data class PreviewRowsResult(
+  val previewId: String,
+  val rows: List<PreviewRowDto>,
+)
 
 @Serializable
-data class PreviewRowDto(
+public data class PreviewRowDto(
   /** Zero-based position in the provider's value sequence. */
   val index: Int,
   /** The row token — a derived label (`Dark`) or `PARAM_<index>`. See docs/RENDER_FILENAMES.md. */
@@ -1417,13 +1440,13 @@ data class PreviewRowDto(
 // ---------------------------------------------------------------------------
 
 @Serializable
-data class DataFetchParams(
+public data class DataFetchParams(
   val previewId: String,
   val kind: String,
   val params: JsonElement? = null,
   val inline: Boolean = false,
 ) {
-  companion object {
+  public companion object {
     /**
      * `params` key: when `true`, a `requiresRerender` kind re-renders even if its on-disk artefact
      * already exists — used by the serve host's `?scroll=long` lane to force a fresh render at the
@@ -1431,19 +1454,19 @@ data class DataFetchParams(
      * differently-themed file must be re-rendered rather than served). Ignored by kinds that don't
      * re-render.
      */
-    const val PARAM_FORCE_RERENDER: String = "force"
+    public const val PARAM_FORCE_RERENDER: String = "force"
 
     /**
      * `params` key: a serialized [PreviewOverrides] the daemon threads into a `requiresRerender`
      * re-render, so the produced artefact reflects the caller's theme / device / locale /
      * font-scale / knob overrides rather than the preview's defaults.
      */
-    const val PARAM_OVERRIDES: String = "overrides"
+    public const val PARAM_OVERRIDES: String = "overrides"
   }
 }
 
 @Serializable
-data class DataFetchResult(
+public data class DataFetchResult(
   val kind: String,
   val schemaVersion: Int,
   val payload: JsonElement? = null,
@@ -1471,7 +1494,7 @@ data class DataFetchResult(
  * "Recomposition + interactive mode".
  */
 @Serializable
-data class DataSubscribeParams(
+public data class DataSubscribeParams(
   val previewId: String,
   val kind: String,
   val params: JsonElement? = null,
@@ -1480,9 +1503,9 @@ data class DataSubscribeParams(
 /** Acknowledgement-only result; trivial by design so growing it stays additive. */
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class DataSubscribeResult(@EncodeDefault val ok: Boolean = true) {
-  companion object {
-    val OK: DataSubscribeResult = DataSubscribeResult(ok = true)
+public data class DataSubscribeResult(@EncodeDefault val ok: Boolean = true) {
+  public companion object {
+    public val OK: DataSubscribeResult = DataSubscribeResult(ok = true)
   }
 }
 
@@ -1491,7 +1514,7 @@ data class DataSubscribeResult(@EncodeDefault val ok: Boolean = true) {
 // =====================================================================
 
 @Serializable
-data class DiscoveryUpdatedParams(
+public data class DiscoveryUpdatedParams(
   // PreviewInfo is the schema emitted by DiscoverPreviewsTask plus the
   // sourceFile field added in P0.2. Carried as JsonElement here because the
   // canonical shape lives in :gradle-plugin and we don't want to duplicate
@@ -1503,10 +1526,10 @@ data class DiscoveryUpdatedParams(
   val totalPreviews: Int,
 )
 
-@Serializable data class RenderStartedParams(val id: String, val queuedMs: Long)
+public @Serializable data class RenderStartedParams(val id: String, val queuedMs: Long)
 
 @Serializable
-data class RenderFinishedParams(
+public data class RenderFinishedParams(
   val id: String,
   val pngPath: String,
   val tookMs: Long,
@@ -1535,7 +1558,7 @@ data class RenderFinishedParams(
  * PNG). Always omitted on the wire when empty so pre-feature clients ignore it.
  */
 @Serializable
-data class DataProductAttachment(
+public data class DataProductAttachment(
   val kind: String,
   val schemaVersion: Int,
   val payload: JsonElement? = null,
@@ -1560,7 +1583,7 @@ data class DataProductAttachment(
  * processors and extras".
  */
 @Serializable
-data class DataProductExtra(
+public data class DataProductExtra(
   val name: String,
   val path: String,
   val mediaType: String? = null,
@@ -1568,13 +1591,13 @@ data class DataProductExtra(
 )
 
 @Serializable
-data class RenderMetrics(
+public data class RenderMetrics(
   val heapAfterGcMb: Long,
   val nativeHeapMb: Long,
   val sandboxAgeRenders: Long,
   val sandboxAgeMs: Long,
 ) {
-  companion object {
+  public companion object {
     /**
      * The four flat-map keys [RenderHost] implementations populate on `RenderResult.metrics` to
      * carry B2.3 measurement values across the renderer-agnostic seam.
@@ -1582,10 +1605,10 @@ data class RenderMetrics(
      * Pinned here so `:daemon:core`, `:daemon:android`, `:daemon:desktop`, and `:daemon:harness`
      * agree on the exact spelling without each reaching for a string literal at the call site.
      */
-    const val KEY_HEAP_AFTER_GC_MB: String = "heapAfterGcMb"
-    const val KEY_NATIVE_HEAP_MB: String = "nativeHeapMb"
-    const val KEY_SANDBOX_AGE_RENDERS: String = "sandboxAgeRenders"
-    const val KEY_SANDBOX_AGE_MS: String = "sandboxAgeMs"
+    public const val KEY_HEAP_AFTER_GC_MB: String = "heapAfterGcMb"
+    public const val KEY_NATIVE_HEAP_MB: String = "nativeHeapMb"
+    public const val KEY_SANDBOX_AGE_RENDERS: String = "sandboxAgeRenders"
+    public const val KEY_SANDBOX_AGE_MS: String = "sandboxAgeMs"
 
     /**
      * Translates the flat `Map<String, Long>` carrier on `RenderResult.metrics` into a structured
@@ -1600,7 +1623,7 @@ data class RenderMetrics(
      * partial-map case and observe drift — a common shape early in a host backend's measurement
      * plumbing.
      */
-    fun fromFlatMap(map: Map<String, Long>?): FromFlatMapResult {
+    public fun fromFlatMap(map: Map<String, Long>?): FromFlatMapResult {
       if (map == null) return FromFlatMapResult.AbsentSource
       val heap = map[KEY_HEAP_AFTER_GC_MB]
       val native = map[KEY_NATIVE_HEAP_MB]
@@ -1634,19 +1657,19 @@ data class RenderMetrics(
    *   logs a warn-level notification so caller-side drift is observable.
    * - [Populated] — all four keys present; the wire carries the structured object.
    */
-  sealed interface FromFlatMapResult {
-    data object AbsentSource : FromFlatMapResult
+  public sealed interface FromFlatMapResult {
+    public data object AbsentSource : FromFlatMapResult
 
-    data class PartialMap(val missingKeys: List<String>) : FromFlatMapResult
+    public data class PartialMap(val missingKeys: List<String>) : FromFlatMapResult
 
-    data class Populated(val metrics: RenderMetrics) : FromFlatMapResult
+    public data class Populated(val metrics: RenderMetrics) : FromFlatMapResult
   }
 }
 
-@Serializable data class RenderFailedParams(val id: String, val error: RenderError)
+public @Serializable data class RenderFailedParams(val id: String, val error: RenderError)
 
 @Serializable
-data class RenderError(
+public data class RenderError(
   val kind: RenderErrorKind,
   val message: String,
   val stackTrace: String? = null,
@@ -1676,7 +1699,7 @@ data class RenderError(
  * value here stays additive for old clients. Every `when (kind)` must carry an explicit `else`.
  */
 @Serializable(with = RenderErrorKindSerializer::class)
-enum class RenderErrorKind(val wire: String) {
+public enum class RenderErrorKind(public val wire: String) {
   COMPILE("compile"),
   RUNTIME("runtime"),
   CAPTURE("capture"),
@@ -1701,7 +1724,7 @@ enum class RenderErrorKind(val wire: String) {
  * 4.1 enum discipline). This is what keeps adding a new failure discriminant an additive,
  * non-breaking change for older clients.
  */
-object RenderErrorKindSerializer : KSerializer<RenderErrorKind> {
+public object RenderErrorKindSerializer : KSerializer<RenderErrorKind> {
   override val descriptor: SerialDescriptor =
     PrimitiveSerialDescriptor(
       "ee.schimke.composeai.daemon.protocol.RenderErrorKind",
@@ -1719,21 +1742,21 @@ object RenderErrorKindSerializer : KSerializer<RenderErrorKind> {
 }
 
 @Serializable
-data class ClasspathDirtyParams(
+public data class ClasspathDirtyParams(
   val reason: ClasspathDirtyReason,
   val detail: String,
   val changedPaths: List<String>? = null,
 )
 
 @Serializable
-enum class ClasspathDirtyReason {
+public enum class ClasspathDirtyReason {
   @SerialName("fingerprintMismatch") FINGERPRINT_MISMATCH,
   @SerialName("fileChanged") FILE_CHANGED,
   @SerialName("manifestMissing") MANIFEST_MISSING,
 }
 
 @Serializable
-data class SandboxRecycleParams(
+public data class SandboxRecycleParams(
   val reason: SandboxRecycleReason,
   val ageMs: Long,
   val renderCount: Long,
@@ -1741,7 +1764,7 @@ data class SandboxRecycleParams(
 )
 
 @Serializable
-enum class SandboxRecycleReason {
+public enum class SandboxRecycleReason {
   @SerialName("heapCeiling") HEAP_CEILING,
   @SerialName("heapDrift") HEAP_DRIFT,
   @SerialName("renderTimeDrift") RENDER_TIME_DRIFT,
@@ -1751,10 +1774,10 @@ enum class SandboxRecycleReason {
   @SerialName("manual") MANUAL,
 }
 
-@Serializable data class DaemonWarmingParams(val etaMs: Long)
+public @Serializable data class DaemonWarmingParams(val etaMs: Long)
 
 @Serializable
-class DaemonReadyParams {
+public class DaemonReadyParams {
   // Empty-object payload per PROTOCOL.md § 6 ("daemonReady"). Modelled as a
   // class with no fields so kotlinx-serialization emits/accepts {}.
   override fun equals(other: Any?): Boolean = other is DaemonReadyParams
@@ -1765,7 +1788,7 @@ class DaemonReadyParams {
 }
 
 @Serializable
-data class LogParams(
+public data class LogParams(
   val level: LogLevel,
   val message: String,
   val category: String? = null,
@@ -1773,7 +1796,7 @@ data class LogParams(
 )
 
 @Serializable
-enum class LogLevel {
+public enum class LogLevel {
   @SerialName("debug") DEBUG,
   @SerialName("info") INFO,
   @SerialName("warn") WARN,
@@ -1795,7 +1818,7 @@ enum class LogLevel {
 // =====================================================================
 
 @Serializable
-data class HistoryListParams(
+public data class HistoryListParams(
   val previewId: String? = null,
   val since: String? = null,
   val until: String? = null,
@@ -1814,7 +1837,7 @@ data class HistoryListParams(
 )
 
 @Serializable
-data class HistoryListResult(
+public data class HistoryListResult(
   val entries: List<JsonElement>,
   val nextCursor: String? = null,
   val totalCount: Int,
@@ -1823,17 +1846,21 @@ data class HistoryListResult(
 // `ref` (H10-read) — read this id from an on-demand git reporting branch instead of the configured
 // sources; must match the `ref` the id was listed from.
 @Serializable
-data class HistoryReadParams(val id: String, val inline: Boolean = false, val ref: String? = null)
+public data class HistoryReadParams(
+  val id: String,
+  val inline: Boolean = false,
+  val ref: String? = null,
+)
 
 @Serializable
-data class HistoryReadResultDto(
+public data class HistoryReadResultDto(
   val entry: JsonElement,
   val previewMetadata: JsonElement? = null,
   val pngPath: String,
   val pngBytes: String? = null,
 )
 
-@Serializable data class HistoryAddedParams(val entry: JsonElement)
+public @Serializable data class HistoryAddedParams(val entry: JsonElement)
 
 // =====================================================================
 // 5b. Interactive (live-stream) mode — see docs/daemon/INTERACTIVE.md § 8.
@@ -1847,7 +1874,7 @@ data class HistoryReadResultDto(
 // =====================================================================
 
 @Serializable
-data class InteractiveStartParams(
+public data class InteractiveStartParams(
   val previewId: String,
   /**
    * Optional `LocalInspectionMode` override for held interactive sessions. Null preserves the
@@ -1874,7 +1901,7 @@ data class InteractiveStartParams(
  * right frame stream and drop stale ids cleanly.
  */
 @Serializable
-data class InteractiveStartResult(
+public data class InteractiveStartResult(
   val frameStreamId: String,
   /**
    * True when the daemon acquired a held composition for this stream. False means the stream is
@@ -1885,7 +1912,7 @@ data class InteractiveStartResult(
   val fallbackReason: String? = null,
 )
 
-@Serializable data class InteractiveStopParams(val frameStreamId: String)
+public @Serializable data class InteractiveStopParams(val frameStreamId: String)
 
 /**
  * `interactive/setRemoteCompose` notification — push a single Remote Compose state edit into a held
@@ -1900,7 +1927,7 @@ data class InteractiveStartResult(
  * the notification.
  */
 @Serializable
-data class InteractiveSetRemoteComposeParams(
+public data class InteractiveSetRemoteComposeParams(
   /**
    * Routing key — same `frameStreamId` `interactive/start` allocated and `interactive/input` uses.
    */
@@ -1921,7 +1948,7 @@ data class InteractiveSetRemoteComposeParams(
  * `renderNow`.
  */
 @Serializable
-data class InteractiveSetLottieParams(
+public data class InteractiveSetLottieParams(
   /**
    * Routing key — same `frameStreamId` `interactive/start` allocated and `interactive/input` uses.
    */
@@ -1942,20 +1969,21 @@ data class InteractiveSetLottieParams(
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 @kotlinx.serialization.json.JsonClassDiscriminator("field")
-sealed class RemoteComposeChange {
+public sealed class RemoteComposeChange {
   /** Replace the active platform profile. `value = null` clears it. */
   @Serializable
   @SerialName("profile")
-  data class Profile(val value: RemoteComposeProfile? = null) : RemoteComposeChange()
+  public data class Profile(val value: RemoteComposeProfile? = null) : RemoteComposeChange()
 
   /** Merge a single typed named value. Preserves other entries in the controller. */
   @Serializable
   @SerialName("namedValue")
-  data class NamedValue(val name: String, val value: RemoteNamedValue) : RemoteComposeChange()
+  public data class NamedValue(val name: String, val value: RemoteNamedValue) :
+    RemoteComposeChange()
 }
 
 @Serializable
-data class InteractiveInputParams(
+public data class InteractiveInputParams(
   val frameStreamId: String,
   val kind: InteractiveInputKind,
   /** Image-natural physical pixels, dispatched without density conversion. */
@@ -2016,13 +2044,13 @@ data class InteractiveInputParams(
  * backends know how to synthesise. Unknown / absent values fall back to [TOUCH] so a client that
  * predates the field keeps its old dispatch behaviour exactly.
  */
-enum class InteractivePointerType {
+public enum class InteractivePointerType {
   MOUSE,
   TOUCH,
   PEN;
 
-  companion object {
-    fun parse(wire: String?): InteractivePointerType =
+  public companion object {
+    public fun parse(wire: String?): InteractivePointerType =
       when (wire?.trim()?.lowercase()) {
         "mouse" -> MOUSE
         "pen" -> PEN
@@ -2043,7 +2071,7 @@ enum class InteractivePointerType {
  * than one (for testTag / role+text) is an unresolved target; refs are unique by construction.
  */
 @Serializable
-data class SemanticsInputTarget(
+public data class SemanticsInputTarget(
   val ref: String? = null,
   val testTag: String? = null,
   val role: String? = null,
@@ -2051,7 +2079,7 @@ data class SemanticsInputTarget(
 )
 
 @Serializable
-enum class InteractiveInputKind {
+public enum class InteractiveInputKind {
   @SerialName("click") CLICK,
   @SerialName("pointerDown") POINTER_DOWN,
   @SerialName("pointerMove") POINTER_MOVE,
@@ -2071,7 +2099,7 @@ enum class InteractiveInputKind {
 // ---------------------------------------------------------------------------
 
 @Serializable
-enum class HistoryDiffMode {
+public enum class HistoryDiffMode {
   @SerialName("metadata") METADATA,
   @SerialName("pixel") PIXEL,
   // Structural text diff of the two entries' `compose/semantics` trees (issue #1785) — the cheap,
@@ -2086,7 +2114,7 @@ enum class HistoryDiffMode {
 }
 
 @Serializable
-data class HistoryDiffParams(
+public data class HistoryDiffParams(
   val from: String,
   val to: String,
   val mode: HistoryDiffMode = HistoryDiffMode.METADATA,
@@ -2096,7 +2124,7 @@ data class HistoryDiffParams(
 )
 
 @Serializable
-data class HistoryDiffResult(
+public data class HistoryDiffResult(
   val pngHashChanged: Boolean,
   val fromMetadata: JsonElement,
   val toMetadata: JsonElement,
@@ -2128,7 +2156,7 @@ data class HistoryDiffResult(
  * `dryRun = true` returns the would-remove set without touching disk.
  */
 @Serializable
-data class HistoryPruneParams(
+public data class HistoryPruneParams(
   val maxEntriesPerPreview: Int? = null,
   val maxAgeDays: Int? = null,
   val maxTotalSizeBytes: Long? = null,
@@ -2136,7 +2164,7 @@ data class HistoryPruneParams(
 )
 
 @Serializable
-data class HistoryPruneSourceResult(val removedEntryIds: List<String>, val freedBytes: Long)
+public data class HistoryPruneSourceResult(val removedEntryIds: List<String>, val freedBytes: Long)
 
 /**
  * Result of `history/prune`. [removedEntries] / [freedBytes] are the cross-source aggregate;
@@ -2144,7 +2172,7 @@ data class HistoryPruneSourceResult(val removedEntryIds: List<String>, val freed
  * are listed — read-only git/HTTP sources don't participate in pruning).
  */
 @Serializable
-data class HistoryPruneResult(
+public data class HistoryPruneResult(
   val removedEntries: List<String>,
   val freedBytes: Long,
   val sourceResults: Map<String, HistoryPruneSourceResult>,
@@ -2155,14 +2183,14 @@ data class HistoryPruneResult(
  * pass — auto-prune passes that removed nothing produce no notification.
  */
 @Serializable
-data class HistoryPrunedParams(
+public data class HistoryPrunedParams(
   val removedIds: List<String>,
   val freedBytes: Long,
   val reason: PruneReasonWire,
 )
 
 @Serializable
-enum class PruneReasonWire {
+public enum class PruneReasonWire {
   @SerialName("auto") AUTO,
   @SerialName("manual") MANUAL,
 }
@@ -2203,7 +2231,7 @@ enum class PruneReasonWire {
  *   Defaults to `false` (scripted mode); see RECORDING.md § "live mode".
  */
 @Serializable
-data class RecordingStartParams(
+public data class RecordingStartParams(
   val previewId: String,
   val fps: Int? = null,
   val scale: Float? = null,
@@ -2224,7 +2252,7 @@ data class RecordingStartParams(
  * the analogous wire shape there is `recording/script`.
  */
 @Serializable
-data class RecordingInputParams(
+public data class RecordingInputParams(
   val recordingId: String,
   val kind: InteractiveInputKind,
   /** Image-natural physical pixels, dispatched without density conversion. */
@@ -2282,10 +2310,10 @@ data class RecordingInputParams(
  * subsequent `recording/script`, `recording/stop`, and `recording/encode` so the daemon can route
  * to the right held session.
  */
-@Serializable data class RecordingStartResult(val recordingId: String)
+public @Serializable data class RecordingStartResult(val recordingId: String)
 
 @Serializable
-enum class RecordingScriptEventStatus {
+public enum class RecordingScriptEventStatus {
   @SerialName("applied") APPLIED,
   @SerialName("unsupported") UNSUPPORTED,
   /**
@@ -2299,7 +2327,7 @@ enum class RecordingScriptEventStatus {
 
 /** One scripted input/control event on the virtual timeline. */
 @Serializable
-data class RecordingScriptEvent(
+public data class RecordingScriptEvent(
   /** Virtual time offset from `recording/start`, in milliseconds. Must be ≥ 0. */
   val tMs: Long,
   /**
@@ -2428,9 +2456,12 @@ data class RecordingScriptEvent(
 )
 
 @Serializable
-data class RecordingScriptParams(val recordingId: String, val events: List<RecordingScriptEvent>)
+public data class RecordingScriptParams(
+  val recordingId: String,
+  val events: List<RecordingScriptEvent>,
+)
 
-@Serializable data class RecordingStopParams(val recordingId: String)
+public @Serializable data class RecordingStopParams(val recordingId: String)
 
 /**
  * Compact semantics snapshot of one node, captured at a `recording.probe` marker (issue #1786).
@@ -2456,7 +2487,7 @@ data class RecordingScriptParams(val recordingId: String, val events: List<Recor
  * became present) instead of a hand-filled TODO stub.
  */
 @Serializable
-data class RecordingProbeNode(
+public data class RecordingProbeNode(
   val testTag: String? = null,
   val text: String? = null,
   val contentDescription: String? = null,
@@ -2474,10 +2505,10 @@ data class RecordingProbeNode(
  * violation.
  */
 @Serializable
-data class RecordingA11yFinding(val level: String, val type: String, val message: String)
+public data class RecordingA11yFinding(val level: String, val type: String, val message: String)
 
 @Serializable
-data class RecordingScriptEvidence(
+public data class RecordingScriptEvidence(
   val tMs: Long,
   val kind: String,
   val status: RecordingScriptEventStatus,
@@ -2515,7 +2546,7 @@ data class RecordingScriptEvidence(
  * PNG per virtual frame to [framesDir], and freed the held scene.
  */
 @Serializable
-data class RecordingStopResult(
+public data class RecordingStopResult(
   /**
    * Number of frames written. Equals `ceil(durationMs * fps / 1000) + 1` (inclusive of frame 0).
    */
@@ -2553,7 +2584,7 @@ data class RecordingStopResult(
  * derived default.
  */
 @Serializable
-data class RecordingGenerateTestParams(
+public data class RecordingGenerateTestParams(
   /** Preview the recording was driven against. Used to resolve the composable's function name. */
   val previewId: String,
   /** The captured timeline — typically [RecordingStopResult.capturedScript]. */
@@ -2568,7 +2599,7 @@ data class RecordingGenerateTestParams(
   val packageName: String? = null,
 )
 
-@Serializable data class RecordingGenerateTestResult(val source: String)
+public @Serializable data class RecordingGenerateTestResult(val source: String)
 
 /**
  * v1 supports only animated PNG (pure JVM, no native deps, plays in every browser/webview). mp4 /
@@ -2585,7 +2616,7 @@ data class RecordingGenerateTestParams(
  * `protocolVersion`.
  */
 @Serializable
-enum class RecordingFormat {
+public enum class RecordingFormat {
   @SerialName("apng") APNG,
   @SerialName("gif") GIF,
   @SerialName("mp4") MP4,
@@ -2593,13 +2624,13 @@ enum class RecordingFormat {
 }
 
 @Serializable
-data class RecordingEncodeParams(
+public data class RecordingEncodeParams(
   val recordingId: String,
   val format: RecordingFormat = RecordingFormat.APNG,
 )
 
 @Serializable
-data class RecordingEncodeResult(
+public data class RecordingEncodeResult(
   /** Absolute path of the encoded video file. */
   val videoPath: String,
   /**
@@ -2633,7 +2664,7 @@ data class RecordingEncodeResult(
 // =====================================================================
 
 @Serializable
-enum class StreamCodec {
+public enum class StreamCodec {
   /** Raw PNG bytes — same encoding the renderer already produces. The default. */
   @SerialName("png") PNG,
   /**
@@ -2663,7 +2694,7 @@ enum class StreamCodec {
  *   very high-density devices feeding a small webview.
  */
 @Serializable
-data class StreamStartParams(
+public data class StreamStartParams(
   val previewId: String,
   val codec: StreamCodec? = null,
   val maxFps: Int? = null,
@@ -2687,14 +2718,14 @@ data class StreamStartParams(
  * - [fallbackReason] carries a human-readable string when [heldSession] is `false`.
  */
 @Serializable
-data class StreamStartResult(
+public data class StreamStartResult(
   val frameStreamId: String,
   val codec: StreamCodec,
   val heldSession: Boolean,
   val fallbackReason: String? = null,
 )
 
-@Serializable data class StreamStopParams(val frameStreamId: String)
+public @Serializable data class StreamStopParams(val frameStreamId: String)
 
 /**
  * `stream/visibility` — fire-and-forget signal the client uses to throttle a stream when the
@@ -2709,7 +2740,7 @@ data class StreamStartResult(
  *   [visible] is true.
  */
 @Serializable
-data class StreamVisibilityParams(
+public data class StreamVisibilityParams(
   val frameStreamId: String,
   val visible: Boolean,
   val fps: Int? = null,
@@ -2736,7 +2767,7 @@ data class StreamVisibilityParams(
  *   state on receipt.
  */
 @Serializable
-data class StreamFrameParams(
+public data class StreamFrameParams(
   val frameStreamId: String,
   val seq: Long,
   val ptsMillis: Long,
@@ -2778,7 +2809,7 @@ data class StreamFrameParams(
  * first frame as a `streamFrame` notification.
  */
 @Serializable
-data class XrStartParams(
+public data class XrStartParams(
   val previewId: String,
   val scene: JsonElement,
   /** Directory the scene's relative panel textures resolve against. */
@@ -2795,7 +2826,7 @@ data class XrStartParams(
 
 /** `xr/start` result — the allocated stream id + negotiated codec frames will arrive on. */
 @Serializable
-data class XrStartResult(
+public data class XrStartResult(
   val frameStreamId: String,
   val codec: StreamCodec,
   val available: Boolean = true,
@@ -2805,16 +2836,22 @@ data class XrStartResult(
  * `xr/updatePanels` — per-frame panel mutations; each entry is `{id, texture?, poseInRoot?,
  * sizeDp?}`.
  */
-@Serializable data class XrUpdatePanelsParams(val frameStreamId: String, val panels: JsonArray)
+public @Serializable data class XrUpdatePanelsParams(
+  val frameStreamId: String,
+  val panels: JsonArray,
+)
 
 /** `xr/stop` — close the held XR session for [frameStreamId]. */
-@Serializable data class XrStopParams(val frameStreamId: String)
+public @Serializable data class XrStopParams(val frameStreamId: String)
 
 /** `xr/structure` — fetch the held scene's panel tree + poses for [frameStreamId]. */
-@Serializable data class XrStructureParams(val frameStreamId: String)
+public @Serializable data class XrStructureParams(val frameStreamId: String)
 
 /**
  * `xr/structure` result — the `SpatialScene` structure (panel tree + poses) the session was opened
  * with, inline as JSON (mirrors `a11y/hierarchy`).
  */
-@Serializable data class XrStructureResult(val frameStreamId: String, val structure: JsonElement)
+public @Serializable data class XrStructureResult(
+  val frameStreamId: String,
+  val structure: JsonElement,
+)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/SemanticsTargetUnresolvedReason.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.Serializable
  * and ignore [targetUnresolvedReason].
  */
 @Serializable
-data class SemanticsTargetUnresolvedReason(
+public data class SemanticsTargetUnresolvedReason(
   /** Coarse cause — see [SemanticsTargetUnresolvedCode]. */
   val code: SemanticsTargetUnresolvedCode,
   /** Echo of the target the agent supplied, so the failure is self-describing in a trace. */
@@ -49,7 +49,7 @@ data class SemanticsTargetUnresolvedReason(
  * [RecordingScriptEvidence.message].
  */
 @Serializable
-enum class SemanticsTargetUnresolvedCode {
+public enum class SemanticsTargetUnresolvedCode {
   /** The held session hasn't produced a semantics tree yet (nothing rendered). */
   @SerialName("noSemanticsRoot") NO_SEMANTICS_ROOT,
   /**
@@ -72,7 +72,7 @@ enum class SemanticsTargetUnresolvedCode {
  * JSON-serializable, no Compose dep; the backends map their `ComposeSemanticsNode`s onto it.
  */
 @Serializable
-data class SemanticsTargetCandidate(
+public data class SemanticsTargetCandidate(
   /** The stable handle to pass back as `{ ref }` — unique within a render, the unambiguous pick. */
   val ref: String? = null,
   val testTag: String? = null,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/StreamFrameHeader.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/StreamFrameHeader.kt
@@ -29,7 +29,7 @@ import java.nio.ByteOrder
  * start-pts back in. Keeping the header at 20 bytes lets a busy stream amortise the header cost
  * down to ~2% of payload for typical 1 KB+ WebP frames.
  */
-data class StreamFrameHeader(
+public data class StreamFrameHeader(
   val codec: StreamCodec?,
   val seq: Long,
   val ptsMillis: Long,
@@ -52,7 +52,7 @@ data class StreamFrameHeader(
   /**
    * Pack to the canonical 20-byte header. Use [encodeTo] when you want header+payload back-to-back.
    */
-  fun pack(): ByteArray {
+  public fun pack(): ByteArray {
     val buf = ByteBuffer.allocate(HEADER_BYTES).order(ByteOrder.LITTLE_ENDIAN)
     buf.put(MAGIC)
     buf.put(VERSION)
@@ -67,7 +67,7 @@ data class StreamFrameHeader(
   }
 
   /** Convenience: returns header bytes immediately followed by [payload]. */
-  fun encodeTo(payload: ByteArray): ByteArray {
+  public fun encodeTo(payload: ByteArray): ByteArray {
     require(payload.size == payloadLen) {
       "payload size ${payload.size} != header.payloadLen $payloadLen"
     }
@@ -78,10 +78,10 @@ data class StreamFrameHeader(
     return out
   }
 
-  companion object {
-    const val MAGIC: Byte = 0xCF.toByte()
-    const val VERSION: Byte = 1
-    const val HEADER_BYTES: Int = 20
+  public companion object {
+    public const val MAGIC: Byte = 0xCF.toByte()
+    public const val VERSION: Byte = 1
+    public const val HEADER_BYTES: Int = 20
     private const val FLAG_KEYFRAME: Int = 0x01
     private const val FLAG_FINAL: Int = 0x02
     private const val CODEC_PNG: Byte = 0
@@ -93,7 +93,7 @@ data class StreamFrameHeader(
      * [IllegalArgumentException] when the magic byte / version / codec byte don't match — caller is
      * expected to surface as a wire-protocol error.
      */
-    fun parse(bytes: ByteArray, offset: Int = 0): StreamFrameHeader {
+    public fun parse(bytes: ByteArray, offset: Int = 0): StreamFrameHeader {
       require(bytes.size - offset >= HEADER_BYTES) {
         "stream header needs $HEADER_BYTES bytes, only ${bytes.size - offset} available"
       }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/UiAutomatorUnsupportedReason.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
  * response side.
  */
 @Serializable
-data class UiAutomatorUnsupportedReason(
+public data class UiAutomatorUnsupportedReason(
   /** Coarse cause — see [UiAutomatorUnsupportedReasonCode]. */
   val code: UiAutomatorUnsupportedReasonCode,
   /** Action kind the dispatch attempted (`"click"`, `"longClick"`, `"inputText"`, …). */
@@ -55,7 +55,7 @@ data class UiAutomatorUnsupportedReason(
  * [RecordingScriptEvidence.message].
  */
 @Serializable
-enum class UiAutomatorUnsupportedReasonCode {
+public enum class UiAutomatorUnsupportedReasonCode {
   /** Agent omitted the `selector` object entirely. */
   @SerialName("missingSelector") MISSING_SELECTOR,
   /** Agent omitted the `inputText` payload required by `uia.inputText`. */
@@ -87,7 +87,7 @@ enum class UiAutomatorUnsupportedReasonCode {
  * JSON-serializable, no Compose dep.
  */
 @Serializable
-data class UiAutomatorNearMatchNode(
+public data class UiAutomatorNearMatchNode(
   val text: String? = null,
   val contentDescription: String? = null,
   val testTag: String? = null,


### PR DESCRIPTION
#3824 preparation item 6, largest module. **776 declarations** — 55% of the item's total — matching the pre-measured count exactly (772 visibility + 4 return type).

`:daemon:core` is the JSON-RPC protocol contract an extracted preview server compiles against across a repo boundary, and the widest surface of the twelve. The committed dump is **7317 lines**: a surface that until now existed only implicitly, where a change would have appeared as a downstream break rather than a diff in review. That artifact is the point of the whole item.

## Every annotation is `public`

`:daemon:core` is already published, so each implicitly-public declaration is *already in a shipped ABI* and `internal` would be a breaking change. This pass **records** the surface rather than deciding it.

#4558's `:daemon-client` was the sole module where narrowing was free — it had never been published — and nothing there needed it either. The build comment states which regime applies so a later reader need not reconstruct it.

## 767 mechanical, 8 by hand

Every hand-fixed shape was one already met in #4558 / #4561, which is the payoff from doing the small modules first:

- **3 constructor `val` parameters** — `Entry`, `BtaCompileDiagnosticException`, `RenderErrorKind`. The compiler reports these at the *parameter column*, not the line start, so a line-prefixing pass can't touch them and stalls instead of converging. The loop's applied-count-zero guard surfaced them rather than spinning.
- **4 properties needing explicit types** — `CompositeDataProductRegistry.capabilities`, `PixelDiff.DEFAULT`, `DeviceSpec.DEFAULT` / `DEFAULT_WEAR`.
- **1 missing import**, and this one is worth recording. Annotating an **overridden** property with its explicit type can introduce a compile error the implicit version never had: `capabilities`' type came from the interface, and `CompositeDataProductRegistry.kt` had never imported `DataProductCapability`. My first guess didn't resolve, so I looked the declaration up instead of guessing again.

## Verifying the gate is not decorative

Falsified on `:daemon:core` itself:

```
EXIT WITH EXTRA PUBLIC FN: 1     BUILD FAILED
EXIT AFTER RESTORE:        0
```

The `check` → `checkKotlinAbi` wiring remains the load-bearing half — KGP does not add it, so without it the gate is configured and never runs.

## Test plan

- `:daemon:core:check` — **green**, full test suite plus `checkKotlinAbi`
- `ktfmtFormat` applied; dump regenerated afterwards
- 0 remaining explicit-API errors
- Gate falsified, then restored

Non-visual change (visibility modifiers and build wiring), so no rendered evidence applies.

## Item 6 after this

| Module | Declarations | |
| --- | ---: | --- |
| `:daemon-client` | 57 | ✅ #4558 |
| eight small contracts | 166 | ✅ #4561 |
| `:daemon:core` | 776 | ⬅ this PR |
| `data/render/core` | 230 | remaining |
| `data/layoutinspector/core` | 181 | remaining |

## Expect inherited red

`main`'s three timing tests — `AndroidRippleFrameTest:121`, `LivePressRippleTest:92` (`:daemon:android`), `ServeStatusLiveFramesTest:127` (`:cli`). The failing subset varies per run, which is what establishes they are load-dependent rather than diff-caused. Analysis and a proposed patch in #4547.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_