### PR TITLE
feat(deploy): turn the image lane on where its gating repository is named

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1340,6 +1340,13 @@ jobs:
       # breaks unrelated deployments on their next roll or quietly disables the lane — both silent.
       - name: Run deploy agent-grant default tests
         run: ./deploy/image/test-agent-grants-default.sh
+      # The image lane derives its default from its own gating repository, and both halves are
+      # silent when wrong: too narrow and an operator who named SERVE_IMAGE_UPLOAD_REPO gets a box
+      # that 404s POST /images with nothing logged, too wide (keying on SERVE_GITHUB_AUTH_*, whose
+      # repo this image defaults to yschimke/compose-ai-tools) and every adopter's box grows an
+      # upload lane gated by our collaborators rather than theirs.
+      - name: Run deploy image-lane default tests
+        run: ./deploy/image/test-image-lane-default.sh
       # The version-control config overlay is opt-in, so nothing exercises it on the way to a
       # release — a wrong source path or mount target is found on a box, after a restart, serving a
       # stale catalog set. Every failure mode is silent: a missing source makes Docker create an

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -266,6 +266,46 @@ unavailable. Once resolved it is **pinned for the life of the process**: a later
 does not move it, because live snippet JVMs hold those jars open. Restart the container to compile
 against a newer catalog ABI.
 
