### PR TITLE
fix(deploy): refuse a .env line continuation instead of serving 502

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -226,7 +226,9 @@ genuinely explain why this box differs from stock are buried.
 ./env-redundant.sh
 ```
 
-Reports which entries restate a compose or entrypoint default and which are set but empty (the same
+It first refuses any line ending in a backslash — `.env` is not a shell script, and that typo takes
+the box down with a 502 and no explanation. Then it reports which entries restate a compose or
+entrypoint default and which are set but empty (the same
 as unset), then lists the keys that genuinely differ — **by name only**. It never prints a value:
 the file holds `SERVE_TOKEN`, `SERVE_ADMIN_TOKEN`, the GitHub OAuth secret and the deploy hook
 token, and the output is meant to be safe to paste into an issue or a chat.
@@ -238,13 +240,14 @@ is still filling, that trade is backwards: an empty cache means every theme a vi
 cold render, so the fastest route to a *responsive* box is to let the optimizer have the machine for
 a few hours and then hand it back.
 
+> **One line, no backslashes.** `.env` is not a shell script: docker compose reads every line as its
+> own `KEY=VALUE`, so a trailing `\` becomes part of the value and the continuation lines are parsed
+> as junk keys. That backslash then reaches `JAVA_TOOL_OPTIONS`, the JVM refuses to start on an
+> unrecognised option, and the container restart-loops behind a 502 — with nothing in the compose
+> output naming the cause. This example is long; keep it on one line anyway.
+
 ```
-SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 \
-  -Dcomposeai.serve.optimizerStopLoadPerCpu=3.0 \
-  -Dcomposeai.serve.optimizerResumeLoadPerCpu=2.0 \
-  -Dcomposeai.serve.optimizerStopCpuUtilization=0.98 \
-  -Dcomposeai.serve.optimizerResumeCpuUtilization=0.92 \
-  -Dcomposeai.serve.optimizerResumeQuietMillis=5000
+SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 -Dcomposeai.serve.optimizerResumeQuietMillis=5000 -Dcomposeai.serve.optimizerStopLoadPerCpu=3.0 -Dcomposeai.serve.optimizerResumeLoadPerCpu=2.0 -Dcomposeai.serve.optimizerStopCpuUtilization=0.98 -Dcomposeai.serve.optimizerResumeCpuUtilization=0.92
 ```
 
 Read that as: start a pass after ten seconds of quiet rather than sixty, only stand down when the

--- a/deploy/image/env-redundant.sh
+++ b/deploy/image/env-redundant.sh
@@ -38,6 +38,24 @@ done < <(
   } | sed 's/^\${//; s/}$//'
 )
 
+# A trailing backslash is not a continuation here, it is a fatal typo — and a silent one. Compose
+# reads every line as its own KEY=VALUE, so the backslash becomes part of the value and the lines
+# below it are parsed as junk keys. When the value is SERVE_JAVA_OPTS that backslash reaches
+# JAVA_TOOL_OPTIONS, the JVM refuses to start on an unrecognised option, and the box serves 502
+# behind a restart-looping container with nothing in the compose output naming the cause.
+continuations=()
+while IFS= read -r line; do
+  [[ "${line}" =~ ^[[:space:]]*# ]] && continue
+  [[ "${line}" == *\\ ]] && continuations+=("${line%%=*}")
+done < "${env_file}"
+
+if ((${#continuations[@]})); then
+  echo "BROKEN — these lines end in a backslash, which .env does not treat as a continuation:" >&2
+  printf '  %s\n' "${continuations[@]}" >&2
+  echo "Join each onto one line. Left as is, the container will not start." >&2
+  exit 1
+fi
+
 redundant=()
 empty=()
 active=()

--- a/deploy/image/test-env-redundant.sh
+++ b/deploy/image/test-env-redundant.sh
@@ -77,4 +77,30 @@ ENV_FILE="${tmp}/absent" "${here}/env-redundant.sh" >/dev/null 2>&1 || {
 }
 echo "PASS: a missing .env exits cleanly"
 
+# 7. A trailing backslash is fatal and must be reported as such — this is the failure that took
+#    preview.coo.ee down: .env is not a shell script, so the backslash lands in the value, reaches
+#    JAVA_TOOL_OPTIONS, and the JVM refuses to start behind a 502 with nothing naming the cause.
+cat > "${tmp}/.env-cont" <<'ENV'
+SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 \
+  -Dcomposeai.serve.optimizerResumeQuietMillis=5000
+ENV
+if ENV_FILE="${tmp}/.env-cont" "${here}/env-redundant.sh" >/dev/null 2>&1; then
+  echo "FAIL: a line ending in a backslash must be reported and must exit non-zero" >&2
+  exit 1
+fi
+cont_out="$(ENV_FILE="${tmp}/.env-cont" "${here}/env-redundant.sh" 2>&1 || true)"
+grep -q "SERVE_JAVA_OPTS" <<<"${cont_out}" || {
+  echo "FAIL: the offending key was not named" >&2
+  echo "${cont_out}" >&2
+  exit 1
+}
+echo "PASS: a trailing backslash is reported as fatal"
+
+# 8. ...and a normal file must not trip that check.
+ENV_FILE="${tmp}/.env" "${here}/env-redundant.sh" >/dev/null || {
+  echo "FAIL: a well-formed .env must still exit cleanly" >&2
+  exit 1
+}
+echo "PASS: a well-formed .env is unaffected"
+
 echo "PASS: all env-redundant checks"


### PR DESCRIPTION
`preview.coo.ee` served 502 because of an example in this README that I wrote.

## What happened

`.env` is not a shell script. Compose reads every line as its own `KEY=VALUE`, so a trailing `\` becomes part of the value and the lines beneath it are parsed as junk keys. When the value is `SERVE_JAVA_OPTS`, that backslash reaches `JAVA_TOOL_OPTIONS`, the JVM refuses to start on an unrecognised option, and the container restart-loops behind a 502 — with nothing in the compose output naming the cause.

The aggressive-warming recipe added a few hours ago was written like this:

```
SERVE_JAVA_OPTS=-Dcomposeai.serve.themeOptimizationIdleMillis=10000 \
  -Dcomposeai.serve.optimizerStopLoadPerCpu=3.0 \
  ...
```

Copy-pasteable, correct-looking, and fatal. It reads as shell because everything else in the file's surroundings is shell.

## Two changes

**The example is one line**, with a note explaining why it stays one line however long it gets — the reason is not obvious, and the next person will be as tempted to wrap it as I was.

**`env-redundant.sh` refuses such a file outright.** It names the offending keys and exits non-zero *before* doing anything else, because a `.env` that will not boot the container is not a tidiness problem. The script already reads the file, so it is the natural place to catch this, and it is the one command an operator runs against `.env` by hand.

## Test plan

Two cases added to `test-env-redundant.sh`, already wired into CI:

- a trailing backslash exits non-zero and names the offending key
- a well-formed `.env` is unaffected — the guard must not turn a working file into a failure

Plus the existing checks (defaults reported, empties reported, differing keys kept by name only, **no secret value on stdout**, the leak self-test, missing file exits cleanly). `test-compose-env-passthrough.sh`, `test-java-opts-append.sh` and `test-env-migrations.sh` (11 passed) all still green.

Docs and a shell guard; no rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLG1ozUh9Sr22Yn28gLSFX)_