### PR TITLE
fix(serve): three guards the artifact index needs before it is executed

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2182,8 +2182,22 @@ class ServeCatalogStore(
    * which is what makes this purely additive. An index that parses and names nothing is a different
    * answer: an empty list, honoured as one.
    */
-  private fun knownDifferenceArtifactPlan(base: String, documentBytes: ByteArray): List<String> =
-    publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
+  private fun knownDifferenceArtifactPlan(base: String, documentBytes: ByteArray): List<String> {
+    // **The document's own length gates everything, index or no index.**
+    //
+    // Past [ServeKnownDifferences.MAX_DOCUMENT_BYTES] the reader answers `TooLarge` and the engine
+    // refuses the document whole — reading not one artifact. So every byte fetched for one is a
+    // byte fetched for no verdict, and at the caps that is 512 individually legal files on every
+    // refresh. The transport's ceiling is 25× the contract's, so a document in that band arrives
+    // intact, its index arrives intact, and preferring the index walked straight past the guard
+    // that made this cheap.
+    //
+    // This is **not** the derivation coming back. It is one property of a file already in hand,
+    // measured rather than interpreted — the cheapest fact there is, and the only class of verdict
+    // a fetch planner has to know in advance. The per-record rules stay where they belong.
+    if (documentBytes.size > ServeKnownDifferences.MAX_DOCUMENT_BYTES) return emptyList()
+    return publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
+  }
 
   /**
    * The producer's artifact list, or null when this catalog publishes none.
@@ -2213,9 +2227,21 @@ class ServeCatalogStore(
 
     val paths = LinkedHashSet<String>()
     for (entry in artifacts) {
-      val path = (entry as? JsonPrimitive)?.takeIf { it.isString }?.content ?: continue
-      // The reader's own lexical rule, applied to the producer's list exactly as it is applied to
-      // the document's. A list is a convenience, not a licence.
+      // **A wrongly-typed entry rejects the whole index**, rather than being skipped past.
+      //
+      // Skipping looks harmless and is the opposite: `{"artifacts":[null]}` would reduce to an
+      // empty list, and an empty list is honoured as a producer saying "I carried nothing" — so a
+      // document naming perfectly good artifacts would stage none of them and every record would
+      // read as `artifact-unreadable`. That is the changed-verdict failure this file exists to
+      // prevent, reached through the malformed-index fallback that was written to prevent it.
+      //
+      // Returning null instead hands the caller back to the derivation, which is what "this
+      // producer published no usable index" has to mean for every other malformation here.
+      val path = (entry as? JsonPrimitive)?.takeIf { it.isString }?.content ?: return null
+      // A path that parses but names something this host will not look up is a different case: the
+      // reader's own lexical rule, applied to the producer's list exactly as it is applied to the
+      // document's. One refused path does not make the list unreadable — a list is a convenience,
+      // not a licence, and this is the licence half.
       if (ServeKnownDifferences.isLookupPath(path)) paths += path
     }
     return paths.toList()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -717,6 +717,56 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `an index does not stage artifacts for a document past the byte ceiling`() {
+    // The transport's envelope is 25x the contract's, so a document between the two arrives intact
+    // and its index arrives with it — but the reader answers `TooLarge` and the engine refuses the
+    // document whole, reading not one artifact. Preferring the index walked straight past the
+    // length guard that made that cheap, so 512 individually legal files could be fetched and
+    // staged on every refresh for a verdict that names none of them.
+    val oversized =
+      """{"schema":"compose-preview-known-differences/v1","acceptances":[],"pad":"""" +
+        "x".repeat(ServeKnownDifferences.MAX_DOCUMENT_BYTES) +
+        """"}"""
+    val (_, requested) =
+      loadWithArtifactIndex(
+        """
+        {"schema":"compose-preview-known-difference-artifacts/v1",
+         "artifacts":["glyph/mask.png","glyph/accepted-candidate.png"]}
+        """
+          .trimIndent(),
+        document = oversized,
+      )
+
+    assertTrue(
+      requested.none { it.contains("/parity/known-differences/") },
+      "artifacts were staged for a document the reader refuses whole: $requested",
+    )
+  }
+
+  @Test
+  fun `an index with a wrongly typed entry falls back rather than staging nothing`() {
+    // Skipping a malformed entry looks harmless and is the opposite: the list reduces to a shorter
+    // one — possibly empty — and an empty list is honoured as the producer saying it carried
+    // nothing. A document naming perfectly good artifacts would then stage none of them and every
+    // record would read as `artifact-unreadable`, which is the changed-verdict failure reached
+    // through the fallback written to prevent it.
+    // `[null]` rather than `["glyph/mask.png", null]`: with a surviving entry, skipping and
+    // rejecting both end up fetching that entry, so the assertion would pass either way and prove
+    // nothing. The list that reduces to *empty* is the one where the two behaviours diverge.
+    val (_, requested) =
+      loadWithArtifactIndex(
+        """{"schema":"compose-preview-known-difference-artifacts/v1","artifacts":[null]}""",
+        document = DERIVATION_ACCEPTS,
+      )
+
+    // Fell back to the derivation, which this document supports — so the artifacts still arrive.
+    assertTrue(
+      requested.any { it.endsWith("/parity/known-differences/glyph/mask.png") },
+      "a wrongly-typed entry must reject the index, not silently empty it: $requested",
+    )
+  }
+
+  @Test
   fun `an index cannot name a path the reader would refuse to look up`() {
     // A fetch plan, not a licence. The producer's list goes through exactly the lexical rule the
     // document's paths do, so an index is never a way around it.


### PR DESCRIPTION
Three review findings on #4562 from @chatgpt-codex-connector. All three arrived within five minutes of that PR merging — two before, one after — so none was addressed and all three are on `main`. Each was verified against the merged code before being fixed.

## 1 (P1). The document's byte ceiling stopped gating the fetch plan

`knownDifferenceArtifactPaths` opens with a length guard, and preferring the index skipped past it:

```kotlin
publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
```

The transport's envelope is **25× the contract's**, so a document between 1 MiB and 25 MiB arrives intact and its index arrives with it. `ServeKnownDifferences.document` then answers `TooLarge`, the engine refuses the document **whole** and reads not one artifact — while up to 512 individually legal files have been fetched and staged for a verdict that names none of them. On every refresh.

The guard now sits in the plan chooser, ahead of the index.

Not the derivation creeping back, since removing it was the point of #4520: this is **one property of a file already in hand, measured rather than interpreted** — the cheapest fact available, and the only class of verdict a fetch planner has to know in advance. The per-record rules stay unmirrored.

## 2 (P2). A malformed entry silently emptied the list instead of rejecting it

```kotlin
val path = (entry as? JsonPrimitive)?.takeIf { it.isString }?.content ?: continue
```

`{"artifacts":[null]}` reduced to an empty list — and an empty list is deliberately honoured as a producer saying "I carried nothing". So a document naming perfectly good artifacts staged **none** of them, and every record read as `artifact-unreadable`: the changed-verdict failure reached through the fallback written to prevent it.

A wrongly-typed entry now returns null, handing the caller back to the derivation. A path that *parses* but fails `isLookupPath` stays filtered rather than fatal — a broken file and a producer naming something this host will not look up are different, and one refused path does not make the rest unreadable.

## 3 (P2). Two spellings of one file raced each other

`glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable, and on Windows or a default macOS volume they are **one file**. The plan is executed by a worker pool, so staging both schedules two workers writing the same path: last writer wins, and the canonical spelling left on disk may be the one `ServeKnownDifferences.artifact` then rejects for case. A record's real artifact overwritten by a sibling the document never named, differently on each refresh.

Reachable specifically through the index, which may legitimately carry siblings the document does not name. Framed as a **staging invariant** — never schedule two writes that can land on one file — rather than a contract rule being mirrored. The whole list is rejected rather than one spelling dropped: nothing here can know which the producer meant.

## Left alone deliberately, and raised on the thread

The **derivation has the same case-folding hazard** — `mask: "m.png"` with `acceptedCandidate: "M.PNG"` in one record — and always has. #4520 named it as one of three families deliberately unmirrored, on the reasoning that their absence "costs a wasted fetch". With concurrent writes that is incomplete: it costs nondeterministic file content.

Not changed here. It is long-standing documented behaviour rather than something #4562 introduced, and revisiting #4520's reasoning is the author's call, not a side effect of fixing the index. Raised on that thread with the proposed one-line change.

## Tests

- `an index does not stage artifacts for a document past the byte ceiling`
- `an index with a wrongly typed entry falls back rather than staging nothing`
- `an index naming two spellings of one file falls back`

Each verified to fail with only its own source change reverted.

The second one is worth flagging: my first version used `["glyph/mask.png", null]` and **passed with the fix reverted** — with a surviving entry, skipping and rejecting both end up fetching it. It uses `[null]` now, the case where the two behaviours actually diverge. That is the second vacuous fixture I have written in this area; both were caught by reverting the source and re-running, which is why that step is not optional here.

- `:cli:test` — all passing
- `check-serve-seam` — `OK — 151 crossing symbol(s)`

Non-visual (staging plumbing), so no rendered before/after applies.