### PR TITLE
fix(serve): keep warmed theme renders across a release, and regenerate them

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -159,6 +159,7 @@ internal object CliFlagValidation {
             "--catalog-cache-dir",
             "--catalog-cache-max-bytes",
             "--theme-cache-dir",
+            "--theme-cache-evict",
             "--theme-cache-max-bytes",
             "--theme-optimizer-coordination-dir",
             "--catalog-feed-idle-timeout",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1089,7 +1089,16 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
       args.flagValue("--theme-cache-max-bytes")?.toLongOrNull()?.takeIf { it > 0 }
         ?: ThemeCacheStore.DEFAULT_MAX_BYTES
     System.err.println("serve: theme cache at $preferred (cap ${maxBytes / (1024 * 1024)} MB)")
-    ThemeCacheStore(preferred, maxBytes = maxBytes)
+    ThemeCacheStore(preferred, maxBytes = maxBytes).also { store ->
+      // Before anything opens a generation, so eviction can never race a live write. Renders
+      // survive a release now (see [ThemeCacheFingerprint]) and the load-time sample is what
+      // catches a renderer that moved — this is the lever for the case where the operator already
+      // knows it moved and would rather not wait to be told.
+      if ("--theme-cache-evict" in args) {
+        val evicted = store.evictAll()
+        System.err.println("serve: theme cache evicted on request — $evicted generation(s) removed")
+      }
+    }
   }
 
   /**
@@ -1196,7 +1205,6 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
                 extraPayloads = listOfNotNull(launch.manifestPath),
               ),
             variant = launch.variant,
-            toolVersion = BUNDLE_VERSION,
             renderConfig =
               ThemeCacheFingerprint.renderConfig(launch.systemProperties, launch.jvmArgs),
             routing = routing,
@@ -4847,6 +4855,13 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
                           ${ThemeCacheStore.DEFAULT_MAX_BYTES / (1024L * 1024 * 1024)} GB). Superseded
                           generations are reclaimed; generations still in use are never evicted, so
                           exceeding this is reported rather than acted on.
+        --theme-cache-evict
+                          Delete every persisted theme-render generation at startup, before any is
+                          opened. For when the pixels on the volume are known to be wrong — a base
+                          image that changed the installed fonts, say, which no fingerprint sees.
+                          Ordinary renderer changes need no eviction: entries written by another
+                          build are withheld until a re-rendered sample agrees with them, and the
+                          whole generation is discarded when it does not.
         --background-renders <n>
                           Background (theme-optimizer) renders admitted at once, server-wide.
                           Defaults to a value derived from --live-seats, which clamps at

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -29,12 +29,30 @@ import java.security.MessageDigest
  *   worth paying for: it is the only input that is derived from the thing itself rather than
  *   asserted about it.
  * - **The daemon variant.** Desktop and Android/Robolectric are different renderers reading the
- *   same classpath, and they do not agree pixel-for-pixel.
- * - **The tool version.** Covers the renderer, and stands proxy for the container image — hence the
- *   JVM, Skia and the installed fonts, none of which are visible from here. **That proxying is an
- *   assumption, not a proof:** a base-image bump that ships without a release would slip through
- *   it. It is recorded in the generation manifest so a mismatch is at least explainable after the
- *   fact, and the sample verification is what actually catches it.
+ *   same classpath, and they do not agree pixel-for-pixel. What is deliberately **not** keyed on,
+ *   and why:
+ * - **The tool version.** It used to be, and that made a release throw away every warmed render on
+ *   the box. Measured on preview.coo.ee, whose theme optimization needs the better part of a day to
+ *   fill 18,604 entries: four versions shipped inside four hours, each one starting the pass again
+ *   from zero, so the cache could never be adopted once. A cache that is invalidated faster than it
+ *   can be filled is not a cache.
+ *
+ *   The version was never proof of anything — it stood *proxy* for the renderer and the container
+ *   image (the JVM, Skia, the installed fonts), none of which are visible from here, and the class
+ *   doc above already conceded that proxying is an assumption rather than a proof: a base-image
+ *   bump shipping without a release slipped through it either way. So it was a key that failed open
+ *   on the case it was supposed to cover, while failing closed on every case it was not.
+ *
+ *   What actually catches a renderer that moved is [CatalogThemeCache.verifySample], which
+ *   re-renders a sample of the adopted entries against the running renderer and discards the whole
+ *   generation on any mismatch — the same net that was always covering the unenumerated inputs.
+ *   Crossing a version boundary is now exactly that case: every entry reads as adopted (it came
+ *   from another process), so it is withheld from the read path until the sample settles. A version
+ *   that renders differently costs a re-warm; it does not serve a wrong pixel.
+ *
+ *   The version is still recorded in the generation manifest, so which build last wrote a
+ *   generation stays answerable, and `--theme-cache-evict` discards the store outright for the case
+ *   where an operator *knows* the pixels moved and does not want to wait for a sample to notice.
  * - **The render config.** The server-side defaults that never appear in a cache key — density,
  *   default device, font scale, image encoding. The easiest inputs to forget precisely *because*
  *   they are absent from the key, so they are named explicitly by the caller.
@@ -69,7 +87,6 @@ object ThemeCacheFingerprint {
   fun of(
     classpath: List<File>,
     variant: String,
-    toolVersion: String,
     renderConfig: String,
     /**
      * Digest of the catalog-id to daemon-preview routing this generation renders through.
@@ -86,7 +103,8 @@ object ThemeCacheFingerprint {
     val digest = MessageDigest.getInstance("SHA-256")
     digest.line("schema", SCHEMA)
     digest.line("variant", variant)
-    digest.line("version", toolVersion)
+    // NOT the tool version — see the class doc. A release must not orphan the warmed renders; the
+    // load-time sample verification is what covers a renderer that actually moved.
     digest.line("renderConfig", renderConfig)
     digest.line("routing", routing)
     // Hashed in the order the descriptor lists them, NOT sorted. Classpath order is semantically

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -115,11 +115,66 @@ class ThemeCacheStore(
     return Generation(dir, system)
   }
 
+  /**
+   * Write the generation's manifest, or refresh it when a **different build** has opened the same
+   * generation.
+   *
+   * The early return used to be unconditional, on the reasoning that the directory name is the
+   * decision and the manifest is only commentary. That held while the fingerprint keyed on the tool
+   * version, because a new build could never reach an existing generation. It no longer does — a
+   * release now adopts its predecessor's renders (see [ThemeCacheFingerprint]) — so leaving the
+   * manifest alone would have it name a build that has not written here since, which is precisely
+   * the question the manifest exists to answer when someone is working out whether the pixels on
+   * this volume can be trusted.
+   *
+   * [GenerationInputs.createdAtEpochMillis] is preserved across the rewrite: it is what the sweep's
+   * grace window reads to spare a generation belonging to a replica that is still serving, and
+   * restamping it on every open would make a long-lived generation permanently young.
+   */
   private fun writeManifest(dir: File, inputs: GenerationInputs) {
     val file = File(dir, MANIFEST_NAME)
-    if (file.isFile) return
-    runCatching { file.writeText(json.encodeToString(inputs.copy(createdAtEpochMillis = clock()))) }
+    val existing =
+      if (file.isFile) {
+        runCatching { json.decodeFromString(GenerationInputs.serializer(), file.readText()) }
+          .getOrNull()
+      } else {
+        null
+      }
+    // An unreadable manifest beside a live generation is rewritten rather than left: the sweep
+    // falls back to the directory's own timestamp for it, and a readable one is strictly better.
+    if (existing != null && existing.toolVersion == inputs.toolVersion) return
+    val createdAt = existing?.createdAtEpochMillis?.takeIf { it > 0 } ?: clock()
+    runCatching {
+      file.writeText(json.encodeToString(inputs.copy(createdAtEpochMillis = createdAt)))
+    }
       .onFailure { recordFailure(dir.name, "manifest: ${it.message}") }
+  }
+
+  /**
+   * Delete every generation in the store, unconditionally, and report how many went.
+   *
+   * The escape hatch for "the pixels on this volume are wrong and I already know it" — a base-image
+   * bump that changed the installed fonts, say, which no fingerprint sees and which a five-entry
+   * verification sample can miss. [sweep] cannot serve this purpose: it deliberately spares any
+   * generation inside its grace window, which is exactly the freshly-written one an operator wants
+   * gone.
+   *
+   * Called only from an explicit `--theme-cache-evict`, and only before any generation is opened,
+   * so it can never race a live [Generation]'s writes.
+   */
+  fun evictAll(): Int {
+    var deleted = 0
+    for (systemDir in root.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+      for (generationDir in systemDir.listFiles()?.filter { it.isDirectory }.orEmpty()) {
+        if (generationDir.deleteRecursively()) deleted++
+        else recordFailure(systemDir.name, "could not evict ${generationDir.name}")
+      }
+      if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
+    }
+    knownGenerations.set(0)
+    knownGenerationsBySystem.set(emptyMap())
+    knownBytes.set(0)
+    return deleted
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -42,9 +42,8 @@ class ThemeCachePersistenceTest {
   private fun fingerprint(
     classpath: List<File>,
     variant: String = "desktop",
-    version: String = "1.14.0",
     renderConfig: String = "density=2",
-  ) = ThemeCacheFingerprint.of(classpath, variant, version, renderConfig)
+  ) = ThemeCacheFingerprint.of(classpath, variant, renderConfig)
 
   // ---- fingerprint ----------------------------------------------------------------------------
 
@@ -84,18 +83,74 @@ class ThemeCachePersistenceTest {
   }
 
   @Test
-  fun `renderer version, daemon variant and render config each change the generation`() {
+  fun `daemon variant and render config each change the generation, and the tool version does not`() {
     val dir = tempDir()
     val cp = listOf(jar(dir, "catalog.jar", "CLASSES"))
     val base = fingerprint(cp)
 
-    // The version stands proxy for the whole container image — JVM, Skia, fonts — so a release must
-    // never read the previous release's pixels.
-    assertNotEquals(base, fingerprint(cp, version = "1.15.0"))
     // Desktop and Android/Robolectric read the same classpath and do not agree pixel-for-pixel.
     assertNotEquals(base, fingerprint(cp, variant = "android"))
     // The inputs that never appear in a cache key, and are therefore the easiest to forget.
     assertNotEquals(base, fingerprint(cp, renderConfig = "density=3"))
+  }
+
+  /**
+   * The version used to be keyed on, and a release therefore orphaned every warmed render on the
+   * box. On preview.coo.ee, where a full pass is 18,604 entries and the better part of a day, four
+   * versions shipped inside four hours — so the cache was invalidated faster than it could ever be
+   * filled, and was adopted exactly zero times.
+   *
+   * It was never proof of anything either: it stood *proxy* for the container image, which a
+   * base-image bump changes without moving the version at all. What actually covers a renderer that
+   * moved is the load-time sample verification, which the next test exercises — crossing a version
+   * boundary is simply the adopted-entry case, and adopted entries are withheld until the sample
+   * agrees.
+   */
+  @Test
+  fun `a new build reads the previous build's generation`() {
+    val dir = tempDir()
+    val cp = listOf(jar(dir, "catalog.jar", "CLASSES"))
+    assertEquals(
+      fingerprint(cp),
+      fingerprint(cp),
+      "the same inputs name the same generation whatever build is asking",
+    )
+
+    // And the manifest still answers which build last wrote here, so a volume whose pixels are in
+    // question stays diagnosable.
+    val root = tempDir()
+    val fp = assertNotNull(fingerprint(cp))
+    store(root).open("m3-catalog", fp, inputs(fp).copy(toolVersion = "1.14.0"))
+    val reopened = store(root).open("m3-catalog", fp, inputs(fp).copy(toolVersion = "1.15.0"))
+    assertNotNull(reopened)
+    val manifest =
+      kotlinx.serialization.json.Json.decodeFromString(
+        GenerationInputs.serializer(),
+        File(File(File(root, "m3-catalog"), fp), ThemeCacheStore.MANIFEST_NAME).readText(),
+      )
+    assertEquals("1.15.0", manifest.toolVersion, "the manifest names the build that last opened it")
+  }
+
+  @Test
+  fun `evictAll discards every generation, including one the sweep would spare`() {
+    val root = tempDir()
+    // A real store, so the grace window is in force — this is the case `sweep` cannot serve, and
+    // therefore the whole reason `evictAll` exists.
+    val guarded = ThemeCacheStore(root, maxBytes = ThemeCacheStore.DEFAULT_MAX_BYTES)
+    val generation = assertNotNull(guarded.open("m3-catalog", "fp-a", inputs("fp-a")))
+    generation.put("preview|dark", ByteArray(8) { 1 })
+
+    assertEquals(
+      0,
+      guarded.sweep(live = emptySet()).deletedGenerations,
+      "the grace window spares a freshly written generation, which is exactly the problem",
+    )
+    assertEquals(1, guarded.evictAll(), "evict takes it anyway")
+    assertEquals(
+      false,
+      File(File(root, "m3-catalog"), "fp-a").exists(),
+      "and the bytes are gone from the volume",
+    )
   }
 
   @Test
@@ -231,7 +286,6 @@ class ThemeCachePersistenceTest {
       ThemeCacheFingerprint.of(
         cp,
         variant = "desktop",
-        toolVersion = "1.14.0",
         renderConfig = "density=2",
         routing = ThemeCacheFingerprint.routingDigest(alias),
       )

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -325,6 +325,26 @@ that decides the pixels; because an input nobody thought of could still escape i
 re-renders a sample of the adopted entries at startup and discards the entire generation on any
 mismatch, so a fingerprint miss costs a re-render rather than serving wrong pixels.
 
+**A release keeps the warmed renders.** The tool version used to be part of that fingerprint, which
+meant every release orphaned the whole store — and with four versions shipping inside four hours
+here against a pass that needs the better part of a day, the cache was invalidated faster than it
+could ever fill and was adopted exactly zero times. The version was never proof of anything anyway:
+it stood *proxy* for the container image, which a base-image bump changes without moving the version
+at all. Renders written by another build are now adopted, and treated exactly like any other adopted
+entry — withheld from reads until the re-rendered sample agrees, whole generation discarded when it
+does not. The version stays in each generation's manifest, so which build last wrote a generation
+remains answerable.
+
+For the case where you already **know** the pixels moved — a base image that changed the installed
+fonts, which no fingerprint sees and a five-entry sample can miss — evict the store outright:
+
+```
+SERVE_THEME_CACHE_EVICT=1
+```
+
+It fires on **every** start while set, so leave it in for one roll and then take it out again. An
+ordinary renderer change needs none of this; the sample verification is what that is for.
+
 Read `themeCache` on [`/status.json`](https://preview.coo.ee/status.json) to confirm it is on — it
 is `null` when there is no disk tier, and each catalog's `renderCache.persisted` is `null` beside
 it. `renderCache.persistenceOff` names the reason when a catalog fell back to memory-only for some

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -211,6 +211,10 @@ services:
       # this is roughly 4x headroom for superseded generations awaiting their sweep — while leaving
       # the box's disk to the catalog blob pool beside it, which really does sit at its full 8 GB.
       SERVE_THEME_CACHE_MAX_BYTES: "${SERVE_THEME_CACHE_MAX_BYTES:-4294967296}"
+      # Set to 1 for ONE roll to discard every persisted generation at startup, then unset it — it
+      # fires on every start while set. Only for pixels known to be wrong (a base-image change no
+      # fingerprint sees); an ordinary renderer change is already covered by the load-time sample.
+      SERVE_THEME_CACHE_EVICT: "${SERVE_THEME_CACHE_EVICT:-}"
       # The heavy bytes a catalog FETCHES (as opposed to the pixels it renders): each live
       # catalog's executable liveBundle — ~100 MB — its per-preview split bundles, and the
       # externalised font/resource pool. Held content-addressed, so a rolled replica reads them

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -463,6 +463,13 @@ fi
 [[ -n "${SERVE_THEME_CACHE_DIR:-}" ]] && args+=(--theme-cache-dir "${SERVE_THEME_CACHE_DIR}")
 [[ -n "${SERVE_THEME_CACHE_MAX_BYTES:-}" ]] &&
   args+=(--theme-cache-max-bytes "${SERVE_THEME_CACHE_MAX_BYTES}")
+# One-shot: discard every persisted generation at startup. For when the pixels on the volume are
+# known to be wrong (a base image that changed the installed fonts, say) — an ordinary renderer
+# change needs no eviction, because entries from another build are withheld until a re-rendered
+# sample agrees with them. Leave it set for one roll, then unset it: it fires on EVERY start.
+if [[ "${SERVE_THEME_CACHE_EVICT:-}" == "1" || "${SERVE_THEME_CACHE_EVICT:-}" == "true" ]]; then
+  args+=(--theme-cache-evict)
+fi
 
 # The heavy bytes a catalog fetches — its executable liveBundle, the per-preview splits and the
 # externalised resource pool — kept on a volume so a rolled replica reads them instead of pulling


### PR DESCRIPTION
Completes the thread from #4536 / #4541 / #4550. Those made theme optimization *fast enough*; this stops a release throwing the result away, then stops the inherited pixels being trusted forever.

Two commits: adopt across a release, then regenerate what was adopted.

## 1. The version was the wrong cache key

`preview.coo.ee` now has the disk tier on (#4550), and `/status.json` showed the cache holding bytes nothing would read:

```
themeCache.bytes   103369      ← renders from the previous version, on disk
themeCache.hits    0
every catalog      0 / N cached
```

The generation fingerprint keyed on the tool version, so a release could never reach its predecessor's generation. Against a pass needing the better part of a day to fill 18,604 entries, four versions shipped in four hours today — v1.35.0, v1.36.0, v1.37.0, v1.37.1. **The cache was invalidated faster than it could be filled, and was adopted exactly zero times.**

It was never proof of anything either. It stood **proxy** for the container image — the JVM, Skia, the installed fonts — and the class doc already conceded the point: *"That proxying is an assumption, not a proof: a base-image bump that ships without a release would slip through it."* So it failed **open** on the case it existed to cover and **closed** on every case it did not.

What covers it instead is the net that always covered the unenumerated inputs: `verifySample` re-renders a sample of the adopted entries and discards on mismatch, with adopted entries withheld from reads until it settles. Crossing a version boundary is now simply the adopted-entry case.

## 2. Adopted is not the same as current

Adoption alone leaves a catalog serving another build's pixels indefinitely — warm is warm, so the optimizer's "not cached yet" filter passes straight over them.

So renders written before a different build opened the generation are **dirty**: still warm, still served once the sample has vouched for them, and **queued for re-render**. The optimizer works that queue after the gaps are filled — they are the lowest-value work it has, because unlike a gap they are already serving something.

**Dirtiness is derived, not tracked.** The manifest records a boundary; an entry is dirty if its own file timestamp predates it. Re-rendering moves a file past the boundary for free, so there is no parallel index to keep consistent with 18,604 files and no write amplification on the path this exists to drive. Marking a whole catalog dirty is then just moving the line — which is what the follow-up's "regenerate this catalog" action will do.

**A failed sample now drops only the dirty renders.** Discarding the whole generation was right while every entry present at open came from the same suspect build. It is wrong once this process has spent an hour rendering into the same directory: those entries are the one thing the sample just *confirmed*, and taking them costs an hour of rendering to fix a problem they do not have.

**Both tiers had to be taught to overwrite**, and this is where the design nearly failed quietly. The disk tier declined any write to a key already present unless it was *adopted* — which an entry an operator marked is not — and the memory window kept serving the older copy for as long as its LRU held it. Either alone would have left the pass re-rendering every slice and never clearing a single flag.

Supporting changes: the manifest is refreshed when a different build opens an existing generation (preserving `createdAtEpochMillis`, which the sweep's grace window reads), and `--theme-cache-evict` / `SERVE_THEME_CACHE_EVICT=1` discards the store at startup for the case an operator already knows the pixels moved — `sweep` cannot serve that, since it spares anything inside its grace window.

## Test plan

- `ThemeCachePersistenceTest`
  - *a new build reads the previous build's generation* — same inputs name the same generation whatever build asks, and the manifest names the build that last opened it.
  - *renders inherited from another build are dirty until re-rendered* — inherited entries are dirty **and** still `contains`, re-rendering one clears that one only, and the regenerated bytes are what the store then serves.
  - *a failed sample drops the dirty renders and keeps the ones this build made*.
  - *marking a catalog dirty queues its renders without taking them away*, and the mark survives a restart — an operator's request must not be forgotten by the next roll.
  - *evictAll discards every generation, including one the sweep would spare* — the contrast that is the reason the method exists.
  - *daemon variant and render config each change the generation, and the tool version does not*.
- `./gradlew :cli:test` — full module suite green.
- All eight `deploy/image/test-*.sh` guards pass.

Two things worth knowing about the tests. `present` holds **hashed** file names and the hash is one-way, so every internal walk over what is on disk goes through a name-based helper while only the caller-facing `isDirty` hashes — routing an internal walk through the latter double-hashes, misses the file, and (since a missing file reads as dirty) reports the whole generation dirty. That was a real bug the tests caught. And the tests backdate their fixture PNGs rather than skewing the store's clock: skewing also distorts the writes the test then makes *through* that store, leaving regenerated entries permanently dirty.

Not visually verified: cache keying and background work — no rendered surface.

## Follow-up

The per-catalog **regenerate** (mark dirty) and **drop** actions on the status page are a separate PR on top of this one.

## What to expect on the box

The first restart after this ships still starts from zero — the generations on the volume were written under the old scheme and their directory names carry the version. From the restart after that, `themeCache.hits` should be non-zero, entries should survive a release, and each catalog's `themeOptimization.dirty` should fall steadily as the background pass converges on this renderer.