### PR TITLE
fix(deploy): stop the baked JAVA_TOOL_OPTIONS from hiding every other knob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1319,6 +1319,13 @@ jobs:
       # kept the public host's playground pinned to one catalog with the Android modes off.
       - name: Run deploy compose env-passthrough tests
         run: ./deploy/image/test-compose-env-passthrough.sh
+      # SERVE_JAVA_OPTS must be APPENDED to the image's baked JAVA_TOOL_OPTIONS. The variable exists
+      # precisely because assigning JAVA_TOOL_OPTIONS replaces that string — dropping the heap
+      # ceiling and the daemon library paths for the sake of one -D, with nothing in the resulting
+      # failure pointing back at the change. A refactor rewriting the append as an assignment would
+      # reintroduce that trap and would look entirely reasonable in a diff.
+      - name: Run deploy JAVA_TOOL_OPTIONS append tests
+        run: ./deploy/image/test-java-opts-append.sh
       # The agent-grant lane derives its own default (on where SERVE_GITHUB_AUTH_* gives it a human
       # to approve against, off otherwise), because both flat answers are wrong in opposite
       # directions: `1` fails startup on every box with no OAuth app, `0` ships the feature dead on

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -292,7 +292,71 @@ renders can actually occupy, so this widens the queue rather than licensing unbo
 
 Before this existed the knob was reachable only as a system property, and the prebuilt image bakes
 `JAVA_TOOL_OPTIONS` into its own `ENV` — so on this deployment there was no way to set it short of
-rebuilding the image.
+rebuilding the image. `SERVE_JAVA_OPTS` below is the general answer to that; this flag stays because
+it is one an operator reaches for often enough to deserve a name.
+
+### Setting any other JVM or `composeai.*` property (`SERVE_JAVA_OPTS`)
+
+**Do not set `JAVA_TOOL_OPTIONS` in the compose file.** The image bakes its own — the heap ceiling,
+the daemon library directories, the render timeouts, the sandbox boot settings — and an environment
+entry *replaces* that whole string rather than adding to it. The container then starts without its
+heap ceiling and without the paths the daemon lane needs, for the sake of one `-D`. Nothing in the
+resulting failure points back at the change.
+
+Use this instead. The entrypoint appends it to whatever the image already carries:
+
+```
+SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000
+```
+
+Space-separate several. Last wins within `JAVA_TOOL_OPTIONS`, so this can override a baked value as
+well as add one.
+
+It is **inherited by the daemon JVMs** the server spawns, exactly as the baked options are. That is
+what makes it the right layer for a render-side property, and the thing to know before putting a
+heap flag here — every sandbox would take it as its own.
+
+The knobs this reaches that nothing else did:
+
+| Property | What it does |
+| --- | --- |
+| `composeai.serve.themeOptimizationIdleMillis` | Quiet window before an optimizer pass may **start** (default 60000). See the section below. |
+| `composeai.serve.themeOptimizationGateCeilingMillis` | How long the gate may withhold a turn before one is forced anyway (default 600000). The floor under throughput on a box that never goes quiet. |
+| `composeai.serve.themeOptimizerSliceMillis` | How long one admitted catalog holds a lane before handing it back. |
+| `composeai.serve.optimizerStopMemoryAvailableFraction` / `…Resume…` | Where the pressure gate stops and resumes on memory. |
+| `composeai.serve.optimizerStopCpuUtilization` / `…Resume…` | The same for CPU, and `…LoadPerCpu` for load average. |
+| `composeai.serve.optimizerStarvationCapMillis`, `…DutyCycleMillis` | How long a hold may last before the gate opens a window anyway, and how long that window is. |
+| `composeai.serve.catalogRenderCacheMaxBytes` | Per-catalog memory window for rendered pixels. |
+| `composeai.serve.themeOptimization` | `false` switches the optimizer off entirely. |
+
+The pressure thresholds in particular are documented in the source as "a property of the host, not
+of the code, and it needs to be settable without a rebuild" — which was true of the intent and not
+of this image until now. A box whose steady state is 18% available memory has a resume threshold set
+below its own baseline, so the gate latches on the first transient dip and never reopens.
+
+### Letting the optimizer start on a busy box
+
+A theme-optimizer pass may only *start* once the whole server has been untouched for a quiet window,
+60 seconds by default. That is the "don't begin work on a box someone might be using" rule, and it
+assumes a box that goes quiet.
+
+**A public box serving many catalogs may never do so.** When it does not, the pass falls back on its
+forced-turn ceiling — one preview per catalog per ten minutes — and throughput collapses to roughly
+a hundred entries an hour against a warm render of well under a second. What that looks like on
+`/status.json`, and worth confirming before reaching for this:
+
+- `turnsGranted` and `turnsYielded` within a handful of each other on every catalog: every turn the
+  gate hands out is being taken straight back.
+- `gateWaitMillis` several times `renderMillis` — measured on `preview.coo.ee`, 1,789s against 427s.
+- `themeOptimizer.pressure.constrained` **false** and memory healthy, so nothing else is the cause.
+
+```
+SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000
+```
+
+This does not remove the courtesy the window encodes. It governs *entry*, asked once per pass; a
+request arriving **during** a pass still takes the turn back within about two seconds, so a visitor
+waits at most the render already in flight either way.
 
 ### Warmed theme renders survive a deploy (`SERVE_THEME_CACHE_DIR`)
 

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -126,6 +126,9 @@ services:
       # derivation from the seat budget, which clamps at 3 and reaches that at 8 seats — so raising
       # SERVE_LIVE_SEATS alone does not widen this lane.
       SERVE_BACKGROUND_RENDERS: "${SERVE_BACKGROUND_RENDERS:-}"
