### PR TITLE
fix(deploy): derive the live-seat budget from cores as well as memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1351,6 +1351,11 @@ jobs:
       # a diff and would quietly turn a tidy-up tool into a credential leak.
       - name: Run deploy .env redundancy tests
         run: ./deploy/image/test-env-redundant.sh
+      # The live-seat budget is derived at container start from memory AND cores. Getting it wrong
+      # is silent: too low and a large box runs a fraction of what it affords, too high and it
+      # spawns daemons it cannot feed. Neither shows up as an error, only as throughput.
+      - name: Run deploy live-seat derivation tests
+        run: ./deploy/image/test-derive-live-seats.sh
       # The agent-grant lane derives its own default (on where SERVE_GITHUB_AUTH_* gives it a human
       # to approve against, off otherwise), because both flat answers are wrong in opposite
       # directions: `1` fails startup on every box with no OAuth app, `0` ships the feature dead on

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -198,12 +198,16 @@ a box rendering flat out sits above that. The thresholds take the same units.
 | Knob | What it bounds | Default |
 | --- | --- | --- |
 | `PREVIEW_MEM_LIMIT` | Memory the whole container may use | `0` (unlimited) |
-| `SERVE_LIVE_SEATS` | Concurrent daemon *residency*, weighted (Android costs 2) | derived: `(mem_mb − 1024) / 1200`, clamped to `[2, 8]` |
+| `SERVE_LIVE_SEATS` | Concurrent daemon *residency*, weighted (Android costs 2) | derived: `min(memory, cores × 2)`, clamped to `[2, 32]` |
 | `SERVE_BACKGROUND_RENDERS` | Optimizer renders admitted at once | derived from seats, clamped to 3 |
 
-**Both derivations clamp**, so on a large box you are running a fraction of what the hardware
-affords unless you name a number. That is what these variables are for; the seat budget still bounds
-how many daemons those renders can occupy.
+The seat budget derives from **both** memory and cores — a permit buys a render daemon and a render
+is CPU-bound, so a RAM-rich, core-poor box must not derive a budget it cannot work. `cores × 2` is
+one Android daemon per core, Android being the heaviest backend at two permits each.
+
+**`SERVE_BACKGROUND_RENDERS` still clamps at 3**, though, so on a box deriving more than 8 seats the
+optimizer lane becomes the binding constraint even once the seats are right. Name it explicitly
+until that derivation scales too; `(seats − 2) / 2` is the arithmetic the seat budget can afford.
 
 Measure before choosing, because the container's own `free` reports the HOST's memory and will
 happily claim 60 GiB available inside a 3 GiB container:

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -294,10 +294,45 @@ fi
 # see LiveSeatLimiter), so one heavy catalog can't hog a flat seat count and starve the cheap CMP
 # lanes. An over-budget viewer is refused (WS 1013) rather than OOM-ing the box.
 #
-# When SERVE_LIVE_SEATS is unset we AUTO-DERIVE the budget from the container's memory limit so a
-# bigger box scales up on its own (no compose edit, no rebuild): reserve ~1 GB for the serve host +
-# OS, budget ~1.2 GB of headroom per permit, and clamp to [2, 8]. The floor of 2 means even the
-# reference 4 GB box always runs at least two cheap CMP sessions concurrently (4 GB → 2; 8 GB → 5).
+# The seat arithmetic, kept as a function so `test-derive-live-seats.sh` can exercise it with
+# synthetic values instead of faking /proc/meminfo and /sys/fs/cgroup.
+SEATS_PER_CPU=2
+SEATS_FLOOR=2
+SEATS_CEILING=32
+derive_live_seats() {
+  local eff_mb="$1" cpus="$2" mem_seats cpu_seats seats
+  mem_seats=${SEATS_FLOOR}
+  (( eff_mb > 0 )) && mem_seats=$(( (eff_mb - 1024) / 1200 ))
+  # An unknown core count must not derive zero seats. Falling back to the memory figure keeps the
+  # old behaviour exactly, which is the right answer when half the inputs are missing.
+  if (( cpus > 0 )); then
+    cpu_seats=$(( cpus * SEATS_PER_CPU ))
+  else
+    cpu_seats=${mem_seats}
+  fi
+  seats=$(( mem_seats < cpu_seats ? mem_seats : cpu_seats ))
+  (( seats < SEATS_FLOOR )) && seats=${SEATS_FLOOR}
+  (( seats > SEATS_CEILING )) && seats=${SEATS_CEILING}
+  echo "${seats}"
+}
+
+# When SERVE_LIVE_SEATS is unset we AUTO-DERIVE the budget from the box: reserve ~1 GB for the serve
+# host + OS, budget ~1.2 GB of headroom per permit, and take the SMALLER of what memory affords and
+# what the CPUs afford.
+#
+# **Memory alone was the wrong input.** A permit buys a render daemon, and a render is CPU-bound —
+# so a box with plenty of RAM and few cores derived a budget it could not actually work, while the
+# [2, 8] clamp meant a large box stopped scaling entirely. Measured on preview.coo.ee (48 GiB
+# limit, 8 cores): memory afforded 40 permits, the clamp allowed 8, and the box ran a fifth of what
+# its cores could have driven.
+#
+# `SEATS_PER_CPU` of 2 is one Android daemon per core, since Android costs two permits and is the
+# heaviest backend. A render is not purely on-CPU — it waits on daemon startup and I/O — so one
+# renderable slot per core would leave cores idle, and much more than two would thrash them.
+#
+# The floor of 2 keeps the reference 4 GB box running two cheap CMP sessions concurrently. The
+# ceiling is now 32 rather than 8: still a bound (a runaway derivation should not spawn daemons
+# without limit) but one a real box reaches rather than one every serious box exceeds.
 # Set SERVE_LIVE_SEATS explicitly to override, or 0 for unbounded.
 if [[ -z "${SERVE_LIVE_SEATS:-}" ]]; then
   # Detect the cgroup memory limit (v2 then v1), capped by physical RAM so an "unlimited" sentinel
