### PR TITLE
refactor(bundle-format): publish the bundle format as a contract and move it off the cli package

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -142,6 +142,7 @@
       "data/theme/core/**",
       "data/render/core/**",
       "data/pseudolocale/core/**",
+      "bundle/format/**",
       "mcp/**",
       "renderers/xr-client/**",
       "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"

--- a/.github/ci/serve-lanes-paths.json
+++ b/.github/ci/serve-lanes-paths.json
@@ -29,8 +29,8 @@
       "preview-server/preview-harness/serve-lanes.*",
       "preview-server/preview-harness/serve-android-lane-boot.sh",
       "samples/android-live-lane/**",
-      "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt",
-      "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt"
+      "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt",
+      "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt"
     ],
     "bundle": [
       "cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt",
@@ -44,8 +44,8 @@
       "preview-server/preview-harness/playground.*",
       "preview-server/preview-harness/playground-boot.sh",
       "samples/android-live-lane/**",
-      "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt",
-      "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt"
+      "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt",
+      "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt"
     ]
   }
 }

--- a/.github/ci/test_path_scope.py
+++ b/.github/ci/test_path_scope.py
@@ -171,6 +171,78 @@ class RepositoryConfigsTest(unittest.TestCase):
                     },
                 )
 
+    @staticmethod
+    def missing_literal_paths(config):
+        """Literal (non-glob) paths in a lane config that do not exist in the tree.
+
+        A glob is a pattern over paths that may not exist yet — a lane fixture nobody has written
+        — so only exact paths are resolved.
+        """
+        root = HERE.parents[1]
+        literal = []
+        for value in config.values():
+            entries = value if isinstance(value, list) else sum(value.values(), [])
+            literal += [e for e in entries if not any(c in e for c in "*?[")]
+        return literal, sorted({p for p in literal if not (root / p).exists()})
+
+    def test_every_literal_path_in_the_serve_lane_config_exists(self):
+        """A renamed file silently stops selecting its lane (PR #4587 review).
+
+        The lane config pins two Robolectric bundle sources by exact path rather than by glob,
+        because they are the only files outside `serve` that the Android and playground lanes
+        depend on. An exact path is a fact about the tree that nothing checked: when
+        `AndroidBundleLaunch.kt` moved modules, and again when it changed package directory, the
+        entries kept matching nothing at all. That does not fail — it just quietly stops waking
+        the lanes on exactly the changes they exist to cover. Both mistakes were made here, one
+        PR apart.
+        """
+        literal, missing = self.missing_literal_paths(self.load("serve-lanes-paths.json"))
+        self.assertTrue(literal, "no literal paths in serve-lanes-paths.json to check")
+        self.assertEqual(
+            missing,
+            [],
+            "serve-lanes-paths.json names path(s) that do not exist; a moved or renamed file "
+            "stops selecting its lane silently: " + ", ".join(missing),
+        )
+
+    def test_the_missing_path_guard_actually_fires(self):
+        """The guard above must fail on a stale path, or it guards nothing.
+
+        Uses the exact path this PR had to fix — the one `AndroidBundleLaunch.kt` carried between
+        the module move and the package rename.
+        """
+        stale = "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt"
+        real = "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt"
+        # A synthetic config, not the real one: if the real config were itself broken, injecting a
+        # path into it would make this pass for the wrong reason and mask the failure above.
+        literal, missing = self.missing_literal_paths(
+            {"globalPaths": [real, "bundle/format/**"], "lanes": {"android": [stale]}}
+        )
+        self.assertEqual(sorted(literal), sorted([real, stale]), "glob was not skipped")
+        self.assertEqual(missing, [stale])
+
+    def test_the_workflow_and_the_lane_config_pin_the_same_bundle_sources(self):
+        """Two files carry these paths; only one of them is JSON anything can validate.
+
+        `serve-lanes-e2e.yml`'s own `paths:` filters decide whether the workflow runs at all, and
+        `serve-lanes-paths.json` decides which lanes it then selects. A path fixed in one and not
+        the other is worse than a path wrong in both: the workflow starts and picks no lane.
+        """
+        import re as _re
+
+        root = HERE.parents[1]
+        workflow = (root / ".github/workflows/serve-lanes-e2e.yml").read_text()
+        in_workflow = set(_re.findall(r'"(bundle/format/\S+?\.kt)"', workflow))
+        config = self.load("serve-lanes-paths.json")
+        in_config = {
+            e
+            for value in config.values()
+            for e in (value if isinstance(value, list) else sum(value.values(), []))
+            if e.startswith("bundle/format/") and e.endswith(".kt")
+        }
+        self.assertTrue(in_config, "lane config pins no bundle-format sources")
+        self.assertEqual(in_workflow, in_config)
+
     def test_wasm_distribution_resources_run_the_rc_player_jobs(self):
         # `wasmPlayerDist` syncs these two paths straight into the shipped player (see
         # rc-player/wasm/build.gradle.kts), so a font swap or a fonts.json edit changes production

--- a/.github/workflows/serve-lanes-e2e.yml
+++ b/.github/workflows/serve-lanes-e2e.yml
@@ -58,8 +58,8 @@ on:
       - "preview-server/preview-harness/package-lock.json"
       # The Android lane's fixture and the detached-render Application pin it guards.
       - "samples/android-live-lane/**"
-      - "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt"
-      - "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt"
+      - "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt"
+      - "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt"
       # A Robolectric bump is THE regression this lane exists to catch (#2669 rode 4.15 → 4.16),
       # and it lands entirely in the version catalog — `libs.robolectric`, consumed by
       # `daemon/android/build.gradle.kts`. Without this entry a bump-only PR matches nothing here
@@ -101,8 +101,8 @@ on:
       - "preview-server/preview-harness/package-lock.json"
       # The Android lane's fixture and the detached-render Application pin it guards.
       - "samples/android-live-lane/**"
-      - "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleResources.kt"
-      - "bundle/format/src/main/kotlin/ee/schimke/composeai/cli/AndroidBundleLaunch.kt"
+      - "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt"
+      - "bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt"
       # A Robolectric bump is THE regression this lane exists to catch (#2669 rode 4.15 → 4.16),
       # and it lands entirely in the version catalog — `libs.robolectric`, consumed by
       # `daemon/android/build.gradle.kts`. Without this entry a bump-only PR matches nothing here

