### PR TITLE
fix(serve): let the load thresholds hold a load average, not a fraction

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmission.kt
@@ -89,8 +89,10 @@ data class OptimizerPressureThresholds(
     fun fromSystemProperties(): OptimizerPressureThresholds {
       val defaults = OptimizerPressureThresholds()
       return OptimizerPressureThresholds(
-        stopLoadPerCpu = fraction("optimizerStopLoadPerCpu") ?: defaults.stopLoadPerCpu,
-        resumeLoadPerCpu = fraction("optimizerResumeLoadPerCpu") ?: defaults.resumeLoadPerCpu,
+        // `ratio`, NOT `fraction`. Load average per CPU is not bounded by 1.0 — it is a queue
+        // depth, and a host rendering flat out sits well above one runnable task per core.
+        stopLoadPerCpu = ratio("optimizerStopLoadPerCpu") ?: defaults.stopLoadPerCpu,
+        resumeLoadPerCpu = ratio("optimizerResumeLoadPerCpu") ?: defaults.resumeLoadPerCpu,
         stopCpuUtilization = fraction("optimizerStopCpuUtilization") ?: defaults.stopCpuUtilization,
         resumeCpuUtilization =
           fraction("optimizerResumeCpuUtilization") ?: defaults.resumeCpuUtilization,
@@ -115,6 +117,31 @@ data class OptimizerPressureThresholds(
     /** A ratio in `0.0..1.0`; anything outside that is a typo, so ignore it rather than obey it. */
     private fun fraction(name: String): Double? =
       System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf { it in 0.0..1.0 }
+
+    /**
+     * A load average per CPU, which is a **queue depth and not a fraction**: one runnable task per
+     * core reads 1.0, and a host deliberately rendering flat out sits above that.
+     *
+     * These two thresholds were parsed by [fraction] and silently lost every value over 1.0. On
+     * preview.coo.ee, whose load while the optimizer works measures 1.03 to 1.74 per CPU, that made
+     * the load limb impossible to relax: the stop side could not be raised past its 0.85 default,
+     * so the gate tripped on the optimizer's own rendering and the override an operator wrote was
+     * dropped without a word. Failing closed is right for a typo in a percentage; it is wrong for a
+     * number whose legitimate range simply is not `0..1`.
+     *
+     * Still bounded, because a typo is still a typo — but at a ceiling no real box reaches rather
+     * than at one every busy box exceeds. Above it, the default stands, as before.
+     */
+    private fun ratio(name: String): Double? =
+      System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf {
+        it in 0.0..MAX_LOAD_PER_CPU
+      }
+
+    /**
+     * Ceiling for a load-per-CPU threshold. A box whose load average is 64x its core count is not a
+     * box an operator is tuning; it is one that has already fallen over.
+     */
+    private const val MAX_LOAD_PER_CPU = 64.0
 
     /** Zero is meaningful (sample every call, never hold), so only negatives are rejected. */
     private fun millis(name: String): Long? =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/HostOptimizerAdmissionTest.kt
@@ -612,6 +612,73 @@ class HostOptimizerAdmissionTest {
     assertFalse(gate.snapshot().constrained)
   }
 
+  /**
+   * Load average per CPU is a queue depth, not a percentage.
+   *
+   * Both load thresholds were parsed as fractions and silently discarded every value over 1.0 —
+   * which is every value that matters on a host rendering flat out. Measured on preview.coo.ee
+   * while the optimizer worked: 1.03, 1.12 and 1.74 per CPU. The stop side therefore could not be
+   * lifted off its 0.85 default, so the gate tripped on the optimizer's own load and the operator's
+   * override vanished without a word.
+   */
+  @Test
+  fun `a load threshold above one is a setting, not a typo`() {
+    val stop = "composeai.serve.optimizerStopLoadPerCpu"
+    val resume = "composeai.serve.optimizerResumeLoadPerCpu"
+    val previousStop = System.getProperty(stop)
+    val previousResume = System.getProperty(resume)
+    try {
+      // The case the box actually needs: hold only once load passes two runnable tasks per core,
+      // and resume at one and a half. Neither is expressible as a fraction.
+      System.setProperty(stop, "2.5")
+      System.setProperty(resume, "1.5")
+      val tuned = OptimizerPressureThresholds.fromSystemProperties()
+      assertEquals(2.5, tuned.stopLoadPerCpu)
+      assertEquals(1.5, tuned.resumeLoadPerCpu)
+
+      // Still bounded — a typo is still a typo, just not at a ceiling every busy box exceeds.
+      System.setProperty(stop, "1000")
+      assertEquals(
+        OptimizerPressureThresholds().stopLoadPerCpu,
+        OptimizerPressureThresholds.fromSystemProperties().stopLoadPerCpu,
+      )
+
+      // Negative load is meaningless, so it falls back too.
+      System.setProperty(stop, "-1")
+      assertEquals(
+        OptimizerPressureThresholds().stopLoadPerCpu,
+        OptimizerPressureThresholds.fromSystemProperties().stopLoadPerCpu,
+      )
+    } finally {
+      if (previousStop == null) System.clearProperty(stop)
+      else System.setProperty(stop, previousStop)
+      if (previousResume == null) System.clearProperty(resume)
+      else System.setProperty(resume, previousResume)
+    }
+  }
+
+  /**
+   * The limbs that ARE fractions must stay fractions — the fix above must not widen CPU or memory,
+   * where a value over 1.0 really is a percentage someone forgot to divide.
+   */
+  @Test
+  fun `a cpu or memory threshold above one is still refused`() {
+    val cpu = "composeai.serve.optimizerStopCpuUtilization"
+    val previous = System.getProperty(cpu)
+    try {
+      System.setProperty(cpu, "96")
+      assertEquals(
+        OptimizerPressureThresholds().stopCpuUtilization,
+        OptimizerPressureThresholds.fromSystemProperties().stopCpuUtilization,
+        "96 means 96%, and obeying it as a ratio would disable the CPU limb entirely",
+      )
+      System.setProperty(cpu, "0.96")
+      assertEquals(0.96, OptimizerPressureThresholds.fromSystemProperties().stopCpuUtilization)
+    } finally {
+      if (previous == null) System.clearProperty(cpu) else System.setProperty(cpu, previous)
+    }
+  }
+
   @Test
   fun `thresholds fall back to defaults when system properties are absent or unparseable`() {
     val key = "composeai.serve.optimizerStopMemoryAvailableFraction"

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -168,6 +168,39 @@ point: that edit is drift from `main`.
 > docker compose exec preview cat /config/catalogs.json
 > ```
 
+### Warming the theme cache aggressively
+
+The pressure gate's defaults assume a box whose spare capacity belongs to visitors. While the cache
+is still filling, that trade is backwards: an empty cache means every theme a visitor picks is a
+cold render, so the fastest route to a *responsive* box is to let the optimizer have the machine for
+a few hours and then hand it back.
+
+```
+SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 \
+  -Dcomposeai.serve.optimizerStopLoadPerCpu=3.0 \
+  -Dcomposeai.serve.optimizerResumeLoadPerCpu=2.0 \
+  -Dcomposeai.serve.optimizerStopCpuUtilization=0.98 \
+  -Dcomposeai.serve.optimizerResumeCpuUtilization=0.92
+```
+
+Read that as: start a pass after ten seconds of quiet rather than sixty, and only stand down when
+the box is genuinely saturated rather than merely busy.
+
+**Leave the memory thresholds alone.** CPU and load contention costs latency and recovers on its
+own; running out of memory kills render daemons and takes the catalog with them. `0.15` stop /
+`0.25` resume is the one limb where the conservative default is earning something.
+
+**The load thresholds are per-CPU load averages, not percentages.** One runnable task per core reads
+`1.0`, so a box rendering flat out sits *above* 1.0 — `3.0` means "three deep per core". Values
+above `1.0` were silently discarded before the fix that added this section, which is why raising
+this limb appeared to do nothing.
+
+Watch `themeOptimizer.pressure.reason` on `/status.json` to see which limb is actually holding:
+`load N per CPU`, `CPU N%`, `memory available N%`, or `host recovering` (a limb that tripped and has
+not yet fallen back to its resume side). Tune the one that is named; the others are not the problem.
+
+Undo it by removing the properties and restarting once the catalogs report converged.
+
 ### Regenerating a catalog's warmed theme renders
 
 Two admin routes for pixels you suspect are wrong for a reason no fingerprint sees — a base-image


### PR DESCRIPTION
Asked to make theme optimization more aggressive on `preview.coo.ee`, I found the setting that would do it cannot be set.

## A validator that rejected every value worth writing

`optimizerStopLoadPerCpu` and `optimizerResumeLoadPerCpu` were parsed by the same `fraction` helper as the CPU and memory limbs:

```kotlin
private fun fraction(name: String): Double? =
  System.getProperty("composeai.serve.$name")?.toDoubleOrNull()?.takeIf { it in 0.0..1.0 }
```

Load average per CPU is not a fraction. It is a **queue depth** — one runnable task per core reads `1.0`, and a host deliberately rendering flat out sits above that. So every value that would have relaxed this limb was discarded on the way in, and the 0.85 default stood.

Measured on `preview.coo.ee` while the optimizer worked: **1.03, 1.12, 1.74** per CPU. The gate was tripping on the optimizer's own rendering, against a stop side that could not be lifted. The operator's override vanished silently — the failure mode a validator that "ignores typos" always has when its idea of a typo is wrong.

Parsed with a `ratio` helper instead: still bounded, but at 64× cores — a ceiling no real box reaches rather than one every busy box exceeds. CPU and memory keep `fraction`, where a value over 1.0 genuinely is a percentage someone forgot to divide.

## Test plan

- `HostOptimizerAdmissionTest`
  - *a load threshold above one is a setting, not a typo* — `2.5` / `1.5` are accepted (the values the box actually needs, neither expressible as a fraction); `1000` and `-1` still fall back to the default.
  - *a cpu or memory threshold above one is still refused* — `96` falls back rather than being obeyed as a ratio, which would disable the CPU limb outright; `0.96` is accepted. This is the guard that the fix did not widen the limbs that really are fractions.
- `./gradlew :cli:serve:test` green; `ktfmtCheckMain` / `ktfmtCheckTest` clean.

## Also: how to warm aggressively

The deploy README gains a section, because the gate's defaults assume spare capacity belongs to visitors — and while the cache is empty that trade is backwards. Every theme a visitor picks is a cold render anyway, so the fastest route to a responsive box is to let the optimizer have the machine for a few hours and then hand it back.

It calls out the one limb to leave alone: **memory**. CPU and load contention cost latency and recover on their own; running out of memory kills the render daemons and takes the catalog with them. It also explains reading `pressure.reason` to find which limb is actually holding, so the next person tunes the named one rather than all of them.

Not visually verified: threshold parsing and operator docs — no rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_