### PR TITLE
docs(deploy): explain the readings that make this box look mis-tuned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1345,6 +1345,12 @@ jobs:
       # reintroduce that trap and would look entirely reasonable in a diff.
       - name: Run deploy JAVA_TOOL_OPTIONS append tests
         run: ./deploy/image/test-java-opts-append.sh
+      # env-redundant.sh reads a file holding SERVE_TOKEN, SERVE_ADMIN_TOKEN, the GitHub OAuth
+      # secret and the deploy hook token, and exists so its output can be pasted somewhere. A
+      # refactor that started echoing key=value for the active list would read as an improvement in
+      # a diff and would quietly turn a tidy-up tool into a credential leak.
+      - name: Run deploy .env redundancy tests
+        run: ./deploy/image/test-env-redundant.sh
       # The agent-grant lane derives its own default (on where SERVE_GITHUB_AUTH_* gives it a human
       # to approve against, off otherwise), because both flat answers are wrong in opposite
       # directions: `1` fails startup on every box with no OAuth app, `0` ships the feature dead on

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -168,6 +168,69 @@ point: that edit is drift from `main`.
 > docker compose exec preview cat /config/catalogs.json
 > ```
 
+### Reading `/status.json` before you tune anything
+
+Four readings mislead if taken at face value. Each cost real debugging time on `preview.coo.ee`, so
+they are written down rather than rediscovered.
+
+**`pressure.reason` describes the HOLD, not the moment.** `host recovering` means a limb tripped at
+some point and the gate is now waiting out `optimizerResumeQuietMillis` (30s) of *continuous* calm
+before reopening — not that anything is over a threshold now. A box can read `memory available 81%`,
+`CPU 29%`, `load 0.42 per CPU` — every limb comfortably inside its resume side — and still be held.
+On a workload as bursty as rendering, the optimizer's own next burst re-trips a limb inside the
+recovery window, so the gate can stay shut almost permanently while every individual sample looks
+healthy. **If throughput is poor and the numbers look fine, this is why**, and
+`optimizerResumeQuietMillis` is the knob.
+
+**`daemons.running` counts sessions, not processes.** Thirteen "running" daemons on a box with four
+JVMs is normal. Multiply that by a per-daemon memory estimate and you will invent a memory crisis
+that does not exist. `docker compose exec preview ps -eo rss,comm --sort=-rss` is the honest answer.
+
+**`pressure.memoryAvailableFraction` is a spot sample, and it is spiky.** One low reading is not a
+trend — consecutive samples on this box have run 0.19, 0.34, 0.23, 0.48, 0.08, 0.81. Take two before
+believing one, and cross-check against `docker stats`.
+
+**`pressure.loadPerCpu` is a queue depth, not a percentage.** One runnable task per core reads `1.0`;
+a box rendering flat out sits above that. The thresholds take the same units.
+
+### Sizing the box
+
+| Knob | What it bounds | Default |
+| --- | --- | --- |
+| `PREVIEW_MEM_LIMIT` | Memory the whole container may use | `0` (unlimited) |
+| `SERVE_LIVE_SEATS` | Concurrent daemon *residency*, weighted (Android costs 2) | derived: `(mem_mb − 1024) / 1200`, clamped to `[2, 8]` |
+| `SERVE_BACKGROUND_RENDERS` | Optimizer renders admitted at once | derived from seats, clamped to 3 |
+
+**Both derivations clamp**, so on a large box you are running a fraction of what the hardware
+affords unless you name a number. That is what these variables are for; the seat budget still bounds
+how many daemons those renders can occupy.
+
+Measure before choosing, because the container's own `free` reports the HOST's memory and will
+happily claim 60 GiB available inside a 3 GiB container:
+
+```bash
+free -h; nproc                                                   # what the host has
+docker stats --no-stream --format \
+  'table {{.Name}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.CPUPerc}}'          # what the container uses
+docker compose exec preview ps -eo rss,comm --sort=-rss | head   # what is actually resident
+```
+
+### Tidying `.env`
+
+An `.env` accumulates lines faster than anyone removes them — a value copied from this README during
+setup, a knob turned once during an incident and turned back, a setting that later *became* the
+default. The file then reads as configuration when most of it is decoration, and the few lines that
+genuinely explain why this box differs from stock are buried.
+
+```bash
+./env-redundant.sh
+```
+
+Reports which entries restate a compose or entrypoint default and which are set but empty (the same
+as unset), then lists the keys that genuinely differ — **by name only**. It never prints a value:
+the file holds `SERVE_TOKEN`, `SERVE_ADMIN_TOKEN`, the GitHub OAuth secret and the deploy hook
+token, and the output is meant to be safe to paste into an issue or a chat.
+
 ### Warming the theme cache aggressively
 
 The pressure gate's defaults assume a box whose spare capacity belongs to visitors. While the cache
@@ -180,11 +243,20 @@ SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 \
   -Dcomposeai.serve.optimizerStopLoadPerCpu=3.0 \
   -Dcomposeai.serve.optimizerResumeLoadPerCpu=2.0 \
   -Dcomposeai.serve.optimizerStopCpuUtilization=0.98 \
-  -Dcomposeai.serve.optimizerResumeCpuUtilization=0.92
+  -Dcomposeai.serve.optimizerResumeCpuUtilization=0.92 \
+  -Dcomposeai.serve.optimizerResumeQuietMillis=5000
 ```
 
