### PR TITLE
feat(design-artifacts): anchor every row of the cross-system matches page

### DIFF
--- a/scripts/design-artifacts/render-cross-system-html.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.mjs
@@ -137,14 +137,24 @@ function rendersBothSides(pair, opts) {
 /**
  * One `<tr>` per pairing. Both renders are baked static thumbnails that link to
  * the live server; nothing is resolved at view time.
+ *
+ * The row is ANCHORED, `id="c-<slug>"`, and its component id is a self-link — the
+ * same `c-<slug>` scheme `renderIndexHtml` already uses, so one convention covers
+ * both pages. This is the page a cross-system bug report wants to point at: it is
+ * the only one carrying the kit reference and both renditions of a cell side by
+ * side, which is the whole argument such a report makes. Without a per-row anchor
+ * the best a report could do was link the page and name the row, so three
+ * upstream issues in yschimke/wear-m3-catalog (#89, #90, #91) had to commit a
+ * composed triptych image apiece instead.
  */
 function pairRow(pair, opts) {
   const { local, parallelId, other } = pair;
   const id = local.componentId ?? "(unnamed)";
   const group = local.group ?? "Components";
+  const anchor = `c-${slug(id)}`;
   const design = opts.designRefById ? `<td class="col-d">${designEmbed(pair, opts)}</td>` : "";
-  return `<tr class="crow">
-  <th scope="row" class="rowhead"><span class="cid">${esc(id)}</span><span class="grp">${esc(group)}</span></th>
+  return `<tr class="crow" id="${esc(anchor)}">
+  <th scope="row" class="rowhead"><a class="cid anchor" href="#${esc(anchor)}">${esc(id)}</a><span class="grp">${esc(group)}</span></th>
   ${design}<td class="col-a">${localEmbed(local)}</td>
   <td class="col-b">${otherEmbed(pair, opts)}</td>
   <td class="rel"><code>${esc(parallelId)}</code>${other ? "" : `<span class="badge" title="the parallel isn't in the ${esc(opts.otherSystem)} catalog yet">unpaired</span>`}</td>
@@ -284,6 +294,14 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
   tbody tr.crow { border-bottom:1px solid var(--line); }
   th.rowhead { text-align:left; font-weight:600; padding:12px; vertical-align:middle; width:22%; }
   th.rowhead .cid { display:block; word-break:break-word; }
+  /* scroll-margin-top because thead th is sticky: without it a row jumped to from
+     its #c-slug anchor lands underneath the header and reads as the wrong row. */
+  tr.crow { scroll-margin-top:44px; }
+  a.anchor { color:inherit; text-decoration:none; }
+  a.anchor:hover, a.anchor:focus-visible { text-decoration:underline; }
+  a.anchor::after { content:" #"; color:var(--muted); opacity:0; }
+  tr.crow:hover a.anchor::after, a.anchor:focus-visible::after { opacity:1; }
+  tr.crow:target { outline:2px solid var(--accent); outline-offset:-2px; }
   th.rowhead .grp { display:block; margin-top:3px; font-weight:400; font-size:11px; color:var(--muted); }
   td { padding:10px 12px; vertical-align:middle; }
 ${previewEmbedStyles({ accent: "var(--link)", muted: "var(--muted)" })}

--- a/scripts/design-artifacts/render-cross-system-html.test.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.test.mjs
@@ -286,3 +286,36 @@ test("a sibling title fetched from another repo cannot inject markup into the su
   // The arrow span is ours and stays real markup.
   assert.match(html, /<span class="arrow">↔<\/span>/);
 });
+
+test("every paired row is anchored, and its component id links to itself", () => {
+  // The page a cross-system bug report wants to point at: it is the only one
+  // carrying the kit reference and both renditions of a cell side by side. Before
+  // this, the best a report could do was link the page and name the row.
+  const html = renderCrossSystemHtml(catalog, opts);
+
+  assert.match(html, /<tr class="crow" id="c-button-filled">/);
+  assert.match(html, /<a class="cid anchor" href="#c-button-filled">Button\/Filled<\/a>/);
+  // Same `c-<slug>` scheme renderIndexHtml uses, so one convention covers both pages.
+  assert.match(html, /<tr class="crow" id="c-button-icon">/);
+  // Sticky `thead th` would otherwise hide the row an anchor jumps to.
+  assert.match(html, /tr\.crow \{ scroll-margin-top:/);
+});
+
+test("an anchor cannot be smuggled out of a component id", () => {
+  // componentId reaches the id attribute AND an href. `slug` collapses everything
+  // non-alphanumeric, so the danger is a quote surviving into either — assert on
+  // the slug rather than trusting escaping alone.
+  const hostile = {
+    system: "remote-m3",
+    components: [{ componentId: 'Button/"><img src=x>', group: "Buttons", images: [] }],
+  };
+  const html = renderCrossSystemHtml(hostile, {
+    parallelById: { 'Button/"><img src=x>': "Button/Filled" },
+    otherComponents,
+    otherManifest,
+    otherSystem: "wear-m3-catalog",
+  });
+
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.match(html, /id="c-button-img-src-x"/);
+});


### PR DESCRIPTION
`matches.html` is the page a cross-system bug report wants to point at. It is the only one carrying the kit reference and both renditions of a cell side by side — which is the whole argument such a report makes: two implementations reproduce one published cell, one of them is wrong, and the kit is what says which.

It had no per-row anchor, so the best a report could do was link the page and name the row.

## How the gap showed up

Three upstream issues in [wear-m3-catalog](https://github.com/yschimke/wear-m3-catalog) — [#89](https://github.com/yschimke/wear-m3-catalog/issues/89), [#90](https://github.com/yschimke/wear-m3-catalog/issues/90), [#91](https://github.com/yschimke/wear-m3-catalog/issues/91) — each argue about one row of this page. With no anchor to link, each had to commit a **composed triptych image** to say what one URL should have said. That is three PNGs, a README paragraph explaining how to rebuild them, and a standing obligation to redo them whenever any column moves — in place of a link.

`index.html` on the same branch already anchors every component as `c-<slug>`, which is what made the absence conspicuous: a reader who has seen one of those URLs would reasonably guess the other exists.

## The change

Each paired row is now `id="c-<slug>"`, and its component id is a self-link, using the same `slug()` and the same `c-` prefix `renderIndexHtml` uses — one convention across both pages.

- the `#` affordance appears on row hover and on keyboard focus, so it is discoverable without being noise;
- `:target` outlines the row you landed on, because a table row is easy to lose;
- `scroll-margin-top` keeps that row clear of the sticky `thead`, which otherwise hides it and silently shows the reader the *wrong* row.

## Tests

Two, on `render-cross-system-html.test.mjs`:

1. a paired row emits the anchor and the self-link, and the sticky-header offset is present;
2. a component id cannot smuggle markup into either the `id` attribute or the `href`. It asserts on the **resulting slug** rather than on escaping alone — `slug` collapsing every non-alphanumeric run is what actually makes the attribute safe, and a test that only checked `esc()` would keep passing if the id stopped going through the slug.

## Test plan

```
node --test scripts/design-artifacts/render-cross-system-html.test.mjs   # 16
node --test scripts/design-artifacts/render-compare-html.test.mjs        # 26
node --test scripts/design-artifacts/render-index-html.test.mjs          # 10
node --test scripts/design-artifacts/cross-system-compare.test.mjs       # 14
```

All green — the neighbours are included because they share the row markup and the `slug` helper.

Non-visual in the rendered-catalog sense: this changes a generated HTML report, not any preview render. The visible effect is the `#` affordance and the `:target` outline, both on `matches.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx)_