### PR TITLE
fix(figma-svg): carry the variant seed through the desktop preview router

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.devices.frameDpOverriddenBy
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import kotlinx.serialization.Serializable
@@ -209,7 +211,14 @@ class PreviewManifestRouter(
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
       inbound["slotMode"]?.let { append("slotMode=").append(it).append(';') }
       inbound["clearBackground"]?.let { append("clearBackground=").append(it).append(';') }
-      inbound["overrides"]?.let { append("overrides=").append(it).append(';') }
+      // A synthetic `_VARIANT_` preview carries its `@OverrideVariant` seed on the manifest entry,
+      // not on the wire — the inbound payload for a batch render is `previewId=<id>` and nothing
+      // else. Merge the two rather than forwarding the inbound token alone, or the baked seed is
+      // dropped and every variant composes its base state (issue #3616, and yschimke/m3-catalog#201
+      // for the desktop half that this router lane kept reproducing).
+      overridesTokenFor(inbound["overrides"], resolved.overrides)?.let {
+        append("overrides=").append(it).append(';')
+      }
       // `@PreviewWrapper(SomeProvider::class)` FQN sourced from `previews.json` (the
       // gradle plugin's `extractWrapperFqn` reads it off the class-file annotation tables
       // — the upstream annotation is `AnnotationRetention.BINARY` and invisible to
@@ -280,6 +289,33 @@ class PreviewManifestRouter(
     return map
   }
 
+  /**
+   * Layers a live request override over the synthetic preview's baked `@OverrideVariant` seed.
+   *
+   * The inbound token is the sparse per-call bag a knob edit sends; the baked one is the whole
+   * variant. Layering (rather than picking a side) is what lets a served `?knob.size=l` edit of a
+   * `_VARIANT_disabled` sticker keep the disabled seed it did not touch — the same merge
+   * `DesktopHost.specFromPreviewIdPayload` performs on the resolver lane.
+   */
+  private fun overridesTokenFor(inboundToken: String?, baseOverrides: PreviewOverrides?): String? {
+    if (baseOverrides == null) return inboundToken
+    val inbound = inboundToken?.let {
+      runCatching {
+        json.decodeFromString(
+          PreviewOverrides.serializer(),
+          String(java.util.Base64.getUrlDecoder().decode(it), Charsets.UTF_8),
+        )
+      }
+        .getOrNull()
+    }
+    val merged = inbound.layeredOver(baseOverrides) ?: return inboundToken
+    return java.util.Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), merged).toByteArray(Charsets.UTF_8)
+      )
+  }
+
   companion object {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -308,7 +344,7 @@ class PreviewManifestRouter(
      * which collapses cleanly into the host's existing "no resolver match → throw
      * UnsupportedOperationException" path.
      */
-    private fun manifestPreviewSpecResolver(
+    internal fun manifestPreviewSpecResolver(
       byId: Map<String, PreviewManifestEntry>
     ): (String) -> RenderSpec? = { previewId ->
       // Row-addressed ids (issue #3749) resolve here too, so a held session — `interactive/start`,
@@ -338,6 +374,10 @@ class PreviewManifestRouter(
           // follow-up).
           uiMode = if ((resolved.uiMode and 0x30) == 0x20) RenderSpec.SpecUiMode.DARK else null,
           wrapperClassName = resolved.wrapperClassName,
+          // The baked `@OverrideVariant` seed, so a held interactive / recording session of a
+          // `_VARIANT_` id composes its own state. `DesktopHost.specFromPreviewIdPayload` layers
+          // any live per-call bag over this one.
+          overrides = resolved.overrides,
           previewParameterProviderClassName = resolved.previewParameterProviderClassName,
           previewParameterLimit = resolved.previewParameterLimit,
           previewParameterRow = split?.row,
@@ -384,6 +424,8 @@ data class PreviewManifestEntry(
    * the flat fields below.
    */
   val params: PreviewParamsEntry? = null,
+  /** Baked state seed for a synthetic `_VARIANT_` preview emitted by discovery. */
+  val overrides: OverrideVariantSpec? = null,
   val widthPx: Int? = null,
   val heightPx: Int? = null,
   val density: Float? = null,
@@ -473,6 +515,13 @@ data class PreviewManifestEntry(
     val previewParameterProviderClassName =
       previewParameterProviderClassName ?: p?.previewParameterProviderClassName
     val previewParameterLimit = previewParameterLimit ?: p?.previewParameterLimit ?: Int.MAX_VALUE
+    // An all-unparseable seed set yields an empty map, which is "no seed" rather than "seed
+    // nothing" — `takeIf` keeps it null so the router forwards the inbound token untouched.
+    val bakedOverrides =
+      overrides
+        ?.toNamedOverrides()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { PreviewOverrides(namedOverrides = it) }
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,
@@ -484,6 +533,7 @@ data class PreviewManifestEntry(
       uiMode = uiMode,
       outputBaseName = outputBaseName ?: id,
       wrapperClassName = wrapperClassName,
+      overrides = bakedOverrides,
       kind = p?.kind,
       assetPath = p?.assetPath,
       wrapWidth = wrapWidth,
@@ -587,6 +637,8 @@ data class ResolvedRenderParams(
   val uiMode: Int = 0,
   val outputBaseName: String,
   val wrapperClassName: String? = null,
+  /** Baked state seed for a synthetic `_VARIANT_` preview. */
+  val overrides: PreviewOverrides? = null,
   val kind: String? = null,
   val assetPath: String? = null,
   /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -89,6 +89,77 @@ class OverrideIntegrationTest {
     }
   }
 
+  /**
+   * The same guarantee as [discoveredOverrideVariantKeepsItsOwnFigmaSvgAndState], through the lane
+   * a **production** desktop daemon actually takes.
+   *
+   * The gradle plugin sets `composeai.harness.previewsManifest` unconditionally for CMP / desktop
+   * modules (the "harness" prefix is historical — see `ComposePreviewTasks.kt`), so `DaemonMain`
+   * mounts [PreviewManifestRouter] rather than the `previewIndexBackedSpecResolver` the sibling
+   * test drives. The router forwards a `previewId=<id>` payload and nothing else, so until it
+   * learned to carry the manifest entry's `@OverrideVariant` seed, every variant of every
+   * desktop-rendered catalog exported its BASE state — a disabled button drawn as the enabled
+   * container, a `size=l` cell drawn small — beside a correct PNG, because the PNG comes from the
+   * standalone renderer, which seeds the controller itself (issue #3616's desktop half;
+   * yschimke/m3-catalog#201).
+   */
+  @Test
+  fun routedOverrideVariantKeepsItsOwnFigmaSvgAndState() {
+    val outputDir = tempFolder.newFolder("renders-routed-override-variant")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val baseId = "FilledButton_Light"
+    val variantId = "FilledButton_Light_VARIANT_disabled"
+    fun entry(id: String, overrides: OverrideVariantSpec? = null) =
+      PreviewManifestEntry(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "OverridableSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        outputBaseName = id,
+        overrides = overrides,
+      )
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                entry(baseId),
+                entry(
+                  variantId,
+                  OverrideVariantSpec(
+                    name = "disabled",
+                    seeds =
+                      listOf(
+                        OverrideSeed(key = "fill", kind = OverrideSeedKind.COLOR, raw = "#FF42A5F5")
+                      ),
+                  ),
+                ),
+              )
+          ),
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(PreviewOverridesPreviewOverrideExtension()))
+          ),
+      )
+    host.start()
+    try {
+      host.submit(RenderRequest.Render(payload = "previewId=$baseId"), timeoutMs = 30_000)
+      host.submit(RenderRequest.Render(payload = "previewId=$variantId"), timeoutMs = 30_000)
+      val dataDir = outputDir.parentFile!!.resolve("data")
+      val baseSvg = dataDir.resolve(baseId).resolve("compose-figma.svg").readText()
+      val variantSvg = dataDir.resolve(variantId).resolve("compose-figma.svg").readText()
+      assertTrue("base SVG must retain the author-default red fill", baseSvg.contains("#EF5350"))
+      assertTrue("variant SVG must carry its baked blue fill", variantSvg.contains("#42A5F5"))
+      assertNotEquals("base and variant SVGs must not collide", baseSvg, variantSvg)
+    } finally {
+      host.shutdown()
+    }
+  }
+
   @Test
   fun widthPxOverrideChangesRenderedDimensions() {
     val outputDir = tempFolder.newFolder("renders-width")

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterOverrideVariantTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouterOverrideVariantTest.kt
@@ -1,0 +1,135 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.OverrideSeed
+import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
+import ee.schimke.composeai.data.overrides.PreviewOverrideValue
+import java.util.Base64
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The desktop half of issue #3616 — a synthetic `_VARIANT_` preview must carry its
+ * `@OverrideVariant` seed through [PreviewManifestRouter], not compose its base state.
+ *
+ * #3652 fixed this on `:daemon:android` only, and the router is production on **both** backends
+ * (the gradle plugin sets `composeai.harness.previewsManifest` unconditionally — the "harness"
+ * prefix is historical; see `ComposePreviewTasks.kt`). So every desktop / CMP catalog kept
+ * publishing base-state `compose-figma.svg`, `layout-inspector.json` and `compose-semantics.json`
+ * for each variant beside a correct PNG — the PNG comes from the standalone renderer, which seeds
+ * the controller itself. yschimke/m3-catalog#201 is that divergence: a disabled button whose
+ * exported vector is the enabled container, and a `size=l` cell exported at the small size.
+ *
+ * The inbound payload for a batch render is `previewId=<id>` and nothing else, so the seed can only
+ * reach the engine off the manifest entry.
+ */
+class PreviewManifestRouterOverrideVariantTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun entry(id: String, overrides: OverrideVariantSpec? = null) =
+    PreviewManifestEntry(
+      id = id,
+      className = "com.example.ButtonsKt",
+      functionName = "FilledButton",
+      widthPx = 64,
+      heightPx = 64,
+      density = 1.0f,
+      overrides = overrides,
+    )
+
+  private fun disabledSeed() =
+    OverrideVariantSpec(
+      name = "disabled",
+      seeds = listOf(OverrideSeed(key = "state", kind = OverrideSeedKind.STRING, raw = "disabled")),
+    )
+
+  private fun tokenFor(overrides: PreviewOverrides): String =
+    Base64.getUrlEncoder()
+      .withoutPadding()
+      .encodeToString(
+        json.encodeToString(PreviewOverrides.serializer(), overrides).toByteArray(Charsets.UTF_8)
+      )
+
+  @Test
+  fun `a variant entry's baked seed reaches the routed RenderSpec`() {
+    val id = "FilledButton_Light_VARIANT_disabled"
+    val router =
+      PreviewManifestRouter(PreviewManifest(previews = listOf(entry(id, disabledSeed()))))
+
+    val spec = RenderSpec.parseFromPayload(router.routePayload("previewId=$id"))
+
+    assertEquals(
+      PreviewOverrideValue.StringValue("disabled"),
+      spec.overrides?.namedOverrides?.get("state"),
+    )
+  }
+
+  @Test
+  fun `an ordinary entry routes with no overrides token`() {
+    val router =
+      PreviewManifestRouter(PreviewManifest(previews = listOf(entry("FilledButton_Light"))))
+
+    val spec = RenderSpec.parseFromPayload(router.routePayload("previewId=FilledButton_Light"))
+
+    assertNull(spec.overrides)
+  }
+
+  @Test
+  fun `a live knob edit wins per key and leaves the rest of the seed standing`() {
+    val id = "FilledButton_Light_VARIANT_disabled"
+    val seed =
+      OverrideVariantSpec(
+        name = "disabled",
+        seeds =
+          listOf(
+            OverrideSeed(key = "state", kind = OverrideSeedKind.STRING, raw = "disabled"),
+            OverrideSeed(key = "shape", kind = OverrideSeedKind.STRING, raw = "square"),
+          ),
+      )
+    val router = PreviewManifestRouter(PreviewManifest(previews = listOf(entry(id, seed))))
+    val live =
+      tokenFor(
+        PreviewOverrides(
+          namedOverrides = mapOf("shape" to PreviewOverrideValue.StringValue("round"))
+        )
+      )
+
+    val spec = RenderSpec.parseFromPayload(router.routePayload("previewId=$id;overrides=$live"))
+
+    val named = spec.overrides?.namedOverrides.orEmpty()
+    assertEquals(PreviewOverrideValue.StringValue("round"), named["shape"])
+    assertEquals(PreviewOverrideValue.StringValue("disabled"), named["state"])
+  }
+
+  @Test
+  fun `an undecodable inbound token does not cost the variant its seed`() {
+    val id = "FilledButton_Light_VARIANT_disabled"
+    val router =
+      PreviewManifestRouter(PreviewManifest(previews = listOf(entry(id, disabledSeed()))))
+
+    val spec =
+      RenderSpec.parseFromPayload(router.routePayload("previewId=$id;overrides=not-base64"))
+
+    assertEquals(
+      PreviewOverrideValue.StringValue("disabled"),
+      spec.overrides?.namedOverrides?.get("state"),
+    )
+  }
+
+  @Test
+  fun `a variant entry seeds the interactive spec resolver too`() {
+    val id = "FilledButton_Light_VARIANT_disabled"
+    val entries = listOf(entry(id, disabledSeed()))
+
+    val spec = PreviewManifestRouter.manifestPreviewSpecResolver(entries.associateBy { it.id })(id)
+
+    assertEquals(
+      PreviewOverrideValue.StringValue("disabled"),
+      spec?.overrides?.namedOverrides?.get("state"),
+    )
+  }
+}


### PR DESCRIPTION
Fixes the desktop half of #3616. Reported as [yschimke/m3-catalog#201](https://github.com/yschimke/m3-catalog/issues/201) ("Button SVG doesn't have correct states").

## What was wrong

On the published `m3-catalog` delivery branch, **every** `@OverrideVariant` cell's exported vector is byte-identical to its base render — only the raster href differs:

| `figma/button-filled/…` | container fill | viewBox | PNG beside it |
| --- | --- | --- | --- |
| `ideal__default__light.svg` | `#6750A4` | 249×126 | 249×126 ✅ |
| `ideal__disabled.svg` | `#6750A4` | 249×126 | 249×126, grey ❌ |
| `ideal__l.svg` | `#6750A4` | 249×126 | **521×252** ❌ |
| `ideal__xl.svg` | `#6750A4` | 249×126 | **687×357** ❌ |

`layout-inspector.json` and `compose-semantics.json` for `FilledButton_Light_VARIANT_disabled` agree with the SVG and not with reality — `backgroundColor: "#FF6750A4"`, `textColor.foreground: "#FFFFFFFF"`, `clickable: true` on a *disabled* button. The PNG is correct because it comes from the standalone renderer, which seeds `PreviewOverrideController` itself; everything derived from the **daemon** render carries the base state. `_Dark` (a real `@Preview`) exports correctly, so the failure is specific to synthetic `_VARIANT_` ids.

The same catalog rendered on the Android backend (`wear-m3-catalog`) exports its disabled variants correctly — `#F6EDFF` at `fill-opacity="0.12"` with a `0.38` label — which is what localises this to desktop.

## Why

#3652 fixed this bug class on `:daemon:android` only. But `PreviewManifestRouter` is the **production** lane on both backends: the gradle plugin sets `composeai.harness.previewsManifest` unconditionally for CMP / desktop modules (`ComposePreviewTasks.kt` — the "harness" prefix is historical), so `DaemonMain` mounts the router rather than the `previewIndexBackedSpecResolver` that `renderSpecFromInfo` already seeds. The desktop router forwarded the inbound `overrides=` token and nothing else, and a batch render's inbound payload is a bare `previewId=` plus the id — so the baked seed had no way in.

## What changed

Ports the android router's three seams to `:daemon:desktop`:

- `overrides: OverrideVariantSpec?` on `PreviewManifestEntry`, resolved into a `PreviewOverrides` bag on `ResolvedRenderParams`;
- `overridesTokenFor(...)` on the routed payload, layering any live per-call token **over** the baked seed (so a `?knob.size=l` edit of a `_VARIANT_disabled` sticker keeps the disabled seed it didn't touch);
- `overrides = resolved.overrides` on `manifestPreviewSpecResolver`, so held interactive / recording sessions of a `_VARIANT_` id compose their own state too.

## Not in scope

Interaction variants (`hovered` / `focused` / `pressed`) are unchanged and still export the resting state. Those are harness **captures**, not seeds — `PreviewCaptureDto` deliberately carries only `scroll` / `settle`, and the daemon's one-frame-per-id surface drives no input device. That gap is cross-backend (no published catalog exports a correct interaction-state vector today), so it is filed separately as #4639 rather than guessed at here.

## Test plan

New coverage, all of which fails on `main`:

- `PreviewManifestRouterOverrideVariantTest` (5 cases) — the baked seed reaches the routed `RenderSpec`; an ordinary entry still routes with no `overrides` token; a live knob edit wins per key while the rest of the seed stands; an undecodable inbound token doesn't cost the variant its seed; the interactive spec resolver is seeded too.
- `OverrideIntegrationTest.routedOverrideVariantKeepsItsOwnFigmaSvgAndState` — end-to-end through the router: renders base + variant, asserts `compose-figma.svg` carries `#EF5350` and `#42A5F5` respectively and that the two don't collide. This is the sibling of the existing `discoveredOverrideVariantKeepsItsOwnFigmaSvgAndState`, which only ever covered the resolver lane — which is why the router lane stayed broken after #3652.

Verified the new tests fail against the unfixed router (4 of 6 red; the 5th passes because the interactive-resolver seam is a separate site), then pass with the fix.

```
./gradlew :daemon:desktop:test :daemon:desktop:ktfmtCheckMain :daemon:desktop:ktfmtCheckTest   # BUILD SUCCESSFUL
```

Text-only PR body is correct here: no rendered surface changes in this repo. The visible effect is on consumers' delivery branches, and needs a release + version bump before it can be captured.