### PR TITLE
fix(serve): never schedule two staging writes that land on one file

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2196,7 +2196,38 @@ class ServeCatalogStore(
     // measured rather than interpreted — the cheapest fact there is, and the only class of verdict
     // a fetch planner has to know in advance. The per-record rules stay where they belong.
     if (documentBytes.size > ServeKnownDifferences.MAX_DOCUMENT_BYTES) return emptyList()
-    return publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
+    return oneWritePerFile(
+      publishedArtifactIndex(base) ?: knownDifferenceArtifactPaths(documentBytes)
+    )
+  }
+
+  /**
+   * The plan with any path that would write a file an earlier path already claims removed.
+   *
+   * **A staging invariant, not a contract rule**: never schedule two writes that can land on one
+   * file. `glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable, both fetched
+   * from different URLs — and on Windows or a default macOS volume they are ONE file. The plan runs
+   * concurrently, so staging both means last-finisher-wins: the bytes left behind are whichever
+   * worker returned second, and the canonical spelling on disk may be the one
+   * [ServeKnownDifferences.artifact] then rejects for case. A record's real artifact can be
+   * overwritten by a sibling, differently on each refresh.
+   *
+   * [publishedArtifactIndex] already refuses such a list outright, and can: refusing it means
+   * falling back to the derivation, so nothing is lost. The **derivation** has nothing below it, so
+   * rejecting there would strip every legal record in the document of its artifacts — the
+   * changed-verdict failure that whole path is written to avoid. Hence first-spelling-wins rather
+   * than reject: it drops a path only when another path in the SAME plan already targets that file,
+   * so no artifact is lost that was not already liable to be clobbered by its colliding sibling.
+   * What it buys is that the outcome is a deterministic function of the document rather than of
+   * which fetch returned last.
+   *
+   * Applied to the plan rather than to either source, because it is a property of executing the
+   * plan — a future third source would need it just the same. It is a no-op on an index, which has
+   * already been rejected if it collides.
+   */
+  private fun oneWritePerFile(paths: List<String>): List<String> {
+    val claimed = HashSet<String>()
+    return paths.filter { claimed.add(it.lowercase()) }
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -800,6 +800,48 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `the derivation stages one write per file, and keeps the rest of the document`() {
+    // The same hazard one layer down, where the index's answer is not available. A record naming
+    // `mask.png` and `MASK.PNG` derives two portable paths fetched from two URLs that are ONE file
+    // on Windows and on a default macOS volume; the plan runs concurrently, so staging both leaves
+    // behind whichever worker returned last — and the canonical spelling on disk may be the one the
+    // reader then rejects for case.
+    //
+    // Rejecting the whole list the way `publishedArtifactIndex` does is NOT available here: an
+    // index that is refused falls back to the derivation, while a derivation that is refused leaves
+    // nothing, so every legal record in the document would lose its artifacts. First spelling wins
+    // instead — which drops a path only when another path in the same plan already claims that
+    // file, and makes the outcome a function of the document rather than of fetch timing.
+    val document =
+      """
+      {"schema":"compose-preview-known-differences/v1","acceptances":[
+        {"id":"glyph","issue":"https://github.com/yschimke/m3-catalog/issues/40",
+         "mask":"mask.png","acceptedCandidate":"MASK.PNG"},
+        {"id":"other","issue":"https://github.com/yschimke/m3-catalog/issues/41",
+         "mask":"mask.png","acceptedCandidate":"accepted-candidate.png"}]}
+      """
+        .trimIndent()
+    val (_, requested) = loadWithArtifactIndex(index = null, document = document)
+
+    val staged = requested.filter { it.contains("/parity/known-differences/") }
+    assertTrue(
+      staged.none { it.contains("MASK.PNG") },
+      "the second spelling of one file must not be scheduled: $staged",
+    )
+    assertTrue(
+      staged.any { it.endsWith("/parity/known-differences/glyph/mask.png") },
+      "the first spelling is the one that wins, not neither: $staged",
+    )
+    // The point of not rejecting outright: a colliding record must not cost its neighbours their
+    // artifacts, which is exactly what returning an empty plan here would do.
+    assertTrue(
+      staged.any { it.endsWith("/parity/known-differences/other/mask.png") } &&
+        staged.any { it.endsWith("/parity/known-differences/other/accepted-candidate.png") },
+      "an unrelated record lost its artifacts to a sibling's collision: $staged",
+    )
+  }
+
+  @Test
   fun `an index cannot name a path the reader would refuse to look up`() {
     // A fetch plan, not a licence. The producer's list goes through exactly the lexical rule the
     // document's paths do, so an index is never a way around it.


### PR DESCRIPTION
Closes the gap raised on the #4562 thread, with a different fix than the one-liner proposed there — see **Why not mirror the index's rule** below.

## The hazard

`glyph/mask.png` and `glyph/MASK.PNG` are distinct strings, both portable, fetched from two different URLs — and on Windows or a default macOS volume they are **one file**. `fetchCatalogAssetsToFiles` runs the plan concurrently, so naming both means last-finisher-wins: the bytes left behind are whichever worker returned second, and the canonical spelling on disk may be the one `ServeKnownDifferences.artifact` then rejects for case. A record's real artifact can be overwritten by a sibling, differently on each refresh.

`publishedArtifactIndex` has guarded exactly this since #4520 (`collision` → return null). The **derivation** below it never did, and the derivation is what every catalog published before the index existed still runs.

#4520 left it unmirrored reasoning that the absence of the per-record refusals "costs a wasted fetch". That reasoning holds for the refusals it was written about — mirroring `isSafeId` or `schemaReasons` would build a third implementation of the contract, and its cost really is only bytes. It does not hold for this one: the cost here is not a wasted fetch but nondeterministic file content, and the rule is not a contract rule at all.

## The fix

`oneWritePerFile` on the plan: drop any path whose case-folded form an earlier path already claims.

```kotlin
private fun oneWritePerFile(paths: List<String>): List<String> {
    val claimed = HashSet<String>()
    return paths.filter { claimed.add(it.lowercase()) }
}
```

It is a **staging invariant, not a contract rule** — never schedule two writes that can land on one file — which is why it sits on the plan rather than on either source: a future third source needs it just the same. It is a no-op on an index, which is already rejected if it collides.

## Why not mirror the index's rule

Rejecting the whole list, which is what I originally proposed on #4562, is available to the index and **not** to the derivation. Refusing an index means falling back to the derivation, so nothing is lost. Refusing the derivation leaves nothing under it, so every legal record in the document loses its artifacts and reads `artifact-unreadable` — the changed-verdict failure that whole path is written to avoid. Copying the rule across would have reintroduced the exact failure #4520 exists to remove, one layer down.

First-spelling-wins drops a path only when another path in the *same plan* already targets that file, so no artifact is lost that was not already liable to be clobbered by its colliding sibling. What it buys is that the staged bytes become a deterministic function of the document rather than of which fetch returned last.

Verdict-wise this is free in the case that actually arises: a record naming two spellings of one file is refused by the engine **pre-read** (`path-not-contained`, from the case-folded `mask`/`acceptedCandidate` check), so it reads neither artifact either way.

## Test plan

New `ServeCatalogStoreTest` case — a document with a colliding record *and* an unrelated healthy one — asserting all three properties that matter:

- the second spelling is never scheduled;
- the **first** spelling still is (dropping both would be a different bug);
- the unrelated record keeps both its artifacts — the thing rejecting outright would have broken.

Checked against a reverted implementation: it fails without the fix. `./gradlew :cli:test --tests '*ServeCatalogStoreTest*'` green, `python3 scripts/check-serve-seam.py` OK (151 crossing symbols), ktfmt clean.

Text-only: no visual surface is touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LGTFxnPjv7GGD68eAZAYwd)_