### PR TITLE
refactor(serve): close the serve to cli direction of the seam register

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -143,6 +143,7 @@
       "data/render/core/**",
       "data/pseudolocale/core/**",
       "bundle/format/**",
+      "bundle/coordinates/**",
       "mcp/**",
       "renderers/xr-client/**",
       "cli/src/main/kotlin/ee/schimke/composeai/cli/serve/**"

--- a/bundle/coordinates/api/bundle-coordinates.api
+++ b/bundle/coordinates/api/bundle-coordinates.api
@@ -1,0 +1,38 @@
+public final class ee/schimke/composeai/bundle/coordinates/CoordinateResolver {
+	public static final field Companion Lee/schimke/composeai/bundle/coordinates/CoordinateResolver$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLjava/util/List;Ljava/io/File;Lokio/FileSystem;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;ZLjava/util/List;Ljava/io/File;Lokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun resolve (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;)Lee/schimke/composeai/bundle/coordinates/CoordinateResolver$Resolution;
+	public final fun resolveAll (Ljava/util/List;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/bundle/coordinates/CoordinateResolver$Companion {
+	public final fun defaultDownloadCacheDir ()Ljava/io/File;
+	public final fun defaultNetworkEnabled ()Z
+	public final fun defaultRepositoryRoots ()Ljava/util/List;
+	public final fun getDEFAULT_REMOTE_REPOSITORIES ()Ljava/util/List;
+	public final fun isSnapshot (Ljava/lang/String;)Z
+	public final fun snapshotVersion (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/coordinates/CoordinateResolver$Resolution {
+	public fun <init> (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;Ljava/io/File;ZZZ)V
+	public synthetic fun <init> (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;Ljava/io/File;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;
+	public final fun component2 ()Ljava/io/File;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;Ljava/io/File;ZZZ)Lee/schimke/composeai/bundle/coordinates/CoordinateResolver$Resolution;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/coordinates/CoordinateResolver$Resolution;Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;Ljava/io/File;ZZZILjava/lang/Object;)Lee/schimke/composeai/bundle/coordinates/CoordinateResolver$Resolution;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoordinate ()Lee/schimke/composeai/bundle/BundleReader$ClasspathEntry$Maven;
+	public final fun getDownloaded ()Z
+	public final fun getFile ()Ljava/io/File;
+	public final fun getMismatch ()Z
+	public final fun getVerified ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/bundle/coordinates/build.gradle.kts
+++ b/bundle/coordinates/build.gradle.kts
@@ -1,0 +1,58 @@
+// Resolving a preview bundle's Maven coordinates into local jars.
+//
+// A `.previewbundle` records its classpath as coordinates (`ClasspathEntry.Maven`) rather than
+// carrying every jar, so anything that *runs* a bundle — `compose-preview bundle daemon`,
+// `bundle render`, and `serve` — has to turn those coordinates back into files: check the local
+// Gradle/Maven caches first, then fetch from the configured remote repositories.
+//
+// Split out of `:cli` for #3824 preparation item 7. `serve` needed it, and while it lived in
+// `:cli` an extracted preview server could only have got it by depending on the CLI. It is not
+// part of `:bundle-format`: reading the format is offline and synchronous, while this does HTTP
+// over ktor and coroutines, and a format module should not drag a network client onto the render
+// subprocess classpath.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+  // The manifest's `ClasspathEntry.Maven` shape is what gets resolved, so the format types are
+  // part of this module's public surface.
+  api(project(":bundle-format"))
+
+  // Okio file IO for the cache probes and the downloaded-jar writes.
+  api(project(":common-io"))
+
+  // HTTP fetch for coordinates absent from the local caches. `implementation`: a caller resolves
+  // coordinates, it does not speak ktor.
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.okhttp)
+
+  testImplementation(libs.junit)
+  testImplementation(kotlin("test"))
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "bundle-coordinates",
+    displayName = "Compose Preview — Bundle Coordinate Resolution",
+    description =
+      "Resolve a preview bundle's recorded Maven coordinates into local jars: local Gradle and " +
+        "Maven cache probes first, then a fetch from the configured remote repositories. Used by " +
+        "the CLI's bundle commands and by an extracted preview server.",
+  )
+  inceptionYear.set("2026")
+}
+
+kotlin {
+  // Published contract an extracted preview server compiles against across a repo boundary
+  // (#3824), so every declaration states its visibility and every public one its return type.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/bundle/coordinates/src/main/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolver.kt
+++ b/bundle/coordinates/src/main/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolver.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle.coordinates
 
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.io.SystemFileSystem
@@ -51,7 +51,7 @@ import okio.openZip
  * so the caller proceeds with a partial classpath (the bundled renderer's Compose stack covers the
  * common surface).
  */
-internal class CoordinateResolver(
+public class CoordinateResolver(
   private val repositoryRoots: List<File> = defaultRepositoryRoots(),
   private val warn: (String) -> Unit = { System.err.println("compose-preview: $it") },
   private val networkEnabled: Boolean = defaultNetworkEnabled(),
@@ -61,7 +61,7 @@ internal class CoordinateResolver(
 ) {
 
   /** Outcome of resolving one coordinate. [file] is null when nothing was found or downloaded. */
-  data class Resolution(
+  public data class Resolution(
     val coordinate: BundleReader.ClasspathEntry.Maven,
     val file: File?,
     val verified: Boolean,
@@ -75,11 +75,12 @@ internal class CoordinateResolver(
    * [Resolution] per input coordinate in order; callers typically take `mapNotNull { it.file }` for
    * the classpath and surface the misses to the user.
    */
-  fun resolveAll(coords: List<BundleReader.ClasspathEntry.Maven>): List<Resolution> = coords.map {
-    resolve(it)
-  }
+  public fun resolveAll(coords: List<BundleReader.ClasspathEntry.Maven>): List<Resolution> =
+    coords.map {
+      resolve(it)
+    }
 
-  fun resolve(coord: BundleReader.ClasspathEntry.Maven): Resolution {
+  public fun resolve(coord: BundleReader.ClasspathEntry.Maven): Resolution {
     val candidates = locate(coord)
     val expected = coord.sha256
 
@@ -336,9 +337,9 @@ internal class CoordinateResolver(
       hashing.hash.hex()
     }
 
-  companion object {
+  public companion object {
     /** Maven Central + Google Maven, the two repos that serve almost every Compose/AndroidX dep. */
-    val DEFAULT_REMOTE_REPOSITORIES: List<String> =
+    public val DEFAULT_REMOTE_REPOSITORIES: List<String> =
       listOf("https://repo1.maven.org/maven2", "https://dl.google.com/dl/android/maven2")
 
     /**
@@ -354,7 +355,7 @@ internal class CoordinateResolver(
       }
 
     /** A Maven snapshot version — the only kind whose artifact file name isn't the version. */
-    internal fun isSnapshot(version: String): Boolean = version.endsWith("-SNAPSHOT")
+    public fun isSnapshot(version: String): Boolean = version.endsWith("-SNAPSHOT")
 
     /**
      * The unique-snapshot version (`1.0.0-20260818.194125-1`) a version-level `maven-metadata.xml`
@@ -366,7 +367,7 @@ internal class CoordinateResolver(
      * whose `<extension>` matches wins — a version-level metadata document carries one classifier-
      * free entry per extension, the current publication.
      */
-    internal fun snapshotVersion(metadataXml: String, extension: String): String? =
+    public fun snapshotVersion(metadataXml: String, extension: String): String? =
       SNAPSHOT_VERSION_BLOCK.findAll(metadataXml)
         .map { it.groupValues[1] }
         .filterNot { "<classifier>" in it }
@@ -389,7 +390,7 @@ internal class CoordinateResolver(
      * `maven.repo.local` override and `GRADLE_USER_HOME`; falls back to the conventional `~/.m2`
      * and `~/.gradle` locations. Non-existent roots are simply skipped at lookup time.
      */
-    fun defaultRepositoryRoots(): List<File> {
+    public fun defaultRepositoryRoots(): List<File> {
       val home = System.getProperty("user.home")?.let(::File)
       val roots = mutableListOf<File>()
       System.getProperty("maven.repo.local")?.let { roots += File(it) }
@@ -406,14 +407,14 @@ internal class CoordinateResolver(
      * `COMPOSE_PREVIEW_OFFLINE=1` (env) — an escape hatch for sandboxes / air-gapped machines that
      * want strictly-local resolution.
      */
-    fun defaultNetworkEnabled(): Boolean {
+    public fun defaultNetworkEnabled(): Boolean {
       if (System.getProperty("composeai.bundle.offline").toBoolean()) return false
       if (System.getenv("COMPOSE_PREVIEW_OFFLINE") == "1") return false
       return true
     }
 
     /** Where downloaded coordinate jars are cached (Maven layout). Override-able for tests. */
-    fun defaultDownloadCacheDir(): File {
+    public fun defaultDownloadCacheDir(): File {
       System.getProperty("composeai.bundle.cacheDir")?.let {
         return File(it)
       }

--- a/bundle/coordinates/src/test/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolverTest.kt
+++ b/bundle/coordinates/src/test/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolverTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.bundle.coordinates
 
 import com.sun.net.httpserver.HttpServer
 import ee.schimke.composeai.bundle.BundleReader

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -213,6 +213,11 @@ dependencies {
   // package, so every existing call site (including `serve`) resolves them unchanged.
   api(project(":bundle-format"))
 
+  // Turning a bundle's recorded Maven coordinates back into local jars — the `bundle daemon` and
+  // `bundle render` subcommands and `serve` all need it. Split out of this module for #3824
+  // preparation item 7. `api` for source-compat with the existing in-package call sites.
+  api(project(":bundle-coordinates"))
+
   // Okio-based file IO (`SystemFileSystem` + suspend helpers) the CLI commands read/write through.
   implementation(project(":common-io"))
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -21,6 +21,7 @@ import ee.schimke.composeai.cli.serve.RenderOutcome
 import ee.schimke.composeai.cli.serve.ServeBundleDaemon
 import ee.schimke.composeai.cli.serve.ServeRenderHost
 import ee.schimke.composeai.cli.serve.SvgOutcome
+import ee.schimke.composeai.cli.serve.WebEmbed
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import ee.schimke.composeai.io.SystemFileSystem

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleDaemonCommand.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.bundle.AndroidBundleLaunch
 import ee.schimke.composeai.bundle.AndroidBundleResources
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
 import ee.schimke.composeai.bundle.extractBundleIrArtifacts
 import ee.schimke.composeai.bundle.locateBundleSidecarJars

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleRenderer.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.AndroidBundleLaunch
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.bundle.expandZipBytesSafely
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.TemporaryDirectory

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleWebEmbedData.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.cli.serve.WebEmbed
 import ee.schimke.composeai.previewdata.PreviewManifest
 import java.io.ByteArrayInputStream
 import java.io.File

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspath.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
-import ee.schimke.composeai.cli.CoordinateResolver
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import okio.FileSystem

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBugReport.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBugReport.kt
@@ -58,7 +58,7 @@ internal object ServeBugReport {
 
   /** Facts about the running server, independent of which page the visitor came from. */
   data class Server(
-    /** `BUNDLE_VERSION` — the build the bug is in. */
+    /** `SERVE_VERSION` — the build the bug is in. */
     val version: String?,
     /** True when the host answers without a token (`--public`). */
     val public: Boolean,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundle.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundle.kt
@@ -1,7 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.ZIP_DOS_EPOCH_MS
-import ee.schimke.composeai.cli.WebEmbed
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.zip.ZipEntry

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleDaemon.kt
@@ -4,10 +4,10 @@ import ee.schimke.composeai.bundle.AndroidBundleLaunch
 import ee.schimke.composeai.bundle.AndroidBundleResources
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.bundleSidecarSearchDescription
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.bundle.extractBundleClassesAndManifest
 import ee.schimke.composeai.bundle.extractBundleIrArtifacts
 import ee.schimke.composeai.bundle.locateBundleSidecarJars
-import ee.schimke.composeai.cli.CoordinateResolver
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1,6 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.BUNDLE_VERSION
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
@@ -625,7 +624,7 @@ class ServeHttpServer(
                 "That page was not found on this site.",
                 current.linkToken(),
                 isPublic,
-                version = BUNDLE_VERSION,
+                version = SERVE_VERSION,
                 siteName = skin.first,
                 themeCss = skin.second,
                 themeStorageKey = skin.third,
@@ -722,7 +721,7 @@ class ServeHttpServer(
           call.respondText(
             JSON.encodeToString(
               VersionResponse.serializer(),
-              VersionResponse(version = BUNDLE_VERSION, public = isPublic),
+              VersionResponse(version = SERVE_VERSION, public = isPublic),
             ),
             ContentType.Application.Json,
           )
@@ -1920,7 +1919,7 @@ class ServeHttpServer(
         linkToken(),
         isPublic,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         siteName = skin.first,
         themeCss = skin.second,
         themeStorageKey = skin.third,
@@ -1945,7 +1944,7 @@ class ServeHttpServer(
         ttlSeconds = store.ttlSeconds,
         urlUploadAllowed = store.urlFetchAllowed,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
       ),
       ContentType.Text.Html,
     )
@@ -2062,7 +2061,7 @@ class ServeHttpServer(
         preselectCatalog = call.request.queryParameters["catalog"],
         pinnedCatalogSystems = service.pinnedCatalogSystems,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         editingLeaseEnabled = service.editLeasesEnabled && githubAuth?.currentLogin(call) != null,
       ),
       ContentType.Text.Html,
@@ -2097,7 +2096,7 @@ class ServeHttpServer(
         token = linkToken(),
         isPublic = isPublic,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
       ),
       ContentType.Text.Html,
       HttpStatusCode.ServiceUnavailable,
@@ -2393,7 +2392,7 @@ class ServeHttpServer(
         token = linkToken(),
         isPublic = isPublic,
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
       ),
       ContentType.Text.Html,
     )
@@ -2948,7 +2947,7 @@ class ServeHttpServer(
                 ServeWeb.designToolLabel(it.source.provider)
               }
             } ?: renderHost.parityActivity()?.figma?.let { "Figma" },
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           // Catalog provenance (delivery branch, generation date, tool versions) for the strip
           // under the header; null for a plain (non-catalog) module session.
           provenance = catalogBundleHost(renderHost)?.provenance,
@@ -3208,7 +3207,7 @@ class ServeHttpServer(
           referencesFor = renderHost::designReferencesFor,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
           reportIssue = reportIssue,
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           // A top-level site's pages carry their session in the ORIGIN, so same-session links
           // drop the `?session=` the rooted legacy form would add. See [ServeSites].
@@ -3313,7 +3312,7 @@ class ServeHttpServer(
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           themeCss = catalogBundleHost(renderHost)?.webThemeCss.orEmpty(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           hasReferenceFor = hasReference,
           parityIssues = issues,
@@ -3523,7 +3522,7 @@ class ServeHttpServer(
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           themeCss = catalogBundleHost(renderHost)?.webThemeCss.orEmpty(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           sessionInOrigin = siteSystem() != null,
         ),
@@ -3558,7 +3557,7 @@ class ServeHttpServer(
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           themeCss = catalogBundleHost(renderHost)?.webThemeCss.orEmpty(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           // A top-level site's pages carry their session in the ORIGIN, so same-session links
           // drop the `?session=` the rooted legacy form would add. See [ServeSites].
@@ -3623,7 +3622,7 @@ class ServeHttpServer(
           trust = catalogBundleHost(renderHost)?.let { BundleVerifier.summary(it.trust) },
           themeCss = catalogBundleHost(renderHost)?.webThemeCss.orEmpty(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           // A top-level site's pages carry their session in the ORIGIN, so same-session links
           // drop the `?session=` the rooted legacy form would add. See [ServeSites].
@@ -3783,7 +3782,7 @@ class ServeHttpServer(
           // must not drop back to the built-in chrome mid-journey.
           themeCss = catalogBundleHost(renderHost)?.webThemeCss.orEmpty(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           displayTitle = catalogBundleHost(renderHost)?.title,
           // Annotation layers describe the CURRENT catalog's layout and typography. Drawing them
           // over a pinned pair would overlay today's bounds on historical pixels and label the
@@ -4376,7 +4375,7 @@ class ServeHttpServer(
         linkToken(),
         isPublic = isPublic,
         componentBrowser = componentBrowserMode(),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         unfurl = unfurl,
         githubAuth = githubAuthStatus(),
       ),
@@ -4612,7 +4611,7 @@ class ServeHttpServer(
           ),
           linkToken(),
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           siteName = skin.first,
           themeCss = skin.second,
           themeStorageKey = skin.third,
@@ -4693,7 +4692,7 @@ class ServeHttpServer(
     val status = withContext(Dispatchers.IO) { buildStatusData(onlySystem = siteSystem()) }
     val server =
       ServeBugReport.Server(
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         public = isPublic,
         uptimeSeconds = status.uptimeSeconds,
         java = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")})",
@@ -4795,7 +4794,7 @@ class ServeHttpServer(
         // possibly off-origin URL into the markup, which is exactly what `sanitizeFrom` refuses to
         // do for every other use of the value. There is nothing to unfurl per-report anyway.
         unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalOrigin() + ServeBugReport.PATH),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         siteName = skin.first,
         themeCss = skin.second,
         themeStorageKey = skin.third,
@@ -5563,7 +5562,7 @@ class ServeHttpServer(
       // is both wasted work and two answers that can disagree.
       val imageOccupancy = imageStore?.occupancy()
       return StatusResponse(
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         public = isPublic,
         status = if (overallOk) "ok" else "degraded",
         uptimeSeconds = uptimeSeconds,
@@ -5918,7 +5917,7 @@ class ServeHttpServer(
       return ServeWeb.StatusView(
         agentGrants = agentGrants,
         agentGrantRequests = agentGrantRequests,
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         public = isPublic,
         nowMillis = nowMillis,
         overallOk = overallOk,
@@ -6985,7 +6984,7 @@ class ServeHttpServer(
               isPublic = isPublic,
               revisions = revisions,
               unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-              version = BUNDLE_VERSION,
+              version = SERVE_VERSION,
               siteName = skin.first,
               themeCss = skin.second,
               themeStorageKey = skin.third,
@@ -7222,7 +7221,7 @@ class ServeHttpServer(
               imageWidth = imageSize?.first,
               imageHeight = imageSize?.second,
             ),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           sourceHref = sourceHref,
           reportIssue = reportIssue,
           // The Figma node this preview is specified by, when the catalog publishes a Figma-backed
@@ -9236,7 +9235,7 @@ class ServeHttpServer(
           agentGrantCsrf.seal(request.id, approver.name, ServeAgentGrants.Csrf.ACTION_DENY),
         formAction = ServeAgentGrants.approvalPath(request.id) + agentGrantTokenQuery(),
         navSuffix = agentGrantTokenQuery(),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         siteName = skin.first,
         themeCss = skin.second,
         selectableCapabilities =
@@ -9432,7 +9431,7 @@ class ServeHttpServer(
         message = message,
         detail = detail,
         navSuffix = agentGrantTokenQuery(),
-        version = BUNDLE_VERSION,
+        version = SERVE_VERSION,
         siteName = skin.first,
         themeCss = skin.second,
       ),
@@ -9555,7 +9554,7 @@ class ServeHttpServer(
           linkToken(),
           isPublic,
           unfurl = ServeWeb.UnfurlMetadata(pageUrl = externalPageUrl()),
-          version = BUNDLE_VERSION,
+          version = SERVE_VERSION,
           componentBrowser = componentBrowserMode(),
           githubAuth = githubAuthStatus(),
         ),
@@ -10018,7 +10017,7 @@ class ServeHttpServer(
 @Serializable
 private data class VersionResponse(
   val schema: String = "compose-preview-serve/version/v1",
-  /** The host CLI's released version ([BUNDLE_VERSION]). */
+  /** The host CLI's released version ([SERVE_VERSION]). */
   val version: String,
   /**
    * The schema id the `/api/previews` + page surface speaks, so a client can feature-detect. `v2`
@@ -10038,7 +10037,7 @@ private data class VersionResponse(
 @Serializable
 private data class StatusResponse(
   val schema: String = "compose-preview-serve/status/v1",
-  /** The host CLI's released version ([BUNDLE_VERSION]). */
+  /** The host CLI's released version ([SERVE_VERSION]). */
   val version: String,
   /** True when the box serves token-free (public preview server). */
   val public: Boolean,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeVersion.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeVersion.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.cli.serve
+
+import java.util.Properties
+
+/**
+ * Version the preview server reports to its clients — in `/version`, in the session-viewer
+ * handshake, and in the bug-report bundle.
+ *
+ * Deliberately the server's own constant rather than `:cli`'s `SERVE_VERSION`, even though the two
+ * resolve to the same string today because `serve` still ships inside the CLI jar. #3824 splits the
+ * server into its own build, and on that day "the version the server reports" and "the version of
+ * the CLI that happens to launch it" stop being the same fact: a client talking to a deployed
+ * server is asking what the *server* is, and the seam register counted every one of these reads as
+ * the server reaching into the CLI for an answer only the server has.
+ *
+ * Resolved from the same `cli-version.properties` resource for now, which keeps the reported value
+ * byte-identical to what it was. When `serve` becomes its own module it generates its own resource
+ * and this constant stops pointing at the CLI's — a one-line change here rather than at the ~30
+ * call sites that read it.
+ */
+internal val SERVE_VERSION: String by lazy {
+  val props = Properties()
+  val stream =
+    object {}
+      .javaClass
+      .classLoader
+      .getResourceAsStream("ee/schimke/composeai/cli/cli-version.properties")
+      ?: error("cli-version.properties missing from compose-preview jar")
+  stream.use { props.load(it) }
+  props.getProperty("version") ?: error("version property missing from cli-version.properties")
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -5098,9 +5098,9 @@ ${captureControlsHtml().prependIndent("          ")}
     token: String,
     isPublic: Boolean = false,
     /**
-     * Running server version (the CLI's `BUNDLE_VERSION`), surfaced in the minimal footer beside
-     * the source/`/version` links so the live build is visible on the front door. Null omits it;
-     * the fixture golden passes a fixed string so a release never churns the committed HTML.
+     * Running server version (the CLI's `SERVE_VERSION`), surfaced in the minimal footer beside the
+     * source/`/version` links so the live build is visible on the front door. Null omits it; the
+     * fixture golden passes a fixed string so a release never churns the committed HTML.
      */
     version: String? = null,
     /** Absolute page + representative hero URLs for Open Graph/Twitter link previews. */
@@ -5419,7 +5419,7 @@ ${captureControlsHtml().prependIndent("          ")}
     isPublic: Boolean,
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -5825,7 +5825,7 @@ ${captureControlsHtml().prependIndent("          ")}
     pinnedCatalogSystems: Set<String> = emptySet(),
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -6585,7 +6585,7 @@ ${captureControlsHtml().prependIndent("          ")}
     isPublic: Boolean,
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -6667,7 +6667,7 @@ ${captureControlsHtml().prependIndent("          ")}
     urlUploadAllowed: Boolean,
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -6797,7 +6797,7 @@ ${captureControlsHtml().prependIndent("          ")}
     isPublic: Boolean,
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -7179,7 +7179,7 @@ ${captureControlsHtml().prependIndent("          ")}
     view: StatusView,
     token: String,
     unfurl: UnfurlMetadata? = null,
-    /** Running server version (`BUNDLE_VERSION`), shown in the minimal footer. */
+    /** Running server version (`SERVE_VERSION`), shown in the minimal footer. */
     version: String? = null,
     /**
      * The catalog whose colours and name this page wears, when it is served on a **top-level site**
@@ -8006,9 +8006,9 @@ ${captureControlsHtml().prependIndent("          ")}
      */
     presenceUrl: String = "",
     /**
-     * Running server version (the CLI's `BUNDLE_VERSION`), surfaced in the minimal footer beside
-     * the source/`/version` links. Null omits it; the fixture golden passes a fixed string so a
-     * release never churns the committed HTML.
+     * Running server version (the CLI's `SERVE_VERSION`), surfaced in the minimal footer beside the
+     * source/`/version` links. Null omits it; the fixture golden passes a fixed string so a release
+     * never churns the committed HTML.
      */
     version: String? = null,
     /**
@@ -8848,7 +8848,7 @@ ${captureControlsHtml().prependIndent("          ")}
      */
     reportIssue: ReportIssue? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -9377,7 +9377,7 @@ $rows
     themeCss: String = "",
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -10655,7 +10655,7 @@ $cards
     themeCss: String = "",
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -11422,7 +11422,7 @@ ${scriptTag("known-differences.js")}
     /** Absolute viewer + PNG URLs for Open Graph/Twitter link previews. */
     unfurl: UnfurlMetadata? = null,
     /**
-     * Running server version (`BUNDLE_VERSION`), shown in the minimal footer. Null omits the build
+     * Running server version (`SERVE_VERSION`), shown in the minimal footer. Null omits the build
      * span.
      */
     version: String? = null,
@@ -13395,7 +13395,7 @@ ${scriptTag("known-differences.js")}
      */
     headerBreadcrumb: String = "",
     /**
-     * Running server version (the CLI's `BUNDLE_VERSION`), shown in the minimal [siteFooter] every
+     * Running server version (the CLI's `SERVE_VERSION`), shown in the minimal [siteFooter] every
      * page ends with. Null omits just the build span; the fixture goldens pass a fixed string so a
      * release never churns the committed HTML.
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/SkikoNativePairing.kt
@@ -32,9 +32,9 @@ import java.io.File
  *
  * A bundle that promotes Skiko bindings must bring its **own** native. So when the recorded
  * coordinates name bindings at version V with no `skiko-awt-runtime-<host>` at V, synthesize that
- * coordinate and let [ee.schimke.composeai.cli.CoordinateResolver] fetch it like any other — it is
- * a published artifact on the same repository the bindings came from. Bindings and native then
- * travel together, exactly as they do on a Gradle-resolved render classpath
+ * coordinate and let [ee.schimke.composeai.bundle.coordinates.CoordinateResolver] fetch it like any
+ * other — it is a published artifact on the same repository the bindings came from. Bindings and
+ * native then travel together, exactly as they do on a Gradle-resolved render classpath
  * ([ee.schimke.composeai.plugin.ValidateComposePreviewClasspathTask] enforces the same invariant
  * there).
  *
@@ -123,9 +123,10 @@ internal object SkikoNativePairing {
    * no published native, a bundle that recorded a native for the wrong platform. **Classpath order
    * decides**, because both halves are plain classloader lookups: the bindings are `.class` files
    * and `libskiko-<target>.so` is a root-level resource in the platform jar
-   * ([ee.schimke.composeai.cli.CoordinateResolver] puts each resolved jar where the caller asked).
-   * So the pair that runs is the FIRST of each on the ordered `-cp`, which is what this reads — not
-   * the set of versions present, which would call a harmless shadowed duplicate a skew.
+   * ([ee.schimke.composeai.bundle.coordinates.CoordinateResolver] puts each resolved jar where the
+   * caller asked). So the pair that runs is the FIRST of each on the ordered `-cp`, which is what
+   * this reads — not the set of versions present, which would call a harmless shadowed duplicate a
+   * skew.
    *
    * The **first of each**, never a count of distinct versions — the distinction #4234/#4235 drew
    * for the Gradle-side guard, and it holds here for the same reason. Two independently-resolved

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/WebEmbed.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/serve/WebEmbed.kt
@@ -1,6 +1,5 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.serve.WebEscaping
 import java.util.Base64
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleEmbedDataTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.embedWebIntoZip
 import ee.schimke.composeai.bundle.resolveInBundleTarget
+import ee.schimke.composeai.cli.serve.WebEmbed
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/PlaygroundCatalogClasspathTest.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleReader
-import ee.schimke.composeai.cli.CoordinateResolver
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleTest.kt
@@ -1,6 +1,5 @@
 package ee.schimke.composeai.cli.serve
 
-import ee.schimke.composeai.cli.WebEmbed
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.zip.ZipInputStream

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -105,8 +105,8 @@ class ServeWebFixtureTest {
   private val moduleLabel = ":samples:cmp"
 
   // A FIXED server version for the goldens: the footer surfaces the running build, but pinning a
-  // constant here (rather than the real BUNDLE_VERSION) keeps the committed HTML stable across
-  // releases — production passes BUNDLE_VERSION, the fixtures pass this.
+  // constant here (rather than the real SERVE_VERSION) keeps the committed HTML stable across
+  // releases — production passes SERVE_VERSION, the fixtures pass this.
   private val version = "0.0.0-fixture"
 
   // Catalog provenance for the public compose-m3 landing golden — captures the provenance strip

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/WebEmbedTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/serve/WebEmbedTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli
+package ee.schimke.composeai.cli.serve
 
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream

--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -109,10 +109,18 @@ needed Gradle: `PreviewParameterFanout` has no imports at all, and `PreviewResul
 `previewSha256` use only Okio and the DTOs. They moved down into `:preview-data-api` instead.
 `:gradle-preview-driver` is not a contract and serve no longer names it.
 
-The three that remain are genuinely declared in `:cli` and each needs a decision rather than a
-move: `BUNDLE_VERSION` (does an extracted server report its own version, or the CLI's?),
-`CoordinateResolver`, and `WebEmbed`. They belong to preparation item 7. The `cli→serve` direction
-is untouched at 102 entries and is dominated by `ServeCommand.kt`.
+The three that remained were genuinely declared in `:cli`, and each needed a decision rather than a
+move. All three are now resolved, and **`cliInternalsUsedByServe` is empty in both source sets** —
+the `serve→cli` direction of this register is closed:
+
+| symbol | resolution |
+| --- | --- |
+| `BUNDLE_VERSION` | became serve's own `SERVE_VERSION`. A deployed server answering `/version` is being asked what the *server* is, not what the CLI that happened to launch it is. Same resource today, so the reported string is unchanged; when serve is its own module it generates its own. |
+| `CoordinateResolver` | moved to a published `:bundle-coordinates`. It is not part of `:bundle-format` — reading the format is offline and synchronous, this does HTTP over ktor, and a format module should not drag a network client onto the render subprocess classpath. |
+| `WebEmbed` | moved into the `serve` package. That converts it from a `serve→cli` crossing into a `cli→serve` one, which is the direction that does not block extraction: an extracted `:cli` depends on the server module, not the reverse. |
+
+What is left is `serveInternalsUsedByCli` — 102 entries on `main`, dominated by `ServeCommand.kt`.
+That is the rest of preparation item 7: the module extraction itself.
 
 ### 2. `scripts/check-preview-server-contracts.sh` — the artifact probe
 

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -64,6 +64,10 @@ val contracts =
     // existed it did that by reaching into `:cli`. It was the one entry in the dependency-floor
     // table below that was not a module at all; naming it here is what stops it being a blocker.
     "bundle-format",
+    // Turning those coordinates back into local jars. `serve` resolves a bundle's classpath before
+    // it can hand the daemon a `-cp`, and while this lived in `:cli` that was the last thing
+    // making an extracted server depend on the CLI. Preparation item 7.
+    "bundle-coordinates",
   )
 
 dependencies {

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.previewserver.contract
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
@@ -87,4 +88,11 @@ object ContractSurface {
    * checked claim rather than a stated one.
    */
   val bundleManifest: KClass<BundleReader.Manifest> = BundleReader.Manifest::class
+
+  /**
+   * Turning a bundle's recorded Maven coordinates back into local jars. Serve resolves a bundle's
+   * classpath before it can hand the daemon a `-cp`, and while this lived in `:cli` it was the last
+   * thing that made an extracted server depend on the CLI (preparation item 7).
+   */
+  val coordinateResolver: KClass<CoordinateResolver> = CoordinateResolver::class
 }

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -43,6 +43,7 @@ CONTRACT_PROJECTS=(
   ":data-render-core"
   ":data-pseudolocale-core"
   ":bundle-format"
+  ":bundle-coordinates"
 )
 
 # Recorded leaks, published only so the probe can resolve at all. Every name here is a module an

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -32,6 +32,15 @@
     "The three left are genuinely declared in `:cli` and each needs a decision, not a move:",
     "BUNDLE_VERSION (does an extracted server report its own version?), CoordinateResolver, and",
     "WebEmbed. They are #3824 preparation item 7's problem.",
+    "Those three are now resolved, and cliInternalsUsedByServe is EMPTY in both source sets — the",
+    "serve->cli direction of this register is closed. BUNDLE_VERSION became serve's own",
+    "SERVE_VERSION (a deployed server reports what the server is, not what the CLI that launched",
+    "it is); CoordinateResolver moved into a published :bundle-coordinates, mapped below;",
+    "WebEmbed moved into the serve package, which turns it from a serve->cli crossing into a",
+    "cli->serve one — the direction that does not block extraction, since an extracted `:cli`",
+    "depends on the server module rather than the other way round.",
+    "What is left is serveInternalsUsedByCli, 102 on main, dominated by ServeCommand.kt. That is",
+    "the rest of preparation item 7: the module extraction itself.",
     "serveInternalsUsedByCli: the CLI reaching into serve. Each entry must either move to the",
     "server build with serve, or move down into a contract module the CLI can keep using. The",
     "long tail here is ServeCommand.kt, which #3824 wants reduced to a thin entry point.",
@@ -67,6 +76,7 @@
   ],
   "contractPackages": {
     "ee.schimke.composeai.bundle": "bundle-format",
+    "ee.schimke.composeai.bundle.coordinates": "bundle-coordinates",
     "ee.schimke.composeai.daemon": "daemon-core",
     "ee.schimke.composeai.daemon.bta": "daemon-core",
     "ee.schimke.composeai.daemon.devices": "daemon-core",
@@ -111,11 +121,7 @@
     }
   },
   "main": {
-    "cliInternalsUsedByServe": [
-      "BUNDLE_VERSION",
-      "CoordinateResolver",
-      "WebEmbed"
-    ],
+    "cliInternalsUsedByServe": [],
     "serveInternalsUsedByCli": [
       "serve.BundleVerifier",
       "serve.CatalogBlobPool",
@@ -210,7 +216,7 @@
       "serve.ThemeCacheFingerprint",
       "serve.ThemeCacheStore",
       "serve.TrustStore",
-      "serve.WebEscaping",
+      "serve.WebEmbed",
       "serve.clampTo",
       "serve.contentBoxFillsRender",
       "serve.declaredThemesFromPreviews",
@@ -222,10 +228,7 @@
     ]
   },
   "test": {
-    "cliInternalsUsedByServe": [
-      "CoordinateResolver",
-      "WebEmbed"
-    ],
+    "cliInternalsUsedByServe": [],
     "serveInternalsUsedByCli": [
       "serve.BundleVerifier",
       "serve.FakeRenderSession",
@@ -245,7 +248,8 @@
       "serve.TrustStore",
       "serve.TrustedBranch",
       "serve.TrustedIdentity",
-      "serve.TrustedKey"
+      "serve.TrustedKey",
+      "serve.WebEmbed"
     ]
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -245,6 +245,14 @@ include(":bundle-format")
 
 project(":bundle-format").projectDir = file("bundle/format")
 
+// Resolving a bundle's recorded Maven coordinates into local jars — cache probes then an HTTP
+// fetch. Split out of `:cli` for #3824 preparation item 7: `serve` needs it, and while it lived in
+// `:cli` an extracted preview server could only have reached it through the CLI. Deliberately not
+// part of `:bundle-format`, which stays offline and network-free.
+include(":bundle-coordinates")
+
+project(":bundle-coordinates").projectDir = file("bundle/coordinates")
+
 // The mobile + Wear "session viewer" client apps (`:clients:*`) were split out to their own repo,
 // yschimke/compose-preview-client (issue #2533). They consumed `compose-preview serve` purely
 // through the wire contract (docs/serve/SESSION-VIEWER-PROTOCOL.md), never a code dependency, so the


### PR DESCRIPTION
First step of #3824 preparation item 7.

**`cliInternalsUsedByServe` is now empty in both source sets.** Nothing in `serve` reaches into `:cli` any more. That is the precondition for a `:cli:serve` module and for `checkServeModuleBoundary` — a module cannot depend on the thing that depends on it.

| | `main.cliInternalsUsedByServe` | `test` |
| --- | --- | --- |
| before the split work | 21 | 9 |
| after #4581 / #4587 (item 5) | 3 | 2 |
| after #4593 (contract renames) | 3 | 2 |
| **this PR** | **0** | **0** |

## The three, each a decision rather than a move

**`BUNDLE_VERSION` → serve's own `SERVE_VERSION`.** A deployed server answering `/version` is being asked what the *server* is, not what the CLI that happened to launch it is. While serve ships inside the CLI jar both read the same `cli-version.properties`, so the reported string is byte-identical; when serve becomes its own module it generates its own resource — a one-line change in `ServeVersion.kt` rather than at the ~30 call sites that read it.

**`CoordinateResolver` → a new published `:bundle-coordinates`** (`bundle/coordinates`), with `explicitApi()`, a committed ABI dump, and a place in the contract probe. Deliberately **not** part of `:bundle-format`: reading the format is offline and synchronous, this does HTTP over ktor, and a format module should not drag a network client onto the render subprocess classpath. Its `:cli` callers (`bundle daemon`, `bundle render`) keep working — resolving a bundle's classpath is not a server concern, so folding it into `serve` would have been the wrong direction.

**`WebEmbed` → the `serve` package.** It already reached into `serve`'s escaping helpers. Moving it converts a `serve→cli` crossing into a `cli→serve` one, which is the direction that does not block extraction: an extracted `:cli` depends on the server module, not the reverse. It is the one new `serveInternalsUsedByCli` entry, and `check-serve-seam.py` requires that be justified in the PR body — this paragraph is that justification.

## One non-obvious bit of wiring

`:bundle-coordinates` is registered as a contract in all four places (`CONTRACT_PROJECTS`, the probe's `contracts`, `contractPackages`, and the `preview_server_contracts` CI path group), and `ContractSurface.kt` names `CoordinateResolver`.

Its `contractPackages` entry is not bookkeeping: without it, `ee.schimke.composeai.bundle.coordinates` prefix-matches the existing `ee.schimke.composeai.bundle` mapping and silently resolves to `bundle-format`, which does not declare it. `test_each_imported_type_is_mapped_to_a_module_that_declares_it` is what would eventually catch that, against the published artifacts.

## What is left of item 7

`serveInternalsUsedByCli` — 102 entries on `main`, 20 on `test`, dominated by `ServeCommand.kt` (~4.9k lines) — plus the module extraction itself (135 source files, ~73k lines, and 183 test files). That is the next PR.

## Test plan

- `./gradlew :bundle-coordinates:check` — green, including `checkKotlinAbi` against the new dump.
- `./gradlew :cli:check :bundle-format:check` — green (5m18s), full `:cli` test suite included.
- `scripts/check-preview-server-contracts.sh` — green end to end: publishes 14 contracts from source, builds `preview-server` against them, `checkContractSurface` finds no leak.
- `python3 scripts/check-serve-seam.py` — OK, 122 crossings, `main.cliInternalsUsedByServe=0`, `test.cliInternalsUsedByServe=0`; `scripts/test_check_serve_seam.py` 45 tests OK.
- `python3 scripts/check-daemon-launch-schema.py` — OK. All five `.github/ci/test_*.py` suites — OK.

Non-visual: module boundaries and a version constant. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_