### PR TITLE
docs(render): record why the pressed still still needs the software ripple

### DIFF
--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -3163,6 +3163,18 @@ private const val RIPPLE_HOST_VIEW_DRAWABLE_FIELD = "ripple"
  * the patterned ripple but no ripple at all. `PressedRippleSoftwarePathTest` pins the hidden API
  * this leans on so a Robolectric or `compileSdk` bump that removes it fails loudly instead of
  * quietly restoring the coin-flip.
+ *
+ * **Not made redundant by [ShadowPausedClockHardwareRenderer].** That shadow (#4578) stops
+ * Robolectric pacing native render-thread animations off host wall-clock time, and it is what makes
+ * an `@InteractionPreview` recording reproducible *with* its patterned ripple — so the obvious
+ * follow-up is to drop the software force here and let a pressed still keep the patterned ripple
+ * too. Measured, with the shadow registered and only `forceSoftwareRipple` removed: three renders
+ * of `:samples:design-catalog-wear-m3`'s `ButtonPressed` agree with each other and publish
+ * `#D4C8EC` — pixel-identical to `ButtonFocused`, i.e. no press at all, which
+ * `WearFocusedPressPixelTest` fails on with `per-channel deltas [0, 0, 0]`. Fixing the animation's
+ * *clock* does not help an animation that never runs: a still draws one frame, and the patterned
+ * enter animation has no render thread to start on. The shadow and this force answer two different
+ * halves of the same problem, and both are load-bearing.
  */
 private fun settlePressedRipple(rule: AndroidComposeTestRule<*, ComponentActivity>) {
   val looper = org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PressedRippleSoftwarePathTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/PressedRippleSoftwarePathTest.kt
@@ -18,6 +18,11 @@ import org.robolectric.annotation.Config
  * comes down to luck. `RippleDrawable.setForceSoftware(true)` moves it onto ordinary
  * `ValueAnimator`s, which the main looper drives and `ShadowLooper.idleFor` can settle.
  *
+ * Still required after [ee.schimke.composeai.renderer.ShadowPausedClockHardwareRenderer] (#4578)
+ * put the render lane's native animations back on the paused clock: with the shadow registered and
+ * the software force removed, `ButtonPressed` publishes the focused fill exactly — the clock was
+ * never the reason a *still*'s patterned ripple sits at progress zero. See `settlePressedRipple`.
+ *
  * The method is `@UnsupportedAppUsage`, so it is reached by reflection and could disappear under a
  * `compileSdk` or Robolectric bump. If it does, the render does not break — it silently goes back
  * to publishing whatever the shard layout happened to produce, which is exactly the regression


### PR DESCRIPTION
Follow-up to #4589. **Negative result, written down** — no behaviour change.

## The tempting cleanup

`ShadowPausedClockHardwareRenderer` (#4578) put the render lane's native animations back on the paused clock, and it is what makes an `@InteractionPreview` recording reproducible *with* its patterned (AGSL) ripple. That makes `settlePressedRipple`'s `forceSoftwareRipple` look like a fidelity cost nothing pays for any more: same determinism, and it publishes a software ripple no device draws. Deleting it looks like free fidelity.

## It isn't

With the shadow registered and **only** `hosts.forEach(::forceSoftwareRipple)` removed, three renders of `:samples:design-catalog-wear-m3`'s `ButtonPressed`:

| | `ButtonPressed` fill at (30, 68) | run-to-run |
| --- | --- | --- |
| today (software force) | `#C5B8DE` | stable |
| force removed, shadow alone | `#D4C8EC` | stable |
| `ButtonFocused`, for reference | `#D4C8EC` | stable |

The pressed sticker becomes **pixel-identical to the focused one** — no press at all. It is now stably wrong rather than unstably wrong, which is worse, because it looks settled. `WearFocusedPressPixelTest` catches it:

```
pressed #D4C8EC vs focused #D4C8EC: per-channel deltas [0, 0, 0], need every channel >= 8
```

Fixing an animation's *clock* does not help an animation that never runs. A still draws one frame, and `RippleDrawable`'s patterned enter animation has no render thread to start on. The shadow and the software force answer different halves of one problem, and both are load-bearing:

| | what it fixes | where it matters |
| --- | --- | --- |
| `ShadowPausedClockHardwareRenderer` | *when* a running native animation is sampled | multi-frame captures — `@InteractionPreview`, the daemon's live lane |
| `forceSoftwareRipple` | whether the ripple animates **at all** | one-frame stills — `@FocusedPreview(pressed = true)` |

## What changed

Two KDoc blocks — `settlePressedRipple` and `PressedRippleSoftwarePathTest` — so the next reader finds the measurement instead of re-running it and, worse, possibly landing the deletion on a day the pixel test is skipped.

## Test plan

- `:renderer-android:testDebugUnitTest --tests "*PressedRippleSoftwarePathTest*"` — passes.
- `:renderer-android:ktfmtCheckMain` / `ktfmtCheckTest` — pass.
- The numbers above: 3 × `composePreviewRender` filtered to `ButtonPressed,ButtonFocused,FilledButton` in each configuration, plus `WearFocusedPressPixelTest` run against the no-force renders to confirm the guard fires.

No rendered output changes — the reverted experiment is not in this diff, so text-only is the correct evidence here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwS3a4G3yg6482YUcbB4JP)_