### PR TITLE
fix(serve): a size refusal is a refusal on the motion route and in telemetry

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStats.kt
@@ -77,7 +77,17 @@ class BranchFetchStats(private val clock: () -> Long = System::currentTimeMillis
         is BranchFetch.Transport -> transport++
         is BranchFetch.TooLarge -> tooLarge++
       }
-      if (outcome !is BranchFetch.Ok && outcome !is BranchFetch.NotFound) {
+      // `lastFailure*` describes the **branch host**, which is what an operator reads it for — and
+      // [BranchFetchSnapshot.tooLarge] already says a size refusal is "not a fault of the branch
+      // host the way `throttled` and `unavailable` are", naming those three as the ones to alert
+      // on. Recording it here contradicted that: a catalog publishing one large asset showed up as
+      // the server's last failure, with its reason, next to a timestamp that reads as an incident.
+      // It belongs with `notFound` — a fact about what was published, counted and not alarmed on.
+      if (
+        outcome !is BranchFetch.Ok &&
+          outcome !is BranchFetch.NotFound &&
+          outcome !is BranchFetch.TooLarge
+      ) {
         lastFailureAtEpochMillis = clock()
         lastFailureReason = outcome.summary.take(MAX_REASON_CHARS)
       }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -8153,6 +8153,17 @@ class ServeHttpServer(
       // does not exist, which is what "The recorded interaction could not be loaded" meant for both
       // cases and what made diagnosing this lane a manual exercise. 503 with `Retry-After` says the
       // true thing to a browser, a monitor and a person reading a log alike.
+      //
+      // And a capture past the transport's envelope is a third thing again: it exists, it is not
+      // coming, and asking again will not shrink it. `TooLarge` carries no bytes and is not
+      // transient, so it lands in neither branch above by default — 404 for a file the branch is
+      // holding, which is the absence-versus-refusal confusion this block exists to end, arriving
+      // through the outcome added to end it elsewhere. 413 is the answer the rest of this server
+      // already gives for a body past a ceiling.
+      if (outcome is BranchFetch.TooLarge) {
+        call.respondText(outcome.summary, status = HttpStatusCode.PayloadTooLarge)
+        return
+      }
       if (outcome.isTransient) {
         call.response.headers.append(
           HttpHeaders.RetryAfter,

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BranchFetchStatsTest.kt
@@ -57,6 +57,26 @@ class BranchFetchStatsTest {
   }
 
   @Test
+  fun `a size refusal is counted but not alarmed on`() {
+    // `tooLarge`'s own documentation says it is "not a fault of the branch host the way `throttled`
+    // and `unavailable` are", and names those three as the ones to alert on — but the
+    // `lastFailure*`
+    // fields, which exist to describe the branch host, recorded it anyway. A catalog publishing one
+    // large asset then showed up as this server's last failure, with a reason and a timestamp that
+    // read as an incident.
+    //
+    // It belongs with `notFound`: a fact about what the producer published, worth its own counter
+    // and not worth waking anyone.
+    val stats = BranchFetchStats(clock = { 9L })
+    stats.record(BranchFetch.TooLarge(25L * 1024 * 1024))
+
+    val snap = stats.snapshot()!!
+    assertEquals(1, snap.tooLarge, "the refusal must still be visible as its own number")
+    assertNull(snap.lastFailureAtEpochMillis, "a large published asset is not a branch-host fault")
+    assertNull(snap.lastFailureReason)
+  }
+
+  @Test
   fun `the branch host's own failures carry a reason and a time`() {
     val stats = BranchFetchStats(clock = { 42L })
     stats.record(BranchFetch.Unavailable(503))

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1327,6 +1327,17 @@ class ServeHttpRoutingTest {
       answer = BranchFetch.NotFound
       assertEquals(404 to null, fetchMotion())
 
+      // A capture past the transport's envelope is a third answer again: it exists, it is not
+      // coming, and asking again will not shrink it. It carries no bytes and is not transient, so
+      // without a case of its own it lands in the 404 branch — a file the branch is holding,
+      // reported as one that was never published. That is the absence-versus-refusal confusion this
+      // whole route exists to end, arriving through the outcome added to end it elsewhere.
+      //
+      // Not 503 either: `Retry-After` on something that will be exactly as oversized next time is a
+      // promise the server cannot keep.
+      answer = BranchFetch.TooLarge(25L * 1024 * 1024)
+      assertEquals(413 to null, fetchMotion())
+
       // …and once the branch serves it, it serves.
       answer = BranchFetch.Ok("capture".toByteArray())
       assertEquals(200 to null, fetchMotion())


### PR DESCRIPTION
Two gaps left by #4552, which introduced `BranchFetch.TooLarge` but did not reach these. Both were found reviewing #4559, which I closed as superseded by #4552 — the first is @chatgpt-codex-connector's P2 there, which on checking applies to `main` rather than to that branch.

## 1. An over-sized capture is reported as absent

`ServeHttpServer.handleMotion` maps every byte-less, non-transient outcome to 404:

```kotlin
if (outcome.isTransient) { … 503 + Retry-After … } else { … 404 … }
```

`TooLarge` is byte-less and not transient, so a published capture past the 25 MiB envelope lands in the 404 branch — **a file the branch is holding, reported as one that was never published.** That is the absence-versus-refusal confusion this route exists to end, arriving through the outcome that was added to end it elsewhere.

It is a regression in the strict sense: before `TooLarge` existed, the size error was an `IllegalArgumentException` that `ServeBundleHost.motionFile`'s `runCatching` converted into `BranchFetch.Transport`, and the route answered 503. That was also wrong — `Retry-After` on something that will be exactly as oversized next time is a promise the server cannot keep — so this is not a restoration of the old behaviour but the third answer neither branch was giving.

Now 413, which is what the rest of this server already answers for a body past a ceiling.

## 2. A size refusal reads as a branch-host incident

`BranchFetchSnapshot.tooLarge` documents itself:

> Not a fault of the branch host the way `throttled` and `unavailable` are — the file arrived, it is simply bigger than this server will carry

and the type's header names `throttled`/`unavailable`/`transport` as the ones to alert on. But `BranchFetchStats.record` still folds it into `lastFailureAtEpochMillis`/`lastFailureReason`, which exist to describe the branch host. So a catalog publishing one large asset shows up as this server's last failure, with a reason and a timestamp that read as an incident.

It now sits with `notFound`: counted in its own number, not alarmed on. The counter itself is unchanged — the point is that it is visible *as a size refusal* rather than as an outage.

## Tests

- `a capture the branch is refusing is a 503, not a 404` gains the `TooLarge` case. That test already walks `Throttled` → 503 with the branch's own interval, `Unavailable` → 503 with a usable one, `NotFound` → 404, `Ok` → 200; adding 413 puts all five answers in one place, which is where the next person deciding what a new outcome should return will look.
- `a size refusal is counted but not alarmed on` — asserts the counter climbs *and* the failure fields stay null, so the fix cannot be "stop counting it".

Both verified to fail with only the source change reverted (tests kept in place):

```
BranchFetchStatsTest > a size refusal is counted but not alarmed on() FAILED
ServeHttpRoutingTest > a capture the branch is refusing is a 503, not a 404() FAILED
```

- `:cli:test` — all passing
- `check-serve-seam` — `OK — 151 crossing symbol(s)`

Non-visual (route status mapping and telemetry), so no rendered before/after applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_