+### Image lane on `preview.coo.ee`
+
+`POST /images` lets an agent that just rendered a preview hand the PNG to this box and get back an
+embeddable `/i/<id>.png` for a pull-request body — the mechanism
+[`share-preview --mechanism serve`](../../docs/public-preview-server.md#uploading-a-preview-image---accept-images)
+uses when it has neither `gh` nor push rights. Uploading is **never anonymous, on a `--public` box
+too**: the caller presents `Authorization: Bearer <github-token>` and GitHub itself is asked whether
+that account has access to the gating repository. Reading is open by design — GitHub's image proxy
+fetches an embedded image anonymously, so the unguessable 128-bit id is the whole grant.
+
+Turning it on is naming that repository:
+
+```bash
+SERVE_IMAGE_UPLOAD_REPO=yschimke/compose-ai-tools
+# optional: SERVE_IMAGE_TTL=604800 (7d default) · SERVE_IMAGE_RATE_LIMIT=60 (uploads/min/account)
+```
+
+`SERVE_ACCEPT_IMAGES` is derived from it (`entrypoint.sh`, guarded by
+[`test-image-lane-default.sh`](test-image-lane-default.sh)), because that variable exists for
+nothing but this lane — naming it and still getting a 404 from `POST /images` is nobody's intent,
+and the miss is silent at both ends. Set `SERVE_ACCEPT_IMAGES=0` to keep the lane shut with the
+repository named, or `=1` without one to get the server's own startup refusal.
+
+The derivation deliberately does **not** key on GitHub auth being configured, the way
+`SERVE_AGENT_GRANTS` does. The gating repository falls back to `SERVE_GITHUB_AUTH_REPO`, which this
+image defaults to `yschimke/compose-ai-tools` for the playground — so keying on auth would open an
+upload lane on every adopter's box gated by *our* collaborators rather than theirs. An operator who
+wants that fallback still gets it by naming the repository explicitly.
+
+Verify after a roll — the row on `/status`, and the refusal an unauthenticated caller gets, which is
+the same route answering rather than a 404:
+
+```bash
+curl -s https://preview.coo.ee/status.json | jq '.config | {acceptImages, imageUploadRepository}'
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST --data-binary @render.png \
+  'https://preview.coo.ee/images?name=after.png'                       # 401 — lane is up, no credential
+curl -sS -H "Authorization: Bearer $(gh auth token)" --data-binary @render.png \
+  'https://preview.coo.ee/images?name=after.png'                       # 201 + the markdown to paste
+```
+
 ### Widening the background render lane (`SERVE_BACKGROUND_RENDERS`)
 
 The theme optimizer's renders run in their own server-wide lane, so a visitor's render is never

--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -245,7 +245,14 @@ services:
       # preview and embeds the returned URL in the PR body. Unlike the document lane above,
       # uploading is never anonymous: it needs a GitHub token with access to
       # SERVE_IMAGE_UPLOAD_REPO (which falls back to SERVE_GITHUB_AUTH_REPO), and the lane refuses
-      # to start without one. Off unless asked for.
+      # to start without one.
+      # Empty means "let the entrypoint decide": on when SERVE_IMAGE_UPLOAD_REPO below names the
+      # repository uploads are gated on, off otherwise. Setting that variable is what asks for the
+      # lane — naming it and still getting a 404 from POST /images is nobody's intent, and the
+      # miss is silent at both ends. The derivation deliberately does NOT key on
+      # SERVE_GITHUB_AUTH_*: that repo defaults to yschimke/compose-ai-tools for the playground, so
+      # it would gate an adopter's upload lane on someone else's collaborators. `0` opts out
+      # explicitly with the repository still named.
       SERVE_ACCEPT_IMAGES: "${SERVE_ACCEPT_IMAGES:-}"
       # Empty means "let the entrypoint decide": on when SERVE_GITHUB_AUTH_* gives it a human to
       # approve against, off otherwise (the lane refuses to start with no approver, so a flat
@@ -260,6 +267,9 @@ services:
       SERVE_AGENT_GRANT_MAX_TTL: "${SERVE_AGENT_GRANT_MAX_TTL:-}"
       SERVE_AGENT_GRANT_MAX_ACTIVE: "${SERVE_AGENT_GRANT_MAX_ACTIVE:-}"
       SERVE_AGENT_GRANT_RATE_LIMIT: "${SERVE_AGENT_GRANT_RATE_LIMIT:-}"
+      # Naming this turns the image lane on (see SERVE_ACCEPT_IMAGES above): the repository an
+      # uploader's GitHub token must have access to. Write access on a public repo, any grant on a
+      # private one.
       SERVE_IMAGE_UPLOAD_REPO: "${SERVE_IMAGE_UPLOAD_REPO:-}"
       SERVE_IMAGE_TTL: "${SERVE_IMAGE_TTL:-}"
       SERVE_IMAGE_RATE_LIMIT: "${SERVE_IMAGE_RATE_LIMIT:-}"

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -362,7 +362,25 @@ fi
 # back at an embeddable /i/<id>.png (POST /images). Unlike the document lane above this is never
 # anonymous — an uploader must present a GitHub token with access to SERVE_IMAGE_UPLOAD_REPO (which
 # falls back to SERVE_GITHUB_AUTH_REPO), and the lane refuses to start without one. Reading stays
-# open, because GitHub's image proxy fetches a PR body's images anonymously. Off unless asked for.
+# open, because GitHub's image proxy fetches a PR body's images anonymously.
+# Unset means "on when the operator named the gate": naming SERVE_IMAGE_UPLOAD_REPO is not a
+# preference about some other feature — that variable exists for nothing but this lane, so setting
+# it and getting a box where POST /images 404s is never what was meant, and the failure is silent
+# on both ends (no startup line, and an uploader's own 404 reads like a wrong --serve-url). The
+# derivation cannot be widened to "any box that could gate uploads somehow": the repository also
+# falls back to SERVE_GITHUB_AUTH_REPO, which this image defaults to yschimke/compose-ai-tools for
+# the playground, so keying on that would open an upload lane on every adopter's box gated by OUR
+# collaborators. An operator can still force either answer explicitly (`SERVE_ACCEPT_IMAGES=0` to
+# name the repo and keep the lane shut, `=1` without a repository to get the server's own refusal,
+# which is the honest failure).
+if [[ -z "${SERVE_ACCEPT_IMAGES:-}" ]]; then
+  if [[ -n "${SERVE_IMAGE_UPLOAD_REPO:-}" ]]; then
+    SERVE_ACCEPT_IMAGES=1
+  else
+    SERVE_ACCEPT_IMAGES=0
+  fi
+fi
+
 if [[ "${SERVE_ACCEPT_IMAGES:-}" == "1" || "${SERVE_ACCEPT_IMAGES:-}" == "true" ]]; then
   args+=(--accept-images)
   [[ -n "${SERVE_IMAGE_UPLOAD_REPO:-}" ]] &&

--- a/deploy/image/test-image-lane-default.sh
+++ b/deploy/image/test-image-lane-default.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Guard: the image lane turns itself on exactly where the operator named its gate.
+#
+# Why this needs a test rather than a comment. SERVE_IMAGE_UPLOAD_REPO exists for nothing but this
+# lane, so a box that has it set and still 404s POST /images is never what the operator meant — and
+# that failure is silent at both ends: the server logs nothing about a lane it wasn't asked for, and
+# an uploader's 404 reads like a wrong --serve-url. Hence the derivation.
+#
+# The derivation must ALSO stay narrow, which is the half a comment protects worst. The gating
+# repository falls back to SERVE_GITHUB_AUTH_REPO, which this image defaults to
+# yschimke/compose-ai-tools for the playground — so keying the default on "auth is configured", the
+# way the agent-grant lane legitimately does, would open an authenticated upload lane on every
+# adopter's box, gated by OUR collaborators rather than theirs. That is one edited condition away at
+# all times, and nothing else would catch it.
+#
+# Runs the real gate out of entrypoint.sh rather than a copy, so the two cannot drift.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+
+# The derivation block, lifted verbatim from the entrypoint by its sentinel comment so this test
+# exercises the shipped logic. Extracted rather than sourced because entrypoint.sh runs a server.
+gate="$(awk '/^# Unset means "on when the operator named the gate"/,/^fi$/' "${entrypoint}")"
+[[ -n "${gate}" ]] || {
+  echo "FAIL: could not find the SERVE_ACCEPT_IMAGES derivation in ${entrypoint}" >&2
+  echo "      (did the leading comment change? this test locates it by that line)" >&2
+  exit 1
+}
+
+# $1 = expected value, $2 = description, $3… = environment assignments
+expect() {
+  local want="$1" desc="$2"
+  shift 2
+  local got
+  # `env -i` — an EMPTY environment, so an operator or runner shell that already exports
+  # SERVE_IMAGE_UPLOAD_REPO / SERVE_GITHUB_AUTH_* cannot make a case pass for the wrong reason.
+  # PATH is restored because bash needs it; nothing else is.
+  got="$(env -i PATH="${PATH}" "$@" bash -c "set -euo pipefail; ${gate}; echo \"\${SERVE_ACCEPT_IMAGES:-}\"")"
+  if [[ "${got}" != "${want}" ]]; then
+    echo "FAIL: ${desc}: expected SERVE_ACCEPT_IMAGES=${want}, got '${got}'" >&2
+    exit 1
+  fi
+  echo "  ok: ${desc} -> ${got}"
+}
+
+auth=(
+  SERVE_GITHUB_AUTH_CLIENT_ID=id
+  SERVE_GITHUB_AUTH_CLIENT_SECRET=secret
+  SERVE_GITHUB_AUTH_COOKIE_SECRET=cookie
+)
+
+echo "==> SERVE_ACCEPT_IMAGES derivation"
+expect 1 "unset + an upload repository => on" SERVE_IMAGE_UPLOAD_REPO=owner/repo
+expect 0 "unset + no upload repository => off"
+
+# The narrowness above, stated as cases: neither GitHub auth nor a playground-shaped auth repo is a
+# request for an upload lane, because neither is this lane's variable.
+expect 0 "unset + GitHub auth configured, no upload repository => off" "${auth[@]}"
+expect 0 "unset + an auth repository only => off" \
+  "${auth[@]}" SERVE_GITHUB_AUTH_REPO=yschimke/compose-ai-tools
+expect 1 "unset + both, upload repository wins => on" \
+  "${auth[@]}" SERVE_GITHUB_AUTH_REPO=owner/other SERVE_IMAGE_UPLOAD_REPO=owner/repo
+
+# An explicit answer always wins, in both directions — including "insist without a repository",
+# which is meant to reach the server's own refusal rather than being silently downgraded here.
+expect 0 "explicit 0 with an upload repository => stays off" \
+  SERVE_ACCEPT_IMAGES=0 SERVE_IMAGE_UPLOAD_REPO=owner/repo
+expect 1 "explicit 1 without a repository => stays on (server refuses, honestly)" \
+  SERVE_ACCEPT_IMAGES=1
+expect true "explicit 'true' is passed through untouched" SERVE_ACCEPT_IMAGES=true
+
+echo "PASS: the lane enables itself only where its own gating repository is named"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -3032,8 +3032,14 @@ content-sniffed, so an upload must *be* one of these and a mislabelled file is r
 SVG is deliberately absent: it is an image to a human and a scriptable document to a browser, so
 serving one would hand an uploader active content on this origin.
 
