### PR TITLE
fix(serve): close the convergence and ownership gaps in the dirty model

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1127,6 +1127,12 @@ class ServeHttpServer(
               return@post
             }
             val dropped = withContext(Dispatchers.IO) { cache.dropPersisted() }
+            // Wake the pass, exactly as the regenerate route does. A drop leaves a catalog that
+            // was warm everywhere full of gaps, and a converged catalog's optimizer task has
+            // already exited — so without this the 200 advertises a rewarming that waits on the
+            // capacity-limited resume rotation, or on a visitor's heartbeat, before it starts. The
+            // drop is the more urgent of the two, not the less: every preview is cold now.
+            if (dropped) withContext(Dispatchers.IO) { sessions.wakeOptimizer(system) }
             call.response.headers.append(HttpHeaders.CacheControl, "no-store")
             call.respondText(
               Json.encodeToString(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -145,6 +145,13 @@ class ThemeCacheStore(
     if (existing != null && existing.toolVersion == inputs.toolVersion)
       return MarkOutcome.NOT_NEEDED
     val createdAt = existing?.createdAtEpochMillis?.takeIf { it > 0 } ?: clock()
+    // Renders are here that this build did not write. Usually the manifest says so; when it is
+    // MISSING OR CORRUPT it says nothing, and "says nothing" was being read as "this build created
+    // the generation". A manifest write interrupted mid-flight leaves exactly that state beside a
+    // full set of another build's PNGs, which would then open with a zero boundary, verify on a
+    // five-entry sample, and never be regenerated. Files of unknown ownership are not ours.
+    val inherited =
+      existing != null || dir.listFiles()?.any { it.name.endsWith(PNG_SUFFIX) } == true
     // A DIFFERENT build is opening renders another one wrote, so everything already here is dirty.
     // On a generation this build created there is nothing older to mark, and the boundary stays at
     // zero.
@@ -159,7 +166,7 @@ class ThemeCacheStore(
     //
     // The cost is that some of this build's OWN early renders fall under the boundary and are
     // re-rendered once. That is the right direction to be wrong in.
-    val boundary = if (existing != null) clock() + graceMillis else 0L
+    val boundary = if (inherited) clock() + graceMillis else 0L
     val wrote = runCatching {
       file.writeText(
         json.encodeToString(
@@ -179,7 +186,7 @@ class ThemeCacheStore(
     // re-render of a catalog the volume could not record anything about, which is the right
     // direction to be wrong in.
     return when {
-      existing == null -> MarkOutcome.NOT_NEEDED
+      !inherited -> MarkOutcome.NOT_NEEDED
       wrote -> MarkOutcome.RECORDED
       else -> MarkOutcome.UNRECORDED
     }
@@ -473,6 +480,23 @@ class ThemeCacheStore(
         // not the same answer as ours.
         if (modified != writtenAt) dirtyNames += name
       }
+      // The reconcile is itself a way of REACHING convergence, and in the ordinary case — no
+      // co-replica overwrote anything — it is the last thing that happens: the dirty set emptied
+      // some time ago and the at-risk set empties here, with no further write to notice. Leaving
+      // the clear to `put` alone stranded the future-dated boundary in the manifest for exactly the
+      // rollout this bookkeeping exists to serve.
+      clearBoundaryIfConverged()
+    }
+
+    /**
+     * Drop the durable boundary once every render on this volume is one this process made, and
+     * nothing it wrote during a rollout overlap is still unverified.
+     *
+     * Called from both places convergence can be reached — the write that clears the last dirty
+     * name, and the reconcile that clears the last at-risk one — because either can be the last.
+     */
+    private fun clearBoundaryIfConverged() {
+      if (dirtyBefore > 0L && dirtyNames.isEmpty() && atRiskWrites.isEmpty()) clearDirtyBoundary()
     }
 
     /** Whether [cacheKey] is on disk from an older build and has not been re-rendered since. */
@@ -510,23 +534,39 @@ class ThemeCacheStore(
      * them, so asking for a refresh does not cost every preview a cold render.
      */
     fun markAllDirty(): Int {
-      val now = clock()
-      // Persist FIRST, and refuse to claim the mark if it did not land. The contract this action
-      // sells is that a request survives the next roll; a full or read-only volume would otherwise
-      // leave the boundary in memory only, answer the operator 200 with a queued count, and forget
-      // the whole thing at the next restart — the one failure a durable-sounding API must not have.
-      val persisted = runCatching {
-        val file = File(dir, MANIFEST_NAME)
-        val existing = json.decodeFromString(GenerationInputs.serializer(), file.readText())
-        file.writeText(json.encodeToString(existing.copy(dirtyBeforeEpochMillis = now)))
+      // Under the generation write lock, because the transition races the one thing that undoes it.
+      // A render publishing the last dirty entry calls `clearDirtyBoundary` from inside `put`,
+      // which holds this lock — so an unlocked mark could write its boundary, be overwritten by
+      // that older in-flight convergence, then repopulate `dirtyNames` and report a durable mark
+      // that is not on disk. Regeneration would proceed in this process and a restart before it
+      // finished would silently forget the rest of the operator's request.
+      val generationWriteLock = tryGenerationWriteLock() ?: return -1
+      try {
+        val now = clock()
+        // Persist FIRST, and refuse to claim the mark if it did not land. The contract this action
+        // sells is that a request survives the next roll; a full or read-only volume would
+        // otherwise leave the boundary in memory only, answer the operator 200 with a queued count,
+        // and forget the whole thing at the next restart — the one failure a durable-sounding API
+        // must not have.
+        val persisted = runCatching {
+          val file = File(dir, MANIFEST_NAME)
+          val existing = json.decodeFromString(GenerationInputs.serializer(), file.readText())
+          file.writeText(json.encodeToString(existing.copy(dirtyBeforeEpochMillis = now)))
+        }
+          .onFailure { recordFailure(system, "manifest: ${it.message}") }
+          .isSuccess
+        if (!persisted) return -1
+        dirtyBefore = now
+        // Everything on disk predates a boundary set to now, so the whole of `present` is dirty.
+        dirtyNames.addAll(present)
+        // A mark supersedes the overlap bookkeeping: every one of those entries is dirty now, so
+        // there is nothing left for the reconcile to decide, and leaving it populated would block
+        // the convergence clear for a window that has already been overtaken.
+        atRiskWrites.clear()
+        return dirtyNames.size
+      } finally {
+        generationWriteLock.close()
       }
-        .onFailure { recordFailure(system, "manifest: ${it.message}") }
-        .isSuccess
-      if (!persisted) return -1
-      dirtyBefore = now
-      // Everything on disk predates a boundary set to now, so the whole of `present` is dirty.
-      dirtyNames.addAll(present)
-      return dirtyNames.size
     }
 
     // Per-generation counters. The store-wide ones next to them answer "is the volume being used";
@@ -637,7 +677,7 @@ class ThemeCacheStore(
         // grace window into the FUTURE, so leaving it behind would have the next start reclassify
         // this build's own early renders as another build's work and regenerate them again, once
         // per restart, forever.
-        if (dirtyBefore > 0L && dirtyNames.isEmpty() && atRiskWrites.isEmpty()) clearDirtyBoundary()
+        clearBoundaryIfConverged()
         writes.incrementAndGet()
         generationWrites.incrementAndGet()
         knownBytes.addAndGet(png.size.toLong() - previousSize)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -441,6 +441,88 @@ class ThemeCachePersistenceTest {
     )
   }
 
+  /**
+   * A manifest that says nothing is not a manifest saying "this build made these".
+   *
+   * A write interrupted mid-flight leaves exactly this: a full set of another build's PNGs beside a
+   * missing or unparseable manifest. Reading that absence as "we created the generation" opens it
+   * with a zero boundary, and a five-entry sample then verifies renders nobody can account for.
+   */
+  @Test
+  fun `renders beside an unreadable manifest are of unknown ownership, so dirty`() {
+    val root = tempDir()
+    val fp = "fp-a"
+    val first = assertNotNull(store(root).open("m3-catalog", fp, inputs(fp)))
+    first.put("preview|dark", ByteArray(8) { 1 })
+    first.put("preview|light", ByteArray(8) { 2 })
+    ageRenders(root, "m3-catalog", fp, byMillis = 10_000)
+    assertTrue(File(File(File(root, "m3-catalog"), fp), ThemeCacheStore.MANIFEST_NAME).delete())
+
+    // Same tool version, so nothing about the BUILD says these are suspect — only the fact that
+    // the volume can no longer account for them.
+    val next = assertNotNull(store(root).open("m3-catalog", fp, inputs(fp)))
+    assertEquals(
+      2,
+      next.dirtyCount(),
+      "a manifest that cannot say who wrote these is not evidence that we did",
+    )
+  }
+
+  /**
+   * The reconcile is a way of reaching convergence, so it has to be able to finish the job.
+   *
+   * In the ordinary rollout — nobody overwrote anything — the dirty set empties first and the
+   * at-risk set empties later, in the reconcile, with no further write to notice. Leaving the clear
+   * to `put` alone strands the future-dated boundary in the manifest, which is the very thing that
+   * re-dirties this build's own renders on the next restart.
+   */
+  @Test
+  fun `convergence reached by the overlap reconcile clears the boundary too`() {
+    val root = tempDir()
+    val fp = "fp-a"
+    val first = assertNotNull(store(root).open("m3-catalog", fp, inputs(fp)))
+    first.put("a|dark", ByteArray(8) { 1 })
+    ageRenders(root, "m3-catalog", fp, byMillis = 10_000)
+
+    var now = System.currentTimeMillis()
+    val incoming =
+      assertNotNull(
+        ThemeCacheStore(
+            root,
+            maxBytes = ThemeCacheStore.DEFAULT_MAX_BYTES,
+            graceMillis = 60_000,
+            clock = { now },
+          )
+          .open("m3-catalog", fp, inputs(fp).copy(toolVersion = "1.15.0"))
+      )
+    // Regenerated inside the overlap window, so the dirty set empties but the at-risk set does not.
+    incoming.put("a|dark", ByteArray(8) { 2 }, replaceExisting = true)
+    assertEquals(0, incoming.dirtyCount())
+    val duringOverlap =
+      kotlinx.serialization.json.Json.decodeFromString(
+        GenerationInputs.serializer(),
+        File(File(File(root, "m3-catalog"), fp), ThemeCacheStore.MANIFEST_NAME).readText(),
+      )
+    assertTrue(
+      duringOverlap.dirtyBeforeEpochMillis > 0,
+      "still standing while a co-replica could be writing",
+    )
+
+    // Past the window, with no further write of any kind: the reconcile is the last thing to run.
+    now += 120_000
+    assertEquals(0, incoming.dirtyCount())
+    val settled =
+      kotlinx.serialization.json.Json.decodeFromString(
+        GenerationInputs.serializer(),
+        File(File(File(root, "m3-catalog"), fp), ThemeCacheStore.MANIFEST_NAME).readText(),
+      )
+    assertEquals(
+      0L,
+      settled.dirtyBeforeEpochMillis,
+      "nothing moved under us and the window is shut, so the line has nothing left to mark",
+    )
+  }
+
   @Test
   fun `a partly failed dirty discard keeps the quarantine rather than reporting success`() {
     val root = tempDir()


### PR DESCRIPTION
Follow-up to #4573, which merged between this branch's ancestor check and its push. Four findings from the review of its final commit — three of them holes that commit opened.

## A manifest that says nothing is not a manifest saying "ours"

`writeManifest` read a missing or unparseable manifest as *this build created the generation*. A write interrupted mid-flight leaves exactly that state beside a full set of another build's PNGs, and the generation then opened with a zero boundary, verified on a five-entry sample, and never regenerated the rest.

Ownership is now inferred from what is actually on the volume: renders present with no manifest to account for them are inherited, not ours.

## Convergence has two endings, and only one cleared the line

The boundary clear lived in `put`. But in the ordinary rollout — nobody overwrote anything — the dirty set empties first and the at-risk set empties later, in the **reconcile**, with no further write to notice. So the future-dated boundary stayed in the manifest and re-dirtied this build's own grace-window renders on every restart, which is precisely the bug the clear was added to #4573 to fix.

Both paths now go through one `clearBoundaryIfConverged`, because either can be the last step.

## A durable mark that a concurrent convergence could erase

`markAllDirty` wrote its boundary unlocked. A render publishing the last dirty entry calls `clearDirtyBoundary` from inside `put`, under the generation write lock — so the mark could land, be overwritten by that older in-flight convergence, then repopulate `dirtyNames` and report durable success. Regeneration would proceed in this process and a restart before it finished would silently forget the rest of the request, which is the one failure this API's contract forbids.

It now runs under the generation write lock, and clears the overlap bookkeeping rather than leaving entries that would block a later convergence.

## The drop route left the catalog cold

`regenerate` wakes the pass; `drop` did not, though it is the more urgent of the two — it empties a catalog that was warm everywhere, so every preview is cold at once. Its 200 advertised a rewarming that waited on the capacity-limited resume rotation, or on a visitor's heartbeat.

## Test plan

- `ThemeCachePersistenceTest`
  - *renders beside an unreadable manifest are of unknown ownership, so dirty* — same tool version, manifest deleted, renders still classified inherited.
  - *convergence reached by the overlap reconcile clears the boundary too* — asserts the manifest boundary stands during the window and is zero after it, with no further write of any kind in between.
- `./gradlew :cli:test` green on `origin/main` + this commit; `ktfmtCheckMain` / `ktfmtCheckTest` clean.

Not visually verified: cache bookkeeping and one admin route — no rendered surface.

## Not included

One finding I did not treat as a defect, argued on [its thread](https://github.com/yschimke/compose-ai-tools/pull/4573#discussion_r3872047230): a foreground render completing just after `discard()` releases the lock republishes to disk, so a dropped cache is not empty. Those bytes come from the renderer that is running *now* — they are not among the pixels the drop declared wrong — and a `CATALOG_CACHE` hit cannot take that path, since `renderInternal` returns it before `cacheCatalogRender`. Worth revisiting if the drop's contract is ever meant to be "empty until I say otherwise" rather than "the stale bytes are gone".

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_