### PR TITLE
fix(deploy): never retire a catalog we cannot put back

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -70,8 +70,10 @@ sites_skipped=0
 # only means catalogs land ungrouped — no reason to skip them.
 post() {
   local path="$1" body="$2" label="$3"
+  last_post=failed
   if [[ "${DRY_RUN}" == 1 ]]; then
     echo "POST ${path} ${body}"
+    last_post=ok
     return 0
   fi
   local response code payload
@@ -83,8 +85,14 @@ post() {
   code="${response##*$'\n'}"
   payload="${response%$'\n'*}"
   case "${code}" in
-    200 | 201) echo "  ${label}: applied" ;;
-    409) echo "  ${label}: already present" ;;
+    200 | 201)
+      echo "  ${label}: applied"
+      last_post=ok
+      ;;
+    409)
+      echo "  ${label}: already present"
+      last_post=present
+      ;;
     404)
       echo "::warning::${path} returned 404 — route not available on this box; skipping the rest of this section."
       return 2
@@ -108,13 +116,21 @@ post() {
   return 0
 }
 
-# DELETE one admin path. 200 = retired, 409 = it was not there (both fine — the goal is "gone").
-# Only used to retire a registration this file is about to re-create under a different `repo`; see
-# `retire_if_repo_moved` below.
+# DELETE one admin path. Sets `last_delete` to ok | absent | refused.
+#
+# A 409 is NOT uniformly "it was already gone". `ServeCatalogAdmin.unregister` answers 409 for two
+# opposite situations: the catalog is not published here (benign — the POST below will create it),
+# and the catalog is published as a TOP-LEVEL SITE, which refuses retirement outright so a hostname
+# is never stranded. Reading the second as success is how a move on m3-catalog or wear-m3-catalog —
+# the two catalogs that ARE sites — would come back green having changed nothing: the delete is
+# refused, the re-post 409s on the repo mismatch, and `post` calls that "already present". So
+# discriminate on the payload, and let the caller decide.
 delete() {
   local path="$1" label="$2"
+  last_delete=refused
   if [[ "${DRY_RUN}" == 1 ]]; then
     echo "DELETE ${path}"
+    last_delete=ok
     return 0
   fi
   local response code payload
@@ -124,11 +140,28 @@ delete() {
   code="${response##*$'\n'}"
   payload="${response%$'\n'*}"
   case "${code}" in
-    200 | 201) echo "  ${label}: retired the stale registration" ;;
-    409 | 404) echo "  ${label}: nothing to retire" ;;
+    200 | 201)
+      echo "  ${label}: retired the stale registration"
+      last_delete=ok
+      ;;
+    404)
+      echo "  ${label}: nothing to retire"
+      last_delete=absent
+      ;;
+    409)
+      if [[ "${payload}" == *"is not published here"* ]]; then
+        echo "  ${label}: nothing to retire"
+        last_delete=absent
+      else
+        rejected=$((rejected + 1))
+        echo "::error::${label}: cannot be retired — ${payload}"
+        last_delete=refused
+      fi
+      ;;
     *)
       rejected=$((rejected + 1))
       echo "::error::${label}: retiring failed, HTTP ${code} — ${payload}"
+      last_delete=refused
       ;;
   esac
   return 0
@@ -192,12 +225,26 @@ if [[ "${DRY_RUN}" != 1 ]]; then
     "${BASE_URL}/admin/catalogs" 2>/dev/null || true)
 fi
 
