### PR TITLE
feat(serve): re-point a catalog's repo atomically instead of refusing it

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -124,6 +124,32 @@ class CatalogLoadTracker(
       true
     }
 
+  /**
+   * Replace [system]'s **provenance** — the repository and branch its bytes come from — keeping its
+   * position and its load state. Returns false when it isn't tracked.
+   *
+   * The counterpart to [relist], and deliberately a separate call with a much narrower contract,
+   * because the two are safe at different moments. [relist] may run at any time: it moves a card on
+   * the front page and changes nothing about what is served. This one may run in exactly one
+   * situation — **after** the new source has already been loaded and registered under [system] —
+   * because until then the served content and this record would disagree about where the bytes came
+   * from, and that record is what the trust verdict and the permalinks are built from.
+   *
+   * [ServeCatalogAdmin.register] is the only caller, and it loads first for that reason: a failed
+   * load leaves the old catalog serving and never reaches here. Re-pointing by retiring and
+   * re-publishing instead — what the admin API used to require — has no such property: the retire
+   * succeeds, the publish fetches, and a fetch that fails leaves the system published nowhere.
+   */
+  fun repoint(system: String, repo: String, branch: String): Boolean =
+    synchronized(lock) {
+      val existing = states[system] ?: return false
+      val updated = existing.config.copy(repo = repo, branch = branch)
+      states[system] = existing.copy(config = updated)
+      val at = ordered.indexOfFirst { it.system == system }
+      if (at >= 0) ordered[at] = updated
+      true
+    }
+
   /** Retire a catalog. Returns false when it wasn't configured. */
   fun remove(system: String): Boolean =
     synchronized(lock) {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
@@ -173,20 +173,56 @@ class ServeCatalogAdmin(
     // what made a committed config unable to catch up with a running box: re-posting an entry whose
     // group or listed flag had changed was rejected, so the box kept its original placement
     // forever.
-    // The content is untouched — no re-fetch, no dropped load state — and a repo change is still
-    // refused, since that decides what bytes get served (retire and re-publish for that).
+    // The content is untouched — no re-fetch, no dropped load state. A repo change is handled
+    // separately just below: it DOES decide what bytes get served, so it re-fetches, and it does
+    // that before anything is dropped.
     // `loadPriority` converges the same way: it changes nothing about a catalog already registered,
     // but the point of writing it back is the NEXT boot's fetch order, and the deployment reconcile
     // (.github/scripts/publish-config-to-box.sh) is additive — without this, re-declaring a
     // priority on an already-published catalog would 409 and never reach the box's config.
     tracker.configFor(entry.system)?.let { current ->
-      if (current.repo != repo) {
-        return Result.Conflict(
-          "catalog '${entry.system}' is published from ${current.repo}; retire it before " +
-            "re-publishing from $repo"
-        )
-      }
       val resolved = homeGroup(entry, repo, declared)
+      // A REPO CHANGE is a swap, not a conflict — and the order here is the whole point.
+      //
+      // This used to answer 409 "retire it before re-publishing from …", which made re-pointing a
+      // catalog a two-step dance every caller had to get right: DELETE, then POST. It is not a safe
+      // dance. `load` fetches before anything is persisted, and the failure path below drops the
+      // entry it added — so a retire that succeeds followed by a publish that cannot fetch leaves
+      // the system published NOWHERE, and the deployment reconcile that drives this is
+      // non-blocking, so it stays that way. The 409 also read as success to that reconcile
+      // (.github/scripts/publish-config-to-box.sh), which is how a moved catalog went on being
+      // served from the repository it had left, with a green log either side of it.
+      //
+      // Loading FIRST removes the window instead of narrowing it. A load that fails returns before
+      // it touches any registration, so the old catalog is still serving and this returns Failed
+      // with that said plainly; a load that succeeds re-registers the host in place — exactly what
+      // the branch refresher does on every poll — so the swap is one atomic replacement of content
+      // followed by [CatalogLoadTracker.repoint] recording where it now comes from.
+      //
+      // It works for a catalog published as a top-level site, too, which the retire-first route
+      // could not: `unregister` refuses those outright to keep a hostname from being stranded, and
+      // a swap never strands one because the system never stops existing.
+      if (current.repo != repo) {
+        val failure = runCatching {
+          load(entry.system, repo)
+        }
+          .getOrElse { it.message ?: "load failed" }
+        if (failure != null) {
+          return Result.Failed(
+            entry.system,
+            "could not re-point '${entry.system}' to $repo, still serving ${current.repo}: $failure",
+          )
+        }
+        tracker.repoint(entry.system, repo = repo, branch = "$branchPrefix${entry.system}")
+        tracker.relist(
+          entry.system,
+          listed = entry.listed,
+          group = resolved,
+          loadPriority = entry.loadPriority,
+        )
+        onLog("serve: catalog ${entry.system} re-pointed ${current.repo} -> $repo via admin API")
+        return Result.Ok(entry.system, persist { it.withEntry(entry.copy(repo = repo)) })
+      }
       if (
         current.group == resolved &&
           current.listed == entry.listed &&

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTrackerTest.kt
@@ -126,6 +126,32 @@ class CatalogLoadTrackerTest {
   }
 
   @Test
+  fun `re-pointing swaps provenance in place, keeping position and load state`() {
+    val tracker = tracker()
+    tracker.recordSuccess("jetnews")
+
+    assertTrue(
+      tracker.repoint("jetnews", repo = "someorg/new-home", branch = "design-artifacts/jetnews")
+    )
+
+    val jetnews = tracker.snapshot().single { it.config.system == "jetnews" }
+    assertEquals("someorg/new-home", jetnews.config.repo)
+    assertEquals("design-artifacts/jetnews", jetnews.config.branch)
+    // The registered copy is untouched — this records where the bytes came from, it does not fetch
+    // them, and [ServeCatalogAdmin] only calls it once the new source is already loaded.
+    assertTrue(jetnews.available, "a provenance change must not drop the registered copy")
+    assertEquals(listOf("jetnews", "reply"), tracker.snapshot().map { it.config.system })
+  }
+
+  @Test
+  fun `re-pointing a system that is not tracked reports it rather than adding one`() {
+    val tracker = tracker()
+
+    assertFalse(tracker.repoint("nope", repo = "someorg/nope", branch = "design-artifacts/nope"))
+    assertEquals(listOf("jetnews", "reply"), tracker.snapshot().map { it.config.system })
+  }
+
+  @Test
   fun `relisting carries the new load priority without touching load state`() {
     val tracker = tracker()
     tracker.recordSuccess("reply")

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -69,7 +69,7 @@ class ServeAdminRoutingTest {
     )
 
   /** Systems the stubbed "fetch" refuses, so the failure path is reachable from a request. */
-  private val unfetchable = setOf("ghost")
+  private val unfetchable = mutableSetOf("ghost")
 
   private val admin =
     ServeCatalogAdmin(
@@ -504,15 +504,50 @@ class ServeAdminRoutingTest {
   }
 
   @Test
-  fun `re-publishing from a different repo is refused rather than silently re-pointed`() {
+  fun `re-publishing from a different repo re-points it in place`() {
     send("/admin/catalogs", method = "POST", body = """{"system":"moved","repo":"someorg/one"}""")
 
     val (code, msg) =
       send("/admin/catalogs", method = "POST", body = """{"system":"moved","repo":"someorg/two"}""")
 
-    assertEquals(409, code)
-    assertTrue(msg.contains("retire"), msg)
-    assertEquals("someorg/one", tracker.configFor("moved")?.repo)
+    // This used to be a 409 telling the caller to retire it first — a two-step dance whose failure
+    // mode was a catalog published nowhere, and whose 409 read as success to the deployment
+    // reconcile that drives this route. A repo change is now one atomic swap: fetch the new source,
+    // then record where the bytes come from.
+    assertEquals(200, code, msg)
+    assertEquals("someorg/two", tracker.configFor("moved")?.repo)
+    assertTrue(send("/admin/catalogs").second.contains("someorg/two"))
+    // Still served, and still there — the swap replaced content rather than dropping a session.
+    assertEquals(
+      200,
+      Request.Builder().url(url("/moved/")).build().let { req ->
+        client.newCall(req).execute().use { it.code }
+      },
+    )
+    // And it survives a restart under the new provenance.
+    assertEquals("someorg/two", configFile.load().catalogs.single { it.system == "moved" }.repo)
+  }
+
+  @Test
+  fun `a re-point that cannot be fetched leaves the catalog on its old repo`() {
+    send("/admin/catalogs", method = "POST", body = """{"system":"stays","repo":"someorg/one"}""")
+    unfetchable += "stays"
+
+    val (code, msg) =
+      send("/admin/catalogs", method = "POST", body = """{"system":"stays","repo":"someorg/two"}""")
+
+    // The load runs BEFORE anything is dropped, so a source that cannot be fetched costs nothing
+    // but the attempt. Under retire-then-publish this is where the catalog disappeared.
+    assertEquals(502, code, msg)
+    assertTrue(msg.contains("still serving someorg/one"), msg)
+    assertEquals("someorg/one", tracker.configFor("stays")?.repo)
+    assertEquals(
+      200,
+      Request.Builder().url(url("/stays/")).build().let { req ->
+        client.newCall(req).execute().use { it.code }
+      },
+    )
+    assertEquals("someorg/one", configFile.load().catalogs.single { it.system == "stays" }.repo)
   }
 
   // --- producer trust ----------------------------------------------------------------------------

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
@@ -230,6 +230,88 @@ class ServeCatalogAdminTest {
   }
 
   @Test
+  fun `a repo change is a swap - it loads first, keeps its place, and retires nothing`() {
+    seedConfig(
+      ServeCatalogsConfig(
+        groups = listOf(ServeCatalogsConfig.Group("ds", "Design Systems", "design system(s)")),
+        catalogs =
+          listOf(
+            ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/compose-ai-tools"),
+            ServeCatalogsConfig.Entry("cadence", repo = "yschimke/cadence"),
+          ),
+      )
+    )
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config(
+          "remote-m3",
+          true,
+          "yschimke/compose-ai-tools",
+          "design-artifacts/remote-m3",
+        ),
+        CatalogLoadTracker.Config("cadence", false, "yschimke/cadence", "design-artifacts/cadence"),
+      )
+    tracker.recordSuccess("remote-m3")
+
+    val result =
+      admin(tracker)
+        .register(
+          ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/wear-m3-catalog", listed = true)
+        )
+
+    assertEquals(ServeCatalogAdmin.Result.Ok("remote-m3", warning = null), result)
+    // Loaded from the NEW repo, and nothing was retired on the way — the old registration was
+    // replaced in place rather than dropped and rebuilt.
+    assertEquals(listOf("remote-m3" to "yschimke/wear-m3-catalog"), loaded)
+    assertEquals(emptyList(), unloaded)
+    // Provenance moved…
+    val config = assertNotNull(tracker.configFor("remote-m3"))
+    assertEquals("yschimke/wear-m3-catalog", config.repo)
+    assertEquals("design-artifacts/remote-m3", config.branch)
+    // …and its place on the front page did not.
+    assertEquals(listOf("remote-m3", "cadence"), tracker.snapshot().map { it.config.system })
+    assertEquals(
+      "yschimke/wear-m3-catalog",
+      file.load().catalogs.single { it.system == "remote-m3" }.repo,
+    )
+  }
+
+  @Test
+  fun `a repo change that cannot be fetched leaves the old catalog serving`() {
+    seedConfig(
+      ServeCatalogsConfig(
+        catalogs = listOf(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/old-home"))
+      )
+    )
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config(
+          "remote-m3",
+          true,
+          "yschimke/old-home",
+          "design-artifacts/remote-m3",
+        )
+      )
+
+    val result =
+      admin(tracker, failWith = "could not fetch catalog.json")
+        .register(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/nowhere", listed = true))
+
+    // The whole reason the load runs first: a source that cannot be fetched costs nothing. This is
+    // the case that, under retire-then-publish, left the system published NOWHERE.
+    assertTrue(result is ServeCatalogAdmin.Result.Failed, "$result")
+    assertTrue(
+      (result as ServeCatalogAdmin.Result.Failed)
+        .reason
+        .contains("still serving yschimke/old-home"),
+      result.reason,
+    )
+    assertEquals(emptyList(), unloaded)
+    assertEquals("yschimke/old-home", assertNotNull(tracker.configFor("remote-m3")).repo)
+    assertEquals("yschimke/old-home", file.load().catalogs.single().repo)
+  }
+
+  @Test
   fun `the tracker keeps configured order and reports what is served`() {
     val tracker = tracker(CatalogLoadTracker.Config("a", true, "o/r", "b"))
     tracker.recordSuccess("a")


### PR DESCRIPTION
Follow-up from #4588 / #4595 — the server-side half the client could only narrow.

## What was wrong

`register()` answered 409 `"retire it before re-publishing from …"` when a system already existed under a different repo. That made re-pointing a catalog a two-step dance — DELETE, then POST — and the dance is unsafe in both directions:

- **It can lose the catalog.** `register` fetches before it persists and drops the entry it added when the fetch fails. So a retire that succeeds followed by a publish that cannot fetch leaves the system published **nowhere** — not rolled back. The deployment reconcile driving this route is non-blocking, so it stays that way until someone notices.
- **The 409 read as success.** `publish-config-to-box.sh` treats 409 as "already present". That is how `remote-m3` went on being served from the repository it had left, with a green publish log either side of it ([run #9](https://github.com/yschimke/compose-ai-tools/actions/runs/33108444534)).

## What it does now

One swap, and the order is the whole point:

```
load(system, newRepo)   ← fetches; on failure returns before touching any registration
        ↓ success
tracker.repoint(...)    ← records where the bytes now come from
```

A failed load leaves the old catalog serving and returns `502 … still serving <old repo>`. A successful load re-registers the host **in place** — precisely what the branch refresher does on every poll, so a repo swap is just a refresh from a different source — and `repoint` then moves the provenance without disturbing position or load state.

`repoint` is deliberately a separate tracker call from `relist`, which refuses to touch `repo`/`branch`. The two are safe at different moments: `relist` moves a card on the front page and changes nothing served, so it is safe whenever; this one is safe **only after** the new source is loaded, because until then the served content and the record would disagree about provenance — and that record is what the trust verdict and the permalinks are built from. Each KDoc says which moment it belongs to.

It also fixes a case retire-first could never handle: a catalog published as a **top-level site**. `unregister` refuses those outright so a hostname is never stranded, so `m3-catalog` and `wear-m3-catalog` could not be re-pointed at all. A swap never strands a host, because the system never stops existing.

## Deliberately not in this PR

`publish-config-to-box.sh` keeps its retire-then-re-post path. It has to go on working against a box that has not been updated yet, and switching it to rely on server-side swapping before the box runs this would reintroduce the silent no-op on an older server. Simplifying it is a follow-up for once the box is on this build.

## Test plan

Five tests, at both levels:

**`ServeCatalogAdminTest`** (stubbed load/registry — the decision-making)
- a repo change loads from the new repo, retires nothing (`unloaded` stays empty), moves `repo`/`branch`, keeps its position in the configured order, and persists.
- a repo change whose load fails returns `Failed` naming the old repo, retires nothing, and leaves both the tracker and `catalogs.json` on the old repo.

**`ServeAdminRoutingTest`** (real server, over HTTP)
- `re-publishing from a different repo re-points it in place` — 200, listing and persisted config show the new repo, `/moved/` still serves. This **replaces** the old test that pinned the 409; the behaviour changed deliberately, so the test states the new contract rather than being deleted.
- `a re-point that cannot be fetched leaves the catalog on its old repo` — 502, message contains `still serving someorg/one`, `/stays/` still serves, config unchanged. (`unfetchable` became a `mutableSetOf` so a system can be made unfetchable mid-test.)

**`CatalogLoadTrackerTest`**
- `repoint` swaps provenance in place, keeps position and keeps the registered copy available; returns false for an untracked system rather than inventing one.

**Not run locally:** this environment has no Android SDK, so Gradle cannot configure the build and I could not execute the Kotlin suite — CI is the verification, and that is the honest state of it. What I did check: ktfmt (0.64, the version the pinned plugin resolves) over every changed file, and that no other test pinned the old refuse-a-repo-change behaviour (`grep` for its message found only the source comment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_