### PR TITLE
refactor(serve): move shared contracts out of the server module

### DIFF
--- a/bundle/format/api/bundle-format.api
+++ b/bundle/format/api/bundle-format.api
@@ -670,6 +670,96 @@ public final class ee/schimke/composeai/bundle/BundleSigning$Signatures$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class ee/schimke/composeai/bundle/BundleVerifier {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/BundleVerifier;
+	public final fun summary (Lee/schimke/composeai/bundle/BundleVerifier$Verdict;)Ljava/lang/String;
+	public final fun verify (Ljava/io/File;Lee/schimke/composeai/bundle/TrustStore;Lee/schimke/composeai/bundle/BundleVerifier$Origin;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict;
+	public final fun verify ([BLee/schimke/composeai/bundle/TrustStore;Lee/schimke/composeai/bundle/BundleVerifier$Origin;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict;
+	public static synthetic fun verify$default (Lee/schimke/composeai/bundle/BundleVerifier;Ljava/io/File;Lee/schimke/composeai/bundle/TrustStore;Lee/schimke/composeai/bundle/BundleVerifier$Origin;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict;
+	public static synthetic fun verify$default (Lee/schimke/composeai/bundle/BundleVerifier;[BLee/schimke/composeai/bundle/TrustStore;Lee/schimke/composeai/bundle/BundleVerifier$Origin;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict;
+}
+
+public abstract interface class ee/schimke/composeai/bundle/BundleVerifier$Basis {
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Basis$Branch : ee/schimke/composeai/bundle/BundleVerifier$Basis {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Branch;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Basis$Branch;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Branch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Basis$Provenance : ee/schimke/composeai/bundle/BundleVerifier$Basis {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Provenance;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Basis$Provenance;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Provenance;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIdentity ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Basis$Signature : ee/schimke/composeai/bundle/BundleVerifier$Basis {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Signature;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Basis$Signature;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Basis$Signature;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getProducer ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Origin {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleVerifier$Origin;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Origin;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Origin;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class ee/schimke/composeai/bundle/BundleVerifier$Verdict {
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Verdict$Trusted : ee/schimke/composeai/bundle/BundleVerifier$Verdict {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Trusted;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Trusted;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Trusted;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBases ()Ljava/util/List;
+	public final fun getPrimary ()Lee/schimke/composeai/bundle/BundleVerifier$Basis;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/BundleVerifier$Verdict$Unverified : ee/schimke/composeai/bundle/BundleVerifier$Verdict {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Unverified;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Unverified;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleVerifier$Verdict$Unverified;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class ee/schimke/composeai/bundle/FigmaRasterScalingKt {
 	public static final field MAX_FIGMA_RASTER_EDGE_PX I
 	public static final fun downscaleRaster ([BI)[B
@@ -704,5 +794,139 @@ public final class ee/schimke/composeai/bundle/PreviewBundleFormatKt {
 	public static final fun resolveInBundleTarget (Ljava/lang/String;Ljava/lang/String;Z)Ljava/lang/String;
 	public static final fun rewriteRawZipEntries (Ljava/io/File;Ljava/util/Map;Ljava/util/Set;Lokio/FileSystem;)V
 	public static synthetic fun rewriteRawZipEntries$default (Ljava/io/File;Ljava/util/Map;Ljava/util/Set;Lokio/FileSystem;ILjava/lang/Object;)V
+}
+
+public final class ee/schimke/composeai/bundle/TrustStore {
+	public static final field Companion Lee/schimke/composeai/bundle/TrustStore$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/bundle/TrustStore;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/TrustStore;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/TrustStore;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranches ()Ljava/util/List;
+	public final fun getKeys ()Ljava/util/List;
+	public final fun getOidc ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun keyName (Ljava/lang/String;)Ljava/lang/String;
+	public final fun publicKeyFor (Ljava/lang/String;)Ljava/security/PublicKey;
+	public fun toString ()Ljava/lang/String;
+	public final fun trustsBranch (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun trustsIdentity (Ljava/lang/String;)Z
+}
+
+public final synthetic class ee/schimke/composeai/bundle/TrustStore$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/TrustStore$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/TrustStore;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/TrustStore;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustStore$Companion {
+	public final fun encode (Lee/schimke/composeai/bundle/TrustStore;)Ljava/lang/String;
+	public final fun getEMPTY ()Lee/schimke/composeai/bundle/TrustStore;
+	public final fun globMatch (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun load (Ljava/io/File;)Lee/schimke/composeai/bundle/TrustStore;
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/bundle/TrustStore;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public final fun validateBranch (Lee/schimke/composeai/bundle/TrustedBranch;)Ljava/lang/String;
+	public final fun validateIdentity (Lee/schimke/composeai/bundle/TrustedIdentity;)Ljava/lang/String;
+	public final fun validateKey (Lee/schimke/composeai/bundle/TrustedKey;)Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedBranch {
+	public static final field Companion Lee/schimke/composeai/bundle/TrustedBranch$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/TrustedBranch;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/TrustedBranch;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/TrustedBranch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBranch ()Ljava/lang/String;
+	public final fun getRepo ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/TrustedBranch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/TrustedBranch$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/TrustedBranch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/TrustedBranch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedBranch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedIdentity {
+	public static final field Companion Lee/schimke/composeai/bundle/TrustedIdentity$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lee/schimke/composeai/bundle/TrustedIdentity;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/TrustedIdentity;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/TrustedIdentity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIdentity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/TrustedIdentity$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/TrustedIdentity$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/TrustedIdentity;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/TrustedIdentity;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedIdentity$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedKey {
+	public static final field Companion Lee/schimke/composeai/bundle/TrustedKey$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/bundle/TrustedKey;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/TrustedKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/bundle/TrustedKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeyId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPublicKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class ee/schimke/composeai/bundle/TrustedKey$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lee/schimke/composeai/bundle/TrustedKey$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lee/schimke/composeai/bundle/TrustedKey;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lee/schimke/composeai/bundle/TrustedKey;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class ee/schimke/composeai/bundle/TrustedKey$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleVerifier.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/BundleVerifier.kt
@@ -1,6 +1,5 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.bundle
 
-import ee.schimke.composeai.bundle.BundleSigning
 import java.io.File
 
 /**
@@ -13,28 +12,28 @@ import java.io.File
  * Verification is fail-closed: anything the store can't positively attribute is
  * [Verdict.Unverified].
  */
-object BundleVerifier {
+public object BundleVerifier {
 
   /** Where the server obtained the bundle, when it fetched it itself (vs. a client upload). */
-  data class Origin(val repo: String, val branch: String)
+  public data class Origin(val repo: String, val branch: String)
 
-  sealed interface Verdict {
+  public sealed interface Verdict {
     /** At least one trust basis matched. [bases] lists every basis that did, strongest first. */
-    data class Trusted(val bases: List<Basis>) : Verdict {
-      val primary: Basis
+    public data class Trusted(val bases: List<Basis>) : Verdict {
+      public val primary: Basis
         get() = bases.first()
     }
 
     /** No basis matched. [reason] is a short human-readable explanation. */
-    data class Unverified(val reason: String) : Verdict
+    public data class Unverified(val reason: String) : Verdict
   }
 
-  sealed interface Basis {
+  public sealed interface Basis {
     /** A pinned Ed25519 key signed the canonical digest and verified. The strongest basis. */
-    data class Signature(val keyId: String, val producer: String?) : Basis
+    public data class Signature(val keyId: String, val producer: String?) : Basis
 
     /** The server fetched the bundle from a trusted branch (origin/TLS trust). */
-    data class Branch(val repo: String, val branch: String) : Basis
+    public data class Branch(val repo: String, val branch: String) : Basis
 
     /**
      * Supplementary CI-provenance context recorded **only alongside a cryptographically-verified
@@ -46,11 +45,11 @@ object BundleVerifier {
      * then this basis only annotates a signature a pinned key already verified, so it expands the
      * displayed provenance but never the trust decision.
      */
-    data class Provenance(val identity: String, val type: String) : Basis
+    public data class Provenance(val identity: String, val type: String) : Basis
   }
 
   /** Verify a bundle file. [origin] is non-null only when the server fetched it itself. */
-  fun verify(bundle: File, trust: TrustStore, origin: Origin? = null): Verdict =
+  public fun verify(bundle: File, trust: TrustStore, origin: Origin? = null): Verdict =
     verifyCore(
       BundleSigning.canonicalDigest(bundle),
       BundleSigning.readSignatures(bundle)?.signatures.orEmpty(),
@@ -63,7 +62,7 @@ object BundleVerifier {
    * a file. Accepts either a plain zip or a PNG+ZIP polyglot ([BundleSigning.zipBytesOf]
    * normalizes).
    */
-  fun verify(rawBundleBytes: ByteArray, trust: TrustStore, origin: Origin? = null): Verdict {
+  public fun verify(rawBundleBytes: ByteArray, trust: TrustStore, origin: Origin? = null): Verdict {
     val zip = BundleSigning.zipBytesOf(rawBundleBytes)
     return verifyCore(
       BundleSigning.canonicalDigest(zip),
@@ -76,7 +75,7 @@ object BundleVerifier {
   /**
    * Short one-line label for logs / API / UI badge, e.g. `signature:ci`, `branch`, `unverified`.
    */
-  fun summary(verdict: Verdict): String =
+  public fun summary(verdict: Verdict): String =
     when (verdict) {
       is Verdict.Trusted ->
         when (val b = verdict.primary) {

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/TrustStore.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/TrustStore.kt
@@ -1,6 +1,5 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.bundle
 
-import ee.schimke.composeai.bundle.BundleSigning
 import java.io.File
 import java.security.PublicKey
 import kotlinx.serialization.Serializable
@@ -27,29 +26,31 @@ import kotlinx.serialization.json.Json
  * server with no trust store still serves data tiers but never re-renders untrusted Compose.
  */
 @Serializable
-data class TrustStore(
-  val keys: List<TrustedKey> = emptyList(),
-  val branches: List<TrustedBranch> = emptyList(),
-  val oidc: List<TrustedIdentity> = emptyList(),
+public data class TrustStore(
+  public val keys: List<TrustedKey> = emptyList(),
+  public val branches: List<TrustedBranch> = emptyList(),
+  public val oidc: List<TrustedIdentity> = emptyList(),
 ) {
 
   /** Resolve the pinned public key for [keyId], or null when the store doesn't trust it. */
-  fun publicKeyFor(keyId: String): PublicKey? {
+  public fun publicKeyFor(keyId: String): PublicKey? {
     val entry = keys.firstOrNull { it.keyId == keyId } ?: return null
     return runCatching { BundleSigning.parsePublicKey(entry.publicKey) }.getOrNull()
   }
 
-  fun keyName(keyId: String): String? = keys.firstOrNull { it.keyId == keyId }?.name
+  public fun keyName(keyId: String): String? = keys.firstOrNull { it.keyId == keyId }?.name
 
   /** True when the store trusts catalogs fetched from [repo]@[branch] (glob-matched). */
-  fun trustsBranch(repo: String, branch: String): Boolean = branches.any {
+  public fun trustsBranch(repo: String, branch: String): Boolean = branches.any {
     globMatch(it.repo, repo) && globMatch(it.branch, branch)
   }
 
   /** True when the store trusts a CI provenance [identity] (glob-matched). */
-  fun trustsIdentity(identity: String): Boolean = oidc.any { globMatch(it.identity, identity) }
+  public fun trustsIdentity(identity: String): Boolean = oidc.any {
+    globMatch(it.identity, identity)
+  }
 
-  companion object {
+  public companion object {
     private val json = Json { ignoreUnknownKeys = true }
 
     /**
@@ -67,14 +68,15 @@ data class TrustStore(
     }
 
     /** The empty, fail-closed store — trusts nothing. */
-    val EMPTY = TrustStore()
+    public val EMPTY: TrustStore = TrustStore()
 
-    fun load(file: File): TrustStore =
+    public fun load(file: File): TrustStore =
       json.decodeFromString(serializer(), file.readText(Charsets.UTF_8))
 
-    fun parse(text: String): TrustStore = json.decodeFromString(serializer(), text)
+    public fun parse(text: String): TrustStore = json.decodeFromString(serializer(), text)
 
-    fun encode(store: TrustStore): String = writerJson.encodeToString(serializer(), store) + "\n"
+    public fun encode(store: TrustStore): String =
+      writerJson.encodeToString(serializer(), store) + "\n"
 
     /**
      * Producer patterns are globs, so this is deliberately looser than a catalog repo slug — but
@@ -93,7 +95,7 @@ data class TrustStore(
      * on GitHub. There is no legitimate use for it, and the failure mode is bad enough that a typo
      * shouldn't be able to reach it.
      */
-    fun validateBranch(branch: TrustedBranch): String? =
+    public fun validateBranch(branch: TrustedBranch): String? =
       when {
         !REPO_PATTERN_RE.matches(branch.repo) -> "invalid repo pattern '${branch.repo}'"
         !BRANCH_PATTERN_RE.matches(branch.branch) -> "invalid branch pattern '${branch.branch}'"
@@ -105,7 +107,7 @@ data class TrustStore(
     /**
      * Why [key] is unusable, or null when it's well-formed (and its public key actually parses).
      */
-    fun validateKey(key: TrustedKey): String? =
+    public fun validateKey(key: TrustedKey): String? =
       when {
         key.keyId.isBlank() -> "key entry needs a keyId"
         key.publicKey.isBlank() -> "key '${key.keyId}' needs a publicKey"
@@ -115,7 +117,7 @@ data class TrustStore(
       }
 
     /** Why [identity] is unusable, or null when it's well-formed. */
-    fun validateIdentity(identity: TrustedIdentity): String? =
+    public fun validateIdentity(identity: TrustedIdentity): String? =
       if (identity.identity.isBlank()) "oidc entry needs an identity" else null
 
     /**
@@ -124,7 +126,7 @@ data class TrustStore(
      * `repo:yschimke/compose-ai-tools:ref:...`. Anchored (full-string) and case-sensitive. A
      * literal pattern with no `*` is exact-match.
      */
-    fun globMatch(pattern: String, value: String): Boolean {
+    public fun globMatch(pattern: String, value: String): Boolean {
       if (!pattern.contains('*')) return pattern == value
       val regex = buildString {
         append('^')
@@ -140,10 +142,10 @@ data class TrustStore(
 
 /** A pinned producer public key. [publicKey] is PEM or base64 X.509 SPKI (see [BundleSigning]). */
 @Serializable
-data class TrustedKey(val keyId: String, val publicKey: String, val name: String? = null)
+public data class TrustedKey(val keyId: String, val publicKey: String, val name: String? = null)
 
 /** A GitHub branch the server may fetch trusted catalogs from. `branch` defaults to "any". */
-@Serializable data class TrustedBranch(val repo: String, val branch: String = "*")
+@Serializable public data class TrustedBranch(val repo: String, val branch: String = "*")
 
 /** A trusted CI workload identity (GitHub OIDC subject / Sigstore identity), glob-matched. */
-@Serializable data class TrustedIdentity(val identity: String)
+@Serializable public data class TrustedIdentity(val identity: String)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -199,6 +199,7 @@ dependencies {
   // `:data-a11y-core` used for the D2.2 extraction. External consumers (contrib scripting,
   // third-party tooling) pull `:preview-data-api` directly, not transitively through `:cli`.
   api(project(":preview-data-api"))
+  implementation(project(":common-image-crop"))
 
   // Gradle Tooling-API render pipeline + the `GradleConnection` / `PreviewModule` /
   // `CapturedTestFailure` / `TerminalProgress` plumbing the CLI used to host inline. `api` again

--- a/cli/serve/build.gradle.kts
+++ b/cli/serve/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
   // Published wire-format DTOs and the bundle format. `api` because they appear in this module's
   // own signatures, which `:cli` reads.
   api(project(":preview-data-api"))
+  implementation(project(":common-image-crop"))
   api(project(":bundle-format"))
   api(project(":bundle-coordinates"))
   api(project(":daemon:core"))

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -1,11 +1,16 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.data.overrides.PreviewOverridesPayload
 import ee.schimke.composeai.data.pseudolocale.LocaleDirection
 import ee.schimke.composeai.data.pseudolocale.Pseudolocale
+import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.computeGutterCrop
+import ee.schimke.composeai.imagecrop.computeThumbCrop
+import ee.schimke.composeai.imagecrop.pngAlphaBounds
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlin.math.roundToInt

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStore.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleSigning
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleClasspathHydration
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.designpages.DesignPagesJson

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImages.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImages.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.computeThumbCrop
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.data.layoutinspector.ComposeFigmaSvgProduct
@@ -7,6 +8,7 @@ import ee.schimke.composeai.data.layoutinspector.ExplodedSvg
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.remotecompose.RemoteComposeKnobDeclaration
 import ee.schimke.composeai.designpages.DesignPage
+import ee.schimke.composeai.imagecrop.ContentCrop
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.TrustStore
 import ee.schimke.composeai.previewdata.PreviewManifest
 import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.File

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.AndroidBundleLaunch
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
 import ee.schimke.composeai.bundle.locateBundleSidecarJars
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.previewdata.PreviewInfo

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundles.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.URI

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdmin.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
+import ee.schimke.composeai.bundle.TrustedIdentity
+import ee.schimke.composeai.bundle.TrustedKey
 import ee.schimke.composeai.io.SystemFileSystem
 import kotlinx.serialization.Serializable
 import okio.FileSystem

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1,11 +1,13 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.data.overrides.PreviewOverrideOption
 import ee.schimke.composeai.data.render.PreviewBackdrop
 import ee.schimke.composeai.data.render.PreviewBackground
 import ee.schimke.composeai.data.render.PreviewClip
 import ee.schimke.composeai.designpages.DesignPage
 import ee.schimke.composeai.designpages.PageNode
+import ee.schimke.composeai.imagecrop.ContentCrop
 import java.time.Instant
 import java.util.Locale
 import kotlinx.serialization.json.Json

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.imagecrop.ContentCrop
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleStoreTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleSigning
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedKey
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
+import ee.schimke.composeai.imagecrop.ContentCrop
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.TrustStore
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStartupBundlesTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeStatusTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeTrustAdminTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
+import ee.schimke.composeai.bundle.TrustedIdentity
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.imagecrop.ContentCrop
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.computeGutterCrop
+import ee.schimke.composeai.imagecrop.computeThumbCrop
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSignCommand.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleSigning
-import ee.schimke.composeai.cli.serve.BundleVerifier
-import ee.schimke.composeai.cli.serve.TrustStore
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
 import java.io.File
 import kotlin.system.exitProcess
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleSplit.kt
@@ -8,11 +8,11 @@ import ee.schimke.composeai.bundle.BUNDLE_PREVIEWS_DIR
 import ee.schimke.composeai.bundle.BUNDLE_SEMANTICS_SUFFIX
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.ZIP_DOS_EPOCH_MS
-import ee.schimke.composeai.cli.serve.clampTo
-import ee.schimke.composeai.cli.serve.contentBoxFillsRender
-import ee.schimke.composeai.cli.serve.pngAlphaBounds
-import ee.schimke.composeai.cli.serve.svgContentBox
-import ee.schimke.composeai.cli.serve.union
+import ee.schimke.composeai.imagecrop.clampTo
+import ee.schimke.composeai.imagecrop.contentBoxFillsRender
+import ee.schimke.composeai.imagecrop.pngAlphaBounds
+import ee.schimke.composeai.imagecrop.svgContentBox
+import ee.schimke.composeai.imagecrop.union
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.bundle.TrustStore
 import ee.schimke.composeai.cli.serve.CatalogBlobPool
 import ee.schimke.composeai.cli.serve.GitWorktrees
 import ee.schimke.composeai.cli.serve.PlaygroundBundleSource
@@ -29,7 +30,6 @@ import ee.schimke.composeai.cli.serve.ServeSites
 import ee.schimke.composeai.cli.serve.ServeStartupBundles
 import ee.schimke.composeai.cli.serve.ServeUrls
 import ee.schimke.composeai.cli.serve.ThemeCacheStore
-import ee.schimke.composeai.cli.serve.TrustStore
 import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.File
 import okio.Path.Companion.toPath

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSignCommandTest.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleSigning
-import ee.schimke.composeai.cli.serve.TrustStore
-import ee.schimke.composeai.cli.serve.TrustedBranch
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/BundleSigningTest.kt
@@ -2,12 +2,12 @@ package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.BundleSigning
+import ee.schimke.composeai.bundle.BundleVerifier
+import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.bundle.TrustedBranch
+import ee.schimke.composeai.bundle.TrustedIdentity
+import ee.schimke.composeai.bundle.TrustedKey
 import ee.schimke.composeai.bundle.injectRawZipEntries
-import ee.schimke.composeai.cli.serve.BundleVerifier
-import ee.schimke.composeai.cli.serve.TrustStore
-import ee.schimke.composeai.cli.serve.TrustedBranch
-import ee.schimke.composeai.cli.serve.TrustedIdentity
-import ee.schimke.composeai.cli.serve.TrustedKey
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.File

--- a/common/image-crop/api/common-image-crop.api
+++ b/common/image-crop/api/common-image-crop.api
@@ -1,0 +1,58 @@
+public final class ee/schimke/composeai/imagecrop/ContentCrop {
+	public fun <init> (IIIIIIZII)V
+	public synthetic fun <init> (IIIIIIZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (IIIIIIZII)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentCrop;IIIIIIZIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoxH ()I
+	public final fun getBoxW ()I
+	public final fun getClip ()Z
+	public final fun getImgH ()I
+	public final fun getImgW ()I
+	public final fun getLeft ()I
+	public final fun getNatBoxW ()I
+	public final fun getNatCapAxis ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/imagecrop/ContentCropGeometryKt {
+	public static final fun clampTo (Lee/schimke/composeai/imagecrop/SvgContentBox;II)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static final fun computeGutterCrop (IIIIIII)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun computeGutterCrop$default (IIIIIIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static final fun computeThumbCrop (Ljava/lang/String;IILee/schimke/composeai/imagecrop/SvgContentBox;I)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun computeThumbCrop$default (Ljava/lang/String;IILee/schimke/composeai/imagecrop/SvgContentBox;IILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static final fun contentBoxFillsRender (Lee/schimke/composeai/imagecrop/SvgContentBox;II)Z
+	public static final fun pngAlphaBounds ([BI)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static synthetic fun pngAlphaBounds$default ([BIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static final fun svgContentBox (Ljava/lang/String;)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static final fun union (Lee/schimke/composeai/imagecrop/SvgContentBox;Lee/schimke/composeai/imagecrop/SvgContentBox;)Lee/schimke/composeai/imagecrop/SvgContentBox;
+}
+
+public final class ee/schimke/composeai/imagecrop/SvgContentBox {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/SvgContentBox;IIIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getH ()I
+	public final fun getW ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/common/image-crop/build.gradle.kts
+++ b/common/image-crop/build.gradle.kts
@@ -1,0 +1,44 @@
+// Content-crop geometry for preview renders: where the component actually is inside its canvas.
+//
+// A render PNG is often much larger than the component it shows — a Wear sticker is drawn on a
+// fixed 454x454 watch canvas with the component centred and small. Deciding the crop window is
+// pure arithmetic over an SVG `viewBox`, a PNG's alpha bounds, and a recorded gutter, and both
+// halves of #3824's split need the *same* arithmetic: the preview server crops catalog thumbnails
+// at page build, and the CLI's `bundle split` crops the same renders on the way into a bundle.
+//
+// It lived in `:cli:serve` as `ServeThumbCrop.kt`, which made a CLI command depend on the server
+// for arithmetic. Published, and deliberately tiny: `javax.imageio` and `kotlin.math`, nothing
+// else — no Okio, no serve types, no bundle format.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+  testImplementation(libs.junit)
+  testImplementation(kotlin("test"))
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "common-image-crop",
+    displayName = "Compose Preview — Image Crop Geometry",
+    description =
+      "Content-crop geometry for compose-preview renders: SVG content boxes, PNG alpha bounds, " +
+        "recorded gutters, and the thumbnail crop windows derived from them.",
+  )
+  inceptionYear.set("2026")
+}
+
+kotlin {
+  // `explicitApi()` — this is a published contract both halves of the #3824 split compile against
+  // across a repo boundary, so an implicitly-public declaration is an API decision nobody made.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
+++ b/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.imagecrop
 
 import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
@@ -22,7 +22,7 @@ import kotlin.math.roundToInt
  * [computeThumbCrop] returns `null` (no-op) for them — only the framed-in-a-canvas stickers get
  * cropped.
  */
-data class ContentCrop(
+public data class ContentCrop(
   /** Clip-window size (px) — the component box scaled to fit [CAP]. */
   val boxW: Int,
   val boxH: Int,
@@ -71,14 +71,14 @@ private val VIEWBOX_RE = Regex("""viewBox="0 0 (\d+(?:\.\d+)?) (\d+(?:\.\d+)?)""
  * [computeThumbCrop] adds the display scaling on top, while the bundle PNG crop
  * ([ee.schimke.composeai.cli] `bundle split`) uses it at full resolution.
  */
-data class SvgContentBox(val x: Int, val y: Int, val w: Int, val h: Int)
+public data class SvgContentBox(val x: Int, val y: Int, val w: Int, val h: Int)
 
 /**
  * Parse a figma-svg's content box (root `viewBox` size + `translate` origin) in render pixels, or
  * `null` when the svg carries no parseable `viewBox`. A missing `translate` places the box at the
  * origin.
  */
-fun svgContentBox(svgText: String): SvgContentBox? {
+public fun svgContentBox(svgText: String): SvgContentBox? {
   val vb = VIEWBOX_RE.find(svgText) ?: return null
   val w = vb.groupValues[1].toDouble()
   val h = vb.groupValues[2].toDouble()
@@ -95,11 +95,11 @@ fun svgContentBox(svgText: String): SvgContentBox? {
  * canvas) — the shared "within 10% on both axes" no-op guard. Consumers that read a pre-cropped PNG
  * then find their box ≈ the image and no-op via this same test.
  */
-fun contentBoxFillsRender(box: SvgContentBox, renderW: Int, renderH: Int): Boolean =
+public fun contentBoxFillsRender(box: SvgContentBox, renderW: Int, renderH: Int): Boolean =
   box.w >= renderW * 0.9 && box.h >= renderH * 0.9
 
 /** The smallest box covering both [this] and [other]. */
-fun SvgContentBox.union(other: SvgContentBox): SvgContentBox {
+public fun SvgContentBox.union(other: SvgContentBox): SvgContentBox {
   val x1 = min(x, other.x)
   val y1 = min(y, other.y)
   val x2 = max(x + w, other.x + other.w)
@@ -108,7 +108,7 @@ fun SvgContentBox.union(other: SvgContentBox): SvgContentBox {
 }
 
 /** Clamp [this] to a [renderW]×[renderH] canvas (origin ≥ 0, extent within bounds). */
-fun SvgContentBox.clampTo(renderW: Int, renderH: Int): SvgContentBox {
+public fun SvgContentBox.clampTo(renderW: Int, renderH: Int): SvgContentBox {
   val nx = x.coerceIn(0, renderW)
   val ny = y.coerceIn(0, renderH)
   return SvgContentBox(nx, ny, max(1, min(x + w, renderW) - nx), max(1, min(y + h, renderH) - ny))
@@ -122,7 +122,7 @@ fun SvgContentBox.clampTo(renderW: Int, renderH: Int): SvgContentBox {
  * (see [computeThumbCrop]) guarantees the crop never clips real pixels, self-correcting per variant
  * without needing a per-variant figma-svg.
  */
-fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): SvgContentBox? {
+public fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): SvgContentBox? {
   val img = runCatching { ImageIO.read(ByteArrayInputStream(pngBytes)) }.getOrNull() ?: return null
   val w = img.width
   val h = img.height
@@ -170,7 +170,7 @@ fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): SvgContentBox? {
  * The edges are PHYSICAL — whoever published the record resolved the annotation's leading/trailing
  * against the direction the render was composed in, so there is no direction left to guess at here.
  */
-fun computeGutterCrop(
+public fun computeGutterCrop(
   gutterLeft: Int,
   gutterTop: Int,
   gutterRight: Int,
@@ -211,7 +211,7 @@ fun computeGutterCrop(
   )
 }
 
-fun computeThumbCrop(
+public fun computeThumbCrop(
   svgText: String,
   renderW: Int,
   renderH: Int,

--- a/common/image-crop/src/test/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometryTest.kt
+++ b/common/image-crop/src/test/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometryTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.imagecrop
 
 import java.awt.Color
 import java.awt.image.BufferedImage

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -50,6 +50,10 @@ val contracts =
     "render-session-api",
     "render-session-subprocess",
     "common-io",
+    // Content-crop geometry, extracted from `ServeThumbCrop.kt` during the ServeCommand split.
+    // Both halves need the same arithmetic — the server crops catalog thumbnails, `bundle split`
+    // crops the same renders — so it is a contract rather than a thing to keep two copies of.
+    "common-image-crop",
     "data-layoutinspector-core",
     "data-preview-overrides-core",
     "data-remotecompose-core",

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -36,6 +36,7 @@ CONTRACT_PROJECTS=(
   ":render-session-api"
   ":render-session-subprocess"
   ":common-io"
+  ":common-image-crop"
   ":data-layoutinspector-core"
   ":data-preview-overrides-core"
   ":data-remotecompose-core"

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -93,6 +93,7 @@
     "ee.schimke.composeai.data.render": "data-render-core",
     "ee.schimke.composeai.data.theme": "data-theme-core",
     "ee.schimke.composeai.designpages": "preview-data-api",
+    "ee.schimke.composeai.imagecrop": "common-image-crop",
     "ee.schimke.composeai.io": "common-io",
     "ee.schimke.composeai.previewdata": "preview-data-api",
     "ee.schimke.composeai.render.session": "render-session-api",
@@ -128,7 +129,6 @@
   "main": {
     "cliInternalsUsedByServe": [],
     "serveInternalsUsedByCli": [
-      "serve.BundleVerifier",
       "serve.CatalogBlobPool",
       "serve.GitWorktrees",
       "serve.PlaygroundBundleSource",
@@ -165,19 +165,12 @@
       "serve.ServeUrls",
       "serve.SvgOutcome",
       "serve.ThemeCacheStore",
-      "serve.TrustStore",
-      "serve.WebEmbed",
-      "serve.clampTo",
-      "serve.contentBoxFillsRender",
-      "serve.pngAlphaBounds",
-      "serve.svgContentBox",
-      "serve.union"
+      "serve.WebEmbed"
     ]
   },
   "test": {
     "cliInternalsUsedByServe": [],
     "serveInternalsUsedByCli": [
-      "serve.BundleVerifier",
       "serve.FakeRenderSession",
       "serve.PreviewHistoryManifest",
       "serve.ServeAgentGrantScope",
@@ -192,10 +185,6 @@
       "serve.ServeRenderHost",
       "serve.ServeSessionRegistry",
       "serve.ServeUrls",
-      "serve.TrustStore",
-      "serve.TrustedBranch",
-      "serve.TrustedIdentity",
-      "serve.TrustedKey",
       "serve.WebEmbed"
     ]
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -280,6 +280,13 @@ include(":common-io")
 
 project(":common-io").projectDir = file("common/io")
 
+// Content-crop geometry shared by the preview server (catalog thumbnails) and the CLI
+// (`bundle split`). Extracted from `:cli:serve`'s `ServeThumbCrop.kt` so a CLI command does not
+// depend on the server for arithmetic — #3824 preparation.
+include(":common-image-crop")
+
+project(":common-image-crop").projectDir = file("common/image-crop")
+
 // Step B of the clean-API carve-out: the Gradle Tooling-API render pipeline that previously
 // lived inside `:cli`'s `Command` base class. Exposes a `GradlePreviewDriver` library so
 // external consumers (contrib scripting, third-party tooling) can render previews and read the


### PR DESCRIPTION
Stacked on #4613 — review that first.

#3824 preparation, continuing from the `ServeCommand` split. That one cut the server's entry point loose; this goes after what is left, which is a different shape: not one big file but a handful of types that both halves use and that happen to live on the server's side of the line.

**`serveInternalsUsedByCli` 44 → 37**, and the test register **20 → 15**. Cumulative with #4613: **102 → 37** and **20 → 15**.

## `:common-image-crop` — a new published module

`ServeThumbCrop.kt` was content-crop geometry: SVG content boxes, PNG alpha bounds, recorded gutters, and the thumbnail windows derived from them. The server crops catalog thumbnails with it at page build; the CLI's `bundle split` crops the same renders with it on the way into a bundle. Identical arithmetic — so a CLI command was depending on the preview server to do maths.

240 lines, no dependency beyond `javax.imageio` and `kotlin.math`. `explicitApi()` + an ABI dump, like the other published contracts. Registered in three places, and the probe caught the third on its own:

- the seam allowlist's `contractPackages`
- `contracts` in `preview-server/contract-probe/build.gradle.kts`
- `CONTRACT_PROJECTS` in `scripts/check-preview-server-contracts.sh` — **missed initially**, and `checkContractSurface` failed with `Could not find ee.schimke.composeai:common-image-crop:0.0.0-contract-probe-SNAPSHOT`. A contract that isn't published simply won't resolve, which is precisely what that gate exists to say.

## `BundleVerifier` and `TrustStore` → `:bundle-format`

Both are about verifying a signed bundle, and `BundleSigning` — the thing they verify against — was already there. `bundle sign` and `bundle verify` no longer reach into the server to check a signature.

## Three moves attempted and reverted

Worth recording, because the reason is the same each time and is invisible in a file's import list:

| type | blocked by |
|---|---|
| `PreviewHistory` | `GitRunner`, `GitWorktrees` |
| `PreviewHistoryManifest` | `ServeCatalogStore` |
| `WebEmbed` | `WebEscaping` (shared by 11 serve files) |

None of those appear as an `import`, because they are in the same package. **"This file imports nothing of ours" is not evidence that it is portable** — the only real test is compiling it in the module you want it to live in, which is how all three surfaced.

`WebEmbed` could have been forced across by dragging HTML escaping into a bundle-format contract. That would have put a server-wide utility into a published artifact for the wrong reason, so it stays put until `WebEscaping` has a home that makes sense.

The same false-negative bit the import rewrite from the other side: `union` and `clampTo` are *also* Kotlin stdlib extensions, so a name-based sweep added six imports to files whose `union` was `Set.union`. **They compiled cleanly** — which is exactly why they had to be found by reading rather than by build result.

## On what separability actually requires

The direction that blocks it is **serve → `:cli`**, and that is **0** and gated by `checkServeModuleBoundary`. A `:cli` → serve crossing is satisfiable by depending on the published server artifact, so the remaining 37 are not blockers — the register keeps them deliberate rather than accidental. What was worth moving here is the subset that is neither CLI nor server but genuinely shared, and that is what these two modules now hold.

## Test plan

- `:common-image-crop:check`, `:bundle-format:check`, `:preview-data-api:check` — green (includes `checkKotlinAbi` for all three).
- `:cli:serve:test`, `:cli:test` — green.
- `scripts/check-preview-server-contracts.sh` — green end to end, publishing the new module at the probe SNAPSHOT.
- `check-serve-seam.py` OK at `main.serveInternalsUsedByCli=37`, `cliInternalsUsedByServe=0`; `test_check_serve_seam.py` 45/45.
- ABI dumps regenerated for `:common-image-crop` (new) and `:bundle-format`.
- `ktfmtCheck` clean.

Non-visual: module boundaries and file moves. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_