### PR TITLE
test(serve): record fetch byte ceilings in a concurrent map

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -7,6 +7,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.zip.ZipInputStream
 import javax.imageio.ImageIO
@@ -2315,7 +2316,11 @@ class ServeCatalogStoreTest {
          {"path":"images/button/ideal__default.png","previewId":"ButtonPreview"}]}]}
       """
         .trimIndent()
-    val requestedLimits = linkedMapOf<String, Long>()
+    // Written from the `serve-catalog-fetch` pool (up to ASSET_FETCH_CONCURRENCY threads call the
+    // transport at once), so the recorder has to be concurrent and the assertions have to run off a
+    // snapshot — a plain map races put-with-put and iteration-with-put. Insertion order is not
+    // relied on: both assertions select by key.
+    val requestedLimits = ConcurrentHashMap<String, Long>()
     // Outcome-shaped like the seam it stands in for: one transport, so no lane can reach the
     // network around an injected one.
     val networkFetch: (String, Long) -> BranchFetch = { url, maxBytes ->
@@ -2345,13 +2350,11 @@ class ServeCatalogStoreTest {
       )
 
     assertTrue(store.load("jetsnack") is ServeCatalogStore.Result.Ok)
-    assertEquals(
-      25L * 1024 * 1024,
-      requestedLimits.entries.single { it.key.endsWith("/catalog.json") }.value,
-    )
+    val limits = requestedLimits.toMap()
+    assertEquals(25L * 1024 * 1024, limits.entries.single { it.key.endsWith("/catalog.json") }.value)
     assertEquals(
       ServeCatalogStore.MAX_LIVE_BUNDLE_FETCH_BYTES,
-      requestedLimits.entries.single { it.key.endsWith("bundle/bundle.png") }.value,
+      limits.entries.single { it.key.endsWith("bundle/bundle.png") }.value,
     )
     assertTrue(builderCalled)
   }


### PR DESCRIPTION
Fixes #4556.

## Summary

`live bundles use the larger dedicated download envelope` recorded the byte ceiling each URL was fetched with into a plain `linkedMapOf`. That recorder *is* the injected transport, and `fetchCatalogAssetsToFiles` calls it from a pool of up to `ASSET_FETCH_CONCURRENCY` (12) `serve-catalog-fetch` threads — so `put` raced `put`, and the assertions iterated the map with `entries.single { … }` while a straggler worker could still be writing. That second hazard is the `ConcurrentModificationException` seen once in a full `:cli:test` run (3173 tests, 1 failed).

The fix is the test's own bookkeeping, not the code under test: `ConcurrentHashMap` for the recorder, and assert against a `toMap()` snapshot. Insertion order is not relied on — both assertions select by key (`it.key.endsWith(…)`).

## The other collectors in this class

The issue asked for a sweep of anything else the same pool can write to:

- `requested` / `asked` / `unsettled` — already `CopyOnWriteArrayList`. This is the pattern `requestedLimits` had missed.
- `buildCalls` (~line 3338) and `cleared` (~line 1903) — written from the `buildTrustedSource` / `buildTrustedBundles` / `clearTrustedBundles` seams, which `ServeCatalogStore` invokes on the calling `load` thread (`ServeCatalogStore.kt:1084`, `1165`, `1214`), all outside the fetch pool. There is also no `@TestInstance(PER_CLASS)` and no parallel-execution config, so each test gets its own instance. Not exposed to this race; left alone.

So `requestedLimits` was the only one.

## Test plan

- `./gradlew :cli:test --tests '*ServeCatalogStoreTest*'` — **not yet green in this environment**: every attempt so far has failed during dependency resolution with `429 Too Many Requests` from `repo.maven.apache.org` (`kotlin-util-klib-metadata`, `kotlin-build-tools-api`, `com.gradleup.tapmoc`), i.e. the build never reached the test task. A retry-with-backoff loop is still running locally. CI on this PR is the real verification.
- No product behaviour changes — the diff is confined to one test's recorder and its assertions, so the risk of the untested state is a compile error at worst, which CI catches immediately.

Text-only evidence is correct here: nothing visual changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGSXKvVUW7CEkzNLqDtKxB)_