-Read that as: start a pass after ten seconds of quiet rather than sixty, and only stand down when
-the box is genuinely saturated rather than merely busy.
+Read that as: start a pass after ten seconds of quiet rather than sixty, only stand down when the
+box is genuinely saturated rather than merely busy, and — the one that usually matters most — stop
+demanding half a minute of unbroken calm before coming back.
+
+**`optimizerResumeQuietMillis` is the knob people miss.** Rendering is bursty by nature, so a
+30-second recovery window is long enough for the optimizer's own next burst to re-trip whichever
+limb it just cleared. The gate then holds more or less permanently on a box whose every individual
+reading looks healthy — see *Reading `/status.json`* above for the signature. Measured on
+`preview.coo.ee`, gate-wait ran 5-35x the actual render time in that state, and roughly half of all
+turns had to be granted by the ten-minute forced-turn ceiling rather than by the gate opening.
 
 **Leave the memory thresholds alone.** CPU and load contention costs latency and recovers on its
 own; running out of memory kills render daemons and takes the catalog with them. `0.15` stop /

--- a/deploy/image/env-redundant.sh
+++ b/deploy/image/env-redundant.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Report .env entries that only restate a default, so an operator can delete them.
+#
+# Why this is worth a script. Every variable the compose file and the entrypoint read carries its
+# own default, and an .env accumulates lines faster than anyone removes them: a value copied from
+# the README during setup, a knob turned once during an incident and turned back, a setting that
+# later BECAME the default. The file then reads as configuration when most of it is decoration, and
+# the handful of lines that genuinely differ from stock — the ones that explain why this box behaves
+# unlike a fresh one — are buried among them.
+#
+# Values are never printed. The file holds SERVE_TOKEN, SERVE_ADMIN_TOKEN, the GitHub OAuth secret
+# and the deploy hook token; a tidy-up tool that pastes those into a terminal (and from there into
+# an issue, or a chat with an agent) would be a poor trade for the tidiness. Only key names, and
+# defaults that are already public in this repo, reach stdout.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+env_file="${ENV_FILE:-${here}/.env}"
+compose="${COMPOSE_FILE_UNDER_TEST:-${here}/docker-compose.yml}"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+
+[[ -f "${env_file}" ]] || {
+  echo "no .env at ${env_file} — nothing to check" >&2
+  exit 0
+}
+
+# Collect VAR -> default from both files. The compose file decides what reaches the container at
+# all, so it wins where the two disagree; the entrypoint's defaults apply to what compose passed
+# through empty.
+declare -A default_of
+while IFS= read -r pair; do
+  key="${pair%%:-*}"
+  value="${pair#*:-}"
+  [[ -n "${default_of[$key]+set}" ]] || default_of["$key"]="$value"
+done < <(
+  { grep -oE '\$\{[A-Z_][A-Z0-9_]*:-[^}]*\}' "${compose}" || true
+    grep -oE '\$\{[A-Z_][A-Z0-9_]*:-[^}]*\}' "${entrypoint}" || true
+  } | sed 's/^\${//; s/}$//'
+)
+
+redundant=()
+empty=()
+active=()
+while IFS= read -r line; do
+  [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+  [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+  [[ "${line}" == *=* ]] || continue
+  key="${line%%=*}"
+  key="${key#export }"
+  key="${key//[[:space:]]/}"
+  value="${line#*=}"
+  # Strip one layer of surrounding quotes, the way compose does.
+  value="${value%\"}"; value="${value#\"}"
+  value="${value%\'}"; value="${value#\'}"
+  if [[ -z "${value}" ]]; then
+    empty+=("${key}")
+  elif [[ -n "${default_of[$key]+set}" && "${value}" == "${default_of[$key]}" ]]; then
+    redundant+=("${key}=${default_of[$key]}")
+  else
+    active+=("${key}")
+  fi
+done < "${env_file}"
+
+if ((${#redundant[@]})); then
+  echo "Restating a default — safe to delete:"
+  printf '  %s\n' "${redundant[@]}"
+else
+  echo "Nothing restates a default."
+fi
+
+if ((${#empty[@]})); then
+  echo
+  echo "Set but empty — same as unset, safe to delete:"
+  printf '  %s\n' "${empty[@]}"
+fi
+
+echo
+echo "Genuinely differs from stock (${#active[@]} keys, values not shown):"
+printf '  %s\n' "${active[@]}"

--- a/deploy/image/test-env-redundant.sh
+++ b/deploy/image/test-env-redundant.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Guard: env-redundant.sh finds the dead lines, keeps the live ones, and NEVER prints a value.
+#
+# The no-values property is the one worth a test. The file it reads holds SERVE_TOKEN,
+# SERVE_ADMIN_TOKEN, the GitHub OAuth secret and the deploy hook token, and the whole point of the
+# tool is that its output can be pasted somewhere — an issue, a chat, an agent session. A refactor
+# that started echoing "$key=$value" for the active list would look like an improvement in a diff
+# and would quietly turn a tidy-up into a credential leak.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+cat > "${tmp}/.env" <<'ENV'
+# A comment, and a blank line follow.
+
+ROLLOUT_INTERVAL=1200
+SERVE_THEME_CACHE_DIR=/theme-cache
+SERVE_PUBLIC=1
+SERVE_CATALOG_MAX_IMAGES=
+SERVE_TOKEN=sup3rs3cr3t-token-value
+SERVE_ADMIN_TOKEN="quoted-secret-value"
+SERVE_LIVE_SEATS=8
+ROLLOUT_HEALTH_TIMEOUT=900
+ENV
+
+out="$(ENV_FILE="${tmp}/.env" "${here}/env-redundant.sh")"
+
+# 1. Values that equal a compose default are named as deletable.
+for key in ROLLOUT_INTERVAL SERVE_THEME_CACHE_DIR SERVE_PUBLIC; do
+  grep -q "^  ${key}=" <<<"${out}" || {
+    echo "FAIL: ${key} restates a default and was not reported" >&2
+    echo "${out}" >&2
+    exit 1
+  }
+done
+echo "PASS: entries restating a default are reported"
+
+# 2. An empty assignment is the same as unset.
+grep -q "SERVE_CATALOG_MAX_IMAGES" <<<"${out}" || {
+  echo "FAIL: an empty assignment was not reported" >&2
+  exit 1
+}
+echo "PASS: empty assignments are reported"
+
+# 3. Values that genuinely differ are kept, by NAME only.
+for key in SERVE_LIVE_SEATS ROLLOUT_HEALTH_TIMEOUT SERVE_TOKEN; do
+  grep -q "  ${key}$" <<<"${out}" || {
+    echo "FAIL: ${key} differs from stock and was not listed as active" >&2
+    echo "${out}" >&2
+    exit 1
+  }
+done
+echo "PASS: entries that differ from stock are kept"
+
+# 4. THE property: no secret value appears anywhere in the output.
+for secret in sup3rs3cr3t-token-value quoted-secret-value; do
+  if grep -qF "${secret}" <<<"${out}"; then
+    echo "FAIL: a secret VALUE reached stdout — this tool's output is meant to be pasteable" >&2
+    exit 1
+  fi
+done
+echo "PASS: no value reaches stdout"
+
+# 5. Self-test of the detector: a tool that printed key=value for actives would fail check 4.
+if ! grep -qF "sup3rs3cr3t-token-value" <<<"SERVE_TOKEN=sup3rs3cr3t-token-value"; then
+  echo "FAIL: self-test — the secret matcher does not match a key=value line" >&2
+  exit 1
+fi
+echo "PASS: self-test — the secret matcher would catch a key=value leak"
+
+# 6. A missing .env is not an error; there is simply nothing to tidy.
+ENV_FILE="${tmp}/absent" "${here}/env-redundant.sh" >/dev/null 2>&1 || {
+  echo "FAIL: a missing .env must exit cleanly" >&2
+  exit 1
+}
+echo "PASS: a missing .env exits cleanly"
+
+echo "PASS: all env-redundant checks"


### PR DESCRIPTION
Four `/status.json` readings mislead if taken at face value. I know because I took all four at face value this week and drew the wrong conclusion from three of them, twice recommending changes that would have made `preview.coo.ee` slower.

## The four

**`pressure.reason` describes the HOLD, not the moment.** `host recovering` means a limb tripped earlier and the gate now wants `optimizerResumeQuietMillis` (30s) of *continuous* calm before reopening — not that anything is over a threshold now. Rendering is bursty, so the optimizer's own next burst re-trips the limb inside that window. The gate stays shut more or less permanently while every individual reading looks healthy.

Measured on the box: `memory available 81%`, `CPU 29%`, `load 0.42 per CPU` — every limb comfortably inside its resume side — and still `host recovering`. Gate-wait ran **5–35× actual render time**, and about half of all turns were granted by the ten-minute forced-turn ceiling rather than by the gate opening at all.

That makes `optimizerResumeQuietMillis` the knob that usually matters most, and the one nobody reaches for. The aggressive-warming recipe now sets it.

**`daemons.running` counts sessions, not processes.** Thirteen "running" daemons against **four** JVMs is normal. I multiplied that figure by a per-daemon memory estimate and invented a memory crisis on a container using 3.1 GiB of 48.

**`memoryAvailableFraction` is a spot sample and it is spiky.** Consecutive readings on one box: `0.19, 0.34, 0.23, 0.48, 0.08, 0.81`. I acted on the `0.08`.

**`loadPerCpu` is a queue depth, not a percentage.** One runnable task per core reads `1.0`.

## Sizing

A table for `PREVIEW_MEM_LIMIT` / `SERVE_LIVE_SEATS` / `SERVE_BACKGROUND_RENDERS`, because **both derivations clamp** — seats at 8, the background lane at 3 — so a large host runs a fraction of what it affords unless the numbers are named.

With the commands to measure first, since the container's own `free` reports the **host's** memory and will cheerfully claim 60 GiB available inside a 3 GiB container.

## `env-redundant.sh`

An `.env` accumulates lines faster than anyone removes them: a value copied from the README at setup, a knob turned once in an incident and turned back, a setting that later *became* the default. What genuinely explains why a box differs from stock gets buried.

The script reports what restates a default, what is set but empty (same as unset), and then lists the rest **by name only**. It never prints a value — the file holds `SERVE_TOKEN`, `SERVE_ADMIN_TOKEN`, the GitHub OAuth secret and the deploy hook token, and the output is meant to be safe to paste into an issue or a chat.

## Test plan

- `test-env-redundant.sh` — defaults reported; empty assignments reported; differing keys kept; **no secret value reaches stdout**; a self-test proving the matcher would catch a `key=value` leak; a missing `.env` exits cleanly. Wired into CI beside the other deploy guards, with a comment saying why that last assertion exists — a refactor echoing `key=value` for the active list would read as an improvement in a diff and would turn a tidy-up tool into a credential leak.
- `test-compose-env-passthrough.sh`, `test-java-opts-append.sh`, `test-env-migrations.sh` (11 passed) all still green.
- `ci.yml` and `bash -n` on the new script both parse.

Docs and a shell script; no rendered surface, so nothing visual to diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_