### PR TITLE
fix(ci): key the backdrop opt-out on GIF, and run the image tests in CI

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -155,12 +155,21 @@ _HIGH_CONTRAST_PIXEL_TOLERANCE = 4
 # backdrop: mid-grey content cancels against it.
 #
 # An opaque pair skips this and compares exactly as it always did, so the cost is
-# paid only where it buys something. So does an animated GIF, deliberately: its
-# frames are 1-bit alpha, the per-frame budget below is tuned around an AA edge
-# that thresholds into a handful of flipping pixels per run, and on an opaque
-# backdrop every one of those flips becomes a maximum-contrast difference. The
-# GIF path has no demonstrated miss to weigh against that — the two motion
-# captures in the change these fixtures come from were both reported correctly.
+# paid only where it buys something. So does a **GIF**, deliberately: its frames
+# are 1-bit alpha, the per-frame budget below is tuned around an AA edge that
+# thresholds into a handful of flipping pixels per run, and on an opaque backdrop
+# every one of those flips becomes a maximum-contrast difference. That path has
+# no demonstrated miss to weigh against the flake risk — the two motion captures
+# in the change these fixtures come from were both reported correctly.
+#
+# GIF, not "animated". APNG is the other multi-frame format here and it is the
+# opposite case: `PreviewDiscovery` reaches for it precisely BECAUSE it carries
+# full alpha where "GIF's 1-bit alpha thresholds the anti-aliased edge into a
+# churn-prone hard boundary", and `@InteractionPreview` writes `.apng` by
+# default. So an APNG has no 1-bit churn to absorb and is exactly the
+# light-on-transparency content this backdrop pass exists for. Keying the opt-out
+# on frame count rather than on format would have carried the GIF's exemption
+# over to it and left the bug in place for every interaction capture.
 _COMPARE_BACKDROPS = ((0, 0, 0, 255), (255, 255, 255, 255))
 
 
