### PR TITLE
fix(ci): schedule the contract probe for common/image-crop sources

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -135,6 +135,7 @@
       "daemon/client/**",
       "api/preview-data-api/**",
       "common/io/**",
+      "common/image-crop/**",
       "render-session/**",
       "data/layoutinspector/core/**",
       "data/preview-overrides/core/**",


### PR DESCRIPTION
## main is red

`Actions Script Tests` has been failing on `main` since #4613:

```
FAIL: test_every_contract_project_reaches_the_probe_job
AssertionError: Lists differ: [':common-image-crop (common/image-crop)'] != []
  contract project(s) whose sources do not schedule preview-server-contracts:
  :common-image-crop (common/image-crop)
```

Reproduced on a clean checkout of `origin/main` — not a flake, and not any one PR's: every PR inherits it through its merge commit.

## The drift

#4613 (`refactor(serve): split ServeCommand across the module boundary`) added `:common-image-crop` to `CONTRACT_PROJECTS` in `scripts/check-preview-server-contracts.sh` but no covering path in `ci-paths.json`'s `preview_server_contracts` group. That combination is precisely what the test was written to catch, in its own words:

> The CI path group is not [checked by the build] — adding a contract without a path covering its source means a later PR touching only that module skips `preview-server-contracts`, the sole job that publishes it and resolves it from the separate build.

So the consequence is not only a red check: a PR touching only `common/image-crop` would have skipped the one job that validates its contract surface.

## The fix

One line, next to its `common/io/**` neighbour:

```json
"common/io/**",
"common/image-crop/**",
```

## Test plan

- `python3 .github/ci/test_path_scope.py` — was `FAILED (failures=1)` on `origin/main`, now `Ran 22 tests … OK`.
- The whole `Actions Script Tests` set green locally: `test_affected_gradle_tests`, `test_android_all_cache_key`, `test_change_scope`, `test_daemon_roundtrip`, `test_path_scope`.
- `ci-paths.json` re-validated as JSON.

Note `test_a_contract_added_without_a_path_is_caught` guards the guard, so this stays enforced rather than merely repaired.

Non-visual change — CI configuration only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_