### PR TITLE
fix(serve): take the generation lock before clearing the dirty boundary

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogThemeCache.kt
@@ -406,6 +406,19 @@ class CatalogThemeCache(
   }
 
   /**
+   * Whether a background pass exists that could refill this cache.
+   *
+   * The same question [markPersistedDirty] answers with `-1`, asked by a caller that has already
+   * done its work and only needs to know whether waking anything would achieve something. With
+   * `-Dcomposeai.serve.themeOptimization=false` the startup configures [persistableKeys] and
+   * deliberately leaves [targetKeys] empty: renders still persist, but there is no pass with a
+   * queue to work, so a wake buys nothing and costs a resumed host, a possible Android daemon cold
+   * start and a live seat.
+   */
+  val hasOptimizationTargets: Boolean
+    get() = targetKeys.isNotEmpty()
+
+  /**
    * Mark every persisted render for this catalog dirty, and report how many.
    *
    * The operator's "regenerate this catalog", for pixels suspected wrong by something no

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1133,7 +1133,17 @@ class ServeHttpServer(
             // already exited — so without this the 200 advertises a rewarming that waits on the
             // capacity-limited resume rotation, or on a visitor's heartbeat, before it starts. The
             // drop is the more urgent of the two, not the less: every preview is cold now.
-            if (dropped) withContext(Dispatchers.IO) { sessions.wakeOptimizer(system) }
+            //
+            // And exactly as the regenerate route does, only when there is a pass to wake.
+            // `-Dcomposeai.serve.themeOptimization=false` leaves the catalog with no optimization
+            // targets, and regenerate declines the whole action on that (`markPersistedDirty`
+            // answers -1, so `queued > 0` is false). The drop still succeeds — throwing the bytes
+            // away needs no pass — but the wake behind it would resume a suspended host and carry
+            // `keepLiveWarm` on into `scheduleWarm`, cold-starting an Android daemon and taking a
+            // live seat for a refill that cannot happen.
+            if (dropped && cache.hasOptimizationTargets) {
+              withContext(Dispatchers.IO) { sessions.wakeOptimizer(system) }
+            }
             call.response.headers.append(HttpHeaders.CacheControl, "no-store")
             call.respondText(
               Json.encodeToString(

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ThemeCacheStore.kt
@@ -469,9 +469,19 @@ class ThemeCacheStore(
      * Costs one `stat` per at-risk write, once: the map is emptied on the way out and never
      * refilled, because past [dirtyBefore] no other replica is still writing here. Anything that
      * moved under us goes back on the dirty queue to be rendered again.
+     *
+     * An **empty** at-risk map is not an early return, even though it has nothing to stat. The
+     * convergence clear below can be refused — it is try-lock, and a foreground render publishing
+     * at that instant holds the lock — and the map is drained by the loop whether or not the clear
+     * that follows it succeeds. Returning early on an empty map would therefore strand a
+     * future-dated boundary in the manifest permanently, on the one interleaving where the clear
+     * had to be deferred: every later call would see nothing to reconcile and never reach the
+     * retry. The cost of not returning is three field reads in
+     * [clearBoundaryIfConvergedUnderLock]'s own pre-check, which is what keeps the status path off
+     * the file lock.
      */
     private fun reconcileAtRiskWrites() {
-      if (atRiskWrites.isEmpty() || clock() < dirtyBefore) return
+      if (clock() < dirtyBefore) return
       for ((name, writtenAt) in atRiskWrites.toList()) {
         atRiskWrites.remove(name)
         if (name !in present) continue
@@ -485,7 +495,7 @@ class ThemeCacheStore(
       // some time ago and the at-risk set empties here, with no further write to notice. Leaving
       // the clear to `put` alone stranded the future-dated boundary in the manifest for exactly the
       // rollout this bookkeeping exists to serve.
-      clearBoundaryIfConverged()
+      clearBoundaryIfConvergedUnderLock()
     }
 
     /**
@@ -494,9 +504,45 @@ class ThemeCacheStore(
      *
      * Called from both places convergence can be reached — the write that clears the last dirty
      * name, and the reconcile that clears the last at-risk one — because either can be the last.
+     *
+     * **The caller must hold the generation write lock.** The condition read here is exactly the
+     * one [markAllDirty] inverts, so a reader that decides outside the lock is deciding about a
+     * state that can have been replaced by the time it acts. See
+     * [clearBoundaryIfConvergedUnderLock].
      */
     private fun clearBoundaryIfConverged() {
       if (dirtyBefore > 0L && dirtyNames.isEmpty() && atRiskWrites.isEmpty()) clearDirtyBoundary()
+    }
+
+    /**
+     * [clearBoundaryIfConverged] for a caller that does **not** already hold the generation write
+     * lock — the rollout reconcile, which reaches convergence from `dirtyCount()` on the status
+     * path rather than from inside a write.
+     *
+     * The interleaving this closes loses an operator's regenerate outright. The reconcile observes
+     * both sets empty; [markAllDirty] then takes the lock, persists a fresh boundary, repopulates
+     * `dirtyNames` and answers the admin route `{"queued": true, "entries": N}`; and the reconcile,
+     * still acting on what it saw before any of that, writes a zero boundary over the new mark and
+     * clears the queue it never looked at. The endpoint has promised a request that survives the
+     * next roll and there is nothing left of it, in memory or on disk.
+     *
+     * So the decision is re-taken under the lock, and `markAllDirty` — which is already try-lock
+     * and already answers `-1` when it cannot have the lock — reports an honest failure instead of
+     * a mark that is about to be erased. Whichever of the two gets the lock first, the other sees
+     * its result rather than a stale copy of the state it replaced.
+     *
+     * The pre-check outside the lock is not the decision, only an early exit: `dirtyCount()` is on
+     * the status path and the ordinary answer is "there is no boundary to clear", which should not
+     * cost a file lock per call.
+     */
+    private fun clearBoundaryIfConvergedUnderLock() {
+      if (dirtyBefore == 0L || dirtyNames.isNotEmpty() || atRiskWrites.isNotEmpty()) return
+      val generationWriteLock = tryGenerationWriteLock() ?: return
+      try {
+        clearBoundaryIfConverged()
+      } finally {
+        generationWriteLock.close()
+      }
     }
 
     /** Whether [cacheKey] is on disk from an older build and has not been re-rendered since. */

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ThemeCachePersistenceTest.kt
@@ -12,6 +12,7 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 /**
  * The disk tier for warmed theme renders, and the identity that decides when it may be read.
@@ -829,6 +830,16 @@ class ThemeCachePersistenceTest {
     pngs.forEach { assertTrue(it.setLastModified(at), "could not backdate ${it.name}") }
   }
 
+  /** The durable dirty boundary recorded in a generation's manifest. */
+  private fun boundaryOf(root: File, fingerprint: String): Long = Json {
+    ignoreUnknownKeys = true
+  }
+    .decodeFromString(
+      GenerationInputs.serializer(),
+      File(File(File(root, "m3-catalog"), fingerprint), ThemeCacheStore.MANIFEST_NAME).readText(),
+    )
+    .dirtyBeforeEpochMillis
+
   private fun inputs(fingerprint: String) =
     GenerationInputs(
       system = "m3-catalog",
@@ -1211,6 +1222,112 @@ class ThemeCachePersistenceTest {
         )
       }
     }
+  }
+
+  /**
+   * The reconcile's convergence clear races the operator's regenerate, and used to lose it.
+   *
+   * `dirtyCount()` can reach the clear concurrently with `markAllDirty`, and unlike the clear
+   * inside `put` it held no generation write lock. It could observe both sets empty; `markAllDirty`
+   * could then take the lock, persist a fresh boundary, repopulate the queue and answer the admin
+   * route `{"queued": true, "entries": N}`; and the reconcile — still acting on what it saw before
+   * any of that — would write a zero boundary over the new mark and clear the queue it never looked
+   * at. A durable request, promised to survive the next roll, gone in both tiers.
+   */
+  @Test
+  fun `the convergence clear is refused while the generation write lock is held`() {
+    val root = tempDir()
+    val fp = "c".repeat(64)
+    val grace = 60 * 60_000L
+    // Anchored to the real clock, then advanced by hand: the dirty boundary is compared against
+    // FILE timestamps, so a clock starting anywhere else classifies every render as current.
+    var now = System.currentTimeMillis()
+
+    // A previous build's render, so the cross-build open dates a boundary into the future and the
+    // overlap bookkeeping is in play at all.
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(1))
+    ageRenders(root, "m3-catalog", fp, byMillis = 10_000)
+
+    val rolling = ThemeCacheStore(root, graceMillis = grace, clock = { now })
+    val generation =
+      assertNotNull(rolling.open("m3-catalog", fp, inputs(fp).copy(toolVersion = "1.15.0")))
+    val boundary = now + grace
+    assertEquals(1, generation.dirtyCount(), "the previous build's render is queued")
+    assertEquals(boundary, boundaryOf(root, fp))
+
+    // Re-rendered inside the overlap window: the dirty queue empties, but the write is at risk of a
+    // co-replica renaming over it, so convergence is not reached yet.
+    generation.put("one", byteArrayOf(2), replaceExisting = true)
+    assertEquals(0, generation.dirtyCount())
+    assertEquals(boundary, boundaryOf(root, fp), "still future-dated — the overlap is not over")
+
+    // The overlap closes. The reconcile now has nothing left to re-dirty and would clear.
+    now += grace + 1_000
+    val lockFile = File(File(File(root, "m3-catalog"), fp), ".write.lock")
+    RandomAccessFile(lockFile, "rw").use { raf ->
+      raf.channel.lock().use {
+        generation.dirtyCount()
+        assertEquals(
+          boundary,
+          boundaryOf(root, fp),
+          "the clear is deferred rather than racing whatever holds the lock",
+        )
+      }
+    }
+
+    // And deferred is not lost: the next call retries, which is why an empty at-risk map is no
+    // longer an early return.
+    generation.dirtyCount()
+    assertEquals(0L, boundaryOf(root, fp), "convergence lands once the lock is free")
+  }
+
+  @Test
+  fun `an operator's regenerate is not erased by a converging reconcile`() {
+    // The same interleaving from the other side: whichever of the two gets the lock first, the
+    // other sees its result rather than a stale copy of the state it replaced.
+    val root = tempDir()
+    val fp = "d".repeat(64)
+    val grace = 60 * 60_000L
+    var now = System.currentTimeMillis()
+
+    store(root).open("m3-catalog", fp, inputs(fp))!!.put("one", byteArrayOf(1))
+    ageRenders(root, "m3-catalog", fp, byMillis = 10_000)
+    val rolling = ThemeCacheStore(root, graceMillis = grace, clock = { now })
+    val generation =
+      assertNotNull(rolling.open("m3-catalog", fp, inputs(fp).copy(toolVersion = "1.15.0")))
+    generation.put("one", byteArrayOf(2), replaceExisting = true)
+    now += grace + 1_000
+
+    // The operator marks first.
+    assertEquals(1, generation.markAllDirty(), "the regenerate takes the lock and lands")
+    assertEquals(now, boundaryOf(root, fp))
+
+    // The reconcile runs afterwards and must leave the mark alone: it re-reads the condition under
+    // the lock, and the queue is no longer empty.
+    assertEquals(1, generation.dirtyCount(), "the operator's request survives")
+    assertEquals(now, boundaryOf(root, fp), "on disk too, so it survives the next roll")
+  }
+
+  @Test
+  fun `a disabled optimizer has no targets to wake, even though it still persists`() {
+    // `-Dcomposeai.serve.themeOptimization=false` configures the persistable set and deliberately
+    // leaves the target set empty: renders still reach disk, but no pass has a queue to work. The
+    // regenerate route already refuses on this (`markPersistedDirty` answers -1); the drop route
+    // succeeded and then woke the optimizer anyway, resuming a suspended host and carrying
+    // `keepLiveWarm` on into `scheduleWarm` — an Android daemon cold start and a live seat spent on
+    // a refill that cannot happen.
+    val root = tempDir()
+    val fp = "e".repeat(64)
+    val generation = assertNotNull(store(root).open("m3-catalog", fp, inputs(fp)))
+    val cache = CatalogThemeCache(persistence = generation)
+    cache.configurePersistable(listOf("one", "two"))
+
+    assertFalse(cache.hasOptimizationTargets, "nothing would work a queue")
+    assertEquals(-1, cache.markPersistedDirty(), "and regenerate says so")
+    assertTrue(cache.dropPersisted(), "but the drop itself still succeeds — no pass is needed")
+
+    cache.configureTargets(listOf("one", "two"))
+    assertTrue(cache.hasOptimizationTargets, "an enabled pass is worth waking")
   }
 
   @Test