@@ -325,14 +360,10 @@ if [[ -z "${SERVE_LIVE_SEATS:-}" ]]; then
   else
     eff_mb=${mem_total_mb}
   fi
-  seats=2
-  if (( eff_mb > 0 )); then
-    seats=$(( (eff_mb - 1024) / 1200 ))
-    (( seats < 2 )) && seats=2
-    (( seats > 8 )) && seats=8
-  fi
-  SERVE_LIVE_SEATS="${seats}"
-  echo "entrypoint: auto live-seat budget ${SERVE_LIVE_SEATS} (effective mem ${eff_mb} MB)" >&2
+  cpus=$(nproc 2>/dev/null || echo 0)
+  SERVE_LIVE_SEATS="$(derive_live_seats "${eff_mb}" "${cpus}")"
+  echo "entrypoint: auto live-seat budget ${SERVE_LIVE_SEATS}" \
+    "(effective mem ${eff_mb} MB, ${cpus} cpus)" >&2
 fi
 [[ -n "${SERVE_LIVE_SEATS}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
 # Background (theme-optimizer) renders admitted at once, server-wide. Unset leaves the server's own

--- a/deploy/image/test-derive-live-seats.sh
+++ b/deploy/image/test-derive-live-seats.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guard: the auto-derived live-seat budget reflects BOTH memory and cores.
+#
+# Memory alone was the wrong input. A permit buys a render daemon and a render is CPU-bound, so a
+# RAM-rich, core-poor box derived a budget it could not work — and the old [2, 8] clamp meant a large
+# box stopped scaling at all. Measured on preview.coo.ee (48 GiB, 8 cores): memory afforded 40, the
+# clamp allowed 8, and the box ran a fifth of what its cores could drive.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
+
+# Pull just the constants and the function out, so this exercises the real arithmetic without
+# running an entrypoint that expects to be inside the container.
+eval "$(sed -n '/^SEATS_PER_CPU=/,/^}$/p' "${entrypoint}")"
+declare -F derive_live_seats >/dev/null || {
+  echo "FAIL: derive_live_seats not found in ${entrypoint} — the extractor is broken." >&2
+  exit 1
+}
+
+check() { # eff_mb cpus expected why
+  local got; got="$(derive_live_seats "$1" "$2")"
+  [[ "${got}" == "$3" ]] || {
+    echo "FAIL: ${4} — ${1}MB/${2}cpu gave ${got}, expected ${3}" >&2
+    exit 1
+  }
+  echo "PASS: ${4} (${1}MB, ${2} cpu -> ${got})"
+}
+
+# The deployed box. Memory affords 40, cores afford 16; the cores govern.
+check 49152 8 16 "a large box is bounded by its cores, not clamped at 8"
+
+# The old ceiling was 8. Prove we are past it — this is the regression that matters.
+[[ "$(derive_live_seats 49152 8)" -gt 8 ]] || {
+  echo "FAIL: the old 8-seat clamp is still in force" >&2
+  exit 1
+}
+echo "PASS: the old 8-seat clamp is gone"
+
+# Core-poor, RAM-rich: memory would have said 40, the cores say 4.
+check 49152 2 4 "cores bound a RAM-rich box"
+
+# RAM-poor, core-rich: the reverse — memory governs.
+check 4096 32 2 "memory bounds a core-rich box"
+
+# The reference 4 GB box still gets its floor.
+check 4096 4 2 "the 4 GB reference box keeps the floor of 2"
+
+# 8 GB / 4 cores: memory affords 5, cores 8 — memory governs, as it did before.
+check 8192 4 5 "an 8 GB box derives what it always did"
+
+# A very large box is still bounded, so a runaway derivation cannot spawn daemons without limit.
+check 262144 128 32 "a huge box is capped at the ceiling"
+
+# Unknown core count must not derive zero. Falling back to memory keeps the old behaviour, which is
+# the right answer when half the inputs are missing.
+check 49152 0 32 "an unknown core count falls back to the memory figure"
+check 8192 0 5 "an unknown core count on a small box matches the old derivation"
+
+# Unknown memory must not underflow into a negative seat count.
+check 0 8 2 "unknown memory falls back to the floor, not a negative"
+
+echo "PASS: all derive_live_seats checks"


### PR DESCRIPTION
Asked whether any of the tuning could be automatic, I went looking at what already is. The live-seat budget auto-derives — from the wrong input, and then clamps the answer.

## Memory alone cannot size this

A permit buys a render daemon, and a render is **CPU-bound**. The derivation only ever consulted memory:

```
seats = (eff_mb − 1024) / 1200,  clamped to [2, 8]
```

Both halves are wrong on a real box:

| Box | Memory affords | Old answer | Actually right |
| --- | --- | --- | --- |
| 48 GiB, 8 cores (`preview.coo.ee`) | 40 | **8** | 16 |
| 48 GiB, 2 cores | 40 | **8** | 4 — it cannot work 8 |
| 48 GiB, 32 cores | 40 | **8** | 32 — a quarter of the machine idle |

The deployed box has been running a fifth of what its cores could drive, and the clamp is why raising it needed a manual override at all.

## Now

```
seats = min( memory affords , cores × 2 ),  clamped to [2, 32]
```

`cores × 2` is one Android daemon per core — Android being the heaviest backend at two permits each. A render is not purely on-CPU (it waits on daemon startup and I/O), so one slot per core would leave cores idle, and much more than two would thrash them.

The ceiling moves 8 → 32: still a bound, so a runaway derivation cannot spawn daemons without limit, but at a size a real box reaches rather than one every serious box exceeds.

**On the deployed box this derives 16** — the figure hand-tuning had independently arrived at, which is the check I actually wanted before believing the formula.

Missing inputs fall back rather than fail: an unknown core count derives from memory exactly as before, and unknown memory takes the floor rather than underflowing negative.

## What this does *not* fix

`SERVE_BACKGROUND_RENDERS` still clamps at **3**, so above 8 seats the optimizer lane becomes the binding constraint instead of the seat budget. The derivation `(seats − 2) / 2` already scales correctly; only `MAX_DERIVED_CONCURRENT_RENDERS` is arbitrary.

I've left it alone deliberately. Its clamp carries a documented safety rationale ("a lane of 3 is a licence for up to fifteen concurrent daemons"), which the seat budget is what bounds — so it becomes safe to scale *because of* this change, and that is worth its own evidence rather than being bundled in. The README now names it and gives the arithmetic so it can be set explicitly meanwhile.

## Test plan

`test-derive-live-seats.sh`, wired into CI beside the other deploy guards. The arithmetic moved into a `derive_live_seats` function so the test drives it with synthetic values rather than faking `/proc/meminfo` and `/sys/fs/cgroup`:

- cores bound a RAM-rich box (48 GiB / 2 cores → 4)
- memory bounds a core-rich box (4 GiB / 32 cores → 2)
- the 4 GB reference box keeps its floor
- an 8 GB / 4-core box derives 5, exactly as it did before
- a huge box hits the ceiling (256 GiB / 128 cores → 32)
- both missing-input fallbacks
- an explicit guard that the old 8-seat clamp is gone — the regression that matters

`test-env-redundant.sh`, `test-compose-env-passthrough.sh`, `test-java-opts-append.sh` and `test-env-migrations.sh` (11 passed) all still green; `ci.yml` parses.

Shell and docs; no rendered surface, so nothing visual to diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_