### PR TITLE
feat(cli): carry preview-id exclusions in a file, so an id may contain a comma

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -157,6 +157,17 @@ class BundleCommand(args: List<String>) : Command(args) {
                             -PcomposePreview.idExclude; also read from the
                             ORG_GRADLE_PROJECT_composePreview.idExclude env var when the flag is
                             absent, so an env-only setup thins the semantics pass too.
+        --exclude-preview-id-file <path>
+                            The same exclusions, one per line, read from a file. Use this for a
+                            GENERATED list: a preview id may itself contain a comma (a
+                            @Preview(widthDp = …, heightDp = …) mints
+                            `…Button_width=227dp, height=100dp, dpi=320`), which the
+                            comma-separated flag above cannot carry — the split shatters each id
+                            into fragments and, since a plain pattern matches on substring, a
+                            fragment like `dpi=320` excludes the whole module. Forwarded to Gradle
+                            as -PcomposePreview.idExcludeFile (a path, never re-joined). Wins over
+                            --exclude-preview-id and the env var. An unreadable path is an error,
+                            not an empty exclusion list.
         --exclude-preview-row <label|glob>
                             Skip rendering the @PreviewParameter rows whose label matches — the fan-out
                             --exclude-preview-id can't reach, because discovery never sees the rows
@@ -274,6 +285,17 @@ private class PackSubcommand(private val args: List<String>) {
   private val excludePreviewIds: List<String> = PackPreviewIdExclusions.fromArgs(args)
 
   /**
+   * `--exclude-preview-id-file`, when one was passed: the same patterns as [excludePreviewIds], but
+   * kept as a FILE so the render can be handed the path instead of a comma-joined string.
+   *
+   * That distinction is the whole point of the flag. A preview id may contain a comma, so joining
+   * the list for `-PcomposePreview.idExclude` and splitting it back shatters each id into
+   * fragments; because a plain pattern matches on substring, a fragment such as `dpi=320` then
+   * excludes every preview in the module.
+   */
+  private val excludePreviewIdFile: java.io.File? = PackPreviewIdExclusions.fileFromArgs(args)
+
+  /**
    * `--exclude-preview-row` labels — the `@PreviewParameter` rows this pack must not render. Render
    * only: the semantics capture is per preview, so a parameterized preview costs one capture
    * whatever its provider fans out to and there is nothing to thin there.
@@ -320,7 +342,15 @@ private class PackSubcommand(private val args: List<String>) {
               // `--exclude-preview-id` convention. Passed explicitly rather than relying on the
               // inherited env var so `--exclude-preview-id` works from any shell, and so the
               // patterns the semantics pass below skips are provably the same ones the render did.
-              if (excludePreviewIds.isNotEmpty())
+              // The FILE form when there is one — see [excludePreviewIdFile] for why joining is
+              // not equivalent. Absolute, because the render's Gradle build runs in the module's
+              // own directory rather than the CLI's.
+              if (excludePreviewIdFile != null)
+                add(
+                  "-P${PackPreviewIdExclusions.FILE_GRADLE_PROPERTY}=" +
+                    excludePreviewIdFile.absolutePath
+                )
+              else if (excludePreviewIds.isNotEmpty())
                 add(
                   "-P${PackPreviewIdExclusions.GRADLE_PROPERTY}=" +
                     excludePreviewIds.joinToString(",")
@@ -479,7 +509,15 @@ private class PackSubcommand(private val args: List<String>) {
               // them off here would accept the flags and then render every excluded preview/row
               // anyway. `--id` still selects which previews get *packed*; these thin what is
               // *drawn*.
-              if (excludePreviewIds.isNotEmpty())
+              // The FILE form when there is one — see [excludePreviewIdFile] for why joining is
+              // not equivalent. Absolute, because the render's Gradle build runs in the module's
+              // own directory rather than the CLI's.
+              if (excludePreviewIdFile != null)
+                add(
+                  "-P${PackPreviewIdExclusions.FILE_GRADLE_PROPERTY}=" +
+                    excludePreviewIdFile.absolutePath
+                )
+              else if (excludePreviewIds.isNotEmpty())
                 add(
                   "-P${PackPreviewIdExclusions.GRADLE_PROPERTY}=" +
                     excludePreviewIds.joinToString(",")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -247,6 +247,7 @@ internal object CliFlagValidation {
           setOf(
             "--embed-deps",
             "--exclude-preview-id",
+            "--exclude-preview-id-file",
             "--exclude-preview-row",
             "--ext",
             "--external-images",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -31,6 +31,7 @@ internal object CliFlags {
       "--filter",
       "--id",
       "--exclude-preview-id",
+      "--exclude-preview-id-file",
       "--exclude-preview-row",
       "--output",
       // The short alias, classified for the same reason as its long form: it consumes the next

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -38,7 +38,48 @@ internal object PackPreviewIdExclusions {
    * command line can narrow an inherited environment.
    */
   fun fromArgs(args: List<String>, env: (String) -> String? = System::getenv): List<String> =
-    patternsFor(args, "--exclude-preview-id", ENV_VAR, env)
+    fileFromArgs(args)?.let(::linesOf) ?: patternsFor(args, "--exclude-preview-id", ENV_VAR, env)
+
+  /** The Gradle property carrying a PATH to a newline-delimited exclusion list. */
+  const val FILE_GRADLE_PROPERTY = "composePreview.idExcludeFile"
+
+  /**
+   * `--exclude-preview-id-file <path>`, the delimiter-free form of `--exclude-preview-id`.
+   *
+   * A preview id may contain a comma — `@Preview(widthDp = …, heightDp = …)` mints
+   * `…CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320` — so the comma-separated flag
+   * cannot carry one. Joining and re-splitting shatters each id into fragments, and because a plain
+   * pattern matches on **substring**, a fragment like `dpi=320` matches every preview in the
+   * module: a list deferring 47 of 58 previews excluded all 58 and the render died with "nothing
+   * would render". One pattern per line has no such ambiguity, because a line break cannot occur
+   * inside an id.
+   *
+   * Returns the file, not its contents, because both consumers need it: the semantics capture reads
+   * the lines here, and the render is handed the PATH (via [FILE_GRADLE_PROPERTY]) so nothing
+   * re-joins them downstream.
+   */
+  fun fileFromArgs(args: List<String>): java.io.File? =
+    args
+      .flagValuesAll("--exclude-preview-id-file")
+      .lastOrNull()
+      ?.trim()
+      ?.takeIf(String::isNotEmpty)
+      ?.let { java.io.File(it) }
+
+  /**
+   * The patterns in [file], one per line, blanks dropped.
+   *
+   * An unreadable file throws rather than yielding an empty list: an exclusion set that silently
+   * became "exclude nothing" renders the whole sheet and reports success, which is exactly the
+   * quiet failure this path exists to prevent.
+   */
+  fun linesOf(file: java.io.File): List<String> {
+    check(file.isFile) {
+      "--exclude-preview-id-file '${file.path}' is not a readable file. Refusing to fall back to " +
+        "an empty exclusion list, which would render every preview and look like success."
+    }
+    return file.readLines().map(String::trim).filter(String::isNotEmpty)
+  }
 
   /** The Gradle property carrying `@PreviewParameter` **row** label exclusions. */
   const val ROW_GRADLE_PROPERTY = "composePreview.rowExclude"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -5,6 +5,109 @@ import kotlin.test.assertEquals
 
 class PackPreviewIdExclusionsTest {
 
+  private val tmpRoot: java.io.File =
+    java.nio.file.Files.createTempDirectory("pack-id-exclusions-").toFile().also {
+      it.deleteOnExit()
+    }
+
+  /**
+   * The id shape that motivated the file flag: `@Preview(widthDp = …, heightDp = …)` mints an id
+   * with commas in it, so the comma-separated flag cannot carry one.
+   */
+  private val commaBearingIds =
+    listOf(
+      "ee.schimke.wearm3catalog.remote.CatalogPreviewsKt." +
+        "CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320",
+      "ee.schimke.wearm3catalog.remote.CatalogPreviewsKt." +
+        "NamedLabelRemoteButton_width=227dp, height=100dp, dpi=320",
+    )
+
+  private fun fileWith(lines: List<String>): java.io.File =
+    java.io.File.createTempFile("excludes-", ".txt", tmpRoot).apply {
+      deleteOnExit()
+      writeText(lines.joinToString("\n"))
+    }
+
+  @Test
+  fun `a file carries an id that contains commas, intact`() {
+    val f = fileWith(commaBearingIds)
+    assertEquals(
+      commaBearingIds,
+      PackPreviewIdExclusions.fromArgs(
+        listOf("pack", "--exclude-preview-id-file", f.path),
+        noEnv,
+      ),
+    )
+  }
+
+  @Test
+  fun `the comma flag shatters the same ids - the regression the file flag exists for`() {
+    // Not aspirational: this is what `--exclude-preview-id` does, and why it must not be used for
+    // a generated list. Each id becomes three fragments.
+    val shattered =
+      PackPreviewIdExclusions.fromArgs(
+        listOf("pack", "--exclude-preview-id", commaBearingIds.joinToString(",")),
+        noEnv,
+      )
+    assertEquals(6, shattered.size)
+    assertEquals(true, shattered.contains("dpi=320"))
+  }
+
+  @Test
+  fun `a shattered fragment excludes every preview, but the file form excludes only its own`() {
+    // The live failure: `dpi=320` is a substring of every id in the module, and a plain pattern
+    // matches on substring — so the render was left with nothing to draw.
+    val all = commaBearingIds + listOf("ee.schimke.Other.ThirdSticker_width=227dp, dpi=320")
+    val shattered =
+      PackPreviewIdExclusions.fromArgs(
+        listOf("pack", "--exclude-preview-id", commaBearingIds.joinToString(",")),
+        noEnv,
+      )
+    assertEquals(emptyList(), PackPreviewIdExclusions.retain(all, shattered))
+
+    val f = fileWith(commaBearingIds)
+    val fromFile =
+      PackPreviewIdExclusions.fromArgs(listOf("pack", "--exclude-preview-id-file", f.path), noEnv)
+    assertEquals(listOf(all[2]), PackPreviewIdExclusions.retain(all, fromFile))
+  }
+
+  @Test
+  fun `the file wins over both the flag and the env var`() {
+    val f = fileWith(listOf("OnlyThis"))
+    assertEquals(
+      listOf("OnlyThis"),
+      PackPreviewIdExclusions.fromArgs(
+        listOf("pack", "--exclude-preview-id-file", f.path, "--exclude-preview-id", "Ignored"),
+        envWith("AlsoIgnored"),
+      ),
+    )
+  }
+
+  @Test
+  fun `blank lines are dropped and entries trimmed`() {
+    val f = fileWith(listOf("  Foo_Dark  ", "", "   ", "Bar_Dark"))
+    assertEquals(
+      listOf("Foo_Dark", "Bar_Dark"),
+      PackPreviewIdExclusions.fromArgs(listOf("pack", "--exclude-preview-id-file", f.path), noEnv),
+    )
+  }
+
+  @Test
+  fun `a missing file fails loudly rather than excluding nothing`() {
+    val missing = java.io.File(tmpRoot, "nope.txt")
+    val e =
+      kotlin
+        .runCatching {
+          PackPreviewIdExclusions.fromArgs(
+            listOf("pack", "--exclude-preview-id-file", missing.path),
+            noEnv,
+          )
+        }
+        .exceptionOrNull()
+    assertEquals(true, e is IllegalStateException)
+    assertEquals(true, e!!.message!!.contains("not a readable file"))
+  }
+
   private val noEnv: (String) -> String? = { null }
 
   private fun envWith(value: String): (String) -> String? = { name ->

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewFilter.kt
@@ -42,6 +42,23 @@ public object PreviewFilter {
   /** System property carrying the comma-separated `--exclude-preview-id` id patterns. */
   public const val ID_EXCLUDE_PROPERTY: String = "composeai.preview.idExclude"
 
+  /**
+   * System property carrying a **path** to a newline-delimited `--exclude-preview-id` pattern file.
+   *
+   * The comma-delimited [ID_EXCLUDE_PROPERTY] cannot express a pattern that contains a comma, and
+   * preview ids routinely do: an `@Preview(widthDp = …, heightDp = …)` mints
+   * `…CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320`. Joining such ids and splitting
+   * them back shatters each into three fragments, and because a plain pattern matches on
+   * **substring**, the fragment `dpi=320` then matches every preview in the module — an exclusion
+   * list meant to defer 47 of 58 previews excluded all 58 and the render failed with "nothing would
+   * render" (yschimke/wear-m3-catalog `:remote-catalog`).
+   *
+   * One pattern per line has no such ambiguity: a line break cannot occur inside an id. When this
+   * property is set it REPLACES [ID_EXCLUDE_PROPERTY] rather than adding to it, so a caller that
+   * can write a file never pays the delimiter's cost.
+   */
+  public const val ID_EXCLUDE_FILE_PROPERTY: String = "composeai.preview.idExcludeFile"
+
   /** System property carrying the comma-separated `--exclude-preview-row` label patterns. */
   public const val ROW_EXCLUDE_PROPERTY: String = "composeai.preview.rowExclude"
 
@@ -56,6 +73,36 @@ public object PreviewFilter {
     read: (String) -> String? = System::getProperty,
   ): List<String> =
     read(property)?.split(",")?.map(String::trim)?.filter(String::isNotEmpty) ?: emptyList()
+
+  /**
+   * The `--exclude-preview-id` patterns: the newline-delimited file named by [fileProperty] when
+   * that property is set and readable, else the comma-separated [property].
+   *
+   * The file wins outright instead of merging — a caller passing a file is expressing the whole
+   * exclusion set, and merging would silently reinstate a comma-shattered copy of it.
+   *
+   * A file that is named but cannot be read is an error, not an empty list: a filter that silently
+   * became "exclude nothing" renders the full sheet and looks like success, which is the failure
+   * mode this whole path exists to avoid.
+   */
+  public fun idExcludesFrom(
+    property: String = ID_EXCLUDE_PROPERTY,
+    fileProperty: String = ID_EXCLUDE_FILE_PROPERTY,
+    read: (String) -> String? = System::getProperty,
+    readFile: (String) -> List<String>? = { path ->
+      java.io.File(path).takeIf(java.io.File::isFile)?.readLines()
+    },
+  ): List<String> {
+    val path =
+      read(fileProperty)?.trim()?.takeIf(String::isNotEmpty) ?: return patternsFrom(property, read)
+    val lines =
+      readFile(path)
+        ?: throw IllegalStateException(
+          "$fileProperty names '$path', which is not a readable file. Refusing to fall back to " +
+            "an empty exclusion list, which would render every preview and look like success."
+        )
+    return lines.map(String::trim).filter(String::isNotEmpty)
+  }
 
   /**
    * True when [functionName] (owned by [className]) matches at least one of [patterns], or when

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/PreviewFilterTest.kt
@@ -259,4 +259,91 @@ class PreviewFilterTest {
     // Unanchored keeps its documented substring behaviour.
     assertTrue(PreviewFilter.matchesId(listOf("Foo_Light"), "Foo_Light_VARIANT_off"))
   }
+
+  // --- idExcludesFrom: the delimiter-free exclusion file (see ID_EXCLUDE_FILE_PROPERTY) ---
+
+  private fun props(vararg pairs: Pair<String, String>): (String) -> String? {
+    val m = pairs.toMap()
+    return { m[it] }
+  }
+
+  @Test
+  fun `with no file property, falls back to the comma-separated property`() {
+    assertEquals(
+      listOf("Foo", "Bar"),
+      PreviewFilter.idExcludesFrom(read = props(PreviewFilter.ID_EXCLUDE_PROPERTY to "Foo, Bar")),
+    )
+  }
+
+  @Test
+  fun `a file carries an id containing commas intact, and wins over the joined property`() {
+    val ids =
+      listOf(
+        "ee.schimke.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320",
+        "ee.schimke.CatalogPreviewsKt.NamedLabelRemoteButton_width=227dp, height=100dp, dpi=320",
+      )
+    assertEquals(
+      ids,
+      PreviewFilter.idExcludesFrom(
+        read =
+          props(
+            PreviewFilter.ID_EXCLUDE_FILE_PROPERTY to "/excludes.txt",
+            PreviewFilter.ID_EXCLUDE_PROPERTY to "ignored",
+          ),
+        readFile = { path -> if (path == "/excludes.txt") ids else null },
+      ),
+    )
+  }
+
+  /**
+   * The live failure this guards: joined and re-split, `dpi=320` becomes a pattern of its own, and
+   * a plain pattern matches on SUBSTRING — so it excludes every preview in the module.
+   */
+  @Test
+  fun `the joined form shatters such ids into a pattern that excludes everything`() {
+    val ids =
+      listOf(
+        "ee.schimke.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320",
+        "ee.schimke.CatalogPreviewsKt.KeepMe_width=227dp, height=100dp, dpi=320",
+      )
+    val shattered =
+      PreviewFilter.idExcludesFrom(
+        read = props(PreviewFilter.ID_EXCLUDE_PROPERTY to ids.joinToString(","))
+      )
+    assertTrue(shattered.contains("dpi=320"))
+    assertFailsWith<IllegalStateException> {
+      PreviewFilter.excludeById(items = ids, excludes = shattered, id = { it })
+    }
+
+    // The file form removes only the id it names.
+    val fromFile =
+      PreviewFilter.idExcludesFrom(
+        read = props(PreviewFilter.ID_EXCLUDE_FILE_PROPERTY to "/x"),
+        readFile = { listOf(ids[0]) },
+      )
+    assertEquals(listOf(ids[1]), PreviewFilter.excludeById(ids, fromFile, id = { it }))
+  }
+
+  @Test
+  fun `blank lines are dropped and entries trimmed`() {
+    assertEquals(
+      listOf("Foo", "Bar"),
+      PreviewFilter.idExcludesFrom(
+        read = props(PreviewFilter.ID_EXCLUDE_FILE_PROPERTY to "/x"),
+        readFile = { listOf("  Foo ", "", "   ", "Bar") },
+      ),
+    )
+  }
+
+  @Test
+  fun `an unreadable file fails loudly rather than excluding nothing`() {
+    val e =
+      assertFailsWith<IllegalStateException> {
+        PreviewFilter.idExcludesFrom(
+          read = props(PreviewFilter.ID_EXCLUDE_FILE_PROPERTY to "/missing"),
+          readFile = { null },
+        )
+      }
+    assertTrue(e.message!!.contains("not a readable file"))
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -2456,6 +2456,7 @@ internal object AndroidPreviewSupport {
             nameFilters = previewFilters,
             idFilters = previewIdFilters,
             idExcludes = previewIdExcludes,
+            idExcludeFile = ComposePreviewTasks.previewIdExcludeFileProperty(project),
             rowExcludes = previewRowExcludes,
             permutations = permutations,
           )
@@ -2924,6 +2925,7 @@ internal object AndroidPreviewSupport {
             nameFilters = ComposePreviewTasks.previewFilterProperty(project),
             idFilters = ComposePreviewTasks.previewIdFilterProperty(project),
             idExcludes = ComposePreviewTasks.previewIdExcludeProperty(project),
+            idExcludeFile = ComposePreviewTasks.previewIdExcludeFileProperty(project),
             // Forwarded for uniformity; the XR subspace render has no `@PreviewParameter` fan-out
             // to thin, so it is inert there rather than meaningful.
             rowExcludes = ComposePreviewTasks.previewRowExcludeProperty(project),
@@ -3750,6 +3752,13 @@ internal object AndroidPreviewSupport {
     @get:org.gradle.api.tasks.Input val nameFilters: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input val idFilters: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input val idExcludes: org.gradle.api.provider.Provider<List<String>>,
+    /**
+     * Path to the newline-delimited exclusion file, when the build was given one. `@Internal`
+     * deliberately: [idExcludes] already carries this file's RESOLVED lines, so the contents drive
+     * the up-to-date check and the path itself must not — a workspace that moves would otherwise
+     * invalidate a render whose exclusion set never changed.
+     */
+    @get:org.gradle.api.tasks.Internal val idExcludeFile: org.gradle.api.provider.Provider<String>,
     @get:org.gradle.api.tasks.Input val rowExcludes: org.gradle.api.provider.Provider<List<String>>,
     @get:org.gradle.api.tasks.Input
     val permutations: org.gradle.api.provider.Provider<List<String>>,
@@ -3757,7 +3766,30 @@ internal object AndroidPreviewSupport {
     override fun asArguments(): Iterable<String> = buildList {
       arg("composeai.preview.filter", nameFilters.getOrElse(emptyList()))
       arg("composeai.preview.idFilter", idFilters.getOrElse(emptyList()))
-      arg("composeai.preview.idExclude", idExcludes.getOrElse(emptyList()))
+      // The FILE wins when there is one, and the comma-joined form is then not emitted at all.
+      // Re-joining here is what the file exists to avoid: a preview id may contain a comma, so the
+      // round trip shatters each id into fragments that — matching by substring — exclude the whole
+      // module. Pass the path and let `PreviewFilter.idExcludesFrom` read the lines.
+      // …but only while the file is still what [idExcludes] came FROM. `--exclude-preview-id` on
+      // the task overrides the property convention (see RenderPreviewsTask's option help), and the
+      // file property is read independently, so forwarding the path unconditionally would let a
+      // stale `-PcomposePreview.idExcludeFile` silently win over an explicit option. Comparing the
+      // resolved lists is what tells the two apart: equal ⇒ the file is the source and travels as
+      // a path; different ⇒ the caller overrode it and their patterns travel as before.
+      val excludeFile = idExcludeFile.orNull?.trim().orEmpty()
+      val resolved = idExcludes.getOrElse(emptyList()).map(String::trim).filter(String::isNotEmpty)
+      val fromFile =
+        java.io
+          .File(excludeFile)
+          .takeIf { excludeFile.isNotEmpty() && it.isFile }
+          ?.readLines()
+          ?.map(String::trim)
+          ?.filter(String::isNotEmpty)
+      if (fromFile != null && fromFile == resolved) {
+        add("-Dcomposeai.preview.idExcludeFile=${java.io.File(excludeFile).absolutePath}")
+      } else {
+        arg("composeai.preview.idExclude", resolved)
+      }
       // The `@PreviewParameter` row axis. It has to travel separately from the id patterns because
       // this backend, like the desktop one, applies the id filters to DISCOVERED entries — before
       // `expandParameterProvider` mints the per-row ids — so an id pattern can never name a row.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1556,10 +1556,37 @@ internal object ComposePreviewTasks {
    * (issue #2977); see [previewIdFilterProperty] for how it reaches the Android render.
    */
   internal fun previewIdExcludeProperty(project: Project): Provider<List<String>> =
-    project.providers
-      .gradleProperty("composePreview.idExclude")
-      .map { v -> v.split(",").map(String::trim).filter(String::isNotEmpty) }
+    previewIdExcludeFileProperty(project)
+      .map { path ->
+        val file = java.io.File(path)
+        check(file.isFile) {
+          "composePreview.idExcludeFile names '$path', which is not a readable file. Refusing to " +
+            "fall back to an empty exclusion list, which would render every preview and look " +
+            "like success."
+        }
+        file.readLines().map(String::trim).filter(String::isNotEmpty)
+      }
+      .orElse(
+        project.providers.gradleProperty("composePreview.idExclude").map { v ->
+          v.split(",").map(String::trim).filter(String::isNotEmpty)
+        }
+      )
       .orElse(emptyList())
+
+  /**
+   * `Provider<String>` for the `composePreview.idExcludeFile` Gradle property — a **path** to a
+   * newline-delimited exclusion list, the delimiter-free form of [previewIdExcludeProperty].
+   *
+   * Exists because a preview id may contain a comma (`@Preview(widthDp = …, heightDp = …)` mints
+   * `…_width=227dp, height=100dp, dpi=320`), so the comma-separated property cannot carry one: the
+   * split shatters each id into fragments, and since a plain pattern matches on substring, a
+   * fragment like `dpi=320` then excludes the entire module. Set by `bundle pack
+   * --exclude-preview-id-file`. When present it REPLACES `composePreview.idExclude`.
+   */
+  internal fun previewIdExcludeFileProperty(project: Project): Provider<String> =
+    project.providers.gradleProperty("composePreview.idExcludeFile").map(String::trim).filter {
+      it.isNotEmpty()
+    }
 
   /**
    * `Provider<List<String>>` for the `composePreview.rowExclude` Gradle property — the

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewFilterSystemPropsProviderTest.kt
@@ -17,6 +17,18 @@ class PreviewFilterSystemPropsProviderTest {
   private fun list(vararg v: String) =
     project.objects.listProperty(String::class.java).apply { set(v.toList()) }
 
+  /** No `--exclude-preview-id-file`: the comma-joined wire format stays in force. */
+  private val noFile = project.objects.property(String::class.java)
+
+  private fun fileWith(lines: List<String>): java.io.File =
+    java.io.File.createTempFile("excludes-", ".txt").apply {
+      deleteOnExit()
+      writeText(lines.joinToString("\n"))
+    }
+
+  private fun path(f: java.io.File) =
+    project.objects.property(String::class.java).apply { set(f.path) }
+
   @Test
   fun `emits one comma-joined -D per non-empty filter`() {
     val args =
@@ -24,6 +36,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list("Foo", "Bar"),
           idFilters = list("*_Light"),
           idExcludes = list("*_Dark"),
+          idExcludeFile = noFile,
           rowExcludes = list("Dark", "ExtraDark"),
           permutations = list("accessibility"),
         )
@@ -47,6 +60,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(),
           idFilters = list(),
           idExcludes = list(),
+          idExcludeFile = noFile,
           rowExcludes = list(),
           permutations = list(),
         )
@@ -63,6 +77,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(" Foo ", "", "  "),
           idFilters = list(),
           idExcludes = list(),
+          idExcludeFile = noFile,
           rowExcludes = list(),
           permutations = list(),
         )
@@ -82,6 +97,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(),
           idFilters = list(),
           idExcludes = list(),
+          idExcludeFile = noFile,
           rowExcludes = list("Dark", " ExtraDark "),
           permutations = list(),
         )
@@ -98,6 +114,7 @@ class PreviewFilterSystemPropsProviderTest {
           nameFilters = list(),
           idFilters = list(),
           idExcludes = list(),
+          idExcludeFile = noFile,
           rowExcludes = list(),
           permutations = list(" accessibility,foo ", "accessibility"),
         )
@@ -105,5 +122,52 @@ class PreviewFilterSystemPropsProviderTest {
         .toList()
 
     assertThat(args).containsExactly("-Dcomposeai.preview.permutations=accessibility,foo")
+  }
+
+  /**
+   * The reason the file form exists: a preview id may contain a comma, so the joined property
+   * cannot carry it. When the file is the source of the patterns, the PATH travels instead —
+   * absolute, because the render's Gradle build runs in the module directory, not the CLI's.
+   */
+  @Test
+  fun `a file-sourced exclusion list travels as a path, not a joined string`() {
+    val ids = listOf("Foo_width=227dp, dpi=320", "Bar_width=227dp, dpi=320")
+    val f = fileWith(ids)
+    val args =
+      AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
+          nameFilters = list(),
+          idFilters = list(),
+          idExcludes = list(*ids.toTypedArray()),
+          idExcludeFile = path(f),
+          rowExcludes = list(),
+          permutations = list(),
+        )
+        .asArguments()
+        .toList()
+
+    assertThat(args).containsExactly("-Dcomposeai.preview.idExcludeFile=${f.absolutePath}")
+  }
+
+  /**
+   * `--exclude-preview-id` on the task overrides the property convention, so a stale
+   * `-PcomposePreview.idExcludeFile` must not win. The resolved lists differing is what marks the
+   * override.
+   */
+  @Test
+  fun `an overridden exclusion list ignores the file and travels joined`() {
+    val f = fileWith(listOf("FromFile"))
+    val args =
+      AndroidPreviewSupport.PreviewFilterSystemPropsProvider(
+          nameFilters = list(),
+          idFilters = list(),
+          idExcludes = list("TypedOnTheCommandLine"),
+          idExcludeFile = path(f),
+          rowExcludes = list(),
+          permutations = list(),
+        )
+        .asArguments()
+        .toList()
+
+    assertThat(args).containsExactly("-Dcomposeai.preview.idExclude=TypedOnTheCommandLine")
   }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -193,7 +193,7 @@ object PreviewManifestLoader {
         items = manifest.previews,
         nameFilters = PreviewFilter.patternsFrom(PreviewFilter.NAME_FILTER_PROPERTY),
         idFilters = PreviewFilter.patternsFrom(PreviewFilter.ID_FILTER_PROPERTY),
-        idExcludes = PreviewFilter.patternsFrom(PreviewFilter.ID_EXCLUDE_PROPERTY),
+        idExcludes = PreviewFilter.idExcludesFrom(),
         functionName = { it.functionName },
         className = { it.className },
         id = { it.id },

--- a/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
+++ b/renderers/xr/src/main/kotlin/ee/schimke/composeai/renderer/xr/XrSubspaceRenderTest.kt
@@ -74,7 +74,7 @@ public class XrSubspaceRenderTest(private val preview: XrManifestReader.XrPrevie
         items = XrManifestReader.xrPreviews(File(manifest)),
         nameFilters = PreviewFilter.patternsFrom(PreviewFilter.NAME_FILTER_PROPERTY),
         idFilters = PreviewFilter.patternsFrom(PreviewFilter.ID_FILTER_PROPERTY),
-        idExcludes = PreviewFilter.patternsFrom(PreviewFilter.ID_EXCLUDE_PROPERTY),
+        idExcludes = PreviewFilter.idExcludesFrom(),
         functionName = { it.functionName },
         className = { it.className },
         id = { it.id },


### PR DESCRIPTION
## The bug

`--exclude-preview-id` is comma-delimited at every hop, but **a preview id may contain a comma**. `@Preview(widthDp = …, heightDp = …)` mints ids like:

```
ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp, height=100dp, dpi=320
```

Joining a list of those and splitting it back shatters each id into three fragments. Because a plain pattern matches on **substring** (`PreviewFilter.matchOne`), the fragment `dpi=320` then matches every preview in the module — so an exclusion list meant to defer 47 of 58 previews excluded all 58:

```
── initializationError
java.lang.IllegalStateException: composePreviewRender --exclude-preview-id excluded every one of
the 58 preview(s) for '…CustomShapeRemoteButton_width=227dp', 'height=100dp', 'dpi=320', … —
nothing would render.
	at ee.schimke.composeai.data.render.PreviewFilter.excludeById(PreviewFilter.kt:187)
```

That is wear-m3-catalog's `:remote-catalog` parity render, red since the module landed. The same module renders fine **unscoped** in design-artifacts on the same commit (`43ddcc9`: Design Artifacts succeeded in 18 min, Design parity failed in 2), because nothing builds an exclusion list there.

The comma round trip happens three times — CLI arg parsing, `-PcomposePreview.idExclude`, then `-Dcomposeai.preview.idExclude` — so fixing one hop is not enough.

## The fix

A path travels instead of a joined string. One pattern per line; a line break cannot occur inside an id.

- **`--exclude-preview-id-file <path>`** on `bundle pack`. Wins over `--exclude-preview-id` and the env var.
- **`-PcomposePreview.idExcludeFile`** — the Gradle property, forwarded as an absolute path.
- **`-Dcomposeai.preview.idExcludeFile`** — the system property `PreviewFilter.idExcludesFrom` reads.

Additive: every existing comma-separated caller keeps working unchanged, and the joined form is still what travels when no file is given.

Two details worth review:

1. **An unreadable file throws rather than yielding an empty list**, at all three layers. A filter that silently became "exclude nothing" renders the whole sheet and reports success — the quiet failure this path exists to prevent.
2. **`--exclude-preview-id` on the task still overrides the property.** The file property is read independently, so forwarding the path unconditionally would let a stale `-PcomposePreview.idExcludeFile` beat an explicit option. `PreviewFilterSystemPropsProvider` compares the resolved lists: equal ⇒ the file is the source and travels as a path; different ⇒ the caller overrode it and their patterns travel joined. The path is `@Internal` because `idExcludes` already carries the file's resolved lines, so contents drive the up-to-date check and a moved workspace does not invalidate a render whose exclusion set never changed.

## Test plan

New tests pin the regression itself, not just the happy path — each asserts the shattering behaviour *and* that the file form avoids it:

- `PackPreviewIdExclusionsTest` — a file carries comma-bearing ids intact; the comma flag shatters the same two ids into six fragments including `dpi=320`; that fragment set excludes **every** id while the file form excludes only its own; file beats flag and env; blanks trimmed; a missing file throws.
- `PreviewFilterTest` — same three-way coverage at the renderer boundary, including `excludeById` throwing "nothing would render" on the shattered set.
- `PreviewFilterSystemPropsProviderTest` — a file-sourced list travels as `-Dcomposeai.preview.idExcludeFile=<absolute>`; an overridden list ignores the file and travels joined.

Not verified locally: this container has no Android SDK, so Gradle cannot configure and I could not compile or run the suites. All 12 files parse cleanly under ktfmt 0.64 (Google style), which is a real syntax check but not a type check — CI is the first compile.

**Follow-up, not in this PR:** design-parity's reusable workflow should pass `--exclude-preview-id-file slice-excluded.txt` (it already writes exactly that file, one id per line). That change has to wait for a release carrying this flag, since the parity job installs the CLI from the `composePreviewPlugin` pin.

Text-only is correct here: this changes filter plumbing, not rendered output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_