### PR TITLE
fix(cli): restore ktfmt formatting in ServeCatalogStoreTest

### DIFF
--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -2401,7 +2401,10 @@ class ServeCatalogStoreTest {
 
     assertTrue(store.load("jetsnack") is ServeCatalogStore.Result.Ok)
     val limits = requestedLimits.toMap()
-    assertEquals(25L * 1024 * 1024, limits.entries.single { it.key.endsWith("/catalog.json") }.value)
+    assertEquals(
+      25L * 1024 * 1024,
+      limits.entries.single { it.key.endsWith("/catalog.json") }.value,
+    )
     assertEquals(
       ServeCatalogStore.MAX_LIVE_BUNDLE_FETCH_BYTES,
       limits.entries.single { it.key.endsWith("bundle/bundle.png") }.value,


### PR DESCRIPTION
## Summary

**`main` is currently red on the format check, and this fixes it.**

#4568 landed with the first `assertEquals` in `live bundles use the larger dedicated download envelope` collapsed onto a single 101-column line — one character over ktfmt's googleStyle limit. The `ktfmt (Google style)` job has been failing on `main` ever since, naming this file:

```
src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
BUILD FAILED in 59s
```

[Format Check run 33068582833](https://github.com/yschimke/compose-ai-tools/actions/runs/33068582833) on `eba916b` — the commit before it (`8f5fcce`) was green.

This wraps the call the way ktfmt does, matching the sibling `assertEquals` three lines below it. Formatting only; the assertion, its arguments, and every other line are untouched.

## How this got in

Honest account, since it's the useful part: I spotted the over-length line myself and pushed the wrapped version to the #4568 branch — but #4568 was squash-merged in the seconds before that push landed, so the merge took the unwrapped commit and my fix stayed on the branch. I read the "merged" event as the end state and reported the PR as done without re-checking what had actually landed on `main`. The lesson is that a force-push racing a merge needs the merge commit re-read afterwards, not the local branch trusted.

## Test plan

- `./gradlew :cli:ktfmtCheck` — **still not runnable in this environment**: every attempt (including for #4568) dies in dependency resolution with `429 Too Many Requests` from `repo.maven.apache.org`, so the build never reaches the task. This diff was verified by measuring the line in characters (101 → wrapped, longest resulting line 71) and confirming that every other >100-column line in the file sits inside a `"""` raw-string JSON fixture that ktfmt cannot break. The `ktfmt (Google style)` job on this PR is the real check.

Text-only evidence is correct here: whitespace change in a test file, nothing visual.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGSXKvVUW7CEkzNLqDtKxB)_