### PR TITLE
feat(serve): publish the preview server so the CLI can depend on it across repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, renderer-desktop, data-*, preview-annotations, daemon-*, mcp to Maven Central
+      - name: Publish plugin, renderer-android, renderer-desktop, data-*, preview-annotations, daemon-*, mcp, serve to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/cli/serve/build.gradle.kts
+++ b/cli/serve/build.gradle.kts
@@ -24,6 +24,7 @@ import org.gradle.process.CommandLineArgumentProvider
 plugins {
   id("composeai.base-conventions")
   id("composeai.jvm-conventions")
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
   // `FakeRenderSession` is scaffolding this module's own tests share with `:cli`'s
@@ -54,6 +55,22 @@ version =
 // `serve.jar` (the default from the project name) says nothing and could collide. Same naming as
 // `:cli`'s `compose-preview` and `:mcp`'s `compose-preview-mcp`.
 base { archivesName.set("compose-preview-serve") }
+
+// Published, because after #3824's repo split `:cli` cannot reach the server any other way.
+//
+// The seam register is down to 16 `:cli` -> serve crossings (`ServeCommand`'s four seam types plus
+// `bundle`, `auth` and the history commands), and every one of them is a compile-time dependency.
+// Once the two live in separate repositories the only way to satisfy them is a published artifact,
+// so an unpublished `:cli:serve` is the remaining hard blocker on the split regardless of how low
+// that number goes. Every project dependency this module has is already published, so nothing here
+// makes a POM that points at something nobody can resolve.
+//
+// Deliberately WITHOUT `explicitApi()`, unlike the contract modules (`:common-io`,
+// `:bundle-format`, `:common-image-crop`). Turning it on here reports 1,719 declarations needing an
+// explicit modifier — this is the server, not a contract, and marking all 1,719 `public` would
+// freeze an ABI nobody designed, which is the exact failure `explicitApi()` exists to prevent. The
+// surface worth designing is the 16 symbols `:cli` actually uses; narrowing to that, and only then
+// turning the gate on, is its own change.
 
 dependencies {
   // Published wire-format DTOs and the bundle format. `api` because they appear in this module's
@@ -361,3 +378,14 @@ val stageRcFontResources =
   }
 
 sourceSets.main.get().resources.srcDir(stageRcFontResources)
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "compose-preview-serve",
+    displayName = "Compose Preview — Preview Server",
+    description =
+      "The `compose-preview serve` preview server: catalog hosting, live render sessions, the " +
+        "playground and the viewer web surfaces, as a library the CLI drives through ServeOptions.",
+  )
+  inceptionYear.set("2026")
+}


### PR DESCRIPTION
#3824 preparation. Follows #4599, #4613, #4617 and #4625, which took the seam register from **102 → 16**.

**This is the piece that makes 16 survivable.** Every one of those crossings is a compile-time dependency, so once `:cli` and the preview server live in separate repositories the only way to satisfy them is a published artifact. An unpublished `:cli:serve` was the remaining *hard* blocker on the split, independent of how low the crossing count goes — at 16 or at 1, `:cli` could not have compiled.

## Verified in three places rather than assumed

**Nothing dangling in the POM.** Every project dependency this module has already applies `composeai.maven-publishing`. Confirmed by publishing to mavenLocal and reading the generated POM: 29 dependencies, all resolvable, and no `cli` / `compose-preview` artifact among them.

**The release actually picks it up.** `release.yml` fans root-level `publishAndReleaseToMavenCentral` out to every subproject applying the plugin. `:cli:serve` is *nested*, so whether the fan-out reaches it is exactly the sort of thing worth checking — this series has already produced three gates that existed without running. `:daemon:core` is nested identically (`include(":daemon:core")`) and is already published by that same fan-out, and `:cli:serve:publishAndReleaseToMavenCentral` exists on the project. So no workflow change is needed beyond the step's name, which enumerates what it publishes.

A `--dry-run` of the fan-out returned zero matches at first and I nearly took that as proof the enrolment was broken. It wasn't: the dry-run aborted on a missing Android SDK in this container before it ever reached the task graph. Recording it because a false negative from a failed command reads exactly like a true negative.

**`--version` is unaffected.** `compose-preview --version` from the assembled distribution still reports `1.41.1-SNAPSHOT`, so the module-owned `serve-version.properties` resource #4599 introduced survives being published.

## No `explicitApi()`, deliberately

Unlike `:common-io`, `:bundle-format` and `:common-image-crop`. Turning it on here reports **1,719** declarations needing an explicit modifier.

Those are not annotations, they are 1,719 API decisions. Marking them all `public` would freeze an ABI nobody designed — the precise failure `explicitApi()` exists to prevent, and the reason `:common-io`'s build file gives for having it. This module is the *server*, not a contract.

The surface worth designing is the 16 symbols `:cli` actually uses. Narrowing to that and then turning the gate on is its own change; doing it here would bury a publishing decision under a 1,700-line diff.

## Test plan

- `:cli:serve:check` — green.
- `:cli:test` — green.
- `:cli:serve:publishToMavenLocal` — succeeds; POM inspected as above.
- `:cli:installDist` then `compose-preview --version` — `1.41.1-SNAPSHOT`.
- `check-serve-seam.py` OK at `main.serveInternalsUsedByCli=16`, `cliInternalsUsedByServe=0`, `test=17`.
- `ktfmtCheck` clean.

## Where this leaves the split

`serve → :cli` is **0** and enforced by `checkServeModuleBoundary` against the resolved runtime classpath. `:cli → serve` is 16, now satisfiable across a repo boundary. Between them that is the mechanical readiness #3824 asked for.

Still open, none of them blocking:

- the 16 remaining crossings — the agent-grant protocol types (`ServeAgentGrants`, `ServeAgentGrantStore`, `ServeAgentGrantCapability`, `ServeAgentGrantScope`, shared by `AuthCommand` and `AgentAccessStore`) look like the next contract module;
- `WebEmbed`, blocked on `WebEscaping` finding a sensible home;
- the history-manifest pair, blocked on `GitWorktrees` / `ServeCatalogStore`;
- designing serve's published surface, then `explicitApi()` + an ABI dump.

Non-visual: a publishing decision. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_