-# The `repo` the box currently serves for a system, or empty if it serves no such catalog.
-box_repo_for() {
+# One field of the box's current registration for a system, or empty if it serves no such catalog.
+box_field_for() {
   [[ -n "${box_catalogs}" ]] || return 0
   printf '%s' "${box_catalogs}" |
-    jq -r --arg s "$1" '.catalogs // [] | map(select(.system == $s)) | .[0].repo // ""' 2>/dev/null ||
-    true
+    jq -r --arg s "$1" --arg f "$2" \
+      '.catalogs // [] | map(select(.system == $s)) | .[0][$f] // ""' 2>/dev/null || true
+}
+
+# Is <repo> actually publishing <branch>? A repo move retires the live registration before the POST
+# re-creates it, and `ServeCatalogAdmin.register` FETCHES before it persists — so a POST that cannot
+# load removes the entry it just added and the catalog is left published nowhere, not rolled back to
+# where it was. This is the cheap half of closing that window: refuse to retire anything until the
+# replacement branch is known to exist. It does not prove the box can load it, which is why the
+# caller still shouts if the re-post fails.
+delivery_branch_exists() {
+  local repo="$1" branch="$2" heads
+  [[ -n "${repo}" && -n "${branch}" ]] || return 1
+  heads=$(git ls-remote --heads "https://github.com/${repo}.git" "refs/heads/${branch}" 2>/dev/null) ||
+    return 2
+  [[ -n "${heads}" ]]
 }
 
 echo "Reconciling catalogs from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
@@ -205,10 +252,29 @@ while IFS= read -r entry; do
   [[ -n "${entry}" ]] || continue
   system=$(printf '%s' "${entry}" | jq -r '.system')
   declared_repo=$(printf '%s' "${entry}" | jq -r '.repo // ""')
-  current_repo=$(box_repo_for "${system}")
-  if [[ -n "${current_repo}" && -n "${declared_repo}" && "${current_repo}" != "${declared_repo}" ]]; then
+  current_repo=$(box_field_for "${system}" repo)
+  moved=0
+  if [[ -n "${current_repo}" && -z "${declared_repo}" ]]; then
+    # No `repo` here means "the box's own --catalog-repo default", which this file cannot see. The
+    # POST would resolve it, find a mismatch, 409, and be logged as success. Say so rather than
+    # letting that read green; every entry in this repository's config names its repo explicitly.
+    echo "::warning::catalog ${system}: no repo declared, so a move away from ${current_repo} cannot be detected here — declare the repo explicitly."
+  elif [[ -n "${current_repo}" && "${current_repo}" != "${declared_repo}" ]]; then
     echo "  catalog ${system}: repo moved ${current_repo} -> ${declared_repo}"
-    delete "/admin/catalogs/${system}" "catalog ${system}"
+    # The branch name does not depend on the repo — it is `<branchPrefix><system>` either way — so
+    # the live registration tells us what to look for on the new side.
+    target_branch=$(box_field_for "${system}" branch)
+    if delivery_branch_exists "${declared_repo}" "${target_branch}"; then
+      moved=1
+      delete "/admin/catalogs/${system}" "catalog ${system}"
+      [[ "${last_delete}" == refused ]] && moved=0
+    else
+      case $? in
+        2) echo "::error::catalog ${system}: could not reach github.com to check ${declared_repo}@${target_branch}; leaving it on ${current_repo}." ;;
+        *) echo "::error::catalog ${system}: ${declared_repo} publishes no ${target_branch} yet; leaving it on ${current_repo} rather than retiring a catalog with nothing to replace it." ;;
+      esac
+      rejected=$((rejected + 1))
+    fi
   fi
   # Preserve the declared shape — an unlisted catalog must stay off the front page, a group
   # claim has to survive or the card lands under the owner fallback instead of its section, and
@@ -222,6 +288,13 @@ while IFS= read -r entry; do
       break
     fi
   }
+  if [[ "${moved}" == 1 && "${last_post}" != ok ]]; then
+    # The retire succeeded and the re-publish did not, so this catalog is now published NOWHERE —
+    # `register` drops the entry it added when the fetch fails. Never let that end up in a green
+    # log: it is the one outcome an operator has to act on immediately.
+    rejected=$((rejected + 1))
+    echo "::error::catalog ${system} was retired from ${current_repo} but could not be re-published from ${declared_repo} — it is currently unpublished. Re-run this workflow once ${declared_repo} serves ${target_branch}, or re-post the old entry to restore it."
+  fi
 done < <(jq -c '.catalogs // [] | .[]' "${CATALOGS_FILE}")
 
 # Sites LAST: a site may only name a catalog the box already serves, so it has to follow the

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -236,6 +236,24 @@ printf 'ok\n200'
 SH
 chmod +x "${shim}/curl"
 
