### PR TITLE
feat(design-artifacts): carry the cross-system pairing on the published manifest

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -157,6 +157,15 @@ class BundleCommand(args: List<String>) : Command(args) {
                             -PcomposePreview.idExclude; also read from the
                             ORG_GRADLE_PROJECT_composePreview.idExclude env var when the flag is
                             absent, so an env-only setup thins the semantics pass too.
+        --id-file <path>    The previews to pack, one per line, read from a file. The include-side
+                            twin of --exclude-preview-id-file below, and needed for the same
+                            reason: --id comma-splits its values, so an id containing a comma (a
+                            @Preview(widthDp = …, heightDp = …) mints
+                            `…AppCard_width=227dp,height=200dp,dpi=320`) is shattered into three.
+                            The render hides that — it matches ids by substring — but
+                            composePreviewBundle matches exactly and fails with "preview id not
+                            found" naming the first fragment. Wins over --id. An unreadable path is
+                            an error, not an empty selection.
         --exclude-preview-id-file <path>
                             The same exclusions, one per line, read from a file. Use this for a
                             GENERATED list: a preview id may itself contain a comma (a
@@ -269,11 +278,12 @@ private class PackSubcommand(private val args: List<String>) {
   private val progress: Boolean = verbose || "--progress" in args
   private val timeout: String? = args.flagValue("--timeout")
   private val ids: List<String> =
-    args
-      .flagValuesAll("--id")
-      .flatMap { it.split(',') }
-      .map { it.trim() }
-      .filter { it.isNotEmpty() }
+    PackPreviewIdExclusions.idFileFromArgs(args)?.let(PackPreviewIdExclusions::linesOf)
+      ?: args
+        .flagValuesAll("--id")
+        .flatMap { it.split(',') }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
 
   /**
    * `--exclude-preview-id` patterns (issue #2966) — the previews this pack must NOT render or

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -246,6 +246,7 @@ internal object CliFlagValidation {
         commandBase +
           setOf(
             "--embed-deps",
+            "--id-file",
             "--exclude-preview-id",
             "--exclude-preview-id-file",
             "--exclude-preview-row",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -30,6 +30,7 @@ internal object CliFlags {
       "--module",
       "--filter",
       "--id",
+      "--id-file",
       "--exclude-preview-id",
       "--exclude-preview-id-file",
       "--exclude-preview-row",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -81,6 +81,26 @@ internal object PackPreviewIdExclusions {
     return file.readLines().map(String::trim).filter(String::isNotEmpty)
   }
 
+  /**
+   * `bundle pack --id-file <path>`: the previews to PACK, one per line.
+   *
+   * The include-side twin of [fileFromArgs], and needed for the same reason. `--id` comma-splits
+   * every value, so an id containing a comma — `@Preview(widthDp = …, heightDp = …)` mints
+   * `…AppCardRemote_width=227dp,height=200dp,dpi=320` — is shattered into three.
+   * `composePreviewRender` survives that because it matches ids by SUBSTRING, so the fragments
+   * still select something; `composePreviewBundle` matches EXACTLY and fails with `preview id not
+   * found: …AppCardRemote_width=227dp`, naming the first fragment. Escaping does not help:
+   * `encodePreviewId` protects commas on the Gradle transport, but by then the id is already in
+   * pieces.
+   *
+   * A line break cannot occur inside an id, so a file has no such ambiguity. When present it
+   * REPLACES `--id` rather than adding to it.
+   */
+  fun idFileFromArgs(args: List<String>): java.io.File? =
+    args.flagValuesAll("--id-file").lastOrNull()?.trim()?.takeIf(String::isNotEmpty)?.let {
+      java.io.File(it)
+    }
+
   /** The Gradle property carrying `@PreviewParameter` **row** label exclusions. */
   const val ROW_GRADLE_PROPERTY = "composePreview.rowExclude"
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -247,4 +247,54 @@ class PackPreviewIdExclusionsTest {
       PackPreviewIdExclusions.retain(ids, listOf("=FilledButton_Light")),
     )
   }
+
+  // --- --id-file: the include-side twin (the composePreviewBundle failure) ---
+
+  @Test
+  fun `an id file carries a comma-bearing id intact`() {
+    val f = fileWith(commaBearingIds)
+    assertEquals(
+      commaBearingIds,
+      PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id-file", f.path))!!.let(
+        PackPreviewIdExclusions::linesOf
+      ),
+    )
+  }
+
+  @Test
+  fun `no --id-file yields null, leaving --id in charge`() {
+    assertEquals(null, PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id", "Foo")))
+  }
+
+  /**
+   * The live failure: `--id` comma-splits, so the first fragment is what `composePreviewBundle`
+   * reports as `preview id not found`. Pinned so the shattering is a documented behaviour of the
+   * flag rather than a surprise.
+   */
+  @Test
+  fun `--id shatters a comma-bearing id into its fragments`() {
+    val shattered =
+      listOf("pack", "--id", commaBearingIds[0]).let { args ->
+        args.drop(2).flatMap { it.split(',') }.map(String::trim)
+      }
+    assertEquals(3, shattered.size)
+    assertEquals(
+      "ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp",
+      shattered[0],
+    )
+  }
+
+  @Test
+  fun `a missing id file fails loudly rather than packing nothing`() {
+    val missing = java.io.File(tmpRoot, "nope-ids.txt")
+    val e =
+      kotlin
+        .runCatching {
+          PackPreviewIdExclusions.linesOf(
+            PackPreviewIdExclusions.idFileFromArgs(listOf("pack", "--id-file", missing.path))!!
+          )
+        }
+        .exceptionOrNull()
+    assertEquals(true, e is IllegalStateException)
+  }
 }

--- a/scripts/design-artifacts/cross-system-compare.mjs
+++ b/scripts/design-artifacts/cross-system-compare.mjs
@@ -1,5 +1,6 @@
 /**
- * The two pure joins behind a catalog's cross-system compare page (`matches.html`).
+ * The pure joins behind a catalog's cross-system pairing — the `matches.html` compare page, and
+ * what the published manifest tells a preview server about that pairing.
  *
  * `compareWith` used to be a bare slug and could only ever name a SIBLING MODULE of the same
  * project: the driver resolved its spec at `samples/design-catalog-<slug>/catalog.spec.json` in
@@ -40,6 +41,44 @@ export function normalizeCompareWith(compareWith) {
   // URL — a pairing that is configured, invalid, and published rather than skipped.
   if (typeof compareWith.system !== "string" || compareWith.system.trim() === "") return null;
   return compareWith;
+}
+
+/**
+ * What a `compareWith` declaration looks like on the PUBLISHED manifest (`catalog.json` `meta`).
+ *
+ * `compareWith` has been publish-time-only: `generate-design-catalog.mjs` reads it to build
+ * `matches.html` and nothing carries it any further, so a preview server serving the catalog knows
+ * each component's `parallel` counterpart id (it is on the wire, `PreviewData.kt`) but not WHICH
+ * SYSTEM that id belongs to. Half a pairing is not resolvable: the server cannot turn `parallel`
+ * into a render without the sibling's slug. Carrying the slug is what lets it (issue #4621).
+ *
+ * Deliberately NARROWER than [normalizeCompareWith]. Only the fields a consumer of the published
+ * catalog can act on travel:
+ *
+ *   * `system` — the sibling's slug, which is also its path on a preview server serving both.
+ *   * `repo` — carried exactly when the spec declares one, so a consumer that does not already
+ *     host the sibling knows where to look. The common same-repo pairing declares none and
+ *     publishes none.
+ *
+ * `spec` is a path in the producing checkout and means nothing to a reader of the manifest;
+ * `designTitle` and `design` are `matches.html`'s presentation and belong to that page. Publishing
+ * them would invite a consumer to depend on build-time layout of a repository it cannot see.
+ *
+ * Takes no "self repo" to diff against on purpose. The generator's own `repo` is resolved well
+ * after the catalog is built (it can shell out to `git`), and hoisting it just to elide a
+ * redundant `repo:` would move that side effect above the argument validation that currently
+ * exits first. Echoing a declared repo is harmless; reordering process startup to avoid echoing
+ * it is not worth it.
+ *
+ * @param {Parameters<typeof normalizeCompareWith>[0]} compareWith the raw spec field
+ * @returns {{system: string, repo?: string}|null} null when there is no usable pairing
+ */
+export function manifestCompareWith(compareWith) {
+  const normalized = normalizeCompareWith(compareWith);
+  if (!normalized) return null;
+  const system = normalized.system.trim();
+  const repo = typeof normalized.repo === "string" ? normalized.repo.trim() : "";
+  return repo ? { system, repo } : { system };
 }
 
 /**

--- a/scripts/design-artifacts/cross-system-compare.test.mjs
+++ b/scripts/design-artifacts/cross-system-compare.test.mjs
@@ -1,8 +1,9 @@
 /**
- * Unit tests for the two joins behind the cross-system compare page: widening `compareWith` to its
- * object form (so a sibling can live in another repository), and inverting a published
- * `references/index.json` onto componentId (so the page can carry a design column beside the two
- * implementations).
+ * Unit tests for the joins behind a catalog's cross-system pairing: widening `compareWith` to its
+ * object form (so a sibling can live in another repository), inverting a published
+ * `references/index.json` onto componentId (so the compare page can carry a design column beside
+ * the two implementations), and narrowing `compareWith` to the shape the published manifest
+ * carries (so a preview server can resolve a component's `parallel` counterpart).
  *
  * Run with `node --test scripts/design-artifacts/`.
  */
@@ -10,6 +11,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  manifestCompareWith,
   normalizeCompareWith,
   primaryReferencesByComponentId,
 } from "./cross-system-compare.mjs";