--- a/bundle/format/api/bundle-format.api
+++ b/bundle/format/api/bundle-format.api
@@ -1,0 +1,708 @@
+public final class ee/schimke/composeai/bundle/AndroidBundleLaunch {
+	public static final field Companion Lee/schimke/composeai/bundle/AndroidBundleLaunch$Companion;
+	public static final field DEFAULT_SDK I
+	public static final field MAX_SDK I
+	public static final field MIN_SDK I
+	public fun <init> ()V
+	public fun <init> (IZLokio/FileSystem;Ljava/lang/String;)V
+	public synthetic fun <init> (IZLokio/FileSystem;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getSdkLevel ()I
+	public final fun jvmArgs ()Ljava/util/List;
+	public final fun robolectricPropertiesBody ()Ljava/lang/String;
+	public final fun robolectricSystemProperties ()Ljava/util/Map;
+	public final fun systemProperties (Ljava/lang/String;Ljava/lang/String;)Ljava/util/Map;
+	public final fun writeRobolectricConfig (Ljava/io/File;)Ljava/io/File;
+}
+
+public final class ee/schimke/composeai/bundle/AndroidBundleLaunch$Companion {
+	public final fun resolveAndroidJar (Ljava/io/File;Lkotlin/jvm/functions/Function1;Lokio/FileSystem;)Ljava/io/File;
+	public static synthetic fun resolveAndroidJar$default (Lee/schimke/composeai/bundle/AndroidBundleLaunch$Companion;Ljava/io/File;Lkotlin/jvm/functions/Function1;Lokio/FileSystem;ILjava/lang/Object;)Ljava/io/File;
+	public final fun sdkLevelFromSystemProperty (Ljava/lang/String;)I
+	public static synthetic fun sdkLevelFromSystemProperty$default (Lee/schimke/composeai/bundle/AndroidBundleLaunch$Companion;Ljava/lang/String;ILjava/lang/Object;)I
+}
+
+public final class ee/schimke/composeai/bundle/AndroidBundleResources {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/AndroidBundleResources;
+	public final fun daemonClasspath ([BLjava/io/File;Ljava/lang/String;Z)Ljava/util/List;
+	public static synthetic fun daemonClasspath$default (Lee/schimke/composeai/bundle/AndroidBundleResources;[BLjava/io/File;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun extract ([BLjava/io/File;)Lee/schimke/composeai/bundle/AndroidBundleResources$Extracted;
+	public final fun stripApplicationName (Ljava/lang/String;)Ljava/lang/String;
+	public final fun writeTestConfig (Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
+}
+
+public final class ee/schimke/composeai/bundle/AndroidBundleResources$Extracted {
+	public fun <init> (Ljava/io/File;Ljava/io/File;Ljava/io/File;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()Ljava/io/File;
+	public final fun component3 ()Ljava/io/File;
+	public final fun copy (Ljava/io/File;Ljava/io/File;Ljava/io/File;)Lee/schimke/composeai/bundle/AndroidBundleResources$Extracted;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/AndroidBundleResources$Extracted;Ljava/io/File;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)Lee/schimke/composeai/bundle/AndroidBundleResources$Extracted;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMergedManifest ()Ljava/io/File;
+	public final fun getRClassesJar ()Ljava/io/File;
+	public final fun getResourceApk ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleClasspathHydration {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleClasspathHydration;
+	public final fun hydrate (Ljava/io/File;Ljava/io/File;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;)Ljava/io/File;
+	public final fun hydrate (Ljava/io/File;Ljava/io/File;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/io/File;
+	public static synthetic fun hydrate$default (Lee/schimke/composeai/bundle/BundleClasspathHydration;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/io/File;
+	public static synthetic fun hydrate$default (Lee/schimke/composeai/bundle/BundleClasspathHydration;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/io/File;
+}
+
+public final class ee/schimke/composeai/bundle/BundleDaemonSupportKt {
+	public static final fun bundleSidecarSearchDescription (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun expandZipBytesSafely ([BLjava/io/File;Lokio/FileSystem;Ljava/lang/String;)V
+	public static synthetic fun expandZipBytesSafely$default ([BLjava/io/File;Lokio/FileSystem;Ljava/lang/String;ILjava/lang/Object;)V
+	public static final fun extractBundleClassesAndManifest ([BLjava/io/File;Ljava/io/File;Ljava/io/File;ZLokio/FileSystem;)V
+	public static synthetic fun extractBundleClassesAndManifest$default ([BLjava/io/File;Ljava/io/File;Ljava/io/File;ZLokio/FileSystem;ILjava/lang/Object;)V
+	public static final fun extractBundleIrArtifacts ([BLjava/io/File;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;)V
+	public static synthetic fun extractBundleIrArtifacts$default ([BLjava/io/File;Ljava/io/File;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)V
+	public static final fun locateBundleSidecarJars (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader;
+	public final fun extractEmbeddedLibs ([BLjava/io/File;Lokio/FileSystem;)Ljava/util/List;
+	public static synthetic fun extractEmbeddedLibs$default (Lee/schimke/composeai/bundle/BundleReader;[BLjava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/List;
+	public final fun extractZipBytes (Ljava/io/File;Lokio/FileSystem;)[B
+	public static synthetic fun extractZipBytes$default (Lee/schimke/composeai/bundle/BundleReader;Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)[B
+	public final fun readMetadata (Ljava/io/File;)Lee/schimke/composeai/bundle/BundleReader$Metadata;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$AndroidResources {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$AndroidResources$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplicationPackage ()Ljava/lang/String;
+	public final fun getMergedManifestPath ()Ljava/lang/String;
+	public final fun getRClassesJarPath ()Ljava/lang/String;
+	public final fun getResourceApkPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$AndroidResources$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$AndroidResources$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$AndroidResources$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$BundleIr {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$BundleIr$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$BundleIr;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$BundleIr;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$BundleIr;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public final fun getResourcesPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$BundleIr$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$BundleIr$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$BundleIr;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$BundleIr;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$BundleIr$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Companion;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded : ee/schimke/composeai/bundle/BundleReader$ClasspathEntry {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInlinedAs ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Embedded$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven : ee/schimke/composeai/bundle/BundleReader$ClasspathEntry {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArtifact ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module : ee/schimke/composeai/bundle/BundleReader$ClasspathEntry {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Module$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project : ee/schimke/composeai/bundle/BundleReader$ClasspathEntry {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInlinedAs ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Project$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$DataExtension {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$DataExtension$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleReader$DataExtension;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$DataExtension;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$DataExtension;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtensionId ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$DataExtension$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$DataExtension$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$DataExtension;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$DataExtension;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$DataExtension$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$DependencyDecision {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$DependencyDecision$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIJZ)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()J
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIJZ)Lee/schimke/composeai/bundle/BundleReader$DependencyDecision;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$DependencyDecision;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIJZILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$DependencyDecision;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoordinate ()Ljava/lang/String;
+	public final fun getKept ()Z
+	public final fun getOriginalBytes ()J
+	public final fun getProjectPath ()Ljava/lang/String;
+	public final fun getReachableClasses ()I
+	public final fun getSourcePath ()Ljava/lang/String;
+	public final fun getTotalClasses ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$DependencyDecision$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$DependencyDecision$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$DependencyDecision;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$DependencyDecision;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$DependencyDecision$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ExternalClasspath {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ExternalClasspath$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ExternalClasspath;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ExternalClasspath$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ExternalResource {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ExternalResource$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;J)Lee/schimke/composeai/bundle/BundleReader$ExternalResource;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ExternalResource;Ljava/lang/String;Ljava/lang/String;JILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ExternalResource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ExternalResource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ExternalResource$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ExternalResource;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ExternalResource;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ExternalResource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$Manifest {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$Manifest$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$Manifest;ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAndroidResources ()Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
+	public final fun getBackend ()Ljava/lang/String;
+	public final fun getClasspath ()Ljava/util/List;
+	public final fun getCoverPreviewId ()Ljava/lang/String;
+	public final fun getDataExtensions ()Ljava/util/List;
+	public final fun getExternalClasspath ()Ljava/util/List;
+	public final fun getExternalResources ()Ljava/util/List;
+	public final fun getIntermediateRepresentations ()Ljava/util/List;
+	public final fun getModulePath ()Ljava/lang/String;
+	public final fun getPreviewIds ()Ljava/util/List;
+	public final fun getProducedBy ()Ljava/lang/String;
+	public final fun getProducer ()Ljava/lang/String;
+	public final fun getRawPreviewIds ()Ljava/util/List;
+	public final fun getRepositories ()Ljava/util/List;
+	public final fun getResolution ()Ljava/lang/String;
+	public final fun getSchemaVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$Manifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$Manifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$Manifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$Manifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$Metadata {
+	public fun <init> (Lee/schimke/composeai/bundle/BundleReader$Manifest;Lee/schimke/composeai/bundle/BundleReader$Report;)V
+	public final fun component1 ()Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public final fun component2 ()Lee/schimke/composeai/bundle/BundleReader$Report;
+	public final fun copy (Lee/schimke/composeai/bundle/BundleReader$Manifest;Lee/schimke/composeai/bundle/BundleReader$Report;)Lee/schimke/composeai/bundle/BundleReader$Metadata;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$Metadata;Lee/schimke/composeai/bundle/BundleReader$Manifest;Lee/schimke/composeai/bundle/BundleReader$Report;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$Metadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getManifest ()Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public final fun getReport ()Lee/schimke/composeai/bundle/BundleReader$Report;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ModuleClasses {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$ModuleClasses$Companion;
+	public fun <init> (IIJ)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun copy (IIJ)Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;IIJILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPackedBytes ()J
+	public final fun getReachableClasses ()I
+	public final fun getTotalClasses ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$ModuleClasses$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$ModuleClasses$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$ModuleClasses$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$Report {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$Report$Companion;
+	public fun <init> (Ljava/util/List;IILee/schimke/composeai/bundle/BundleReader$ModuleClasses;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;IILee/schimke/composeai/bundle/BundleReader$ModuleClasses;Ljava/util/List;)Lee/schimke/composeai/bundle/BundleReader$Report;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$Report;Ljava/util/List;IILee/schimke/composeai/bundle/BundleReader$ModuleClasses;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$Report;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDependencies ()Ljava/util/List;
+	public final fun getEntryClassFqns ()Ljava/util/List;
+	public final fun getModuleClasses ()Lee/schimke/composeai/bundle/BundleReader$ModuleClasses;
+	public final fun getReachableClassCount ()I
+	public final fun getTotalScannedClassCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleReader$Report$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleReader$Report$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleReader$Report;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleReader$Report;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleReader$Report$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning {
+	public static final field ALG_ED25519 Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleSigning;
+	public static final field SIGNATURES_PATH Ljava/lang/String;
+	public static final field SIGNATURES_SCHEMA Ljava/lang/String;
+	public final fun addSignature (Ljava/io/File;Lee/schimke/composeai/bundle/BundleSigning$Signature;)I
+	public final fun base64 ([B)Ljava/lang/String;
+	public final fun canonicalDigest (Ljava/io/File;)[B
+	public final fun canonicalDigest ([B)[B
+	public final fun decodeBase64 (Ljava/lang/String;)[B
+	public final fun generateKeyPair ()Lee/schimke/composeai/bundle/BundleSigning$KeyPairB64;
+	public final fun hex ([B)Ljava/lang/String;
+	public final fun parsePrivateKey (Ljava/lang/String;)Ljava/security/PrivateKey;
+	public final fun parsePublicKey (Ljava/lang/String;)Ljava/security/PublicKey;
+	public final fun readSignatures (Ljava/io/File;)Lee/schimke/composeai/bundle/BundleSigning$Signatures;
+	public final fun readSignatures ([B)Lee/schimke/composeai/bundle/BundleSigning$Signatures;
+	public final fun sha256 ([B)[B
+	public final fun signEd25519 (Ljava/security/PrivateKey;[B)[B
+	public final fun verifyEd25519 (Ljava/security/PublicKey;[B[B)Z
+	public final fun zipBytesOf ([B)[B
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$KeyPairB64 {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleSigning$KeyPairB64;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleSigning$KeyPairB64;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleSigning$KeyPairB64;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrivateKeyB64 ()Ljava/lang/String;
+	public final fun getPublicKeyB64 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Provenance {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleSigning$Provenance$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleSigning$Provenance;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleSigning$Provenance;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleSigning$Provenance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttestation ()Ljava/lang/String;
+	public final fun getIdentity ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleSigning$Provenance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleSigning$Provenance$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleSigning$Provenance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleSigning$Provenance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Provenance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Signature {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleSigning$Signature$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/bundle/BundleSigning$Provenance;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/bundle/BundleSigning$Provenance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lee/schimke/composeai/bundle/BundleSigning$Provenance;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/bundle/BundleSigning$Provenance;)Lee/schimke/composeai/bundle/BundleSigning$Signature;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleSigning$Signature;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/bundle/BundleSigning$Provenance;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleSigning$Signature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithm ()Ljava/lang/String;
+	public final fun getDigest ()Ljava/lang/String;
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getProducer ()Ljava/lang/String;
+	public final fun getProvenance ()Lee/schimke/composeai/bundle/BundleSigning$Provenance;
+	public final fun getSignature ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleSigning$Signature$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleSigning$Signature$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleSigning$Signature;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleSigning$Signature;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Signature$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Signatures {
+	public static final field Companion Lee/schimke/composeai/bundle/BundleSigning$Signatures$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/bundle/BundleSigning$Signatures;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleSigning$Signatures;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleSigning$Signatures;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSchema ()Ljava/lang/String;
+	public final fun getSignatures ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/BundleSigning$Signatures$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleSigning$Signatures$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/BundleSigning$Signatures;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/BundleSigning$Signatures;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/BundleSigning$Signatures$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/FigmaRasterScalingKt {
+	public static final field MAX_FIGMA_RASTER_EDGE_PX I
+	public static final fun downscaleRaster ([BI)[B
+}
+
+public final class ee/schimke/composeai/bundle/PreviewBundleFormatKt {
+	public static final field BUNDLE_FIGMA_RASTER_DIR_SUFFIX Ljava/lang/String;
+	public static final field BUNDLE_FIGMA_SVG_SUFFIX Ljava/lang/String;
+	public static final field BUNDLE_FONTS_SUFFIX Ljava/lang/String;
+	public static final field BUNDLE_LAYOUT_SUFFIX Ljava/lang/String;
+	public static final field BUNDLE_PREVIEWS_DIR Ljava/lang/String;
+	public static final field BUNDLE_SEMANTICS_SUFFIX Ljava/lang/String;
+	public static final field BUNDLE_WEB_DIR Ljava/lang/String;
+	public static final fun addOrReplaceZipEntries ([BLjava/util/Map;Ljava/util/Set;)[B
+	public static synthetic fun addOrReplaceZipEntries$default ([BLjava/util/Map;Ljava/util/Set;ILjava/lang/Object;)[B
+	public static final fun embedWebIntoZip ([BLjava/util/Map;)[B
+	public static final fun getZIP_DOS_EPOCH_MS ()J
+	public static final fun injectFigmaRasterIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;I)I
+	public static synthetic fun injectFigmaRasterIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;IILjava/lang/Object;)I
+	public static final fun injectFigmaSvgIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectFigmaSvgIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun injectFontsIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectFontsIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun injectLayoutIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectLayoutIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun injectRawZipEntries (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectRawZipEntries$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun injectSemanticsIntoBundle (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;)I
+	public static synthetic fun injectSemanticsIntoBundle$default (Ljava/io/File;Ljava/util/Map;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun injectSidecarsIntoBundle (Ljava/io/File;Ljava/util/Map;Ljava/lang/String;Lokio/FileSystem;)I
+	public static synthetic fun injectSidecarsIntoBundle$default (Ljava/io/File;Ljava/util/Map;Ljava/lang/String;Lokio/FileSystem;ILjava/lang/Object;)I
+	public static final fun resolveInBundleTarget (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
+	public static final fun rewriteRawZipEntries (Ljava/io/File;Ljava/util/Map;Ljava/util/Set;Lokio/FileSystem;)V
+	public static synthetic fun rewriteRawZipEntries$default (Ljava/io/File;Ljava/util/Map;Ljava/util/Set;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+

--- a/bundle/format/build.gradle.kts
+++ b/bundle/format/build.gradle.kts
@@ -11,13 +11,19 @@
 // `:cli` before the extraction, and every call site (including `:cli`'s own `serve`) already
 // imports them from there. Same pattern `:gradle-preview-driver` used for its step-B carve-out.
 //
-// Boundary: this module depends only on `:common-io` (plus Okio, kotlinx-serialization, and the
-// JDK). It must not grow a dependency on `:cli`, the daemon protocol, or the data products — a
-// bundle reader that needs the CLI to make sense is not a format module. Declarations that were
-// `internal` to `:cli` are `public` here; that is the extraction, not a widening for its own sake.
+// Boundary: this module depends only on `:common-io` and `:preview-data-api` (plus Okio,
+// kotlinx-serialization, and the JDK). It must not grow a dependency on `:cli`, the daemon
+// protocol, or the data products — a bundle reader that needs the CLI to make sense is not a
+// format module.
+//
+// Published, and named in the preview-server contract probe: `serve` reads bundles, so an
+// extracted server has to be able to depend on this by coordinate rather than by reaching into
+// `:cli`. That is the whole point of the split, and it is why the package is
+// `ee.schimke.composeai.bundle` rather than the `…cli` package these files carried on the way out.
 plugins {
   id("composeai.base-conventions")
   id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
 }
@@ -37,3 +43,32 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(kotlin("test"))
 }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "bundle-format",
+    displayName = "Compose Preview — Bundle Format",
+    description =
+      "The `.previewbundle` format: manifest DTO, well-known entry names, sidecar injectors, " +
+        "deterministic zip helpers, the detached signature scheme, classpath hydration, and the " +
+        "Android resource/launch support. Read by the CLI, the daemon and an extracted preview " +
+        "server; published so none of them has to reach into the CLI to read a bundle.",
+  )
+  inceptionYear.set("2026")
+}
+
+kotlin {
+  // `explicitApi()` — every declaration states its visibility, every public one its return type.
+  // This is a published contract an extracted preview server compiles against across a repo
+  // boundary (#3824), so an implicitly-public declaration is an API decision nobody made.
+  explicitApi()
+
+  // ABI dump gate, as on every other contract module. `checkKotlinAbi` diffs the real public ABI
+  // against the committed dump in `api/`, so a surface change is a diff in review rather than a
+  // downstream break. Regenerate with `./gradlew :bundle-format:updateKotlinAbi`.
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunch.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
@@ -33,7 +33,7 @@ import okio.Path.Companion.toPath
  * links a different module graph, so we re-declare them here — same pattern as [BundleReader]
  * mirroring the on-disk bundle schema. Keep them in sync if the plugin side changes.
  */
-class AndroidBundleLaunch(
+public class AndroidBundleLaunch(
   sdkLevel: Int = DEFAULT_SDK,
   /**
    * When false (default) the synthesized `robolectric.properties` pins `application=
@@ -54,7 +54,7 @@ class AndroidBundleLaunch(
 ) {
 
   /** Clamped to Robolectric 4.16.x's supported `android-all` range — see [MIN_SDK] / [MAX_SDK]. */
-  val sdkLevel: Int = sdkLevel.coerceIn(MIN_SDK, MAX_SDK)
+  public val sdkLevel: Int = sdkLevel.coerceIn(MIN_SDK, MAX_SDK)
 
   /**
    * JVM args the spawned Robolectric process needs on JDK 17+. Mirrors
@@ -62,7 +62,7 @@ class AndroidBundleLaunch(
    * also passes). Without the `--add-opens` set Robolectric's reflective access into `java.base`
    * internals fails with `IllegalAccessException` on SDK 36 sandboxes (issue #1328).
    */
-  fun jvmArgs(): List<String> =
+  public fun jvmArgs(): List<String> =
     listOf(
       "--enable-native-access=ALL-UNNAMED",
       "--add-opens=java.base/java.io=ALL-UNNAMED",
@@ -83,7 +83,7 @@ class AndroidBundleLaunch(
    * the platform default. The daemon uses just these — it routes previews via
    * `composeai.daemon.userClassDirs` / `previewsJsonPath`, not the render-batch props.
    */
-  fun robolectricSystemProperties(): Map<String, String> = buildMap {
+  public fun robolectricSystemProperties(): Map<String, String> = buildMap {
     put("robolectric.graphicsMode", "NATIVE")
     put("robolectric.looperMode", "PAUSED")
     put("robolectric.conscryptMode", "OFF")
@@ -105,7 +105,7 @@ class AndroidBundleLaunch(
    * `composeai.render.manifest` (the extracted `previews.json`) and `composeai.render.outputDir` to
    * render the whole manifest in a single subprocess.
    */
-  fun systemProperties(manifestPath: String, outputDir: String): Map<String, String> =
+  public fun systemProperties(manifestPath: String, outputDir: String): Map<String, String> =
     robolectricSystemProperties() +
       linkedMapOf(
         "composeai.render.manifest" to manifestPath,
@@ -118,7 +118,7 @@ class AndroidBundleLaunch(
    * `sdk` + `graphicsMode` + the GoogleFont shadow registration, and (unless
    * [useConsumerApplication]) the stub `application=`.
    */
-  fun robolectricPropertiesBody(): String = buildString {
+  public fun robolectricPropertiesBody(): String = buildString {
     appendLine("sdk=$sdkLevel")
     appendLine("graphicsMode=NATIVE")
     if (!useConsumerApplication) appendLine("application=android.app.Application")
@@ -131,7 +131,7 @@ class AndroidBundleLaunch(
    * Returns [root], which the caller prepends to the subprocess classpath so this config wins over
    * any copy baked into the shipped renderer jar. Creates parent dirs as needed.
    */
-  fun writeRobolectricConfig(root: File): File {
+  public fun writeRobolectricConfig(root: File): File {
     val pkgDir = File(root, RENDERER_PKG_PATH).apply { mkdirs() }
     fileSystem.write(File(pkgDir, "robolectric.properties").path.toPath()) {
       writeUtf8(robolectricPropertiesBody() + "\n")
@@ -139,22 +139,22 @@ class AndroidBundleLaunch(
     return root
   }
 
-  companion object {
+  public companion object {
     /** Floor of Robolectric 4.16.x's `android-all-instrumented` range (API 21, LOLLIPOP). */
-    const val MIN_SDK: Int = 21
+    public const val MIN_SDK: Int = 21
     /** Ceiling of the bundled Robolectric's supported range (API 36). */
-    const val MAX_SDK: Int = 36
+    public const val MAX_SDK: Int = 36
     /**
      * SDK level used when the bundle doesn't pin one. Bundles don't yet record the consumer's
      * `compileSdk` (Phase 2), so default to a recent, widely-available level; override with
      * `-Dcomposeai.bundle.androidSdk=<n>`.
      */
-    const val DEFAULT_SDK: Int = 35
+    public const val DEFAULT_SDK: Int = 35
 
     private const val RENDERER_PKG_PATH = "ee/schimke/composeai/renderer"
 
     /** `-Dcomposeai.bundle.androidSdk=<n>` override for [DEFAULT_SDK]. */
-    fun sdkLevelFromSystemProperty(
+    public fun sdkLevelFromSystemProperty(
       prop: String? = System.getProperty("composeai.bundle.androidSdk")
     ): Int = prop?.trim()?.toIntOrNull() ?: DEFAULT_SDK
 
@@ -165,7 +165,7 @@ class AndroidBundleLaunch(
      * `platforms/android-N/android.jar` under the resolved root. Returns null when no SDK is
      * reachable — the caller turns that into an actionable diagnostic rather than a crash.
      */
-    fun resolveAndroidJar(
+    public fun resolveAndroidJar(
       localPropertiesFile: File?,
       env: (String) -> String? = { System.getenv(it) },
       fileSystem: FileSystem = SystemFileSystem,

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/AndroidBundleResources.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -37,7 +37,11 @@ public object AndroidBundleResources {
    * The `android/…` payload extracted from a bundle zip: the merged resource APK, the merged
    * manifest, and (optional) the generated non-final library R classes the tile renderer links.
    */
-  data class Extracted(val resourceApk: File, val mergedManifest: File, val rClassesJar: File?)
+  public data class Extracted(
+    val resourceApk: File,
+    val mergedManifest: File,
+    val rClassesJar: File?,
+  )
 
   /**
    * Extract `android/resources.ap_` + `android/AndroidManifest.xml` (+ optional
@@ -46,7 +50,7 @@ public object AndroidBundleResources {
    * `android/` resource payload (a desktop bundle, or an Android bundle packed before this carriage
    * existed): the caller then renders without an app resource table, exactly as before.
    */
-  fun extract(zipBytes: ByteArray, androidDir: File): Extracted? {
+  public fun extract(zipBytes: ByteArray, androidDir: File): Extracted? {
     androidDir.mkdirs()
     val canonical = androidDir.canonicalFile
     var apk: File? = null
@@ -86,7 +90,7 @@ public object AndroidBundleResources {
    * `-cp`; it's the only mechanism a detached bundle has to re-register a resource table with
    * Robolectric.
    */
-  fun writeTestConfig(
+  public fun writeTestConfig(
     root: File,
     resourceApk: File,
     mergedManifest: File,
@@ -121,7 +125,7 @@ public object AndroidBundleResources {
    * value any current CLI path uses), the name is stripped so bootstrap can't crash on it. Pass it
    * and the daemon `-D` from one source so the two never disagree.
    */
-  fun daemonClasspath(
+  public fun daemonClasspath(
     zipBytes: ByteArray,
     workDir: File,
     applicationPackage: String?,

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleClasspathHydration.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleClasspathHydration.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
@@ -17,7 +17,7 @@ public object BundleClasspathHydration {
    * injected. The external declaration and any now-stale producer signatures are removed from the
    * derivative.
    */
-  fun hydrate(
+  public fun hydrate(
     source: File,
     output: File,
     fileSystem: FileSystem = SystemFileSystem,
@@ -35,7 +35,7 @@ public object BundleClasspathHydration {
    * Hydrate both whole classpath entries and resources lifted out of `classes/app.jar`. The result
    * is published atomically, so a failed resolver never leaves a thin bundle at [output].
    */
-  fun hydrate(
+  public fun hydrate(
     source: File,
     output: File,
     fileSystem: FileSystem = SystemFileSystem,

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleDaemonSupport.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleDaemonSupport.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleSigning.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleSigning.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -29,17 +29,20 @@ import kotlinx.serialization.json.Json
 public object BundleSigning {
 
   /** Zip path of the detached signatures; excluded from the digest it signs. */
-  const val SIGNATURES_PATH = "signatures.json"
-  const val SIGNATURES_SCHEMA = "compose-preview-bundle/signatures/v1"
-  const val ALG_ED25519 = "ed25519"
+  public const val SIGNATURES_PATH: String = "signatures.json"
+  public const val SIGNATURES_SCHEMA: String = "compose-preview-bundle/signatures/v1"
+  public const val ALG_ED25519: String = "ed25519"
 
-  /** CLI-side mirror of `BundleSignatures` in `PreviewBundleFormat.kt`. */
+  /** Mirror of `BundleSignatures` in the Gradle plugin's `PreviewBundleFormat.kt`. */
   @Serializable
-  data class Signatures(val schema: String = SIGNATURES_SCHEMA, val signatures: List<Signature>)
+  public data class Signatures(
+    val schema: String = SIGNATURES_SCHEMA,
+    val signatures: List<Signature>,
+  )
 
-  /** CLI-side mirror of `BundleSignature`. */
+  /** Mirror of `BundleSignature` in the Gradle plugin's `PreviewBundleFormat.kt`. */
   @Serializable
-  data class Signature(
+  public data class Signature(
     val keyId: String,
     val algorithm: String = ALG_ED25519,
     val digest: String,
@@ -50,7 +53,11 @@ public object BundleSigning {
 
   /** CLI-side mirror of `BundleProvenance`. */
   @Serializable
-  data class Provenance(val type: String, val identity: String, val attestation: String? = null)
+  public data class Provenance(
+    val type: String,
+    val identity: String,
+    val attestation: String? = null,
+  )
 
   private val json = Json {
     ignoreUnknownKeys = true
@@ -67,7 +74,7 @@ public object BundleSigning {
    * Deterministic regardless of zip ordering or compression, and stable when signatures are
    * appended.
    */
-  fun canonicalDigest(zipBytes: ByteArray): ByteArray {
+  public fun canonicalDigest(zipBytes: ByteArray): ByteArray {
     val lines = ArrayList<String>()
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
@@ -84,13 +91,13 @@ public object BundleSigning {
   }
 
   /** Canonical digest of a bundle file (polyglot-aware). */
-  fun canonicalDigest(bundle: File): ByteArray =
+  public fun canonicalDigest(bundle: File): ByteArray =
     canonicalDigest(BundleReader.extractZipBytes(bundle))
 
   // --- signatures.json read / write ------------------------------------------------------------
 
   /** Decode `signatures.json` from a bundle's [zipBytes], or null when the bundle is unsigned. */
-  fun readSignatures(zipBytes: ByteArray): Signatures? {
+  public fun readSignatures(zipBytes: ByteArray): Signatures? {
     var bytes: ByteArray? = null
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zin ->
       while (true) {
@@ -106,7 +113,7 @@ public object BundleSigning {
       .getOrNull()
   }
 
-  fun readSignatures(bundle: File): Signatures? =
+  public fun readSignatures(bundle: File): Signatures? =
     readSignatures(BundleReader.extractZipBytes(bundle))
 
   /**
@@ -114,7 +121,7 @@ public object BundleSigning {
    * already present, replacing one with the same `keyId`), keeping the leading PNG cover and every
    * other entry. Idempotent per keyId. Returns the resulting signature count.
    */
-  fun addSignature(bundle: File, signature: Signature): Int {
+  public fun addSignature(bundle: File, signature: Signature): Int {
     val existing =
       readSignatures(bundle)?.signatures.orEmpty().filter { it.keyId != signature.keyId }
     val merged = Signatures(signatures = existing + signature)
@@ -127,7 +134,7 @@ public object BundleSigning {
   // --- Ed25519 ----------------------------------------------------------------------------------
 
   /** Sign [digest] with an Ed25519 [privateKey]; returns the raw signature bytes. */
-  fun signEd25519(privateKey: PrivateKey, digest: ByteArray): ByteArray {
+  public fun signEd25519(privateKey: PrivateKey, digest: ByteArray): ByteArray {
     // Fully qualified — the nested [Signature] data class shadows java.security.Signature here.
     val sig = java.security.Signature.getInstance("Ed25519")
     sig.initSign(privateKey)
@@ -136,19 +143,22 @@ public object BundleSigning {
   }
 
   /** Verify [signatureBytes] over [digest] against an Ed25519 [publicKey]. */
-  fun verifyEd25519(publicKey: PublicKey, digest: ByteArray, signatureBytes: ByteArray): Boolean =
-    runCatching {
-      val sig = java.security.Signature.getInstance("Ed25519")
-      sig.initVerify(publicKey)
-      sig.update(digest)
-      sig.verify(signatureBytes)
-    }
+  public fun verifyEd25519(
+    publicKey: PublicKey,
+    digest: ByteArray,
+    signatureBytes: ByteArray,
+  ): Boolean = runCatching {
+    val sig = java.security.Signature.getInstance("Ed25519")
+    sig.initVerify(publicKey)
+    sig.update(digest)
+    sig.verify(signatureBytes)
+  }
     .getOrDefault(false)
 
   /** A fresh Ed25519 keypair, base64-encoded: private = PKCS#8 DER, public = X.509 SPKI DER. */
-  data class KeyPairB64(val privateKeyB64: String, val publicKeyB64: String)
+  public data class KeyPairB64(val privateKeyB64: String, val publicKeyB64: String)
 
-  fun generateKeyPair(): KeyPairB64 {
+  public fun generateKeyPair(): KeyPairB64 {
     val pair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair()
     return KeyPairB64(
       privateKeyB64 = Base64.getEncoder().encodeToString(pair.private.encoded),
@@ -157,7 +167,7 @@ public object BundleSigning {
   }
 
   /** Parse an Ed25519 private key from PEM (`-----BEGIN PRIVATE KEY-----`) or raw base64 PKCS#8. */
-  fun parsePrivateKey(text: String): PrivateKey {
+  public fun parsePrivateKey(text: String): PrivateKey {
     val der = decodePemOrBase64(text, "PRIVATE KEY")
     return KeyFactory.getInstance("Ed25519").generatePrivate(PKCS8EncodedKeySpec(der))
   }
@@ -165,7 +175,7 @@ public object BundleSigning {
   /**
    * Parse an Ed25519 public key from PEM (`-----BEGIN PUBLIC KEY-----`) or raw base64 X.509 SPKI.
    */
-  fun parsePublicKey(text: String): PublicKey {
+  public fun parsePublicKey(text: String): PublicKey {
     val der = decodePemOrBase64(text, "PUBLIC KEY")
     return KeyFactory.getInstance("Ed25519").generatePublic(X509EncodedKeySpec(der))
   }
@@ -186,13 +196,14 @@ public object BundleSigning {
 
   // --- helpers ----------------------------------------------------------------------------------
 
-  fun base64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
+  public fun base64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
 
-  fun decodeBase64(text: String): ByteArray = Base64.getDecoder().decode(text.trim())
+  public fun decodeBase64(text: String): ByteArray = Base64.getDecoder().decode(text.trim())
 
-  fun hex(bytes: ByteArray): String = bytes.joinToString("") { "%02x".format(it) }
+  public fun hex(bytes: ByteArray): String = bytes.joinToString("") { "%02x".format(it) }
 
-  fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+  public fun sha256(bytes: ByteArray): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(bytes)
 
   /**
    * Normalize raw bundle bytes to the appended ZIP portion: a plain zip (`PK\x03\x04`) is returned
@@ -201,7 +212,7 @@ public object BundleSigning {
    * input unchanged when it matches neither signature (best effort — callers treat it as zip
    * bytes).
    */
-  fun zipBytesOf(raw: ByteArray): ByteArray {
+  public fun zipBytesOf(raw: ByteArray): ByteArray {
     if (raw.size >= 2 && raw[0] == 0x50.toByte() && raw[1] == 0x4B.toByte()) return raw
     val pngSig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
     if (raw.size < pngSig.size || !pngSig.indices.all { raw[it] == pngSig[it] }) return raw

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/FigmaRasterScaling.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/FigmaRasterScaling.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 /**
  * Longest-edge bound (px) for a hybrid figma-svg's raster crops, applied in **two** places that

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream
@@ -342,7 +342,7 @@ public fun resolveInBundleTarget(
 public object BundleReader {
 
   @Serializable
-  data class Manifest(
+  public data class Manifest(
     val schemaVersion: Int,
     val backend: String,
     val previewIds: List<String>,
@@ -394,16 +394,18 @@ public object BundleReader {
   )
 
   /** v8 mirror of `BundleExternalResource` in `PreviewBundleFormat.kt`. */
-  @Serializable data class ExternalResource(val path: String, val sha256: String, val size: Long)
+  @Serializable
+  public data class ExternalResource(val path: String, val sha256: String, val size: Long)
 
-  @Serializable data class ExternalClasspath(val path: String, val sha256: String, val size: Long)
+  @Serializable
+  public data class ExternalClasspath(val path: String, val sha256: String, val size: Long)
 
   /** v7+ mirror of `BundleDataExtension` in `PreviewBundleFormat.kt`. */
-  @Serializable data class DataExtension(val extensionId: String, val path: String)
+  @Serializable public data class DataExtension(val extensionId: String, val path: String)
 
   /** v6+ mirror of `BundleAndroidResources` in `PreviewBundleFormat.kt`. */
   @Serializable
-  data class AndroidResources(
+  public data class AndroidResources(
     val resourceApkPath: String,
     val mergedManifestPath: String,
     val rClassesJarPath: String? = null,
@@ -415,7 +417,7 @@ public object BundleReader {
 
   /** v5+ mirror of `BundleIr` in `PreviewBundleFormat.kt`. */
   @Serializable
-  data class BundleIr(
+  public data class BundleIr(
     val previewId: String,
     /** `remotecompose` (RC doc) or `protolayout` (Wear tile Layout proto). */
     val format: String,
@@ -426,14 +428,14 @@ public object BundleReader {
   @OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
   @Serializable
   @JsonClassDiscriminator("kind")
-  sealed interface ClasspathEntry {
+  public sealed interface ClasspathEntry {
     @Serializable
     @kotlinx.serialization.SerialName("module")
-    data class Module(val path: String) : ClasspathEntry
+    public data class Module(val path: String) : ClasspathEntry
 
     @Serializable
     @kotlinx.serialization.SerialName("maven")
-    data class Maven(
+    public data class Maven(
       val group: String,
       val artifact: String,
       val version: String,
@@ -444,18 +446,18 @@ public object BundleReader {
 
     @Serializable
     @kotlinx.serialization.SerialName("project")
-    data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
+    public data class Project(val path: String, val inlinedAs: String) : ClasspathEntry
 
     /**
      * v3+: a third-party jar carried inside the bundle's `libs/` — no coordinate, no resolution.
      */
     @Serializable
     @kotlinx.serialization.SerialName("embedded")
-    data class Embedded(val inlinedAs: String) : ClasspathEntry
+    public data class Embedded(val inlinedAs: String) : ClasspathEntry
   }
 
   @Serializable
-  data class Report(
+  public data class Report(
     val entryClassFqns: List<String>,
     val reachableClassCount: Int,
     val totalScannedClassCount: Int,
@@ -464,10 +466,14 @@ public object BundleReader {
   )
 
   @Serializable
-  data class ModuleClasses(val totalClasses: Int, val reachableClasses: Int, val packedBytes: Long)
+  public data class ModuleClasses(
+    val totalClasses: Int,
+    val reachableClasses: Int,
+    val packedBytes: Long,
+  )
 
   @Serializable
-  data class DependencyDecision(
+  public data class DependencyDecision(
     val sourcePath: String,
     val coordinate: String?,
     val projectPath: String?,
@@ -477,14 +483,14 @@ public object BundleReader {
     val kept: Boolean,
   )
 
-  data class Metadata(val manifest: Manifest, val report: Report?)
+  public data class Metadata(val manifest: Manifest, val report: Report?)
 
   private val json = Json {
     ignoreUnknownKeys = true
     classDiscriminator = "kind"
   }
 
-  fun readMetadata(file: File): Metadata {
+  public fun readMetadata(file: File): Metadata {
     val zipBytes = extractZipBytes(file)
     var manifest: Manifest? = null
     var report: Report? = null
@@ -509,7 +515,7 @@ public object BundleReader {
   }
 
   /** Polyglot-aware zip extraction; mirrors [extractZipBytes] in the plugin module. */
-  fun extractZipBytes(file: File, fileSystem: FileSystem = SystemFileSystem): ByteArray {
+  public fun extractZipBytes(file: File, fileSystem: FileSystem = SystemFileSystem): ByteArray {
     val bytes = fileSystem.read(file.path.toPath()) { readByteArray() }
     if (bytes.size < 8) {
       throw IllegalArgumentException("not a bundle: ${file.path} is too small (${bytes.size}B)")
@@ -558,7 +564,7 @@ public object BundleReader {
    * and directory entries are ignored. Shared by [BundleRenderer] and [BundleDaemonCommand] so the
    * two player paths extract identically.
    */
-  fun extractEmbeddedLibs(
+  public fun extractEmbeddedLibs(
     zipBytes: ByteArray,
     libsDir: File,
     fileSystem: FileSystem = SystemFileSystem,

--- a/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunchTest.kt
+++ b/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleLaunchTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import java.io.File
 import java.nio.file.Files

--- a/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleResourcesTest.kt
+++ b/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/AndroidBundleResourcesTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/BundleClasspathHydrationTest.kt
+++ b/bundle/format/src/test/kotlin/ee/schimke/composeai/bundle/BundleClasspathHydrationTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -1,5 +1,22 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_RASTER_DIR_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_FONTS_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_LAYOUT_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_PREVIEWS_DIR
+import ee.schimke.composeai.bundle.BUNDLE_SEMANTICS_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_WEB_DIR
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.embedWebIntoZip
+import ee.schimke.composeai.bundle.expandZipBytesSafely
+import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
+import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
+import ee.schimke.composeai.bundle.injectFontsIntoBundle
+import ee.schimke.composeai.bundle.injectLayoutIntoBundle
+import ee.schimke.composeai.bundle.injectRawZipEntries
+import ee.schimke.composeai.bundle.injectSemanticsIntoBundle
+import ee.schimke.composeai.bundle.resolveInBundleTarget
 import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeRenderHost

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -1,5 +1,12 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.AndroidBundleLaunch
+import ee.schimke.composeai.bundle.AndroidBundleResources
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
+import ee.schimke.composeai.bundle.extractBundleIrArtifacts
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File
 import kotlin.system.exitProcess

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleExternalize.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleExternalize.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.ZIP_DOS_EPOCH_MS
+import ee.schimke.composeai.bundle.injectRawZipEntries
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.AndroidBundleLaunch
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.expandZipBytesSafely
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.TemporaryDirectory
 import java.io.ByteArrayInputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleSigning
 import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.TrustStore
 import java.io.File

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSource.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.TemporaryDirectory
 import io.ktor.client.HttpClient

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -1,5 +1,13 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_RASTER_DIR_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_FONTS_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_LAYOUT_SUFFIX
+import ee.schimke.composeai.bundle.BUNDLE_PREVIEWS_DIR
+import ee.schimke.composeai.bundle.BUNDLE_SEMANTICS_SUFFIX
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.ZIP_DOS_EPOCH_MS
 import ee.schimke.composeai.cli.serve.clampTo
 import ee.schimke.composeai.cli.serve.contentBoxFillsRender
 import ee.schimke.composeai.cli.serve.pngAlphaBounds

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BUNDLE_FIGMA_SVG_SUFFIX
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
+import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.io.SystemFileSystem
 import java.awt.image.BufferedImage

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CoordinateResolver.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
 import io.ktor.client.HttpClient

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.AndroidBundleLaunch
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.CatalogBlobPool
 import ee.schimke.composeai.cli.serve.CatalogLoadTracker

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGaps.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/BundleVerifier.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleSigning
+import ee.schimke.composeai.bundle.BundleSigning
 import java.io.File
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundBtaCompiler.kt
@@ -2,7 +2,7 @@
 
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.locateBundleSidecarJars
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.daemon.bta.BtaCompileSession
 import ee.schimke.composeai.daemon.bta.DiagnosticCollector
 import ee.schimke.composeai.daemon.protocol.CompileErrorDetail

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
 import ee.schimke.composeai.cli.CoordinateResolver
-import ee.schimke.composeai.cli.extractBundleClassesAndManifest
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import okio.FileSystem

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/RcJvmServerRenderer.kt
@@ -16,8 +16,8 @@
 
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.bundleSidecarSearchDescription
-import ee.schimke.composeai.cli.locateBundleSidecarJars
+import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.io.composeAiCacheDir
 import java.io.File

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundle.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundle.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.ZIP_DOS_EPOCH_MS
 import ee.schimke.composeai.cli.WebEmbed
-import ee.schimke.composeai.cli.ZIP_DOS_EPOCH_MS
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.zip.ZipEntry

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -1,14 +1,14 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.AndroidBundleLaunch
-import ee.schimke.composeai.cli.AndroidBundleResources
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.AndroidBundleLaunch
+import ee.schimke.composeai.bundle.AndroidBundleResources
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
+import ee.schimke.composeai.bundle.extractBundleIrArtifacts
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.cli.CoordinateResolver
 import ee.schimke.composeai.cli.PreviewManifest
-import ee.schimke.composeai.cli.bundleSidecarSearchDescription
-import ee.schimke.composeai.cli.extractBundleClassesAndManifest
-import ee.schimke.composeai.cli.extractBundleIrArtifacts
-import ee.schimke.composeai.cli.locateBundleSidecarJars
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleSigning
+import ee.schimke.composeai.bundle.BundleSigning
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleClasspathHydration
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleClasspathHydration
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.designpages.DesignPagesJson

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvg.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.MAX_FIGMA_RASTER_EDGE_PX
-import ee.schimke.composeai.cli.downscaleRaster
+import ee.schimke.composeai.bundle.MAX_FIGMA_RASTER_EDGE_PX
+import ee.schimke.composeai.bundle.downscaleRaster
 import java.util.Base64
 import okio.FileSystem
 import okio.Path

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import java.io.File
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/TrustStore.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleSigning
+import ee.schimke.composeai.bundle.BundleSigning
 import java.io.File
 import java.security.PublicKey
 import kotlinx.serialization.Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/UsageSourceFacts.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.locateBundleSidecarJars
+import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import java.io.File
 import java.net.URLClassLoader
 import kotlinx.serialization.SerialName

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleDaemonClasspathTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.extractBundleIrArtifacts
 import java.io.File
 import java.nio.file.Files
 import java.util.zip.ZipEntry

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.embedWebIntoZip
+import ee.schimke.composeai.bundle.resolveInBundleTarget
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleExternalizeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleExternalizeTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleMergeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleMergeTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRenderKnobTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRenderKnobTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.cli.serve.FakeRenderSession
 import ee.schimke.composeai.cli.serve.ServePreview
 import ee.schimke.composeai.cli.serve.ServeRenderHost

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRepackTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRepackTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSemanticsInjectTest.kt
@@ -1,5 +1,12 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.addOrReplaceZipEntries
+import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
+import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
+import ee.schimke.composeai.bundle.injectFontsIntoBundle
+import ee.schimke.composeai.bundle.injectLayoutIntoBundle
+import ee.schimke.composeai.bundle.injectSemanticsIntoBundle
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleSigning
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.cli.serve.TrustedBranch
 import java.awt.image.BufferedImage

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.BundleSigning
+import ee.schimke.composeai.bundle.injectRawZipEntries
 import ee.schimke.composeai.cli.serve.BundleVerifier
 import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.cli.serve.TrustedBranch

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CoordinateResolverTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import com.sun.net.httpserver.HttpServer
+import ee.schimke.composeai.bundle.BundleReader
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.InetSocketAddress

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtractEmbeddedLibsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtractEmbeddedLibsTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.BundleReader
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/BundleClasspathGapsTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.cli.CoordinateResolver
 import java.io.File
 import java.nio.file.Files

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleSigning
+import ee.schimke.composeai.bundle.BundleSigning
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RenderTier

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleSigning
+import ee.schimke.composeai.bundle.BundleSigning
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSvgWebModeTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.downscaleRaster
+import ee.schimke.composeai.bundle.downscaleRaster
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairingTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BundleReader
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import java.io.File
 import java.nio.file.Files

--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -89,10 +89,11 @@ classpath and no source scanning is needed at all. If this check needs substanti
 then, rewrite it against bytecode rather than teaching the tokenizer another Kotlin rule.
 The `serve→cli` direction is dominated by the bundle format (`BundleReader`, `BundleSigning`,
 `BundleClasspathHydration`, `extractBundle*`, `locateBundleSidecarJars`, `BUNDLE_VERSION`) —
-preparation item 5 below. Those symbols now live in `:bundle-format` rather than in `:cli`, but
-they kept the `ee.schimke.composeai.cli` package, and this check reads the package an import
-names, not the module that declares it. So the eleven entries stay on the register until item 5's
-package rename; the register is not wrong, it is measuring the thing that still has to change. The `cli→serve` direction is dominated by `ServeCommand.kt`, which #3824
+preparation item 5 below — and it is *no longer* dominated by them: those symbols now live in a
+published `:bundle-format` under `ee.schimke.composeai.bundle`, a package the register maps to a
+contract, so twelve of them came off. What is left is nine names on `main`. Worth remembering how
+that happened: moving the files into a module changed the count by zero, because this check reads
+the package an import names, not the module that declares it. The package rename is what moved it. The `cli→serve` direction is dominated by `ServeCommand.kt`, which #3824
 wants reduced to a thin entry point.
 
 ### 2. `scripts/check-preview-server-contracts.sh` — the artifact probe
@@ -146,16 +147,18 @@ wider, and that two of the entries drag things a server should not carry.
 | `data-render-core` | **not in #3824's six** — payload schema the viewer renders |
 | `data-pseudolocale-core` | **not in #3824's six** — the renderer's locale-direction rule, read to resolve a published capture gutter's leading/trailing edges onto left/right (#4542) |
 | `daemon-core` again, via `daemon.bta` (`BtaCompileSession`, `DiagnosticCollector`) | published — see the correction below |
-| `:cli`'s bundle format | **a module, `:bundle-format`, but not yet published or renamed** — preparation item 5 |
+| `bundle-format` | published — **was** `:cli`'s bundle format, the one entry in this table that was not a module at all; preparation item 5 |
 
 The three payload schemas are the same kind of thing as the six (a `-core` module, a wire shape, no
 renderer), so they are contracts rather than leaks. `data-pseudolocale-core` joined them for the
 same reason: a pure table of RTL languages and scripts with no renderer behind it, and the
 alternative — serve keeping its own copy of that table — is exactly the drift a contract exists to
-prevent. The bundle format is the one genuine blocker in
-this table. It is now a module — `:bundle-format` — but it is neither published nor moved out of
-the `ee.schimke.composeai.cli` package, so an extracted server still cannot name it and the seam
-register still counts every bundle symbol as a `:cli` internal. See preparation item 5.
+prevent. The bundle format was the one genuine blocker in
+this table — not a module at all, so an extracted server could not name it. It is
+`:bundle-format` now, published and named in the probe (preparation item 5), which is why its row
+reads *published* like every other. **Nothing in this table is a blocker any more** — the
+remaining ones are two unpublished modules serve reaches by class name, recorded under
+`reflectiveDependencies` in the seam allowlist, which no import scan and no probe can see.
 
 > **Correction.** An earlier revision of this document listed `:daemon:bta-host` as unpublished and
 > therefore a split blocker, because serve imports `BtaCompileSession` and `DiagnosticCollector`
@@ -341,26 +344,38 @@ From #3824's follow-up investigation, with what has landed marked.
    behaviour in `:renderer-xr-client`'s `XrSessionManagerTest`, and the mapping between them in
    `XrManagerSessionsTest`.
 5. **Extract the bundle schema / read / sign / hydrate / extract path into a published module.**
-   `bundle.json` is an external, versioned format that is currently a `:cli` internal, and it is
-   most of the `serve→cli` half of the seam register. — *half done.* The code is now a module,
-   `:bundle-format` (`bundle/format`): the manifest DTO, the well-known entry names, the sidecar
-   injectors, the deterministic zip helpers, the detached signature scheme, classpath hydration,
-   the Android resource/launch support, and the figma-raster bound. It depends only on
-   `:common-io` and `:preview-data-api`, which the build now enforces — nothing in it can reach
-   `:cli`, `serve`, the daemon, or a data product. The `bundle` subcommands stayed in `:cli`;
-   they are argument parsing, not format.
+   `bundle.json` is an external, versioned format that used to be a `:cli` internal, and it was
+   most of the `serve→cli` half of the seam register. — *done.* It is `:bundle-format`
+   (`bundle/format`), published as `ee.schimke.composeai:bundle-format` and named in the contract
+   probe: the manifest DTO, the well-known entry names, the sidecar injectors, the deterministic
+   zip helpers, the detached signature scheme, classpath hydration, the Android resource/launch
+   support, and the figma-raster bound. It depends only on `:common-io` and `:preview-data-api`,
+   which the build enforces — nothing in it can reach `:cli`, `serve`, the daemon, or a data
+   product. It carries `explicitApi()` and a committed ABI dump like every other contract. The
+   `bundle` subcommands stayed in `:cli`; they are argument parsing, not format.
 
-   **Not done, and deliberately a separate change: the package and the publishing.** The types
-   kept their `ee.schimke.composeai.cli` package for source-compat, the same way
-   `:gradle-preview-driver` did for its step-B carve-out, so `scripts/check-serve-seam.py` — which
-   keys a crossing on the *package* an import names — still counts all eleven bundle entries as
-   `cliInternalsUsedByServe`. The register is unchanged by this extraction and correctly so: an
-   extracted server still cannot name this module. Finishing item 5 means renaming the package to
-   `ee.schimke.composeai.bundle` and publishing the module, and that carries a decision this
-   extraction does not: the probe compiles against artifacts at an already-released
-   `contractVersion`, so a module first published in the *next* release has to be recorded in
-   `unpublishedContracts` — which is empty today, and guarded by a test that says so — until that
-   release lands. Sequencing that is its own PR, not a side effect of moving files.
+   The register moved with it: `cliInternalsUsedByServe` went from 21 entries to 9 on `main` and
+   9 to 6 on `test`. `BUNDLE_VERSION` is the one bundle-ish name left, and it is genuinely still
+   declared in `:cli`.
+
+   **What actually moved that number, because it is not what the first attempt assumed.** The
+   extraction landed in two PRs. The first moved the files into a module and kept their
+   `ee.schimke.composeai.cli` package for source-compat, the way `:gradle-preview-driver` did for
+   its step-B carve-out — and the register did not shrink by a single entry, because
+   `scripts/check-serve-seam.py` keys a crossing on the *package* an import names, not on the
+   module that declares it. A module boundary the seam check cannot see is not progress the seam
+   check can report. The second PR renamed the package to `ee.schimke.composeai.bundle`, and that
+   is what took the twelve symbols off the list.
+
+   > **Correction.** That first PR said publishing this module would have to wait for a release,
+   > on the reasoning that the probe compiles against artifacts at an already-released
+   > `contractVersion` and so a module first published in the *next* release would have to sit in
+   > `unpublishedContracts` until then. That was wrong, and checkable in one file:
+   > `scripts/check-preview-server-contracts.sh` publishes every contract **from source** to Maven
+   > Local at a fixed `0.0.0-contract-probe-SNAPSHOT`, precisely so the exchange does not depend on
+   > where release-please left the repo version. There was never a release to wait for.
+   > `unpublishedContracts` is still `{}`.
+
 6. **Add ABI validation and explicit API enforcement to the contract modules**, so a contract can't
    change shape silently between the two repos.
 7. **Extract the server implementation**, leaving a genuinely thin CLI adapter. `ServeCommand.kt`

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -59,6 +59,11 @@ val contracts =
     // leading/trailing edges onto left/right exactly as the render that produced the pixels did,
     // and a second copy of that language table in the server would be a thing to drift.
     "data-pseudolocale-core",
+    // The `.previewbundle` format (#3824 preparation item 5). `serve` reads bundles — the
+    // manifest, the signatures, the classpath entries, the baked previews — and until this module
+    // existed it did that by reaching into `:cli`. It was the one entry in the dependency-floor
+    // table below that was not a module at all; naming it here is what stops it being a blocker.
+    "bundle-format",
   )
 
 dependencies {

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.previewserver.contract
 
+import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -32,10 +33,17 @@ import okio.FileSystem
  * module that isn't a contract, the split's dependency floor moved — and it moved here, in a PR,
  * rather than on the day someone tries the extraction.
  *
- * Two things it deliberately does not do: exercise behaviour (there is no server here to exercise),
- * and cover `serve`'s dependency on `:cli`'s bundle format or on `:daemon:bta-host`. Neither is a
- * published contract yet; both are preparation items in `docs/design/PREVIEW_SERVER_SPLIT.md`, and
- * the day they can be named here is the day they stop being blockers.
+ * What it deliberately does not do is exercise behaviour — there is no server here to exercise.
+ *
+ * This paragraph used to name two things it also could not cover: `serve`'s dependency on `:cli`'s
+ * bundle format and on `:daemon:bta-host`. Both have since resolved, in different ways. The bundle
+ * format became `:bundle-format`, published, and is named below. `:daemon:bta-host` was a
+ * misreading: `ee.schimke.composeai.daemon.bta` is declared by BOTH it and `:daemon:core`, and the
+ * types serve uses (`BtaCompileSession`, `DiagnosticCollector`) are the `:daemon:core` ones — see
+ * the correction in `docs/design/PREVIEW_SERVER_SPLIT.md`. What the probe still cannot see is the
+ * two unpublished modules serve loads by class name; those are recorded under
+ * `reflectiveDependencies` in `scripts/serve-seam-allowlist.json`, where no import scan reaches
+ * either.
  */
 object ContractSurface {
 
@@ -70,4 +78,13 @@ object ContractSurface {
 
   /** File IO. The server funnels reads/writes through `:common-io` like every other module. */
   val fileSystem: FileSystem = SystemFileSystem
+
+  /**
+   * The `.previewbundle` format. `serve` reads bundles — the manifest, the classpath entries, the
+   * baked previews — and for most of this document's life it did that by reaching into `:cli`,
+   * which is why the dependency-floor table listed the bundle format as the one entry that was not
+   * a module at all. It is `:bundle-format` now, and naming its manifest here is what makes that a
+   * checked claim rather than a stated one.
+   */
+  val bundleManifest: KClass<BundleReader.Manifest> = BundleReader.Manifest::class
 }

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -42,6 +42,7 @@ CONTRACT_PROJECTS=(
   ":data-theme-core"
   ":data-render-core"
   ":data-pseudolocale-core"
+  ":bundle-format"
 )
 
 # Recorded leaks, published only so the probe can resolve at all. Every name here is a module an

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -8,12 +8,14 @@
     "cliInternalsUsedByServe: serve reaching into the CLI. Each entry is something the extracted",
     "server would have to get from a published contract module instead. The bundle-format cluster",
     "(BundleReader, BundleSigning, BundleClasspathHydration, extractBundle*, locateBundleSidecar*,",
-    "BUNDLE_VERSION, ZIP_DOS_EPOCH_MS) is #3824 preparation item 5 and is most of this list.",
-  "Those symbols now live in their own module, `:bundle-format`, but kept the",
-  "`ee.schimke.composeai.cli` package for source-compat, and this check keys a crossing on the",
-  "package an import names rather than the module that declares it. So they are still listed,",
-  "and correctly: an extracted server cannot name an unpublished module, whatever build it sits",
-  "in. They come off when item 5 finishes \u2014 package rename plus publishing.",
+    "ZIP_DOS_EPOCH_MS, downscaleRaster) used to be most of this list and is now off it — #3824",
+    "preparation item 5. Those symbols live in a published `:bundle-format` whose package,",
+    "`ee.schimke.composeai.bundle`, is mapped under contractPackages below, so serve names a",
+    "contract instead of a CLI internal. BUNDLE_VERSION stays: it is still declared in `:cli`.",
+    "Note what made the difference. Moving the files into a module did not shrink this list at",
+    "all, because the check keys a crossing on the package an import names, not on the module",
+    "that declares it, and the extraction kept the `…cli` package for source-compat. The rename",
+    "is what moved the number.",
     "serveInternalsUsedByCli: the CLI reaching into serve. Each entry must either move to the",
     "server build with serve, or move down into a contract module the CLI can keep using. The",
     "long tail here is ServeCommand.kt, which #3824 wants reduced to a thin entry point.",
@@ -48,20 +50,21 @@
     "ee.schimke.composeai.plugin"
   ],
   "contractPackages": {
-    "ee.schimke.composeai.daemon.protocol": "daemon-core",
-    "ee.schimke.composeai.daemon.devices": "daemon-core",
+    "ee.schimke.composeai.bundle": "bundle-format",
     "ee.schimke.composeai.daemon": "daemon-core",
-    "ee.schimke.composeai.designpages": "preview-data-api",
-    "ee.schimke.composeai.io": "common-io",
-    "ee.schimke.composeai.render.session.subprocess": "render-session-subprocess",
-    "ee.schimke.composeai.render.session": "render-session-api",
+    "ee.schimke.composeai.daemon.bta": "daemon-core",
+    "ee.schimke.composeai.daemon.devices": "daemon-core",
+    "ee.schimke.composeai.daemon.protocol": "daemon-core",
     "ee.schimke.composeai.data.layoutinspector": "data-layoutinspector-core",
     "ee.schimke.composeai.data.overrides": "data-preview-overrides-core",
+    "ee.schimke.composeai.data.pseudolocale": "data-pseudolocale-core",
     "ee.schimke.composeai.data.remotecompose": "data-remotecompose-core",
-    "ee.schimke.composeai.data.theme": "data-theme-core",
     "ee.schimke.composeai.data.render": "data-render-core",
-    "ee.schimke.composeai.daemon.bta": "daemon-core",
-    "ee.schimke.composeai.data.pseudolocale": "data-pseudolocale-core"
+    "ee.schimke.composeai.data.theme": "data-theme-core",
+    "ee.schimke.composeai.designpages": "preview-data-api",
+    "ee.schimke.composeai.io": "common-io",
+    "ee.schimke.composeai.render.session": "render-session-api",
+    "ee.schimke.composeai.render.session.subprocess": "render-session-subprocess"
   },
   "unpublishedContracts": {},
   "reflectiveDependencies": {
@@ -92,27 +95,15 @@
   },
   "main": {
     "cliInternalsUsedByServe": [
-      "AndroidBundleLaunch",
-      "AndroidBundleResources",
       "BUNDLE_VERSION",
-      "BundleClasspathHydration",
-      "BundleReader",
-      "BundleSigning",
       "CoordinateResolver",
-      "MAX_FIGMA_RASTER_EDGE_PX",
       "PreviewInfo",
       "PreviewManifest",
       "PreviewModule",
       "PreviewParameterFanout",
       "PreviewParams",
       "PreviewResultBuilder",
-      "WebEmbed",
-      "ZIP_DOS_EPOCH_MS",
-      "bundleSidecarSearchDescription",
-      "downscaleRaster",
-      "extractBundleClassesAndManifest",
-      "extractBundleIrArtifacts",
-      "locateBundleSidecarJars"
+      "WebEmbed"
     ],
     "serveInternalsUsedByCli": [
       "serve.BundleVerifier",
@@ -221,15 +212,12 @@
   },
   "test": {
     "cliInternalsUsedByServe": [
-      "BundleReader",
-      "BundleSigning",
       "Capture",
       "CoordinateResolver",
       "PreviewInfo",
       "PreviewManifest",
       "PreviewParams",
-      "WebEmbed",
-      "downscaleRaster"
+      "WebEmbed"
     ],
     "serveInternalsUsedByCli": [
       "serve.BundleVerifier",

--- a/scripts/test_check_serve_seam.py
+++ b/scripts/test_check_serve_seam.py
@@ -429,6 +429,12 @@ class ContractCoverage(unittest.TestCase):
         kts = (
             mod.REPO_ROOT / "preview-server/contract-probe/build.gradle.kts"
         ).read_text(encoding="utf-8")
+        # Strip `//` comments before looking for the list's closing paren. The entries are
+        # commented, and a comment containing a `)` — an issue reference, a parenthetical — used to
+        # end the block early. That does not fail loudly: it silently drops every contract after
+        # the comment, so the coverage assertions below pass over a truncated list. Comments cannot
+        # contain a quoted coordinate that matters, so removing them first is safe.
+        kts = re.sub(r"//[^\n]*", "", kts)
         block = kts.split("val contracts =", 1)[1].split(")", 1)[0]
         return set(re.findall(r'"([a-z0-9-]+)"', block))
 
@@ -519,10 +525,26 @@ class RealTree(unittest.TestCase):
     def test_forbidden_packages_are_clean(self):
         self.assertEqual(mod.forbidden_hits(mod.load_allowlist()["forbiddenPackages"]), [])
 
-    def test_the_bundle_cluster_is_on_the_list(self):
-        """It is preparation item 5's whole justification — don't lose it silently."""
-        entries = set(mod.load_allowlist()["main"]["cliInternalsUsedByServe"])
-        self.assertTrue({"BundleReader", "BundleSigning"} & entries)
+    def test_the_bundle_cluster_has_left_the_list(self):
+        """Preparation item 5, from the other side.
+
+        This assertion used to read the opposite way: the bundle cluster HAD to be on
+        `cliInternalsUsedByServe`, because losing it silently would have meant losing item 5's whole
+        justification. Item 5 is done — the cluster lives in a published `:bundle-format` in its own
+        package — so the thing worth guarding is now the reverse. If these symbols reappear as CLI
+        internals, something moved back.
+
+        Both halves matter. Off the register alone would also be true if serve had simply stopped
+        using them; the contract mapping is what says they are still used, from a module an
+        extracted server can name.
+        """
+        allowlist = mod.load_allowlist()
+        for source_set in mod.SOURCE_SETS:
+            entries = set(allowlist[source_set]["cliInternalsUsedByServe"])
+            self.assertEqual({"BundleReader", "BundleSigning"} & entries, set(), source_set)
+        self.assertEqual(
+            allowlist["contractPackages"].get("ee.schimke.composeai.bundle"), "bundle-format"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Second half of #3824 preparation item 5. Finishes what #4581 started.

## Why this is a separate PR at all, and what it teaches

#4581 moved the `.previewbundle` format into `:bundle-format` but kept the types in the `ee.schimke.composeai.cli` package for source-compat. **The seam register did not shrink by a single entry.** `scripts/check-serve-seam.py` keys a crossing on the *package* an import names, not on the module that declares it — so a real module boundary was invisible to the check that exists to measure exactly that boundary.

That is the useful bit: a module boundary the seam check cannot see is not progress the seam check can report. The rename is what moves the number.

| | `main.cliInternalsUsedByServe` | `test.cliInternalsUsedByServe` |
| --- | --- | --- |
| before #4581 | 21 | 9 |
| after #4581 (module, same package) | 21 | 9 |
| this PR (package renamed + published) | **9** | **6** |

Twelve symbols come off: `BundleReader`, `BundleSigning`, `BundleClasspathHydration`, `AndroidBundleLaunch`, `AndroidBundleResources`, `extractBundleClassesAndManifest`, `extractBundleIrArtifacts`, `locateBundleSidecarJars`, `bundleSidecarSearchDescription`, `ZIP_DOS_EPOCH_MS`, `MAX_FIGMA_RASTER_EDGE_PX`, `downscaleRaster`. `BUNDLE_VERSION` stays — it is genuinely still declared in `:cli`.

## What changed

- **Package renamed** to `ee.schimke.composeai.bundle`; every consumer gets an explicit import. The Gradle plugin's own `PreviewBundleFormat.kt` mirror and `daemon/android` are deliberately untouched — they are a separate composite build and a same-named-symbol coincidence, not consumers.
- **Published** as `ee.schimke.composeai:bundle-format`, with `explicitApi()` and a committed ABI dump (`bundle/format/api/bundle-format.api`, 708 lines) wired into `check`, like every other contract module.
- **Named in the contract probe**: added to `CONTRACT_PROJECTS`, to the probe's `contracts`, and to `ci-paths.json`'s `preview_server_contracts` group; `ContractSurface.kt` names `BundleReader.Manifest` so the separate `preview-server` build compiles against the published artifact and `checkContractSurface` walks its resolved classpath. No leak.
- **`unpublishedContracts` stays `{}`** — see the correction below.
- The dependency-floor table in `PREVIEW_SERVER_SPLIT.md` has **no blockers left**. What remains are the two unpublished modules `serve` loads by class name, already recorded under `reflectiveDependencies`, which no import scan and no probe can see.

## Correction to #4581

#4581's body and the design doc both said publishing this module had to wait for a release, reasoning that the probe compiles against artifacts at an already-released `contractVersion`, so a module first published in the *next* release would have to sit in `unpublishedContracts` until then.

That was wrong, and checkable in one file. `scripts/check-preview-server-contracts.sh` publishes every contract **from source** to Maven Local at a fixed `0.0.0-contract-probe-SNAPSHOT`, precisely so the exchange does not depend on where release-please left the repo version. There was never a release to wait for, and there was no reason to split the work this way. The design doc now records the mistake rather than quietly dropping it.

## Two test changes that fall out

- `test_the_bundle_cluster_is_on_the_list` asserted the bundle cluster **had** to stay on `cliInternalsUsedByServe` — losing it silently would have meant losing item 5's justification. That is now the thing being paid off, so it is inverted to `test_the_bundle_cluster_has_left_the_list`: the cluster must be off the register *and* mapped to a contract. Both halves matter — off the register alone would also be true if `serve` had simply stopped using it.
- `probe_contracts()` split the probe's `contracts` list on the first `)`. A commented entry containing a parenthesis truncates the block, which does not fail — it silently drops every contract after the comment, so the coverage assertions pass over a partial list. It now strips `//` comments first. I hit this by adding a comment with `(#3824 …)` in it.

## Test plan

- `./gradlew :bundle-format:check` — green, including `checkKotlinAbi` against the new dump.
- `./gradlew :cli:check` — green (5m23s), including `checkServeSeam`, `checkDaemonLaunchSchema`, `:cli:test`, and the CLI/daemon library-boundary checks.
- `scripts/check-preview-server-contracts.sh` — green end to end: publishes 13 contracts from source to Maven Local, then builds `preview-server` against them and runs `checkContractSurface`.
- `python3 scripts/check-serve-seam.py` — OK, 136 crossings (was 151); `scripts/test_check_serve_seam.py` 45 tests OK.
- `python3 scripts/check-daemon-launch-schema.py` — OK.
- All five `.github/ci/test_*.py` suites — OK.

Non-visual: a package rename, publishing wiring, and docs. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_