### PR TITLE
fix(serve): key the theme cache on the render environment, not a sample

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheFingerprint.kt
@@ -29,8 +29,16 @@ import java.security.MessageDigest
  *   worth paying for: it is the only input that is derived from the thing itself rather than
  *   asserted about it.
  * - **The daemon variant.** Desktop and Android/Robolectric are different renderers reading the
- *   same classpath, and they do not agree pixel-for-pixel. What is deliberately **not** keyed on,
- *   and why:
+ *   same classpath, and they do not agree pixel-for-pixel.
+ * - **The render environment** — the JVM, the rasteriser shared objects and the installed system
+ *   fonts, none of which the classpath can reach. See [ThemeCacheFingerprint.rendererIdentity] for
+ *   what is read and why it is stat rather than bytes. This is the input the tool version used to
+ *   stand proxy for, keyed on directly.
+ * - **The render config.** The server-side defaults that never appear in a cache key — density,
+ *   default device, font scale, image encoding. The easiest inputs to forget precisely *because*
+ *   they are absent from the key, so they are named explicitly by the caller.
+ *
+ * What is deliberately **not** keyed on, and why:
  * - **The tool version.** It used to be, and that made a release throw away every warmed render on
  *   the box. Measured on preview.coo.ee, whose theme optimization needs the better part of a day to
  *   fill 18,604 entries: four versions shipped inside four hours, each one starting the pass again
@@ -38,28 +46,30 @@ import java.security.MessageDigest
  *   can be filled is not a cache.
  *
  *   The version was never proof of anything — it stood *proxy* for the renderer and the container
- *   image (the JVM, Skia, the installed fonts), none of which are visible from here, and the class
+ *   image (the JVM, Skia, the installed fonts), none of which were visible from here, and the class
  *   doc above already conceded that proxying is an assumption rather than a proof: a base-image
  *   bump shipping without a release slipped through it either way. So it was a key that failed open
  *   on the case it was supposed to cover, while failing closed on every case it was not.
  *
- *   What actually catches a renderer that moved is [CatalogThemeCache.verifySample], which
- *   re-renders a sample of the adopted entries against the running renderer and discards the whole
- *   generation on any mismatch — the same net that was always covering the unenumerated inputs.
- *   Crossing a version boundary is now exactly that case: every entry reads as adopted (it came
- *   from another process), so it is withheld from the read path until the sample settles. A version
- *   that renders differently costs a re-warm; it does not serve a wrong pixel.
+ *   [rendererIdentity] is what replaced it, and the substitution is the point: it moves when the
+ *   *image* moves and holds still when only the build number does, which is the exact opposite of
+ *   the version on both halves. Four builds shipped out of one base image share a generation; one
+ *   build shipped on a bumped base image does not.
  *
- *   The version is still recorded in the generation manifest, so which build last wrote a
- *   generation stays answerable, and `--theme-cache-evict` discards the store outright for the case
- *   where an operator *knows* the pixels moved and does not want to wait for a sample to notice.
- * - **The render config.** The server-side defaults that never appear in a cache key — density,
- *   default device, font scale, image encoding. The easiest inputs to forget precisely *because*
- *   they are absent from the key, so they are named explicitly by the caller.
+ *   Behind that sits [CatalogThemeCache.verifySample], which re-renders a sample of the adopted
+ *   entries against the running renderer and discards the whole generation on any mismatch. It is
+ *   the net for inputs nobody enumerated, and it is a *sample* — the first five sorted adopted keys
+ *   — so it is a backstop and not a substitute for keying on an input that can be named. Anything
+ *   the key covers is caught structurally, before a wrong pixel is ever a candidate.
  *
