### PR TITLE
fix(serve): let --background-renders widen the passes, not just the permits

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBackgroundWork.kt
@@ -51,9 +51,16 @@ class ServeBackgroundWork(
    * that permit and 43.5% of what remained spent *re-warming* daemons that got yielded before they
    * rendered anything: 10,120 entries with 8 cached after half an hour, an ETA of 21 days.
    *
-   * Capping the passes fixes what capping the renders cannot. Two at a time still saturates an
-   * 8-permit render lane (each pass batches up to five wide), while leaving the rest parked cheaply
-   * instead of parked expensively.
+   * Capping the passes fixes what capping the renders cannot: the rest are parked cheaply instead
+   * of parked expensively.
+   *
+   * **This must not be set below [maxConcurrentRenders].** A pass takes one permit for the whole of
+   * its batch — `withRenderPermit { renderOptimizerBatch(...) }` — so it holds exactly one however
+   * wide the batch is, and every permit past the lane count is unreachable. An earlier note here
+   * claimed the opposite, that two passes saturate an eight-permit lane "because each pass batches
+   * up to five wide"; the batch runs *inside* the one permit, so they saturate two. `ServeCommand`
+   * consequently passes the render lane for both, which also means an admitted pass never waits at
+   * the permit — the waiting this cap exists to prevent.
    */
   maxConcurrentOptimizers: Int = DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
   private val hostCoordinator: OptimizerHostCoordinator = OptimizerHostCoordinator.NONE,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -928,15 +928,29 @@ class ServeCommand(args: List<String>, private val browseProject: Boolean = fals
 
   private val backgroundWork by lazy {
     val pressureSampler = LinuxHostResourceSampler()
+    // One number, used three times deliberately.
+    //
+    // A pass holds ONE render permit for the whole of its batch —
+    // `withRenderPermit { renderOptimizerBatch(...) }` — so the number of passes admitted, not the
+    // width of a batch, is what bounds concurrent background renders. Leaving the lane count at its
+    // own default therefore left every permit past the second unreachable: the derived lane clamps
+    // at MAX_DERIVED_CONCURRENT_RENDERS (3) against DEFAULT_MAX_CONCURRENT_OPTIMIZERS (2), so even
+    // with no override the third permit was dead, and `--background-renders 5` — which this help
+    // text offers as the way past the derivation's ceiling — bought nothing at all.
+    //
+    // Matching them also removes permit contention rather than merely allowing it: every admitted
+    // pass holds a permit already, so no pass sits inside the door holding a warm daemon and a live
+    // seat while it waits for one. That waiting is what the lane cap was introduced to stop.
+    //
+    // The cross-replica coordinator takes the same number because it caps passes for the physical
+    // host; left at the old default it would re-impose the ceiling this removes.
+    val renderLane = backgroundRenders ?: ServeBackgroundWork.renderLaneFor(liveSeatLimiter)
     ServeBackgroundWork(
-      maxConcurrentRenders =
-        backgroundRenders ?: ServeBackgroundWork.renderLaneFor(liveSeatLimiter),
+      maxConcurrentRenders = renderLane,
+      maxConcurrentOptimizers = renderLane,
       hostCoordinator =
         optimizerCoordinationDirectory?.let {
-          FileOptimizerHostCoordinator(
-            directory = it,
-            lanes = ServeBackgroundWork.DEFAULT_MAX_CONCURRENT_OPTIMIZERS,
-          )
+          FileOptimizerHostCoordinator(directory = it, lanes = renderLane)
         } ?: OptimizerHostCoordinator.NONE,
       pressureGate =
         OptimizerPressureGate(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.cli.serve.ServeBackgroundWork
 import ee.schimke.composeai.cli.serve.ServeCatalogStore
 import ee.schimke.composeai.cli.serve.ServeUrls
 import kotlin.test.Test
@@ -54,6 +55,28 @@ class ServeCommandTest {
     assertFalse(command.field("allowRenderTrusted"))
     assertEquals(ServeCatalogStore.DEFAULT_MAX_IMAGES, command.field<Int>("catalogMaxImages"))
   }
+
+  /**
+   * `--background-renders` widens the passes, not just the permits.
+   *
+   * A pass takes ONE render permit for the whole of its batch, so the permits are reachable only up
+   * to the number of passes admitted. Wiring the render lane while leaving the optimizer lanes at
+   * their own default made every permit past the second dead: the flag documented as the way past
+   * the derivation's ceiling bought nothing above 2, and the cross-replica coordinator re-imposed
+   * the same ceiling on the physical host.
+   */
+  @Test
+  fun `the optimizer lane count follows the background render lane`() {
+    val command = ServeCommand(listOf("--background-renders", "5"))
+
+    assertEquals(5, command.backgroundWork().optimizerAdmissionSnapshot().lanes)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun ServeCommand.backgroundWork(): ServeBackgroundWork =
+    (javaClass.getDeclaredField("backgroundWork\$delegate").apply { isAccessible = true }.get(this)
+        as Lazy<ServeBackgroundWork>)
+      .value
 
   @Suppress("UNCHECKED_CAST")
   private fun <T> Any.field(name: String): T =


### PR DESCRIPTION
## Summary

A P1 left on #4560 after it merged, and it is worse than the finding said.

A pass takes **one** render permit for the whole of its batch — `withRenderPermit { renderOptimizerBatch(...) }` — so it holds exactly one however wide the batch is. The permits are therefore reachable only up to the number of *passes* admitted. `ServeCommand` wired the render lane and left `maxConcurrentOptimizers` at its own default, so every permit past the second was dead.

The reported case was `--background-renders 5` being inert. The stronger case is that the **default path is broken too**: the derivation clamps at `MAX_DERIVED_CONCURRENT_RENDERS` (3) against `DEFAULT_MAX_CONCURRENT_OPTIMIZERS` (2), so on any box with ≥8 seats the third permit has never been reachable. And `FileOptimizerHostCoordinator` took the old default as well, re-imposing the same ceiling across replicas on the physical host.

**Why it looked safe.** The KDoc on `maxConcurrentOptimizers` claimed two passes saturate an eight-permit lane *"because each pass batches up to five wide"*. The batch runs **inside** the one permit, so two passes saturate two. That sentence is corrected, and the invariant now sits where the parameter is declared.

Matching the two also removes permit contention rather than merely allowing it: every admitted pass already holds a permit, so no pass sits inside the door holding a warm daemon and a live seat while it waits for one — which is the waiting the lane cap was introduced to stop in the first place.

## Capacity note for review

This is a behaviour change on the **derived** path, not only for operators who name the flag: a box with 8+ seats goes from 2 concurrent passes to 3. I think that is right — `renderLaneFor` already derives from the seat budget, so the widening is bounded by the same budget that bounded it before, and the help text already promises "the seat budget still bounds how many daemons the renders can occupy". Flagging it explicitly because it changes what `preview.coo.ee` does, and the alternative (honour only an explicitly named lane, leave the derived default at 2) is a one-line change if you'd rather.

## Test plan

- New `ServeCommandTest.the optimizer lane count follows the background render lane` — constructs `ServeCommand(listOf("--background-renders", "5"))` and asserts `optimizerAdmissionSnapshot().lanes == 5`. Verified load-bearing: reverting only the wiring gives

  ```
  ServeCommandTest > the optimizer lane count follows the background render lane() FAILED
  ```

- `:cli:test --tests '*Serve*'` green; `:cli:ktfmtCheckMain/Test` and `:cli:serve:ktfmtCheckMain` clean.
- No visual surface — the change is admission wiring plus a KDoc correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_