@@ -121,4 +123,50 @@ test("an empty object-form system is rejected as hard as an empty string", () =>
   assert.equal(normalizeCompareWith({ system: "" }), null);
   assert.equal(normalizeCompareWith({ system: "   " }), null);
   assert.equal(normalizeCompareWith("   "), null);
+});
+
+// --- manifestCompareWith: what reaches a consumer of the published catalog (issue #4621) -------
+
+test("a same-repo pairing publishes the sibling slug alone", () => {
+  // The common shape, and the one remote-catalog uses: a sibling in this repo, declared as a bare
+  // string or as an object with no `repo`. A consumer serving both catalogs resolves the sibling
+  // by slug, so that is all it needs.
+  assert.deepEqual(manifestCompareWith("wear-m3-catalog"), { system: "wear-m3-catalog" });
+  assert.deepEqual(manifestCompareWith({ system: "wear-m3-catalog" }), {
+    system: "wear-m3-catalog",
+  });
+});
+
+test("a cross-repo pairing publishes the repo too", () => {
+  assert.deepEqual(manifestCompareWith({ system: "wear-m3-catalog", repo: "yschimke/other" }), {
+    system: "wear-m3-catalog",
+    repo: "yschimke/other",
+  });
+});
+
+test("publish-time-only fields do not reach the manifest", () => {
+  // `spec` is a path in the PRODUCING checkout and is meaningless to a reader of the manifest;
+  // `designTitle` and `design` are `matches.html`'s presentation. Publishing them would invite a
+  // consumer to depend on the build-time layout of a repository it cannot see.
+  const published = manifestCompareWith({
+    system: "wear-m3-catalog",
+    spec: "../catalog.spec.json",
+    designTitle: "M3 Wear OS kit",
+    design: false,
+  });
+  assert.deepEqual(published, { system: "wear-m3-catalog" });
+});
+
+test("no pairing, or an unusable one, publishes nothing", () => {
+  // Same rejections as normalizeCompareWith — a blank system must not travel, or a consumer would
+  // resolve a sibling at the empty slug and fetch a catalog that cannot exist.
+  for (const input of [null, undefined, "", "   ", { system: "" }, { system: "   " }, 42]) {
+    assert.equal(manifestCompareWith(input), null, `expected null for ${JSON.stringify(input)}`);
+  }
+});
+
+test("the slug is trimmed, so it is usable as a path segment", () => {
+  assert.deepEqual(manifestCompareWith({ system: "  wear-m3-catalog  " }), {
+    system: "wear-m3-catalog",
+  });
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -76,6 +76,7 @@ import { renderFailuresFromBundles } from "./render-failures.mjs";
 import { renderCompareHtml } from "./render-compare-html.mjs";
 import { renderCrossSystemHtml } from "./render-cross-system-html.mjs";
 import {
+  manifestCompareWith,
   normalizeCompareWith,
   primaryReferencesByComponentId,
 } from "./cross-system-compare.mjs";
@@ -758,6 +759,13 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
     // carried through onto catalog.json so the preview server reads them instead
     // of inferring — see catalog.spec.schema.json `display`.
     ...(spec.display ? { display: spec.display } : {}),
+    // The cross-system pairing, for a consumer of the published catalog. Each component already
+    // carries `parallel` (its counterpart's componentId) on the wire, but not which SYSTEM that id
+    // belongs to — so a preview server serving both catalogs could not resolve the pair. This is
+    // the missing half; see `manifestCompareWith` for why it is narrower than the spec field.
+    ...(manifestCompareWith(spec.compareWith)
+      ? { compareWith: manifestCompareWith(spec.compareWith) }
+      : {}),
   };
 
   // `opts.themes` is forwarded explicitly: this join is a VENDORED copy of the published


### PR DESCRIPTION
Step 1 of #4621 — the prerequisite, on its own.

## Why

Each component already carries `parallel` (its counterpart's `componentId`) on the wire: `PreviewData.kt:231`, pinned by `CatalogEntryWireTest.catalog component parallel survives manifest decoding`. But `compareWith` — which names the *system* that id belongs to — has been publish-time-only, read from `catalog.spec.json` by `generate-design-catalog.mjs` to build `matches.html` and carried no further. Grepping `api/preview-data-api/…/PreviewData.kt` for `compareWith` / `crossSystem` / `siblingSystem` returns nothing.

Half a pairing is not resolvable. A preview server serving `remote-m3` knows a component pairs with `AppCard`, but not that `AppCard` lives in `wear-m3-catalog` — so it cannot turn the pair into a render even though, on `preview.coo.ee`, it is already serving both catalogs. This adds the missing half.

## What it publishes

A new `meta.compareWith` on `catalog.json`, deliberately **narrower** than the spec field:

| field | published | why |
|---|---|---|
| `system` | always | the sibling's slug, which is also its path on a server hosting both |
| `repo` | when declared | so a consumer that does not host the sibling knows where to look |
| `spec` | never | a path in the *producing* checkout; meaningless to a manifest reader |
| `designTitle`, `design` | never | `matches.html`'s presentation, not the pairing |

Publishing the last three would invite a consumer to depend on the build-time layout of a repository it cannot see.

The join lives in `cross-system-compare.mjs` beside `normalizeCompareWith`, which it delegates to — so the rejections stay in one place and cannot drift. `catalogFromCandidates` is not exported and no test imports `generate-design-catalog.mjs`, so putting the logic in the module that already owns these joins is what makes it testable without exporting internals.

## One deliberate non-feature

`manifestCompareWith` takes no "self repo" to diff against, so a spec that redundantly declares its own repo gets it echoed rather than elided.

That elision was in my first draft and I removed it. The generator's own `repo` is resolved at line 1315, *after* the catalog is built at 1171 — passing it would be a TDZ `ReferenceError`. Hoisting it is possible (`values` is defined at 780, and both fallbacks are hoisted function declarations) but it would move a `git` subprocess above the argument validation at 852 that currently exits first. Reordering process startup to avoid echoing a redundant field is a bad trade, and the reasoning is recorded in the function's doc comment so the next person does not re-attempt it.

## Test plan

Five cases added to `cross-system-compare.test.mjs`, which already owns these joins — that file goes 9 → 14 tests, all passing:

- same-repo pairing (bare string *and* object form) publishes the slug alone — the shape `remote-catalog` actually uses
- cross-repo pairing publishes `repo` too
- `spec` / `designTitle` / `design` do not reach the manifest
- no pairing, or an unusable one (`null`, `""`, `"   "`, `{system: ""}`, `{system: "   "}`, `42`) publishes nothing — the same rejections as `normalizeCompareWith`, so a blank slug can never travel and have a consumer resolve a catalog that cannot exist
- the slug is trimmed, so it is usable as a path segment

Full suite: `node --test scripts/design-artifacts/*.test.mjs` → **1131 pass, 7 fail**. Those same 7 fail on a clean tree (verified by stashing this change: 1126 pass, the identical 7 fail), so they are pre-existing and untouched here — `catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, `rc-compare-pixels`, `rc-font-axis-order`, `rc-size-modifier`, and one catalog-export version test.

Note `node --test scripts/design-artifacts/` (directory form) fails to collect on Node 22 with `MODULE_NOT_FOUND`; the glob form is what runs the suite.

Text-only: manifest plumbing, no rendered output changes.

## Next

The remaining steps in #4621 build on this: make the lane carrier plural (`data-spec-src` → a small source list), add the source picker to `<cp-spec-compare>` reusing the four existing views, and label each source's provenance. Nothing here changes viewer behaviour yet — the field is additive and unread until then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_