+# The pre-flight asks github.com whether the replacement branch exists; stub it so these cases are
+# hermetic. `present` = the branch is there, `missing` = it is not, `down` = ls-remote itself failed.
+git_stub() {
+  cat > "${shim}/git" <<SH
+#!/usr/bin/env bash
+if [[ "\$1" == ls-remote ]]; then
+  case "$1" in
+    present) echo "deadbeef	refs/heads/x"; exit 0 ;;
+    missing) exit 0 ;;
+    down)    exit 128 ;;
+  esac
+fi
+exec /usr/bin/git "\$@"
+SH
+  chmod +x "${shim}/git"
+}
+git_stub present
+
 moved=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
   TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
   bash "${UNDER_TEST}" 2>&1)
@@ -277,6 +295,127 @@ printf '%s' "${no_listing}" | grep -q 'catalog compose-m3: applied' ||
   fail "an unreadable listing must not stop catalogs being published:\n${no_listing}"
 printf '%s' "${no_listing}" | grep -q 'retired the stale registration' &&
   fail "an unreadable listing must not retire anything:\n${no_listing}"
+
+# 10c. A catalog published as a TOP-LEVEL SITE refuses retirement (unregister answers 409 with
+#      "published as the top-level site"), and reading that as "nothing to retire" is how a move on
+#      m3-catalog or wear-m3-catalog would finish green having changed nothing.
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+method=GET
+for a in "$@"; do
+  case "$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+if [[ "$method" == GET ]]; then
+  for a in "$@"; do
+    case "$a" in
+      */admin/catalogs)
+        cat <<'JSON'
+{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}
+JSON
+        exit 0 ;;
+    esac
+  done
+  exit 0
+fi
+if [[ "$method" == DELETE ]]; then
+  printf "catalog 'compose-m3' is published as the top-level site 'm3.preview.coo.ee'; remove the site first\n409"
+  exit 0
+fi
+printf 'ok\n200'
+SH
+chmod +x "${shim}/curl"
+git_stub present
+
+sited=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+
+printf '%s' "${sited}" | grep -q '::error::catalog compose-m3: cannot be retired' ||
+  fail "a site-protected 409 must be an error, not 'nothing to retire':\n${sited}"
+printf '%s' "${sited}" | grep -q 'catalog compose-m3: nothing to retire' &&
+  fail "a site-protected 409 must NOT read as absent:\n${sited}"
+
+# 10d. The replacement branch does not exist yet. Retiring first would leave the catalog published
+#      NOWHERE — `register` fetches before it persists and drops the entry it added on failure — so
+#      nothing may be retired until the new side is known to publish something.
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+method=GET
+for a in "$@"; do
+  case "$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+if [[ "$method" == GET ]]; then
+  for a in "$@"; do
+    case "$a" in
+      */admin/catalogs)
+        printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+        exit 0 ;;
+    esac
+  done
+  exit 0
+fi
+printf 'ok\n200'
+SH
+chmod +x "${shim}/curl"
+git_stub missing
+
+no_branch=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+
+printf '%s' "${no_branch}" | grep -q 'publishes no design-artifacts/compose-m3 yet' ||
+  fail "a missing replacement branch must be reported:\n${no_branch}"
+printf '%s' "${no_branch}" | grep -q 'DELETE\|retired the stale registration' &&
+  fail "nothing may be retired when the replacement branch is missing:\n${no_branch}"
+
+# 10e. The retire succeeded and the re-publish did not: the catalog is now published nowhere, which
+#      is the one outcome that must never end up in a green log.
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+method=GET
+for a in "$@"; do
+  case "$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+case "$method" in
+  GET)
+    for a in "$@"; do
+      case "$a" in
+        */admin/catalogs)
+          printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+          exit 0 ;;
+      esac
+    done
+    exit 0 ;;
+  DELETE) printf 'ok\n200'; exit 0 ;;
+  POST)
+    for a in "$@"; do
+      case "$a" in
+        *compose-m3*) printf 'fetch failed\n502'; exit 0 ;;
+      esac
+    done
+    printf 'ok\n200'; exit 0 ;;
+esac
+SH
+chmod +x "${shim}/curl"
+git_stub present
+
+stranded=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+
+printf '%s' "${stranded}" | grep -q 'it is currently unpublished' ||
+  fail "a retire that could not be re-published must be a loud error:\n${stranded}"
+
+rm -f "${shim}/git"
 
 if [[ "${failures}" -gt 0 ]]; then
   echo "${failures} check(s) failed" >&2

--- a/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
+++ b/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
@@ -22,12 +22,16 @@ links libGL and draws offscreen, so its Gradle test runs under `xvfb-run`.
 In-session, on this machine, over the real `remote-m3` catalog (24 `ir/*.rc` documents):
 
 ```sh
-# 1. render the real catalog to a bundle (Robolectric baked PNGs + ir/*.rc).
-#    The catalog moved to yschimke/wear-m3-catalog (#4588), so run this in a checkout of that
-#    repo — or skip the render and take its published bundle straight off the delivery branch:
-#      git fetch https://github.com/yschimke/wear-m3-catalog.git design-artifacts/remote-m3
-#      git show FETCH_HEAD:bundle/bundle.png > bundle.png
-compose-preview bundle pack --module :remote-catalog --with-semantics -o bundle.png
+# 1. get the real catalog as a bundle (Robolectric baked PNGs + ir/*.rc).
+#    The catalog moved to yschimke/wear-m3-catalog (#4588), so the render itself no longer happens
+#    in this checkout. Take the published bundle instead — same bytes, no Gradle, and every command
+#    below then runs from the compose-ai-tools root as written:
+git fetch https://github.com/yschimke/wear-m3-catalog.git design-artifacts/remote-m3
+git show FETCH_HEAD:bundle/bundle.png > bundle.png
+#    (to render it yourself instead: `cd` to a wear-m3-catalog checkout, run
+#     `compose-preview bundle pack --module :remote-catalog --with-semantics -o bundle.png`,
+#     and copy that bundle.png back here before step 2 — the script and both harness modules
+#     live in THIS repository.)
 
 # 2. stage the documents once (shared by both embedded lanes)
 node rc-compare.mjs --bundle bundle.png --player <rc-player>/bundle.js --out out --stage-embedded rc-in

--- a/docs/design/evidence/rc-outlined-card-double-draw/README.md
+++ b/docs/design/evidence/rc-outlined-card-double-draw/README.md
@@ -53,14 +53,31 @@ the baked reference**, independent of this fix.
 
 ## Regenerating
 
-The `remote-m3` catalog now lives in yschimke/wear-m3-catalog as `:remote-catalog` (compose-ai-tools#4588), so the render half of this runs in a checkout of that repo. The harness below is unchanged and still runs here.
+The `remote-m3` catalog now lives in yschimke/wear-m3-catalog as `:remote-catalog`
+(compose-ai-tools#4588). The harness itself is unchanged and still runs here.
+
+It wants a directory of `<id>.rc` plus a `manifest.json`. Two ways to get one — the
+second needs no Gradle and no second checkout, because the delivery branch carries the documents
+inside `bundle.png` rather than as loose files:
+
+```sh
+# (a) render the catalog, in a yschimke/wear-m3-catalog checkout:
+./gradlew :remote-catalog:composePreviewRenderAll
+#     → remote-catalog/build/compose-previews/renders/<id>.rc (no manifest.json — see (b))
+
+# (b) or stage them straight from the published bundle, entirely inside this checkout:
+git fetch https://github.com/yschimke/wear-m3-catalog.git design-artifacts/remote-m3
+git show FETCH_HEAD:bundle/bundle.png > /tmp/remote-m3.png
+node scripts/design-artifacts/rc-compare.mjs \
+  --bundle /tmp/remote-m3.png \
+  --player cli/src/main/resources/rc-player/bundle.js \
+  --out /tmp/rc-out --stage-embedded /tmp/rc-in
+#     → /tmp/rc-in/<id>.rc + /tmp/rc-in/manifest.json, which is what -Prc.embedded.input reads
+```
+
+Then run the harness here:
 
 ```
-# card .rc sidecars, in a yschimke/wear-m3-catalog checkout:
-#   ./gradlew :remote-catalog:composePreviewRenderAll
-#   → remote-catalog/build/compose-previews/renders/<id>.rc
-# or take them off the delivery branch with no build at all:
-#   git fetch https://github.com/yschimke/wear-m3-catalog.git design-artifacts/remote-m3
 ./gradlew :third-party-rc-embedded-player:testDebugUnitTest \
   --tests 'ee.schimke.composeai.rcembedded.RcEmbeddedRenderHarness' \
   -Prc.embedded.input=<dir with <id>.rc + manifest.json> -Prc.embedded.output=<out>


