### PR TITLE
feat(design-artifacts): publish each component's cross-system parallel

### DIFF
--- a/scripts/design-artifacts/apply-parallels.mjs
+++ b/scripts/design-artifacts/apply-parallels.mjs
@@ -1,0 +1,62 @@
+/**
+ * Stamp each spec component's `parallel` (its counterpart in the `compareWith` sibling) onto the
+ * built catalog manifest.
+ *
+ * `parallel` has been build-time-only in practice. It is on the *bundle* wire model
+ * (`PreviewData.kt`'s `CatalogEntry.parallel`) and the generator reads it off the spec to build
+ * `matches.html` — but the PUBLISHED `catalog.json` never carried it, because `toCatalogManifest`
+ * allow-lists the component fields it knows and drops the rest with no error anywhere. The same
+ * silent drop that hid `motion` for a day (see {@link file://./motion-carried.mjs}) and that
+ * `compareWith` needs its own post-write stamp to escape.
+ *
+ * Measured, not assumed: `remote-m3`'s published catalog — a sheet whose entire purpose is the
+ * cross-system pairing — listed 51 components and zero `parallel` fields.
+ *
+ * That is what keeps a consumer of the published catalog from resolving the pairing at all. The
+ * manifest's `compareWith` says WHICH SYSTEM the counterpart lives in; `parallel` says WHICH
+ * COMPONENT. Half a pairing resolves to nothing, so both have to travel for a preview server to
+ * offer the sibling as a comparison source (issue #4621).
+ *
+ * Additive and idempotent, exactly like {@link file://./apply-spec-sections.mjs}:
+ *  - only components whose spec entry declares a `parallel` are touched;
+ *  - a component that already carries one (a future `toCatalogManifest` that learns the field) is
+ *    left as-is, so bumping the pin makes this a no-op rather than a conflict.
+ *
+ * This carries the declaration verbatim and does NOT check that the sibling has such a component.
+ * That resolution already happens where it can be done properly — against the sibling's own
+ * inventory, when the compare page is built — and a `parallel` naming nothing there is reported
+ * as an unpaired row there. Silently dropping it here would hide a spec typo behind an absent
+ * field instead.
+ *
+ * @param {{components?: Array<{componentId: string, parallel?: string}>}} manifest
+ *   The parsed `catalog.json`, mutated in place.
+ * @param {{groups?: Array<{components?: Array<{componentId: string, parallel?: string}>}>}} spec
+ *   The catalog spec the manifest was built from.
+ * @returns {number} how many components had a `parallel` newly stamped.
+ */
+export function applyParallels(manifest, spec) {
+  const parallelByComponentId = new Map();
+  for (const group of spec?.groups ?? []) {
+    for (const component of group.components ?? []) {
+      // A blank declaration is the annotation default (`@CatalogComponent(parallel = "")`), which
+      // means "no counterpart" — publishing it as an empty string would make an absent pairing
+      // look like a declared one to every consumer that tests for the field's presence.
+      const parallel =
+        typeof component?.parallel === "string"
+          ? component.parallel.trim()
+          : "";
+      if (parallel) parallelByComponentId.set(component.componentId, parallel);
+    }
+  }
+
+  let stamped = 0;
+  for (const component of manifest?.components ?? []) {
+    if (component.parallel !== undefined) continue; // never clobber an exporter that carries it
+    const parallel = parallelByComponentId.get(component.componentId);
+    if (parallel !== undefined) {
+      component.parallel = parallel;
+      stamped += 1;
+    }
+  }
+  return stamped;
+}