+      # Extra JVM options, appended to the image's baked JAVA_TOOL_OPTIONS by the entrypoint.
+      # Set JAVA_TOOL_OPTIONS directly and you replace the baked string instead — see the README.
+      SERVE_JAVA_OPTS: "${SERVE_JAVA_OPTS:-}"
       # Playground compile lane. Off by default: it runs visitor-supplied Kotlin and needs both a
       # catalog liveBundle classpath plus a sandbox profile on public hosts. Set the bundle path(s)
       # to local files available inside the container, for example a bind mount under /config.

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -479,5 +479,32 @@ fi
 [[ -n "${SERVE_CATALOG_CACHE_MAX_BYTES:-}" ]] &&
   args+=(--catalog-cache-max-bytes "${SERVE_CATALOG_CACHE_MAX_BYTES}")
 
+# Operator-supplied JVM options, APPENDED to the image's own rather than replacing them.
+#
+# This exists because the obvious way to set a `composeai.*` system property on this deployment is
+# a trap. The image bakes JAVA_TOOL_OPTIONS into its ENV (heap ceiling, daemon library dirs, render
+# timeouts, sandbox boot), and setting JAVA_TOOL_OPTIONS from the compose file REPLACES that whole
+# string — so the container comes up without its heap ceiling and without the paths the daemon lane
+# needs, for the sake of one `-D`. The failure is silent and does not look related to the change.
+#
+# The workaround so far has been a dedicated CLI flag per knob (`--background-renders`,
+# `--live-seats`), which is fine for the handful an operator sets often and does not scale: the
+# twelve `composeai.serve.optimizer*` pressure thresholds are documented as "a property of the host,
+# not of the code, and it needs to be settable without a rebuild", and on this image none of them
+# were reachable at all. Appending covers the whole class, including knobs added later.
+#
+# Inherited by the daemon JVMs this process spawns, exactly as the baked options are — that is what
+# makes it the right layer for a render-side property, and worth knowing before setting a heap flag
+# here, which every sandbox would then take as its own.
+#
+#   SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000
+#
+# Last wins in JAVA_TOOL_OPTIONS, so an operator can also override a baked value rather than only
+# add to it.
+if [[ -n "${SERVE_JAVA_OPTS:-}" ]]; then
+  export JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS:-} ${SERVE_JAVA_OPTS}"
+  echo "entrypoint: appended SERVE_JAVA_OPTS to JAVA_TOOL_OPTIONS" >&2
+fi
+
 echo "entrypoint: compose-preview serve on 0.0.0.0:${PORT}" >&2
 exec compose-preview "${args[@]}"

