### PR TITLE
docs(steward): verify a reported agent commit identity before acting on it

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -85,8 +85,45 @@ job only to confirm one of the cases above, or if it died before any test body r
 - Larger asks from a **human** reviewer on a PR you did not open: reply with your
   proposal; the author decides.
 - After pushing for a changes-requested review, re-request that reviewer.
+- One finding is wrong often enough to need its own handling: a reported **agent
+  commit identity**. See below.
 
 An approval you would lose is never a reason to hold a fix.
+
+### A reported agent commit identity
+
+The review bot periodically reports that a commit's author or committer is an agent
+(`Codex`, `Claude`, an `@openai.com` address) and asks for the commit to be
+recreated. Over 27–28 Aug 2026 it raised this 22 times across this repo and
+`design-parity`. **One** was right: a `git cherry-pick` had left the committer as
+`Claude <noreply@anthropic.com>`. The other 21 landed on commits authored by a human
+or by `renovate[bot]` / `github-actions[bot]`, and seven cited SHAs that do not
+exist in the repository at all.
+
+So it is neither trustworthy nor safely ignorable — it is the one finding to
+**verify before believing**, rather than treating as a bug report like the rest:
+
+```sh
+git log -1 --format='A=%an <%ae> | C=%cn <%ce>' <head>
+.github/scripts/agent-attribution-scan.sh --range 'origin/main..<branch>'
+```
+
+- **Human identities, scanner exits 0** → false positive. Reply with those two
+  lines of output and react 👎 on the comment (the bot's own feedback channel), then
+  change nothing. Never recreate, rebase or amend a commit on the claim alone —
+  on someone else's branch that is also a "never" outright.
+- **The scan does find an agent identity** → a bug to fix, not a default to
+  tolerate ([Git conventions](../../../docs/AGENTS.md#git-conventions)). The usual
+  cause is a cherry-pick or amend that took `user.email` from the container instead
+  of the `-c user.name=… -c user.email=…` the branch's other commits carry.
+- **The cited SHA does not resolve** (`git cat-file -e <sha>`) → say so. A scan of a
+  commit that is not in the repository is not evidence of anything.
+
+Agent containers here really do default `user.email` to `noreply@anthropic.com`, so
+the underlying risk is real even though most reports of it are not. Installing the
+hooks (`scripts/install-git-hooks.sh` — the `SessionStart` hook normally does it)
+closes it at the source: `pre-push` scans every commit a push would add, including
+the cherry-picked and amended ones `commit-msg` never sees.
 
 ## Evidence and tracking
 


### PR DESCRIPTION
## Summary

`steward` tells an agent that a review bot's finding is a bug report to verify and fix. That is right for every finding this reviewer produces except one: a reported **agent commit identity**.

Over 27–28 Aug the reviewer raised that finding 22 times across this repo and `design-parity`. Checked against the GitHub API, one was right — a `git cherry-pick` on design-parity#395 had left the committer as `Claude <noreply@anthropic.com>`, exactly the failure the hooks exist to prevent. The other 21 landed on commits authored by a human or by `renovate[bot]` / `github-actions[bot]`, and **seven cited SHAs that do not resolve in the repository at all** (`933b4302`, `b9c2bca7`, `c30f4e6`, `7de3249`, `627b661`, `eaf9b189`, `c55e6cf`).

Neither existing posture covered that. "Verify it and push the small fix" invites recreating history on the strength of a false claim, and the non-convergence escape hatch is about churn rather than a finding that is simply wrong. Muting it would be worse, since the one true positive is real and the hazard is live — this container's git identity defaults to `Claude <noreply@anthropic.com>`.

So the handling is now explicit in the one place an agent reads when a review comment arrives: run the two commands, dismiss with the output and a 👎 if the identities are human and the scanner exits 0, fix it if the scanner agrees, and say so when the cited commit does not exist.

Docs only — one new subsection under **Review comments** in `.claude/skills/steward/SKILL.md`. No behaviour, no visual surface.

## Test plan

- `scripts/check-agent-entrypoints.sh` → exit 0; all five invariants still anchored in `AGENTS.md` only, `AGENTS.md` unchanged at 7497 bytes (22% of the Codex budget). The new text is in a skill, so it adds nothing to any agent's per-turn cost.
- `.github/scripts/agent-attribution-scan.sh --range 'origin/main..HEAD'` → *No agent co-author trailers or agent commit identities found.*
- Hooks installed via `scripts/install-git-hooks.sh`; commit authored and committed as `Yuri Schimke <yuri@schimke.ee>`.
- Claims in the new subsection were verified per-commit through the GitHub API rather than asserted; the 21 false positives now carry a rebuttal and a 👎 on their threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_