- * Nothing here is asserted by hand: change the renderer and the version moves, change the catalog
- * and the classpath moves. There is no cache-version constant to remember to bump, because a
- * constant someone must remember is a constant that will eventually be wrong.
+ *   The version is still recorded in the generation manifest — as the build that last **opened**
+ *   the generation, see [GenerationInputs.toolVersion] — and `--theme-cache-evict` discards the
+ *   store outright for the case where an operator *knows* the pixels moved and does not want to
+ *   wait for a sample to notice.
+ *
+ * Nothing here is asserted by hand: change the image and the renderer identity moves, change the
+ * catalog and the classpath moves. There is no cache-version constant to remember to bump, because
+ * a constant someone must remember is a constant that will eventually be wrong.
  */
 object ThemeCacheFingerprint {
 
@@ -98,13 +108,25 @@ object ThemeCacheFingerprint {
      * pixels, and a five-entry verification sample would very likely miss the one row that moved.
      */
     routing: String = "",
+    /**
+     * Digest of the render *environment* this generation's pixels come out of — see
+     * [rendererIdentity].
+     *
+     * The one input the classpath cannot reach. Everything else here is derived from files the
+     * catalog carries; this is derived from the container image underneath them, and a base image
+     * that swaps the JVM, freetype or the installed fonts moves the pixels without moving a single
+     * byte of the classpath.
+     */
+    renderer: String = currentRendererIdentity,
   ): String? {
     if (classpath.isEmpty() || classpath.size > MAX_CLASSPATH_ENTRIES) return null
     val digest = MessageDigest.getInstance("SHA-256")
     digest.line("schema", SCHEMA)
     digest.line("variant", variant)
     // NOT the tool version — see the class doc. A release must not orphan the warmed renders; the
-    // load-time sample verification is what covers a renderer that actually moved.
+    // load-time sample verification is what covers a renderer that actually moved. The *renderer*
+    // is keyed on directly instead, which is the thing the version only ever stood proxy for.
+    digest.line("renderer", renderer)
     digest.line("renderConfig", renderConfig)
     digest.line("routing", routing)
     // Hashed in the order the descriptor lists them, NOT sorted. Classpath order is semantically
@@ -199,6 +221,161 @@ object ThemeCacheFingerprint {
     value.startsWith(File.separator) ||
       value.contains("=${File.separator}") ||
       Regex("^[A-Za-z]:[\\\\/]").containsMatchIn(value)
+
+  /**
+   * Digest of the render environment — the container image's half of what produces a pixel.
+   *
+   * ### The hole this fills
+   *
+   * Dropping the tool version from [of] was right for the reason the class doc gives, but it left
+   * the thing the version stood *proxy* for uncovered: the JVM, the native rasteriser and the
+   * installed fonts all live in the image rather than in the catalog, so a base-image bump changes
+   * the pixels while every hashed input holds still. The only remaining net was
+   * [CatalogThemeCache.verifySample], and that net has a known-size hole — it re-renders the first
+   * five sorted adopted keys, so a change touching any of the other 18,599 entries passes the
+   * sample and the whole generation is then trusted. Keying on the environment directly closes the
+   * case rather than sampling for it: a moved renderer gets a different generation directory and
+   * nothing is adopted at all.
+   *
+   * Unlike the version, this does **not** move on a release. Four builds shipped in four hours out
+   * of the same base image produce four identical identities, so the pathology that got the version
+   * removed does not come back.
+   *
+   * ### What it reads, and why stat rather than bytes
+   *
+   * - **The JVM**, from its own system properties. `eclipse-temurin:21.0.12_8` and `21.0.13_11` are
+   *   different text here, which is the whole requirement.
+   * - **The architecture**, because the native halves of both renderers are per-arch binaries.
+   * - **The system font inventory** — every file under the standard font roots, by relative path
+   *   and size. Not by content: these are hundreds of megabytes on a fontconfig-equipped image and
+   *   this runs on the catalog-load path. Not by mtime either, because a package layer rebuilt from
+   *   identical sources restamps mtimes and that would reintroduce churn-per-build. A base image
+   *   that swaps or upgrades a font package moves a name or a size; one that does not, does not.
+   *   (The *downloadable* font cache is a different thing and is already hashed by content — see
+   *   [CONTENT_PATH_PROPERTIES].)
+   * - **The rasteriser libraries** — freetype, fontconfig and harfbuzz, by name and size. A
+   *   freetype bump changes glyph rasterisation on the Android/Robolectric path with nothing else
+   *   moving at all, and it is the same cheap stat walk.
+   *
+   * Anything unreadable is simply recorded as absent rather than failing the fingerprint: unlike a
+   * classpath entry, a missing font root is the ordinary state of most machines, and refusing to
+   * persist on a developer laptop with no `/usr/share/fonts` would be a bug rather than caution.
+   */
+  fun rendererIdentity(
+    systemProperties: Map<String, String> = jvmProperties(),
+    fontRoots: List<File> = DEFAULT_FONT_ROOTS,
+    libraryRoots: List<File> = DEFAULT_LIBRARY_ROOTS,
+  ): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.line("schema", SCHEMA)
+    for (key in RENDERER_PROPERTIES) digest.line(key, systemProperties[key].orEmpty())
+    for (root in fontRoots) {
+      digest.line("fonts", inventory(root, FONT_ROOT_DEPTH) { true })
+    }
+    for (root in libraryRoots) {
+      digest.line("libs", inventory(root, LIBRARY_ROOT_DEPTH) { it in RASTERISER_LIBRARIES })
+    }
+    return digest.digest().hex()
+  }
+
+  /**
+   * `<relative path>:<size>` for every accepted file under [root], sorted, or `""` when [root] is
+   * not there.
+   *
+   * Two bounds, and both of them are about not hanging a catalog load rather than about tidiness:
+   * - **[maxDepth]**, because a font root is a shallow tree and a library root is one directory,
+   *   while `/usr/lib` beneath it is neither. Recursing it would stat tens of thousands of files to
+   *   find three.
+   * - **[MAX_CLASSPATH_ENTRIES] against files VISITED, not files kept.** Counting only the kept
+   *   ones would let a filtered walk — the library one, which keeps almost nothing — run without
+   *   limit down a symlink loop, and `walkTopDown` follows directory symlinks. The overflow answer
+   *   is the root's name alone: stable across boots, and honestly saying "this root is bigger than
+   *   I will read" rather than a truncated inventory that would look like an identity while
+   *   truncating somewhere different each time.
+   */
+  private fun inventory(root: File, maxDepth: Int, accept: (String) -> Boolean): String =
+    runCatching {
+      if (!root.isDirectory) return@runCatching ""
+      val entries = mutableListOf<String>()
+      var visited = 0
+      for (file in root.walkTopDown().maxDepth(maxDepth)) {
+        if (file.isDirectory) continue
+        if (++visited > MAX_CLASSPATH_ENTRIES) return@runCatching "${root.name}:overflow"
+        if (!accept(file.name)) continue
+        entries += "${file.relativeTo(root).invariantPath()}:${file.length()}"
+      }
+      entries.sorted().joinToString("\n")
+    }
+    // An unreadable root is "nothing here", not a reason to decline to persist — see
+    // [rendererIdentity].
+    .getOrDefault("")
+
+  /** Deep enough for `/usr/share/fonts/truetype/<family>/<face>.ttf` and its usual variations. */
+  private const val FONT_ROOT_DEPTH = 6
+
+  /** A rasteriser shared object sits directly in its library directory; below that is not ours. */
+  private const val LIBRARY_ROOT_DEPTH = 1
+
+  /**
+   * [rendererIdentity] for the process this is running in, computed once.
+   *
+   * Cached because it walks the font roots and a multi-module catalog fingerprints once per bundle,
+   * so an uncached default would stat the same few thousand files several times per load for an
+   * answer that cannot change without the process being replaced.
+   */
+  val currentRendererIdentity: String by lazy { rendererIdentity() }
+
+  /** The JVM's own description of itself, for [rendererIdentity]. */
+  private fun jvmProperties(): Map<String, String> = RENDERER_PROPERTIES.associateWith {
+    System.getProperty(it).orEmpty()
+  }
+
+  /**
+   * System properties naming the renderer's environment rather than the catalog's configuration.
+   *
+   * Deliberately not `java.home` or any other path: the value would churn across hosts that render
+   * identically. What is wanted is the JVM's *identity*, and these three carry it.
+   */
+  val RENDERER_PROPERTIES: List<String> =
+    listOf("java.vm.vendor", "java.vm.version", "java.runtime.version", "os.arch")
+
+  /** Where a Linux/macOS/Windows image keeps the fonts fontconfig will hand the rasteriser. */
+  val DEFAULT_FONT_ROOTS: List<File> =
+    listOf(
+        "/usr/share/fonts",
+        "/usr/local/share/fonts",
+        "/System/Library/Fonts",
+        "/Library/Fonts",
+        System.getProperty("user.home")?.let { "$it/.fonts" },
+        System.getProperty("user.home")?.let { "$it/.local/share/fonts" },
+        System.getenv("WINDIR")?.let { "$it\\Fonts" },
+      )
+      .filterNotNull()
+      .map(::File)
+
+  /** Where the rasteriser shared objects named in [RASTERISER_LIBRARIES] live. */
+  val DEFAULT_LIBRARY_ROOTS: List<File> =
+    listOf("/usr/lib/${System.getProperty("os.arch") ?: ""}-linux-gnu", "/usr/lib", "/usr/lib64")
+      .map(::File)
+
+  /**
+   * Shared objects whose version decides how a glyph is rasterised.
+   *
+   * Matched on the **soname**, not on a prefix. A prefix match would also take
+   * `libfreetype.so.6.18.3`, and Debian ships that as a real file beside the `libfreetype.so.6`
+   * symlink pointing at it — so a package upgrade that renames the versioned file would move the
+   * fingerprint twice over, while the soname link the loader actually resolves already carries the
+   * change through its own size.
+   */
+  val RASTERISER_LIBRARIES: Set<String> =
+    setOf(
+      "libfreetype.so",
+      "libfreetype.so.6",
+      "libfontconfig.so",
+      "libfontconfig.so.1",
+      "libharfbuzz.so",
+      "libharfbuzz.so.0",
+    )
 
   /** Stable digest of a catalog-id to daemon-id map, for [of]'s `routing`. */
   fun routingDigest(alias: Map<String, String>): String {
@@ -315,6 +492,10 @@ object ThemeCacheFingerprint {
    * Bumped only when the fingerprint's own *composition* changes in a way that should invalidate
    * everything already on disk. Not a cache version anyone has to remember for ordinary changes —
    * the inputs cover those on their own.
+   *
+   * `/2` folded the render environment in ([rendererIdentity]). Every generation written under `/1`
+   * was named without it, so none of them can be adopted: on a box mid-warm that is one re-warm,
+   * paid once, for a key that stops depending on a five-entry sample to notice the image moved.
    */
-  private const val SCHEMA = "theme-cache/1"
+  private const val SCHEMA = "theme-cache/2"
 }

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -89,6 +89,8 @@ class ThemeCacheStore(
   private val knownGenerationsBySystem = AtomicReference<Map<String, Int>>(emptyMap())
   private val lastFailure = ConcurrentHashMap<String, String>()
   private val tempSequence = AtomicLong()
+  /** Cache for [evictedAtEpochMillis]; -1 until the marker has been looked for. */
+  private val evictedAt = AtomicLong(-1)
   /** Distinguishes this process's in-flight writes from a concurrently deployed replica's. */
   private val writerId: String =
     ProcessHandle.current().pid().toString(36) + "-" + System.identityHashCode(this).toString(36)
@@ -123,9 +125,19 @@ class ThemeCacheStore(
    * decision and the manifest is only commentary. That held while the fingerprint keyed on the tool
    * version, because a new build could never reach an existing generation. It no longer does — a
    * release now adopts its predecessor's renders (see [ThemeCacheFingerprint]) — so leaving the
-   * manifest alone would have it name a build that has not written here since, which is precisely
-   * the question the manifest exists to answer when someone is working out whether the pixels on
-   * this volume can be trusted.
+   * manifest alone would have it name a build that has not been near this directory since.
+   *
+   * What the refreshed manifest then records is the build that last **opened** the generation, and
+   * [GenerationInputs.toolVersion] says so. It is deliberately not the build that last *wrote* a
+   * PNG here, and the difference is load-bearing during a rollout: this rewrite happens at open,
+   * before this process has rendered anything, and the incoming replica can fail readiness
+   * immediately afterwards while the outgoing one carries on as the volume's only real writer. An
+   * investigator reading `toolVersion` as "who made these pixels" would be pointed at a build that
+   * made none of them. Deferring the rewrite to the first successful [Generation.put] would fix
+   * that half and break the other: [dirtyBeforeEpochMillis] has to be on disk *before* a single
+   * render is served from this directory, or the adopted set is trusted for however long the first
+   * write takes. The boundary is the correctness half, so it wins, and the version is documented as
+   * what it actually is.
    *
    * [GenerationInputs.createdAtEpochMillis] is preserved across the rewrite: it is what the sweep's
    * grace window reads to spare a generation belonging to a replica that is still serving, and
@@ -140,9 +152,24 @@ class ThemeCacheStore(
       } else {
         null
       }
+    // Everything on this volume older than the last eviction plus the rollout grace window is
+    // untrusted, whoever wrote it and whatever build they were — see [evictAll]. `+ graceMillis`
+    // for the same reason the cross-build boundary uses it: the writes that have to be caught are
+    // the OUTGOING replica's, and those land after the eviction instant, not before it.
+    val evictionBoundary = evictedAtEpochMillis().takeIf { it > 0 }?.plus(graceMillis) ?: 0L
     // An unreadable manifest beside a live generation is rewritten rather than left: the sweep
     // falls back to the directory's own timestamp for it, and a readable one is strictly better.
-    if (existing != null && existing.toolVersion == inputs.toolVersion)
+    //
+    // The eviction clause is what stops the same-build case slipping through. An operator can evict
+    // and restart WITHOUT a release — that is the ordinary shape of "I know the pixels moved" — and
+    // then the outgoing replica carries this build's own version string, the early return fires on
+    // it, and the boundary it repopulated the generation under is whatever the previous manifest
+    // said. Which is usually zero.
+    if (
+      existing != null &&
+        existing.toolVersion == inputs.toolVersion &&
+        existing.dirtyBeforeEpochMillis >= evictionBoundary
+    )
       return MarkOutcome.NOT_NEEDED
     val createdAt = existing?.createdAtEpochMillis?.takeIf { it > 0 } ?: clock()
     // Renders are here that this build did not write. Usually the manifest says so; when it is
@@ -166,7 +193,14 @@ class ThemeCacheStore(
     //
     // The cost is that some of this build's OWN early renders fall under the boundary and are
     // re-rendered once. That is the right direction to be wrong in.
-    val boundary = if (inherited) clock() + graceMillis else 0L
+    //
+    // `maxOf` with the eviction boundary rather than either one alone: the two answer different
+    // questions ("did another BUILD write here" and "was this volume evicted under a writer that
+    // is still going"), a generation can be in both states at once, and the later line is the only
+    // one that makes both answers safe. The eviction half applies even to a directory this process
+    // created — a generation deleted by the eviction and recreated under the same fingerprint by
+    // the outgoing replica reaches here as brand new, which is precisely the case.
+    val boundary = maxOf(if (inherited) clock() + graceMillis else 0L, evictionBoundary)
     val wrote = runCatching {
       file.writeText(
         json.encodeToString(
@@ -186,6 +220,7 @@ class ThemeCacheStore(
     // re-render of a catalog the volume could not record anything about, which is the right
     // direction to be wrong in.
     return when {
+      // Nothing on disk to be on the wrong side of either boundary.
       !inherited -> MarkOutcome.NOT_NEEDED
       wrote -> MarkOutcome.RECORDED
       else -> MarkOutcome.UNRECORDED
@@ -220,14 +255,32 @@ class ThemeCacheStore(
   /**
    * Delete every generation in the store, unconditionally, and report how many went.
    *
-   * The escape hatch for "the pixels on this volume are wrong and I already know it" — a base-image
-   * bump that changed the installed fonts, say, which no fingerprint sees and which a five-entry
-   * verification sample can miss. [sweep] cannot serve this purpose: it deliberately spares any
-   * generation inside its grace window, which is exactly the freshly-written one an operator wants
-   * gone.
+   * The escape hatch for "the pixels on this volume are wrong and I already know it" — a change to
+   * the render environment that [ThemeCacheFingerprint.rendererIdentity] does not read, say, which
+   * no fingerprint sees and which a five-entry verification sample can miss. [sweep] cannot serve
+   * this purpose: it deliberately spares any generation inside its grace window, which is exactly
+   * the freshly-written one an operator wants gone.
    *
-   * Called only from an explicit `--theme-cache-evict`, and only before any generation is opened,
-   * so it can never race a live [Generation]'s writes.
+   * ### Deleting is not enough on a shared volume
+   *
+   * This is called before this process opens a generation, so it cannot race **this** process's
+   * writes — and that used to be the whole of the reasoning, which was a single-process argument
+   * about a volume that is not single-process. The deployment this store was built for performs a
+   * **zero-downtime rollout**: the outgoing replica keeps serving, and keeps writing PNGs, against
+   * the same mounted `/config` volume while the incoming one boots and evicts. Every render it
+   * publishes in that window repopulates a generation with precisely the pixels the eviction was
+   * meant to destroy, and they land *after* the deletion, so they carry fresh timestamps and read
+   * as this build's own work.
+   *
+   * So the deletion also leaves a mark. [EVICTED_NAME] records when it happened, and every
+   * generation opened from here on treats anything written before that instant plus the rollout
+   * grace window as dirty — the same boundary mechanism, and the same grace window, that
+   * [writeManifest] already uses for the cross-build case, because it is the same question about
+   * the same other replica. An operator gets the eviction they asked for without having to prove
+   * that every other writer has stopped first.
+   *
+   * The mark is not a lock and does not claim to be one. It cannot stop the old replica writing; it
+   * makes what the old replica writes untrusted, which is the outcome that was wanted.
    */
   fun evictAll(): Int {
     var deleted = 0
@@ -238,10 +291,36 @@ class ThemeCacheStore(
       }
       if (systemDir.listFiles()?.isEmpty() == true) systemDir.delete()
     }
+    // Stamped AFTER the deletion, so a crash midway leaves the volume looking un-evicted rather
+    // than leaving surviving generations under a boundary nothing has been deleted against. The
+    // operator re-runs the flag; the alternative silently reports a completed eviction that only
+    // half happened.
+    val at = clock()
+    val stamped = runCatching { File(root, EVICTED_NAME).writeText(at.toString()) }.isSuccess
+    if (stamped) evictedAt.set(at)
+    // A volume that cannot record the eviction cannot make the old replica's repopulated renders
+    // dirty either, and that is worth saying out loud rather than reporting a clean eviction.
+    else recordFailure("store", "evicted but could not record the boundary in $EVICTED_NAME")
     knownGenerations.set(0)
     knownGenerationsBySystem.set(emptyMap())
     knownBytes.set(0)
     return deleted
+  }
+
+  /**
+   * When this store was last evicted, or 0 when it never was.
+   *
+   * Read off disk once and remembered: it is consulted on every [open] and it can only be changed
+   * by an [evictAll] in this same process, which updates the cached value itself. A concurrently
+   * deployed replica evicting under us is not a case worth polling for — that replica is the one
+   * booting, and the boundary it writes is read by the *next* open on either side.
+   */
+  private fun evictedAtEpochMillis(): Long = evictedAt.updateAndGet { cached ->
+    if (cached >= 0) cached
+    else
+      runCatching { File(root, EVICTED_NAME).readText().trim().toLong() }
+        .getOrDefault(0L)
+        .coerceAtLeast(0L)
   }
 
   /**
@@ -901,6 +980,16 @@ class ThemeCacheStore(
     /** Long enough to cover a rollout's readiness window, short enough to reclaim the same day. */
     const val DEFAULT_SWEEP_GRACE_MILLIS: Long = 60L * 60 * 1000
     const val MANIFEST_NAME: String = "manifest.json"
+
+    /**
+     * Store-root marker recording the epoch millis of the last [evictAll].
+     *
+     * At the ROOT rather than inside a generation, because the generations it applies to are the
+     * ones that do not exist yet: an eviction deletes what is on the volume, and what it has to
+     * survive is what gets written next. A plain integer in a plain file so that an operator
+     * looking at a mounted volume can read and clear it without tooling.
+     */
+    const val EVICTED_NAME: String = "evicted-at"
     const val MAX_REASON_CHARS: Int = 200
     private const val PNG_SUFFIX = ".png"
     private const val TEMP_SUFFIX = ".png.tmp"
@@ -947,6 +1036,15 @@ class ThemeCacheStore(
 data class GenerationInputs(
   val system: String,
   val fingerprint: String,
+  /**
+   * The build that last **opened** this generation — not necessarily one that wrote a PNG into it.
+   *
+   * Rewritten by [ThemeCacheStore.writeManifest] at open time, before this process has rendered
+   * anything, so a replica that fails readiness still leaves its version here. Read it as "the last
+   * build that thought this generation was its own", which is the question the dirty boundary
+   * beside it was set to answer; do not read it as authorship of the pixels. See that function's
+   * doc for why it is stamped at open rather than on the first write.
+   */
   val toolVersion: String,
   val variant: String,
   val renderConfig: String,

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -618,6 +618,91 @@ class ThemeCachePersistenceTest {
   }
 
   @Test
+  fun `an eviction makes the outgoing replica's repopulated renders dirty`() {
+    // The rollout this store was built for is zero-downtime: the outgoing replica keeps serving,
+    // and keeps writing PNGs, against the same volume while the incoming one boots and evicts.
+    // `evictAll` runs before this process opens anything, so it cannot race THIS process — which
+    // was the whole of the old reasoning, and is a single-process argument about a volume that is
+    // not single-process. Everything the old replica publishes in that window is precisely the
+    // pixels the eviction was meant to destroy, landing after the deletion with fresh timestamps.
+    val root = tempDir()
+    val grace = 60 * 60_000L
+
+    val outgoing = ThemeCacheStore(root, graceMillis = grace)
+    val old = assertNotNull(outgoing.open("m3-catalog", "fp-a", inputs("fp-a")))
+    old.put("preview|dark", ByteArray(8) { 1 })
+
+    // The incoming replica evicts. SAME build: an operator who knows the pixels moved does not need
+    // a release to say so, and that is the case a version comparison alone cannot see — the early
+    // return would fire on the matching version and keep whatever boundary was already recorded.
+    val incoming = ThemeCacheStore(root, graceMillis = grace)
+    assertEquals(1, incoming.evictAll())
+    assertTrue(File(root, ThemeCacheStore.EVICTED_NAME).isFile, "the boundary is on the volume")
+
+    // The old replica, still serving, repopulates the same fingerprint after the deletion.
+    val repopulated = assertNotNull(outgoing.open("m3-catalog", "fp-a", inputs("fp-a")))
+    repopulated.put("preview|dark", ByteArray(8) { 1 })
+
+    // The incoming replica now opens what looks like a fresh generation full of fresh timestamps.
+    val adopted = assertNotNull(incoming.open("m3-catalog", "fp-a", inputs("fp-a")))
+    assertTrue(
+      adopted.isDirty("preview|dark"),
+      "a render written after an eviction by a writer the eviction could not stop is not trusted",
+    )
+    assertTrue(adopted.contains("preview|dark"), "dirty is not absent — it stays warm meanwhile")
+  }
+
+  @Test
+  fun `renders written past the eviction's grace window are clean again`() {
+    // The boundary is a window, not a permanent condemnation of the volume. Once every writer that
+    // could predate the eviction has had the rollout's grace to stop, what lands next is this
+    // build's own work; re-rendering it forever would be a treadmill rather than a safeguard.
+    //
+    // An eviction stamped in the past with no grace, so every real render timestamp is past it.
+    val root = tempDir()
+    val store = ThemeCacheStore(root, graceMillis = 0, clock = { 1_000_000L })
+    assertEquals(0, store.evictAll())
+
+    val generation = assertNotNull(store.open("m3-catalog", "fp-a", inputs("fp-a")))
+    generation.put("preview|dark", ByteArray(8) { 1 })
+
+    assertFalse(generation.isDirty("preview|dark"))
+    assertEquals(0, generation.dirtyCount())
+  }
+
+  @Test
+  fun `a store that was never evicted carries no boundary`() {
+    val root = tempDir()
+    val store = ThemeCacheStore(root, graceMillis = 60 * 60_000)
+    val generation = assertNotNull(store.open("m3-catalog", "fp-a", inputs("fp-a")))
+    generation.put("preview|dark", ByteArray(8) { 1 })
+
+    assertFalse(generation.isDirty("preview|dark"), "nothing to be on the wrong side of")
+    assertFalse(File(root, ThemeCacheStore.EVICTED_NAME).exists())
+  }
+
+  @Test
+  fun `the eviction marker survives the sweep and a later eviction moves it forward`() {
+    // It lives at the store root beside the system directories, and both walks filter to
+    // directories. A marker a sweep could reclaim would quietly reopen the window it closes.
+    val root = tempDir()
+    var now = 1_000_000L
+    val store = ThemeCacheStore(root, graceMillis = 0, clock = { now })
+    assertNotNull(store.open("m3-catalog", "fp-a", inputs("fp-a")))
+    store.evictAll()
+    val marker = File(root, ThemeCacheStore.EVICTED_NAME)
+    assertEquals("1000000", marker.readText())
+
+    now += 1_000
+    store.sweep(live = emptySet())
+    assertEquals("1000000", marker.readText(), "a sweep must not reclaim the boundary")
+
+    now += 1_000
+    store.evictAll()
+    assertEquals("1002000", marker.readText(), "a second eviction moves the boundary forward")
+  }
+
+  @Test
   fun `an unreadable classpath declines to name the generation at all`() {
     // Null means "do not persist". Inventing an identity for a classpath we could not read is how
     // two different generations end up agreeing on a name, which is the origin of every wrong pixel
@@ -639,6 +724,130 @@ class ThemeCachePersistenceTest {
     jar(classes, "Button.class", "v2")
 
     assertNotEquals(before, fingerprint(listOf(classes)))
+  }
+
+  // ---- renderer identity ----------------------------------------------------------------------
+
+  @Test
+  fun `a bumped JVM is a different generation, with the classpath untouched`() {
+    // The case the tool version used to stand proxy for and failed open on: a base-image bump moves
+    // the renderer while every hashed catalog input holds still. Before this was keyed on, the only
+    // thing standing between that and a wrong pixel was a five-entry sample.
+    val dir = tempDir()
+    val classpath = listOf(jar(dir, "catalog.jar", "CLASSES"))
+
+    fun withJvm(version: String) =
+      ThemeCacheFingerprint.of(
+        classpath = classpath,
+        variant = "desktop",
+        renderConfig = "density=2",
+        renderer =
+          ThemeCacheFingerprint.rendererIdentity(
+            systemProperties = mapOf("java.vm.vendor" to "Eclipse", "java.vm.version" to version),
+            fontRoots = emptyList(),
+            libraryRoots = emptyList(),
+          ),
+      )
+
+    assertNotEquals(withJvm("21.0.12+8"), withJvm("21.0.13+11"))
+    assertEquals(withJvm("21.0.12+8"), withJvm("21.0.12+8"), "an unchanged JVM must not re-warm")
+  }
+
+  @Test
+  fun `a swapped system font is a different generation`() {
+    val fonts = tempDir()
+    val dir = tempDir()
+    val classpath = listOf(jar(dir, "catalog.jar", "CLASSES"))
+    jar(fonts, "truetype/Roboto-Regular.ttf", "GLYPHS")
+
+    fun now() =
+      ThemeCacheFingerprint.of(
+        classpath = classpath,
+        variant = "desktop",
+        renderConfig = "density=2",
+        renderer =
+          ThemeCacheFingerprint.rendererIdentity(
+            systemProperties = emptyMap(),
+            fontRoots = listOf(fonts),
+            libraryRoots = emptyList(),
+          ),
+      )
+
+    val before = now()
+    // Size, not content: the inventory stats rather than reads, because a fontconfig image carries
+    // hundreds of megabytes here and this runs on the catalog-load path.
+    jar(fonts, "truetype/Roboto-Regular.ttf", "DIFFERENT GLYPHS")
+    assertNotEquals(before, now(), "a font package swap must not read the old renderer's pixels")
+
+    val after = now()
+    jar(fonts, "truetype/NotoSans-Regular.ttf", "MORE")
+    assertNotEquals(after, now(), "an ADDED font changes what fontconfig will fall back to")
+  }
+
+  @Test
+  fun `a bumped rasteriser library is a different generation, and unrelated libraries are not`() {
+    // freetype decides how a glyph is rasterised on the Android path with nothing else moving at
+    // all. The filter is what keeps this from being a hash of /usr/lib.
+    val libs = tempDir()
+    val dir = tempDir()
+    val classpath = listOf(jar(dir, "catalog.jar", "CLASSES"))
+    jar(libs, "libfreetype.so.6", "FT")
+    jar(libs, "libcurl.so.4", "UNRELATED")
+    // The versioned real file behind the soname link. Matched on the soname alone, so a package
+    // upgrade that renames this does not move the fingerprint a second time.
+    jar(libs, "libfreetype.so.6.18.3", "FT")
+
+    fun now() =
+      ThemeCacheFingerprint.of(
+        classpath = classpath,
+        variant = "desktop",
+        renderConfig = "density=2",
+        renderer =
+          ThemeCacheFingerprint.rendererIdentity(
+            systemProperties = emptyMap(),
+            fontRoots = emptyList(),
+            libraryRoots = listOf(libs),
+          ),
+      )
+
+    val before = now()
+    jar(libs, "libcurl.so.4", "A DIFFERENT UNRELATED LIBRARY")
+    assertEquals(before, now(), "a library that cannot touch a pixel must not orphan the cache")
+
+    jar(libs, "libfreetype.so.6", "FT UPGRADED")
+    assertNotEquals(before, now())
+  }
+
+  @Test
+  fun `a missing font root is absence, not a refusal to persist`() {
+    // Unlike a classpath entry, a font root that is not there is the ordinary state of most
+    // machines. Declining to persist on a developer laptop would be a bug, not caution.
+    val dir = tempDir()
+    val classpath = listOf(jar(dir, "catalog.jar", "CLASSES"))
+
+    assertNotNull(
+      ThemeCacheFingerprint.of(
+        classpath = classpath,
+        variant = "desktop",
+        renderConfig = "density=2",
+        renderer =
+          ThemeCacheFingerprint.rendererIdentity(
+            systemProperties = emptyMap(),
+            fontRoots = listOf(File(dir, "no-such-font-root")),
+            libraryRoots = listOf(File(dir, "no-such-lib-root")),
+          ),
+      )
+    )
+  }
+
+  @Test
+  fun `the process renderer identity is stable across calls`() {
+    // It walks the real font roots, so it is cached; a default that changed between two bundles of
+    // one multi-module catalog would give the catalog a fingerprint per module load.
+    assertEquals(
+      ThemeCacheFingerprint.currentRendererIdentity,
+      ThemeCacheFingerprint.currentRendererIdentity,
+    )
   }
 
   @Test

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -203,8 +203,9 @@ Undo it by removing the properties and restarting once the catalogs report conve
 
 ### Regenerating a catalog's warmed theme renders
 
-Two admin routes for pixels you suspect are wrong for a reason no fingerprint sees — a base-image
-bump that changed the installed fonts being the case that motivated them.
+Two admin routes for pixels you suspect are wrong for a reason no fingerprint sees. A base-image
+bump that changed the installed fonts was the case that motivated them; the fingerprint now reads
+the font inventory and the rasteriser sonames itself, so these are for whatever is left over.
 
 ```bash
 # Mark this catalog's warmed renders for re-render. Nothing is deleted: every preview keeps
@@ -509,25 +510,39 @@ that decides the pixels; because an input nobody thought of could still escape i
 re-renders a sample of the adopted entries at startup and discards the entire generation on any
 mismatch, so a fingerprint miss costs a re-render rather than serving wrong pixels.
 
-**A release keeps the warmed renders.** The tool version used to be part of that fingerprint, which
-meant every release orphaned the whole store — and with four versions shipping inside four hours
-here against a pass that needs the better part of a day, the cache was invalidated faster than it
-could ever fill and was adopted exactly zero times. The version was never proof of anything anyway:
-it stood *proxy* for the container image, which a base-image bump changes without moving the version
-at all. Renders written by another build are now adopted, and treated exactly like any other adopted
-entry — withheld from reads until the re-rendered sample agrees, whole generation discarded when it
-does not. The version stays in each generation's manifest, so which build last wrote a generation
-remains answerable.
+**A release keeps the warmed renders; a new base image does not.** The tool version used to be part
+of that fingerprint, which meant every release orphaned the whole store — and with four versions
+shipping inside four hours here against a pass that needs the better part of a day, the cache was
+invalidated faster than it could ever fill and was adopted exactly zero times. The version was never
+proof of anything anyway: it stood *proxy* for the container image, which a base-image bump changes
+without moving the version at all.
 
-For the case where you already **know** the pixels moved — a base image that changed the installed
-fonts, which no fingerprint sees and a five-entry sample can miss — evict the store outright:
+So the fingerprint reads the **render environment** directly instead — the JVM's own version, the
+architecture, the inventory of `/usr/share/fonts` and friends, and the freetype / fontconfig /
+harfbuzz sonames. Four builds out of one base image share a generation and adopt each other's
+renders; one build on a bumped base image gets its own directory and warms from cold, which is the
+correct answer and used to depend on a five-entry sample happening to draw one of the rows that
+moved. Renders written by another build of the same image are adopted and treated like any other
+adopted entry — withheld from reads until the re-rendered sample agrees, whole generation discarded
+when it does not. Each generation's manifest names the build that last **opened** it (not
+necessarily one that wrote a PNG there — a replica that fails readiness still leaves its version
+behind).
+
+For the case where you already **know** the pixels moved for a reason none of that reads, evict the
+store outright:
 
 ```
 SERVE_THEME_CACHE_EVICT=1
 ```
 
-It fires on **every** start while set, so leave it in for one roll and then take it out again. An
-ordinary renderer change needs none of this; the sample verification is what that is for.
+It fires on **every** start while set, so leave it in for one roll and then take it out again. The
+eviction also leaves an `evicted-at` marker at the store root, because the rollout is zero-downtime:
+the outgoing replica keeps rendering into the same volume while the incoming one boots, and anything
+it writes inside the following grace window would otherwise repopulate the generation with exactly
+the pixels you evicted. The marker makes those renders dirty instead, so you do not have to stop
+every writer first. Clearing the marker by hand is safe once the roll has settled. An ordinary
+renderer change needs none of this; the fingerprint and the sample verification are what that is
+for.
 
 Read `themeCache` on [`/status.json`](https://preview.coo.ee/status.json) to confirm it is on — it
 is `null` when there is no disk tier, and each catalog's `renderCache.persisted` is `null` beside

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -816,10 +816,14 @@ stays a 128 MB window onto it — a fully warmed catalog is several times that �
 through to disk and promote, and `cached` counts both tiers.
 
 Reuse is decided by a **fingerprint of what produced the pixels**, not by the cache key alone: the
-content hash of the classpath the daemon renders with, the daemon variant, the tool version, and the
-render config. Each `(system, fingerprint)` pair is its own directory, so a new catalog revision or
-a new server build simply writes a new generation and reads none of the old one — invalidation is
-structural rather than something a reader must remember to check. Generations nothing can read any
+content hash of the classpath the daemon renders with, the daemon variant, the render config, the
+id-to-daemon routing, and the **render environment** — the JVM, the rasteriser shared objects and
+the installed system fonts, none of which the classpath can reach. Deliberately *not* the tool
+version: it moved on every release while holding still on the base-image bump it was supposed to
+cover, so the environment it stood proxy for is keyed on directly instead. Each
+`(system, fingerprint)` pair is its own directory, so a new catalog revision or a new base image
+simply writes a new generation and reads none of the old one — invalidation is structural rather
+than something a reader must remember to check. Generations nothing can read any
 more are swept once the catalog pass finishes; a live set that exceeds `--theme-cache-max-bytes` is
 reported rather than evicted, because deleting what is currently being warmed would just make the
 optimizer render it again.


### PR DESCRIPTION
Closes the three unaddressed review findings left on #4564 after it merged.

## The hole

Dropping the tool version from the generation fingerprint was right for the reason `ThemeCacheFingerprint`'s class doc gives — a release must not orphan a cache that needs the better part of a day to fill, and four versions shipped in four hours meant it was adopted exactly zero times. But it left uncovered the thing the version stood *proxy* for. The JVM, the rasteriser shared objects and the installed system fonts live in the container image, not in the catalog, so a base-image bump moves the pixels while every hashed input holds still.

The only remaining net was `CatalogThemeCache.verifySample`, and it is a **sample**: `persistableKeys.filter(store::wasAdopted).sorted().take(5)`. A renderer change touching any of the other 18,599 entries on `preview.coo.ee` passes those five comparisons, the whole generation is marked trusted, and stale pixels are served for the life of the process.

## What changed

**1. `ThemeCacheFingerprint.rendererIdentity()` (P1 — "Retain a renderer identity in the generation fingerprint")**

The environment is keyed on directly rather than sampled for:

| Read | Why |
| --- | --- |
| `java.vm.vendor`, `java.vm.version`, `java.runtime.version` | `eclipse-temurin:21.0.12_8` and `21.0.13_11` are different text here. The daemon forks from `System.getProperty("java.home")`, so the server's JVM *is* the renderer's. |
| `os.arch` | Both renderers have per-arch native halves. |
| Font-root inventory — relative path + size | Stat, not bytes: hundreds of MB on a fontconfig image and this is on the catalog-load path. Not mtime either, or a package layer rebuilt from identical sources would reintroduce churn-per-build. |
| freetype / fontconfig / harfbuzz sonames | A freetype bump changes glyph rasterisation on the Android path with nothing else moving. Matched on the soname, so the versioned real file beside the link does not move the fingerprint twice. |

Crucially this does **not** move on a release, so the pathology that got the version removed does not come back: four builds out of one base image share a generation, one build on a bumped base image does not.

The walks are bounded on **depth** (`/usr/lib` under a library root is not ours) and on **files visited** rather than files kept — counting only the kept ones would let the filtered library walk run without limit down a symlink loop, since `walkTopDown` follows directory symlinks. The result is cached per process; a multi-module catalog fingerprints once per bundle and the answer cannot change under a running process.

A missing font root is recorded as absence, not as a refusal to persist — unlike a classpath entry it is the ordinary state of most machines.

**Cost, stated plainly:** `SCHEMA` goes to `theme-cache/2`, so every generation on disk is orphaned once. On a box mid-warm that is one re-warm, paid a single time, in exchange for a key that stops depending on a five-entry sample to notice the image moved.

**2. An eviction epoch (P1 — "Coordinate eviction with the old rollout replica")**

`evictAll`'s doc claimed it "can never race a live `Generation`'s writes" because it runs before this process opens anything. That is a single-process argument about a volume that is not single-process: the deployment rolls out **zero-downtime**, so the outgoing replica keeps serving and keeps writing PNGs into the same mounted `/config` volume while the incoming one boots and evicts. Every render it publishes in that window repopulates the generation with precisely the pixels the eviction was meant to destroy — landing *after* the deletion, so it carries a fresh timestamp and reads as this build's own work.

The eviction now stamps an `evicted-at` marker at the store root (after the deletion, so a crash midway leaves the volume looking un-evicted rather than under a boundary nothing was deleted against). Every subsequent `open` raises its dirty boundary to `evictedAt + graceMillis`, reusing the same boundary mechanism and the same grace window the cross-build case already had — it is the same question about the same other replica.

The same-build case is what this really closes. An operator who evicts and restarts *without* shipping a release used to hit the matching-`toolVersion` early return, so the boundary stayed at whatever the previous manifest recorded — commonly zero. The early return now also requires the recorded boundary to be at or past the eviction boundary.

The marker is not a lock and does not claim to be one. It cannot stop the old replica writing; it makes what the old replica writes untrusted, which is the outcome that was wanted, and it means an operator does not have to prove every writer has stopped first.

**3. `toolVersion` documented as the last *opener* (P2 — "Update the manifest only after this build writes a render")**

Correct as reported: the manifest is rewritten at open, before this process has rendered anything, so a replica that fails readiness immediately afterwards leaves its version behind while the outgoing one carries on as the volume's only real writer.

Taking the suggested fix — defer the rewrite to the first successful `Generation.put` — would fix that half and break the other: `dirtyBeforeEpochMillis` has to be on disk **before** a single render is served from the directory, or the adopted set is trusted for however long the first write takes. The boundary is the correctness half, so it wins, and the reviewer's own alternative is taken instead: the field is documented as what it actually is, on `GenerationInputs.toolVersion` and in `deploy/image/README.md`.

## Test plan

Nine new tests in `ThemeCachePersistenceTest`, all in `:cli:serve:test` (67 tests, 0 failures):

- a bumped JVM is a different generation with the classpath untouched — and an unchanged one is not
- a swapped system font is a different generation; so is an added one
- a bumped rasteriser soname is; an unrelated library in the same directory is not
- a missing font root is absence, not a refusal to persist
- the process renderer identity is stable across calls
- an eviction makes the outgoing replica's repopulated renders dirty (same build, so the version comparison alone cannot see it) — and they stay warm meanwhile
- renders written past the eviction's grace window are clean again
- a store that was never evicted carries no boundary
- the marker survives a sweep, and a later eviction moves it forward

Gates run locally on the pushed head:

- `./gradlew :cli:serve:test :cli:test` — BUILD SUCCESSFUL
- `./gradlew :cli:checkServeSeam` — `OK — 123 crossing symbol(s), all on the allowlist`
- `python3 scripts/test_check_serve_seam.py` — 45 tests, OK
- `./gradlew ktfmtCheckAll` — clean

No visual surface changes: this is the cache key and the eviction boundary, both invisible to a rendered page. What it changes about pixels is that a base-image bump now gets its own generation instead of possibly adopting the previous image's renders — the correct output, not a new one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_