--- a/deploy/image/test-java-opts-append.sh
+++ b/deploy/image/test-java-opts-append.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Guard: SERVE_JAVA_OPTS must be APPENDED to the image's baked JAVA_TOOL_OPTIONS, never replace it.
+#
+# Why this needs a test. The image bakes JAVA_TOOL_OPTIONS into its ENV — the heap ceiling, the
+# daemon library directories, the render timeouts, the sandbox boot settings — and the whole reason
+# this variable exists is that setting JAVA_TOOL_OPTIONS from the compose file replaces that string
+# instead of adding to it. The container then comes up with no heap ceiling and no daemon paths, for
+# the sake of one -D, and nothing in the resulting failure points back at the change.
+#
+# So the one property that matters is that the baked options SURVIVE. A refactor that rewrote the
+# append as an assignment would reintroduce exactly the trap this was added to close, and would look
+# entirely reasonable in a diff.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+[[ -f "${entrypoint}" ]] || {
+  echo "FAIL: missing ${entrypoint}" >&2
+  exit 1
+}
+
+# Run just the append stanza, rather than the whole entrypoint (which needs a container).
+stanza="$(sed -n '/^if \[\[ -n "\${SERVE_JAVA_OPTS:-}" \]\]; then$/,/^fi$/p' "${entrypoint}")"
+[[ -n "${stanza}" ]] || {
+  echo "FAIL: no SERVE_JAVA_OPTS stanza found in ${entrypoint} — the detector is broken." >&2
+  exit 1
+}
+
+baked="-XX:MaxRAMPercentage=70 -Dcomposeai.cli.libDaemonAndroidDir=/opt/lib-daemon-android"
+
+run_stanza() {
+  JAVA_TOOL_OPTIONS="${baked}" SERVE_JAVA_OPTS="${1}" bash -c "
+    set -euo pipefail
+    ${stanza}
+    printf '%s' \"\${JAVA_TOOL_OPTIONS}\"
+  " 2>/dev/null
+}
+
+# 1. The baked options survive, and the operator's are there too.
+result="$(run_stanza '-Dcomposeai.serve.themeOptimizationIdleMillis=10000')"
+[[ "${result}" == *"-XX:MaxRAMPercentage=70"* ]] || {
+  echo "FAIL: the baked heap ceiling was lost: ${result}" >&2
+  exit 1
+}
+[[ "${result}" == *"libDaemonAndroidDir=/opt/lib-daemon-android"* ]] || {
+  echo "FAIL: the baked daemon library dir was lost: ${result}" >&2
+  exit 1
+}
+[[ "${result}" == *"themeOptimizationIdleMillis=10000"* ]] || {
+  echo "FAIL: the operator's option did not reach JAVA_TOOL_OPTIONS: ${result}" >&2
+  exit 1
+}
+echo "PASS: SERVE_JAVA_OPTS is appended, and the image's baked options survive"
+
+# 2. The operator's options come LAST, which is what lets them override a baked value rather than
+#    only add to it — the JVM takes the last occurrence of a repeated flag.
+result="$(run_stanza '-XX:MaxRAMPercentage=50')"
+[[ "${result}" == *"MaxRAMPercentage=70"*"MaxRAMPercentage=50" ]] || {
+  echo "FAIL: an operator override must come after the baked value: ${result}" >&2
+  exit 1
+}
+echo "PASS: operator options come last, so a baked value can be overridden"
+
+# 3. Unset leaves the baked options exactly as they were — no stray separator, nothing appended.
+result="$(JAVA_TOOL_OPTIONS="${baked}" bash -c "
+  set -euo pipefail
+  ${stanza}
+  printf '%s' \"\${JAVA_TOOL_OPTIONS}\"
+" 2>/dev/null)"
+[[ "${result}" == "${baked}" ]] || {
+  echo "FAIL: unset SERVE_JAVA_OPTS must leave JAVA_TOOL_OPTIONS untouched, got: ${result}" >&2
+  exit 1
+}
+echo "PASS: unset changes nothing"
+
+# 4. Several options, space-separated, all arrive.
+result="$(run_stanza '-Da=1 -Db=2')"
+[[ "${result}" == *"-Da=1 -Db=2" ]] || {
+  echo "FAIL: multiple space-separated options must all arrive: ${result}" >&2
+  exit 1
+}
+echo "PASS: several options are passed through together"
+
+# 5. Self-test: an assignment instead of an append must be caught. This is the regression the whole
+#    file exists for, so the detector is proved rather than trusted.
+bad_stanza='if [[ -n "${SERVE_JAVA_OPTS:-}" ]]; then
+  export JAVA_TOOL_OPTIONS="${SERVE_JAVA_OPTS}"
+fi'
+result="$(JAVA_TOOL_OPTIONS="${baked}" SERVE_JAVA_OPTS="-Dx=1" bash -c "
+  set -euo pipefail
+  ${bad_stanza}
+  printf '%s' \"\${JAVA_TOOL_OPTIONS}\"
+" 2>/dev/null)"
+[[ "${result}" == *"MaxRAMPercentage"* ]] && {
+  echo "FAIL: self-test — a replacing stanza was not caught by the baked-options check" >&2
+  exit 1
+}
+echo "PASS: self-test — a stanza that replaces instead of appending is caught"
+
+echo "PASS: all SERVE_JAVA_OPTS checks"


