### PR TITLE
refactor(api): move the published preview contracts off the cli package

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesAction.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesAction.kt
@@ -1,6 +1,7 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
+import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.Serializable
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
@@ -1,5 +1,6 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
+import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.OutputStream
@@ -18,18 +19,6 @@ import org.gradle.tooling.events.task.TaskSkippedResult
 import org.gradle.tooling.events.task.TaskSuccessResult
 import org.gradle.tooling.events.test.JvmTestOperationDescriptor
 import org.gradle.tooling.events.test.TestOperationDescriptor
-
-/**
- * Handle for a subproject that applies `ee.schimke.composeai.preview`.
- *
- * [gradlePath] is the colon-separated project path **without** its leading colon (e.g. `"app"`,
- * `"auth:composables"`) — used to address Gradle tasks like
- * `":$gradlePath:composePreviewRenderAll"` and to identify the module in CLI output / persisted
- * state. [projectDir] is the actual filesystem directory of that subproject, resolved via Gradle's
- * Tooling API. Using it instead of `projectRoot/$gradlePath` is what makes nested subprojects
- * (`:foo:bar`) and any custom `project.projectDir` override work correctly — see issue #157.
- */
-data class PreviewModule(val gradlePath: String, val projectDir: File) : java.io.Serializable
 
 data class GradleAccessFailure(
   val operation: String,

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradlePreviewDriver.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradlePreviewDriver.kt
@@ -1,5 +1,10 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.PreviewResultBuilder
+import ee.schimke.composeai.previewdata.previewSha256
 import java.io.File
 
 /**

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/RenderFailures.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/RenderFailures.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import java.io.PrintStream
 

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/TerminalProgress.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/TerminalProgress.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 /**
  * OSC 9;4 terminal progress bar protocol.

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/ActionableFailureLinesTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/ActionableFailureLinesTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesActionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesActionTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
 import ee.schimke.composeai.plugin.tooling.ModuleInfo

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesIntegrationTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/DiscoverPreviewModulesIntegrationTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import java.io.File
 import kotlin.test.AfterTest

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/RenderFailuresTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/RenderFailuresTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdriver
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream

--- a/api/preview-data-api/api/preview-data-api.api
+++ b/api/preview-data-api/api/preview-data-api.api
@@ -1,713 +1,3 @@
-public final class ee/schimke/composeai/cli/A11yWireFormatKt {
-	public static final field A11Y_PAYLOAD_SCHEMA_V1 Ljava/lang/String;
-	public static final field A11Y_REPORT_STATUS_ATF_UNAVAILABLE Ljava/lang/String;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityEntry {
-	public static final field Companion Lee/schimke/composeai/cli/AccessibilityEntry$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityEntry;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityEntry;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityEntry;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAnnotatedPath ()Ljava/lang/String;
-	public final fun getFindings ()Ljava/util/List;
-	public final fun getNodes ()Ljava/util/List;
-	public final fun getPreviewId ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/AccessibilityEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityEntry$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityEntry;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityEntry;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityEntry$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityFinding {
-	public static final field Companion Lee/schimke/composeai/cli/AccessibilityFinding$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityFinding;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityFinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityFinding;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBoundsInScreen ()Ljava/lang/String;
-	public final fun getLevel ()Ljava/lang/String;
-	public final fun getMessage ()Ljava/lang/String;
-	public final fun getType ()Ljava/lang/String;
-	public final fun getViewDescription ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/AccessibilityFinding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityFinding$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityFinding;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityFinding;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityFinding$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityNode {
-	public static final field Companion Lee/schimke/composeai/cli/AccessibilityNode$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Z
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityNode;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBoundsInScreen ()Ljava/lang/String;
-	public final fun getLabel ()Ljava/lang/String;
-	public final fun getMerged ()Z
-	public final fun getRef ()Ljava/lang/String;
-	public final fun getRole ()Ljava/lang/String;
-	public final fun getStates ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/AccessibilityNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityNode$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityNode;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityNode;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityNode$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityReport {
-	public static final field Companion Lee/schimke/composeai/cli/AccessibilityReport$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)Lee/schimke/composeai/cli/AccessibilityReport;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/AccessibilityReport;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/cli/AccessibilityReport;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getEntries ()Ljava/util/List;
-	public final fun getModule ()Ljava/lang/String;
-	public final fun getPartial ()Z
-	public final fun getStatus ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/AccessibilityReport$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/AccessibilityReport$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/AccessibilityReport;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/AccessibilityReport;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/AccessibilityReport$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/Capture {
-	public static final field Companion Lee/schimke/composeai/cli/Capture$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
-	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
-	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Long;
-	public final fun component2 ()Lee/schimke/composeai/cli/ScrollCapture;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Z
-	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun component7 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun component8 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun component9 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/cli/Capture;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/Capture;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/cli/Capture;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
-	public final fun getFocus ()Lkotlinx/serialization/json/JsonElement;
-	public final fun getFocusGif ()Lkotlinx/serialization/json/JsonElement;
-	public final fun getGestureHint ()Lkotlinx/serialization/json/JsonElement;
-	public final fun getHover ()Lkotlinx/serialization/json/JsonElement;
-	public final fun getOptional ()Z
-	public final fun getRenderOutput ()Ljava/lang/String;
-	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
-	public final fun getSettle ()Lkotlinx/serialization/json/JsonElement;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/Capture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/Capture$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/Capture;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/Capture;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/Capture$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CaptureGutterDp {
-	public static final field Companion Lee/schimke/composeai/cli/CaptureGutterDp$Companion;
-	public fun <init> ()V
-	public fun <init> (IIII)V
-	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()I
-	public final fun copy (IIII)Lee/schimke/composeai/cli/CaptureGutterDp;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CaptureGutterDp;IIIIILjava/lang/Object;)Lee/schimke/composeai/cli/CaptureGutterDp;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBottom ()I
-	public final fun getEnd ()I
-	public final fun getHorizontal ()I
-	public final fun getStart ()I
-	public final fun getTop ()I
-	public final fun getVertical ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/CaptureGutterDp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/CaptureGutterDp$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CaptureGutterDp;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CaptureGutterDp;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CaptureGutterDp$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CaptureResult {
-	public static final field Companion Lee/schimke/composeai/cli/CaptureResult$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Long;
-	public final fun component2 ()Lee/schimke/composeai/cli/ScrollCapture;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun component6 ()Z
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CaptureResult;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CaptureResult;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CaptureResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
-	public final fun getChanged ()Ljava/lang/Boolean;
-	public final fun getOptional ()Z
-	public final fun getParameterLabel ()Ljava/lang/String;
-	public final fun getParameterRowId ()Ljava/lang/String;
-	public final fun getPngPath ()Ljava/lang/String;
-	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
-	public final fun getSha256 ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/CaptureResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/CaptureResult$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CaptureResult;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CaptureResult;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CaptureResult$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CatalogEntry {
-	public static final field Companion Lee/schimke/composeai/cli/CatalogEntry$Companion;
-	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
-	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lee/schimke/composeai/cli/CatalogRole;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/String;
-	public final fun component12 ()Ljava/util/List;
-	public final fun component13 ()Z
-	public final fun component14 ()Ljava/lang/String;
-	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Ljava/lang/String;
-	public final fun component9 ()Z
-	public final fun copy (Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogEntry;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CatalogEntry;Lee/schimke/composeai/cli/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CatalogEntry;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCaption ()Ljava/lang/String;
-	public final fun getComponentId ()Ljava/lang/String;
-	public final fun getGroup ()Ljava/lang/String;
-	public final fun getKitAxis ()Ljava/lang/String;
-	public final fun getKitValue ()Ljava/lang/String;
-	public final fun getMotionPreview ()Ljava/lang/String;
-	public final fun getNoReference ()Ljava/lang/String;
-	public final fun getParallel ()Ljava/lang/String;
-	public final fun getPerBreakpoint ()Z
-	public final fun getProps ()Ljava/util/List;
-	public final fun getReference ()Ljava/lang/String;
-	public final fun getReferenceContentsOnly ()Z
-	public final fun getReferenceSet ()Ljava/lang/String;
-	public final fun getRole ()Lee/schimke/composeai/cli/CatalogRole;
-	public final fun getSection ()Ljava/lang/String;
-	public final fun getState ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/CatalogEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/CatalogEntry$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CatalogEntry;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CatalogEntry;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CatalogEntry$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CatalogRole : java/lang/Enum {
-	public static final field COMPONENT Lee/schimke/composeai/cli/CatalogRole;
-	public static final field Companion Lee/schimke/composeai/cli/CatalogRole$Companion;
-	public static final field VARIANT Lee/schimke/composeai/cli/CatalogRole;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogRole;
-	public static fun values ()[Lee/schimke/composeai/cli/CatalogRole;
-}
-
-public final class ee/schimke/composeai/cli/CatalogRole$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CatalogVariantProp {
-	public static final field Companion Lee/schimke/composeai/cli/CatalogVariantProp$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/cli/CatalogVariantProp;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/CatalogVariantProp;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/cli/CatalogVariantProp;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getKey ()Ljava/lang/String;
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/CatalogVariantProp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/CatalogVariantProp$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/CatalogVariantProp;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/CatalogVariantProp;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/CatalogVariantProp$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/ExtensionPayload {
-	public static final field Companion Lee/schimke/composeai/cli/ExtensionPayload$Companion;
-	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/cli/ExtensionPayload;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/ExtensionPayload;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/cli/ExtensionPayload;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPayload ()Lkotlinx/serialization/json/JsonElement;
-	public final fun getSchema ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/ExtensionPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/ExtensionPayload$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/ExtensionPayload;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/ExtensionPayload;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/ExtensionPayload$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewDataProduct {
-	public static final field Companion Lee/schimke/composeai/cli/PreviewDataProduct$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/lang/Long;
-	public final fun component5 ()Lee/schimke/composeai/cli/ScrollCapture;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;)Lee/schimke/composeai/cli/PreviewDataProduct;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewDataProduct;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/cli/ScrollCapture;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewDataProduct;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
-	public final fun getKind ()Ljava/lang/String;
-	public final fun getMediaTypes ()Ljava/util/List;
-	public final fun getOutput ()Ljava/lang/String;
-	public final fun getScroll ()Lee/schimke/composeai/cli/ScrollCapture;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/PreviewDataProduct$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewDataProduct$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewDataProduct;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewDataProduct;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewDataProduct$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewInfo {
-	public static final field Companion Lee/schimke/composeai/cli/PreviewInfo$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Z
-	public final fun component11 ()Z
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/Integer;
-	public final fun component6 ()Lee/schimke/composeai/cli/PreviewParams;
-	public final fun component7 ()Ljava/util/List;
-	public final fun component8 ()Ljava/util/List;
-	public final fun component9 ()Lee/schimke/composeai/cli/CatalogEntry;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZ)Lee/schimke/composeai/cli/PreviewInfo;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/cli/CatalogEntry;ZZILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewInfo;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBodyLine ()Ljava/lang/Integer;
-	public final fun getCaptures ()Ljava/util/List;
-	public final fun getCatalog ()Lee/schimke/composeai/cli/CatalogEntry;
-	public final fun getClassName ()Ljava/lang/String;
-	public final fun getDataProducts ()Ljava/util/List;
-	public final fun getFixedTheme ()Z
-	public final fun getFunctionName ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
-	public final fun getIncludeInA11y ()Z
-	public final fun getParams ()Lee/schimke/composeai/cli/PreviewParams;
-	public final fun getSourceFile ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/PreviewInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewInfo$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewInfo;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewInfo;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewInfo$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewManifest {
-	public static final field Companion Lee/schimke/composeai/cli/PreviewManifest$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lee/schimke/composeai/cli/PreviewManifest;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewManifest;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewManifest;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDataExtensionReports ()Ljava/util/Map;
-	public final fun getModule ()Ljava/lang/String;
-	public final fun getPreviews ()Ljava/util/List;
-	public final fun getReportsView ()Ljava/util/Map;
-	public final fun getVariant ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/PreviewManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewManifest$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewManifest;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewManifest;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewManifest$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewParams {
-	public static final field Companion Lee/schimke/composeai/cli/PreviewParams$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/Integer;
-	public final fun component11 ()Ljava/lang/Float;
-	public final fun component12 ()F
-	public final fun component13 ()Z
-	public final fun component14 ()Z
-	public final fun component15 ()J
-	public final fun component16 ()I
-	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Ljava/lang/String;
-	public final fun component19 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component20 ()Ljava/lang/String;
-	public final fun component21 ()I
-	public final fun component22 ()Ljava/lang/String;
-	public final fun component23 ()Lee/schimke/composeai/cli/CaptureGutterDp;
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/Integer;
-	public final fun component5 ()Ljava/lang/Integer;
-	public final fun component6 ()Ljava/lang/Integer;
-	public final fun component7 ()Ljava/lang/Integer;
-	public final fun component8 ()Ljava/lang/Integer;
-	public final fun component9 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;)Lee/schimke/composeai/cli/PreviewParams;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/cli/CaptureGutterDp;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewParams;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBackgroundColor ()J
-	public final fun getCaptureGutter ()Lee/schimke/composeai/cli/CaptureGutterDp;
-	public final fun getDensity ()Ljava/lang/Float;
-	public final fun getDevice ()Ljava/lang/String;
-	public final fun getFontScale ()F
-	public final fun getGroup ()Ljava/lang/String;
-	public final fun getHeightDp ()Ljava/lang/Integer;
-	public final fun getKind ()Ljava/lang/String;
-	public final fun getLocale ()Ljava/lang/String;
-	public final fun getMaxHeightPx ()Ljava/lang/Integer;
-	public final fun getMaxWidthPx ()Ljava/lang/Integer;
-	public final fun getMinHeightPx ()Ljava/lang/Integer;
-	public final fun getMinWidthPx ()Ljava/lang/Integer;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getPreviewParameterLimit ()I
-	public final fun getPreviewParameterProviderClassName ()Ljava/lang/String;
-	public final fun getShowBackground ()Z
-	public final fun getShowSystemUi ()Z
-	public final fun getUiMode ()I
-	public final fun getWidthDp ()Ljava/lang/Integer;
-	public final fun getWrapSandboxHeightDp ()Ljava/lang/Integer;
-	public final fun getWrapSandboxWidthDp ()Ljava/lang/Integer;
-	public final fun getWrapperClassName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/PreviewParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewParams$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewParams;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewParams;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewParams$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewResult {
-	public static final field Companion Lee/schimke/composeai/cli/PreviewResult$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/Boolean;
-	public final fun component12 ()Ljava/util/Map;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Lee/schimke/composeai/cli/PreviewParams;
-	public final fun component8 ()Ljava/util/List;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lee/schimke/composeai/cli/PreviewResult;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/PreviewResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/cli/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/cli/PreviewResult;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCaptures ()Ljava/util/List;
-	public final fun getChanged ()Ljava/lang/Boolean;
-	public final fun getClassName ()Ljava/lang/String;
-	public final fun getDataExtensions ()Ljava/util/Map;
-	public final fun getFunctionName ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
-	public final fun getModule ()Ljava/lang/String;
-	public final fun getParams ()Lee/schimke/composeai/cli/PreviewParams;
-	public final fun getPngPath ()Ljava/lang/String;
-	public final fun getProjectDirectory ()Ljava/lang/String;
-	public final fun getSha256 ()Ljava/lang/String;
-	public final fun getSourceFile ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/PreviewResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/PreviewResult$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/PreviewResult;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/PreviewResult;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/PreviewResult$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/ScrollCapture {
-	public static final field Companion Lee/schimke/composeai/cli/ScrollCapture$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()I
-	public final fun component4 ()Z
-	public final fun component5 ()Z
-	public final fun component6 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)Lee/schimke/composeai/cli/ScrollCapture;
-	public static synthetic fun copy$default (Lee/schimke/composeai/cli/ScrollCapture;Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/cli/ScrollCapture;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAtEnd ()Z
-	public final fun getAxis ()Ljava/lang/String;
-	public final fun getMaxScrollPx ()I
-	public final fun getMode ()Ljava/lang/String;
-	public final fun getReachedPx ()Ljava/lang/Integer;
-	public final fun getReduceMotion ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final synthetic class ee/schimke/composeai/cli/ScrollCapture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lee/schimke/composeai/cli/ScrollCapture$$serializer;
-	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/cli/ScrollCapture;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/cli/ScrollCapture;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/ScrollCapture$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class ee/schimke/composeai/cli/TalkBackOverlayFrames {
-	public static final field DEFAULT_DWELL_MS J
-	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackOverlayFrames;
-	public final fun focusedStopForFrame (IIIJ)I
-	public static synthetic fun focusedStopForFrame$default (Lee/schimke/composeai/cli/TalkBackOverlayFrames;IIIJILjava/lang/Object;)I
-	public final fun totalFrames (IIJ)I
-	public static synthetic fun totalFrames$default (Lee/schimke/composeai/cli/TalkBackOverlayFrames;IIJILjava/lang/Object;)I
-}
-
-public final class ee/schimke/composeai/cli/TalkBackTraversal {
-	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackTraversal;
-	public final fun focusStops (Ljava/util/List;)Ljava/util/List;
-	public final fun next (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
-	public final fun previous (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/cli/AccessibilityNode;
-}
-
-public final class ee/schimke/composeai/cli/TalkBackUtterance {
-	public static final field INSTANCE Lee/schimke/composeai/cli/TalkBackUtterance;
-	public final fun compose (Lee/schimke/composeai/cli/AccessibilityNode;)Ljava/lang/String;
-}
-
 public final class ee/schimke/composeai/designpages/DesignPage {
 	public static final field Companion Lee/schimke/composeai/designpages/DesignPage$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/designpages/PageFrame;Lee/schimke/composeai/designpages/PageImage;Ljava/util/List;Z)V
@@ -937,6 +227,772 @@ public final class ee/schimke/composeai/designpages/PageNodeLink : java/lang/Enu
 
 public final class ee/schimke/composeai/designpages/PageNodeLink$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/A11yWireFormatKt {
+	public static final field A11Y_PAYLOAD_SCHEMA_V1 Ljava/lang/String;
+	public static final field A11Y_REPORT_STATUS_ATF_UNAVAILABLE Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityEntry {
+	public static final field Companion Lee/schimke/composeai/previewdata/AccessibilityEntry$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/previewdata/AccessibilityEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/AccessibilityEntry;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/AccessibilityEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotatedPath ()Ljava/lang/String;
+	public final fun getFindings ()Ljava/util/List;
+	public final fun getNodes ()Ljava/util/List;
+	public final fun getPreviewId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/AccessibilityEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/AccessibilityEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/AccessibilityEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/AccessibilityEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityFinding {
+	public static final field Companion Lee/schimke/composeai/previewdata/AccessibilityFinding$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/AccessibilityFinding;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/AccessibilityFinding;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/AccessibilityFinding;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getViewDescription ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/AccessibilityFinding$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/AccessibilityFinding$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/AccessibilityFinding;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/AccessibilityFinding;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityFinding$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityNode {
+	public static final field Companion Lee/schimke/composeai/previewdata/AccessibilityNode$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)Lee/schimke/composeai/previewdata/AccessibilityNode;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/AccessibilityNode;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/AccessibilityNode;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInScreen ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMerged ()Z
+	public final fun getRef ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getStates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/AccessibilityNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/AccessibilityNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/AccessibilityNode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/AccessibilityNode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityNode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityReport {
+	public static final field Companion Lee/schimke/composeai/previewdata/AccessibilityReport$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Z)Lee/schimke/composeai/previewdata/AccessibilityReport;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/AccessibilityReport;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ZILjava/lang/Object;)Lee/schimke/composeai/previewdata/AccessibilityReport;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPartial ()Z
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/AccessibilityReport$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/AccessibilityReport$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/AccessibilityReport;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/AccessibilityReport;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/AccessibilityReport$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/Capture {
+	public static final field Companion Lee/schimke/composeai/previewdata/Capture$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component7 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component8 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component9 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/previewdata/Capture;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/Capture;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;ZLkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/Capture;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getFocus ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getFocusGif ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getGestureHint ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getHover ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getOptional ()Z
+	public final fun getRenderOutput ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public final fun getSettle ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/Capture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/Capture$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/Capture;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/Capture;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/Capture$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CaptureGutterDp {
+	public static final field Companion Lee/schimke/composeai/previewdata/CaptureGutterDp$Companion;
+	public fun <init> ()V
+	public fun <init> (IIII)V
+	public synthetic fun <init> (IIIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/previewdata/CaptureGutterDp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CaptureGutterDp;IIIIILjava/lang/Object;)Lee/schimke/composeai/previewdata/CaptureGutterDp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBottom ()I
+	public final fun getEnd ()I
+	public final fun getHorizontal ()I
+	public final fun getStart ()I
+	public final fun getTop ()I
+	public final fun getVertical ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/CaptureGutterDp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/CaptureGutterDp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/CaptureGutterDp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/CaptureGutterDp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CaptureGutterDp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CaptureResult {
+	public static final field Companion Lee/schimke/composeai/previewdata/CaptureResult$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/CaptureResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CaptureResult;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/CaptureResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getChanged ()Ljava/lang/Boolean;
+	public final fun getOptional ()Z
+	public final fun getParameterLabel ()Ljava/lang/String;
+	public final fun getParameterRowId ()Ljava/lang/String;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public final fun getSha256 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/CaptureResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/CaptureResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/CaptureResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/CaptureResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CaptureResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogEntry {
+	public static final field Companion Lee/schimke/composeai/previewdata/CatalogEntry$Companion;
+	public fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/previewdata/CatalogRole;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/CatalogEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CatalogEntry;Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/CatalogEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaption ()Ljava/lang/String;
+	public final fun getComponentId ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getKitAxis ()Ljava/lang/String;
+	public final fun getKitValue ()Ljava/lang/String;
+	public final fun getMotionPreview ()Ljava/lang/String;
+	public final fun getNoReference ()Ljava/lang/String;
+	public final fun getParallel ()Ljava/lang/String;
+	public final fun getPerBreakpoint ()Z
+	public final fun getProps ()Ljava/util/List;
+	public final fun getReference ()Ljava/lang/String;
+	public final fun getReferenceContentsOnly ()Z
+	public final fun getReferenceSet ()Ljava/lang/String;
+	public final fun getRole ()Lee/schimke/composeai/previewdata/CatalogRole;
+	public final fun getSection ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/CatalogEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/CatalogEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/CatalogEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/CatalogEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogRole : java/lang/Enum {
+	public static final field COMPONENT Lee/schimke/composeai/previewdata/CatalogRole;
+	public static final field Companion Lee/schimke/composeai/previewdata/CatalogRole$Companion;
+	public static final field VARIANT Lee/schimke/composeai/previewdata/CatalogRole;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/previewdata/CatalogRole;
+	public static fun values ()[Lee/schimke/composeai/previewdata/CatalogRole;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogRole$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogVariantProp {
+	public static final field Companion Lee/schimke/composeai/previewdata/CatalogVariantProp$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/CatalogVariantProp;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CatalogVariantProp;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/CatalogVariantProp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/CatalogVariantProp$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/CatalogVariantProp$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/CatalogVariantProp;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/CatalogVariantProp;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/CatalogVariantProp$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/ExtensionPayload {
+	public static final field Companion Lee/schimke/composeai/previewdata/ExtensionPayload$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lee/schimke/composeai/previewdata/ExtensionPayload;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/ExtensionPayload;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/ExtensionPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPayload ()Lkotlinx/serialization/json/JsonElement;
+	public final fun getSchema ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/ExtensionPayload$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/ExtensionPayload$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/ExtensionPayload;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/ExtensionPayload;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/ExtensionPayload$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewDataProduct {
+	public static final field Companion Lee/schimke/composeai/previewdata/PreviewDataProduct$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;)Lee/schimke/composeai/previewdata/PreviewDataProduct;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewDataProduct;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/previewdata/ScrollCapture;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewDataProduct;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvanceTimeMillis ()Ljava/lang/Long;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getMediaTypes ()Ljava/util/List;
+	public final fun getOutput ()Ljava/lang/String;
+	public final fun getScroll ()Lee/schimke/composeai/previewdata/ScrollCapture;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/PreviewDataProduct$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewDataProduct$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/PreviewDataProduct;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/PreviewDataProduct;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewDataProduct$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewInfo {
+	public static final field Companion Lee/schimke/composeai/previewdata/PreviewInfo$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/previewdata/CatalogEntry;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/previewdata/CatalogEntry;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Lee/schimke/composeai/previewdata/PreviewParams;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lee/schimke/composeai/previewdata/CatalogEntry;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/previewdata/CatalogEntry;ZZ)Lee/schimke/composeai/previewdata/PreviewInfo;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/util/List;Lee/schimke/composeai/previewdata/CatalogEntry;ZZILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBodyLine ()Ljava/lang/Integer;
+	public final fun getCaptures ()Ljava/util/List;
+	public final fun getCatalog ()Lee/schimke/composeai/previewdata/CatalogEntry;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getDataProducts ()Ljava/util/List;
+	public final fun getFixedTheme ()Z
+	public final fun getFunctionName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getIncludeInA11y ()Z
+	public final fun getParams ()Lee/schimke/composeai/previewdata/PreviewParams;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/PreviewInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/PreviewInfo;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/PreviewInfo;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewManifest {
+	public static final field Companion Lee/schimke/composeai/previewdata/PreviewManifest$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lee/schimke/composeai/previewdata/PreviewManifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewManifest;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataExtensionReports ()Ljava/util/Map;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getPreviews ()Ljava/util/List;
+	public final fun getReportsView ()Ljava/util/Map;
+	public final fun getVariant ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/PreviewManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewManifest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/PreviewManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/PreviewManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewModule : java/io/Serializable {
+	public fun <init> (Ljava/lang/String;Ljava/io/File;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/io/File;
+	public final fun copy (Ljava/lang/String;Ljava/io/File;)Lee/schimke/composeai/previewdata/PreviewModule;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewModule;Ljava/lang/String;Ljava/io/File;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewModule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGradlePath ()Ljava/lang/String;
+	public final fun getProjectDir ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewParameterFanout {
+	public static final field INDEX_PREFIX Ljava/lang/String;
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewParameterFanout;
+	public final fun getTokenOrder ()Ljava/util/Comparator;
+	public final fun label (Ljava/lang/String;)Ljava/lang/String;
+	public final fun rowId (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun rowsOf (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Set;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewParameterFanout$Row {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/PreviewParameterFanout$Row;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewParameterFanout$Row;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewParameterFanout$Row;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getOutput ()Ljava/lang/String;
+	public final fun getToken ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewParams {
+	public static final field Companion Lee/schimke/composeai/previewdata/PreviewParams$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/previewdata/CaptureGutterDp;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/previewdata/CaptureGutterDp;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/lang/Float;
+	public final fun component12 ()F
+	public final fun component13 ()Z
+	public final fun component14 ()Z
+	public final fun component15 ()J
+	public final fun component16 ()I
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()I
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Lee/schimke/composeai/previewdata/CaptureGutterDp;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/previewdata/CaptureGutterDp;)Lee/schimke/composeai/previewdata/PreviewParams;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewParams;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Float;FZZJILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Lee/schimke/composeai/previewdata/CaptureGutterDp;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor ()J
+	public final fun getCaptureGutter ()Lee/schimke/composeai/previewdata/CaptureGutterDp;
+	public final fun getDensity ()Ljava/lang/Float;
+	public final fun getDevice ()Ljava/lang/String;
+	public final fun getFontScale ()F
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getHeightDp ()Ljava/lang/Integer;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLocale ()Ljava/lang/String;
+	public final fun getMaxHeightPx ()Ljava/lang/Integer;
+	public final fun getMaxWidthPx ()Ljava/lang/Integer;
+	public final fun getMinHeightPx ()Ljava/lang/Integer;
+	public final fun getMinWidthPx ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPreviewParameterLimit ()I
+	public final fun getPreviewParameterProviderClassName ()Ljava/lang/String;
+	public final fun getShowBackground ()Z
+	public final fun getShowSystemUi ()Z
+	public final fun getUiMode ()I
+	public final fun getWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxHeightDp ()Ljava/lang/Integer;
+	public final fun getWrapSandboxWidthDp ()Ljava/lang/Integer;
+	public final fun getWrapperClassName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/PreviewParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/PreviewParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/PreviewParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewResult {
+	public static final field Companion Lee/schimke/composeai/previewdata/PreviewResult$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lee/schimke/composeai/previewdata/PreviewParams;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lee/schimke/composeai/previewdata/PreviewResult;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/PreviewResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lee/schimke/composeai/previewdata/PreviewParams;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptures ()Ljava/util/List;
+	public final fun getChanged ()Ljava/lang/Boolean;
+	public final fun getClassName ()Ljava/lang/String;
+	public final fun getDataExtensions ()Ljava/util/Map;
+	public final fun getFunctionName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getModule ()Ljava/lang/String;
+	public final fun getParams ()Lee/schimke/composeai/previewdata/PreviewParams;
+	public final fun getPngPath ()Ljava/lang/String;
+	public final fun getProjectDirectory ()Ljava/lang/String;
+	public final fun getSha256 ()Ljava/lang/String;
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/PreviewResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/PreviewResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/PreviewResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewResultBuilder {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/PreviewResultBuilder;
+	public final fun build (Ljava/util/List;Lokio/FileSystem;)Ljava/util/List;
+	public static synthetic fun build$default (Lee/schimke/composeai/previewdata/PreviewResultBuilder;Ljava/util/List;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/List;
+	public final fun readAllManifests (Ljava/util/List;Lokio/FileSystem;)Ljava/util/List;
+	public static synthetic fun readAllManifests$default (Lee/schimke/composeai/previewdata/PreviewResultBuilder;Ljava/util/List;Lokio/FileSystem;ILjava/lang/Object;)Ljava/util/List;
+	public final fun readManifest (Lee/schimke/composeai/previewdata/PreviewModule;Lokio/FileSystem;)Lee/schimke/composeai/previewdata/PreviewManifest;
+	public static synthetic fun readManifest$default (Lee/schimke/composeai/previewdata/PreviewResultBuilder;Lee/schimke/composeai/previewdata/PreviewModule;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/PreviewManifest;
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewResultBuilderKt {
+	public static final fun parameterFanoutOwnedBySibling (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z
+}
+
+public final class ee/schimke/composeai/previewdata/PreviewSha256Kt {
+	public static final fun previewSha256 (Ljava/io/File;Lokio/FileSystem;)Ljava/lang/String;
+	public static synthetic fun previewSha256$default (Ljava/io/File;Lokio/FileSystem;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/previewdata/ScrollCapture {
+	public static final field Companion Lee/schimke/composeai/previewdata/ScrollCapture$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;)Lee/schimke/composeai/previewdata/ScrollCapture;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/ScrollCapture;Ljava/lang/String;Ljava/lang/String;IZZLjava/lang/Integer;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/ScrollCapture;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAtEnd ()Z
+	public final fun getAxis ()Ljava/lang/String;
+	public final fun getMaxScrollPx ()I
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getReachedPx ()Ljava/lang/Integer;
+	public final fun getReduceMotion ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/previewdata/ScrollCapture$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/ScrollCapture$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/previewdata/ScrollCapture;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/previewdata/ScrollCapture;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/ScrollCapture$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/previewdata/TalkBackOverlayFrames {
+	public static final field DEFAULT_DWELL_MS J
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/TalkBackOverlayFrames;
+	public final fun focusedStopForFrame (IIIJ)I
+	public static synthetic fun focusedStopForFrame$default (Lee/schimke/composeai/previewdata/TalkBackOverlayFrames;IIIJILjava/lang/Object;)I
+	public final fun totalFrames (IIJ)I
+	public static synthetic fun totalFrames$default (Lee/schimke/composeai/previewdata/TalkBackOverlayFrames;IIJILjava/lang/Object;)I
+}
+
+public final class ee/schimke/composeai/previewdata/TalkBackTraversal {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/TalkBackTraversal;
+	public final fun focusStops (Ljava/util/List;)Ljava/util/List;
+	public final fun next (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/previewdata/AccessibilityNode;
+	public final fun previous (Ljava/util/List;Ljava/lang/String;)Lee/schimke/composeai/previewdata/AccessibilityNode;
+}
+
+public final class ee/schimke/composeai/previewdata/TalkBackUtterance {
+	public static final field INSTANCE Lee/schimke/composeai/previewdata/TalkBackUtterance;
+	public final fun compose (Lee/schimke/composeai/previewdata/AccessibilityNode;)Ljava/lang/String;
 }
 
 public final class ee/schimke/composeai/xr/OrbitCamera {

--- a/api/preview-data-api/build.gradle.kts
+++ b/api/preview-data-api/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
   // pure `@Serializable` DTO jars (no cycle: `:data-layoutinspector-core` doesn't depend back).
   api(project(":data-layoutinspector-core"))
 
+  // Okio-based file IO for `PreviewResultBuilder`'s manifest read and PNG sha256 (#3824
+  // preparation item 5's follow-on). `api` because `readManifest` takes a `FileSystem` parameter,
+  // so the type is part of this module's public surface. `:common-io` is itself a contract, so an
+  // extracted preview server gains nothing new on its dependency floor by seeing it.
+  api(project(":common-io"))
+
   testImplementation(libs.junit)
   testImplementation(kotlin("test"))
 }

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/A11yWireFormat.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/A11yWireFormat.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import kotlinx.serialization.Serializable
 
@@ -42,7 +42,8 @@ public data class AccessibilityFinding(
  * [AccessibilityNode][ee.schimke.composeai.renderer.AccessibilityNode] field-for-field — same JSON
  * schema, pinned by the wire format rather than Kotlin type identity. The desktop daemon's
  * overlay-only a11y path (Compose-semantics extraction, no ATF) emits these from
- * `ee.schimke.composeai.cli.*` types rather than depending on the Android `:data-a11y-core`.
+ * `ee.schimke.composeai.previewdata.*` types rather than depending on the Android
+ * `:data-a11y-core`.
  */
 @Serializable
 public data class AccessibilityNode(

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewData.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewModule.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewModule.kt
@@ -1,0 +1,15 @@
+package ee.schimke.composeai.previewdata
+
+import java.io.File
+
+/**
+ * Handle for a subproject that applies `ee.schimke.composeai.preview`.
+ *
+ * [gradlePath] is the colon-separated project path **without** its leading colon (e.g. `"app"`,
+ * `"auth:composables"`) — used to address Gradle tasks like
+ * `":$gradlePath:composePreviewRenderAll"` and to identify the module in CLI output / persisted
+ * state. [projectDir] is the actual filesystem directory of that subproject, resolved via Gradle's
+ * Tooling API. Using it instead of `projectRoot/$gradlePath` is what makes nested subprojects
+ * (`:foo:bar`) and any custom `project.projectDir` override work correctly — see issue #157.
+ */
+public data class PreviewModule(val gradlePath: String, val projectDir: File) : java.io.Serializable

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewParameterFanout.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewParameterFanout.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 /**
  * The **one** rule for turning a `@PreviewParameter` fan-out on disk into addressable **row ids**
@@ -21,13 +21,13 @@ package ee.schimke.composeai.cli
  * listing — testable without a render, and indifferent to whether the listing came from Okio, a
  * `java.io.File`, or a fake.
  */
-object PreviewParameterFanout {
+public object PreviewParameterFanout {
 
   /** One value of a provider: the file it rendered to, the token that names it, and its row id. */
-  data class Row(val id: String, val token: String, val output: String)
+  public data class Row(val id: String, val token: String, val output: String)
 
   /** The `<stem>_PARAM_<idx>` spelling the renderer falls back to when no label can be derived. */
-  const val INDEX_PREFIX: String = "PARAM_"
+  public const val INDEX_PREFIX: String = "PARAM_"
 
   /**
    * The rows of the preview whose id is [baseId] and whose manifest template capture renders to
@@ -45,7 +45,7 @@ object PreviewParameterFanout {
    * disk matched — the caller decides what an empty fan-out means (the builder keeps no captures,
    * `serve` keeps the bare id).
    */
-  fun rowsOf(
+  public fun rowsOf(
     baseId: String,
     templateOutput: String,
     fileNames: List<String>,
@@ -86,7 +86,7 @@ object PreviewParameterFanout {
    * The addressable id of one row: `<baseId>_<token>`, exactly the shape the daemon accepts on
    * `renderNow` and `--id` accepts as a selector. The single place that spelling is written down.
    */
-  fun rowId(baseId: String, token: String): String = "${baseId}_$token"
+  public fun rowId(baseId: String, token: String): String = "${baseId}_$token"
 
   /**
    * Human-readable coordinate for a row, for output that shows a row *under* its preview rather
@@ -94,7 +94,7 @@ object PreviewParameterFanout {
    * the token carries nothing to say. Distinct from [rowId] on purpose — this one is lossy, and a
    * selector must never be derived from it.
    */
-  fun label(token: String): String? {
+  public fun label(token: String): String? {
     val parameterIndex =
       token.removePrefix(INDEX_PREFIX).toIntOrNull()?.takeIf { token.startsWith(INDEX_PREFIX) }
     return if (parameterIndex != null) "parameter $parameterIndex"
@@ -106,7 +106,7 @@ object PreviewParameterFanout {
    * preceding it as lexicographic order would; labelled rows after, alphabetically. Provider order
    * isn't recoverable from a filename, so alphabetical is the stable, readable choice.
    */
-  val tokenOrder: Comparator<String> = Comparator { a, b ->
+  public val tokenOrder: Comparator<String> = Comparator { a, b ->
     val ia = a.removePrefix(INDEX_PREFIX).toIntOrNull()?.takeIf { a.startsWith(INDEX_PREFIX) }
     val ib = b.removePrefix(INDEX_PREFIX).toIntOrNull()?.takeIf { b.startsWith(INDEX_PREFIX) }
     when {

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewResultBuilder.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewResultBuilder.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import ee.schimke.composeai.io.SystemFileSystem
 import kotlinx.serialization.json.Json
@@ -19,14 +19,14 @@ import okio.Path.Companion.toPath
  * Results are returned with `changed = null` on every capture — the driver doesn't track diff
  * state. Consumers that want change detection track `sha256` against their own prior run.
  */
-object PreviewResultBuilder {
+public object PreviewResultBuilder {
 
   /**
    * Read a module's `build/compose-previews/previews.json` and decode it into a [PreviewManifest].
    * Returns `null` when the file doesn't exist — `composePreviewRenderAll` is allowed to skip a
    * module that has no previews discovered yet.
    */
-  fun readManifest(
+  public fun readManifest(
     module: PreviewModule,
     fileSystem: FileSystem = SystemFileSystem,
   ): PreviewManifest? {
@@ -42,7 +42,7 @@ object PreviewResultBuilder {
    * Convenience over [readManifest] — drops modules whose manifest file isn't on disk yet.
    * Order-preserving.
    */
-  fun readAllManifests(
+  public fun readAllManifests(
     modules: List<PreviewModule>,
     fileSystem: FileSystem = SystemFileSystem,
   ): List<Pair<PreviewModule, PreviewManifest>> {
@@ -60,7 +60,7 @@ object PreviewResultBuilder {
    *
    * No side effects — pure function over the manifest data + on-disk PNG files.
    */
-  fun build(
+  public fun build(
     manifests: List<Pair<PreviewModule, PreviewManifest>>,
     fileSystem: FileSystem = SystemFileSystem,
   ): List<PreviewResult> {
@@ -236,7 +236,7 @@ object PreviewResultBuilder {
  * `.error.json` sidecars. Two copies of this rule would drift, and a drift means one preview's
  * failure reported under another's name.
  */
-fun parameterFanoutOwnedBySibling(
+public fun parameterFanoutOwnedBySibling(
   templateOutput: String,
   siblingOutput: String,
   candidateOutput: String,

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewSha256.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewSha256.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import ee.schimke.composeai.io.SystemFileSystem
 import java.awt.image.BufferedImage
@@ -27,7 +27,7 @@ import okio.Path.Companion.toPath
  * through `:cli` need the same change-detection hash function so their state files stay compatible
  * with the CLI's.
  */
-fun previewSha256(file: File, fileSystem: FileSystem = SystemFileSystem): String =
+public fun previewSha256(file: File, fileSystem: FileSystem = SystemFileSystem): String =
   if (file.extension.equals("gif", ignoreCase = true)) {
     gifBookendFrameSha256(file, fileSystem) ?: sha256(readAllBytes(file, fileSystem))
   } else {

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/TalkBack.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/TalkBack.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 /**
  * JVM mirror of `:data-a11y-core`'s pure TalkBack helpers (issue #1956), operating on the

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/CatalogEntryWireTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/CatalogEntryWireTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/PreviewResultAbiTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/PreviewResultAbiTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import kotlin.test.Test
 import kotlin.test.assertTrue

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/PreviewResultBuilderTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/PreviewResultBuilderTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import java.io.File
 import java.nio.file.Files

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/TalkBackTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/TalkBackTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.previewdata
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/A11yReportRenderer.kt
@@ -1,6 +1,13 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.A11Y_PAYLOAD_SCHEMA_V1
+import ee.schimke.composeai.previewdata.AccessibilityEntry
+import ee.schimke.composeai.previewdata.AccessibilityReport
+import ee.schimke.composeai.previewdata.ExtensionPayload
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import okio.Path.Companion.toPath

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -24,6 +24,7 @@ import ee.schimke.composeai.cli.serve.SvgOutcome
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.nio.file.Files

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -5,6 +5,8 @@ import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.expandZipBytesSafely
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.TemporaryDirectory
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.UUID

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -6,6 +6,17 @@ import ee.schimke.composeai.bundle.injectFigmaRasterIntoBundle
 import ee.schimke.composeai.bundle.injectFigmaSvgIntoBundle
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.PreviewResultBuilder
+import ee.schimke.composeai.previewdata.previewSha256
+import ee.schimke.composeai.previewdriver.GradleConnection
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
+import ee.schimke.composeai.previewdriver.ProjectDiscoveryFailure
+import ee.schimke.composeai.previewdriver.printCapturedTestFailures
 import java.awt.image.BufferedImage
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcher.kt
@@ -3,6 +3,12 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.daemon.protocol.DataFetchParams
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.A11Y_REPORT_STATUS_ATF_UNAVAILABLE
+import ee.schimke.composeai.previewdata.AccessibilityEntry
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityReport
+import ee.schimke.composeai.previewdata.PreviewModule
 import ee.schimke.composeai.render.session.DataProductException
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import ee.schimke.composeai.previewdriver.GradleAccessFailure
+import ee.schimke.composeai.previewdriver.GradleConnection
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionReportRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionReportRenderer.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+
 /**
  * Strategy for "given a render outcome, surface a canned per-extension report" — the slot the CLI
  * gives each data extension to participate in the `compose-preview <extension>` command shape

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
 import ee.schimke.composeai.plugin.tooling.ModuleFinding
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
 import ee.schimke.composeai.plugin.tooling.RenderPreviewsTaskInfo
+import ee.schimke.composeai.previewdriver.ProjectDiscoveryFailure
 import java.io.Serializable
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -2,6 +2,9 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.mcp.DaemonMcpMain
+import ee.schimke.composeai.previewdriver.DriverOptions
+import ee.schimke.composeai.previewdriver.GradlePreviewDriver
+import ee.schimke.composeai.previewdriver.RenderRequest
 import java.io.File
 import kotlin.system.exitProcess
 import kotlinx.serialization.json.Json

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderMessage.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderMessage.kt
@@ -1,5 +1,11 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdriver.GradleTaskDisposition
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
+
 /*
  * The prose half of issue #3796. `PreviewDiagnosis.kt` holds what is known; this file turns it into
  * sentences, and its one rule is that every sentence is a function taking the evidence it asserts.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/MissingRenderReport.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.cli.serve.RenderFailureFrame
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewResult
 import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewDiagnosis.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewDiagnosis.kt
@@ -1,6 +1,13 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.parameterFanoutOwnedBySibling
+import ee.schimke.composeai.previewdriver.GradleTaskDisposition
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
 import okio.FileSystem
 import okio.Path.Companion.toPath
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewPermutationsCli.kt
@@ -2,6 +2,11 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewDataProduct
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewParams
 
 internal object PreviewPermutationsCli {
   const val PROPERTY: String = "composePreview.permutations"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PreviewRenderScope.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+
 /**
  * Turns a `--id` / `--filter` / `--preview` request into the Gradle property that actually narrows
  * the render (issue #3730; `--preview` joined the selectors in #3744).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RecordPreviewCommand.kt
@@ -6,6 +6,8 @@ import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionConfig
 import ee.schimke.composeai.render.session.RenderSessionException

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderMatrixCommand.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.mcp.ContactSheet
 import ee.schimke.composeai.mcp.MatrixAxes
 import ee.schimke.composeai.mcp.MatrixCell
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.File
 import java.security.MessageDigest
 import kotlin.system.exitProcess

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
 import java.io.File
 import java.security.MessageDigest
 import kotlin.system.exitProcess

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -95,6 +95,9 @@ import ee.schimke.composeai.cli.serve.declaredThemesFromPreviews
 import ee.schimke.composeai.cli.serve.detectedFeaturesOf
 import ee.schimke.composeai.cli.serve.openIsolatedSharedDaemonReplica
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
 import ee.schimke.composeai.render.session.RenderSessionException
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
 import java.awt.Desktop

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/GradleRevisionBuilder.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewModule
-import ee.schimke.composeai.cli.PreviewResultBuilder
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResultBuilder
 import java.io.File
 import java.util.concurrent.TimeUnit
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviews.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
 import kotlinx.serialization.json.Json
 
 /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -8,10 +8,10 @@ import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
 import ee.schimke.composeai.bundle.extractBundleIrArtifacts
 import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.cli.CoordinateResolver
-import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.File
 import kotlinx.serialization.json.Json
 import okio.FileSystem

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -368,12 +368,16 @@ class ServeBundleHost(
    * Compose replays, this preserves each baked preview's explicit `uiMode` for the viewer's
    * Day/Night default. Empty when the bundle carries no manifest.
    */
-  private val previewParamsById: Map<String, ee.schimke.composeai.cli.PreviewParams> by lazy {
+  private val previewParamsById:
+    Map<String, ee.schimke.composeai.previewdata.PreviewParams> by lazy {
     val previewsJson = File(bundleDir, PREVIEWS_JSON).toOkioPath()
     if (!fileSystem.exists(previewsJson)) return@lazy emptyMap()
     try {
       val text = fileSystem.read(previewsJson) { readUtf8() }
-      OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
+      OVERRIDES_JSON.decodeFromString(
+          ee.schimke.composeai.previewdata.PreviewManifest.serializer(),
+          text,
+        )
         .previews
         .associate { it.id to it.params }
     } catch (e: Exception) {
@@ -408,7 +412,7 @@ class ServeBundleHost(
         val text = fileSystem.read(previewsJson) { readUtf8() }
         val manifest =
           OVERRIDES_JSON.decodeFromString(
-            ee.schimke.composeai.cli.PreviewManifest.serializer(),
+            ee.schimke.composeai.previewdata.PreviewManifest.serializer(),
             text,
           )
         for (p in manifest.previews) {
@@ -644,7 +648,7 @@ class ServeBundleHost(
         val text = fileSystem.read(previewsJson) { readUtf8() }
         val manifest =
           OVERRIDES_JSON.decodeFromString(
-            ee.schimke.composeai.cli.PreviewManifest.serializer(),
+            ee.schimke.composeai.previewdata.PreviewManifest.serializer(),
             text,
           )
         for (p in manifest.previews) {
@@ -671,7 +675,10 @@ class ServeBundleHost(
     try {
       val text = fileSystem.read(previewsJson) { readUtf8() }
       val manifest =
-        OVERRIDES_JSON.decodeFromString(ee.schimke.composeai.cli.PreviewManifest.serializer(), text)
+        OVERRIDES_JSON.decodeFromString(
+          ee.schimke.composeai.previewdata.PreviewManifest.serializer(),
+          text,
+        )
       declaredThemesFromPreviews(manifest.previews)
     } catch (e: Exception) {
       emptyList()
@@ -1521,7 +1528,7 @@ private fun rendersRightToLeft(locale: String?): Boolean {
  * the fields a browse surface consults before opening a daemon cross over — the rest of
  * `PreviewParams` (locale, font scale, density) belongs to the render, not to how it is presented.
  */
-private fun ee.schimke.composeai.cli.PreviewParams.asPreviewParamsMeta():
+private fun ee.schimke.composeai.previewdata.PreviewParams.asPreviewParamsMeta():
   ServeCatalogStore.PreviewParamsMeta =
   ServeCatalogStore.PreviewParamsMeta(
     uiMode = uiMode,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRows.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewParameterFanout
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParameterFanout
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -206,9 +206,9 @@ data class ServePreview(
   /**
    * Module-relative source path of the file this preview was authored in
    * (`src/main/kotlin/…/Foo.kt`), from the bundle's `previews.json` manifest
-   * ([ee.schimke.composeai.cli.PreviewInfo.sourceFile]). Lets the viewer link the preview to its
-   * source on GitHub when the session carries delivery provenance (repo + branch). Null for a
-   * bundle without a manifest, a preview whose manifest entry recorded no source path, or a
+   * ([ee.schimke.composeai.previewdata.PreviewInfo.sourceFile]). Lets the viewer link the preview
+   * to its source on GitHub when the session carries delivery provenance (repo + branch). Null for
+   * a bundle without a manifest, a preview whose manifest entry recorded no source path, or a
    * live/local session with no published source to point at.
    */
   val sourceFile: String? = null,
@@ -219,7 +219,7 @@ data class ServePreview(
   val sourceModule: String? = null,
   /**
    * A 1-based line inside this preview's function body within [sourceFile], from the bundle's
-   * `previews.json` ([ee.schimke.composeai.cli.PreviewInfo.bodyLine]).
+   * `previews.json` ([ee.schimke.composeai.previewdata.PreviewInfo.bodyLine]).
    *
    * Lets the playground handoff seed the editor with the one declaration that was clicked rather
    * than the whole file it shares with its group — a section file is one *group*, so opening
@@ -347,12 +347,14 @@ data class RenderFailureFrame(val file: String = "", val line: Int = 0, val func
 
 /**
  * Detected per-preview feature support, folded across a discovery
- * [ee.schimke.composeai.cli.PreviewInfo]'s captures: keyboard focus (`@FocusedPreview` → a
+ * [ee.schimke.composeai.previewdata.PreviewInfo]'s captures: keyboard focus (`@FocusedPreview` → a
  * `focus`/`focusGif` capture) and one-handed gestures (`@GestureHintPreview` → a `gestureHint`
  * capture). Returns the two booleans the viewer gates its feature controls on. A preview with
  * neither annotation yields `(false, false)`.
  */
-fun detectedFeaturesOf(preview: ee.schimke.composeai.cli.PreviewInfo): Pair<Boolean, Boolean> {
+fun detectedFeaturesOf(
+  preview: ee.schimke.composeai.previewdata.PreviewInfo
+): Pair<Boolean, Boolean> {
   val focus = preview.captures.any { it.focus != null || it.focusGif != null }
   val gestures = preview.captures.any { it.gestureHint != null }
   return focus to gestures
@@ -400,7 +402,7 @@ internal fun inferredThemeMode(name: String, providerFqn: String): String? {
  * provider FQN are skipped (nothing to apply). Deduped by FQN.
  */
 fun declaredThemesFromPreviews(
-  previews: List<ee.schimke.composeai.cli.PreviewInfo>
+  previews: List<ee.schimke.composeai.previewdata.PreviewInfo>
 ): List<ServeTheme> =
   previews
     .filter { it.params.kind == "THEME_CATALOG" || it.params.kind == "WEAR_THEME_CATALOG" }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yCommandTest.kt
@@ -1,6 +1,16 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.previewdata.A11Y_PAYLOAD_SCHEMA_V1
+import ee.schimke.composeai.previewdata.AccessibilityEntry
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.ExtensionPayload
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/A11yReportRendererTest.kt
@@ -1,5 +1,15 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.A11Y_PAYLOAD_SCHEMA_V1
+import ee.schimke.composeai.previewdata.AccessibilityEntry
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.ExtensionPayload
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.PrintStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BrowseCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BrowseCommandTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererAndroidOutputTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewInfo
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererSizeBoundsArgsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleRendererSizeBoundsArgsTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParams
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DaemonA11yFetcherTest.kt
@@ -24,6 +24,11 @@ import ee.schimke.composeai.daemon.protocol.RecordingStopResult
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import ee.schimke.composeai.previewdata.A11Y_REPORT_STATUS_ATF_UNAVAILABLE
+import ee.schimke.composeai.previewdata.AccessibilityEntry
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityReport
 import ee.schimke.composeai.render.session.NotificationListener
 import ee.schimke.composeai.render.session.RenderSession
 import ee.schimke.composeai.render.session.RenderSessionBackend

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DiscoveryFailureReportingTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdriver.ProjectDiscoveryFailure
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderMessageInvariantTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderMessageInvariantTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdriver.GradleTaskDisposition
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRenderReportTest.kt
@@ -1,5 +1,15 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewDataProduct
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdriver.GradleTaskDisposition
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/MissingRendersPolicyTest.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.ScrollCapture
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/NarrowedRenderStateTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/NarrowedRenderStateTest.kt
@@ -1,5 +1,11 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -1,5 +1,13 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewDataProduct
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.ScrollCapture
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewManifestReportsViewTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewManifestReportsViewTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewManifest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewReferenceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewReferenceTest.kt
@@ -1,5 +1,11 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRenderScopeTest.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowResultSelectionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowResultSelectionTest.kt
@@ -1,5 +1,13 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdata.PreviewResultBuilder
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewRowSelectorTest.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSha256Test.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSha256Test.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.previewSha256
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.File

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ShowPartialResultsTest.kt
@@ -1,5 +1,13 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.previewdata.CaptureResult
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewModule
+import ee.schimke.composeai.previewdata.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewResult
+import ee.schimke.composeai.previewdriver.GradleTaskDisposition
+import ee.schimke.composeai.previewdriver.GradleTaskOutcome
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundAndroidRenderServiceTest.kt
@@ -1,10 +1,10 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundPreviewsTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewManifest
+import ee.schimke.composeai.previewdata.PreviewManifest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundRcCaptureServiceTest.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.File
 import java.util.Base64
 import kotlin.test.AfterTest

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemonKnobSidecarTest.kt
@@ -1,7 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewManifest
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
@@ -9,6 +7,8 @@ import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeDeclarationsPayload
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.util.zip.ZipEntry

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFeatureDetectionTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeFeatureDetectionTest.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.Capture
-import ee.schimke.composeai.cli.PreviewInfo
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewInfo
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.JsonPrimitive

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewParams
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParams
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRowsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParameterRowsTest.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.Capture
-import ee.schimke.composeai.cli.PreviewInfo
-import ee.schimke.composeai.cli.PreviewParams
+import ee.schimke.composeai.previewdata.Capture
+import ee.schimke.composeai.previewdata.PreviewInfo
+import ee.schimke.composeai.previewdata.PreviewParams
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -119,7 +119,8 @@ dependencies {
   implementation(project(":data-navigation-connector"))
   // Accessibility (desktop, overlay-only) — the desktop a11y path extracts Compose semantics from
   // `ImageComposeScene.semanticsOwners`, draws the Paparazzi-style overlay + legend with AWT, and
-  // emits the wire-format DTOs from `:preview-data-api` (`ee.schimke.composeai.cli.*`). ATF is
+  // emits the wire-format DTOs from `:preview-data-api` (`ee.schimke.composeai.previewdata.*`). ATF
+  // is
   // Android-only, so findings are always empty here — no dependency on `:data-a11y-core` (an
   // android-library). See `DesktopAccessibility*`.
   implementation(project(":preview-data-api"))

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityDataProducer.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityDataProducer.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.cli.AccessibilityFinding
-import ee.schimke.composeai.cli.AccessibilityNode
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.AccessibilityNode
 import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityNodeExtractor.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityNodeExtractor.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.state.ToggleableState
-import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityNode
 
 /**
  * Desktop (Compose Multiplatform) port of `:data-a11y-core`'s `AccessibilityChecker.extractNodes` —

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityOverlay.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityOverlay.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.cli.AccessibilityFinding
-import ee.schimke.composeai.cli.AccessibilityNode
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.AccessibilityFinding
+import ee.schimke.composeai.previewdata.AccessibilityNode
 import java.awt.BasicStroke
 import java.awt.Color
 import java.awt.Font

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -6,9 +6,6 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.ui.input.pointer.PointerEventType
-import ee.schimke.composeai.cli.AccessibilityNode
-import ee.schimke.composeai.cli.TalkBackOverlayFrames
-import ee.schimke.composeai.cli.TalkBackTraversal
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
@@ -21,6 +18,9 @@ import ee.schimke.composeai.data.layoutinspector.SemanticsTargets
 import ee.schimke.composeai.data.layoutinspector.TargetResolution
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import ee.schimke.composeai.io.SystemFileSystem
+import ee.schimke.composeai.previewdata.AccessibilityNode
+import ee.schimke.composeai.previewdata.TalkBackOverlayFrames
+import ee.schimke.composeai.previewdata.TalkBackTraversal
 import ee.schimke.composeai.renderer.encodePngData
 import java.awt.AlphaComposite
 import java.awt.RenderingHints

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlay.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlay.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.cli.AccessibilityNode
-import ee.schimke.composeai.cli.TalkBackTraversal
-import ee.schimke.composeai.cli.TalkBackUtterance
+import ee.schimke.composeai.previewdata.AccessibilityNode
+import ee.schimke.composeai.previewdata.TalkBackTraversal
+import ee.schimke.composeai.previewdata.TalkBackUtterance
 import java.awt.BasicStroke
 import java.awt.Color
 import java.awt.Font

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityNodeExtractorTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityNodeExtractorTest.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityNode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityOverlayTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopAccessibilityOverlayTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityNode
 import java.awt.Color
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlayTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopTalkBackFocusOverlayTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.cli.AccessibilityNode
+import ee.schimke.composeai.previewdata.AccessibilityNode
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream

--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -87,14 +87,32 @@ tokenizer is now tested and the register is stable, and because the check become
 preparation item 7 — once serve is its own module, `checkServeModuleBoundary` reads a resolved
 classpath and no source scanning is needed at all. If this check needs substantial work again before
 then, rewrite it against bytecode rather than teaching the tokenizer another Kotlin rule.
-The `serve→cli` direction is dominated by the bundle format (`BundleReader`, `BundleSigning`,
-`BundleClasspathHydration`, `extractBundle*`, `locateBundleSidecarJars`, `BUNDLE_VERSION`) —
-preparation item 5 below — and it is *no longer* dominated by them: those symbols now live in a
-published `:bundle-format` under `ee.schimke.composeai.bundle`, a package the register maps to a
-contract, so twelve of them came off. What is left is nine names on `main`. Worth remembering how
-that happened: moving the files into a module changed the count by zero, because this check reads
-the package an import names, not the module that declares it. The package rename is what moved it. The `cli→serve` direction is dominated by `ServeCommand.kt`, which #3824
-wants reduced to a thin entry point.
+The `serve→cli` direction used to be dominated by the bundle format (`BundleReader`,
+`BundleSigning`, `BundleClasspathHydration`, `extractBundle*`, `locateBundleSidecarJars`) —
+preparation item 5 — and is now down to **three** entries on `main`. Getting there took the same
+lesson twice, and it is worth writing down because it is not the obvious one.
+
+Moving files into a module changes this number by **zero**. The check keys a crossing on the
+*package* an import names, not on the module that declares it, so `:bundle-format` was invisible to
+it until the package was renamed too. Applying that a second time took the list from 9 to 3: six of
+the nine survivors were never `:cli` internals at all — `PreviewInfo`, `PreviewManifest` and
+`PreviewParams` belong to the published `:preview-data-api`, and `PreviewModule`,
+`PreviewParameterFanout` and `PreviewResultBuilder` to `:gradle-preview-driver`. They only looked
+like coupling because they shared the `…cli` package. Both modules now carry their own
+(`ee.schimke.composeai.previewdata`, `ee.schimke.composeai.previewdriver`), which is a **breaking
+change for external consumers** and was taken deliberately rather than annotated away.
+
+That rename immediately exposed something the shared package had hidden. Serve used three types
+from `:gradle-preview-driver`, whose `api` dependency is the **Gradle Tooling API** — so naming it
+as a contract would have put the Tooling API on an extracted server's floor. None of the three
+needed Gradle: `PreviewParameterFanout` has no imports at all, and `PreviewResultBuilder` /
+`previewSha256` use only Okio and the DTOs. They moved down into `:preview-data-api` instead.
+`:gradle-preview-driver` is not a contract and serve no longer names it.
+
+The three that remain are genuinely declared in `:cli` and each needs a decision rather than a
+move: `BUNDLE_VERSION` (does an extracted server report its own version, or the CLI's?),
+`CoordinateResolver`, and `WebEmbed`. They belong to preparation item 7. The `cli→serve` direction
+is untouched at 102 entries and is dominated by `ServeCommand.kt`.
 
 ### 2. `scripts/check-preview-server-contracts.sh` — the artifact probe
 

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -16,6 +16,22 @@
     "all, because the check keys a crossing on the package an import names, not on the module",
     "that declares it, and the extraction kept the `…cli` package for source-compat. The rename",
     "is what moved the number.",
+    "Applying that lesson a second time took this list from 9 to 3. Six of the nine that remained",
+    "after item 5 were never CLI internals at all: PreviewInfo, PreviewManifest and PreviewParams",
+    "belong to the published :preview-data-api, and PreviewModule, PreviewParameterFanout and",
+    "PreviewResultBuilder to :gradle-preview-driver — all six only looked like coupling because",
+    "they shared the `…cli` package. Both modules now carry their own packages",
+    "(`ee.schimke.composeai.previewdata` / `…previewdriver`), which is a breaking change for",
+    "external consumers and was made deliberately rather than papered over in this file.",
+    "That rename exposed something the package sharing had hidden: serve used three types from",
+    "`:gradle-preview-driver`, a module whose api dependency is the Gradle Tooling API. None of",
+    "the three needed Gradle — PreviewParameterFanout has no imports at all, PreviewResultBuilder",
+    "and previewSha256 use only Okio and the DTOs — so they moved down into :preview-data-api",
+    "rather than dragging the Tooling API onto an extracted server's floor. `…previewdriver` has",
+    "no mapping below because serve no longer names it.",
+    "The three left are genuinely declared in `:cli` and each needs a decision, not a move:",
+    "BUNDLE_VERSION (does an extracted server report its own version?), CoordinateResolver, and",
+    "WebEmbed. They are #3824 preparation item 7's problem.",
     "serveInternalsUsedByCli: the CLI reaching into serve. Each entry must either move to the",
     "server build with serve, or move down into a contract module the CLI can keep using. The",
     "long tail here is ServeCommand.kt, which #3824 wants reduced to a thin entry point.",
@@ -63,6 +79,7 @@
     "ee.schimke.composeai.data.theme": "data-theme-core",
     "ee.schimke.composeai.designpages": "preview-data-api",
     "ee.schimke.composeai.io": "common-io",
+    "ee.schimke.composeai.previewdata": "preview-data-api",
     "ee.schimke.composeai.render.session": "render-session-api",
     "ee.schimke.composeai.render.session.subprocess": "render-session-subprocess"
   },
@@ -97,12 +114,6 @@
     "cliInternalsUsedByServe": [
       "BUNDLE_VERSION",
       "CoordinateResolver",
-      "PreviewInfo",
-      "PreviewManifest",
-      "PreviewModule",
-      "PreviewParameterFanout",
-      "PreviewParams",
-      "PreviewResultBuilder",
       "WebEmbed"
     ],
     "serveInternalsUsedByCli": [
@@ -212,11 +223,7 @@
   },
   "test": {
     "cliInternalsUsedByServe": [
-      "Capture",
       "CoordinateResolver",
-      "PreviewInfo",
-      "PreviewManifest",
-      "PreviewParams",
       "WebEmbed"
     ],
     "serveInternalsUsedByCli": [


### PR DESCRIPTION
Third of three on #3824's seam. `cliInternalsUsedByServe` goes **21 → 9 → 3**.

## The finding

Six of the nine entries left after preparation item 5 were never `:cli` internals:

| symbol | actually lives in |
| --- | --- |
| `PreviewInfo`, `PreviewManifest`, `PreviewParams` | published `:preview-data-api` |
| `PreviewModule`, `PreviewParameterFanout`, `PreviewResultBuilder` | published `:gradle-preview-driver` |

They looked like coupling only because they shared the `ee.schimke.composeai.cli` package — the same illusion `:bundle-format` was under, since `check-serve-seam.py` reads the package an import names, not the module that declares it. So both modules get their own package: `ee.schimke.composeai.previewdata` and `ee.schimke.composeai.previewdriver`.

## ⚠️ Breaking change

`ee.schimke.composeai:preview-data-api` and `ee.schimke.composeai:gradle-preview-driver` publish their types under new packages. External consumers (contrib scripting, third-party tooling) must rewrite imports:

```
ee.schimke.composeai.cli.PreviewResult      → ee.schimke.composeai.previewdata.PreviewResult
ee.schimke.composeai.cli.GradlePreviewDriver → ee.schimke.composeai.previewdriver.GradlePreviewDriver
```

**No type, member, or wire shape changed — only the package.** `@Serializable` classes carry explicit `@SerialName`s or are non-polymorphic, so no JSON moved.

## What the rename immediately exposed

Renaming turned a hidden dependency into a visible one, and it is the interesting part of this PR.

Serve used three types from `:gradle-preview-driver` — whose `api` dependency is the **Gradle Tooling API**. While both modules shared the `cli` package the seam check counted that as CLI-internal coupling and the contract probe never saw it. Once the package moved, `test_every_mapped_module_is_a_probe_contract_or_a_recorded_blocker` failed: mapping `…previewdriver` as a contract would have put the Tooling API on an extracted preview server's dependency floor.

None of the three actually needs Gradle:

- `PreviewParameterFanout` (119 lines) — **zero imports**.
- `PreviewResultBuilder` (264 lines) — `:common-io`, `:preview-data-api`, kotlinx-serialization, Okio.
- `previewSha256` / `PreviewSha256.kt` — Okio, `ImageIO`, `MessageDigest`.
- `PreviewModule` — a one-line `data class (gradlePath, projectDir)` that happened to sit in `GradleConnector.kt`.

So they move down into `:preview-data-api`, which gains `:common-io` — itself already a contract, so the floor does not grow. `:gradle-preview-driver` keeps only the Tooling-API wrapping, is **not** a contract, and serve no longer names it: its `contractPackages` mapping is removed rather than left as an unused entry.

## What is left

The three remaining entries are genuinely declared in `:cli`, and each needs a decision rather than a move — they belong to preparation item 7:

- `BUNDLE_VERSION` — does an extracted server report its own version, or the CLI's?
- `CoordinateResolver`
- `WebEmbed`

`serveInternalsUsedByCli` is untouched at 102 and is still dominated by `ServeCommand.kt`.

## Test plan

- `./gradlew :preview-data-api:check :gradle-preview-driver:check :bundle-format:check :mcp:check` — green, including `checkKotlinAbi` against the regenerated `preview-data-api.api`.
- `./gradlew :cli:check :daemon:core:check :daemon:desktop:compileTestKotlin` — green (5m27s), full `:cli` test suite included.
- `scripts/check-preview-server-contracts.sh` — green end to end: publishes the contracts from source and builds `preview-server` against them, `checkContractSurface` finding no leak.
- `python3 scripts/check-serve-seam.py` — OK, 126 crossings (was 136); `scripts/test_check_serve_seam.py` 45 tests OK.
- `python3 scripts/check-daemon-launch-schema.py` — OK. All five `.github/ci/test_*.py` suites — OK.

Non-visual: a package rename and module boundaries. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_