### PR TITLE
fix(design-artifacts): stamp compareWith onto the written manifest, and refuse an empty id file

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -67,18 +67,32 @@ internal object PackPreviewIdExclusions {
       ?.let { java.io.File(it) }
 
   /**
-   * The patterns in [file], one per line, blanks dropped.
+   * The ids in [file], one per line, blanks dropped. Never empty.
    *
-   * An unreadable file throws rather than yielding an empty list: an exclusion set that silently
-   * became "exclude nothing" renders the whole sheet and reports success, which is exactly the
-   * quiet failure this path exists to prevent.
+   * An unreadable file throws rather than yielding an empty list, and so does a file that is
+   * present but carries no ids. Both would otherwise become "no selection", and for BOTH flags that
+   * reads as *everything* rather than nothing:
+   *
+   * * `--id-file` — an empty list leaves `-PbundlePreviewIds` unset, and `bundle pack` then packs
+   *   the whole catalog. A generated shard file that came out empty would silently pack every
+   *   preview instead of its slice, on every shard.
+   * * `--exclude-preview-id-file` — an empty list excludes nothing, so the whole sheet renders.
+   *
+   * Either way the run reports success while having done the opposite of what the file asked. A
+   * caller with legitimately nothing to select should not pass the flag; that is what the `[ -s …
+   * ]` / non-zero-count guards on the calling side already express.
    */
   fun linesOf(file: java.io.File): List<String> {
     check(file.isFile) {
-      "--exclude-preview-id-file '${file.path}' is not a readable file. Refusing to fall back to " +
-        "an empty exclusion list, which would render every preview and look like success."
+      "'${file.path}' is not a readable file. Refusing to fall back to an empty selection, which " +
+        "would act on every preview and look like success."
     }
-    return file.readLines().map(String::trim).filter(String::isNotEmpty)
+    val lines = file.readLines().map(String::trim).filter(String::isNotEmpty)
+    check(lines.isNotEmpty()) {
+      "'${file.path}' contains no preview ids. Refusing to fall back to an empty selection, which " +
+        "would act on every preview and look like success. Omit the flag instead."
+    }
+    return lines
   }
 
   /**

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -297,4 +297,32 @@ class PackPreviewIdExclusionsTest {
         .exceptionOrNull()
     assertEquals(true, e is IllegalStateException)
   }
+
+  // --- an empty file is not "no selection" ------------------------------------------------------
+
+  /**
+   * The trap: for BOTH flags an empty list reads as *everything*, not nothing. `--id-file` leaves
+   * `-PbundlePreviewIds` unset and `bundle pack` packs the whole catalog; an empty exclusion list
+   * excludes nothing and the whole sheet renders. A generated shard file that came out empty would
+   * silently do the opposite of what it asked, on every shard, and report success.
+   */
+  @Test
+  fun `a present but empty file is refused rather than read as no selection`() {
+    for (content in listOf("", "\n", "   \n\t\n   ")) {
+      val f = fileWith(emptyList()).apply { writeText(content) }
+      val e = kotlin.runCatching { PackPreviewIdExclusions.linesOf(f) }.exceptionOrNull()
+      assertEquals(
+        true,
+        e is IllegalStateException,
+        "expected a throw for ${content.length} blank char(s)",
+      )
+      assertEquals(true, e!!.message!!.contains("contains no preview ids"))
+    }
+  }
+
+  @Test
+  fun `a file with one id among blank lines is still a selection`() {
+    val f = fileWith(listOf("", "   ", commaBearingIds[0], ""))
+    assertEquals(listOf(commaBearingIds[0]), PackPreviewIdExclusions.linesOf(f))
+  }
 }

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -1523,6 +1523,14 @@ if (values["publish-live-bundle"]) {
   // `@design-parity/catalog-export` predates `display` in `toCatalogManifest`; once a release
   // carrying it lands and the dep is bumped, `buildCatalog` writes it and this can be dropped.
   if (spec.display) manifest.display = spec.display;
+  // Same post-process, same reason, and NOT optional: `toCatalogManifest` allow-lists the fields it
+  // knows, so `compareWith` set on `buildCatalog`'s meta above is dropped on the way out and the
+  // field never reaches `catalog.json` — the published manifest looks exactly as it did before and
+  // nothing says otherwise. Setting it in both places is deliberate: the meta is where it belongs
+  // once the pinned exporter learns the field, this stamp is what makes it real today, and the two
+  // agreeing is what lets the stamp be deleted rather than hunted for.
+  const publishedCompareWith = manifestCompareWith(spec.compareWith);
+  if (publishedCompareWith) manifest.compareWith = publishedCompareWith;
   if (webRender) manifest.webRender = webRender;
   if (liveBundle) manifest.liveBundle = liveBundle;
   if (liveBundles.length > 0) manifest.liveBundles = liveBundles;


### PR DESCRIPTION
Two real review findings from #4623 and #4615. Both were correct; #4623 merged before I could push the first, so it lands here.

## 1. `compareWith` never reached `catalog.json` (#4623 was a no-op)

`writeCatalog` converts the in-memory catalog through the pinned `@design-parity/catalog-export`'s allow-listed `toCatalogManifest`, which drops metadata it does not know. #4623 set `compareWith` only on `buildCatalog`'s meta, so it was dropped on the way out: the published manifest looked exactly as before and nothing said otherwise.

The generator already documents this hazard twice and I walked past both:

- line 1523, the `display` stamp: *"the pinned `@design-parity/catalog-export` predates `display` in `toCatalogManifest`; once a release carrying it lands and the dep is bumped, `buildCatalog` writes it and this can be dropped"*
- the `noReference` note: *"on an older pinned package `buildCatalog` drops them and the fields stop here"*

Fixed by mirroring the `display` precedent exactly — set in **both** places. The meta assignment is where the field belongs once the pinned exporter learns it; the post-`writeCatalog` stamp is what makes it real today. Keeping the two in agreement is what lets the stamp be deleted later rather than hunted for.

## 2. An empty id file packed the entire catalog

From #4615's review. `linesOf` returned an empty list for a present-but-empty file, and an empty `ids` is indistinguishable from "no selection" — which for both flags means **everything**, not nothing:

| flag | empty list means |
|---|---|
| `--id-file` | `-PbundlePreviewIds` unset ⇒ `bundle pack` packs the whole catalog |
| `--exclude-preview-id-file` | excludes nothing ⇒ the whole sheet renders |

A generated shard file that came out empty would have silently done the opposite of what it asked, on every shard, and reported success. That is the same class of quiet wrong-answer the `--id-file` flag was added to eliminate.

`linesOf` already refused an *unreadable* file for precisely this reason; it now refuses an empty one too. Fixing it there rather than at the `--id-file` call site covers the exclusion flag as well — the review only flagged the include side, but the hole is symmetric.

**Behaviour change worth naming:** design-parity guards the exclusion flag with `[ -s slice-excluded.txt ]`, but passes `--id-file` whenever the shard's component count is non-zero. If a shard ever had components but no preview ids, that run now fails loudly instead of packing every preview. That is the intended outcome, but it is a new hard failure, not just a better message.

## Test plan

- `PackPreviewIdExclusionsTest` gains two cases: a present-but-empty file is refused (`""`, `"\n"`, and whitespace-only all throw, asserting on the message), and a file with one id among blank lines is still a valid selection.
- `node --test scripts/design-artifacts/*.test.mjs` → 1131 pass, 7 fail; the same 7 fail on a clean tree, unchanged from #4623.
- `cross-system-compare.test.mjs` 14/14.
- ktfmt 0.64 (Google style) clean on both Kotlin files.

Not verified locally: no Android SDK, so Gradle cannot configure and the Kotlin suite could not run here — CI is the first compile. The `.mjs` half I ran.

## The third finding, which was false

The review also claimed commit `f1e22177` records `Codex <codex@openai.com>` as author and committer. That commit does not exist in this repository (`git cat-file -t f1e22177` → *"Not a valid object name"*), every commit on both branches is `Yuri Schimke <yuri@schimke.ee>`, and `.github/scripts/agent-attribution-scan.sh` exits 0. This is the third time that same claim has appeared on a PR of mine and been false; I check it each time rather than assume.

A fourth finding — that `--id-file` needs documenting in the `yschimke/skills` consumer docs per `docs/AGENTS.md:39` — is legitimate and I am doing it separately, in that repo where it belongs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_