### PR TITLE
feat(data-products): enforce explicit API and gate the ABI on the render and layout-inspector payload schemas

### DIFF
--- a/data/layoutinspector/core/api/data-layoutinspector-core.api
+++ b/data/layoutinspector/core/api/data-layoutinspector-core.api
@@ -1,0 +1,2026 @@
+public final class ee/schimke/composeai/data/layoutinspector/ComposeFigmaSvgProduct {
+	public static final field FILE_SVG Ljava/lang/String;
+	public static final field FILE_SVG_LONG Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeFigmaSvgProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field KIND_LONG Ljava/lang/String;
+	public static final field LONG_SUBDIR Ljava/lang/String;
+	public static final field MEDIA_TYPE_SVG Ljava/lang/String;
+	public static final field RASTER_DIR Ljava/lang/String;
+	public static final field RENDER_MODE_LONG Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()Ljava/lang/String;
+	public final fun getEnd ()Ljava/lang/String;
+	public final fun getStart ()Ljava/lang/String;
+	public final fun getTop ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModelsKt {
+	public static final fun insetsPaint (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;)Z
+	public static final fun insetsPaintHorizontally (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;)Z
+	public static final fun insetsPaintVertically (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;)Z
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;
+	public final fun component8 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;
+	public final fun component9 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInRoot ()Ljava/lang/String;
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getClickable ()Z
+	public final fun getEditableText ()Ljava/lang/String;
+	public final fun getInputText ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLayoutText ()Ljava/lang/String;
+	public final fun getMergeMode ()Ljava/lang/String;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getPlaced ()Z
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getTextColor ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;
+	public final fun getTextOverflow ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;
+	public final fun getTokens ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public final fun getTypography ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload$Companion;
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/lang/Float;)V
+	public synthetic fun <init> (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/lang/Float;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Ljava/lang/Float;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getRoot ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsProduct {
+	public static final field FILE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackground ()Ljava/lang/String;
+	public final fun getForeground ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextColor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine$Companion;
+	public fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseline ()I
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getLeft ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextLine$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDidOverflowHeight ()Ljava/lang/Boolean;
+	public final fun getDidOverflowWidth ()Ljava/lang/Boolean;
+	public final fun getLineCount ()Ljava/lang/Integer;
+	public final fun getLines ()Ljava/util/List;
+	public final fun getMaxLines ()Ljava/lang/Integer;
+	public final fun getOverflow ()Ljava/lang/String;
+	public final fun getTruncated ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextOverflow$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan$Companion;
+	public fun <init> (IILjava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (IILjava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (IILjava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan;IILjava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnd ()I
+	public final fun getFontFamily ()Ljava/lang/String;
+	public final fun getFontSize ()Ljava/lang/String;
+	public final fun getFontSizePx ()Ljava/lang/Double;
+	public final fun getFontStyle ()Ljava/lang/String;
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getForegroundColor ()Ljava/lang/String;
+	public final fun getStart ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTextSpan$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public final fun component14 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public final fun component15 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/Double;
+	public final fun component18 ()Ljava/lang/Boolean;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun component3 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Boolean;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()Ljava/lang/String;
+	public final fun getBackgroundGradient ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun getBorderColor ()Ljava/lang/String;
+	public final fun getBorderGradient ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun getBorderWidth ()Ljava/lang/String;
+	public final fun getClipsContent ()Ljava/lang/Boolean;
+	public final fun getCornerRadius ()Ljava/lang/String;
+	public final fun getCornerRadiusPx ()Ljava/lang/String;
+	public final fun getElevation ()Ljava/lang/String;
+	public final fun getGap ()Ljava/lang/String;
+	public final fun getMinHeight ()Ljava/lang/String;
+	public final fun getMinWidth ()Ljava/lang/String;
+	public final fun getOpacity ()Ljava/lang/Double;
+	public final fun getPadding ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public final fun getPaintBox ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getPaintInset ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsInsets;
+	public final fun getShape ()Ljava/lang/String;
+	public final fun getShapePath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/Double;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontFamily ()Ljava/lang/String;
+	public final fun getFontFeatureSettings ()Ljava/lang/String;
+	public final fun getFontSize ()Ljava/lang/String;
+	public final fun getFontSizePx ()Ljava/lang/Double;
+	public final fun getFontStyle ()Ljava/lang/String;
+	public final fun getFontVariationSettings ()Ljava/lang/String;
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getLayoutDirection ()Ljava/lang/String;
+	public final fun getLetterSpacing ()Ljava/lang/String;
+	public final fun getLetterSpacingPx ()Ljava/lang/Double;
+	public final fun getLineHeight ()Ljava/lang/String;
+	public final fun getLineHeightPx ()Ljava/lang/Double;
+	public final fun getSpans ()Ljava/util/List;
+	public final fun getTextAlign ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsTypography$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ComposeSemanticsWireframeProduct {
+	public static final field FILE_PNG Ljava/lang/String;
+	public static final field FILE_SVG Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsWireframeProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field MEDIA_TYPE_PNG Ljava/lang/String;
+	public static final field MEDIA_TYPE_SVG Ljava/lang/String;
+	public static final field PNG_EXTRA_NAME Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ExplodedSvg {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/ExplodedSvg;
+	public static final field MAX_PLANES I
+	public final fun render (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options;)Ljava/lang/String;
+	public static synthetic fun render$default (Lee/schimke/composeai/data/layoutinspector/ExplodedSvg;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options {
+	public fun <init> ()V
+	public fun <init> (DDLjava/lang/Double;IZZ)V
+	public synthetic fun <init> (DDLjava/lang/Double;IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()I
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun copy (DDLjava/lang/Double;IZZ)Lee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options;DDLjava/lang/Double;IZZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/ExplodedSvg$Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGap ()Ljava/lang/Double;
+	public final fun getLabels ()Z
+	public final fun getMaxDepth ()I
+	public final fun getPlates ()Z
+	public final fun getSpinDeg ()D
+	public final fun getTiltDeg ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg;
+	public final fun embedFamily (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun render (Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options;Ljava/util/List;Ljava/util/Map;)Ljava/lang/String;
+	public static synthetic fun render$default (Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg;Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun resolveFamily (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun withGenericFallback (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options {
+	public fun <init> ()V
+	public fun <init> (ZDLjava/lang/String;Z)V
+	public synthetic fun <init> (ZDLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()D
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (ZDLjava/lang/String;Z)Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options;ZDLjava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg$Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotateTokens ()Z
+	public final fun getDefaultFontFamily ()Ljava/lang/String;
+	public final fun getDefaultFontSizePx ()D
+	public final fun getMaterialIconRefs ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode : java/lang/Enum {
+	public static final field CONTENT_SHAPE Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode$Companion;
+	public static final field DEVICE Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public static final field FULL_BLEED Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public static final field NONE Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public static fun values ()[Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster {
+	public fun <init> (Ljava/lang/String;IIIIZZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;)V
+	public synthetic fun <init> (Ljava/lang/String;IIIIZZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun copy (Ljava/lang/String;IIIIZZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;Ljava/lang/String;IIIIZZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAboveShape ()Z
+	public final fun getBottom ()I
+	public final fun getClipBounds ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getClipToShape ()Z
+	public final fun getFromFrame ()Z
+	public final fun getHeight ()I
+	public final fun getHref ()Ljava/lang/String;
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;IIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getRx ()I
+	public final fun getWidth ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgColor {
+	public fun <init> (Ljava/lang/String;DLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;DLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;DLjava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Ljava/lang/String;DLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHex ()Ljava/lang/String;
+	public final fun getOpacity ()D
+	public final fun getTokenName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgFontFace {
+	public fun <init> (Ljava/lang/String;IZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;IZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;IZLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgFontFace;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgFontFace;Ljava/lang/String;IZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgFontFace;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataBase64 ()Ljava/lang/String;
+	public final fun getFamily ()Ljava/lang/String;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getItalic ()Z
+	public final fun getWeight ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgLayer {
+	public fun <init> (Ljava/lang/String;IIIILee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;DLjava/util/List;ZZLjava/lang/String;DLee/schimke/composeai/data/layoutinspector/FigmaSvgText;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;DLee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;DDLjava/util/List;ZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;IIIILee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;DLjava/util/List;ZZLjava/lang/String;DLee/schimke/composeai/data/layoutinspector/FigmaSvgText;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;DLee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;DDLjava/util/List;ZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()D
+	public final fun component14 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgText;
+	public final fun component15 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;
+	public final fun component16 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;
+	public final fun component17 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;
+	public final fun component18 ()D
+	public final fun component19 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun component2 ()I
+	public final fun component20 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun component21 ()D
+	public final fun component22 ()D
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Z
+	public final fun component25 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun component26 ()Ljava/util/List;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun component7 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun component8 ()D
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;IIIILee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;DLjava/util/List;ZZLjava/lang/String;DLee/schimke/composeai/data/layoutinspector/FigmaSvgText;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;DLee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;DDLjava/util/List;ZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;Ljava/lang/String;IIIILee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;DLjava/util/List;ZZLjava/lang/String;DLee/schimke/composeai/data/layoutinspector/FigmaSvgText;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;DLee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;DDLjava/util/List;ZLee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackground ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundRaster;
+	public final fun getBottom ()I
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getCircle ()Z
+	public final fun getClipBox ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getClipChildren ()Z
+	public final fun getContentOpacity ()D
+	public final fun getCornerRadiiPx ()Ljava/util/List;
+	public final fun getCurvedTexts ()Ljava/util/List;
+	public final fun getCut ()Z
+	public final fun getElevationPx ()D
+	public final fun getFill ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun getFillGradient ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun getHeight ()I
+	public final fun getLeft ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOpacity ()D
+	public final fun getPaints ()Z
+	public final fun getRaster ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;
+	public final fun getRight ()I
+	public final fun getRotationDegrees ()D
+	public final fun getShapePathData ()Ljava/lang/String;
+	public final fun getStroke ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun getStrokeGradient ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public final fun getStrokeWidthPx ()D
+	public final fun getText ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgText;
+	public final fun getTop ()I
+	public final fun getVector ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgModel {
+	public static final field BOUNDS_TOLERANCE_PX I
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel$Companion;
+	public static final field DEFAULT_PADDING I
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;IIIIILjava/util/List;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;)V
+	public synthetic fun <init> (Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;IIIIILjava/util/List;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public final fun component10 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun component11 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public final fun component12 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;
+	public final fun component9 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;IIIIILjava/util/List;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;IIIIILjava/util/List;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundRect ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;
+	public final fun getBackgroundShape ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public final fun getCapsuleClip ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgCapsuleClip;
+	public final fun getDeviceBackground ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun getHeight ()I
+	public final fun getMinX ()I
+	public final fun getMinY ()I
+	public final fun getPadding ()I
+	public final fun getRasterTargets ()Ljava/util/List;
+	public final fun getRoot ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgLayer;
+	public final fun getRoundClip ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;
+	public final fun getTx ()I
+	public final fun getTy ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgModel$Companion {
+	public final fun argbToColor (Ljava/lang/String;Ljava/util/Map;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun defaultRasterHref (Ljava/lang/String;)Ljava/lang/String;
+	public final fun from (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Ljava/util/Map;FFILjava/util/Set;Lkotlin/jvm/functions/Function1;ZZZLjava/lang/String;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;
+	public static synthetic fun from$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel$Companion;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Ljava/util/Map;FFILjava/util/Set;Lkotlin/jvm/functions/Function1;ZZZLjava/lang/String;Lee/schimke/composeai/data/layoutinspector/FigmaSvgBackgroundMode;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel;
+	public final fun getDEFAULT_RASTER_COMPONENTS ()Ljava/util/Set;
+	public final fun lineHeightToPx (Ljava/lang/String;Ljava/lang/String;FF)Ljava/lang/Double;
+	public static synthetic fun lineHeightToPx$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel$Companion;Ljava/lang/String;Ljava/lang/String;FFILjava/lang/Object;)Ljava/lang/Double;
+	public final fun parseCornersPx (Ljava/lang/String;F)Ljava/util/List;
+	public final fun parseRawCornersPx (Ljava/lang/String;)Ljava/util/List;
+	public final fun spToPx (Ljava/lang/String;FF)Ljava/lang/Double;
+	public static synthetic fun spToPx$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgModel$Companion;Ljava/lang/String;FFILjava/lang/Object;)Ljava/lang/Double;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgRaster {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRaster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHref ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgRasterTarget {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IIIILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IIIILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IIIILjava/lang/String;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRasterTarget;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgRasterTarget;Ljava/lang/String;Ljava/lang/String;IIIILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRasterTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getHref ()Ljava/lang/String;
+	public final fun getLeft ()I
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getPngBase64 ()Ljava/lang/String;
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgRect {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;IIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRect;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip {
+	public fun <init> (III)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;IIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgRoundClip;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCx ()I
+	public final fun getCy ()I
+	public final fun getR ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgText {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Z
+	public final fun component6 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun component7 ()Ljava/lang/Double;
+	public final fun component8 ()Ljava/lang/Double;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgText;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgText;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgText;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getFontFamily ()Ljava/lang/String;
+	public final fun getFontSizePx ()Ljava/lang/Double;
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getItalic ()Z
+	public final fun getLayoutDirection ()Ljava/lang/String;
+	public final fun getLetterSpacingPx ()Ljava/lang/Double;
+	public final fun getLineHeightPx ()Ljava/lang/Double;
+	public final fun getLines ()Ljava/util/List;
+	public final fun getSpans ()Ljava/util/List;
+	public final fun getTextAlign ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgTextLine {
+	public fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextLine;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextLine;Ljava/lang/String;IILjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextLine;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseline ()I
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getLeft ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgTextSpan {
+	public fun <init> (IILjava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;)V
+	public synthetic fun <init> (IILjava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Z
+	public final fun component7 ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun copy (IILjava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextSpan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextSpan;IILjava/lang/Double;Ljava/lang/String;Ljava/lang/Integer;ZLee/schimke/composeai/data/layoutinspector/FigmaSvgColor;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgTextSpan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor ()Lee/schimke/composeai/data/layoutinspector/FigmaSvgColor;
+	public final fun getEnd ()I
+	public final fun getFontFamily ()Ljava/lang/String;
+	public final fun getFontSizePx ()Ljava/lang/Double;
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getItalic ()Z
+	public final fun getStart ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgVector {
+	public fun <init> (FFIIZDDZZZLee/schimke/composeai/data/layoutinspector/MaterialIconRef;Ljava/util/List;)V
+	public synthetic fun <init> (FFIIZDDZZZLee/schimke/composeai/data/layoutinspector/MaterialIconRef;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component10 ()Z
+	public final fun component11 ()Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component2 ()F
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Z
+	public final fun component6 ()D
+	public final fun component7 ()D
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (FFIIZDDZZZLee/schimke/composeai/data/layoutinspector/MaterialIconRef;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;FFIIZDDZZZLee/schimke/composeai/data/layoutinspector/MaterialIconRef;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgVector;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFillBounds ()Z
+	public final fun getFlipX ()Z
+	public final fun getFlipY ()Z
+	public final fun getFromDrawCapture ()Z
+	public final fun getLayoutHeight ()I
+	public final fun getLayoutWidth ()I
+	public final fun getMaterialIcon ()Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;
+	public final fun getPaths ()Ljava/util/List;
+	public final fun getScaleX ()D
+	public final fun getScaleY ()D
+	public final fun getViewportHeight ()F
+	public final fun getViewportWidth ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/FigmaSvgVectorPath {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()F
+	public final fun component6 ()F
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/data/layoutinspector/FigmaSvgVectorPath;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/FigmaSvgVectorPath;Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/FigmaSvgVectorPath;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvenOdd ()Z
+	public final fun getFillAlpha ()F
+	public final fun getFillArgb ()Ljava/lang/String;
+	public final fun getPathData ()Ljava/lang/String;
+	public final fun getStrokeAlpha ()F
+	public final fun getStrokeArgb ()Ljava/lang/String;
+	public final fun getStrokeCap ()Ljava/lang/String;
+	public final fun getStrokeJoin ()Ljava/lang/String;
+	public final fun getStrokeWidth ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds$Companion;
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;IIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints$Companion;
+	public fun <init> (ILjava/lang/Integer;ILjava/lang/Integer;)V
+	public synthetic fun <init> (ILjava/lang/Integer;ILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (ILjava/lang/Integer;ILjava/lang/Integer;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;ILjava/lang/Integer;ILjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxHeight ()Ljava/lang/Integer;
+	public final fun getMaxWidth ()Ljava/lang/Integer;
+	public final fun getMinHeight ()I
+	public final fun getMinWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText$Companion;
+	public fun <init> (Ljava/lang/String;DDDDDZDLjava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;DDDDDZDLjava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun component6 ()D
+	public final fun component7 ()Z
+	public final fun component8 ()D
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;DDDDDZDLjava/lang/Integer;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText;Ljava/lang/String;DDDDDZDLjava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCenterXPx ()D
+	public final fun getCenterYPx ()D
+	public final fun getClockwise ()Z
+	public final fun getColorArgb ()Ljava/lang/String;
+	public final fun getFontSizePx ()D
+	public final fun getFontWeight ()Ljava/lang/Integer;
+	public final fun getRadiusPx ()D
+	public final fun getStartAngleRadians ()D
+	public final fun getSweepRadians ()D
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorCurvedText$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster$Companion;
+	public fun <init> (IIIILjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (IIIILjava/lang/String;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;IIIILjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getHeight ()I
+	public final fun getLeft ()I
+	public final fun getPngBase64 ()Ljava/lang/String;
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;FFFF)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;FFFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()F
+	public final fun component4 ()F
+	public final fun component5 ()F
+	public final fun component6 ()F
+	public final fun copy (Ljava/util/List;Ljava/util/List;FFFF)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;Ljava/util/List;Ljava/util/List;FFFFILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColors ()Ljava/util/List;
+	public final fun getEndX ()F
+	public final fun getEndY ()F
+	public final fun getStartX ()F
+	public final fun getStartY ()F
+	public final fun getStops ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorGradient$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Z)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPlaceholder ()Z
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorModifier$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorNode {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;ZZLjava/lang/Float;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;ZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;ZZLjava/lang/Float;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;ZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Ljava/lang/Float;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;
+	public final fun component16 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;
+	public final fun component17 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;
+	public final fun component18 ()Z
+	public final fun component19 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun component7 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;
+	public final fun component8 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;ZZLjava/lang/Float;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;ZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;ZZLjava/lang/Float;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;Ljava/util/List;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;ZZLee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttached ()Z
+	public final fun getBounds ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getComponent ()Ljava/lang/String;
+	public final fun getConstraints ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorConstraints;
+	public final fun getCurvedTexts ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getDrawRaster ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorDrawRaster;
+	public final fun getDrawsContent ()Z
+	public final fun getModifiers ()Ljava/util/List;
+	public final fun getModifiesDrawnContent ()Z
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getPlaced ()Z
+	public final fun getPlaceholder ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;
+	public final fun getSize ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getSourceInfo ()Ljava/lang/String;
+	public final fun getTokens ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsTokens;
+	public final fun getTransform ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;
+	public final fun getVectorGraphic ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;
+	public final fun getZIndex ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload$Companion;
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRoot ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorArgb ()Ljava/lang/String;
+	public final fun getCornerRadius ()Ljava/lang/String;
+	public final fun getCornerRadiusPx ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getShape ()Ljava/lang/String;
+	public final fun getVisible ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorPlaceholder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorProduct {
+	public static final field FILE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorSize {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize$Companion;
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;IIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorSize$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorSize;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorSize$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform$Companion;
+	public static final field EPSILON F
+	public static final field ROTATION_EPSILON_DEGREES F
+	public fun <init> ()V
+	public fun <init> (FFF)V
+	public synthetic fun <init> (FFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun copy (FFF)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;FFFILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRotated ()Z
+	public final fun getRotationDegrees ()F
+	public final fun getScaleX ()F
+	public final fun getScaleY ()F
+	public final fun getScaled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorTransform$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic$Companion;
+	public fun <init> (FFLjava/util/List;ZLjava/lang/String;)V
+	public synthetic fun <init> (FFLjava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (FFLjava/util/List;ZLjava/lang/String;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;FFLjava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFromDrawCapture ()Z
+	public final fun getPaths ()Ljava/util/List;
+	public final fun getVectorName ()Ljava/lang/String;
+	public final fun getViewportHeight ()F
+	public final fun getViewportWidth ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorGraphic$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()F
+	public final fun component6 ()F
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath;Ljava/lang/String;Ljava/lang/String;FLjava/lang/String;FFLjava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvenOdd ()Z
+	public final fun getFillAlpha ()F
+	public final fun getFillArgb ()Ljava/lang/String;
+	public final fun getPathData ()Ljava/lang/String;
+	public final fun getStrokeAlpha ()F
+	public final fun getStrokeArgb ()Ljava/lang/String;
+	public final fun getStrokeCap ()Ljava/lang/String;
+	public final fun getStrokeJoin ()Ljava/lang/String;
+	public final fun getStrokeWidth ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/LayoutInspectorVectorPath$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/MaterialIconRef {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;Z)Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoMirrored ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStyle ()Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/MaterialIconRef$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/MaterialIconRef;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style : java/lang/Enum {
+	public static final field FILLED Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public static final field OUTLINED Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public static final field ROUNDED Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public static final field SHARP Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public static final field TWO_TONE Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public final fun getCdnFamily ()Ljava/lang/String;
+	public final fun getComposeName ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+	public static fun values ()[Lee/schimke/composeai/data/layoutinspector/MaterialIconRef$Style;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PlaceholderModifiers {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/PlaceholderModifiers;
+	public static final field KIND_PLACEHOLDER Ljava/lang/String;
+	public static final field KIND_SHIMMER Ljava/lang/String;
+	public static final field NAME_PLACEHOLDER Ljava/lang/String;
+	public static final field NAME_SHIMMER Ljava/lang/String;
+	public final fun isPlaceholderModifier (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun isPlaceholderOrigin (Ljava/lang/String;)Z
+	public final fun kindOf (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PreviewSlot {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/PreviewSlot$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SlotBounds;Lee/schimke/composeai/data/layoutinspector/SlotScope;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SlotBounds;Lee/schimke/composeai/data/layoutinspector/SlotScope;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public final fun component3 ()Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SlotBounds;Lee/schimke/composeai/data/layoutinspector/SlotScope;Z)Lee/schimke/composeai/data/layoutinspector/PreviewSlot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/PreviewSlot;Ljava/lang/String;Lee/schimke/composeai/data/layoutinspector/SlotBounds;Lee/schimke/composeai/data/layoutinspector/SlotScope;ZILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/PreviewSlot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBounds ()Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public final fun getHeight ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getScope ()Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public final fun getScrolling ()Z
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/PreviewSlot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/PreviewSlot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/PreviewSlot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/PreviewSlot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PreviewSlot$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PreviewSlots {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/PreviewSlots;
+	public static final field SLOT_TAG_PREFIX Ljava/lang/String;
+	public final fun extractSlots (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getSlots ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/PreviewSlotsPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsBounds {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SemanticsBounds$Companion;
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/data/layoutinspector/SemanticsBounds;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsBounds;IIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArea ()J
+	public final fun getBottom ()I
+	public final fun getCenterX ()I
+	public final fun getCenterY ()I
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsBounds$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsBounds;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsDelta {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SemanticsDelta$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getChanged ()Ljava/util/List;
+	public final fun getRemoved ()Ljava/util/List;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isEmpty ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/SemanticsDelta$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsDelta$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsDelta$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsDiff {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsDiff;
+	public final fun diff (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+	public final fun diff (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;)Lee/schimke/composeai/data/layoutinspector/SemanticsDelta;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsDiffProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsDiffProduct;
+	public static final field SCHEMA Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsFieldChange {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getField ()Ljava/lang/String;
+	public final fun getFrom ()Ljava/lang/String;
+	public final fun getTo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/SemanticsFieldChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/SemanticsFieldChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsFieldChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsNodeChange {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnchor ()Ljava/lang/String;
+	public final fun getChanges ()Ljava/util/List;
+	public final fun getRef ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/SemanticsNodeChange$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/SemanticsNodeChange;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsNodeChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsNodeSummary$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsPoint {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;IIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsRefs {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsRefs;
+	public static final field ROOT_REF Ljava/lang/String;
+	public final fun anchor (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)Ljava/lang/String;
+	public final fun assign (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun assign (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;)Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+}
+
+public abstract interface class ee/schimke/composeai/data/layoutinspector/SemanticsTarget {
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsTarget$Ref : ee/schimke/composeai/data/layoutinspector/SemanticsTarget {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Ref;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Ref;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Ref;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRef ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsTarget$RoleText : ee/schimke/composeai/data/layoutinspector/SemanticsTarget {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$RoleText;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$RoleText;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$RoleText;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsTarget$Tag : ee/schimke/composeai/data/layoutinspector/SemanticsTarget {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Tag;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Tag;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget$Tag;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTestTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsTargets {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsTargets;
+	public final fun nodeAt (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;II)Lee/schimke/composeai/data/layoutinspector/SemanticsTarget;
+	public final fun resolve (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/data/layoutinspector/SemanticsTarget;)Lee/schimke/composeai/data/layoutinspector/TargetResolution;
+	public final fun resolve (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/layoutinspector/SemanticsTarget;)Lee/schimke/composeai/data/layoutinspector/TargetResolution;
+	public final fun targetableNodes (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;I)Ljava/util/List;
+	public static synthetic fun targetableNodes$default (Lee/schimke/composeai/data/layoutinspector/SemanticsTargets;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;IILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg;
+	public final fun render (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;)Ljava/lang/String;
+	public final fun render (Lee/schimke/composeai/data/layoutinspector/WireframeModel;Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;)Ljava/lang/String;
+	public static synthetic fun render$default (Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;ILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun render$default (Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg;Lee/schimke/composeai/data/layoutinspector/WireframeModel;Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options {
+	public fun <init> ()V
+	public fun <init> (IZI)V
+	public synthetic fun <init> (IZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Z
+	public final fun component3 ()I
+	public final fun copy (IZI)Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;IZIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SemanticsWireframeSvg$Options;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontSize ()I
+	public final fun getPadding ()I
+	public final fun getShowLabels ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SlotBounds {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SlotBounds$Companion;
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/SlotBounds;IIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/layoutinspector/SlotBounds$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/SlotBounds$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/layoutinspector/SlotBounds;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SlotBounds$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SlotBounds;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SlotScope : java/lang/Enum {
+	public static final field BOX Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static final field COLUMN Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/SlotScope$Companion;
+	public static final field LAZY Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static final field ROW Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static final field UNKNOWN Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public static fun values ()[Lee/schimke/composeai/data/layoutinspector/SlotScope;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/SlotScope$Companion {
+	public final fun fromWire (Ljava/lang/String;)Lee/schimke/composeai/data/layoutinspector/SlotScope;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/data/layoutinspector/TargetResolution {
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/TargetResolution$Ambiguous : ee/schimke/composeai/data/layoutinspector/TargetResolution {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/data/layoutinspector/TargetResolution$Ambiguous;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/TargetResolution$Ambiguous;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/TargetResolution$Ambiguous;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCandidates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/TargetResolution$NotFound : ee/schimke/composeai/data/layoutinspector/TargetResolution {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/TargetResolution$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/TargetResolution$Resolved : ee/schimke/composeai/data/layoutinspector/TargetResolution {
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;)Lee/schimke/composeai/data/layoutinspector/TargetResolution$Resolved;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/TargetResolution$Resolved;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/TargetResolution$Resolved;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNode ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun getPoint ()Lee/schimke/composeai/data/layoutinspector/SemanticsPoint;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher {
+	public static final field BOTTOM_PAD I
+	public static final field EDGE_NODE_ID Ljava/lang/String;
+	public static final field GAP I
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher;
+	public final fun stitch (Ljava/lang/String;ILjava/util/List;Ljava/lang/Integer;II)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched;
+	public static synthetic fun stitch$default (Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher;Ljava/lang/String;ILjava/util/List;Ljava/lang/Integer;IIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster {
+	public fun <init> (Ljava/lang/String;ILee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun copy (Ljava/lang/String;ILee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;Ljava/lang/String;ILee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDest ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorBounds;
+	public final fun getNodeId ()Ljava/lang/String;
+	public final fun getSourceTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Slice {
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Slice;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Slice;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Slice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLayout ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorNode;
+	public final fun getSemantics ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsNode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched {
+	public fun <init> (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;IILee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;)V
+	public final fun component1 ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;
+	public final fun component2 ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;
+	public final fun copy (Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;IILee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched;Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;IILee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$Stitched;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEdge ()Lee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher$EdgeRaster;
+	public final fun getHeight ()I
+	public final fun getLayout ()Lee/schimke/composeai/data/layoutinspector/LayoutInspectorPayload;
+	public final fun getSemantics ()Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WireframeBox {
+	public fun <init> (IIIIIZZLjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (IIIIIZZLjava/lang/String;)Lee/schimke/composeai/data/layoutinspector/WireframeBox;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/WireframeBox;IIIIIZZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WireframeBox;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getClearAndSet ()Z
+	public final fun getClickable ()Z
+	public final fun getDepth ()I
+	public final fun getHeight ()I
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getLeft ()I
+	public final fun getRight ()I
+	public final fun getTop ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WireframeModel {
+	public static final field Companion Lee/schimke/composeai/data/layoutinspector/WireframeModel$Companion;
+	public fun <init> (Ljava/util/List;IIIII)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun copy (Ljava/util/List;IIIII)Lee/schimke/composeai/data/layoutinspector/WireframeModel;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/layoutinspector/WireframeModel;Ljava/util/List;IIIIIILjava/lang/Object;)Lee/schimke/composeai/data/layoutinspector/WireframeModel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoxes ()Ljava/util/List;
+	public final fun getHeight ()I
+	public final fun getMinX ()I
+	public final fun getMinY ()I
+	public final fun getPadding ()I
+	public final fun getTx ()I
+	public final fun getTy ()I
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WireframeModel$Companion {
+	public final fun from (Lee/schimke/composeai/data/layoutinspector/ComposeSemanticsPayload;I)Lee/schimke/composeai/data/layoutinspector/WireframeModel;
+}
+
+public final class ee/schimke/composeai/data/layoutinspector/WireframeStyle {
+	public static final field INSTANCE Lee/schimke/composeai/data/layoutinspector/WireframeStyle;
+	public static final field clickAccent I
+	public static final field clickFillOpacity D
+	public static final field fontSize I
+	public static final field ground I
+	public final fun blue (I)I
+	public final fun getClearAndSetDash ()[F
+	public final fun getDepthStrokes ()[I
+	public final fun green (I)I
+	public final fun hex (I)Ljava/lang/String;
+	public final fun red (I)I
+	public final fun strokeColor (Lee/schimke/composeai/data/layoutinspector/WireframeBox;)I
+	public final fun strokeWidth (Lee/schimke/composeai/data/layoutinspector/WireframeBox;)I
+	public final fun truncateToWidth (Ljava/lang/String;II)Ljava/lang/String;
+	public static synthetic fun truncateToWidth$default (Lee/schimke/composeai/data/layoutinspector/WireframeStyle;Ljava/lang/String;IIILjava/lang/Object;)Ljava/lang/String;
+}
+

--- a/data/layoutinspector/core/build.gradle.kts
+++ b/data/layoutinspector/core/build.gradle.kts
@@ -18,3 +18,24 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew
+  // :data-layoutinspector-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -3,8 +3,8 @@ package ee.schimke.composeai.data.layoutinspector
 import kotlin.math.abs
 import kotlinx.serialization.Serializable
 
-object ComposeSemanticsProduct {
-  const val KIND: String = "compose/semantics"
+public object ComposeSemanticsProduct {
+  public const val KIND: String = "compose/semantics"
   // v3 (#1897): each node may carry resolved design-token data (`tokens`) — container colour,
   // corner radius, padding — so design-parity's token-compliance check can populate `actual`
   // instead of degrading to "missing from candidate". Additive: older `compose-semantics.json`
@@ -76,12 +76,12 @@ object ComposeSemanticsProduct {
   // top-left corner. `layout/inspector` has carried the same flag since its first version;
   // this closes the gap on the tree that owns typography. Additive — older entries decode as
   // `placed = true`, which is what every node they describe was assumed to be.
-  const val SCHEMA_VERSION: Int = 15
-  const val FILE: String = "compose-semantics.json"
+  public const val SCHEMA_VERSION: Int = 15
+  public const val FILE: String = "compose-semantics.json"
 }
 
-object LayoutInspectorProduct {
-  const val KIND: String = "layout/inspector"
+public object LayoutInspectorProduct {
+  public const val KIND: String = "layout/inspector"
   // v2 (#1903): each node may carry resolved design `tokens` — the modifier-derived
   // `{backgroundColor, borderColor, cornerRadius, shape, gap, padding}` projection. This is the
   // *canonical* home for those tokens: they come from modifiers, which `layout/inspector` already
@@ -158,8 +158,8 @@ object LayoutInspectorProduct {
   // rather than the drawn rect (Wear's `AlertDialog` confirm button: a 126x108 pill turned -45
   // degrees reports 166x166), so a consumer that places by `bounds` alone draws the node too big
   // and un-turned. Additive — older entries decode with `rotationDegrees = 0f`.
-  const val SCHEMA_VERSION: Int = 17
-  const val FILE: String = "layout-inspector.json"
+  public const val SCHEMA_VERSION: Int = 17
+  public const val FILE: String = "layout-inspector.json"
 }
 
 /**
@@ -168,14 +168,14 @@ object LayoutInspectorProduct {
  * path-transported artifact) and a baked PNG (rides as a [DataProductExtra][name=[PNG_EXTRA_NAME]]
  * for raster-only consumers).
  */
-object ComposeSemanticsWireframeProduct {
-  const val KIND: String = "compose/semantics-wireframe"
-  const val SCHEMA_VERSION: Int = 1
-  const val FILE_SVG: String = "compose-semantics-wireframe.svg"
-  const val FILE_PNG: String = "compose-semantics-wireframe.png"
-  const val PNG_EXTRA_NAME: String = "png"
-  const val MEDIA_TYPE_SVG: String = "image/svg+xml"
-  const val MEDIA_TYPE_PNG: String = "image/png"
+public object ComposeSemanticsWireframeProduct {
+  public const val KIND: String = "compose/semantics-wireframe"
+  public const val SCHEMA_VERSION: Int = 1
+  public const val FILE_SVG: String = "compose-semantics-wireframe.svg"
+  public const val FILE_PNG: String = "compose-semantics-wireframe.png"
+  public const val PNG_EXTRA_NAME: String = "png"
+  public const val MEDIA_TYPE_SVG: String = "image/svg+xml"
+  public const val MEDIA_TYPE_PNG: String = "image/png"
 }
 
 /**
@@ -185,11 +185,11 @@ object ComposeSemanticsWireframeProduct {
  * counterpart of the wireframe: the wireframe is for *reading* the structure, this is for *editing*
  * it in Figma. One file per preview: the layered SVG. See [FigmaLayeredSvg] for the layer mapping.
  */
-object ComposeFigmaSvgProduct {
-  const val KIND: String = "compose/figma-svg"
-  const val SCHEMA_VERSION: Int = 1
-  const val FILE_SVG: String = "compose-figma.svg"
-  const val MEDIA_TYPE_SVG: String = "image/svg+xml"
+public object ComposeFigmaSvgProduct {
+  public const val KIND: String = "compose/figma-svg"
+  public const val SCHEMA_VERSION: Int = 1
+  public const val FILE_SVG: String = "compose-figma.svg"
+  public const val MEDIA_TYPE_SVG: String = "image/svg+xml"
 
   /**
    * `compose/figma-svg-long` — the **full-page** variant of [KIND] for a *scrolling* preview. A
@@ -201,9 +201,9 @@ object ComposeFigmaSvgProduct {
    * viewport-sized [FILE_SVG]. `requiresRerender = true`: a `data/fetch` re-renders in
    * [RENDER_MODE_LONG]. See [docs/design/SCROLLING_SVG.md].
    */
-  const val KIND_LONG: String = "compose/figma-svg-long"
-  const val FILE_SVG_LONG: String = "compose-figma-long.svg"
-  const val RENDER_MODE_LONG: String = "figma-svg-long"
+  public const val KIND_LONG: String = "compose/figma-svg-long"
+  public const val FILE_SVG_LONG: String = "compose-figma-long.svg"
+  public const val RENDER_MODE_LONG: String = "figma-svg-long"
 
   /**
    * Subdirectory (under the preview's output dir) the long export lives in — the SVG plus its own
@@ -213,7 +213,7 @@ object ComposeFigmaSvgProduct {
    * from one render overwriting the other's). Its own subdir keeps each export's crops
    * self-consistent.
    */
-  const val LONG_SUBDIR: String = "figma-long"
+  public const val LONG_SUBDIR: String = "figma-long"
 
   /**
    * Directory (relative to the preview's output dir) holding the per-node `<node>.png` crops a
@@ -221,11 +221,11 @@ object ComposeFigmaSvgProduct {
    * vector-only export. The single source of truth for the prefix [FigmaSvgModel.defaultRasterHref]
    * emits and consumers (the design-catalog carrier) collect.
    */
-  const val RASTER_DIR: String = "figma-raster"
+  public const val RASTER_DIR: String = "figma-raster"
 }
 
 @Serializable
-data class ComposeSemanticsPayload(
+public data class ComposeSemanticsPayload(
   val root: ComposeSemanticsNode,
   /**
    * Render pixels per dp for this capture — the factor that turns a node's
@@ -240,7 +240,7 @@ data class ComposeSemanticsPayload(
 )
 
 @Serializable
-data class ComposeSemanticsNode(
+public data class ComposeSemanticsNode(
   val nodeId: String,
   /**
    * Stable, content-independent handle for this node within the tree, assigned by [SemanticsRefs].
@@ -305,7 +305,7 @@ data class ComposeSemanticsNode(
  * omits the ambiguous field; a node that declares nothing typographic emits no `typography` object.
  */
 @Serializable
-data class ComposeSemanticsTypography(
+public data class ComposeSemanticsTypography(
   /**
    * Resolved text size as `"<value>sp"`, e.g. `"22.0sp"` (was the flat `layoutFontSize`, #1903).
    */
@@ -387,7 +387,7 @@ data class ComposeSemanticsTypography(
 
 /** One effective styled UTF-16 range within a text node. */
 @Serializable
-data class ComposeSemanticsTextSpan(
+public data class ComposeSemanticsTextSpan(
   val start: Int,
   val end: Int,
   val fontSize: String? = null,
@@ -415,7 +415,7 @@ data class ComposeSemanticsTextSpan(
  * takes the raster fallback rather than being emitted as a gradient it isn't.
  */
 @Serializable
-data class LayoutInspectorGradient(
+public data class LayoutInspectorGradient(
   /** `#AARRGGBB` stop colours, in order. */
   val colors: List<String>,
   /** Explicit stop positions (`0..1`), or null for evenly spaced stops. */
@@ -433,7 +433,7 @@ data class LayoutInspectorGradient(
  * surface supplies it).
  */
 @Serializable
-data class ComposeSemanticsTextColor(
+public data class ComposeSemanticsTextColor(
   /** Resolved text foreground colour as ARGB hex (`#AARRGGBB`). */
   val foreground: String? = null,
   /** Resolved text background colour as ARGB hex (`#AARRGGBB`); usually unset. */
@@ -446,7 +446,7 @@ data class ComposeSemanticsTextColor(
  * `layoutDidOverflow{Width,Height}`, all read from the node's `TextLayoutResult`.
  */
 @Serializable
-data class ComposeSemanticsTextOverflow(
+public data class ComposeSemanticsTextOverflow(
   /** Total laid-out line count across the node's text. */
   val lineCount: Int? = null,
   /** The `maxLines` constraint, when one was set (not `Int.MAX_VALUE`). */
@@ -476,7 +476,7 @@ data class ComposeSemanticsTextOverflow(
  * for centred/right-aligned text).
  */
 @Serializable
-data class ComposeSemanticsTextLine(
+public data class ComposeSemanticsTextLine(
   val text: String,
   val left: Int,
   val baseline: Int,
@@ -502,7 +502,7 @@ data class ComposeSemanticsTextLine(
  * policy. All fields are optional: a node emits only the tokens it actually declares.
  */
 @Serializable
-data class ComposeSemanticsTokens(
+public data class ComposeSemanticsTokens(
   /** Resolved container/fill colour as ARGB hex (`#AARRGGBB`), e.g. from `Modifier.background`. */
   val backgroundColor: String? = null,
   /**
@@ -647,7 +647,7 @@ data class ComposeSemanticsTokens(
  * as a paint-insetting padding (it would otherwise suppress the growth heuristic for a Wear control
  * whose chain merely contains `padding(0.dp)`) (issue #2852).
  */
-fun ComposeSemanticsInsets.insetsPaint(): Boolean =
+public fun ComposeSemanticsInsets.insetsPaint(): Boolean =
   insetsPaintHorizontally() || insetsPaintVertically()
 
 /**
@@ -656,24 +656,26 @@ fun ComposeSemanticsInsets.insetsPaint(): Boolean =
  * and `start`/`end` by 12dp *after* it, so its drawn pill is the placed height but the measured
  * width. Suppressing both axes together squashed it to the narrow content box (issue #3573).
  */
-fun ComposeSemanticsInsets.insetsPaintHorizontally(): Boolean = positive(start) || positive(end)
+public fun ComposeSemanticsInsets.insetsPaintHorizontally(): Boolean =
+  positive(start) || positive(end)
 
 /** The vertical half of [insetsPaint] — see there. */
-fun ComposeSemanticsInsets.insetsPaintVertically(): Boolean = positive(top) || positive(bottom)
+public fun ComposeSemanticsInsets.insetsPaintVertically(): Boolean =
+  positive(top) || positive(bottom)
 
 private fun positive(edge: String?): Boolean =
   (edge?.removeSuffix("dp")?.toDoubleOrNull() ?: 0.0) > 0.0
 
 /** Per-edge insets in dp (`"16.0dp"`), as resolved from `Modifier.padding` (issue #1897). */
 @Serializable
-data class ComposeSemanticsInsets(
+public data class ComposeSemanticsInsets(
   val start: String? = null,
   val top: String? = null,
   val end: String? = null,
   val bottom: String? = null,
 )
 
-@Serializable data class LayoutInspectorPayload(val root: LayoutInspectorNode)
+@Serializable public data class LayoutInspectorPayload(val root: LayoutInspectorNode)
 
 /**
  * The scale a node inherits from the `graphicsLayer`s between it and the root — the *drawn* size of
@@ -690,7 +692,7 @@ data class ComposeSemanticsInsets(
  * to its unscaled size (issue #2615).
  */
 @Serializable
-data class LayoutInspectorTransform(
+public data class LayoutInspectorTransform(
   val scaleX: Float = 1f,
   val scaleY: Float = 1f,
   /**
@@ -714,19 +716,19 @@ data class LayoutInspectorTransform(
   val rotated: Boolean
     get() = abs(rotationDegrees) > ROTATION_EPSILON_DEGREES
 
-  companion object {
-    const val EPSILON: Float = 0.001f
+  public companion object {
+    public const val EPSILON: Float = 0.001f
 
     /**
      * Below this the "rotation" is sub-pixel placement noise on any realistic box, and honouring it
      * would re-centre a node the render drew exactly on its bounds.
      */
-    const val ROTATION_EPSILON_DEGREES: Float = 0.5f
+    public const val ROTATION_EPSILON_DEGREES: Float = 0.5f
   }
 }
 
 @Serializable
-data class LayoutInspectorNode(
+public data class LayoutInspectorNode(
   val nodeId: String,
   /**
    * The node's **own** identity — its own `C(Composable)` name, or (when it has none) its
@@ -832,7 +834,7 @@ data class LayoutInspectorNode(
  * placeholder as its own vector layer, in its own [colorArgb] / corner, when [visible] is true.
  */
 @Serializable
-data class LayoutInspectorPlaceholder(
+public data class LayoutInspectorPlaceholder(
   /**
    * [PlaceholderModifiers.KIND_PLACEHOLDER] (the content-covering block) or
    * [PlaceholderModifiers.KIND_SHIMMER] (the sweep overlay drawn over it).
@@ -881,7 +883,7 @@ data class LayoutInspectorPlaceholder(
  * matches what the export did before.
  */
 @Serializable
-data class LayoutInspectorDrawRaster(
+public data class LayoutInspectorDrawRaster(
   /** Captured region in root-pixel space — the union of the node's draw modifiers' own bounds. */
   val left: Int,
   val top: Int,
@@ -906,7 +908,7 @@ data class LayoutInspectorDrawRaster(
  * fill rather than guessing — matching the vector-vs-raster rule the rest of the export follows.
  */
 @Serializable
-data class LayoutInspectorVectorGraphic(
+public data class LayoutInspectorVectorGraphic(
   val viewportWidth: Float,
   val viewportHeight: Float,
   val paths: List<LayoutInspectorVectorPath>,
@@ -940,7 +942,7 @@ data class LayoutInspectorVectorGraphic(
  * One `<path>` of a [LayoutInspectorVectorGraphic]: SVG path data plus its resolved solid paint.
  */
 @Serializable
-data class LayoutInspectorVectorPath(
+public data class LayoutInspectorVectorPath(
   /** SVG path `d` string, in viewport coordinates. */
   val pathData: String,
   /** Solid fill as `#AARRGGBB`, or null when there is no fill (or a non-solid brush fill). */
@@ -972,7 +974,7 @@ data class LayoutInspectorVectorPath(
  * Text reads [clockwise] along the arc at [fontSizePx].
  */
 @Serializable
-data class LayoutInspectorCurvedText(
+public data class LayoutInspectorCurvedText(
   val text: String,
   val centerXPx: Double,
   val centerYPx: Double,
@@ -986,12 +988,17 @@ data class LayoutInspectorCurvedText(
 )
 
 @Serializable
-data class LayoutInspectorBounds(val left: Int, val top: Int, val right: Int, val bottom: Int)
+public data class LayoutInspectorBounds(
+  val left: Int,
+  val top: Int,
+  val right: Int,
+  val bottom: Int,
+)
 
-@Serializable data class LayoutInspectorSize(val width: Int, val height: Int)
+@Serializable public data class LayoutInspectorSize(val width: Int, val height: Int)
 
 @Serializable
-data class LayoutInspectorConstraints(
+public data class LayoutInspectorConstraints(
   val minWidth: Int,
   val maxWidth: Int? = null,
   val minHeight: Int,
@@ -999,7 +1006,7 @@ data class LayoutInspectorConstraints(
 )
 
 @Serializable
-data class LayoutInspectorModifier(
+public data class LayoutInspectorModifier(
   val name: String,
   val value: String? = null,
   val properties: Map<String, String> = emptyMap(),

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ExplodedSvg.kt
@@ -78,10 +78,10 @@ import org.w3c.dom.Node
  * Planes are emitted in ascending k, which is also back-to-front under this camera, so the
  * painter's order is document order and no depth sorting is needed.
  */
-object ExplodedSvg {
+public object ExplodedSvg {
 
   /** Knobs for [render]. Defaults are the "reads like a hardware exploded diagram" preset. */
-  data class Options(
+  public data class Options(
     /** In-plane rotation ψ, degrees. Negative spins the drawing anticlockwise on the page. */
     val spinDeg: Double = -16.0,
     /**
@@ -117,7 +117,7 @@ object ExplodedSvg {
    * Hard cap on [Options.maxDepth]. Each plane is a structural copy of the source tree, so this
    * bounds both the work and the output size for a hostile or pathologically deep input.
    */
-  const val MAX_PLANES: Int = 16
+  public const val MAX_PLANES: Int = 16
 
   /**
    * Clamp for a caller-supplied [Options.tiltDeg]. Past ~75° the sheets are so foreshortened that
@@ -182,7 +182,7 @@ object ExplodedSvg {
    * caller can apply this unconditionally: the worst case is the ordinary flat export, never a
    * broken response.
    */
-  fun render(svg: String, options: Options = Options()): String {
+  public fun render(svg: String, options: Options = Options()): String {
     val doc = parse(svg) ?: return svg
     val root = doc.documentElement ?: return svg
     if (root.localNameOf() != "svg") return svg

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaLayeredSvg.kt
@@ -41,9 +41,9 @@ import kotlin.math.sin
  * Pure and deterministic: model in, SVG string out — no graphics toolkit, no IO — so it lives on
  * the render-subprocess-safe core classpath next to [SemanticsWireframeSvg].
  */
-object FigmaLayeredSvg {
+public object FigmaLayeredSvg {
 
-  data class Options(
+  public data class Options(
     /** Emit the `<title>`/`data-token` theme-role annotations on named-colour shapes. */
     val annotateTokens: Boolean = true,
     /** Fallback text size (px) when a text node didn't resolve one. */
@@ -73,7 +73,7 @@ object FigmaLayeredSvg {
    *   — so it matches the `@font-face` the producer embedded for that file. Unmapped families fall
    *   back to [resolveFamily].
    */
-  fun render(
+  public fun render(
     model: FigmaSvgModel,
     options: Options = Options(),
     fontFaces: List<FigmaSvgFontFace> = emptyList(),
@@ -1435,7 +1435,7 @@ object FigmaLayeredSvg {
    * rather than the sans default (which is what lost serif/monospace specimens their identity); a
    * real captured face keeps its name.
    */
-  fun resolveFamily(captured: String?, defaultFamily: String): String {
+  public fun resolveFamily(captured: String?, defaultFamily: String): String {
     val stated = statedFamily(captured) ?: return defaultFamily
     val generic = stated.lowercase()
     if (generic in SANS_GENERICS) return defaultFamily
@@ -1455,7 +1455,7 @@ object FigmaLayeredSvg {
    * `@font-face` name and the override key) are untouched, so an embedded face still matches by its
    * bare name.
    */
-  fun withGenericFallback(family: String): String {
+  public fun withGenericFallback(family: String): String {
     if (family.lowercase() in CSS_GENERICS) return family
     val lower = family.lowercase()
     val generic =
@@ -1474,7 +1474,7 @@ object FigmaLayeredSvg {
    * [resolveFamily] and the viewer supplies the generic. Shared with the producer so the name it
    * embeds matches what [resolveFamily] would emit for the same capture.
    */
-  fun embedFamily(captured: String?, defaultFamily: String): String? {
+  public fun embedFamily(captured: String?, defaultFamily: String): String? {
     val stated = statedFamily(captured) ?: return defaultFamily
     val generic = stated.lowercase()
     if (generic in SANS_GENERICS) return defaultFamily

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/FigmaSvgModel.kt
@@ -24,7 +24,7 @@ import kotlin.math.roundToInt
  * a single translate ([tx]/[ty]) drops it into the padded canvas. All dp/sp token values are
  * converted to px here (× density) so the renderer never has to know about density.
  */
-data class FigmaSvgColor(
+public data class FigmaSvgColor(
   /** `#RRGGBB` — the opaque RGB channel, ready to drop into an SVG `fill`/`stroke`. */
   val hex: String,
   /** Alpha in `0.0..1.0`; emitted as `fill-opacity`/`stroke-opacity` only when < 1. */
@@ -38,7 +38,7 @@ data class FigmaSvgColor(
 )
 
 /** Editable text carried by a leaf layer, with the typography needed to reproduce its face. */
-data class FigmaSvgText(
+public data class FigmaSvgText(
   val content: String,
   /** Resolved size in px (sp × density), or null when the capture didn't resolve one. */
   val fontSizePx: Double? = null,
@@ -91,7 +91,7 @@ data class FigmaSvgText(
 )
 
 /** One laid-out line of a wrapped [FigmaSvgText], px offsets from the text layer's top-left. */
-data class FigmaSvgTextLine(
+public data class FigmaSvgTextLine(
   val content: String,
   val left: Int,
   val baseline: Int,
@@ -107,7 +107,7 @@ data class FigmaSvgTextLine(
 )
 
 /** One effective styled UTF-16 range within [FigmaSvgText.content]. */
-data class FigmaSvgTextSpan(
+public data class FigmaSvgTextSpan(
   val start: Int,
   val end: Int,
   val fontSizePx: Double? = null,
@@ -124,7 +124,7 @@ data class FigmaSvgTextSpan(
  * the SVG's consumers read natively), or `truetype`/`opentype` when embedding the exact font *file*
  * the render loaded (a downloaded / bundled / custom / variable face the capture recorded by path).
  */
-data class FigmaSvgFontFace(
+public data class FigmaSvgFontFace(
   val family: String,
   val weight: Int,
   val italic: Boolean,
@@ -133,7 +133,7 @@ data class FigmaSvgFontFace(
 )
 
 /** Background-free raster standing in for an opaque, un-vectorisable subtree. */
-data class FigmaSvgRaster(val href: String)
+public data class FigmaSvgRaster(val href: String)
 
 /**
  * An editable vector graphic (an `Icon`/`Image`'s `ImageVector`) emitted as real `<path>` layers —
@@ -142,7 +142,7 @@ data class FigmaSvgRaster(val href: String)
  * slot, allowing the emitter to distinguish an intentionally transformed vector from a merely
  * non-square slot. [fillBounds] preserves an explicit `ContentScale.FillBounds`.
  */
-data class FigmaSvgVector(
+public data class FigmaSvgVector(
   val viewportWidth: Float,
   val viewportHeight: Float,
   val layoutWidth: Int,
@@ -181,7 +181,7 @@ data class FigmaSvgVector(
 )
 
 /** One `<path>` of a [FigmaSvgVector] in viewport coordinates, with its resolved solid paint. */
-data class FigmaSvgVectorPath(
+public data class FigmaSvgVectorPath(
   val pathData: String,
   val fillArgb: String? = null,
   val fillAlpha: Float = 1f,
@@ -201,7 +201,7 @@ data class FigmaSvgVectorPath(
  * box (a padded `Spacer` paints only the bar). Carries its own bounds so the `<image>` lands on the
  * drawn region rather than the layer box.
  */
-data class FigmaSvgBackgroundRaster(
+public data class FigmaSvgBackgroundRaster(
   val href: String,
   val left: Int,
   val top: Int,
@@ -248,7 +248,7 @@ data class FigmaSvgBackgroundRaster(
 }
 
 /** An opaque node to rasterise: its nodeId, `<image>` href, and bounds to capture. */
-data class FigmaSvgRasterTarget(
+public data class FigmaSvgRasterTarget(
   val nodeId: String,
   val href: String,
   val left: Int,
@@ -269,7 +269,7 @@ data class FigmaSvgRasterTarget(
  * (from container tokens), hold editable text, both, or neither (a pure grouping layer for
  * nesting).
  */
-data class FigmaSvgLayer(
+public data class FigmaSvgLayer(
   /** Layer name — the composable name (plus a role/label hint when it disambiguates). */
   val name: String,
   val left: Int,
@@ -421,7 +421,7 @@ data class FigmaSvgLayer(
  * SVG must mask to the same circle or its (square) full-frame background paints the corners the
  * render leaves transparent, tanking render-parity on every round-device scaffold.
  */
-data class FigmaSvgRoundClip(val cx: Int, val cy: Int, val r: Int)
+public data class FigmaSvgRoundClip(val cx: Int, val cy: Int, val r: Int)
 
 /**
  * A capsule (vertical stadium) device-screen clip in root-pixel space. The Wear scroll-SVG export
@@ -432,7 +432,7 @@ data class FigmaSvgRoundClip(val cx: Int, val cy: Int, val r: Int)
  * `applyWearPillClip`. Rendered as a single `<rect rx=width/2>`; degenerates to the round clip's
  * circle when `height == width`.
  */
-data class FigmaSvgCapsuleClip(val x: Int, val y: Int, val width: Int, val height: Int) {
+public data class FigmaSvgCapsuleClip(val x: Int, val y: Int, val width: Int, val height: Int) {
   /**
    * Corner radius of the stadium — half the (narrower) width, so the caps are true half-circles.
    */
@@ -441,7 +441,7 @@ data class FigmaSvgCapsuleClip(val x: Int, val y: Int, val width: Int, val heigh
 }
 
 /** An axis-aligned rectangle in root-pixel space. */
-data class FigmaSvgRect(val x: Int, val y: Int, val width: Int, val height: Int)
+public data class FigmaSvgRect(val x: Int, val y: Int, val width: Int, val height: Int)
 
 /**
  * How the `compose/figma-svg` export treats the background the render painted behind the preview.
@@ -453,7 +453,7 @@ data class FigmaSvgRect(val x: Int, val y: Int, val width: Int, val height: Int)
  * is wanted.
  */
 @kotlinx.serialization.Serializable
-enum class FigmaSvgBackgroundMode {
+public enum class FigmaSvgBackgroundMode {
   /**
    * Export background-free (the default). The tree's own fills still draw — a screen that paints
    * its surface colour keeps painting it; only the *injected* bottom layer is dropped.
@@ -483,14 +483,14 @@ enum class FigmaSvgBackgroundMode {
    */
   FULL_BLEED;
 
-  companion object {
+  public companion object {
     /**
      * Parses a mode from a wire/property string, case- and separator-insensitive (`full-bleed`,
      * `full_bleed`, `fullBleed`). Also accepts the pre-modes booleans: `true` is the device-mask
      * shape the export used to inject unconditionally, `false` is [NONE]. Null when unset or
      * unrecognised, so a typo falls back to the caller's default rather than failing a render.
      */
-    fun parse(raw: String?): FigmaSvgBackgroundMode? =
+    public fun parse(raw: String?): FigmaSvgBackgroundMode? =
       when (raw?.trim()?.lowercase()?.replace("-", "")?.replace("_", "")) {
         null,
         "" -> null
@@ -510,7 +510,7 @@ enum class FigmaSvgBackgroundMode {
   }
 }
 
-data class FigmaSvgModel(
+public data class FigmaSvgModel(
   val root: FigmaSvgLayer,
   val minX: Int,
   val minY: Int,
@@ -559,9 +559,9 @@ data class FigmaSvgModel(
   val ty: Int
     get() = padding - minY
 
-  companion object {
+  public companion object {
     /** Default transparent margin (px) around the diagram extent. */
-    const val DEFAULT_PADDING: Int = 16
+    public const val DEFAULT_PADDING: Int = 16
 
     /**
      * Composable-name fragments exported as opaque `<image>` placeholders (opt in via `from`).
@@ -587,7 +587,7 @@ data class FigmaSvgModel(
      * node by name would pre-empt that capture (the opaque-by-name branch drops the subtree before
      * recursion reaches the drawn leaves), so keep `Slider` out of this set.
      */
-    val DEFAULT_RASTER_COMPONENTS: Set<String> =
+    public val DEFAULT_RASTER_COMPONENTS: Set<String> =
       setOf(
         "Image",
         "AsyncImage",
@@ -603,7 +603,7 @@ data class FigmaSvgModel(
       )
 
     /** Default `<image>` href for an opaque node: a per-node PNG under `figma-raster/`. */
-    fun defaultRasterHref(nodeId: String): String {
+    public fun defaultRasterHref(nodeId: String): String {
       val safe = nodeId.map { if (it.isLetterOrDigit()) it else '_' }.joinToString("")
       return "figma-raster/$safe.png"
     }
@@ -613,7 +613,7 @@ data class FigmaSvgModel(
      * producers round the same float differently (truncate vs. round), so an exact match drops text
      * on fractional pixels; 2px absorbs that skew without bleeding onto a genuinely different node.
      */
-    const val BOUNDS_TOLERANCE_PX: Int = 2
+    public const val BOUNDS_TOLERANCE_PX: Int = 2
 
     /**
      * Builds the export model.
@@ -644,7 +644,7 @@ data class FigmaSvgModel(
      *   no-frame path) falls back to sizing the background from the drawn-content extent.
      * @param frameHeightPx the captured frame PNG's pixel height; see [frameWidthPx].
      */
-    fun from(
+    public fun from(
       layout: LayoutInspectorPayload,
       semantics: ComposeSemanticsPayload? = null,
       colorNames: Map<String, String> = emptyMap(),
@@ -2719,7 +2719,7 @@ data class FigmaSvgModel(
      * resolved font size (in px). Returns null when neither the value nor (for `em`) the font size
      * parses.
      */
-    fun lineHeightToPx(
+    public fun lineHeightToPx(
       value: String,
       fontSize: String?,
       density: Float,
@@ -2808,7 +2808,7 @@ data class FigmaSvgModel(
      * bottom-left) at [density]. Returns null when the value can't be read as dp (e.g. a px corner
      * the resolver left unresolved), so the layer falls back to a sharp rectangle.
      */
-    fun parseCornersPx(value: String, density: Float): List<Double>? {
+    public fun parseCornersPx(value: String, density: Float): List<Double>? {
       val parts = value.split(",").map { it.trim() }
       val dps =
         when (parts.size) {
@@ -2830,7 +2830,7 @@ data class FigmaSvgModel(
      * [parseCornersPx] these are already pixels (a `RoundedCornerShape(<px>f)` corner), so there's
      * no density conversion. Returns null when unreadable or all corners are zero.
      */
-    fun parseRawCornersPx(value: String): List<Double>? {
+    public fun parseRawCornersPx(value: String): List<Double>? {
       val parts = value.split(",").map { it.trim().removeSuffix("px") }
       val px =
         when (parts.size) {
@@ -2856,7 +2856,7 @@ data class FigmaSvgModel(
      * font-size>` must carry the same fontScale or the glyphs float undersized in boxes sized for
      * larger text. [fontScale] defaults to 1.0 (an un-scaled capture).
      */
-    fun spToPx(value: String, density: Float, fontScale: Float = 1f): Double? {
+    public fun spToPx(value: String, density: Float, fontScale: Float = 1f): Double? {
       val n = value.removeSuffix("sp").trim().toDoubleOrNull() ?: return null
       return n * density * fontScale
     }
@@ -2866,7 +2866,7 @@ data class FigmaSvgModel(
      * out into [FigmaSvgColor.opacity] and the theme role name attached when [colorNames] knows it.
      * Returns null for an unparseable value.
      */
-    fun argbToColor(argb: String, colorNames: Map<String, String>): FigmaSvgColor? {
+    public fun argbToColor(argb: String, colorNames: Map<String, String>): FigmaSvgColor? {
       val hex = argb.removePrefix("#")
       val (rgb, opacity) =
         when (hex.length) {

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/MaterialIconRef.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/MaterialIconRef.kt
@@ -30,7 +30,7 @@ package ee.schimke.composeai.data.layoutinspector
  * a network fetch or on this mapping being right: a mis-mapped name is a wrong *label*, not a wrong
  * *drawing*. See `FigmaLayeredSvg` for the emitted shape.
  */
-data class MaterialIconRef(
+public data class MaterialIconRef(
   /** Canonical icon name as fonts.google.com knows it — `account_circle`, `arrow_back`. */
   val name: String,
   /** The style variant the app used. */
@@ -55,11 +55,11 @@ data class MaterialIconRef(
     get() = "https://fonts.gstatic.com/s/i/${style.cdnFamily}/$name/v1/24px.svg"
 
   /** The five drawing styles the Material Icons set (and `Icons.*`) ships. */
-  enum class Style(
+  public enum class Style(
     /** The `Icons.` sub-object name, as it appears in the `ImageVector` name prefix. */
-    val composeName: String,
+    public val composeName: String,
     /** The CDN path segment for this style's drawing. */
-    val cdnFamily: String,
+    public val cdnFamily: String,
   ) {
     FILLED("Filled", "materialicons"),
     OUTLINED("Outlined", "materialiconsoutlined"),
@@ -68,7 +68,7 @@ data class MaterialIconRef(
     TWO_TONE("TwoTone", "materialiconstwotone"),
   }
 
-  companion object {
+  public companion object {
 
     /** The `Icons.AutoMirrored` prefix that precedes the style on a mirrored icon's name. */
     private const val AUTO_MIRRORED = "AutoMirrored"
@@ -106,7 +106,7 @@ data class MaterialIconRef(
      * annotation is only worth emitting when it is certainly right, and an unnamed vector still
      * exports its captured paths exactly as before.
      */
-    fun parse(vectorName: String?): MaterialIconRef? {
+    public fun parse(vectorName: String?): MaterialIconRef? {
       val raw = vectorName?.trim().orEmpty()
       if (raw.isEmpty()) return null
       val parts = raw.split('.')

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PlaceholderModifiers.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PlaceholderModifiers.kt
@@ -23,21 +23,21 @@ package ee.schimke.composeai.data.layoutinspector
  * never forces a raster; what it *does* contribute is its own state-aware layer — see
  * [LayoutInspectorPlaceholder.visible].
  */
-object PlaceholderModifiers {
+public object PlaceholderModifiers {
 
   /** Inspector `nameFallback` of `Modifier.placeholder`. */
-  const val NAME_PLACEHOLDER: String = "placeholder"
+  public const val NAME_PLACEHOLDER: String = "placeholder"
 
   /** Inspector `nameFallback` of `Modifier.placeholderShimmer`. */
-  const val NAME_SHIMMER: String = "placeholderShimmer"
+  public const val NAME_SHIMMER: String = "placeholderShimmer"
 
   /**
    * [LayoutInspectorPlaceholder.kind] for a `Modifier.placeholder` (the content-covering block).
    */
-  const val KIND_PLACEHOLDER: String = "placeholder"
+  public const val KIND_PLACEHOLDER: String = "placeholder"
 
   /** [LayoutInspectorPlaceholder.kind] for a `Modifier.placeholderShimmer` (the sweep overlay). */
-  const val KIND_SHIMMER: String = "shimmer"
+  public const val KIND_SHIMMER: String = "shimmer"
 
   /**
    * True for a placeholder-family modifier, matched by the inspector [name]
@@ -49,7 +49,7 @@ object PlaceholderModifiers {
    * lowers to a bare `drawWithContent` + `graphicsLayer` pair with no identity of its own — see
    * [isPlaceholderOrigin], the other half of the recognition.
    */
-  fun isPlaceholderModifier(name: String?, className: String?): Boolean =
+  public fun isPlaceholderModifier(name: String?, className: String?): Boolean =
     name == NAME_PLACEHOLDER || name == NAME_SHIMMER || className?.startsWith("Placeholder") == true
 
   /**
@@ -67,7 +67,7 @@ object PlaceholderModifiers {
    * Deliberately anchored to a Material package so an application's own `PlaceholderKt` file can't
    * claim the identity.
    */
-  fun isPlaceholderOrigin(className: String?): Boolean {
+  public fun isPlaceholderOrigin(className: String?): Boolean {
     val n = className ?: return false
     val material =
       n.startsWith("androidx.wear.compose.material3.") ||
@@ -81,7 +81,7 @@ object PlaceholderModifiers {
    * The [LayoutInspectorPlaceholder.kind] for a placeholder-family modifier, or null when it isn't
    * one. Shimmer is matched first: `PlaceholderShimmerElement` also starts with `Placeholder`.
    */
-  fun kindOf(name: String?, className: String?): String? =
+  public fun kindOf(name: String?, className: String?): String? =
     when {
       name == NAME_SHIMMER || className?.startsWith("PlaceholderShimmer") == true -> KIND_SHIMMER
       isPlaceholderModifier(name, className) -> KIND_PLACEHOLDER

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/PreviewSlots.kt
@@ -21,9 +21,9 @@ import kotlinx.serialization.Serializable
  * (`dp-slot:content;scope=column;scroll=1`); a bare `dp-slot:<name>` (no attributes) reads back as
  * [SlotScope.UNKNOWN], not scrolling, so older tags still parse.
  */
-object PreviewSlots {
+public object PreviewSlots {
   /** The `testTag` prefix a slot marker applies; the slot name is the suffix (`dp-slot:<name>`). */
-  const val SLOT_TAG_PREFIX: String = "dp-slot:"
+  public const val SLOT_TAG_PREFIX: String = "dp-slot:"
 
   /** Separates the slot name from its optional `key=value` attributes in the tag. */
   private const val ATTR_SEP: Char = ';'
@@ -34,7 +34,7 @@ object PreviewSlots {
    * `boundsInRoot`). Nodes with a blank name or malformed bounds are skipped, so a partial/garbled
    * tree never throws; an unrecognised attribute is ignored (forward-compatible).
    */
-  fun extractSlots(payload: ComposeSemanticsPayload): List<PreviewSlot> {
+  public fun extractSlots(payload: ComposeSemanticsPayload): List<PreviewSlot> {
     val out = mutableListOf<PreviewSlot>()
     fun walk(node: ComposeSemanticsNode) {
       // A slot marker inside a trial-measured subtree marks nothing: it was never placed, so it has
@@ -74,7 +74,7 @@ object PreviewSlots {
  * when the marker didn't record one (a bare `dp-slot:<name>` tag).
  */
 @Serializable
-enum class SlotScope {
+public enum class SlotScope {
   UNKNOWN,
   /** `RowScope` — children are placed horizontally. */
   ROW,
@@ -87,9 +87,9 @@ enum class SlotScope {
    */
   LAZY;
 
-  companion object {
+  public companion object {
     /** The [SlotScope] for a tag's `scope=<wire>` value; [UNKNOWN] for null / anything unknown. */
-    fun fromWire(wire: String?): SlotScope =
+    public fun fromWire(wire: String?): SlotScope =
       when (wire) {
         "row" -> ROW
         "column" -> COLUMN
@@ -105,7 +105,8 @@ enum class SlotScope {
  * depth-first order, tagged with the [previewId] they came from. A structured-screen builder reads
  * this to lay out slot regions and size children to fill them.
  */
-@Serializable data class PreviewSlotsPayload(val previewId: String, val slots: List<PreviewSlot>)
+@Serializable
+public data class PreviewSlotsPayload(val previewId: String, val slots: List<PreviewSlot>)
 
 /**
  * One named slot region — its author-declared [name], its [bounds] (absolute-to-root px), the
@@ -114,7 +115,7 @@ enum class SlotScope {
  * round-trips unchanged.
  */
 @Serializable
-data class PreviewSlot(
+public data class PreviewSlot(
   val name: String,
   val bounds: SlotBounds,
   val scope: SlotScope = SlotScope.UNKNOWN,
@@ -129,10 +130,10 @@ data class PreviewSlot(
 
 /** A slot's box in absolute-to-root px, mirroring the semantics `boundsInRoot` wire form. */
 @Serializable
-data class SlotBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
-  companion object {
+public data class SlotBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+  public companion object {
     /** Parse the `"left,top,right,bottom"` int wire form; null when malformed. */
-    fun parse(wire: String): SlotBounds? {
+    public fun parse(wire: String): SlotBounds? {
       val parts = wire.split(",")
       if (parts.size != 4) return null
       val ints = parts.map { it.trim().toIntOrNull() ?: return null }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsDiff.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
-object SemanticsDiffProduct {
-  const val SCHEMA: String = "compose-semantics-diff/v1"
+public object SemanticsDiffProduct {
+  public const val SCHEMA: String = "compose-semantics-diff/v1"
 }
 
 /**
@@ -20,7 +20,7 @@ object SemanticsDiffProduct {
  * Positional fields ([ComposeSemanticsNode.boundsInRoot]) and the volatile per-render
  * [ComposeSemanticsNode.nodeId] are deliberately ignored — bounds churn is the pixel diff's job.
  */
-object SemanticsDiff {
+public object SemanticsDiff {
 
   /** Semantic fields compared between two nodes sharing a ref, in stable report order. */
   private val COMPARED_FIELDS: List<Pair<String, (ComposeSemanticsNode) -> String?>> =
@@ -48,10 +48,10 @@ object SemanticsDiff {
       "layoutDidOverflowHeight" to { it.textOverflow?.didOverflowHeight?.toString() },
     )
 
-  fun diff(base: ComposeSemanticsPayload, head: ComposeSemanticsPayload): SemanticsDelta =
+  public fun diff(base: ComposeSemanticsPayload, head: ComposeSemanticsPayload): SemanticsDelta =
     diff(base.root, head.root)
 
-  fun diff(base: ComposeSemanticsNode, head: ComposeSemanticsNode): SemanticsDelta {
+  public fun diff(base: ComposeSemanticsNode, head: ComposeSemanticsNode): SemanticsDelta {
     val baseByRef = SemanticsRefs.assign(base).byRef()
     val headByRef = SemanticsRefs.assign(head).byRef()
 
@@ -102,10 +102,11 @@ object SemanticsDiff {
     )
 }
 
-@Serializable data class SemanticsFieldChange(val field: String, val from: String?, val to: String?)
+@Serializable
+public data class SemanticsFieldChange(val field: String, val from: String?, val to: String?)
 
 @Serializable
-data class SemanticsNodeChange(
+public data class SemanticsNodeChange(
   val ref: String,
   /** testTag/role anchor of the node, for human-readable output. */
   val anchor: String? = null,
@@ -113,7 +114,7 @@ data class SemanticsNodeChange(
 )
 
 @Serializable
-data class SemanticsNodeSummary(
+public data class SemanticsNodeSummary(
   val ref: String,
   val role: String? = null,
   val testTag: String? = null,
@@ -123,7 +124,7 @@ data class SemanticsNodeSummary(
 
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class SemanticsDelta(
+public data class SemanticsDelta(
   // `@EncodeDefault` so the versioned schema rides every wire surface — including JSON encoders
   // configured with `encodeDefaults = false` (the daemon's `history/diff mode=SEMANTICS` result and
   // the MCP `diff_semantics` payload). Without it an empty-or-default delta would serialize without

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsRefs.kt
@@ -21,12 +21,12 @@ package ee.schimke.composeai.data.layoutinspector
  * Assignment is deterministic and idempotent: running it twice yields identical refs, so callers
  * can re-assign defensively (the differ does) without surprise.
  */
-object SemanticsRefs {
-  const val ROOT_REF: String = "r"
+public object SemanticsRefs {
+  public const val ROOT_REF: String = "r"
 
   // Copies field by field rather than by `copy()` so a new payload field is a compile-time
   // decision here, not a silent drop — ref assignment sits on the write path of every capture.
-  fun assign(payload: ComposeSemanticsPayload): ComposeSemanticsPayload =
+  public fun assign(payload: ComposeSemanticsPayload): ComposeSemanticsPayload =
     ComposeSemanticsPayload(root = assign(payload.root), density = payload.density)
 
   /**
@@ -38,10 +38,10 @@ object SemanticsRefs {
    * a `SubcomposeLayout` changes which arrangement it places. Consumers that care about the frame
    * (`SemanticsTargets`, the annotation and wireframe walks) filter at the point of use instead.
    */
-  fun assign(root: ComposeSemanticsNode): ComposeSemanticsNode = assignNode(root, ROOT_REF)
+  public fun assign(root: ComposeSemanticsNode): ComposeSemanticsNode = assignNode(root, ROOT_REF)
 
   /** The anchor token for a node, before sibling disambiguation. */
-  fun anchor(node: ComposeSemanticsNode): String =
+  public fun anchor(node: ComposeSemanticsNode): String =
     node.testTag?.trim()?.takeIf { it.isNotEmpty() }?.let { "tag:${sanitize(it)}" }
       ?: node.role?.trim()?.takeIf { it.isNotEmpty() }?.let { "role:${sanitize(it)}" }
       ?: GENERIC_ANCHOR

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsTargets.kt
@@ -10,12 +10,12 @@ package ee.schimke.composeai.data.layoutinspector
  * (unref'd) tree. The returned [SemanticsPoint] is the node's centre in the same root-pixel space
  * as [ComposeSemanticsNode.boundsInRoot].
  */
-object SemanticsTargets {
+public object SemanticsTargets {
 
-  fun resolve(payload: ComposeSemanticsPayload, target: SemanticsTarget): TargetResolution =
+  public fun resolve(payload: ComposeSemanticsPayload, target: SemanticsTarget): TargetResolution =
     resolve(payload.root, target)
 
-  fun resolve(root: ComposeSemanticsNode, target: SemanticsTarget): TargetResolution {
+  public fun resolve(root: ComposeSemanticsNode, target: SemanticsTarget): TargetResolution {
     val refRoot = SemanticsRefs.assign(root)
     val matches =
       when (target) {
@@ -38,7 +38,7 @@ object SemanticsTargets {
    * tree still yields stable refs. Bounded by [limit] to keep the diagnostic payload small on dense
    * trees; the most-targetable nodes (those with a `testTag`) sort first.
    */
-  fun targetableNodes(
+  public fun targetableNodes(
     root: ComposeSemanticsNode,
     limit: Int = DEFAULT_CANDIDATE_LIMIT,
   ): List<ComposeSemanticsNode> =
@@ -70,7 +70,7 @@ object SemanticsTargets {
    * Reassigns refs defensively (same contract as [resolve]) so a raw tree still yields a stable
    * ref.
    */
-  fun nodeAt(root: ComposeSemanticsNode, x: Int, y: Int): SemanticsTarget? {
+  public fun nodeAt(root: ComposeSemanticsNode, x: Int, y: Int): SemanticsTarget? {
     val hit =
       SemanticsRefs.assign(root)
         .flatten()
@@ -162,33 +162,34 @@ object SemanticsTargets {
 }
 
 /** A request to identify a node by stable handle rather than pixel coordinates (issue #1784). */
-sealed interface SemanticsTarget {
+public sealed interface SemanticsTarget {
   /** Match the unique node whose [ComposeSemanticsNode.ref] equals [ref]. */
-  data class Ref(val ref: String) : SemanticsTarget
+  public data class Ref(val ref: String) : SemanticsTarget
 
   /** Match nodes carrying this exact `testTag`. */
-  data class Tag(val testTag: String) : SemanticsTarget
+  public data class Tag(val testTag: String) : SemanticsTarget
 
   /** Match nodes by role and/or accessible text (at least one must be non-null). */
-  data class RoleText(val role: String? = null, val text: String? = null) : SemanticsTarget
+  public data class RoleText(val role: String? = null, val text: String? = null) : SemanticsTarget
 }
 
-sealed interface TargetResolution {
+public sealed interface TargetResolution {
   /** Exactly one node matched; dispatch at [point] (centre of the node, root-pixel space). */
-  data class Resolved(val node: ComposeSemanticsNode, val point: SemanticsPoint) : TargetResolution
+  public data class Resolved(val node: ComposeSemanticsNode, val point: SemanticsPoint) :
+    TargetResolution
 
   /** No node matched. */
-  data object NotFound : TargetResolution
+  public data object NotFound : TargetResolution
 
   /** More than one node matched; the caller should disambiguate among [candidates]. */
-  data class Ambiguous(val candidates: List<ComposeSemanticsNode>) : TargetResolution
+  public data class Ambiguous(val candidates: List<ComposeSemanticsNode>) : TargetResolution
 }
 
 /** A point in the root-pixel coordinate space used by [ComposeSemanticsNode.boundsInRoot]. */
-data class SemanticsPoint(val x: Int, val y: Int)
+public data class SemanticsPoint(val x: Int, val y: Int)
 
 /** Bounds parsed from the `"left,top,right,bottom"` wire string. */
-data class SemanticsBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+public data class SemanticsBounds(val left: Int, val top: Int, val right: Int, val bottom: Int) {
   val centerX: Int
     get() = (left + right) / 2
 
@@ -199,8 +200,8 @@ data class SemanticsBounds(val left: Int, val top: Int, val right: Int, val bott
   val area: Long
     get() = (right - left).toLong().coerceAtLeast(0) * (bottom - top).toLong().coerceAtLeast(0)
 
-  companion object {
-    fun parse(wire: String): SemanticsBounds? {
+  public companion object {
+    public fun parse(wire: String): SemanticsBounds? {
       val parts = wire.split(',')
       if (parts.size != 4) return null
       val ints = parts.map { it.trim().toIntOrNull() ?: return null }

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsWireframe.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsWireframe.kt
@@ -21,10 +21,10 @@ package ee.schimke.composeai.data.layoutinspector
  *
  * Pure and deterministic: input model in, SVG string out, no graphics toolkit, no IO.
  */
-object SemanticsWireframeSvg {
+public object SemanticsWireframeSvg {
 
   /** Tunables for the bake; defaults are chosen to read at a glance on a phone-sized root. */
-  data class Options(
+  public data class Options(
     /** Transparent margin (px) around the diagram extent. */
     val padding: Int = 16,
     /** Draw the top-left label on each box. */
@@ -34,13 +34,13 @@ object SemanticsWireframeSvg {
   )
 
   /** Writes the wireframe SVG for [payload]. */
-  fun render(payload: ComposeSemanticsPayload, options: Options = Options()): String {
+  public fun render(payload: ComposeSemanticsPayload, options: Options = Options()): String {
     val model = WireframeModel.from(payload, options.padding)
     return render(model, options)
   }
 
   /** Writes the wireframe SVG for an already-built [model]. */
-  fun render(model: WireframeModel, options: Options = Options()): String {
+  public fun render(model: WireframeModel, options: Options = Options()): String {
     val sb = StringBuilder()
     sb.append(
       """<svg xmlns="http://www.w3.org/2000/svg" width="${model.width}" height="${model.height}" """ +

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsWireframeModel.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/SemanticsWireframeModel.kt
@@ -7,7 +7,7 @@ package ee.schimke.composeai.data.layoutinspector
  * applies the same translate ([WireframeModel.tx] / [WireframeModel.ty]) and reads the same colours
  * from [WireframeStyle], so the SVG and the PNG agree pixel-for-pixel on layout and encoding.
  */
-data class WireframeBox(
+public data class WireframeBox(
   val left: Int,
   val top: Int,
   val right: Int,
@@ -29,7 +29,7 @@ data class WireframeBox(
  * The full diagram: every parseable box (pre-order) plus the padded extent. [boxes] is empty for a
  * tree with no parseable bounds — renderers emit a minimal [width]×[height] ground in that case.
  */
-data class WireframeModel(
+public data class WireframeModel(
   val boxes: List<WireframeBox>,
   /** Min corner of the union of all boxes (0,0 when empty). */
   val minX: Int,
@@ -46,8 +46,8 @@ data class WireframeModel(
   val ty: Int
     get() = padding - minY
 
-  companion object {
-    fun from(payload: ComposeSemanticsPayload, padding: Int): WireframeModel {
+  public companion object {
+    public fun from(payload: ComposeSemanticsPayload, padding: Int): WireframeModel {
       val boxes = mutableListOf<WireframeBox>()
       collect(payload.root, depth = 0, into = boxes)
       if (boxes.isEmpty()) {
@@ -116,39 +116,39 @@ data class WireframeModel(
  * both the SVG and raster renderers read so they stay identical. Kept toolkit-free (no
  * `android.graphics`, no `java.awt`) so it lives on the render-subprocess-safe core classpath.
  */
-object WireframeStyle {
+public object WireframeStyle {
   /** Muted, high-contrast-on-white stroke palette cycled by nesting depth. */
-  val depthStrokes =
+  public val depthStrokes: IntArray =
     intArrayOf(0x5B6470, 0x2E7D6B, 0x8E6BA8, 0xB0813B, 0x3B72A8, 0xA85B6B, 0x4F8A4A, 0x7A7A33)
 
   /** Accent for clickable (actionable) nodes — fill + stroke. */
-  const val clickAccent: Int = 0x1976D2
+  public const val clickAccent: Int = 0x1976D2
 
   /** Fill opacity (0..1) painted inside clickable boxes. */
-  const val clickFillOpacity: Double = 0.08
+  public const val clickFillOpacity: Double = 0.08
 
   /** White ground so the wireframe reads the same on a dark webview / terminal. */
-  const val ground: Int = 0xFFFFFF
+  public const val ground: Int = 0xFFFFFF
 
   /** Default label font size (px). */
-  const val fontSize: Int = 11
+  public const val fontSize: Int = 11
 
   /** Dotted/dashed stroke for `clearAndSet` boxes: on/off run lengths (px). */
-  val clearAndSetDash = floatArrayOf(4f, 3f)
+  public val clearAndSetDash: FloatArray = floatArrayOf(4f, 3f)
 
-  fun strokeColor(box: WireframeBox): Int =
+  public fun strokeColor(box: WireframeBox): Int =
     if (box.clickable) clickAccent else depthStrokes[box.depth % depthStrokes.size]
 
-  fun strokeWidth(box: WireframeBox): Int = if (box.clickable) 2 else 1
+  public fun strokeWidth(box: WireframeBox): Int = if (box.clickable) 2 else 1
 
   /** `0xRRGGBB` → `#RRGGBB`. */
-  fun hex(rgb: Int): String = "#%06X".format(rgb)
+  public fun hex(rgb: Int): String = "#%06X".format(rgb)
 
-  fun red(rgb: Int): Int = (rgb shr 16) and 0xFF
+  public fun red(rgb: Int): Int = (rgb shr 16) and 0xFF
 
-  fun green(rgb: Int): Int = (rgb shr 8) and 0xFF
+  public fun green(rgb: Int): Int = (rgb shr 8) and 0xFF
 
-  fun blue(rgb: Int): Int = rgb and 0xFF
+  public fun blue(rgb: Int): Int = rgb and 0xFF
 
   /**
    * Truncates [text] with a trailing `…` so the rendered string fits in [maxWidthPx], estimating
@@ -157,7 +157,7 @@ object WireframeStyle {
    * raster bakers measure precisely with their own `FontMetrics`/`Paint`, but share this for parity
    * of intent.
    */
-  fun truncateToWidth(text: String, maxWidthPx: Int, fontSize: Int = this.fontSize): String {
+  public fun truncateToWidth(text: String, maxWidthPx: Int, fontSize: Int = this.fontSize): String {
     if (maxWidthPx <= 0) return ""
     val charWidth = fontSize * 0.6
     val maxChars = (maxWidthPx / charWidth).toInt()

--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/WearScrollSliceStitcher.kt
@@ -21,11 +21,11 @@ package ee.schimke.composeai.data.layoutinspector
  *   frame root much taller than wide, so `FigmaSvgModel.from(roundClip = true)` masks it to the
  *   vertical capsule. Every card, its text, the clock arc and the device face stay editable vector.
  */
-object WearScrollSliceStitcher {
+public object WearScrollSliceStitcher {
   /**
    * One captured scroll slice: the preview's layout + semantics trees at native (viewport) size.
    */
-  data class Slice(val layout: LayoutInspectorNode, val semantics: ComposeSemanticsNode)
+  public data class Slice(val layout: LayoutInspectorNode, val semantics: ComposeSemanticsNode)
 
   /**
    * The settled `EdgeButton` crescent, emitted as one opaque `Image` node ([nodeId]) at [dest]. The
@@ -33,10 +33,14 @@ object WearScrollSliceStitcher {
    * height]` band (black-backed, so it composites onto the black capsule face) and pastes them at
    * [dest].
    */
-  data class EdgeRaster(val nodeId: String, val sourceTop: Int, val dest: LayoutInspectorBounds)
+  public data class EdgeRaster(
+    val nodeId: String,
+    val sourceTop: Int,
+    val dest: LayoutInspectorBounds,
+  )
 
   /** The stitched capsule: combined layout + semantics trees, size, and any edge-crescent spec. */
-  data class Stitched(
+  public data class Stitched(
     val layout: LayoutInspectorPayload,
     val semantics: ComposeSemanticsPayload,
     val width: Int,
@@ -44,14 +48,14 @@ object WearScrollSliceStitcher {
     val edge: EdgeRaster?,
   )
 
-  const val EDGE_NODE_ID: String = "edge-raster"
+  public const val EDGE_NODE_ID: String = "edge-raster"
   private const val EDGE_COMPONENT = "Image"
 
   /** Inter-part gap (px) between the last list item and the EdgeButton. */
-  const val GAP: Int = 6
+  public const val GAP: Int = 6
 
   /** Bottom inset (px) below the EdgeButton, hugging the capsule's bottom curve. */
-  const val BOTTOM_PAD: Int = 8
+  public const val BOTTOM_PAD: Int = 8
 
   /** ~px bucket that treats an item measured a pixel differently across slices as the same item. */
   private const val DEDUP_BUCKET = 6
@@ -62,7 +66,7 @@ object WearScrollSliceStitcher {
    * `width`×`width` square), the crescent is placed below the last item as an [EdgeRaster];
    * otherwise the screen has no bottom control.
    */
-  fun stitch(
+  public fun stitch(
     rootId: String,
     width: Int,
     slices: List<Slice>,

--- a/data/render/core/api/data-render-core.api
+++ b/data/render/core/api/data-render-core.api
@@ -1,0 +1,1532 @@
+public final class ee/schimke/composeai/data/render/IrSidecarChannel {
+	public static final field FORMAT_PROTOLAYOUT Ljava/lang/String;
+	public static final field FORMAT_REMOTECOMPOSE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/IrSidecarChannel;
+	public final fun consume (Ljava/lang/String;)Lee/schimke/composeai/data/render/IrSidecarChannel$IrCapture;
+	public final fun currentPreviewId ()Ljava/lang/String;
+	public final fun offer (Ljava/lang/String;[B[B)V
+	public static synthetic fun offer$default (Lee/schimke/composeai/data/render/IrSidecarChannel;Ljava/lang/String;[B[BILjava/lang/Object;)V
+	public final fun peek (Ljava/lang/String;)Lee/schimke/composeai/data/render/IrSidecarChannel$IrCapture;
+	public final fun setCurrentPreviewId (Ljava/lang/String;)V
+}
+
+public final class ee/schimke/composeai/data/render/IrSidecarChannel$IrCapture {
+	public fun <init> (Ljava/lang/String;[B[B)V
+	public synthetic fun <init> (Ljava/lang/String;[B[BILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()[B
+	public final fun component3 ()[B
+	public final fun copy (Ljava/lang/String;[B[B)Lee/schimke/composeai/data/render/IrSidecarChannel$IrCapture;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/IrSidecarChannel$IrCapture;Ljava/lang/String;[B[BILjava/lang/Object;)Lee/schimke/composeai/data/render/IrSidecarChannel$IrCapture;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBytes ()[B
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getResourcesBytes ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/LinkBufferComposer {
+	public static final field AUTO Ljava/lang/String;
+	public static final field FLAGS_CLASS Ljava/lang/String;
+	public static final field FLAG_FIELD Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/LinkBufferComposer;
+	public static final field PROPERTY Ljava/lang/String;
+	public static final fun applyAndDescribe (Ljava/lang/ClassLoader;)Ljava/lang/String;
+	public static synthetic fun applyAndDescribe$default (Ljava/lang/ClassLoader;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun applyIfRequested ()Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome;
+	public final fun applyIfRequested (Ljava/lang/ClassLoader;)Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome;
+	public final fun applyIfRequested (Ljava/lang/ClassLoader;Ljava/lang/String;)Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome;
+	public static synthetic fun applyIfRequested$default (Lee/schimke/composeai/data/render/LinkBufferComposer;Ljava/lang/ClassLoader;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome;
+	public final fun request (Ljava/lang/String;)Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public static synthetic fun request$default (Lee/schimke/composeai/data/render/LinkBufferComposer;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public final fun requested (Ljava/lang/String;)Z
+	public static synthetic fun requested$default (Lee/schimke/composeai/data/render/LinkBufferComposer;Ljava/lang/String;ILjava/lang/Object;)Z
+}
+
+public abstract interface class ee/schimke/composeai/data/render/LinkBufferComposer$Outcome {
+}
+
+public final class ee/schimke/composeai/data/render/LinkBufferComposer$Outcome$Enabled : ee/schimke/composeai/data/render/LinkBufferComposer$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome$Enabled;
+}
+
+public final class ee/schimke/composeai/data/render/LinkBufferComposer$Outcome$NotRequested : ee/schimke/composeai/data/render/LinkBufferComposer$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome$NotRequested;
+}
+
+public final class ee/schimke/composeai/data/render/LinkBufferComposer$Outcome$Unavailable : ee/schimke/composeai/data/render/LinkBufferComposer$Outcome {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/LinkBufferComposer$Outcome$Unavailable;
+}
+
+public final class ee/schimke/composeai/data/render/LinkBufferComposer$Request : java/lang/Enum {
+	public static final field Off Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public static final field Preferred Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public static final field Required Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+	public static fun values ()[Lee/schimke/composeai/data/render/LinkBufferComposer$Request;
+}
+
+public final class ee/schimke/composeai/data/render/PerfettoTraceDataProducer {
+	public static final field ENABLED_PROP Ljava/lang/String;
+	public static final field FILE Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PerfettoTraceDataProducer;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+	public final fun enabled ()Z
+	public final fun getSectionBackend ()Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$TraceSectionBackend;
+	public final fun recorder (Ljava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder;
+	public static synthetic fun recorder$default (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder;
+	public final fun setSectionBackend (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$TraceSectionBackend;)V
+	public final fun writeArtifacts (Ljava/io/File;Ljava/lang/String;Lee/schimke/composeai/data/render/TracePayload;Lokio/FileSystem;)V
+	public static synthetic fun writeArtifacts$default (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer;Ljava/io/File;Ljava/lang/String;Lee/schimke/composeai/data/render/TracePayload;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Z)V
+	public final fun beginSection (Ljava/lang/String;Ljava/lang/String;)V
+	public static synthetic fun beginSection$default (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun endSection ()V
+	public final fun payload ()Lee/schimke/composeai/data/render/TracePayload;
+	public final fun record (Ljava/lang/String;JJ)V
+	public final fun record (Ljava/lang/String;Ljava/lang/String;JJ)V
+	public final fun record (Ljava/lang/String;Ljava/lang/String;JJI)V
+	public static synthetic fun record$default (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder;Ljava/lang/String;Ljava/lang/String;JJIILjava/lang/Object;)V
+	public final fun renderTrace ()Lee/schimke/composeai/data/render/RenderTrace;
+	public final fun section (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static synthetic fun section$default (Lee/schimke/composeai/data/render/PerfettoTraceDataProducer$Recorder;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun write (Ljava/io/File;)V
+}
+
+public abstract interface class ee/schimke/composeai/data/render/PerfettoTraceDataProducer$TraceSectionBackend {
+	public abstract fun begin (Ljava/lang/String;)V
+	public abstract fun end ()V
+}
+
+public final class ee/schimke/composeai/data/render/PreviewAnimationContext {
+	public fun <init> (ZILjava/lang/Integer;ILjava/util/List;)V
+	public synthetic fun <init> (ZILjava/lang/Integer;ILjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (ZILjava/lang/Integer;ILjava/util/List;)Lee/schimke/composeai/data/render/PreviewAnimationContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewAnimationContext;ZILjava/lang/Integer;ILjava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewAnimationContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEffectiveDurationMs ()Ljava/lang/Integer;
+	public final fun getFrameIntervalMs ()I
+	public final fun getRequestedDurationMs ()I
+	public final fun getSampleTimesMs ()Ljava/util/List;
+	public final fun getShowCurves ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewBackdrop;
+	public static final field M3_LIGHT_BACKGROUND Ljava/lang/String;
+	public final fun isDarkArgb (Ljava/lang/String;)Z
+	public final fun resolve (ZJZLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;Z)Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;
+	public static synthetic fun resolve$default (Lee/schimke/composeai/data/render/PreviewBackdrop;ZJZLjava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;
+	public final fun withCatalogDefault (Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;)Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop$Backdrop {
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewBackdrop$Source;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewBackdrop$Source;)Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewBackdrop$Source;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewBackdrop$Backdrop;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColor ()Ljava/lang/String;
+	public final fun getSource ()Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public fun hashCode ()I
+	public final fun isDark ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface$Companion;
+	public static final field DARK Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;
+	public static final field LIGHT Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;
+	public static fun values ()[Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/data/render/PreviewBackdrop$CatalogSurface;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop$Source : java/lang/Enum {
+	public static final field CATALOG_SURFACE Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field Companion Lee/schimke/composeai/data/render/PreviewBackdrop$Source$Companion;
+	public static final field M3_LIGHT_FALLBACK Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field NONE Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field PREVIEW_BACKGROUND_COLOR Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field PREVIEW_SHOW_BACKGROUND Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field PREVIEW_VARIANT Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field THEME_BACKGROUND Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static final field THEME_SURFACE Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+	public static fun values ()[Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackdrop$Source$Companion {
+	public final fun fromWire (Ljava/lang/String;)Lee/schimke/composeai/data/render/PreviewBackdrop$Source;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackends {
+	public static final field ANDROID Ljava/lang/String;
+	public static final field DESKTOP Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewBackends;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewBackground {
+	public static final field DAY_ARGB I
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewBackground;
+	public static final field NIGHT_ARGB I
+	public static final field TRANSPARENT_ARGB I
+	public final fun isNight (I)Z
+	public final fun resolveArgb (ZJZZ)I
+	public static synthetic fun resolveArgb$default (Lee/schimke/composeai/data/render/PreviewBackground;ZJZZILjava/lang/Object;)I
+	public final fun resolveArgbForUiMode (ZJIZ)I
+	public static synthetic fun resolveArgbForUiMode$default (Lee/schimke/composeai/data/render/PreviewBackground;ZJIZILjava/lang/Object;)I
+}
+
+public final class ee/schimke/composeai/data/render/PreviewClip {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewClip;
+	public final fun cssClipPath (Lee/schimke/composeai/data/render/PreviewClip$Shape;DD)Ljava/lang/String;
+	public final fun resolve (ZLjava/lang/Double;Ljava/lang/Double;)Lee/schimke/composeai/data/render/PreviewClip$Shape;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/PreviewClip$Shape {
+}
+
+public final class ee/schimke/composeai/data/render/PreviewClip$Shape$Circle : ee/schimke/composeai/data/render/PreviewClip$Shape {
+	public fun <init> (DDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun copy (DDD)Lee/schimke/composeai/data/render/PreviewClip$Shape$Circle;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewClip$Shape$Circle;DDDILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewClip$Shape$Circle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCenterXDp ()D
+	public final fun getCenterYDp ()D
+	public final fun getRadiusDp ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewDeviceContext;Lee/schimke/composeai/data/render/PreviewFrameTime;Lee/schimke/composeai/data/render/PreviewInspectionContext;Lee/schimke/composeai/data/render/PreviewAnimationContext;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewDeviceContext;Lee/schimke/composeai/data/render/PreviewFrameTime;Lee/schimke/composeai/data/render/PreviewInspectionContext;Lee/schimke/composeai/data/render/PreviewAnimationContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lee/schimke/composeai/data/render/PreviewDeviceContext;
+	public final fun component6 ()Lee/schimke/composeai/data/render/PreviewFrameTime;
+	public final fun component7 ()Lee/schimke/composeai/data/render/PreviewInspectionContext;
+	public final fun component8 ()Lee/schimke/composeai/data/render/PreviewAnimationContext;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewDeviceContext;Lee/schimke/composeai/data/render/PreviewFrameTime;Lee/schimke/composeai/data/render/PreviewInspectionContext;Lee/schimke/composeai/data/render/PreviewAnimationContext;)Lee/schimke/composeai/data/render/PreviewContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/PreviewDeviceContext;Lee/schimke/composeai/data/render/PreviewFrameTime;Lee/schimke/composeai/data/render/PreviewInspectionContext;Lee/schimke/composeai/data/render/PreviewAnimationContext;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnimation ()Lee/schimke/composeai/data/render/PreviewAnimationContext;
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getDevice ()Lee/schimke/composeai/data/render/PreviewDeviceContext;
+	public final fun getFrameTime ()Lee/schimke/composeai/data/render/PreviewFrameTime;
+	public final fun getInspection ()Lee/schimke/composeai/data/render/PreviewInspectionContext;
+	public final fun getOutputBaseName ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getRenderMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewContext$Builder {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun addSlotTables (Ljava/lang/Iterable;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun animation (Lee/schimke/composeai/data/render/PreviewAnimationContext;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun build ()Lee/schimke/composeai/data/render/PreviewContext;
+	public final fun device (Lee/schimke/composeai/data/render/PreviewDeviceContext;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun deviceFromRenderPixels (Ljava/lang/String;IIFLee/schimke/composeai/data/render/PreviewDeviceSpec;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public static synthetic fun deviceFromRenderPixels$default (Lee/schimke/composeai/data/render/PreviewContext$Builder;Ljava/lang/String;IIFLee/schimke/composeai/data/render/PreviewDeviceSpec;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun frameTime (Lee/schimke/composeai/data/render/PreviewFrameTime;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun parameterInformationCollected ()Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun putInspectionValue (Ljava/lang/String;Ljava/lang/Object;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+	public final fun rootForTest (Ljava/lang/Object;)Lee/schimke/composeai/data/render/PreviewContext$Builder;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewDeviceContext {
+	public static final field Companion Lee/schimke/composeai/data/render/PreviewDeviceContext$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Float;Lee/schimke/composeai/data/render/PreviewDeviceSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Float;Lee/schimke/composeai/data/render/PreviewDeviceSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun component5 ()Lee/schimke/composeai/data/render/PreviewDeviceSpec;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Float;Lee/schimke/composeai/data/render/PreviewDeviceSpec;)Lee/schimke/composeai/data/render/PreviewDeviceContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewDeviceContext;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Float;Lee/schimke/composeai/data/render/PreviewDeviceSpec;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewDeviceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getHeightDp ()Ljava/lang/Double;
+	public final fun getResolvedDevice ()Lee/schimke/composeai/data/render/PreviewDeviceSpec;
+	public final fun getWidthDp ()Ljava/lang/Double;
+	public fun hashCode ()I
+	public final fun isRound ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewDeviceContext$Companion {
+	public final fun fromRenderPixels (Ljava/lang/String;IIFLee/schimke/composeai/data/render/PreviewDeviceSpec;)Lee/schimke/composeai/data/render/PreviewDeviceContext;
+	public static synthetic fun fromRenderPixels$default (Lee/schimke/composeai/data/render/PreviewDeviceContext$Companion;Ljava/lang/String;IIFLee/schimke/composeai/data/render/PreviewDeviceSpec;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewDeviceContext;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewDeviceSpec {
+	public fun <init> (IIFZ)V
+	public synthetic fun <init> (IIFZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()F
+	public final fun component4 ()Z
+	public final fun copy (IIFZ)Lee/schimke/composeai/data/render/PreviewDeviceSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewDeviceSpec;IIFZILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewDeviceSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public final fun getHeightDp ()I
+	public final fun getWidthDp ()I
+	public fun hashCode ()I
+	public final fun isRound ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewFilter {
+	public static final field ANCHOR Ljava/lang/String;
+	public static final field ID_EXCLUDE_PROPERTY Ljava/lang/String;
+	public static final field ID_FILTER_PROPERTY Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewFilter;
+	public static final field NAME_FILTER_PROPERTY Ljava/lang/String;
+	public static final field ROW_EXCLUDE_PROPERTY Ljava/lang/String;
+	public final fun excludeById (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Z)Ljava/util/List;
+	public static synthetic fun excludeById$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun fqName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun keptRowIndices (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
+	public final fun matches (Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun matchesId (Ljava/util/Collection;Ljava/lang/String;)Z
+	public final fun matchesRowLabel (Ljava/util/Collection;Ljava/lang/String;)Z
+	public final fun patternsFrom (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static synthetic fun patternsFrom$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/List;
+	public final fun select (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)Ljava/util/List;
+	public static synthetic fun select$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun selectById (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Z)Ljava/util/List;
+	public static synthetic fun selectById$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun selectByName (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)Ljava/util/List;
+	public static synthetic fun selectByName$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewFrameTime {
+	public fun <init> ()V
+	public fun <init> (Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;Ljava/lang/Long;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;Ljava/lang/Long;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;Ljava/lang/Long;Ljava/lang/Integer;)Lee/schimke/composeai/data/render/PreviewFrameTime;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewFrameTime;Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;Ljava/lang/Long;Ljava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewFrameTime;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrameIndex ()Ljava/lang/Integer;
+	public final fun getMode ()Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public final fun getVirtualTimeMs ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewFrameTime$Mode : java/lang/Enum {
+	public static final field INITIAL_SETTLED_FRAME Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public static final field VIRTUAL_ANIMATION_FRAME Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public static final field WALL_CLOCK_FRAME Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+	public static fun values ()[Lee/schimke/composeai/data/render/PreviewFrameTime$Mode;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewInspectionContext {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Object;Ljava/util/Map;Z)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Object;Ljava/util/Map;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/util/List;Ljava/lang/Object;Ljava/util/Map;Z)Lee/schimke/composeai/data/render/PreviewInspectionContext;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/PreviewInspectionContext;Ljava/util/List;Ljava/lang/Object;Ljava/util/Map;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/PreviewInspectionContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getParameterInformationCollected ()Z
+	public final fun getRootForTest ()Ljava/lang/Object;
+	public final fun getSlotTables ()Ljava/util/List;
+	public final fun getValues ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/PreviewSizeQualifiersKt {
+	public static final fun previewOrientationQualifier (IILjava/lang/String;)Ljava/lang/String;
+	public static final fun previewSizeQualifiers (II)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/render/RenderPreviewExtension {
+	public static final field ID Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/RenderPreviewExtension;
+	public static final field KIND_COMPOSE_AI_TRACE Ljava/lang/String;
+	public static final field KIND_DEVICE_BACKGROUND Ljava/lang/String;
+	public static final field KIND_DEVICE_CLIP Ljava/lang/String;
+	public static final field KIND_TEST_FAILURE Ljava/lang/String;
+	public static final field KIND_TRACE Ljava/lang/String;
+	public final fun getComposeTraceDescriptor ()Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public final fun getComposeTraceProfiler ()Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public final fun getDeviceBackgroundDescriptor ()Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public final fun getDeviceBackgroundProcessor ()Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public final fun getDeviceClipDescriptor ()Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public final fun getDeviceClipProcessor ()Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public final fun getOverlayLegendDescriptor ()Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public final fun getOverlayLegendProcessor ()Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public final fun getRenderTraceDescriptor ()Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public final fun getRenderTraceProfiler ()Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTrace {
+	public static final field Companion Lee/schimke/composeai/data/render/RenderTrace$Companion;
+	public fun <init> (Ljava/lang/String;JLjava/util/List;Ljava/util/List;I)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/util/List;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;JLjava/util/List;Ljava/util/List;I)Lee/schimke/composeai/data/render/RenderTrace;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/RenderTrace;Ljava/lang/String;JLjava/util/List;Ljava/util/List;IILjava/lang/Object;)Lee/schimke/composeai/data/render/RenderTrace;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getDroppedSpans ()I
+	public final fun getSections ()Ljava/util/List;
+	public final fun getSpans ()Ljava/util/List;
+	public final fun getTotalMicros ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/RenderTrace$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/RenderTrace$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/RenderTrace;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/RenderTrace;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTrace$Companion {
+	public final fun of (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;I)Lee/schimke/composeai/data/render/RenderTrace;
+	public static synthetic fun of$default (Lee/schimke/composeai/data/render/RenderTrace$Companion;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/lang/Long;IILjava/lang/Object;)Lee/schimke/composeai/data/render/RenderTrace;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTrace$Recorded {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JJI)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JJI)Lee/schimke/composeai/data/render/RenderTrace$Recorded;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/RenderTrace$Recorded;Ljava/lang/String;Ljava/lang/String;JJIILjava/lang/Object;)Lee/schimke/composeai/data/render/RenderTrace$Recorded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDepth ()I
+	public final fun getEndNanos ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartNanos ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTraceDataProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/RenderTraceDataProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+	public static final field SOURCE_METRICS Ljava/lang/String;
+	public static final field SOURCE_SPANS Ljava/lang/String;
+	public final fun payloadFrom (Ljava/util/Map;)Lkotlinx/serialization/json/JsonElement;
+	public final fun payloadFrom (Ljava/util/Map;Lee/schimke/composeai/data/render/RenderTrace;)Lkotlinx/serialization/json/JsonElement;
+	public static synthetic fun payloadFrom$default (Lee/schimke/composeai/data/render/RenderTraceDataProduct;Ljava/util/Map;Lee/schimke/composeai/data/render/RenderTrace;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTraceSection {
+	public static final field Companion Lee/schimke/composeai/data/render/RenderTraceSection$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IJJJ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IJJJ)Lee/schimke/composeai/data/render/RenderTraceSection;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/RenderTraceSection;Ljava/lang/String;Ljava/lang/String;IJJJILjava/lang/Object;)Lee/schimke/composeai/data/render/RenderTraceSection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getCount ()I
+	public final fun getMaxMicros ()J
+	public final fun getMeanMicros ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTotalMicros ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/RenderTraceSection$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/RenderTraceSection$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/RenderTraceSection;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/RenderTraceSection;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTraceSection$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTraceSpan {
+	public static final field Companion Lee/schimke/composeai/data/render/RenderTraceSpan$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JJI)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JJI)Lee/schimke/composeai/data/render/RenderTraceSpan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/RenderTraceSpan;Ljava/lang/String;Ljava/lang/String;JJIILjava/lang/Object;)Lee/schimke/composeai/data/render/RenderTraceSpan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDepth ()I
+	public final fun getDurationMicros ()J
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartMicros ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/RenderTraceSpan$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/RenderTraceSpan$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/RenderTraceSpan;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/RenderTraceSpan;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/RenderTraceSpan$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TestFailureDataProduct {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/TestFailureDataProduct;
+	public static final field KIND Ljava/lang/String;
+	public static final field SCHEMA_VERSION I
+	public final fun payloadFrom (Ljava/lang/Throwable;Ljava/lang/String;)Lkotlinx/serialization/json/JsonElement;
+	public static synthetic fun payloadFrom$default (Lee/schimke/composeai/data/render/TestFailureDataProduct;Ljava/lang/Throwable;Ljava/lang/String;ILjava/lang/Object;)Lkotlinx/serialization/json/JsonElement;
+}
+
+public final class ee/schimke/composeai/data/render/TraceEvent {
+	public static final field Companion Lee/schimke/composeai/data/render/TraceEvent$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DDIILjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DDIILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()D
+	public final fun component5 ()D
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DDIILjava/util/Map;)Lee/schimke/composeai/data/render/TraceEvent;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/TraceEvent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DDIILjava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/data/render/TraceEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/Map;
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getDurationMicros ()D
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhase ()Ljava/lang/String;
+	public final fun getProcessId ()I
+	public final fun getThreadId ()I
+	public final fun getTimestampMicros ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/TraceEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/TraceEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/TraceEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/TraceEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TraceEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TraceMetadata {
+	public static final field Companion Lee/schimke/composeai/data/render/TraceMetadata$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/data/render/TraceMetadata;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/TraceMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/TraceMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getComposeRuntimeTracingOnClasspath ()Z
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/TraceMetadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/TraceMetadata$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/TraceMetadata;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/TraceMetadata;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TraceMetadata$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TracePayload {
+	public static final field Companion Lee/schimke/composeai/data/render/TracePayload$Companion;
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/data/render/TraceMetadata;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/data/render/TraceMetadata;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lee/schimke/composeai/data/render/TraceMetadata;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/data/render/TraceMetadata;)Lee/schimke/composeai/data/render/TracePayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/TracePayload;Ljava/util/List;Ljava/lang/String;Lee/schimke/composeai/data/render/TraceMetadata;ILjava/lang/Object;)Lee/schimke/composeai/data/render/TracePayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayTimeUnit ()Ljava/lang/String;
+	public final fun getMetadata ()Lee/schimke/composeai/data/render/TraceMetadata;
+	public final fun getTraceEvents ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/TracePayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/TracePayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/TracePayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/TracePayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/TracePayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/CommonDataProducts {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/CommonDataProducts;
+	public final fun getDensity ()Lee/schimke/composeai/data/render/extensions/DataProductKey;
+	public final fun getImageArtifact ()Lee/schimke/composeai/data/render/extensions/DataProductKey;
+	public final fun getSemanticsSnapshot ()Lee/schimke/composeai/data/render/extensions/DataProductKey;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/DataExtension {
+	public abstract fun getDefaultConstraints ()Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public abstract fun getId-FO0b9DY ()Ljava/lang/String;
+	public abstract fun plan (Ljava/lang/Object;)Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtension$DefaultImpls {
+	public static fun getDefaultConstraints (Lee/schimke/composeai/data/render/extensions/DataExtension;)Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionCapability : java/lang/Comparable {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionCapability$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionCapability;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo-Rtxl4MM (Ljava/lang/String;)I
+	public static fun compareTo-Rtxl4MM (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/extensions/DataExtensionCapability$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/DataExtensionCapability$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-l1VYly0 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-zW_meVY (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionCapability$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionConstraints {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints$Companion;
+	public fun <init> ()V
+	public fun <init> (Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;)V
+	public synthetic fun <init> (Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun component4 ()Ljava/util/Set;
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun component7 ()Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public final fun copy (Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;)Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAfter ()Ljava/util/Set;
+	public final fun getBefore ()Ljava/util/Set;
+	public final fun getConflictsWith ()Ljava/util/Set;
+	public final fun getLifecycle ()Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public final fun getPhase ()Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public final fun getProvides ()Ljava/util/Set;
+	public final fun getRequires ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/extensions/DataExtensionConstraints$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionConstraints$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionDescriptor {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-FO0b9DY ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Z
+	public final fun copy-TwftIDk (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Z)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public static synthetic fun copy-TwftIDk$default (Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId-FO0b9DY ()Ljava/lang/String;
+	public final fun getRecordingScriptEvents ()Ljava/util/List;
+	public final fun getRequiresInteractive ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/extensions/DataExtensionDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionHookKind : java/lang/Enum {
+	public static final field AfterCapture Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field AfterRender Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field AroundComposable Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field BeforeRender Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind$Companion;
+	public static final field ComposableExtractor Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field CompositionObserver Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field Fetch Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field RenderFailure Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field ScenarioDriver Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static final field Subscription Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+	public static fun values ()[Lee/schimke/composeai/data/render/extensions/DataExtensionHookKind;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionHookKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionId : java/lang/Comparable {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionId;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo-JW1uwok (Ljava/lang/String;)I
+	public static fun compareTo-JW1uwok (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/extensions/DataExtensionId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/DataExtensionId$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-eDgpnLQ (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-3ZQhOA4 (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionLifecycle : java/lang/Enum {
+	public static final field AttachOnRender Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle$Companion;
+	public static final field ExplicitRerender Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static final field MultiFrame Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static final field OneShot Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static final field Subscribed Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+	public static fun values ()[Lee/schimke/composeai/data/render/extensions/DataExtensionLifecycle;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionLifecycle$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionPhase : java/lang/Enum {
+	public static final field Capture Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/DataExtensionPhase$Companion;
+	public static final field Instrumentation Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field OuterEnvironment Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field PostProcess Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field Publish Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field Scenario Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static final field UserEnvironment Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+	public static fun values ()[Lee/schimke/composeai/data/render/extensions/DataExtensionPhase;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionPhase$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionPlanner {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/DataExtensionPlanner;
+	public final fun plan (Ljava/util/List;Ljava/util/Set;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public static synthetic fun plan$default (Lee/schimke/composeai/data/render/extensions/DataExtensionPlanner;Ljava/util/List;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public final fun planOutputs (Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public static synthetic fun planOutputs$default (Lee/schimke/composeai/data/render/extensions/DataExtensionPlanner;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public final fun planRequest (Ljava/util/List;Ljava/lang/Object;Ljava/util/Set;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public static synthetic fun planRequest$default (Lee/schimke/composeai/data/render/extensions/DataExtensionPlanner;Ljava/util/List;Ljava/lang/Object;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionPlanningError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningError;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getExtensions ()Ljava/util/List;
+	public final fun getMessage ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataExtensionPlanningResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getErrors ()Ljava/util/List;
+	public final fun getOrderedExtensions ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isValid ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataExtensionTarget : java/lang/Enum {
+	public static final field Android Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;
+	public static final field Desktop Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;
+	public static fun values ()[Lee/schimke/composeai/data/render/extensions/DataExtensionTarget;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataProductKey : java/lang/Comparable {
+	public fun <init> (Ljava/lang/String;ILjava/lang/Class;)V
+	public fun compareTo (Lee/schimke/composeai/data/render/extensions/DataProductKey;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/Class;
+	public final fun copy (Ljava/lang/String;ILjava/lang/Class;)Lee/schimke/composeai/data/render/extensions/DataProductKey;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/DataProductKey;Ljava/lang/String;ILjava/lang/Class;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/DataProductKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getSchemaVersion ()I
+	public final fun getType ()Ljava/lang/Class;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/DataProductSink {
+	public abstract fun put (Lee/schimke/composeai/data/render/extensions/DataProductKey;Ljava/lang/Object;)V
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/DataProductSource {
+	public abstract fun get (Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+	public abstract fun require (Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataProductSource$DefaultImpls {
+	public static fun require (Lee/schimke/composeai/data/render/extensions/DataProductSource;Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/DataProductStore : ee/schimke/composeai/data/render/extensions/DataProductSink, ee/schimke/composeai/data/render/extensions/DataProductSource {
+	public abstract fun scopedFor (Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Lee/schimke/composeai/data/render/extensions/DataProductStore;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/DataProductStore$DefaultImpls {
+	public static fun require (Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+	public static fun scopedFor (Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Lee/schimke/composeai/data/render/extensions/DataProductStore;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionContextData {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/ExtensionContextData$Companion;
+	public final fun contains (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;)Z
+	public final fun get (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;)Ljava/lang/Object;
+	public final fun require (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;)Ljava/lang/Object;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionContextData$Companion {
+	public final fun getEmpty ()Lee/schimke/composeai/data/render/extensions/ExtensionContextData;
+	public final fun of ([Lee/schimke/composeai/data/render/extensions/ExtensionContextValue;)Lee/schimke/composeai/data/render/extensions/ExtensionContextData;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionContextDataKt {
+	public static final fun provides (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;Ljava/lang/Object;)Lee/schimke/composeai/data/render/extensions/ExtensionContextValue;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionContextKey {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Class;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Class;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Class;)Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;Ljava/lang/String;Ljava/lang/Class;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/Class;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionContextValue {
+	public fun <init> (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;Ljava/lang/Object;)V
+	public final fun component1 ()Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;Ljava/lang/Object;)Lee/schimke/composeai/data/render/extensions/ExtensionContextValue;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/ExtensionContextValue;Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;Ljava/lang/Object;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/ExtensionContextValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/ExtensionPostCaptureContext {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/ExtensionContextData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/ExtensionContextData;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-FO0b9DY ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lee/schimke/composeai/data/render/extensions/DataProductStore;
+	public final fun component5 ()Lee/schimke/composeai/data/render/extensions/ExtensionContextData;
+	public final fun copy-EAdUfCk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/ExtensionContextData;)Lee/schimke/composeai/data/render/extensions/ExtensionPostCaptureContext;
+	public static synthetic fun copy-EAdUfCk$default (Lee/schimke/composeai/data/render/extensions/ExtensionPostCaptureContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/data/render/extensions/DataProductStore;Lee/schimke/composeai/data/render/extensions/ExtensionContextData;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/ExtensionPostCaptureContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun get (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;)Ljava/lang/Object;
+	public final fun getData ()Lee/schimke/composeai/data/render/extensions/ExtensionContextData;
+	public final fun getExtensionId-FO0b9DY ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getProducts ()Lee/schimke/composeai/data/render/extensions/DataProductStore;
+	public final fun getRenderMode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun require (Lee/schimke/composeai/data/render/extensions/ExtensionContextKey;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/IrReplayComposableProvider {
+	public abstract fun getFormat ()Ljava/lang/String;
+	public abstract fun replayClass ()Ljava/lang/Class;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/IrReplayComposableProviderKt {
+	public static final fun loadIrReplayClass (Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/Class;
+	public static synthetic fun loadIrReplayClass$default (Ljava/lang/String;Ljava/lang/ClassLoader;ILjava/lang/Object;)Ljava/lang/Class;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/OrderedDataExtensionPlan {
+	public fun <init> (Ljava/util/List;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/List;Ljava/util/Set;)Lee/schimke/composeai/data/render/extensions/OrderedDataExtensionPlan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/OrderedDataExtensionPlan;Ljava/util/List;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/OrderedDataExtensionPlan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtensions ()Ljava/util/List;
+	public final fun getInitialCapabilities ()Ljava/util/Set;
+	public final fun getProvidedCapabilities ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/PlannedDataExtension {
+	public abstract fun getConstraints ()Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public abstract fun getHooks ()Ljava/util/Set;
+	public abstract fun getId-FO0b9DY ()Ljava/lang/String;
+	public abstract fun getInputs ()Ljava/util/Set;
+	public abstract fun getOutputs ()Ljava/util/Set;
+	public abstract fun getTargets ()Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/PlannedDataExtension$DefaultImpls {
+	public static fun getInputs (Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Ljava/util/Set;
+	public static fun getOutputs (Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Ljava/util/Set;
+	public static fun getTargets (Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Ljava/util/Set;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/PostCaptureProcessor : ee/schimke/composeai/data/render/extensions/PlannedDataExtension {
+	public abstract fun process (Lee/schimke/composeai/data/render/extensions/ExtensionPostCaptureContext;)V
+}
+
+public final class ee/schimke/composeai/data/render/extensions/PostCaptureProcessor$DefaultImpls {
+	public static fun getInputs (Lee/schimke/composeai/data/render/extensions/PostCaptureProcessor;)Ljava/util/Set;
+	public static fun getOutputs (Lee/schimke/composeai/data/render/extensions/PostCaptureProcessor;)Ljava/util/Set;
+	public static fun getTargets (Lee/schimke/composeai/data/render/extensions/PostCaptureProcessor;)Ljava/util/Set;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitutionKt {
+	public static final fun isStructuralPreviewWrapper (Ljava/lang/String;Ljava/lang/ClassLoader;)Z
+	public static synthetic fun isStructuralPreviewWrapper$default (Ljava/lang/String;Ljava/lang/ClassLoader;ILjava/lang/Object;)Z
+	public static final fun loadPreviewWrapperClass (Ljava/lang/String;Ljava/lang/ClassLoader;)Ljava/lang/Class;
+	public static synthetic fun loadPreviewWrapperClass$default (Ljava/lang/String;Ljava/lang/ClassLoader;ILjava/lang/Object;)Ljava/lang/Class;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitutionProvider {
+	public abstract fun isStructural (Ljava/lang/String;)Z
+	public abstract fun substituteFor (Ljava/lang/String;)Ljava/lang/Class;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitutionProvider$DefaultImpls {
+	public static fun isStructural (Lee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitutionProvider;Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RecordingDataProductStore : ee/schimke/composeai/data/render/extensions/DataProductStore {
+	public fun <init> ()V
+	public fun get (Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+	public fun put (Lee/schimke/composeai/data/render/extensions/DataProductKey;Ljava/lang/Object;)V
+	public fun require (Lee/schimke/composeai/data/render/extensions/DataProductKey;)Ljava/lang/Object;
+	public fun scopedFor (Lee/schimke/composeai/data/render/extensions/PlannedDataExtension;)Lee/schimke/composeai/data/render/extensions/DataProductStore;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensions {
+	public static final field ASSERT_A11Y_EVENT Ljava/lang/String;
+	public static final field ASSERT_NOT_VISIBLE_EVENT Ljava/lang/String;
+	public static final field ASSERT_PIXELS_EVENT Ljava/lang/String;
+	public static final field ASSERT_TEXT_EQUALS_EVENT Ljava/lang/String;
+	public static final field ASSERT_VISIBLE_EVENT Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensions;
+	public static final field PREVIEW_RELOAD_EVENT Ljava/lang/String;
+	public static final field PROBE_EVENT Ljava/lang/String;
+	public static final field STATE_RESTORE_EVENT Ljava/lang/String;
+	public static final field STATE_SAVE_EVENT Ljava/lang/String;
+	public final fun getAssertionA11yDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getAssertionAndroidDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getAssertionDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getDescriptors ()Ljava/util/List;
+	public final fun getRecordingDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getRoadmapDescriptors ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getSummary ()Ljava/lang/String;
+	public final fun getSupported ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RecordingScriptEventDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RenderDensity {
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lee/schimke/composeai/data/render/extensions/RenderDensity;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/RenderDensity;FILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/RenderDensity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDensity ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RenderImageArtifact {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/RenderImageArtifact;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/RenderImageArtifact;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/RenderImageArtifact;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMediaType ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RenderSemanticsSnapshot {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/RenderSemanticsSnapshot;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/RenderSemanticsSnapshot;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/RenderSemanticsSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHandle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/RenderSession {
+	public abstract fun getAppliedExtensionIds ()Ljava/util/Set;
+	public abstract fun isApplied-JW1uwok (Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RenderSession$DefaultImpls {
+	public static fun isApplied-JW1uwok (Lee/schimke/composeai/data/render/extensions/RenderSession;Ljava/lang/String;)Z
+}
+
+public abstract interface class ee/schimke/composeai/data/render/extensions/RenderSessionParticipant {
+	public abstract fun configureSession (Lee/schimke/composeai/data/render/extensions/RenderSession;)V
+	public abstract fun validateSession (Lee/schimke/composeai/data/render/extensions/RenderSession;)V
+}
+
+public final class ee/schimke/composeai/data/render/extensions/RenderSessionParticipant$DefaultImpls {
+	public static fun configureSession (Lee/schimke/composeai/data/render/extensions/RenderSessionParticipant;Lee/schimke/composeai/data/render/extensions/RenderSession;)V
+	public static fun validateSession (Lee/schimke/composeai/data/render/extensions/RenderSessionParticipant;Lee/schimke/composeai/data/render/extensions/RenderSession;)V
+}
+
+public final class ee/schimke/composeai/data/render/extensions/SimplePlannedDataExtension : ee/schimke/composeai/data/render/extensions/PlannedDataExtension {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-FO0b9DY ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public final fun component4 ()Ljava/util/Set;
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun copy-kyj7FFI (Ljava/lang/String;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;)Lee/schimke/composeai/data/render/extensions/SimplePlannedDataExtension;
+	public static synthetic fun copy-kyj7FFI$default (Lee/schimke/composeai/data/render/extensions/SimplePlannedDataExtension;Ljava/lang/String;Ljava/util/Set;Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/SimplePlannedDataExtension;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getConstraints ()Lee/schimke/composeai/data/render/extensions/DataExtensionConstraints;
+	public fun getHooks ()Ljava/util/Set;
+	public fun getId-FO0b9DY ()Ljava/lang/String;
+	public fun getInputs ()Ljava/util/Set;
+	public fun getOutputs ()Ljava/util/Set;
+	public fun getTargets ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/SimpleRenderSession : ee/schimke/composeai/data/render/extensions/RenderSession {
+	public static final field Companion Lee/schimke/composeai/data/render/extensions/SimpleRenderSession$Companion;
+	public fun <init> (Ljava/util/Set;)V
+	public final fun component1 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/Set;)Lee/schimke/composeai/data/render/extensions/SimpleRenderSession;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/extensions/SimpleRenderSession;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/extensions/SimpleRenderSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAppliedExtensionIds ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun isApplied-JW1uwok (Ljava/lang/String;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/extensions/SimpleRenderSession$Companion {
+	public final fun fromIdList (Ljava/lang/String;)Lee/schimke/composeai/data/render/extensions/SimpleRenderSession;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/ExtractionSpec {
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/ExtractionSpec$Companion;
+	public fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ZZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (Ljava/lang/String;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ZZZ)Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;Ljava/lang/String;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;ZZZILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAggregate ()Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getRequiresImage ()Z
+	public final fun getRequiresSemantics ()Z
+	public final fun getSampling ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/pipeline/ExtractionSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/ExtractionSpec$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/ExtractionSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PipelineCapability : java/lang/Enum {
+	public static final field AccessibilityFindings Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field AccessibilityNodes Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field AnimatedArtifact Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field AnnotatedImageArtifact Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PipelineCapability$Companion;
+	public static final field DeviceBackground Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field DeviceClip Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field DeviceGeometry Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field Frames Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field ImageArtifact Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field InteractiveSession Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field MultipleFrames Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field OverlayAnnotations Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field PreviewFunctionAnnotations Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field ScrollState Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field SemanticsSnapshot Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field SingleFrame Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field SuggestedPreviews Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static final field TraceEvents Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+	public static fun values ()[Lee/schimke/composeai/data/render/pipeline/PipelineCapability;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PipelineCapability$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PipelineStepTrait : java/lang/Enum {
+	public static final field AnnotationInspector Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field Check Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait$Companion;
+	public static final field DataExtractor Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field Encoder Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field ExtraPreviewSuggester Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field FinalArtifactProcessor Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field FrameProcessor Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field InteractiveDriver Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field Profiler Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static final field ScenarioDriver Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+	public static fun values ()[Lee/schimke/composeai/data/render/pipeline/PipelineStepTrait;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PipelineStepTrait$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PipelineValidationError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/data/render/pipeline/PipelineValidationError;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/PipelineValidationError;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/PipelineValidationError;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getSteps ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand {
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/Set;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/Set;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/util/Set;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/Set;Ljava/util/List;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZLjava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgentRecommended ()Z
+	public final fun getCommand ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProductKinds ()Ljava/util/List;
+	public final fun getRequiresDaemon ()Z
+	public final fun getSummary ()Ljava/lang/String;
+	public final fun getUsageModes ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog;
+	public final fun commandById (Ljava/lang/String;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionCliCommand;
+	public final fun getCommands ()Ljava/util/List;
+	public final fun getExtensions ()Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor {
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCliCommands ()Ljava/util/List;
+	public final fun getComponentExtensionIds ()Ljava/util/List;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getSteps ()Ljava/util/List;
+	public final fun getUsageModes ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionDescriptor$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode$Companion;
+	public static final field ExplicitEffect Lee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode;
+	public static final field SuggestedExtraPreview Lee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode;
+	public static fun values ()[Lee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewExtensionUsageMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewPipelinePlan {
+	public fun <init> (Ljava/util/List;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/List;Ljava/util/Set;)Lee/schimke/composeai/data/render/pipeline/PreviewPipelinePlan;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/PreviewPipelinePlan;Ljava/util/List;Ljava/util/Set;ILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/PreviewPipelinePlan;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInitialCapabilities ()Ljava/util/Set;
+	public final fun getProvidedCapabilities ()Ljava/util/Set;
+	public final fun getSteps ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewPipelineStep {
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public final fun component11 ()Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/util/Set;
+	public final fun component7 ()Ljava/util/Set;
+	public final fun component8 ()Ljava/util/Set;
+	public final fun component9 ()Ljava/util/Set;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;)Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public static synthetic fun copy$default (Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;ILjava/lang/Object;)Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotationFqns ()Ljava/util/List;
+	public final fun getConflictsWith ()Ljava/util/Set;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getExtraction ()Lee/schimke/composeai/data/render/pipeline/ExtractionSpec;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getProductKinds ()Ljava/util/List;
+	public final fun getProvides ()Ljava/util/Set;
+	public final fun getRequires ()Ljava/util/Set;
+	public final fun getSampling ()Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public final fun getTraits ()Ljava/util/Set;
+	public final fun getUsageModes ()Ljava/util/Set;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/data/render/pipeline/PreviewPipelineStep$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/data/render/pipeline/PreviewPipelineStep;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewPipelineStep$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/PreviewPipelineValidator {
+	public static final field INSTANCE Lee/schimke/composeai/data/render/pipeline/PreviewPipelineValidator;
+	public final fun validate (Lee/schimke/composeai/data/render/pipeline/PreviewPipelinePlan;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/SamplingPolicy : java/lang/Enum {
+	public static final field Aggregate Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static final field Companion Lee/schimke/composeai/data/render/pipeline/SamplingPolicy$Companion;
+	public static final field EachFrame Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static final field End Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static final field Failure Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static final field OnDemand Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static final field Start Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+	public static fun values ()[Lee/schimke/composeai/data/render/pipeline/SamplingPolicy;
+}
+
+public final class ee/schimke/composeai/data/render/pipeline/SamplingPolicy$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/data/render/core/build.gradle.kts
+++ b/data/render/core/build.gradle.kts
@@ -22,3 +22,23 @@ composeAiMavenPublishing {
   )
   inceptionYear.set("2026")
 }
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This module is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  //
+  // Everything here was already public by default and is already in a shipped ABI, so the
+  // annotations preserve the existing surface rather than changing it — narrowing any of these to
+  // `internal` would be a breaking change and is deliberately not part of this pass.
+  explicitApi()
+
+  // ABI dump gate, following `:rc-player-*` and `:daemon-client`. `checkKotlinAbi` diffs the real
+  // public ABI against the committed dump in `api/`, so a surface change is a diff in review rather
+  // than a downstream break. Regenerate with `./gradlew :data-render-core:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/IrSidecarChannel.kt
@@ -17,22 +17,22 @@ package ee.schimke.composeai.data.render
  * Best-effort: an offer outside a render (no current preview id) is a no-op, matching the
  * launcher-widget channel.
  */
-object IrSidecarChannel {
+public object IrSidecarChannel {
 
   /**
    * [format] values — kept in lockstep with `IR_FORMAT_*` in `:gradle-plugin`'s
    * `PreviewBundleFormat`.
    */
-  const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
+  public const val FORMAT_REMOTECOMPOSE: String = "remotecompose"
 
-  const val FORMAT_PROTOLAYOUT: String = "protolayout"
+  public const val FORMAT_PROTOLAYOUT: String = "protolayout"
 
   /**
    * One captured IR. [resourcesBytes] is non-null only for [FORMAT_PROTOLAYOUT] (the tile
    * `Resources` proto, written as the companion `.tileresources` sidecar); Remote Compose carries
    * everything in [bytes].
    */
-  data class IrCapture(
+  public data class IrCapture(
     val format: String,
     val bytes: ByteArray,
     val resourcesBytes: ByteArray? = null,
@@ -63,26 +63,26 @@ object IrSidecarChannel {
    * composition; clear in a `finally`. Producers read it via [offer] so they don't need an explicit
    * `previewId` parameter.
    */
-  fun setCurrentPreviewId(previewId: String?) {
+  public fun setCurrentPreviewId(previewId: String?) {
     if (previewId == null) currentPreviewIdHolder.remove()
     else currentPreviewIdHolder.set(previewId)
   }
 
   /** Current render thread's preview id, or `null` outside a render. */
-  fun currentPreviewId(): String? = currentPreviewIdHolder.get()
+  public fun currentPreviewId(): String? = currentPreviewIdHolder.get()
 
   /**
    * Producer-side: stash the captured IR for the current render's preview. No-op when no current
    * preview id is set (running outside a daemon/test render — bare unit tests, IDE preview pane). A
    * later offer within the same render replaces the previous entry.
    */
-  fun offer(format: String, bytes: ByteArray, resourcesBytes: ByteArray? = null) {
+  public fun offer(format: String, bytes: ByteArray, resourcesBytes: ByteArray? = null) {
     val previewId = currentPreviewIdHolder.get() ?: return
     pending[previewId] = IrCapture(format, bytes, resourcesBytes)
   }
 
   /** Drain (read + remove) the IR captured for [previewId] during the just-finished render. */
-  fun consume(previewId: String): IrCapture? = pending.remove(previewId)
+  public fun consume(previewId: String): IrCapture? = pending.remove(previewId)
 
   /**
    * Read the IR captured for [previewId] **without** removing it. Lets a consumer inspect a
@@ -91,5 +91,5 @@ object IrSidecarChannel {
    * matches, so it never swallows another format's capture (a protolayout tile) that a different
    * consumer is due to drain.
    */
-  fun peek(previewId: String): IrCapture? = pending[previewId]
+  public fun peek(previewId: String): IrCapture? = pending[previewId]
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/LinkBufferComposer.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/LinkBufferComposer.kt
@@ -72,27 +72,27 @@ package ee.schimke.composeai.data.render
  * on every lane, once per JVM, exactly like the opt-in itself. What it drops is the *build
  * failure*, not the report.
  */
-object LinkBufferComposer {
+public object LinkBufferComposer {
 
   /** System property that opts a render JVM into the rewritten `SlotTable`. */
-  const val PROPERTY: String = "composeai.render.linkBufferComposer"
+  public const val PROPERTY: String = "composeai.render.linkBufferComposer"
 
   /** The `auto` wire value — enable where available, degrade (and say so) where not. */
-  const val AUTO: String = "auto"
+  public const val AUTO: String = "auto"
 
   /** Fully-qualified name of the runtime's flag holder. */
-  const val FLAGS_CLASS: String = "androidx.compose.runtime.ComposeRuntimeFlags"
+  public const val FLAGS_CLASS: String = "androidx.compose.runtime.ComposeRuntimeFlags"
 
   /** Name of the static `Boolean` field on [FLAGS_CLASS]. */
-  const val FLAG_FIELD: String = "isLinkBufferComposerEnabled"
+  public const val FLAG_FIELD: String = "isLinkBufferComposerEnabled"
 
   /** What [applyIfRequested] did, so a caller can log it once per JVM rather than per capture. */
-  sealed interface Outcome {
+  public sealed interface Outcome {
     /** Not requested — the runtime keeps whatever default it ships with. */
-    object NotRequested : Outcome
+    public object NotRequested : Outcome
 
     /** The flag was set to `true` on this classloader's copy of [FLAGS_CLASS]. */
-    object Enabled : Outcome
+    public object Enabled : Outcome
 
     /**
      * Requested as [Request.Preferred], and this render's Compose runtime has no such flag — so the
@@ -101,11 +101,11 @@ object LinkBufferComposer {
      * Only reachable from `auto`. [Request.Required] throws instead, which is what keeps "I asked
      * for the new composer and got it" checkable.
      */
-    object Unavailable : Outcome
+    public object Unavailable : Outcome
   }
 
   /** How badly the caller wants the new composer. */
-  enum class Request {
+  public enum class Request {
     /** Unset, blank, or `false` — the runtime keeps whatever default it ships with. */
     Off,
 
@@ -125,7 +125,7 @@ object LinkBufferComposer {
    *
    * @throws IllegalArgumentException when [raw] is set but is none of `true` / `false` / [AUTO].
    */
-  fun request(raw: String? = System.getProperty(PROPERTY)): Request {
+  public fun request(raw: String? = System.getProperty(PROPERTY)): Request {
     val value = raw?.trim().orEmpty()
     if (value.isEmpty()) return Request.Off
     val lowercase = value.lowercase()
@@ -145,7 +145,8 @@ object LinkBufferComposer {
   }
 
   /** Whether [raw] asks for the new composer at all, strictly or otherwise. */
-  fun requested(raw: String? = System.getProperty(PROPERTY)): Boolean = request(raw) != Request.Off
+  public fun requested(raw: String? = System.getProperty(PROPERTY)): Boolean =
+    request(raw) != Request.Off
 
   /**
    * Applies the opt-in to [classLoader]'s copy of the Compose runtime, and reports what happened.
@@ -164,7 +165,7 @@ object LinkBufferComposer {
    *   `false` / [AUTO] (see [request]).
    */
   @JvmOverloads
-  fun applyIfRequested(
+  public fun applyIfRequested(
     classLoader: ClassLoader =
       Thread.currentThread().contextClassLoader ?: LinkBufferComposer::class.java.classLoader,
     raw: String? = System.getProperty(PROPERTY),
@@ -243,7 +244,7 @@ object LinkBufferComposer {
    * that got the new one say *that*.
    */
   @JvmStatic
-  fun applyAndDescribe(
+  public fun applyAndDescribe(
     classLoader: ClassLoader =
       Thread.currentThread().contextClassLoader ?: LinkBufferComposer::class.java.classLoader
   ): String? =

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PerfettoTraceDataProduct.kt
@@ -10,18 +10,18 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 
 /** Core producer/model for Perfetto-importable render trace artifacts. */
-object PerfettoTraceDataProducer {
-  const val KIND: String = "render/composeAiTrace"
-  const val SCHEMA_VERSION: Int = 1
-  const val FILE: String = "render-perfetto-trace.json"
-  const val ENABLED_PROP: String = "composeai.daemon.perfettoTrace"
+public object PerfettoTraceDataProducer {
+  public const val KIND: String = "render/composeAiTrace"
+  public const val SCHEMA_VERSION: Int = 1
+  public const val FILE: String = "render-perfetto-trace.json"
+  public const val ENABLED_PROP: String = "composeai.daemon.perfettoTrace"
 
   private val json = Json {
     encodeDefaults = false
     prettyPrint = false
   }
 
-  fun enabled(): Boolean = System.getProperty(ENABLED_PROP) == "true"
+  public fun enabled(): Boolean = System.getProperty(ENABLED_PROP) == "true"
 
   /**
    * Optional platform-tracing mirror for [Recorder.section] spans. When set, every named section
@@ -36,19 +36,19 @@ object PerfettoTraceDataProducer {
    * the backend is installed once per sandbox classloader. Backend failures must never fail a
    * render, so both calls are guarded at the call site.
    */
-  @Volatile var sectionBackend: TraceSectionBackend? = null
+  @Volatile public var sectionBackend: TraceSectionBackend? = null
 
   /** Begin/end pair for one [Recorder.section] span on a platform tracer. See [sectionBackend]. */
-  interface TraceSectionBackend {
-    fun begin(name: String)
+  public interface TraceSectionBackend {
+    public fun begin(name: String)
 
-    fun end()
+    public fun end()
   }
 
-  fun recorder(previewId: String, backend: String, enabled: Boolean = enabled()): Recorder =
+  public fun recorder(previewId: String, backend: String, enabled: Boolean = enabled()): Recorder =
     Recorder(previewId = previewId, backend = backend, enabled = enabled)
 
-  fun writeArtifacts(
+  public fun writeArtifacts(
     rootDir: File,
     previewId: String,
     trace: TracePayload,
@@ -60,7 +60,7 @@ object PerfettoTraceDataProducer {
     }
   }
 
-  class Recorder(
+  public class Recorder(
     private val previewId: String,
     private val backend: String,
     private val enabled: Boolean,
@@ -128,7 +128,7 @@ object PerfettoTraceDataProducer {
      * Open a section that [endSection] will close. Prefer [section] wherever the work is lexically
      * scoped — an unbalanced pair here silently mis-nests everything after it.
      */
-    fun beginSection(name: String, category: String = "compose-preview") {
+    public fun beginSection(name: String, category: String = "compose-preview") {
       // Mirror the span onto the platform tracer when one is installed (see [sectionBackend]).
       // Independent of [enabled] — the JSON recorder and an atrace capture are separate opt-ins —
       // and guarded so a tracer failure can never fail the render it's observing.
@@ -145,7 +145,7 @@ object PerfettoTraceDataProducer {
     }
 
     /** Close the innermost section opened by [beginSection]. Ignored when none is open. */
-    fun endSection() {
+    public fun endSection() {
       val open = openSections.removeLastOrNull() ?: return
       depth -= 1
       record(
@@ -163,7 +163,7 @@ object PerfettoTraceDataProducer {
       }
     }
 
-    fun <T> section(name: String, category: String = "compose-preview", block: () -> T): T {
+    public fun <T> section(name: String, category: String = "compose-preview", block: () -> T): T {
       beginSection(name = name, category = category)
       try {
         return block()
@@ -173,7 +173,7 @@ object PerfettoTraceDataProducer {
     }
 
     @JvmOverloads
-    fun record(
+    public fun record(
       name: String,
       category: String = "compose-preview",
       startNs: Long,
@@ -215,7 +215,7 @@ object PerfettoTraceDataProducer {
      * Snapshot semantics: call it after the outermost section has closed, or the phases still open
      * are simply absent. Cheap enough to call more than once.
      */
-    fun renderTrace(): RenderTrace =
+    public fun renderTrace(): RenderTrace =
       RenderTrace.of(
         backend = backend,
         events = spans.toList(),
@@ -256,7 +256,7 @@ object PerfettoTraceDataProducer {
         )
     }
 
-    fun payload(): TracePayload =
+    public fun payload(): TracePayload =
       TracePayload(
         traceEvents = events,
         metadata =
@@ -267,7 +267,7 @@ object PerfettoTraceDataProducer {
           ),
       )
 
-    fun write(rootDir: File) {
+    public fun write(rootDir: File) {
       if (enabled) writeArtifacts(rootDir = rootDir, previewId = previewId, trace = payload())
     }
 
@@ -302,14 +302,14 @@ internal object ComposeRuntimeTracingAvailability {
 }
 
 @Serializable
-data class TracePayload(
+public data class TracePayload(
   @SerialName("traceEvents") val traceEvents: List<TraceEvent>,
   val displayTimeUnit: String = "ms",
   val metadata: TraceMetadata,
 )
 
 @Serializable
-data class TraceMetadata(
+public data class TraceMetadata(
   val previewId: String,
   val backend: String,
   val format: String = "chrome-trace-json",
@@ -317,7 +317,7 @@ data class TraceMetadata(
 )
 
 @Serializable
-data class TraceEvent(
+public data class TraceEvent(
   val name: String,
   @SerialName("cat") val category: String,
   @SerialName("ph") val phase: String = "X",

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewContext.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewContext.kt
@@ -8,7 +8,7 @@ package ee.schimke.composeai.data.render
  * understand that runtime can cast and inspect them, while standalone renderers, daemon adapters,
  * and non-Compose producers stay decoupled from Compose internals.
  */
-data class PreviewContext(
+public data class PreviewContext(
   val previewId: String?,
   val backend: String?,
   val renderMode: String?,
@@ -18,7 +18,7 @@ data class PreviewContext(
   val inspection: PreviewInspectionContext = PreviewInspectionContext(),
   val animation: PreviewAnimationContext? = null,
 ) {
-  class Builder(
+  public class Builder(
     private val previewId: String?,
     private val backend: String?,
     private val renderMode: String?,
@@ -32,9 +32,9 @@ data class PreviewContext(
     private var parameterInformationCollected: Boolean = false
     private var rootForTest: Any? = null
 
-    fun device(device: PreviewDeviceContext): Builder = apply { this.device = device }
+    public fun device(device: PreviewDeviceContext): Builder = apply { this.device = device }
 
-    fun deviceFromRenderPixels(
+    public fun deviceFromRenderPixels(
       device: String?,
       widthPx: Int,
       heightPx: Int,
@@ -45,23 +45,27 @@ data class PreviewContext(
         PreviewDeviceContext.fromRenderPixels(device, widthPx, heightPx, density, resolvedDevice)
     }
 
-    fun frameTime(frameTime: PreviewFrameTime): Builder = apply { this.frameTime = frameTime }
+    public fun frameTime(frameTime: PreviewFrameTime): Builder = apply {
+      this.frameTime = frameTime
+    }
 
-    fun animation(animation: PreviewAnimationContext?): Builder = apply {
+    public fun animation(animation: PreviewAnimationContext?): Builder = apply {
       this.animation = animation
     }
 
-    fun addSlotTables(tables: Iterable<Any>): Builder = apply { slotTables.addAll(tables) }
+    public fun addSlotTables(tables: Iterable<Any>): Builder = apply { slotTables.addAll(tables) }
 
-    fun rootForTest(root: Any?): Builder = apply { rootForTest = root }
+    public fun rootForTest(root: Any?): Builder = apply { rootForTest = root }
 
-    fun putInspectionValue(key: String, value: Any): Builder = apply {
+    public fun putInspectionValue(key: String, value: Any): Builder = apply {
       inspectionValues[key] = value
     }
 
-    fun parameterInformationCollected(): Builder = apply { parameterInformationCollected = true }
+    public fun parameterInformationCollected(): Builder = apply {
+      parameterInformationCollected = true
+    }
 
-    fun build(): PreviewContext =
+    public fun build(): PreviewContext =
       PreviewContext(
         previewId = previewId,
         backend = backend,
@@ -81,9 +85,9 @@ data class PreviewContext(
   }
 }
 
-object PreviewBackends {
-  const val DESKTOP: String = "desktop"
-  const val ANDROID: String = "android"
+public object PreviewBackends {
+  public const val DESKTOP: String = "desktop"
+  public const val ANDROID: String = "android"
 }
 
 /**
@@ -94,7 +98,7 @@ object PreviewBackends {
  * as roundness; dimensions may differ from [resolvedDevice] when runtime overrides change the
  * render size.
  */
-data class PreviewDeviceContext(
+public data class PreviewDeviceContext(
   val device: String? = null,
   val widthDp: Double? = null,
   val heightDp: Double? = null,
@@ -104,8 +108,8 @@ data class PreviewDeviceContext(
   val isRound: Boolean
     get() = resolvedDevice?.isRound == true
 
-  companion object {
-    fun fromRenderPixels(
+  public companion object {
+    public fun fromRenderPixels(
       device: String?,
       widthPx: Int,
       heightPx: Int,
@@ -124,7 +128,7 @@ data class PreviewDeviceContext(
   }
 }
 
-data class PreviewDeviceSpec(
+public data class PreviewDeviceSpec(
   val widthDp: Int,
   val heightDp: Int,
   val density: Float,
@@ -138,12 +142,12 @@ data class PreviewDeviceSpec(
  * sample every frame should publish one context per sampled frame, or attach a
  * [PreviewAnimationContext] describing the sampled window.
  */
-data class PreviewFrameTime(
+public data class PreviewFrameTime(
   val mode: Mode = Mode.INITIAL_SETTLED_FRAME,
   val virtualTimeMs: Long? = null,
   val frameIndex: Int? = null,
 ) {
-  enum class Mode {
+  public enum class Mode {
     /** One-shot render after the backend has allowed effects/measure to settle. */
     INITIAL_SETTLED_FRAME,
     /** Deterministic animation or recording frame driven by virtual time. */
@@ -165,7 +169,7 @@ data class PreviewFrameTime(
  * Compose-aware data products inspect the same LayoutNode/semantics tree used by tooling without
  * adding a Compose UI dependency to the core render model.
  */
-data class PreviewInspectionContext(
+public data class PreviewInspectionContext(
   val slotTables: List<Any> = emptyList(),
   val rootForTest: Any? = null,
   val values: Map<String, Any> = emptyMap(),
@@ -181,7 +185,7 @@ data class PreviewInspectionContext(
  * clock to each [sampleTimesMs] entry, and publish sampled values without independently advancing
  * the render clock.
  */
-data class PreviewAnimationContext(
+public data class PreviewAnimationContext(
   val showCurves: Boolean,
   val requestedDurationMs: Int,
   val effectiveDurationMs: Int?,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
@@ -23,7 +23,7 @@ package ee.schimke.composeai.data.render
  * substring. Matching is case-sensitive, any pattern keeps the preview (OR across the list), and an
  * empty pattern list matches everything ("render every preview").
  */
-object PreviewFilter {
+public object PreviewFilter {
 
   /**
    * Prefix marking a pattern as an **exact** match rather than a substring one — the renderer-side
@@ -31,19 +31,19 @@ object PreviewFilter {
    * id is always a substring of its own `_VARIANT_` / row fan-out, so substring exclusion deletes
    * work a sharder meant to keep).
    */
-  const val ANCHOR: String = "="
+  public const val ANCHOR: String = "="
 
   /** System property carrying the comma-separated `--preview` name patterns. */
-  const val NAME_FILTER_PROPERTY: String = "composeai.preview.filter"
+  public const val NAME_FILTER_PROPERTY: String = "composeai.preview.filter"
 
   /** System property carrying the comma-separated `--preview-id` id patterns. */
-  const val ID_FILTER_PROPERTY: String = "composeai.preview.idFilter"
+  public const val ID_FILTER_PROPERTY: String = "composeai.preview.idFilter"
 
   /** System property carrying the comma-separated `--exclude-preview-id` id patterns. */
-  const val ID_EXCLUDE_PROPERTY: String = "composeai.preview.idExclude"
+  public const val ID_EXCLUDE_PROPERTY: String = "composeai.preview.idExclude"
 
   /** System property carrying the comma-separated `--exclude-preview-row` label patterns. */
-  const val ROW_EXCLUDE_PROPERTY: String = "composeai.preview.rowExclude"
+  public const val ROW_EXCLUDE_PROPERTY: String = "composeai.preview.rowExclude"
 
   /**
    * Reads one of the comma-separated pattern system properties into a cleaned list: split on `,`,
@@ -51,7 +51,7 @@ object PreviewFilter {
    * shape the plugin's property resolvers produce, so a single `-PcomposePreview.filter=A,B` or
    * `ORG_GRADLE_PROJECT_composePreview.filter=A,B` reaches both backends identically.
    */
-  fun patternsFrom(
+  public fun patternsFrom(
     property: String,
     read: (String) -> String? = System::getProperty,
   ): List<String> =
@@ -61,7 +61,11 @@ object PreviewFilter {
    * True when [functionName] (owned by [className]) matches at least one of [patterns], or when
    * [patterns] is empty.
    */
-  fun matches(patterns: Collection<String>, functionName: String, className: String): Boolean {
+  public fun matches(
+    patterns: Collection<String>,
+    functionName: String,
+    className: String,
+  ): Boolean {
     val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
     if (cleaned.isEmpty()) return true
     val fqName = fqName(className, functionName)
@@ -69,7 +73,7 @@ object PreviewFilter {
   }
 
   /** True when a preview **id** matches at least one of [patterns], or when [patterns] is empty. */
-  fun matchesId(patterns: Collection<String>, id: String): Boolean {
+  public fun matchesId(patterns: Collection<String>, id: String): Boolean {
     val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
     if (cleaned.isEmpty()) return true
     return cleaned.any { matchOne(it, id, id) }
@@ -80,7 +84,7 @@ object PreviewFilter {
    * is the owning class FQN (a synthetic `…Kt` holder for top-level functions), so only its package
    * segment is meaningful. Falls back to the bare function name in the default package.
    */
-  fun fqName(className: String, functionName: String): String {
+  public fun fqName(className: String, functionName: String): String {
     val pkg = className.substringBeforeLast('.', "")
     return if (pkg.isEmpty()) functionName else "$pkg.$functionName"
   }
@@ -109,7 +113,7 @@ object PreviewFilter {
    * Type-agnostic via the accessor lambdas so the image-render [ee.schimke.composeai.renderer]
    * entry and the XR entry can each pass their own row type.
    */
-  fun <T> select(
+  public fun <T> select(
     items: List<T>,
     nameFilters: List<String>,
     idFilters: List<String>,
@@ -129,7 +133,7 @@ object PreviewFilter {
    * [failOnNoMatch] (the default), else returns an empty list. See [select] for why a sibling view
    * passes `false`.
    */
-  fun <T> selectByName(
+  public fun <T> selectByName(
     items: List<T>,
     patterns: List<String>,
     functionName: (T) -> String,
@@ -151,7 +155,7 @@ object PreviewFilter {
   /**
    * Narrows [items] to those whose id matches [patterns]. No-match behaviour: see [selectByName].
    */
-  fun <T> selectById(
+  public fun <T> selectById(
     items: List<T>,
     patterns: List<String>,
     id: (T) -> String,
@@ -174,7 +178,7 @@ object PreviewFilter {
    * everything, throws if [failOnNoMatch] (the default) else returns the empty list — a
    * kind-restricted sibling may legitimately exclude its whole subset.
    */
-  fun <T> excludeById(
+  public fun <T> excludeById(
     items: List<T>,
     excludes: List<String>,
     id: (T) -> String,
@@ -280,7 +284,7 @@ object PreviewFilter {
    * - if every row matches, none is skipped: a preview that rendered nothing would publish as a
    *   component with no pixels, which is a misconfigured exclusion rather than a deferral.
    */
-  fun keptRowIndices(suffixes: List<String>, patterns: List<String>): List<Int> {
+  public fun keptRowIndices(suffixes: List<String>, patterns: List<String>): List<Int> {
     val all = suffixes.indices.toList()
     val cleaned = patterns.map(String::trim).filter(String::isNotEmpty)
     if (cleaned.isEmpty()) return all
@@ -292,7 +296,7 @@ object PreviewFilter {
   /**
    * True when a row [label] matches one of [patterns] — glob when it has `*`/`?`, else equality.
    */
-  fun matchesRowLabel(patterns: Collection<String>, label: String): Boolean =
+  public fun matchesRowLabel(patterns: Collection<String>, label: String): Boolean =
     patterns.map(String::trim).filter(String::isNotEmpty).any { pattern ->
       if (pattern.any { it == '*' || it == '?' })
         Regex(globToRegex(pattern).pattern, RegexOption.IGNORE_CASE).matches(label)

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewSizeQualifiers.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewSizeQualifiers.kt
@@ -25,7 +25,7 @@ package ee.schimke.composeai.data.render
  * A non-positive axis is dropped — the caller has nothing to say about it, so the previous
  * qualifier state stands.
  */
-fun previewSizeQualifiers(widthDp: Int, heightDp: Int): List<String> = buildList {
+public fun previewSizeQualifiers(widthDp: Int, heightDp: Int): List<String> = buildList {
   listOf(widthDp, heightDp).filter { it > 0 }.minOrNull()?.let { add("sw${it}dp") }
   if (widthDp > 0) add("w${widthDp}dp")
   if (heightDp > 0) add("h${heightDp}dp")
@@ -55,7 +55,7 @@ fun previewSizeQualifiers(widthDp: Int, heightDp: Int): List<String> = buildList
  * "spec:…,orientation=portrait"` has already been rotated into the dimensions by
  * `DeviceDimensions.resolve`, so there is no separate request left to consult.
  */
-fun previewOrientationQualifier(widthDp: Int, heightDp: Int, requested: String?): String? {
+public fun previewOrientationQualifier(widthDp: Int, heightDp: Int, requested: String?): String? {
   if (widthDp <= 0 || heightDp <= 0) return null
   if (widthDp != heightDp) return if (widthDp > heightDp) "land" else "port"
   return when (requested) {

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -8,15 +8,15 @@ import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 
 /** Pipeline metadata for built-in render-level preview extension steps. */
-object RenderPreviewExtension {
-  const val ID: String = "render"
-  const val KIND_DEVICE_CLIP: String = "render/deviceClip"
-  const val KIND_DEVICE_BACKGROUND: String = "render/deviceBackground"
-  const val KIND_TRACE: String = "render/trace"
-  const val KIND_COMPOSE_AI_TRACE: String = "render/composeAiTrace"
-  const val KIND_TEST_FAILURE: String = "test/failure"
+public object RenderPreviewExtension {
+  public const val ID: String = "render"
+  public const val KIND_DEVICE_CLIP: String = "render/deviceClip"
+  public const val KIND_DEVICE_BACKGROUND: String = "render/deviceBackground"
+  public const val KIND_TRACE: String = "render/trace"
+  public const val KIND_COMPOSE_AI_TRACE: String = "render/composeAiTrace"
+  public const val KIND_TEST_FAILURE: String = "test/failure"
 
-  val deviceClipProcessor: PreviewPipelineStep =
+  public val deviceClipProcessor: PreviewPipelineStep =
     PreviewPipelineStep(
       id = "render.deviceClip",
       displayName = "Device clip",
@@ -26,7 +26,7 @@ object RenderPreviewExtension {
       provides = setOf(PipelineCapability.DeviceClip, PipelineCapability.ImageArtifact),
     )
 
-  val deviceBackgroundProcessor: PreviewPipelineStep =
+  public val deviceBackgroundProcessor: PreviewPipelineStep =
     PreviewPipelineStep(
       id = "render.deviceBackground",
       displayName = "Device background",
@@ -36,7 +36,7 @@ object RenderPreviewExtension {
       provides = setOf(PipelineCapability.DeviceBackground, PipelineCapability.ImageArtifact),
     )
 
-  val renderTraceProfiler: PreviewPipelineStep =
+  public val renderTraceProfiler: PreviewPipelineStep =
     PreviewPipelineStep(
       id = "render.trace",
       displayName = "Render trace",
@@ -46,7 +46,7 @@ object RenderPreviewExtension {
       sampling = SamplingPolicy.Aggregate,
     )
 
-  val composeTraceProfiler: PreviewPipelineStep =
+  public val composeTraceProfiler: PreviewPipelineStep =
     PreviewPipelineStep(
       id = "render.composeAiTrace",
       displayName = "Compose composition trace",
@@ -56,7 +56,7 @@ object RenderPreviewExtension {
       sampling = SamplingPolicy.Aggregate,
     )
 
-  val overlayLegendProcessor: PreviewPipelineStep =
+  public val overlayLegendProcessor: PreviewPipelineStep =
     PreviewPipelineStep(
       id = "render.overlayLegend",
       displayName = "Overlay with legend",
@@ -65,7 +65,7 @@ object RenderPreviewExtension {
       provides = setOf(PipelineCapability.ImageArtifact, PipelineCapability.AnnotatedImageArtifact),
     )
 
-  val deviceClipDescriptor: PreviewExtensionDescriptor =
+  public val deviceClipDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "render-device-clip",
       displayName = "Device clip",
@@ -92,7 +92,7 @@ object RenderPreviewExtension {
       steps = listOf(deviceClipProcessor),
     )
 
-  val deviceBackgroundDescriptor: PreviewExtensionDescriptor =
+  public val deviceBackgroundDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "render-device-background",
       displayName = "Device background",
@@ -119,7 +119,7 @@ object RenderPreviewExtension {
       steps = listOf(deviceBackgroundProcessor),
     )
 
-  val renderTraceDescriptor: PreviewExtensionDescriptor =
+  public val renderTraceDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "render-trace",
       displayName = "Render trace",
@@ -147,7 +147,7 @@ object RenderPreviewExtension {
       steps = listOf(renderTraceProfiler),
     )
 
-  val composeTraceDescriptor: PreviewExtensionDescriptor =
+  public val composeTraceDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "compose-trace",
       displayName = "Compose composition trace",
@@ -174,7 +174,7 @@ object RenderPreviewExtension {
       steps = listOf(composeTraceProfiler),
     )
 
-  val overlayLegendDescriptor: PreviewExtensionDescriptor =
+  public val overlayLegendDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "overlay-legend",
       displayName = "Overlay with legend",

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTrace.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Serializable
  * nobody reads that precisely, and milliseconds would round most of a render's phases to zero.
  */
 @Serializable
-data class RenderTraceSpan(
+public data class RenderTraceSpan(
   val name: String,
   val category: String,
   @SerialName("startUs") val startMicros: Long,
@@ -33,7 +33,7 @@ data class RenderTraceSpan(
  * data.
  */
 @Serializable
-data class RenderTraceSection(
+public data class RenderTraceSection(
   val name: String,
   val category: String,
   val count: Int,
@@ -55,7 +55,7 @@ data class RenderTraceSection(
  * one is structured data on the wire and is always available.
  */
 @Serializable
-data class RenderTrace(
+public data class RenderTrace(
   /** Which engine produced it — `"desktop"`, `"android"`, `"android-live"`. */
   val backend: String,
   /** Wall time from the first span opening to the last one closing. */
@@ -78,7 +78,7 @@ data class RenderTrace(
    * recorder appends spans as they **close**, so a parent lands after its children and containment
    * would have to be reconstructed. A counter on the section stack is exact and costs nothing.
    */
-  data class Recorded(
+  public data class Recorded(
     val name: String,
     val category: String,
     val startNanos: Long,
@@ -86,7 +86,7 @@ data class RenderTrace(
     val depth: Int,
   )
 
-  companion object {
+  public companion object {
     /**
      * Build a trace from the recorder's closed sections, rebasing times onto the first span.
      *
@@ -109,7 +109,7 @@ data class RenderTrace(
      * them onto their own minimum while reporting the full duration would scale the bars correctly
      * but place every phase at the wrong offset.
      */
-    fun of(
+    public fun of(
       backend: String,
       events: List<Recorded>,
       sections: List<RenderTraceSection>? = null,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTraceDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderTraceDataProduct.kt
@@ -28,15 +28,15 @@ import kotlinx.serialization.json.putJsonObject
  *   (`"metrics"`) — a client should not have to infer that from `phases.size == 1`,
  * - `droppedSpans`, non-zero only if a pathologically long render blew the recorder's cap.
  */
-object RenderTraceDataProduct {
-  const val KIND: String = "render/trace"
-  const val SCHEMA_VERSION: Int = 2
+public object RenderTraceDataProduct {
+  public const val KIND: String = "render/trace"
+  public const val SCHEMA_VERSION: Int = 2
 
   /** `source` value when [payloadFrom] had real spans to work from. */
-  const val SOURCE_SPANS: String = "spans"
+  public const val SOURCE_SPANS: String = "spans"
 
   /** `source` value for the v1-shaped fallback: one synthetic phase covering `tookMs`. */
-  const val SOURCE_METRICS: String = "metrics"
+  public const val SOURCE_METRICS: String = "metrics"
 
   /**
    * Build the payload for one render.
@@ -47,7 +47,7 @@ object RenderTraceDataProduct {
    * backend) still get a usable, if coarse, answer.
    */
   @JvmOverloads
-  fun payloadFrom(metrics: Map<String, Long>, trace: RenderTrace? = null): JsonElement {
+  public fun payloadFrom(metrics: Map<String, Long>, trace: RenderTrace? = null): JsonElement {
     val totalMs = metrics["tookMs"]?.coerceAtLeast(0L) ?: 0L
     val spans = trace?.spans.orEmpty()
     return buildJsonObject {

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/TestFailureDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/TestFailureDataProduct.kt
@@ -8,11 +8,11 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 
-object TestFailureDataProduct {
-  const val KIND: String = "test/failure"
-  const val SCHEMA_VERSION: Int = 1
+public object TestFailureDataProduct {
+  public const val KIND: String = "test/failure"
+  public const val SCHEMA_VERSION: Int = 1
 
-  fun payloadFrom(cause: Throwable, phase: String = "unknown"): JsonElement {
+  public fun payloadFrom(cause: Throwable, phase: String = "unknown"): JsonElement {
     val stackFrames = cause.stackTrace.map { it.toString() }
     return buildJsonObject {
       put("status", "failed")

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -10,8 +10,11 @@ import kotlinx.serialization.Serializable
  * same key lets planner code stay protocol-compatible while extension implementations depend on
  * compile-time payload types instead of string joins.
  */
-data class DataProductKey<T : Any>(val kind: String, val schemaVersion: Int, val type: Class<T>) :
-  Comparable<DataProductKey<*>> {
+public data class DataProductKey<T : Any>(
+  val kind: String,
+  val schemaVersion: Int,
+  val type: Class<T>,
+) : Comparable<DataProductKey<*>> {
   init {
     require(kind.isNotBlank()) { "Data product kind must not be blank." }
     require(schemaVersion > 0) { "Data product schema version must be positive." }
@@ -24,31 +27,31 @@ data class DataProductKey<T : Any>(val kind: String, val schemaVersion: Int, val
 }
 
 /** Read-only view of declared inputs for an extension. */
-interface DataProductSource {
-  fun <T : Any> get(key: DataProductKey<T>): T?
+public interface DataProductSource {
+  public fun <T : Any> get(key: DataProductKey<T>): T?
 
-  fun <T : Any> require(key: DataProductKey<T>): T =
+  public fun <T : Any> require(key: DataProductKey<T>): T =
     get(key) ?: error("Data product '$key' is not available.")
 }
 
 /** Write-only view for emitting an extension's declared outputs. */
-interface DataProductSink {
-  fun <T : Any> put(key: DataProductKey<T>, value: T)
+public interface DataProductSink {
+  public fun <T : Any> put(key: DataProductKey<T>, value: T)
 }
 
 /** A small in-process product store used by downstream extensions to consume declared inputs. */
-interface DataProductStore : DataProductSource, DataProductSink {
+public interface DataProductStore : DataProductSource, DataProductSink {
   /**
    * Returns a per-extension view that enforces the declared `inputs`/`outputs` contract: `get` only
    * succeeds for keys in [PlannedDataExtension.inputs] (or already produced), `put` only for keys
    * in [PlannedDataExtension.outputs]. Use this to wrap the shared store before handing it to a
    * hook so contract drift is caught at runtime, not days later in a downstream consumer.
    */
-  fun scopedFor(extension: PlannedDataExtension): DataProductStore =
+  public fun scopedFor(extension: PlannedDataExtension): DataProductStore =
     ScopedDataProductStore(this, extension)
 }
 
-class RecordingDataProductStore : DataProductStore {
+public class RecordingDataProductStore : DataProductStore {
   private val values: MutableMap<DataProductKey<*>, Any> = linkedMapOf()
 
   override fun <T : Any> get(key: DataProductKey<T>): T? {
@@ -81,28 +84,28 @@ private class ScopedDataProductStore(
   }
 }
 
-data class RenderImageArtifact(val path: String, val mediaType: String = "image/png")
+public data class RenderImageArtifact(val path: String, val mediaType: String = "image/png")
 
-data class RenderSemanticsSnapshot(val handle: String)
+public data class RenderSemanticsSnapshot(val handle: String)
 
-data class RenderDensity(val density: Float)
+public data class RenderDensity(val density: Float)
 
-object CommonDataProducts {
-  val ImageArtifact: DataProductKey<RenderImageArtifact> =
+public object CommonDataProducts {
+  public val ImageArtifact: DataProductKey<RenderImageArtifact> =
     DataProductKey("render/image", schemaVersion = 1, RenderImageArtifact::class.java)
 
-  val SemanticsSnapshot: DataProductKey<RenderSemanticsSnapshot> =
+  public val SemanticsSnapshot: DataProductKey<RenderSemanticsSnapshot> =
     DataProductKey(
       "render/semanticsSnapshot",
       schemaVersion = 1,
       RenderSemanticsSnapshot::class.java,
     )
 
-  val Density: DataProductKey<RenderDensity> =
+  public val Density: DataProductKey<RenderDensity> =
     DataProductKey("render/density", schemaVersion = 1, RenderDensity::class.java)
 }
 
-enum class DataExtensionTarget {
+public enum class DataExtensionTarget {
   Android,
   Desktop,
 }
@@ -115,7 +118,7 @@ enum class DataExtensionTarget {
  */
 @Serializable
 @JvmInline
-value class DataExtensionId(val value: String) : Comparable<DataExtensionId> {
+public value class DataExtensionId(public val value: String) : Comparable<DataExtensionId> {
   init {
     require(value.isNotBlank()) { "Data extension id must not be blank." }
   }
@@ -133,7 +136,8 @@ value class DataExtensionId(val value: String) : Comparable<DataExtensionId> {
  */
 @Serializable
 @JvmInline
-value class DataExtensionCapability(val value: String) : Comparable<DataExtensionCapability> {
+public value class DataExtensionCapability(public val value: String) :
+  Comparable<DataExtensionCapability> {
   init {
     require(value.isNotBlank()) { "Data extension capability must not be blank." }
   }
@@ -144,7 +148,7 @@ value class DataExtensionCapability(val value: String) : Comparable<DataExtensio
 }
 
 @Serializable
-enum class DataExtensionPhase {
+public enum class DataExtensionPhase {
   OuterEnvironment,
   UserEnvironment,
   Instrumentation,
@@ -155,7 +159,7 @@ enum class DataExtensionPhase {
 }
 
 @Serializable
-enum class DataExtensionLifecycle {
+public enum class DataExtensionLifecycle {
   OneShot,
   Subscribed,
   AttachOnRender,
@@ -164,7 +168,7 @@ enum class DataExtensionLifecycle {
 }
 
 @Serializable
-enum class DataExtensionHookKind {
+public enum class DataExtensionHookKind {
   AroundComposable,
   ComposableExtractor,
   CompositionObserver,
@@ -178,7 +182,7 @@ enum class DataExtensionHookKind {
 }
 
 @Serializable
-data class DataExtensionConstraints(
+public data class DataExtensionConstraints(
   val phase: DataExtensionPhase = DataExtensionPhase.Instrumentation,
   val before: Set<DataExtensionId> = emptySet(),
   val after: Set<DataExtensionId> = emptySet(),
@@ -188,30 +192,30 @@ data class DataExtensionConstraints(
   val lifecycle: DataExtensionLifecycle = DataExtensionLifecycle.OneShot,
 )
 
-interface PlannedDataExtension {
-  val id: DataExtensionId
-  val hooks: Set<DataExtensionHookKind>
-  val constraints: DataExtensionConstraints
-  val inputs: Set<DataProductKey<*>>
+public interface PlannedDataExtension {
+  public val id: DataExtensionId
+  public val hooks: Set<DataExtensionHookKind>
+  public val constraints: DataExtensionConstraints
+  public val inputs: Set<DataProductKey<*>>
     get() = emptySet()
 
-  val outputs: Set<DataProductKey<*>>
+  public val outputs: Set<DataProductKey<*>>
     get() = emptySet()
 
-  val targets: Set<DataExtensionTarget>
+  public val targets: Set<DataExtensionTarget>
     get() = emptySet()
 }
 
-interface DataExtension<in Request> {
-  val id: DataExtensionId
-  val defaultConstraints: DataExtensionConstraints
+public interface DataExtension<in Request> {
+  public val id: DataExtensionId
+  public val defaultConstraints: DataExtensionConstraints
     get() = DataExtensionConstraints()
 
-  fun plan(request: Request): PlannedDataExtension?
+  public fun plan(request: Request): PlannedDataExtension?
 }
 
 @Serializable
-data class DataExtensionDescriptor(
+public data class DataExtensionDescriptor(
   val id: DataExtensionId,
   val displayName: String = id.value,
   val recordingScriptEvents: List<RecordingScriptEventDescriptor> = emptyList(),
@@ -226,7 +230,7 @@ data class DataExtensionDescriptor(
 )
 
 @Serializable
-data class RecordingScriptEventDescriptor(
+public data class RecordingScriptEventDescriptor(
   val id: String,
   val displayName: String = id,
   val summary: String = "",
@@ -256,11 +260,11 @@ data class RecordingScriptEventDescriptor(
  * The legacy aggregate [descriptors] (probe + roadmap) is retained for callers that haven't
  * migrated yet — see the deprecation note.
  */
-object RecordingScriptDataExtensions {
-  const val PROBE_EVENT: String = "recording.probe"
-  const val STATE_SAVE_EVENT: String = "state.save"
-  const val STATE_RESTORE_EVENT: String = "state.restore"
-  const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
+public object RecordingScriptDataExtensions {
+  public const val PROBE_EVENT: String = "recording.probe"
+  public const val STATE_SAVE_EVENT: String = "state.save"
+  public const val STATE_RESTORE_EVENT: String = "state.restore"
+  public const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
 
   /**
    * Assertion script events (Maestro-style `assertVisible` / `assertNotVisible`). Each resolves the
@@ -268,15 +272,15 @@ object RecordingScriptDataExtensions {
    * records [ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.FAILED] evidence when
    * the condition isn't met — turning a recording into a check the `record` command can gate on.
    */
-  const val ASSERT_VISIBLE_EVENT: String = "assert.visible"
-  const val ASSERT_NOT_VISIBLE_EVENT: String = "assert.notVisible"
+  public const val ASSERT_VISIBLE_EVENT: String = "assert.visible"
+  public const val ASSERT_NOT_VISIBLE_EVENT: String = "assert.notVisible"
 
   /**
    * `assert.textEquals` — resolves the event's `target` and fails unless the resolved node's text
    * equals the expected string carried in the event's existing `inputText` field (no new wire
    * field). The Maestro `assertVisible: "text"` / Espresso `withText` equivalent.
    */
-  const val ASSERT_TEXT_EQUALS_EVENT: String = "assert.textEquals"
+  public const val ASSERT_TEXT_EQUALS_EVENT: String = "assert.textEquals"
 
   /**
    * `assert.a11y` — runs the Android Accessibility Test Framework (ATF) against the **held
@@ -285,7 +289,7 @@ object RecordingScriptDataExtensions {
    * `ImageComposeScene` doesn't have. The threshold rides the event's `inputText` field (`errors`
    * default / `warnings`).
    */
-  const val ASSERT_A11Y_EVENT: String = "assert.a11y"
+  public const val ASSERT_A11Y_EVENT: String = "assert.a11y"
 
   /**
    * `assert.pixels` — golden-image assertion (issue #1967). Diffs the recorded frame at the event's
@@ -294,14 +298,14 @@ object RecordingScriptDataExtensions {
    * existing `inputText` field (no new wire field), resolved by the CLI against `--baseline-dir`.
    * Desktop-only today (it reads the frames the desktop session wrote); Android is a follow-up.
    */
-  const val ASSERT_PIXELS_EVENT: String = "assert.pixels"
+  public const val ASSERT_PIXELS_EVENT: String = "assert.pixels"
 
   /**
    * `recording.probe` descriptor with `supported = true`. Returned from each
    * `RenderHost.recordingScriptEventDescriptors()` that wires a real probe handler in its
    * recording-session registry (today: both desktop and android backends).
    */
-  val recordingDescriptor: DataExtensionDescriptor =
+  public val recordingDescriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("recording"),
       displayName = "Recording script markers",
@@ -322,7 +326,7 @@ object RecordingScriptDataExtensions {
    * semantics snapshot doesn't yet carry the refs the resolver needs). Hosts that don't wire them
    * simply omit this descriptor, so the MCP layer rejects `assert.*` up front for those daemons.
    */
-  val assertionDescriptor: DataExtensionDescriptor =
+  public val assertionDescriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("assertion"),
       displayName = "Recording assertions",
@@ -372,7 +376,7 @@ object RecordingScriptDataExtensions {
    * `assertionVisibilityDescriptor`, back when Android was `testTag`-only and text/pixels weren't
    * wired.)
    */
-  val assertionAndroidDescriptor: DataExtensionDescriptor =
+  public val assertionAndroidDescriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("assertion"),
       displayName = "Recording assertions",
@@ -416,7 +420,7 @@ object RecordingScriptDataExtensions {
    * run ATF against the held composition's `View` hierarchy; desktop omits it so `record_preview`
    * rejects `assert.a11y` up front for desktop daemons rather than letting it silently no-op.
    */
-  val assertionA11yDescriptor: DataExtensionDescriptor =
+  public val assertionA11yDescriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
       id = DataExtensionId("assertion-a11y"),
       displayName = "Recording accessibility assertions",
@@ -448,7 +452,7 @@ object RecordingScriptDataExtensions {
    * `lifecycle.event` →
    * [`LifecycleRecordingScriptEvents`][ee.schimke.composeai.daemon.LifecycleRecordingScriptEvents].
    */
-  val roadmapDescriptors: List<DataExtensionDescriptor> = emptyList()
+  public val roadmapDescriptors: List<DataExtensionDescriptor> = emptyList()
 
   /**
    * Combined list of [recordingDescriptor] + [roadmapDescriptors]. Retained for callers that build
@@ -456,10 +460,11 @@ object RecordingScriptDataExtensions {
    * `host.recordingScriptEventDescriptors() + roadmapDescriptors` so the host can opt in / out of
    * the supported half independently.
    */
-  val descriptors: List<DataExtensionDescriptor> = listOf(recordingDescriptor) + roadmapDescriptors
+  public val descriptors: List<DataExtensionDescriptor> =
+    listOf(recordingDescriptor) + roadmapDescriptors
 }
 
-data class SimplePlannedDataExtension(
+public data class SimplePlannedDataExtension(
   override val id: DataExtensionId,
   override val hooks: Set<DataExtensionHookKind> = emptySet(),
   override val constraints: DataExtensionConstraints = DataExtensionConstraints(),
@@ -468,7 +473,7 @@ data class SimplePlannedDataExtension(
   override val targets: Set<DataExtensionTarget> = emptySet(),
 ) : PlannedDataExtension
 
-data class OrderedDataExtensionPlan(
+public data class OrderedDataExtensionPlan(
   val extensions: List<PlannedDataExtension>,
   val initialCapabilities: Set<DataExtensionCapability> = emptySet(),
 ) {
@@ -478,13 +483,13 @@ data class OrderedDataExtensionPlan(
     }
 }
 
-data class DataExtensionPlanningError(
+public data class DataExtensionPlanningError(
   val code: String,
   val message: String,
   val extensions: List<DataExtensionId> = emptyList(),
 )
 
-data class DataExtensionPlanningResult(
+public data class DataExtensionPlanningResult(
   val orderedExtensions: List<PlannedDataExtension>,
   val errors: List<DataExtensionPlanningError>,
 ) {
@@ -492,8 +497,8 @@ data class DataExtensionPlanningResult(
     get() = errors.isEmpty()
 }
 
-object DataExtensionPlanner {
-  fun planOutputs(
+public object DataExtensionPlanner {
+  public fun planOutputs(
     extensions: List<PlannedDataExtension>,
     requestedOutputs: Set<DataProductKey<*>>,
     initialProducts: Set<DataProductKey<*>> = emptySet(),
@@ -558,7 +563,7 @@ object DataExtensionPlanner {
     )
   }
 
-  fun <Request> planRequest(
+  public fun <Request> planRequest(
     extensions: List<DataExtension<Request>>,
     request: Request,
     initialCapabilities: Set<DataExtensionCapability> = emptySet(),
@@ -568,7 +573,7 @@ object DataExtensionPlanner {
       initialCapabilities = initialCapabilities,
     )
 
-  fun plan(
+  public fun plan(
     extensions: List<PlannedDataExtension>,
     initialCapabilities: Set<DataExtensionCapability> = emptySet(),
   ): DataExtensionPlanningResult {

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/ExtensionContextData.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/ExtensionContextData.kt
@@ -11,34 +11,34 @@ package ee.schimke.composeai.data.render.extensions
  * Lives in :data-render-core so non-Compose hook contexts (e.g. [ExtensionPostCaptureContext]) can
  * use the same typed-key shape the Compose-side hooks already rely on.
  */
-data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
+public data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
   init {
     require(name.isNotBlank()) { "Extension context key name must not be blank." }
   }
 }
 
-data class ExtensionContextValue<T : Any>(val key: ExtensionContextKey<T>, val value: T)
+public data class ExtensionContextValue<T : Any>(val key: ExtensionContextKey<T>, val value: T)
 
-infix fun <T : Any> ExtensionContextKey<T>.provides(value: T): ExtensionContextValue<T> =
+public infix fun <T : Any> ExtensionContextKey<T>.provides(value: T): ExtensionContextValue<T> =
   ExtensionContextValue(this, value)
 
 /** Read-only typed container for [ExtensionContextKey] entries. */
-class ExtensionContextData
+public class ExtensionContextData
 private constructor(private val values: Map<ExtensionContextKey<*>, Any>) {
-  fun <T : Any> get(key: ExtensionContextKey<T>): T? {
+  public fun <T : Any> get(key: ExtensionContextKey<T>): T? {
     val value = values[key] ?: return null
     return key.type.cast(value)
   }
 
-  fun <T : Any> require(key: ExtensionContextKey<T>): T =
+  public fun <T : Any> require(key: ExtensionContextKey<T>): T =
     get(key) ?: error("Extension context value '${key.name}' is not available.")
 
-  fun contains(key: ExtensionContextKey<*>): Boolean = key in values
+  public fun contains(key: ExtensionContextKey<*>): Boolean = key in values
 
-  companion object {
-    val Empty: ExtensionContextData = ExtensionContextData(emptyMap())
+  public companion object {
+    public val Empty: ExtensionContextData = ExtensionContextData(emptyMap())
 
-    fun of(vararg values: ExtensionContextValue<*>): ExtensionContextData =
+    public fun of(vararg values: ExtensionContextValue<*>): ExtensionContextData =
       ExtensionContextData(values.associate { it.key to it.value })
   }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProvider.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/IrReplayComposableProvider.kt
@@ -19,15 +19,15 @@ import java.util.ServiceLoader
  * method and a public no-arg constructor, because the renderer instantiates it and invokes `Replay`
  * via `getDeclaredComposableMethod` exactly as it does `PreviewWrapperProvider.Wrap`.
  */
-interface IrReplayComposableProvider {
+public interface IrReplayComposableProvider {
   /**
    * The IR format this provider replays — matches `IrSidecarChannel.FORMAT_*` (e.g.
    * `remotecompose`).
    */
-  val format: String
+  public val format: String
 
   /** The class whose `@Composable Replay(bytes: ByteArray)` method renders the IR. */
-  fun replayClass(): Class<*>
+  public fun replayClass(): Class<*>
 }
 
 /**
@@ -35,7 +35,7 @@ interface IrReplayComposableProvider {
  * (the common non-bundle case, and any format without a connector). The renderer then falls back to
  * its normal class-reflection path. "First wins" in `ServiceLoader` order.
  */
-fun loadIrReplayClass(
+public fun loadIrReplayClass(
   format: String,
   classLoader: ClassLoader =
     Thread.currentThread().contextClassLoader ?: IrReplayComposableProvider::class.java.classLoader,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
@@ -9,16 +9,16 @@ package ee.schimke.composeai.data.render.extensions
  * Non-product context inputs the host hands to extensions go through [data] as typed
  * [ExtensionContextKey] entries.
  */
-data class ExtensionPostCaptureContext(
+public data class ExtensionPostCaptureContext(
   val extensionId: DataExtensionId,
   val previewId: String?,
   val renderMode: String?,
   val products: DataProductStore,
   val data: ExtensionContextData = ExtensionContextData.Empty,
 ) {
-  fun <T : Any> get(key: ExtensionContextKey<T>): T? = data.get(key)
+  public fun <T : Any> get(key: ExtensionContextKey<T>): T? = data.get(key)
 
-  fun <T : Any> require(key: ExtensionContextKey<T>): T = data.require(key)
+  public fun <T : Any> require(key: ExtensionContextKey<T>): T = data.require(key)
 }
 
 /**
@@ -31,6 +31,6 @@ data class ExtensionPostCaptureContext(
  * populated by upstream producers. Implementations should fail fast on missing required inputs via
  * `context.products.require(...)` and emit outputs with `context.products.put(key, value)`.
  */
-interface PostCaptureProcessor : PlannedDataExtension {
-  fun process(context: ExtensionPostCaptureContext)
+public interface PostCaptureProcessor : PlannedDataExtension {
+  public fun process(context: ExtensionPostCaptureContext)
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitution.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PreviewWrapperSubstitution.kt
@@ -19,12 +19,12 @@ import java.util.ServiceLoader
  * `Wrap(content: @Composable () -> Unit)` method, because the renderer constructs and invokes them
  * the same way it would the original.
  */
-interface PreviewWrapperSubstitutionProvider {
+public interface PreviewWrapperSubstitutionProvider {
   /**
    * Return the class to instantiate in place of [originalWrapperFqn], or null to leave the
    * resolution to the next provider (or fall through to a direct `Class.forName` on the original).
    */
-  fun substituteFor(originalWrapperFqn: String): Class<*>?
+  public fun substituteFor(originalWrapperFqn: String): Class<*>?
 
   /**
    * Whether [wrapperFqn] is a **structural** wrapper — see [isStructuralPreviewWrapper]. Providers
@@ -32,7 +32,7 @@ interface PreviewWrapperSubstitutionProvider {
    * installing its own applier / capture surface (the RemoteCompose one) declares it here so a
    * `themeProvider` override nests around it instead of replacing it.
    */
-  fun isStructural(wrapperFqn: String): Boolean = false
+  public fun isStructural(wrapperFqn: String): Boolean = false
 }
 
 /**
@@ -69,7 +69,7 @@ private val BUILT_IN_STRUCTURAL_WRAPPER_FQNS =
  * Consults [PreviewWrapperSubstitutionProvider.isStructural] on every registered service, so a
  * connector's own wrapper classes count too, then falls back to [BUILT_IN_STRUCTURAL_WRAPPER_FQNS].
  */
-fun isStructuralPreviewWrapper(
+public fun isStructuralPreviewWrapper(
   wrapperFqn: String,
   classLoader: ClassLoader =
     Thread.currentThread().contextClassLoader
@@ -88,7 +88,7 @@ fun isStructuralPreviewWrapper(
  * this from their `resolveWrapper` implementations so substitution behaves identically across
  * backends.
  */
-fun loadPreviewWrapperClass(
+public fun loadPreviewWrapperClass(
   originalWrapperFqn: String,
   classLoader: ClassLoader =
     Thread.currentThread().contextClassLoader

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/RenderSessionParticipant.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/RenderSessionParticipant.kt
@@ -10,17 +10,17 @@ package ee.schimke.composeai.data.render.extensions
  * a list of `CompositionLocal` overrides on Android) live on platform-specific subclasses /
  * holders; this interface is the generic surface every backend can rely on.
  */
-interface RenderSession {
+public interface RenderSession {
   /**
    * Ids of every data extension the host has opted into for this session. The Robolectric runner
    * derives this from `composeai.session.extensions`; the daemon derives it from the active
    * `RenderSpec`/subscription state. Extensions consult this to decide whether they're "on" — no
    * standalone toggle is plumbed through the gradle plugin or VS Code.
    */
-  val appliedExtensionIds: Set<DataExtensionId>
+  public val appliedExtensionIds: Set<DataExtensionId>
 
   /** Convenience predicate matching by id string. */
-  fun isApplied(id: DataExtensionId): Boolean = id in appliedExtensionIds
+  public fun isApplied(id: DataExtensionId): Boolean = id in appliedExtensionIds
 }
 
 /**
@@ -37,13 +37,13 @@ interface RenderSession {
  *    up for it. The canonical use is asserting `id in session.appliedExtensionIds` so a
  *    misconfigured render never silently produces data products without the matching opt-in.
  */
-interface RenderSessionParticipant {
+public interface RenderSessionParticipant {
   /**
    * Called once during session setup if this participant's id is in
    * [RenderSession.appliedExtensionIds]. Implementations register any session-wide configuration
    * they require (e.g. CompositionLocal overrides). No-op by default.
    */
-  fun configureSession(session: RenderSession) {}
+  public fun configureSession(session: RenderSession) {}
 
   /**
    * Called before this participant's per-render hooks run. Throws if the session is not in a valid
@@ -51,19 +51,19 @@ interface RenderSessionParticipant {
    * [RenderSession.appliedExtensionIds] (i.e. the host invoked the hook without opting the
    * extension in). Default: no-op (always valid).
    */
-  fun validateSession(session: RenderSession) {}
+  public fun validateSession(session: RenderSession) {}
 }
 
 /** Minimal, immutable [RenderSession] implementation backed by an explicit applied-id set. */
-data class SimpleRenderSession(override val appliedExtensionIds: Set<DataExtensionId>) :
+public data class SimpleRenderSession(override val appliedExtensionIds: Set<DataExtensionId>) :
   RenderSession {
-  companion object {
+  public companion object {
     /**
      * Parse a comma- or semicolon-separated string of extension ids (the format the gradle plugin
      * forwards via `composeai.session.extensions`) into a [SimpleRenderSession]. Blank / null input
      * yields an empty session.
      */
-    fun fromIdList(raw: String?): SimpleRenderSession {
+    public fun fromIdList(raw: String?): SimpleRenderSession {
       if (raw.isNullOrBlank()) return SimpleRenderSession(emptySet())
       val ids =
         raw

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
@@ -10,8 +10,8 @@ import ee.schimke.composeai.data.render.RenderPreviewExtension
  * single shrinkwrapped command surface they can list or route without depending on Android-only
  * extension modules or starting a daemon.
  */
-object PreviewExtensionCommandCatalog {
-  val extensions: List<PreviewExtensionDescriptor> =
+public object PreviewExtensionCommandCatalog {
+  public val extensions: List<PreviewExtensionDescriptor> =
     listOf(
       RenderPreviewExtension.deviceClipDescriptor,
       RenderPreviewExtension.deviceBackgroundDescriptor,
@@ -27,9 +27,11 @@ object PreviewExtensionCommandCatalog {
       scrollGif(),
     )
 
-  val commands: List<PreviewExtensionCliCommand> = extensions.flatMap { it.cliCommands }
+  public val commands: List<PreviewExtensionCliCommand> = extensions.flatMap { it.cliCommands }
 
-  fun commandById(id: String): PreviewExtensionCliCommand? = commands.firstOrNull { it.id == id }
+  public fun commandById(id: String): PreviewExtensionCliCommand? = commands.firstOrNull {
+    it.id == id
+  }
 
   private fun accessibilityHierarchy(): PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
  * available.
  */
 @Serializable
-data class PreviewPipelineStep(
+public data class PreviewPipelineStep(
   val id: String,
   val displayName: String = id,
   val productKinds: List<String> = emptyList(),
@@ -25,13 +25,13 @@ data class PreviewPipelineStep(
 )
 
 @Serializable
-enum class PreviewExtensionUsageMode {
+public enum class PreviewExtensionUsageMode {
   ExplicitEffect,
   SuggestedExtraPreview,
 }
 
 @Serializable
-data class PreviewExtensionDescriptor(
+public data class PreviewExtensionDescriptor(
   val id: String,
   val displayName: String = id,
   val usageModes: Set<PreviewExtensionUsageMode> = setOf(PreviewExtensionUsageMode.ExplicitEffect),
@@ -41,7 +41,7 @@ data class PreviewExtensionDescriptor(
 )
 
 @Serializable
-data class PreviewExtensionCliCommand(
+public data class PreviewExtensionCliCommand(
   val id: String,
   val displayName: String = id,
   val summary: String = "",
@@ -53,7 +53,7 @@ data class PreviewExtensionCliCommand(
 )
 
 @Serializable
-enum class PipelineStepTrait {
+public enum class PipelineStepTrait {
   ScenarioDriver,
   InteractiveDriver,
   AnnotationInspector,
@@ -67,7 +67,7 @@ enum class PipelineStepTrait {
 }
 
 @Serializable
-enum class PipelineCapability {
+public enum class PipelineCapability {
   Frames,
   SingleFrame,
   MultipleFrames,
@@ -89,7 +89,7 @@ enum class PipelineCapability {
 }
 
 @Serializable
-enum class SamplingPolicy {
+public enum class SamplingPolicy {
   Start,
   End,
   EachFrame,
@@ -99,7 +99,7 @@ enum class SamplingPolicy {
 }
 
 @Serializable
-data class ExtractionSpec(
+public data class ExtractionSpec(
   val kind: String,
   val sampling: SamplingPolicy,
   val requiresImage: Boolean = false,
@@ -107,7 +107,7 @@ data class ExtractionSpec(
   val aggregate: Boolean = false,
 )
 
-data class PreviewPipelinePlan(
+public data class PreviewPipelinePlan(
   val steps: List<PreviewPipelineStep>,
   val initialCapabilities: Set<PipelineCapability> = emptySet(),
 ) {
@@ -115,14 +115,14 @@ data class PreviewPipelinePlan(
     steps.fold(initialCapabilities) { provided, step -> provided + step.provides }
 }
 
-data class PipelineValidationError(
+public data class PipelineValidationError(
   val code: String,
   val message: String,
   val steps: List<String> = emptyList(),
 )
 
-object PreviewPipelineValidator {
-  fun validate(plan: PreviewPipelinePlan): List<PipelineValidationError> = buildList {
+public object PreviewPipelineValidator {
+  public fun validate(plan: PreviewPipelinePlan): List<PipelineValidationError> = buildList {
     val steps = plan.steps
 
     addAtMostOneTraitError(


### PR DESCRIPTION
#3824 preparation item 6, **final PR**. `:data-render-core` (230) and `:data-layoutinspector-core` (181) were the last two of the twelve `CONTRACT_PROJECTS` without an explicit API surface. **411 declarations**, matching the pre-measured count exactly (409 visibility + 2 return type).

With this merged, every project the contract probe compiles against has a recorded ABI:

| Module | Declarations | |
| --- | ---: | --- |
| `:daemon-client` | 57 | ✅ #4558 |
| eight small contracts | 166 | ✅ #4561 |
| `:daemon:core` | 776 | ✅ #4563 |
| `:data-render-core` + `:data-layoutinspector-core` | 411 | ⬅ this PR |
| **total** | **1410** | |

## Surface-preserving, like the rest

Both modules are published to Maven, so every implicitly-public declaration is *already in a shipped ABI* — `internal` would be a breaking change. This pass **records** the surface rather than deciding it. Same regime as #4561 and #4563; `:daemon-client` in #4558 remains the only module where narrowing was ever free, because it had never been published.

## 409 mechanical, 2 by hand

The two hand-fixed sites are `WireframeStyle.depthStrokes` and `WireframeStyle.clearAndSetDash`, whose inferred `IntArray` / `FloatArray` had to be written out. No constructor-`val` sites this time — the shape that stalled the fixer on `:daemon:core` simply doesn't occur here, and the applied-count guard confirmed convergence in one pass (409 errors, 409 applied) rather than my assuming it.

ktfmt added a trailing comma in four files where adding `public` pushed a parameter list past the column limit.

**The diff is mechanically verifiable as surface-preserving**: stripping `public` and the two type annotations from the new sources and comparing token streams against `HEAD` leaves only those four trailing commas. That check is worth more than reading 846 changed lines by eye, and it is what I actually relied on.

## Verifying the gate is not decorative

Falsified on `:data-render-core`:

```
EXIT WITH EXTRA PUBLIC FN: 1     BUILD FAILED
  <<<ABI has changed>>>
  +public final class ee/schimke/composeai/data/render/RenderTraceKt {
EXIT AFTER RESTORE:        0
```

The `check` → `checkKotlinAbi` wiring is the load-bearing half — KGP does not add it, so without it the gate is configured and never runs. Confirmed both `checkKotlinAbi` tasks execute under `check`, not just that `check` passes.

## Test plan

- `:data-render-core:check` and `:data-layoutinspector-core:check` — **green**, with `checkKotlinAbi` observed running under both
- Re-run after rebasing onto the post-#4563 `main`, not just on the base I built against
- `ktfmtFormat` applied; dumps regenerated afterwards (1532 + 2026 lines)
- 0 remaining explicit-API errors
- Gate falsified, then restored

Both module paths were already covered by `preview_server_contracts` in `.github/ci/ci-paths.json`, so no CI wiring change is needed.

Non-visual change (visibility modifiers and build wiring), so no rendered evidence applies.

## Expect inherited red

`main`'s three timing tests — `AndroidRippleFrameTest:121`, `LivePressRippleTest:92` (`:daemon:android`), `ServeStatusLiveFramesTest:127` (`:cli`). The failing subset varies per run, which is what establishes they are load-dependent rather than diff-caused. Analysis and a proposed patch in #4547.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_