### PR TITLE
fix(ci): record the test-side ServeBackgroundWork crossing on the seam register

### DIFF
--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -240,6 +240,7 @@
       "serve.PreviewHistoryManifest",
       "serve.ServeAgentGrantScope",
       "serve.ServeAgentGrantStore",
+      "serve.ServeBackgroundWork",
       "serve.ServeBundleHost",
       "serve.ServeCatalogStore",
       "serve.ServeHttpServer",


### PR DESCRIPTION
`main` is red on **Actions Script Tests**, and has been since #4616 ([f124e77](https://github.com/yschimke/compose-ai-tools/commit/f124e77236f8ba0f748b00ca4244e4d22865970c)). Every PR opened against it inherits the failure — I hit it on #4618, whose diff is `.github/actions/lib/*.py` and cannot have caused it, and reproduced the same failure on `origin/main` itself with no changes applied.

```
test — NEW coupling (serveInternalsUsedByCli):
    + serve.ServeBackgroundWork
        cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
  Remove the crossing, or add it to scripts/serve-seam-allowlist.json
  (test.serveInternalsUsedByCli) with a reason in the PR body.
```

`test_check_serve_seam.py` fails twice on it — `RealTree.test_repo_is_green` and `WriteMode.test_rewrite_keeps_every_top_level_key`.

## The reason, as the message asks for

#4616 added `the optimizer lane count follows the background render lane`, which reaches `ServeCommand`'s private `backgroundWork` lazy through reflection:

```kotlin
private fun ServeCommand.backgroundWork(): ServeBackgroundWork =
  (javaClass.getDeclaredField("backgroundWork\$delegate")…).value
```

That names `ServeBackgroundWork` from the **test** source set. The register is per source set, and only `main.serveInternalsUsedByCli` carried the type — so the crossing read as new.

It is not new production coupling. `serve.ServeBackgroundWork` has been on the main-side list all along; the test names the same type across the same boundary, for the same reason, and it comes off this list the moment the main-side entry does. The alternative the message offers — remove the crossing — would mean deleting the test #4616 added to pin the behaviour it fixed, which is the wrong trade for a debt register whose whole point is that the debt is *visible*.

`test.serveInternalsUsedByCli` goes 20 → 21. Every other count is unchanged: `main.cliInternalsUsedByServe=0`, `main.serveInternalsUsedByCli=102`, `test.cliInternalsUsedByServe=0`.

## One note on the tooling

Added by hand rather than through the documented `check-serve-seam.py --write --allow-growth`. The writer serialises with `ensure_ascii` left at its default, so regenerating re-escapes every em-dash and ellipsis in the `_doc` block — a one-line change comes out as 19 lines of `—` churn. Worth a follow-up on the script; deliberately not folded in here, so this stays a one-line unblock.

## Test plan

```
python3 scripts/check-serve-seam.py               # OK, test.serveInternalsUsedByCli=21
python3 scripts/test_check_serve_seam.py          # 45 tests
python3 scripts/test_measure_serve_coupling.py    # 42 tests
python3 scripts/test_check_daemon_launch_schema.py # 55 tests
```

All green. Verified failing on `origin/main` first — same two failures, same symbol.

Non-visual: a JSON debt register. No rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx)_