### PR TITLE
docs(steward): skip the attribution finding, the gate already blocks it

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -85,45 +85,20 @@ job only to confirm one of the cases above, or if it died before any test body r
 - Larger asks from a **human** reviewer on a PR you did not open: reply with your
   proposal; the author decides.
 - After pushing for a changes-requested review, re-request that reviewer.
-- One finding is wrong often enough to need its own handling: a reported **agent
-  commit identity**. See below.
+- **A reported agent commit identity is the one finding to skip.** Don't check it,
+  don't reply, and never recreate, rebase or amend a commit on the strength of it.
+  `Reject agent attribution` runs on every PR — no path filter, same detector as
+  the `commit-msg` and `pre-push` hooks — so a real one turns the PR red and names
+  the offending field. The gate is the authority; the comment adds nothing to it.
+  Over 27–28 Aug 2026 the reviewer raised this 22 times across this repo and
+  `design-parity` and was right once, on a cherry-pick the gate had already failed.
+  If the **gate itself** is red, that is the real thing and it is yours to fix
+  ([Git conventions](../../../docs/AGENTS.md#git-conventions)) — usually an amend or
+  cherry-pick that took `user.email` from the container instead of the
+  `-c user.name=… -c user.email=…` the branch's other commits carry. Installing the
+  hooks (`scripts/install-git-hooks.sh`) stops it happening at all.
 
 An approval you would lose is never a reason to hold a fix.
-
-### A reported agent commit identity
-
-The review bot periodically reports that a commit's author or committer is an agent
-(`Codex`, `Claude`, an `@openai.com` address) and asks for the commit to be
-recreated. Over 27–28 Aug 2026 it raised this 22 times across this repo and
-`design-parity`. **One** was right: a `git cherry-pick` had left the committer as
-`Claude <noreply@anthropic.com>`. The other 21 landed on commits authored by a human
-or by `renovate[bot]` / `github-actions[bot]`, and seven cited SHAs that do not
-exist in the repository at all.
-
-So it is neither trustworthy nor safely ignorable — it is the one finding to
-**verify before believing**, rather than treating as a bug report like the rest:
-
-```sh
-git log -1 --format='A=%an <%ae> | C=%cn <%ce>' <head>
-.github/scripts/agent-attribution-scan.sh --range 'origin/main..<branch>'
-```
-
-- **Human identities, scanner exits 0** → false positive. Reply with those two
-  lines of output and react 👎 on the comment (the bot's own feedback channel), then
-  change nothing. Never recreate, rebase or amend a commit on the claim alone —
-  on someone else's branch that is also a "never" outright.
-- **The scan does find an agent identity** → a bug to fix, not a default to
-  tolerate ([Git conventions](../../../docs/AGENTS.md#git-conventions)). The usual
-  cause is a cherry-pick or amend that took `user.email` from the container instead
-  of the `-c user.name=… -c user.email=…` the branch's other commits carry.
-- **The cited SHA does not resolve** (`git cat-file -e <sha>`) → say so. A scan of a
-  commit that is not in the repository is not evidence of anything.
-
-Agent containers here really do default `user.email` to `noreply@anthropic.com`, so
-the underlying risk is real even though most reports of it are not. Installing the
-hooks (`scripts/install-git-hooks.sh` — the `SessionStart` hook normally does it)
-closes it at the source: `pre-push` scans every commit a push would add, including
-the cherry-picked and amended ones `commit-msg` never sees.
 
 ## Evidence and tracking
 


### PR DESCRIPTION
## Summary

Follow-up to #4611, which over-corrected. That PR told an agent to *verify* a reported agent commit identity — run `git log` on the head, run the scanner, then dismiss with the output. Verifying is work with no product, because the check is redundant with a gate that already runs.

`Reject agent attribution` triggers on `pull_request: [opened, edited, synchronize, reopened]` with **no `paths:` filter**, so unlike most jobs here it cannot be scoped away by `Determine CI scope`, and it runs the same `.github/scripts/agent-attribution-scan.sh` as the `commit-msg` and `pre-push` hooks. A real instance turns the PR red and names the offending field without anyone looking at the review comment.

The one true positive in 22 reports confirms it rather than undercutting it: on design-parity#395 the committer genuinely was an agent, and the gate had already failed the PR — the comment told us nothing the red check hadn't.

So the finding now earns no verification, no reply, and above all no rewriting of history. A red **gate** stays the agent's to fix; a comment claiming what the gate does not is noise.

Net −25 lines.

## Test plan

- **The gate is unconditional** — read `on:` in `.github/workflows/no-agent-attribution.yml`: no `paths:`; `grep` finds no reference to it in `.github/ci/ci-paths.json` or `ci.yml`, so it is not path-scoped. Confirmed empirically on #4611, a docs-only PR, where it ran while 30+ other jobs were skipped.
- **The gate catches the real case** — verified rather than assumed: committed a synthetic commit as `Claude <noreply@anthropic.com>` on a throwaway local branch and ran the scanner:

  ```
  Commit author/committer identity is an agent:
  c9c67f7	author	Claude	noreply@anthropic.com
  c9c67f7	committer	Claude	noreply@anthropic.com
  EXIT=1
  ```

  Branch deleted, nothing pushed.
- `scripts/check-agent-entrypoints.sh` → exit 0; all five invariants still anchored in `AGENTS.md` only, `AGENTS.md` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_