### PR DESCRIPTION
Follow-up to #4592, which merged while its own review was being addressed — so this is a fresh branch off `main`, not more commits on the merged one. Five Codex findings, all checked against `ServeCatalogAdmin` rather than taken on faith. All five were real.

**The re-point itself worked**: on the #4592 merge, [run #10](https://github.com/yschimke/compose-ai-tools/actions/runs/33109250976) printed

```
catalog remote-m3: repo moved yschimke/compose-ai-tools -> yschimke/wear-m3-catalog
catalog remote-m3: retired the stale registration
catalog remote-m3: applied
```

and `preview.coo.ee` now serves `remote-m3` from `yschimke/wear-m3-catalog`. This PR is about the paths where that sequence would have gone badly.

## P1 — the delete/post pair could leave a catalog published nowhere

`ServeCatalogAdmin.register` fetches **before** it persists, and on failure calls `tracker.remove(entry.system)` — it drops the entry it just added. So a successful DELETE followed by a failed POST does not roll back to the old repository; the catalog is simply gone. The reconcile is non-blocking, so it stays gone until someone notices.

Two changes, because neither alone is enough:

- **Nothing is retired until the replacement is known to exist.** A pre-flight `git ls-remote` asks whether the declared repo publishes the same delivery branch (the branch name is `<prefix><system>` regardless of repo, so the live registration says what to look for). No branch, or no reachable github.com → the move is refused and the catalog stays where it is.
- **A retire that could not be re-published is now a loud error**, naming the catalog as currently unpublished and how to restore it. The pre-flight cannot prove the *box* can load the branch, so this is the backstop for the remaining window.

The genuinely atomic fix belongs server-side — let `register` swap a repo in place, fetching the new source before dropping the old session. That is a change to a live serve component with its own tests, and this environment cannot run the Kotlin suite (no Android SDK), so I have not made it here. Worth doing; I'd rather propose it than ship it unverified.

## P2 — two narrower holes in the same path

- **`unregister` answers 409 for two opposite situations**: "is not published here" (benign) and "is published as the top-level site '<host>'", which refuses retirement so a hostname is never stranded. Treating the second as "nothing to retire" is how a move on **m3-catalog** or **wear-m3-catalog** — the two catalogs that *are* sites — would finish green having changed nothing: delete refused, re-post 409s on the repo mismatch, `post` calls that "already present". Now discriminated on the payload.
- **An entry with no `repo`** resolves to the server's own `--catalog-repo`, which this file cannot see, so a move away from it is invisible here and the 409 reads as success. Now a warning rather than silence. Every entry in this repo's config names its repo explicitly, so this is latent, not live.

## P2 — two reproduction recipes this branch got wrong

Mine, from #4592, and both wrong in the same way — I wrote them without checking the artifact:

- The delivery branch carries the documents **inside `bundle.png`**, not as loose `.rc` files (`git ls-tree -r | grep '\.rc$'` → 0 hits). So `git fetch` alone stages nothing for `-Prc.embedded.input`. The no-build path is `rc-compare.mjs --stage-embedded`, which writes the `<id>.rc` + `manifest.json` the harness actually reads.
- The cmp-jvm lane's sequence mixed two checkouts: the render moved to wear-m3-catalog, but `rc-compare.mjs` and both harness modules live here. It now runs start to finish in this checkout by taking the published bundle, with the render-it-yourself route spelled out separately.

## Test plan

- `.github/scripts/test-publish-config-to-box.sh` passes, with three new cases: a site-protected 409 is an error and not "nothing to retire"; a missing replacement branch retires nothing; a retire whose re-post fails is a loud error.
- **All three are mutation-checked** — reverting each behaviour individually fails its own test, and the restored script passes. Same for the existing repo-move case from #4592.
- The pre-flight's `ls-remote` is **stubbed**, so no test touches the network.
- `.github/scripts/agent-attribution-scan.sh` over the message and identity.

Shell, JSON and markdown only — no Kotlin, so no ktfmt run; no rendered surface, so no visual evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_