@@ -207,18 +216,23 @@ def _perceptually_changed(
                 return True
             if prior_frames <= 1:
                 return _over_budget(prior, current, limit)
-            # Animated GIF: `Image.open` only exposes the first frame, so a
-            # frame-0-identical / tail-frame-jittering GIF (the transparent
+            # Animated: `Image.open` only exposes the first frame, so a
+            # frame-0-identical / tail-frame-jittering capture (the transparent
             # Lottie spin case, whose anti-aliased edge the 1-bit GIF alpha
             # thresholds into a handful of flipping pixels per run) would
             # otherwise always read as unchanged — masking real animation
             # edits too. Compare every frame with the same per-frame budget a
             # still render gets; changed if any single frame exceeds it.
+            #
+            # Read the format BEFORE iterating: a frame yielded by
+            # `ImageSequence.Iterator` carries no `.format`. Only GIF opts out
+            # of the backdrops — see `_COMPARE_BACKDROPS` for why APNG must not.
+            gif = "GIF" in (prior.format, current.format)
             for pf, cf in zip(
                 ImageSequence.Iterator(prior), ImageSequence.Iterator(current)
             ):
                 if _over_budget(
-                    pf.convert("RGBA"), cf.convert("RGBA"), limit, backdrops=False
+                    pf.convert("RGBA"), cf.convert("RGBA"), limit, backdrops=not gif
                 ):
                     return True
             return False
@@ -245,9 +259,9 @@ def _over_budget(prior, current, limit: int, *, backdrops: bool = True) -> bool:
 
     A transparent pair is compared once per backdrop in ``_COMPARE_BACKDROPS``
     and is changed if it is over budget on either — see that constant for why
-    pixelmatch cannot be handed these images directly, and why an animated GIF
-    passes ``backdrops=False`` to opt out. An opaque pair takes the single
-    comparison it always took either way.
+    pixelmatch cannot be handed these images directly, and why a GIF's frames
+    pass ``backdrops=False`` to opt out where an APNG's do not. An opaque pair
+    takes the single comparison it always took either way.
     """
     if backdrops and (_has_transparency(prior) or _has_transparency(current)):
         return any(

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import shutil
 import tempfile
 import unittest
@@ -577,6 +578,33 @@ class ResourceSizeAwareToleranceTest(unittest.TestCase):
         )
 
 
+class PerceptualLibrariesTest(unittest.TestCase):
+    """The image classes in this file skip themselves when pixelmatch/Pillow are
+    missing, which is right locally and was silently wrong in CI.
+
+    On a bare `ubuntu-latest` runner neither is installed, so the `actions-tests`
+    job ran this suite with five classes skipped and reported OK — the tests that
+    decide what the diff bot reports had never executed there. A skip is invisible
+    in a green check, so nothing said so.
+
+    `ci.yml` now installs them. This is the guard that keeps it installed: the
+    skip stays a local convenience, and its cost in CI is a failure rather than a
+    quieter pass."""
+
+    def test_the_image_libraries_are_installed_in_ci(self):
+        if not os.environ.get("GITHUB_ACTIONS"):
+            self.skipTest("local run — the image classes may skip themselves")
+        try:
+            from pixelmatch.contrib.PIL import pixelmatch  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError as exc:  # pragma: no cover - the failure is the point
+            self.fail(
+                "pixelmatch/Pillow missing in CI, so every image comparison in "
+                f"this file silently skips: {exc}. Restore the "
+                "'Install perceptual-diff libraries' step in ci.yml."
+            )
+
+
 class TransparentLightContentTest(unittest.TestCase):
     """Light content on transparency, which pixelmatch cannot see on its own.
 
@@ -705,6 +733,76 @@ class TransparentLightContentTest(unittest.TestCase):
             limit = cp._PERCEPTUAL_PIXEL_TOLERANCE
             self.assertTrue(cp._over_budget(a, b, limit))
             self.assertFalse(cp._over_budget(a, b, limit, backdrops=False))
+
+
+class AnimatedBackdropOptOutTest(unittest.TestCase):
+    """Which animated format opts out of the backdrops, and which must not.
+
+    GIF does, because its 1-bit alpha thresholds an anti-aliased edge into a
+    handful of flipping pixels per run and every one of those is a
+    maximum-contrast difference once composited. APNG does **not**, and keying
+    the opt-out on frame count rather than on format would have handed it the
+    GIF's exemption: `PreviewDiscovery` reaches for APNG precisely because it
+    carries full alpha where GIF's would churn, and `@InteractionPreview` writes
+    `.apng` by default — so an interaction capture is exactly the
+    light-on-transparency content the backdrops exist for.
+
+    Both fixtures are written here rather than committed: the point is the
+    container, and two frames of a white square on transparency say it exactly.
+    White on transparency is what cancels against pixelmatch's white blend, so
+    the pair is invisible without a backdrop in either format."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from pixelmatch.contrib.PIL import pixelmatch  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("pixelmatch/Pillow not installed")
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _frames(self, offset: int):
+        """Two frames of a white square on transparency, shifted by ``offset``."""
+        from PIL import Image, ImageDraw
+
+        out = []
+        for i in range(2):
+            frame = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
+            x = 8 + offset + i * 4
+            ImageDraw.Draw(frame).rectangle([x, 8, x + 24, 32], fill=(255, 255, 255, 255))
+            out.append(frame)
+        return out
+
+    def _write(self, name: str, offset: int, **kwargs) -> Path:
+        frames = self._frames(offset)
+        path = self.tmp / name
+        frames[0].save(path, save_all=True, append_images=frames[1:], **kwargs)
+        return path
+
+    def test_apng_frames_take_the_backdrops(self):
+        a = self._write("a.apng", 0)
+        b = self._write("b.apng", 6)
+        from PIL import Image
+
+        with Image.open(a) as ia:
+            self.assertEqual(ia.format, "PNG")
+            self.assertGreater(ia.n_frames, 1)
+        self.assertTrue(cp._perceptually_changed(a, b))
+
+    def test_gif_frames_still_opt_out(self):
+        # The same moved square, in the container whose 1-bit alpha the per-frame
+        # budget is tuned around. Unchanged behaviour, asserted so that keying
+        # the opt-out on the format cannot quietly become keying it on nothing.
+        a = self._write("a.gif", 0, disposal=2, transparency=0)
+        b = self._write("b.gif", 6, disposal=2, transparency=0)
+        from PIL import Image
+
+        with Image.open(a) as ia:
+            self.assertEqual(ia.format, "GIF")
+        self.assertFalse(cp._perceptually_changed(a, b))
 
 
 class GenerateTest(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1215,6 +1215,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # The perceptual-diff libraries the image comparisons need. Without them
+      # `test_compare_previews.py` still exits 0 — it SKIPS every class that
+      # opens a PNG, which was five of them (the AA-flake filter, the
+      # high-contrast pass, the resource tolerance, the animated-frame walk, the
+      # transparent-backdrop pass). So the suite that decides what the diff bot
+      # reports was green here without ever running its own image logic. Pinned
+      # to what the production actions install, and NOT tolerant of a failed
+      # install the way those are: a fallback is right for a diff that can
+      # degrade to strict bytes, and wrong for the tests that prove the diff.
+      # `PerceptualLibrariesTest` fails the suite if this step is ever dropped.
+      - name: Install perceptual-diff libraries
+        run: python3 -m pip install --quiet 'pixelmatch==0.4.0' 'Pillow>=10'
       - name: Run compare-previews tests
         run: python3 .github/actions/lib/test_compare_previews.py -v
       - name: Run vscode-preview-diff tests


### PR DESCRIPTION
Two findings from the Codex review of #4618, which merged before they could be folded in. Both confirmed against the repo rather than taken on trust.

## The opt-out was keyed on frame count, not on format

#4618 sends transparent stills through an opaque backdrop before comparing them, and lets animated captures opt out with `backdrops=False`. That opt-out was reached through `n_frames > 1` — every animated capture — but the reasoning behind it is **GIF's specifically**: 1-bit alpha thresholds an anti-aliased edge into a handful of flipping pixels per run, and on an opaque backdrop each of those is a maximum-contrast difference.

APNG is the opposite case, and this repo says so in its own words. `PreviewDiscovery.kt:960`:

> APNG rather than GIF because the asset renders on a transparent background and GIF's 1-bit alpha thresholds the anti-aliased edge into a churn-prone hard boundary; APNG carries full alpha

and `:3151` — `@InteractionPreview` writes `renders/<id>.apng` **by default**. So every interaction capture is transparent, full-alpha, frequently light content: exactly what the backdrop pass exists for, inheriting an exemption meant for the format that cannot produce the churn it exempts.

The opt-out now reads `Image.format`, taken **before** iterating — a frame yielded by `ImageSequence.Iterator` carries no `.format` of its own, so reading it per-frame would have silently disabled the opt-out for GIFs too.

## The image tests never ran in CI

`actions-tests` runs on a bare `ubuntu-latest` with no pip install, so pixelmatch and Pillow are absent and every class that opens a PNG skips itself. From #4618's own run:

```
setUpClass (AnimatedGifPerceptualFilterTest)  ... skipped 'pixelmatch/Pillow not installed'
setUpClass (HighContrastPassTest)             ... skipped
setUpClass (PerceptualFilterRealLibTest)      ... skipped
setUpClass (ResourceSizeAwareToleranceTest)   ... skipped
setUpClass (TransparentLightContentTest)      ... skipped
Ran 123 tests in 0.041s
OK (skipped=5)
```

`test_vscode_preview_diff.py` skipped 2 more. The suite that decides what the diff bot reports has never executed its image logic in CI — so the icon-size-2dp fix and #4618 were both pinned by tests that ran nowhere but a contributor's laptop. A skip is invisible in a green check, and nothing said so.

`ci.yml` now installs the same pins the production actions use (`pixelmatch==0.4.0`, `Pillow>=10`), deliberately **without** their `|| echo … falling back`: a fallback is right for a diff that can degrade to strict bytes, and wrong for the tests that prove the diff.

Because a dropped step would silently restore the skip, `PerceptualLibrariesTest` fails the suite when `GITHUB_ACTIONS` is set and the imports are missing. The skip stays a local convenience by construction rather than by memory.

## What the new tests pin

`AnimatedBackdropOptOutTest` writes its own two-frame fixtures rather than committing binaries — the *container* is the point, and two frames of a white square on transparency say it exactly (white on transparency is what cancels against pixelmatch's white blend, so the pair is invisible without a backdrop in either format).

Both halves verified non-vacuous:

- the APNG assertion **fails** against the old `n_frames > 1` keying;
- the GIF pair reads changed with backdrops on and unchanged with them off, so its `assertFalse` exercises the opt-out rather than passing by accident.

The CI guard was exercised both ways too: passing with the libraries present, and failing with their imports blocked under `GITHUB_ACTIONS=true`.

## Test plan

```
python3 .github/actions/lib/test_compare_previews.py     # 143 tests
python3 .github/actions/lib/test_vscode_preview_diff.py  # 10
python3 .github/ci/test_path_scope.py                    # 22
```

All green, and `Actions Script Tests` is green on this head — which now means something, since it is the run that actually executes the image logic.

Non-visual: a comparison predicate and a CI step. No rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx