### PR TITLE
fix(ci): reach the repo-wide schema discovery, and stop a poll budget flaking under load

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -113,7 +113,7 @@
       "scripts/daemon-launch-schema-allowlist.json",
       "scripts/test_check_daemon_launch_schema.py",
       "**/*.kt",
-      "vscode-extension/src/daemon/**",
+      "**/*.ts",
       "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**",
       "cli/src/test/kotlin/ee/schimke/composeai/cli/serve/**"
     ],

--- a/.github/ci/test_path_scope.py
+++ b/.github/ci/test_path_scope.py
@@ -64,10 +64,28 @@ class RepositoryConfigsTest(unittest.TestCase):
         )
 
     def test_vscode_only_skips_gradle_ci_groups(self):
+        # Named for what it protects: no group that costs a JDK, a Gradle daemon or a runner
+        # minute should wake for a VS Code-only change.
+        #
+        # `actions_tests` is deliberately excluded from that claim. It is pure-stdlib Python with
+        # no JDK and no Gradle, and it carries the repo-wide checks — `check-serve-seam.py` and
+        # `check-daemon-launch-schema.py` — whose whole value is scanning files nobody enumerated.
+        # Scoping it to `**/*.kt` and `**/*.ts` is what makes those claims true on a PR rather than
+        # only on `main`; the assertion used to read `not any(...)`, which conflated "skips the
+        # expensive groups" with "skips everything" and quietly capped that coverage.
         result = mod.decide(
             ["vscode-extension/src/extension.ts"], self.load("ci-paths.json")
         )
-        self.assertFalse(any(result.values()))
+        gradle_groups = {k: v for k, v in result.items() if k != "actions_tests"}
+        self.assertFalse(
+            any(gradle_groups.values()),
+            f"a VS Code-only change woke a Gradle CI group: {gradle_groups}",
+        )
+        self.assertTrue(
+            result["actions_tests"],
+            "actions_tests must run on a TypeScript change so the repo-wide mirror discovery in "
+            "check-daemon-launch-schema.py executes on the PR that introduces a mirror",
+        )
 
     def test_driver_pin_bump_runs_only_the_actions_validator(self):
         # The export-driver pin bump is opened unattended after every release and

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusLiveFramesTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusLiveFramesTest.kt
@@ -99,13 +99,8 @@ class ServeStatusLiveFramesTest {
 
   /** The daemon-side stream id, once the socket's live session has subscribed. */
   private fun awaitStreamId(session: FakeRenderSession): String {
-    repeat(100) {
-      session.lastFrameStreamId?.let {
-        return it
-      }
-      Thread.sleep(50)
-    }
-    error("the socket never opened a daemon stream")
+    pollUntil({ "the socket never opened a daemon stream" }) { session.lastFrameStreamId }
+    return session.lastFrameStreamId!!
   }
 
   /** `/status.json`'s `liveFrames`, polled until [ready] — frames cross threads to get there. */
@@ -114,17 +109,53 @@ class ServeStatusLiveFramesTest {
     ready: (kotlinx.serialization.json.JsonObject) -> Boolean,
   ): kotlinx.serialization.json.JsonObject {
     var last: kotlinx.serialization.json.JsonObject? = null
-    repeat(100) {
+    return pollUntil({ "liveFrames never reported the expected frames (last seen: $last)" }) {
       val (code, body) = get(server, "/status.json")
       assertEquals(200, code, body)
       val live = Json.parseToJsonElement(body).jsonObject["liveFrames"]?.jsonObject
       if (live != null) {
         last = live
-        if (ready(live)) return live
       }
-      Thread.sleep(50)
+      live?.takeIf(ready)
     }
-    error("liveFrames never reported the expected frames: $last")
+  }
+
+  /**
+   * Poll [probe] until it returns non-null, or the deadline passes.
+   *
+   * The budget is computed at runtime rather than written as a fixed `repeat(100)` of 50ms sleeps,
+   * because that spelled a 5-second ceiling that a loaded CI runner can miss for reasons that have
+   * nothing to do with the behaviour under test — the frames genuinely do cross threads to reach
+   * `/status.json`. On CI the wait is generous; locally it stays short so a real hang still fails
+   * fast rather than idling for half a minute.
+   *
+   * Deliberately not a `@Rule Timeout`: the point is to wait longer for a slow machine, not to
+   * bound the test. A failure here still reports what was actually observed — hence [message] is a
+   * lambda: built eagerly it captured the caller's `last` while it was still null, turning the one
+   * diagnostic this failure carries into "last seen: null" every time.
+   */
+  private fun <T : Any> pollUntil(message: () -> String, probe: () -> T?): T {
+    val deadline = System.nanoTime() + POLL_BUDGET_MS * 1_000_000
+    while (System.nanoTime() < deadline) {
+      probe()?.let {
+        return it
+      }
+      Thread.sleep(POLL_INTERVAL_MS)
+    }
+    error("${message()} — waited ${POLL_BUDGET_MS}ms")
+  }
+
+  private companion object {
+    /** `CI` is set by GitHub Actions; absent locally. */
+    private val ON_CI: Boolean = System.getenv("CI") != null
+
+    /**
+     * How long to wait for a frame to cross threads. 5s was the old fixed budget and is plenty on
+     * an unloaded machine; a CI runner sharing a box with the rest of the matrix is not that.
+     */
+    val POLL_BUDGET_MS: Long = if (ON_CI) 30_000 else 5_000
+
+    const val POLL_INTERVAL_MS: Long = 50
   }
 
   private fun get(server: ServeHttpServer, path: String): Pair<Int, String> =


### PR DESCRIPTION
Two independent ways CI was reporting less than it looked like it was.

## `actions_tests` now runs on TypeScript changes

`check-daemon-launch-schema.py` and `check-serve-seam.py` both make **repo-wide** claims — they fail on a schema-version mirror, or a serve-seam crossing, in a file nobody enumerated. That's only true on a PR if the job carrying them is selected, and it was scoped to `**/*.kt` plus one TypeScript directory. A mirror added anywhere else under `vscode-extension/` was caught on `main` rather than in review.

That gap existed because widening the glob broke `test_path_scope.py::test_vscode_only_skips_gradle_ci_groups`, whose assertion read `not any(...)` — *"selects no group at all"*. I declined to touch it in #4571 on the grounds that relaxing an invariant because it blocked me is the wrong reason; with that decision made deliberately rather than under pressure, the honest reading is that **the assertion was broader than the rule it documents**. The test's name says Gradle groups; `actions_tests` is pure-stdlib Python with no JDK and no Gradle.

So it now asserts what it's named for:

```python
gradle_groups = {k: v for k, v in result.items() if k != "actions_tests"}
self.assertFalse(any(gradle_groups.values()), …)
self.assertTrue(result["actions_tests"], …)
```

…with a comment recording why the exclusion is deliberate, so the next person doesn't narrow it back and silently re-cap the coverage.

**Cost**: that job runs on VS Code-only changes now. It's ~1 minute, no JDK, no Gradle.

## `ServeStatusLiveFramesTest`'s poll budget is computed, not spelled

Two `repeat(100) { … Thread.sleep(50) }` loops spelled a fixed 5-second ceiling for frames that genuinely cross threads to reach `/status.json`. Five seconds is plenty unloaded and isn't a promise a shared CI runner can keep — which is what put this test in the intermittently-red set on `main`.

The budget is now **30s on CI, 5s locally**, so a real hang still fails fast instead of idling for half a minute. Deliberately a deadline rather than a `@Rule Timeout`: the goal is to wait longer for a slow machine, not to bound the test.

### One bug I introduced and caught in falsification

I first wrote the failure message as an eagerly interpolated string. `pollUntil("… (last seen: $last)")` captures the caller's `last` **while it's still null**, so every failure would have reported `last seen: null` — trading the one diagnostic this failure carries for nothing. It's a lambda now, and the falsification run confirms the real payload comes through:

```
liveFrames never reported the expected frames (last seen: {"openSockets":1,"socketsOpened":…
```

That's the same class of mistake as the `pollUntil` fix in #4524, where a bound was unreachable because a `@Test(timeout=)` fired first. Worth stating rather than quietly fixing: a diagnostic that always prints the same thing looks like it works.

## Test plan

- `:cli:test --tests '*ServeStatusLiveFramesTest*'` — green; green again with `CI=1`
- Falsified: an unsatisfiable poll fails **at the budget** rather than hanging, with the observed payload in the message
- `.github/ci/test_path_scope.py` and `test_change_scope.py` — green
- `check-daemon-launch-schema.py` — green; `ktfmtCheckAll` — green

## ⚠️ Two of the three timing tests are NOT fixed here

`AndroidRippleFrameTest` and `LivePressRippleTest` are Robolectric tests in `:daemon:android`. **This container has no Android SDK** — `testDebugUnitTest` fails at configuration with `SDK location not found`, and there's no `sdkmanager` available — so I can't execute them.

Retuning timing-sensitive assertions I can't run is exactly the speculative change that turns CI red, so I've left them alone rather than guessing. Worth noting they're also *not* obviously wall-clock-bound the way the serve test was: they drive a **simulated** looper clock via `advanceTimeMs`, and their assertions are about animation content (`MIN_MOVING_TRANSITIONS`, `tailDelta <= MIN_CHANGED_PCT`). So the mechanism behind their intermittency is genuinely unknown to me, not merely unverified.

They need someone with an SDK, or a container that has one. Happy to do it there.

Non-visual change (CI config, a test's timing, a test's assertion), so no rendered evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_