### PR TITLE
fix(serve): reject an artifact index naming two spellings of one file

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2244,6 +2244,24 @@ class ServeCatalogStore(
       // not a licence, and this is the licence half.
       if (ServeKnownDifferences.isLookupPath(path)) paths += path
     }
+
+    // **Two spellings of one file is a malformed list, not a longer one.**
+    //
+    // `glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable, and on Windows or
+    // a default macOS volume they are *one file*. The plan is executed concurrently, so staging
+    // both schedules two workers writing the same path: whichever finishes last wins, and the
+    // canonical spelling left on disk may be the one `ServeKnownDifferences.artifact` then rejects
+    // for case. A record's real artifact can be overwritten by a sibling the document never named,
+    // differently on each refresh.
+    //
+    // Reachable specifically through the index, which may legitimately carry siblings the document
+    // does not name — so this is not a contract rule being mirrored, it is a staging invariant:
+    // never schedule two writes that can land on one file. Rejecting the whole list rather than
+    // dropping one spelling, because nothing here can know which the producer meant, and the
+    // fallback is the honest answer for a list this host cannot execute safely.
+    val collision = paths.groupingBy { it.lowercase() }.eachCount().any { it.value > 1 }
+    if (collision) return null
+
     return paths.toList()
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -768,6 +768,38 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `an index naming two spellings of one file falls back`() {
+    // `glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable, and on Windows or
+    // a default macOS volume they are one file. The plan is executed concurrently, so staging both
+    // schedules two workers writing the same path — last writer wins, and the canonical spelling
+    // left behind may be the one the reader then rejects for case. A record's real artifact can be
+    // overwritten by a sibling the document never named, differently on each refresh.
+    //
+    // Reachable through the index in particular, because it may carry siblings the document does
+    // not name.
+    val (_, requested) =
+      loadWithArtifactIndex(
+        """
+        {"schema":"compose-preview-known-difference-artifacts/v1",
+         "artifacts":["glyph/mask.png","glyph/MASK.PNG"]}
+        """
+          .trimIndent(),
+        document = DERIVATION_ACCEPTS,
+      )
+
+    // Fell back to the derivation, which names one spelling per field — so the staging plan is
+    // executable again.
+    assertTrue(
+      requested.none { it.contains("MASK.PNG") },
+      "a case-folded collision must reject the list, not race two writes: $requested",
+    )
+    assertTrue(
+      requested.any { it.endsWith("/parity/known-differences/glyph/mask.png") },
+      "the fallback should still stage the document's own artifacts: $requested",
+    )
+  }
+
+  @Test
   fun `an index cannot name a path the reader would refuse to look up`() {
     // A fetch plan, not a licence. The producer's list goes through exactly the lexical rule the
     // document's paths do, so an index is never a way around it.


### PR DESCRIPTION
Re-lands the third of the three findings on #4562. **It missed #4569**: that PR merged at `6f73151` with the first two fixes, and I pushed this commit to the branch afterwards, so it sat on a dead branch and never reached `main`. Verified absent from `main` before re-landing.

The finding is @chatgpt-codex-connector's on #4562, answered [there](https://github.com/yschimke/compose-ai-tools/pull/4562#discussion_r3871432234).

## The defect

`glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable under §4, and on Windows or a default macOS volume they are **one file**.

The fetch plan is executed by a worker pool, so staging both is not two fetches — it is **two workers writing the same path**. Last writer wins, and the canonical spelling left on disk may be the one `ServeKnownDifferences.artifact` then rejects for case. A record's real artifact can be overwritten by a sibling the document never named, differently on each refresh.

Reachable specifically through the index, which may legitimately carry siblings the document does not name.

## The fix

```kotlin
val collision = paths.groupingBy { it.lowercase() }.eachCount().any { it.value > 1 }
if (collision) return null
```

Framed as a **staging invariant** — never schedule two writes that can land on one file — rather than a contract rule being mirrored, which matters given #4520 exists to stop this host interpreting the contract.

The whole list is rejected rather than one spelling dropped: nothing here can know which the producer meant, and the fallback is the honest answer for a list this host cannot execute safely.

## Still not changed, and still the author's call

The **derivation has the same hazard** — `mask: "m.png"` with `acceptedCandidate: "M.PNG"` in one record — and always has. #4520 named it as deliberately unmirrored because its absence "costs a wasted fetch"; with concurrent writes that is incomplete, since it costs nondeterministic file content. Revisiting that reasoning belongs to whoever owns it, not to a fix for the index. The change would be the same one line applied to the derivation's output.

## Test

`an index naming two spellings of one file falls back` — verified to fail with the guard removed. It asserts both directions: `MASK.PNG` is never fetched, **and** the fallback still stages the document's own `mask.png`, so the fix cannot be "reject everything".

- `:cli:test` — all passing
- `check-serve-seam` — `OK — 151 crossing symbol(s)`
- `ktfmtCheckMain` + `ktfmtCheckTest` — clean

Non-visual (staging plumbing), so no rendered before/after applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_