### PR TITLE
fix(serve): say when a warm catalog is serving another build's renders

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -7309,20 +7309,36 @@ ${captureControlsHtml().prependIndent("          ")}
           val loadError = c.loadError?.let { "<div class=\"cp-muted\">${esc(it)}</div>" } ?: ""
           val themeOptimization =
             c.themeOptimization?.let { optimization ->
+              // Dirty renders are the case this row used to report as finished. They are warm and
+              // served, so `cached` counts them and `fullyOptimized` is true — but they were
+              // written by a DIFFERENT build, and the pass is still working through re-rendering
+              // them. A catalog that has adopted its predecessor's whole cache would otherwise
+              // read "themes optimized 10440/10440" while every one of those pixels came from a
+              // renderer that is no longer running, which is precisely the thing an operator
+              // checking this page needs to be told.
+              val inherited =
+                if (optimization.dirty > 0) " · ${optimization.dirty} inherited, re-rendering"
+                else ""
               val detail =
-                if (optimization.fullyOptimized) {
+                if (optimization.converged) {
                   "themes optimized ${optimization.cached}/${optimization.total}"
+                } else if (optimization.fullyOptimized) {
+                  "themes optimized ${optimization.cached}/${optimization.total}$inherited"
                 } else {
                   "theme optimization ${optimization.state} · " +
                     "${optimization.cached}/${optimization.total} cached" +
-                    if (optimization.failed > 0) " · ${optimization.failed} failed" else ""
+                    (if (optimization.failed > 0) " · ${optimization.failed} failed" else "") +
+                    inherited
                 }
               "<div class=\"cp-muted\">${esc(detail)}</div>" +
                 inlineMeter(
                   detail,
                   optimization.cached.toLong(),
                   optimization.total.toLong(),
-                  if (optimization.failed > 0) "warning" else "primary",
+                  // Inherited renders are not a failure — they are serving — but they are not
+                  // finished either, so the meter must not read the same as a converged catalog.
+                  if (optimization.failed > 0) "warning"
+                  else if (optimization.dirty > 0) "secondary" else "primary",
                 )
             } ?: ""
           val renderCache =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -560,6 +560,91 @@ class ServeStatusTest {
     assertFalse(html.contains("<div class=\"cp-muted\">same-session-x</div>"), html)
   }
 
+  /**
+   * A catalog can be warm everywhere and finished nowhere.
+   *
+   * `cached` counts dirty renders and `fullyOptimized` is true for them, because they ARE served —
+   * that is the whole point of the dirty model. But they were written by a different build and the
+   * pass is still replacing them. Reporting "themes optimized 10440/10440" for a catalog whose
+   * every pixel came from a renderer that is no longer running is the one thing an operator reading
+   * this row must not be told.
+   */
+  @Test
+  fun `a catalog holding another build's renders does not read as optimized`() {
+    fun rowFor(cached: Int, dirty: Int, failed: Int = 0): String =
+      ServeWeb.statusPage(
+        token = "unused",
+        view =
+          ServeWeb.StatusView(
+            version = "test",
+            public = true,
+            nowMillis = Instant.parse("2026-08-18T12:00:00Z").toEpochMilli(),
+            overallOk = true,
+            summary = emptyList(),
+            config = emptyList(),
+            catalogs =
+              listOf(
+                ServeWeb.StatusCatalog(
+                  id = "m3-catalog",
+                  title = "Material 3",
+                  listed = true,
+                  trust = "unverified",
+                  previews = 4,
+                  live = true,
+                  running = true,
+                  degradation = null,
+                  provenance =
+                    ServeWeb.CatalogProvenance(
+                      repo = "example/m3-catalog",
+                      branch = "published",
+                      generatedAt = "2026-08-18T10:00:00Z",
+                    ),
+                  themeOptimization =
+                    ThemeOptimizationSnapshot(
+                      state = "complete",
+                      total = 8,
+                      cached = cached,
+                      remaining = 8 - cached,
+                      failed = failed,
+                      cachedBytes = 0,
+                      dirty = dirty,
+                      fullyOptimized = cached == 8,
+                    ),
+                )
+              ),
+            servers = emptyList(),
+            failures = emptyList(),
+          ),
+      )
+
+    // Converged: every target warm AND produced by the renderer that is running.
+    val converged = rowFor(cached = 8, dirty = 0)
+    assertTrue(converged.contains("themes optimized 8/8"), converged)
+    assertFalse(converged.contains("inherited"), converged)
+
+    // Warm everywhere, but every render inherited from another build. Same `cached`, same
+    // `fullyOptimized` — and it must not read the same.
+    val inherited = rowFor(cached = 8, dirty = 8)
+    assertTrue(
+      inherited.contains("themes optimized 8/8 · 8 inherited, re-rendering"),
+      "a fully warm but wholly inherited catalog must say so: $inherited",
+    )
+
+    // Part way through: gaps left AND inherited renders still queued behind them.
+    val partial = rowFor(cached = 5, dirty = 3)
+    assertTrue(partial.contains("5/8 cached"), partial)
+    assertTrue(partial.contains("3 inherited, re-rendering"), partial)
+
+    // A failure still wins the meter's tone — inherited is not an error, it is unfinished work.
+    val broken = rowFor(cached = 5, dirty = 3, failed = 2)
+    assertTrue(broken.contains("2 failed"), broken)
+    assertTrue(broken.contains("cp-inline-meter-fill--warning"), broken)
+    assertTrue(
+      inherited.contains("cp-inline-meter-fill--secondary"),
+      "inherited reads as unfinished, not as failed or as done: $inherited",
+    )
+  }
+
   @Test
   fun `status distinguishes published render failures from an empty catalog`() {
     server =

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -168,6 +168,44 @@ point: that edit is drift from `main`.
 > docker compose exec preview cat /config/catalogs.json
 > ```
 
+### Regenerating a catalog's warmed theme renders
+
+Two admin routes for pixels you suspect are wrong for a reason no fingerprint sees — a base-image
+bump that changed the installed fonts being the case that motivated them.
+
+```bash
+# Mark this catalog's warmed renders for re-render. Nothing is deleted: every preview keeps
+# serving while the background pass replaces them. Answers {"queued": true, "entries": N}.
+curl -sX POST -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
+  https://<host>/admin/catalogs/m3-catalog/theme-cache/regenerate
+
+# Take them instead. Every preview for that catalog goes cold at once and is re-rendered from
+# nothing — the cost `regenerate` exists to avoid, so this is the second choice of the two.
+curl -sX POST -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
+  https://<host>/admin/catalogs/m3-catalog/theme-cache/drop
+```
+
+Both wake the catalog's optimizer, so the work starts with the response rather than waiting on the
+next rotation. A mistyped system is a `404`, not a silent success.
+
+**A `409` from either is "contended, retry"** — a render held the generation write lock as you
+called, and reporting that as success is the one failure mode a drop must not have. From
+`regenerate` it can also mean the request could not be made durable (a full or read-only cache
+volume) or that theme optimization is switched off on this box, so nothing would ever work the
+queue. In every case the answer carries `"queued": false` rather than a count.
+
+**Deliberately not buttons on `/status`.** That page authenticates with `SERVE_TOKEN`; these routes
+require `SERVE_ADMIN_TOKEN`, which is a different and much smaller audience. A button would have to
+bridge that gap, and every way of bridging it either puts the admin credential in a page that
+merely holding the serve token can read, or invents a second, weaker way into an admin route. These
+are rare operator actions, and a drop takes a warm catalog cold across every one of its renders —
+not a thing to make one click away from a page a wider audience can already see.
+
+What `/status` *does* show is when a catalog needs one: a row reading
+`themes optimized 10440/10440 · 10440 inherited, re-rendering` is warm everywhere and finished
+nowhere — every render came from a build that is no longer running, and the pass is replacing them.
+`/status.json` carries the same figure as `catalogList[].themeOptimization.dirty`.
+
 ### GitHub auth on `preview.coo.ee`
 
 To keep catalog browsing public while requiring GitHub sign-in for live sessions and playground,


### PR DESCRIPTION
Closes the observability half of the dirty model, and records the decision not to build its action half as a button.

## The row was telling a true story with a wrong ending

A catalog that adopted its predecessor's whole cache read:

```
themes optimized 10440/10440
```

Both numbers were right. Dirty renders are counted by `cached` and satisfy `fullyOptimized`, because they **are** being served — that is the entire point of the dirty model, a possibly-stale preview beating a cold render. But a different build produced every one of those pixels and the pass is still working through replacing them. "Optimized" is the one word that catalog does not deserve, and it is exactly what an operator opens this page to find out.

Three states now, where there were two:

| | row | meter |
| --- | --- | --- |
| converged | `themes optimized 8/8` | primary |
| warm, wholly inherited | `themes optimized 8/8 · 8 inherited, re-rendering` | secondary |
| gaps + inherited behind them | `theme optimization running · 5/8 cached · 3 inherited, re-rendering` | secondary |
| any failure | `… · 2 failed` | warning |

Inherited work takes the **secondary** tone rather than warning: it is unfinished, not broken. A real failure still wins.

## Why the actions stay curl-only

This is the decision I flagged as worth making deliberately rather than by pattern-match, and having looked at the auth, the answer is no button.

`/status` authenticates with `SERVE_TOKEN` (`rejectBadToken`, and the page carries `linkToken()`). The regenerate and drop routes require `SERVE_ADMIN_TOKEN` (`rejectBadAdminToken`). **Two different credentials with two different audiences** — on `preview.coo.ee` the serve token is held far more widely than the admin token.

A button has to bridge that gap, and both bridges are worse than no button:

- put the admin token in the page — hands the admin credential to everyone who can read `/status`;
- mint a per-`(system, action)` CSRF seal like `ServeAgentGrants.Csrf` — sound in itself, but its security rests on "the page that minted it required admin", and `/status` doesn't. Making that true means teaching `/status` about the admin token, which widens what that page does and what it can leak, to save a `curl` on an action taken maybe twice a year.

And the downside is asymmetric: `drop` takes a warm catalog cold across all 10,440 of its renders. That does not belong one click away from a page a wider audience can already open.

So: **show when a catalog needs the action, keep the action behind the admin token.** The README now documents both routes with copy-pasteable curl, what a `409` means from each (contended lock; or for `regenerate`, a mark that could not be made durable, or optimization switched off), and this reasoning, so the next person doesn't re-litigate it from scratch.

## Test plan

- `ServeStatusTest` — *a catalog holding another build's renders does not read as optimized*: asserts converged reads as before with no "inherited" text; a fully warm but wholly inherited catalog says so; a partly-cached one reports both its gaps and its inherited queue; and a failure wins the meter tone while inherited reads secondary.
- `./gradlew :cli:serve:test` green; `ktfmtCheckMain` / `ktfmtCheckTest` clean.

## Visual evidence

Status-page text and a meter tone class, asserted on the rendered HTML in the test above rather than described — the strings and the `cp-inline-meter-fill--secondary` / `--warning` classes are checked directly. No `@Preview` surface is touched, so there is nothing for the render pipeline to diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_