-On the deployed image set `SERVE_ACCEPT_IMAGES=1` (plus `SERVE_IMAGE_UPLOAD_REPO`, optional
-`SERVE_IMAGE_TTL` / `SERVE_IMAGE_RATE_LIMIT`); it's off by default.
+On the deployed image, naming the gating repository is what turns the lane on:
+`SERVE_IMAGE_UPLOAD_REPO=<owner>/<repo>` (optional `SERVE_IMAGE_TTL` / `SERVE_IMAGE_RATE_LIMIT`).
+`SERVE_ACCEPT_IMAGES` is derived from it — that variable exists for nothing but this lane, so a box
+where it is set and `POST /images` still 404s is nobody's intent — and an explicit `0` (shut with
+the repository named) or `1` (insist without one, and get the server's own refusal) still wins. The
+derivation does not key on `SERVE_GITHUB_AUTH_*`, whose repo the image defaults to
+`yschimke/compose-ai-tools`: that would gate an adopter's upload lane on someone else's
+collaborators. See [deploy/image/README.md](../deploy/image/README.md#image-lane-on-previewcooee).
 
 ## Granting an agent temporary access (`--agent-grants`)
 


### PR DESCRIPTION
## What

`preview.coo.ee` shows `Accept images · off` on `/status`, and `/status.json` agrees
(`acceptImages: false`, `imageUploadRepository: null`). Enabling it is meant to be one line of
deployment config, but today it is two — `SERVE_ACCEPT_IMAGES=1` **and**
`SERVE_IMAGE_UPLOAD_REPO=<owner>/<repo>` — and getting only the second one right leaves a box where
`POST /images` 404s with nothing said about it.

So the entrypoint now derives `SERVE_ACCEPT_IMAGES` from `SERVE_IMAGE_UPLOAD_REPO`, the way it
already derives `SERVE_AGENT_GRANTS` from the presence of an approver. That variable exists for
nothing but this lane: naming it and still getting a 404 is nobody's intent, and the miss is silent
at both ends — the server logs nothing about a lane it was not asked for, and an uploader's 404
reads like a wrong `--serve-url`. An explicit value still wins in both directions: `0` keeps the
lane shut with the repository named, `1` without a repository reaches the server's own startup
refusal rather than being quietly downgraded here.

The derivation deliberately stays narrower than the agent-grant one. The gating repository falls
back to `--github-auth-repo`, which this image defaults to `yschimke/compose-ai-tools` for the
playground — so keying the default on "GitHub auth is configured" would open an authenticated
upload lane on every adopter's box, gated by *our* collaborators rather than theirs. That is one
edited condition away at all times, which is why it is a test rather than a comment.

Nothing about the lane's own posture changes: uploading remains never anonymous, on a `--public`
box too (`Authorization: Bearer <github-token>`, verified live against GitHub for access to the
gating repository), and reading remains open because GitHub's image proxy fetches an embedded image
anonymously.

## Changes

- `deploy/image/entrypoint.sh` — derive `SERVE_ACCEPT_IMAGES` when unset; explicit `0`/`1`/`true`
  pass through untouched.
- `deploy/image/test-image-lane-default.sh` (new) — runs the real derivation block, lifted out of
  `entrypoint.sh` by its sentinel comment so the two cannot drift. Pins both halves: on when the
  upload repository is named, off for GitHub auth alone and for an auth repository alone.
- `.github/workflows/ci.yml` — run it beside `test-agent-grants-default.sh`.
- `deploy/image/docker-compose.yml` — the `SERVE_ACCEPT_IMAGES` / `SERVE_IMAGE_UPLOAD_REPO` comments
  now say what the empty value means.
- `deploy/image/README.md` — a new **Image lane on `preview.coo.ee`** section: what the lane is, the
  one `.env` line that turns it on, why the derivation is narrow, and the `curl`s that verify it
  after a roll.
- `docs/public-preview-server.md` — the deployment paragraph under *Uploading a preview image*
  matches the new default.

## Operator step (not automated by this PR)

The box's `.env` is not in this repo, so nothing here flips the live server on its own. After this
lands and the image rolls, `preview.coo.ee` needs one line:

```bash
SERVE_IMAGE_UPLOAD_REPO=yschimke/compose-ai-tools
```

then `docker compose up -d`. Verification:

```bash
curl -s https://preview.coo.ee/status.json | jq '.config | {acceptImages, imageUploadRepository}'
curl -sS -o /dev/null -w '%{http_code}\n' -X POST --data-binary @render.png \
  'https://preview.coo.ee/images?name=after.png'    # 401 — the lane is up and wants a credential
```

`Accept uploads` (`--accept-bundles`) is untouched and stays off: its ingest gate is the operator
token, and `--public` admits everyone through that, so enabling it on this box would be an anonymous
write surface.

## Test plan

- `./deploy/image/test-image-lane-default.sh` — 8 cases, all green.
- `./deploy/image/test-agent-grants-default.sh` — still green (the two `awk` sentinels don't
  collide).
- `./deploy/image/test-compose-env-passthrough.sh`, `./deploy/image/test-env-migrations.sh` — green.
- `bash -n deploy/image/entrypoint.sh`.

Non-visual (deployment wiring + docs), so no before/after renders. The one user-visible surface is
the `Accept images` row on `/status`, whose both states are already captured in
`docs/design/evidence/serve-image-lane/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTZofn2eQP4QrGdY4PPURy)_