--- a/scripts/design-artifacts/apply-parallels.test.mjs
+++ b/scripts/design-artifacts/apply-parallels.test.mjs
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyParallels } from "./apply-parallels.mjs";
+
+const comp = (componentId, extra = {}) => ({
+  componentId,
+  images: [],
+  ...extra,
+});
+const manifest = (components) => ({
+  schema: "design-parity-catalog/v1",
+  system: "s",
+  components,
+});
+
+test("stamps each spec component's parallel onto the matching manifest component", () => {
+  const spec = {
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Button/Filled", parallel: "FilledButton" },
+          { componentId: "Button/Outlined", parallel: "OutlinedButton" },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("Button/Filled"), comp("Button/Outlined")]);
+
+  assert.equal(applyParallels(m, spec), 2);
+  assert.equal(m.components[0].parallel, "FilledButton");
+  assert.equal(m.components[1].parallel, "OutlinedButton");
+});
+
+test("is a no-op for a catalog that declares no cross-system pairing", () => {
+  const spec = {
+    groups: [
+      { name: "Buttons", components: [{ componentId: "Button/Filled" }] },
+    ],
+  };
+  const m = manifest([comp("Button/Filled")]);
+
+  assert.equal(applyParallels(m, spec), 0);
+  assert.equal("parallel" in m.components[0], false);
+});
+
+test("treats a blank parallel as no counterpart, not as an empty declaration", () => {
+  // `@CatalogComponent(parallel = "")` is the annotation default. Publishing "" would read as a
+  // declared pairing to any consumer testing for the field's presence.
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "A", parallel: "   " },
+          { componentId: "B", parallel: "" },
+        ],
+      },
+    ],
+  };
+  const m = manifest([comp("A"), comp("B")]);
+
+  assert.equal(applyParallels(m, spec), 0);
+  assert.equal("parallel" in m.components[0], false);
+  assert.equal("parallel" in m.components[1], false);
+});
+
+test("trims a declaration rather than publishing its whitespace", () => {
+  const spec = {
+    groups: [
+      { components: [{ componentId: "A", parallel: " FilledButton " }] },
+    ],
+  };
+  const m = manifest([comp("A")]);
+
+  assert.equal(applyParallels(m, spec), 1);
+  assert.equal(m.components[0].parallel, "FilledButton");
+});
+
+test("never clobbers a parallel the exporter already carried", () => {
+  // What a bumped `@design-parity/catalog-export` pin looks like: the field arrives on its own and
+  // this stamp must become a no-op, not a second opinion.
+  const spec = {
+    groups: [{ components: [{ componentId: "A", parallel: "FromSpec" }] }],
+  };
+  const m = manifest([comp("A", { parallel: "FromExporter" })]);
+
+  assert.equal(applyParallels(m, spec), 0);
+  assert.equal(m.components[0].parallel, "FromExporter");
+});
+
+test("leaves manifest components absent from the spec untouched", () => {
+  const spec = {
+    groups: [{ components: [{ componentId: "A", parallel: "X" }] }],
+  };
+  const m = manifest([comp("A"), comp("Orphan/NotInSpec")]);
+
+  applyParallels(m, spec);
+
+  assert.equal(m.components[0].parallel, "X");
+  assert.equal("parallel" in m.components[1], false);
+});
+
+test("carries a parallel verbatim without checking the sibling has such a component", () => {
+  // Resolution belongs to the compare page, which has the sibling's inventory and reports an
+  // unresolved pairing as an unpaired row. Dropping it here would hide a spec typo.
+  const spec = {
+    groups: [{ components: [{ componentId: "A", parallel: "TypoedName" }] }],
+  };
+  const m = manifest([comp("A")]);
+
+  assert.equal(applyParallels(m, spec), 1);
+  assert.equal(m.components[0].parallel, "TypoedName");
+});
+
+test("is idempotent — a second pass stamps nothing", () => {
+  const spec = {
+    groups: [{ components: [{ componentId: "A", parallel: "X" }] }],
+  };
+  const m = manifest([comp("A")]);
+
+  assert.equal(applyParallels(m, spec), 1);
+  assert.equal(applyParallels(m, spec), 0);
+  assert.equal(m.components[0].parallel, "X");
+});
+
+test("tolerates missing/empty groups and components without throwing", () => {
+  assert.equal(applyParallels({ components: [] }, {}), 0);
+  assert.equal(applyParallels({}, { groups: [] }), 0);
+  assert.equal(
+    applyParallels({ components: [comp("X")] }, { groups: [{}] }),
+    0,
+  );
+  assert.equal(applyParallels({ components: [comp("X")] }, undefined), 0);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -136,6 +136,7 @@ import {
   extraOnlyFunctions,
   unbridgeableFunctions,
 } from "./extra-render-fold.mjs";
+import { applyParallels } from "./apply-parallels.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
 import {
@@ -1531,6 +1532,17 @@ if (values["publish-live-bundle"]) {
   // agreeing is what lets the stamp be deleted rather than hunted for.
   const publishedCompareWith = manifestCompareWith(spec.compareWith);
   if (publishedCompareWith) manifest.compareWith = publishedCompareWith;
+  // The other half of that pairing, dropped by the same allow-list for the same reason: the
+  // manifest's `compareWith` names the sibling SYSTEM, each component's `parallel` names the
+  // counterpart COMPONENT in it, and a consumer needs both to resolve anything. Measured before
+  // being fixed: `remote-m3`'s published catalog carried 51 components and zero `parallel` fields,
+  // on a sheet whose whole purpose is the cross-system comparison.
+  const stampedParallels = applyParallels(manifest, spec);
+  if (stampedParallels > 0) {
+    console.log(
+      `[${spec.system}] stamped parallel on ${stampedParallels} component(s) from spec components`,
+    );
+  }
   if (webRender) manifest.webRender = webRender;
   if (liveBundle) manifest.liveBundle = liveBundle;
   if (liveBundles.length > 0) manifest.liveBundles = liveBundles;


### PR DESCRIPTION
## The other half of a pairing

#4629 landed `compareWith` on the published manifest — the sibling **system**. Each component's `parallel` is the counterpart **component** in it. Only the first was travelling, and half a pairing resolves to nothing: a consumer of `catalog.json` knows which sheet to look at and not what to look for.

`parallel` was dropped by the same mechanism, for the same reason: `toCatalogManifest` allow-lists the component fields it knows and discards the rest, with no error anywhere. That is precisely the failure mode `motion-carried.mjs` exists to make loud — a field that was resolved, was correct, and simply never reached the file.

Measured rather than assumed, on the sheet whose entire purpose is the cross-system comparison:

```
$ curl -s .../design-artifacts/remote-m3/catalog.json | …
components: 51   with parallel: 0   compareWith: None
```

## What this does

`applyParallels(manifest, spec)` stamps the declaration post-write, beside the existing `section` / `sourceFile` / `compareWith` stamps, mirroring `applySpecSections` exactly:

- **A blank declaration publishes nothing.** `@CatalogComponent(parallel = "")` is the annotation default and means *no counterpart*; emitting `""` would read as a declared pairing to any consumer that tests for the field's presence.
- **Never clobbers.** A component the exporter already carried a `parallel` for is left alone, so bumping the `@design-parity/catalog-export` pin turns this into a no-op rather than a second opinion.
- **Carries the declaration verbatim.** Whether the sibling actually has such a component is resolved where it can be done properly — against the sibling's own inventory, when the compare page is built, which already reports an unresolved pairing as an unpaired row. Dropping it here would hide a spec typo behind an absent field.

Additive and idempotent; a catalog that declares no pairing is untouched.

## Test plan

- `node --test scripts/design-artifacts/apply-parallels.test.mjs` — 9/9 pass. Covers the stamp, the no-pairing no-op, blank/whitespace declarations, trimming, the never-clobber rule, spec-absent components, verbatim carry of an unresolvable name, idempotence, and missing/empty input.
- Full driver suite (`npm test` in `scripts/design-artifacts`): **1140 pass / 7 fail**. The same 7 fail on a clean tree at this base — `catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, the catalog-export-version test, `rc-compare-pixels`, `rc-font-axis-order`, `rc-size-modifier`. None touch this path.
- `npx prettier --check` clean on both new files. (`generate-design-catalog.mjs` is already unformatted on `main`; not reformatted here, to keep the diff to the twelve added lines.)

Non-visual change — no render surface moves, so no before/after images.

Toward #4621, whose step 1 needed both halves. The next step is the serve host reading the pair out of `catalog.json` so the spec lane can offer the sibling as a second source.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_