--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -291,7 +291,10 @@ curl -sX POST -H "X-Compose-Preview-Admin-Token: $SERVE_ADMIN_TOKEN" \
 ```
 
 Both wake the catalog's optimizer, so the work starts with the response rather than waiting on the
-next rotation. A mistyped system is a `404`, not a silent success.
+next rotation — and both skip the wake when theme optimization is switched off on this box, because
+there is then no pass with a queue to work and resuming a suspended host would cold-start a daemon
+and spend a live seat on a refill that cannot happen. A mistyped system is a `404`, not a silent
+success.
 
 **A `409` from either is "contended, retry"** — a render held the generation write lock as you
 called, and reporting that as success is the one failure mode a drop must not have. From


### PR DESCRIPTION
Closes the two unaddressed review findings left on #4574 after it merged.

## An operator's regenerate could be erased by a converging reconcile (P1)

`reconcileAtRiskWrites` reaches the convergence clear from `dirtyCount()` — the status path — holding **no** generation write lock, unlike the clear inside `put`. The interleaving:

1. the reconcile observes `dirtyNames` and `atRiskWrites` both empty and decides to clear;
2. `markAllDirty` takes the lock, persists a fresh boundary, repopulates `dirtyNames` and returns `N`, so the admin route answers `{"queued": true, "entries": N}`;
3. the reconcile — still acting on what it saw before any of that — calls `clearDirtyBoundary()`, writing a zero boundary over the new mark and clearing the queue it never looked at.

The endpoint has promised a request that survives the next roll, and there is nothing left of it in either tier.

The decision is now re-taken under the same lock (`clearBoundaryIfConvergedUnderLock`). Whichever of the two gets the lock first, the other sees its result rather than a stale copy of the state it replaced — and `markAllDirty` is already try-lock and already answers `-1` when it cannot have the lock, so the contended case reports an honest failure rather than a mark that is about to be erased.

The pre-check outside the lock is not the decision, only an early exit: `dirtyCount()` is on the status path and the ordinary answer is "there is no boundary to clear", which should not cost a file lock per call.

### A retry gap this opened, and closed

Making the clear refusable makes an empty `atRiskWrites` the wrong early return. The map is drained by the reconcile loop whether or not the clear behind it succeeds, so on exactly the interleaving where the clear had to be deferred, every later call would see nothing to reconcile, return early, and never reach the retry — stranding a future-dated boundary in the manifest permanently. Each restart would then reclassify this build's own renders as another build's work.

The guard is now the boundary check alone. `a4b85ae`-style cost accounting: three field reads in the unlocked pre-check on a path that was already doing a `clock()` comparison.

## The drop route woke an optimizer that has no targets (P2)

With `-Dcomposeai.serve.themeOptimization=false`, `ServeCatalogLiveHost.startThemeOptimization()` deliberately configures `persistableKeys` and leaves `targetKeys` empty: renders still persist, but no pass has a queue to work. The regenerate route already refuses the whole action on that (`markPersistedDirty` answers `-1`, so `queued > 0` is false). The drop route did not — it woke unconditionally on success, resuming a suspended host and carrying `keepLiveWarm` on into `scheduleWarm`, cold-starting an Android daemon and spending a live seat for a refill that cannot happen.

The drop itself still succeeds; throwing the bytes away needs no pass. Only the wake behind it is now conditional, on a new `CatalogThemeCache.hasOptimizationTargets` — the same question `markPersistedDirty` answers with `-1`, asked by a caller that has already done its work.

`deploy/image/README.md` said "Both wake the catalog's optimizer" without qualification; it now names the exception.

## Test plan

Three new tests in `ThemeCachePersistenceTest` (`:cli:serve:test`, 61 tests, 0 failures):

- **`the convergence clear is refused while the generation write lock is held`** — a cross-build open dates the boundary into the future, a re-render inside the overlap window empties the dirty queue but leaves the write at-risk, and once the window closes the reconcile would clear. With the lock held from another channel the boundary stays put; released, the *next* `dirtyCount()` clears it, which is what proves the deferral is not a loss.
- **`an operator's regenerate is not erased by a converging reconcile`** — the same interleaving from the other side: the mark lands first, and the reconcile leaves it alone in memory and on disk.
- **`a disabled optimizer has no targets to wake, even though it still persists`** — `configurePersistable` without `configureTargets`: `hasOptimizationTargets` false, `markPersistedDirty` `-1`, and `dropPersisted` still `true`.

The clock in the two boundary tests is anchored to `System.currentTimeMillis()` before being advanced by hand — the boundary is compared against **file** timestamps, so a fake clock starting anywhere else classifies every render as current and the test passes for the wrong reason.

Gates run locally on the pushed head:

- `./gradlew :cli:serve:test :cli:test` — BUILD SUCCESSFUL
- `./gradlew :cli:checkServeSeam` — `OK — 33 crossing symbol(s), all on the allowlist`
- `python3 scripts/test_check_serve_seam.py` — 45 tests, OK
- `./gradlew ktfmtCheckAll` — clean

Non-visual: a lock ordering and a wake condition, neither of which reaches a rendered page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_