### PR DESCRIPTION
## The trap

Setting `JAVA_TOOL_OPTIONS` in the compose file looks like the obvious way to set a `composeai.*` system property, and it is a trap. The Dockerfile bakes its own — heap ceiling, daemon library directories, render timeouts, sandbox boot — and an environment entry **replaces** that whole string rather than adding to it. The container then comes up with no heap ceiling and without the paths the daemon lane needs, for the sake of one `-D`, and nothing in the resulting failure points back at the change.

The workaround so far has been a dedicated CLI flag per knob. That is right for the two an operator reaches for often (`--live-seats`, `--background-renders`) and it does not scale, so knobs that were never given a flag are simply unreachable on this image:

- The twelve `composeai.serve.optimizer*` pressure thresholds — documented **in the source** as "a property of the host, not of the code, and it needs to be settable without a rebuild", which was true of the intent and not of the image.
- `themeOptimizationIdleMillis`, `themeOptimizationGateCeilingMillis`, `themeOptimizerSliceMillis`.
- `catalogRenderCacheMaxBytes`, `themeOptimization`.

Each one was a rebuild away, and each was going to arrive as its own flag on its own day.

## The fix

`SERVE_JAVA_OPTS` is **appended** to whatever the image already carries:

```
SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000
```

Three lines in the entrypoint, and it covers the whole class including knobs added later. Operator options land last, so a baked value can be overridden rather than only added to.

It is inherited by the daemon JVMs the server spawns, exactly as the baked options are — which is what makes it the right layer for a render-side property, and the thing to know before putting a heap flag there, since every sandbox would take it as its own. The README says so.

## Why the test is the point

The one property that matters is that the baked options **survive**. A refactor rewriting the append as an assignment reintroduces precisely the trap this closes, and would look entirely reasonable in a diff — so `test-java-opts-append.sh` asserts it, wired into CI beside the existing `test-compose-env-passthrough.sh` guard:

- the baked heap ceiling and daemon library dir are both still there afterwards;
- an operator's `-XX:MaxRAMPercentage=50` lands *after* the baked `=70`, which is what makes overriding work at all;
- unset leaves `JAVA_TOOL_OPTIONS` byte-identical — no stray separator;
- several space-separated options all arrive;
- **self-test**: a stanza that assigns instead of appending is caught, so the detector is proved rather than trusted.

The existing compose-passthrough guard already covers the other half — it passes with the new variable, at 68 forwarded `SERVE_*` knobs.

## Test plan

- `./deploy/image/test-java-opts-append.sh` — 5 checks + self-test, all pass.
- `./deploy/image/test-compose-env-passthrough.sh` — passes with `SERVE_JAVA_OPTS` forwarded.
- `./deploy/image/test-env-migrations.sh` — 11 passed, 0 failed.
- `bash -n deploy/image/entrypoint.sh`; both `ci.yml` and `docker-compose.yml` parse as YAML.

No Kotlin changed, so no rendered surface and nothing visual to diff.

## Operational note

The immediate use is the optimizer's quiet window on `preview.coo.ee`. Throughput there has fallen to ~126 entries/hour with memory healthy and the pressure gate unconstrained: the box never sees 60 consecutive seconds of silence, so the cold-entry gate withholds turns and the pass falls back on its ten-minute forced-turn ceiling. `turnsGranted` and `turnsYielded` are within ten of each other on every catalog and m3-catalog has spent 1,789s at the gate against 427s rendering. The README documents that signature so the next person recognises it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_