### PR TITLE
feat(cli): add --id-file, so a preview id containing a comma can be packed

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -157,6 +157,15 @@ class BundleCommand(args: List<String>) : Command(args) {
                             -PcomposePreview.idExclude; also read from the
                             ORG_GRADLE_PROJECT_composePreview.idExclude env var when the flag is
                             absent, so an env-only setup thins the semantics pass too.
+        --id-file <path>    The previews to pack, one per line, read from a file. The include-side
+                            twin of --exclude-preview-id-file below, and needed for the same
+                            reason: --id comma-splits its values, so an id containing a comma (a
+                            @Preview(widthDp = …, heightDp = …) mints
+                            `…AppCard_width=227dp,height=200dp,dpi=320`) is shattered into three.
+                            The render hides that — it matches ids by substring — but
+                            composePreviewBundle matches exactly and fails with "preview id not
+                            found" naming the first fragment. Wins over --id. An unreadable path is
+                            an error, not an empty selection.
         --exclude-preview-id-file <path>
                             The same exclusions, one per line, read from a file. Use this for a
                             GENERATED list: a preview id may itself contain a comma (a
@@ -269,11 +278,12 @@ private class PackSubcommand(private val args: List<String>) {
   private val progress: Boolean = verbose || "--progress" in args
   private val timeout: String? = args.flagValue("--timeout")
   private val ids: List<String> =
-    args
-      .flagValuesAll("--id")
-      .flatMap { it.split(',') }
-      .map { it.trim() }
-      .filter { it.isNotEmpty() }
+    PackPreviewIdExclusions.idFileFromArgs(args)?.let(PackPreviewIdExclusions::linesOf)
+      ?: args
+        .flagValuesAll("--id")
+        .flatMap { it.split(',') }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
 
   /**
    * `--exclude-preview-id` patterns (issue #2966) — the previews this pack must NOT render or

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -246,6 +246,7 @@ internal object CliFlagValidation {
         commandBase +
           setOf(
             "--embed-deps",
+            "--id-file",
             "--exclude-preview-id",
             "--exclude-preview-id-file",
             "--exclude-preview-row",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -30,6 +30,7 @@ internal object CliFlags {
       "--module",
       "--filter",
       "--id",
+      "--id-file",
       "--exclude-preview-id",
       "--exclude-preview-id-file",
       "--exclude-preview-row",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -81,6 +81,26 @@ internal object PackPreviewIdExclusions {
     return file.readLines().map(String::trim).filter(String::isNotEmpty)
   }
 
+  /**
+   * `bundle pack --id-file <path>`: the previews to PACK, one per line.
+   *
+   * The include-side twin of [fileFromArgs], and needed for the same reason. `--id` comma-splits
+   * every value, so an id containing a comma — `@Preview(widthDp = …, heightDp = …)` mints
+   * `…AppCardRemote_width=227dp,height=200dp,dpi=320` — is shattered into three.
+   * `composePreviewRender` survives that because it matches ids by SUBSTRING, so the fragments
+   * still select something; `composePreviewBundle` matches EXACTLY and fails with `preview id not
+   * found: …AppCardRemote_width=227dp`, naming the first fragment. Escaping does not help:
+   * `encodePreviewId` protects commas on the Gradle transport, but by then the id is already in
+   * pieces.
+   *
+   * A line break cannot occur inside an id, so a file has no such ambiguity. When present it
+   * REPLACES `--id` rather than adding to it.
+   */
+  fun idFileFromArgs(args: List<String>): java.io.File? =
+    args.flagValuesAll("--id-file").lastOrNull()?.trim()?.takeIf(String::isNotEmpty)?.let {
+      java.io.File(it)
+    }
+
   /** The Gradle property carrying `@PreviewParameter` **row** label exclusions. */
   const val ROW_GRADLE_PROPERTY = "composePreview.rowExclude"
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -247,4 +247,54 @@ class PackPreviewIdExclusionsTest {
       PackPreviewIdExclusions.retain(ids, listOf("=FilledButton_Light")),
     )
   }
+
+  // --- --id-file: the include-side twin (the composePreviewBundle failure) ---
+
+  @Test
+  fun `an id file carries a comma-bearing id intact`() {
+    val f = fileWith(commaBearingIds)
+    assertEquals(
+      commaBearingIds,
+      PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id-file", f.path))!!.let(
+        PackPreviewIdExclusions::linesOf
+      ),
+    )
+  }
+
+  @Test
+  fun `no --id-file yields null, leaving --id in charge`() {
+    assertEquals(null, PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id", "Foo")))
+  }
+
+  /**
+   * The live failure: `--id` comma-splits, so the first fragment is what `composePreviewBundle`
+   * reports as `preview id not found`. Pinned so the shattering is a documented behaviour of the
+   * flag rather than a surprise.
+   */
+  @Test
+  fun `--id shatters a comma-bearing id into its fragments`() {
+    val shattered =
+      listOf("pack", "--id", commaBearingIds[0]).let { args ->
+        args.drop(2).flatMap { it.split(',') }.map(String::trim)
+      }
+    assertEquals(3, shattered.size)
+    assertEquals(
+      "ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp",
+      shattered[0],
+    )
+  }
+
+  @Test
+  fun `a missing id file fails loudly rather than packing nothing`() {
+    val missing = java.io.File(tmpRoot, "nope-ids.txt")
+    val e =
+      kotlin
+        .runCatching {
+          PackPreviewIdExclusions.linesOf(
+            PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id-file", missing.path))!!
+          )
+        }
+        .exceptionOrNull()
+    assertEquals(true, e is IllegalStateException)
+  }
 }


### PR DESCRIPTION
The include-side twin of #4602. Same bug, sibling flag, and it was hiding behind the one #4602 fixed.

## The failure

wear-m3-catalog's `remote-m3` parity render, with #4602 and the 1.40.0 pin already in place:

```
Execution failed for task ':remote-catalog:composePreviewBundle'
> composePreviewBundle: preview id not found:
    ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.AppCardRemote_width=227dp
  Available:
    ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.AppCardRemote_width=227dp,height=200dp,dpi=320
    …
```

The requested id is the available id truncated at its first comma, because:

```kotlin
private val ids: List<String> =
  args.flagValuesAll("--id")
    .flatMap { it.split(',') }     // ← shatters every comma-bearing id
```

`--id "…AppCardRemote_width=227dp,height=200dp,dpi=320"` becomes three ids: `…AppCardRemote_width=227dp`, `height=200dp`, `dpi=320`.

**Why it hid until now.** `composePreviewRender` matches ids by *substring* (`PreviewFilter.matchOne`), so the fragments still selected previews and the render reported success — it was only ever the *bundle* step, which matches exactly, that could notice. With #4602's bug in front of it the render never got far enough to reach the bundle, so this surfaced only once that was fixed.

**Why `encodePreviewId` doesn't already cover it.** That escaping exists precisely to protect commas on the `-PbundlePreviewIds=` transport, and it works — but by the time it runs the id is already in pieces, so it faithfully escapes three fragments.

## The fix

`--id-file <path>`, one id per line — exactly mirroring `--exclude-preview-id-file`. A line break cannot occur inside an id. When present it replaces `--id`; every existing `--id` caller is untouched.

An unreadable path throws rather than yielding an empty selection, same as the exclusion side: a silently-empty include list packs nothing and can look like success.

## Test plan

`PackPreviewIdExclusionsTest` gains four cases, including one that pins the shattering itself so `--id`'s behaviour is documented rather than surprising:

- a file carries the comma-bearing ids intact
- `--id` splits one such id into exactly 3 fragments, the first being the `…_width=227dp` that `composePreviewBundle` reports as not found
- no `--id-file` yields null, leaving `--id` in charge
- a missing file throws

Not verified locally: no Android SDK here, so Gradle cannot configure and I could not compile or run the suite. All five touched files parse under ktfmt 0.64 (Google style) — a syntax check, not a type check. CI is the first compile.

**Follow-up, not in this PR:** design-parity's render step should pass `--id-file slice-previews.txt` (already newline-delimited, exactly as `slice-excluded.txt` was), feature-detected the same way #408 did so consumers on older pins keep working. That needs a release carrying this flag first.

Text-only is correct: this is argument plumbing, no rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_