### PR TITLE
fix(renderer): resolve previews whose parameters are all defaulted

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/AppTourDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/AppTourDiscovery.kt
@@ -32,11 +32,20 @@ object AppTourDiscovery {
   /**
    * Class-name prefixes of activities that manifest-merger injects from libraries (Glance's action
    * trampoline, ui-tooling's `PreviewActivity`, ui-test-manifest's `ComponentActivity`, Play
-   * Services dialogs, …). They're not part of the *app* — not previewable entry points, not tour
-   * material — so they're dropped at parse time.
+   * Services dialogs, Firebase Auth's reCAPTCHA / federated-IdP trampolines, …). They're not part
+   * of the *app* — not previewable entry points, not tour material — so they're dropped at parse
+   * time.
+   *
+   * `com.google.` subsumes the narrower `com.google.android.` this list used to carry, so that
+   * Firebase Auth's `GenericIdpActivity` and `RecaptchaActivity` — headless trampolines that NPE
+   * inside `onResume` the moment they are launched off a real device — stop reaching the catalog as
+   * broken cards, as they did in both Confetti catalogs.
+   *
+   * The list stays evidence-led rather than pre-emptive: every prefix is also a way to silently
+   * drop an app's own screen, so an SDK earns one once it has been seen producing a dead card.
    */
   private val LIBRARY_ACTIVITY_PREFIXES =
-    listOf("android.", "androidx.", "com.android.", "com.google.android.")
+    listOf("android.", "androidx.", "com.android.", "com.google.")
 
   private val xmlFactory: XMLInputFactory =
     XMLInputFactory.newFactory().apply {
@@ -267,10 +276,9 @@ object AppTourDiscovery {
   )
 
   /** Parses one tour spec file. Returns `null` (best-effort) when unreadable or not a tour. */
-  fun parseTourSpec(file: File): TourSpec? =
-    runCatching { TOUR_JSON.decodeFromString(TourSpec.serializer(), file.readText()) }
-      .getOrNull()
-      ?.takeIf { it.steps.isNotEmpty() || it.start != null }
+  fun parseTourSpec(file: File): TourSpec? = runCatching {
+    TOUR_JSON.decodeFromString(TourSpec.serializer(), file.readText())
+  }.getOrNull()?.takeIf { it.steps.isNotEmpty() || it.start != null }
 
   /**
    * Turns committed tour spec files into one synthetic [PreviewKind.APP_TOUR] preview each. Every

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/AppTourDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/AppTourDiscoveryTest.kt
@@ -144,4 +144,39 @@ class AppTourDiscoveryTest {
     assertTrue(previews.isEmpty())
     assertEquals(1, warnings.size)
   }
+
+  @Test
+  fun `library-injected activities are dropped`() {
+    // A merged manifest carries every library's activities alongside the app's own. None of them
+    // are app screens; Firebase Auth's two headless trampolines in particular NPE on launch and
+    // used to land in the Confetti catalogs as permanently-broken cards.
+    val merged =
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.example.app">
+          <application>
+              <activity android:name=".MainActivity" android:exported="true">
+                  <intent-filter>
+                      <action android:name="android.intent.action.MAIN" />
+                      <category android:name="android.intent.category.LAUNCHER" />
+                  </intent-filter>
+              </activity>
+              <activity android:name="androidx.compose.ui.tooling.PreviewActivity" />
+              <activity android:name="com.google.android.gms.common.api.GoogleApiActivity" />
+              <activity android:name="com.google.firebase.auth.internal.GenericIdpActivity" />
+              <activity android:name="com.google.firebase.auth.internal.RecaptchaActivity" />
+              <activity android:name="com.example.app.SettingsActivity" />
+          </application>
+      </manifest>
+      """
+        .trimIndent()
+
+    val activities = AppTourDiscovery.parseManifestActivities(merged.byteInputStream())
+
+    assertEquals(
+      listOf("com.example.app.MainActivity", "com.example.app.SettingsActivity"),
+      activities.map { it.className },
+    )
+  }
 }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -20,6 +20,8 @@ import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.reflect.ComposableMethod
+import androidx.compose.runtime.reflect.asComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -130,7 +132,7 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
     // the full list keeps the lookup shape honest with the invocation.
     val composableMethod =
       if (previewArgs.isEmpty()) {
-        clazz.getDeclaredComposableMethod(preview.functionName)
+        resolveNoArgComposableMethod(clazz, preview.functionName)
       } else {
         findComposableMethodWithArgs(clazz, preview.functionName, previewArgs)
       }
@@ -168,6 +170,84 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
     }
   }
 }
+
+/**
+ * Resolves the `ComposableMethod` for a preview invoked with no arguments.
+ *
+ * `getDeclaredComposableMethod(name)` builds the JVM signature it looks for out of the argument
+ * types the caller passes, so with none it can only ever match `name(Composer, changed[, default])`
+ * — a preview whose own parameter list is empty. That misses the shape Studio renders happily and
+ * that samples reach for constantly: a component that IS its own preview, every parameter defaulted
+ * (`@Preview @Composable fun AverageTimeInBedCard(modifier: Modifier = Modifier)`). Its compiled
+ * signature carries the real parameters ahead of the synthetic tail, the exact-signature lookup
+ * misses, and the preview fails with a bare `NoSuchMethodException` naming a function that is
+ * plainly there (issue: 11 JetLagged renders).
+ *
+ * So: try the officially supported lookup first, and only when it misses fall back to scanning
+ * `declaredMethods` for the name. `ComposableMethod.invoke` already knows how to call a defaulted
+ * composable — it fills every unsupplied parameter with the type's zero value and sets that
+ * parameter's bit in the defaults mask, so the callee substitutes its own default expression. The
+ * fallback therefore only has to find a *defaulted* overload; one without a defaults mask would
+ * have the zero values passed through as real arguments (a null `Modifier`, straight into an NPE),
+ * which is worse than reporting the miss.
+ */
+private fun resolveNoArgComposableMethod(clazz: Class<*>, functionName: String): ComposableMethod {
+  runCatching { clazz.getDeclaredComposableMethod(functionName) }
+    .getOrNull()
+    ?.let {
+      return it
+    }
+  return findDefaultedComposableMethod(clazz, functionName)
+    ?: throw NoSuchMethodException("${clazz.name}.$functionName")
+}
+
+/**
+ * The `declaredMethods` scan behind [resolveNoArgComposableMethod]: the named composable overloads
+ * that can be invoked with no arguments because every real parameter is defaulted. Prefers the
+ * fewest real parameters — a defaulted preview and a fully-applied sibling overload of the same
+ * name both qualify, and the one with less to default is the closer match to "call it with
+ * nothing".
+ */
+internal fun findDefaultedComposableMethod(
+  clazz: Class<*>,
+  functionName: String,
+): ComposableMethod? =
+  clazz.declaredMethods
+    .asSequence()
+    .filter { it.name == functionName }
+    .mapNotNull { method -> method.asComposableMethod()?.takeIf { method.hasComposableDefaults() } }
+    .sortedBy { it.parameterCount }
+    .firstOrNull()
+
+/**
+ * Whether this compiled composable carries a defaults mask — i.e. the source function declared
+ * default arguments.
+ *
+ * The Compose calling convention appends `(Composer, changed…[, default…])` to the real parameters:
+ * one `changed` int per [SLOTS_PER_COMPOSABLE_INT] parameters (counting the dispatch receiver of a
+ * non-static method) and, only when the function has defaults, one `default` int per 31 real
+ * parameters. Both tails are `int`, so the shape — not the types — is what distinguishes them.
+ * Callers must have established that the method IS composable (`asComposableMethod() != null`)
+ * before asking; the arithmetic assumes the synthetic tail is well-formed.
+ */
+private fun java.lang.reflect.Method.hasComposableDefaults(): Boolean {
+  val realParams = parameterTypes.indexOfLast {
+    it == androidx.compose.runtime.Composer::class.java
+  }
+  if (realParams <= 0) return false
+  val thisParams = if (java.lang.reflect.Modifier.isStatic(modifiers)) 0 else 1
+  val changedParams =
+    ceil((realParams + thisParams).toDouble() / SLOTS_PER_COMPOSABLE_INT).toInt().coerceAtLeast(1)
+  return parameterTypes.size > realParams + 1 + changedParams
+}
+
+/**
+ * Real parameters encoded per synthetic `changed` int — `androidx.compose.runtime.internal
+ * .SLOTS_PER_INT`, which is `internal` to the runtime and so restated here. It is part of the
+ * compiled calling convention (every composable ever compiled encodes it), which is what makes
+ * restating it safe: `getDeclaredComposableMethod` depends on the same constant.
+ */
+private const val SLOTS_PER_COMPOSABLE_INT = 10
 
 /**
  * Resolves the `ComposableMethod` for a preview function that declares `@PreviewParameter`

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DefaultedComposableLookupFixtures.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DefaultedComposableLookupFixtures.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Compiled `@Composable` shapes for [DefaultedComposableLookupTest]. They live in their own file so
+ * the Kotlin compiler emits a synthetic `DefaultedComposableLookupFixturesKt` class carrying the
+ * real Compose calling convention — the whole point of the test is the *compiled* signature, which
+ * a hand-written `Method` stub could only approximate.
+ *
+ * Nothing here is ever composed; the test only reflects on the emitted methods.
+ */
+@Suppress("unused") @Composable fun noParameterPreviewFixture() = Unit
+
+/** The JetLagged shape: a component that is its own preview, every parameter defaulted. */
+@Suppress("unused")
+@Composable
+fun defaultedModifierPreviewFixture(modifier: Modifier = Modifier) {
+  @Suppress("UNUSED_EXPRESSION") modifier
+}
+
+/** Several defaulted parameters, mixing a reference type with a primitive. */
+@Suppress("unused")
+@Composable
+fun multiDefaultPreviewFixture(
+  label: String = "",
+  count: Int = 0,
+  modifier: Modifier = Modifier,
+) {
+  @Suppress("UNUSED_EXPRESSION") label
+  @Suppress("UNUSED_EXPRESSION") count
+  @Suppress("UNUSED_EXPRESSION") modifier
+}
+
+/** A required parameter and no defaults — not callable with no arguments. */
+@Suppress("unused")
+@Composable
+fun requiredParameterFixture(label: String) {
+  @Suppress("UNUSED_EXPRESSION") label
+}
+
+/** Not composable at all: the scan must not offer it up. */
+@Suppress("unused") fun plainFunctionFixture(label: String = "") = label

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DefaultedComposableLookupTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/DefaultedComposableLookupTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [findDefaultedComposableMethod] — the fallback that lets a preview whose own
+ * parameters are all defaulted resolve at all.
+ *
+ * `getDeclaredComposableMethod(name)` can only match a parameterless composable, so
+ * `@Preview @Composable fun Card(modifier: Modifier = Modifier)` — a component that is its own
+ * preview, rendered happily by Studio — used to fail with a bare `NoSuchMethodException`.
+ * Reflection over the *compiled* fixtures in `DefaultedComposableLookupFixtures.kt` is the only
+ * honest way to assert the shape, so no Robolectric sandbox is involved.
+ */
+class DefaultedComposableLookupTest {
+
+  private val fixtures =
+    Class.forName("ee.schimke.composeai.renderer.DefaultedComposableLookupFixturesKt")
+
+  @Test
+  fun `finds a preview whose single parameter is defaulted`() {
+    val method = findDefaultedComposableMethod(fixtures, "defaultedModifierPreviewFixture")
+    assertNotNull("A defaulted @Composable must resolve for a no-argument invoke", method)
+    assertEquals(1, method!!.parameterCount)
+  }
+
+  @Test
+  fun `finds a preview with several defaulted parameters`() {
+    val method = findDefaultedComposableMethod(fixtures, "multiDefaultPreviewFixture")
+    assertNotNull(method)
+    assertEquals(3, method!!.parameterCount)
+  }
+
+  @Test
+  fun `skips a composable whose parameter is required`() {
+    // Invoking it with nothing would pass a null `String` straight through as a real argument —
+    // reporting the miss beats an NPE from inside the preview.
+    assertNull(findDefaultedComposableMethod(fixtures, "requiredParameterFixture"))
+  }
+
+  @Test
+  fun `skips a plain function that merely has defaults`() {
+    assertNull(findDefaultedComposableMethod(fixtures, "plainFunctionFixture"))
+  }
+
+  @Test
+  fun `skips a parameterless composable the supported lookup already handles`() {
+    // No real parameters means no defaults mask; the primary
+    // `getDeclaredComposableMethod` path resolves it, and the fallback stays out of the way.
+    assertNull(findDefaultedComposableMethod(fixtures, "noParameterPreviewFixture"))
+  }
+
+  @Test
+  fun `reports a miss for a name that is not there`() {
+    assertNull(findDefaultedComposableMethod(fixtures, "noSuchPreviewFixture"))
+  }
+}


### PR DESCRIPTION
Triage of the 71 failed renders on [preview.coo.ee/status](https://preview.coo.ee/status), and the two root causes that turned out to be ours.

## The triage

Every failure was pulled from each catalog's `catalog.json` `failures[]` on its `design-artifacts/<system>` branch and grouped by root cause. All 71 land in twelve clusters:

| # | Cluster | n | Catalogs | Owner |
|---|---|---|---|---|
| A | Activity tour — Hilt app-level DI | 36 | home-assistant-android ×17, pocketcasts-wear ×10, home-assistant-wear ×8, jetcaster-wear ×1 | renderer (open question, below) |
| B | Activity tour — Koin app-level DI | 2 | confetti-mobile, confetti-wear | same as A |
| C | Activity tour — DI-constructed Activity (Metro `AppComponentFactory`) | 1 | cadence | same as A |
| **D** | **Activity tour — Firebase SDK trampoline** | **4** | confetti-mobile ×2, confetti-wear ×2 | **fixed here** |
| E | Activity tour — needs Intent extras | 1 | confetti-mobile | consumer |
| F | Activity tour — nothing drawn | 1 | home-assistant-android | renderer, unclustered |
| **G** | **Preview — defaulted parameters not resolved** | **11** | jetlagged | **fixed here** |
| H | Preview — `hiltViewModel()` in the tree | 4 | pocketcasts-wear | consumer (fails in Studio too) |
| I | Preview — `AndroidView` needs the app theme | 5 | pocketcasts | consumer (`composePreview.hostTheme`) |
| J | Preview — Glance body under a Compose `@Preview` | 2 | jetchat | consumer / follow-up |
| K | Preview — never reaches idle | 2 | thunderbird | consumer |
| L | Preview — Compose ABI mismatch | 2 | confetti-mobile | consumer |

Two of those are bugs in this repo. They are what this PR fixes; 15 renders.

## G — previews whose parameters are all defaulted (11)

`ComposePreviewStrategy` resolved a no-argument preview through
`clazz.getDeclaredComposableMethod(functionName)`. That builds the JVM signature it looks for out of the argument types the caller passes, so with none it can only ever match `name(Composer, changed[, default])` — a preview whose own parameter list is empty.

It therefore misses the shape Studio renders happily and that samples reach for constantly: a component that *is* its own preview, every parameter defaulted.

```kotlin
@Preview
@Preview(widthDp = 500, name = "larger screen")
@Composable
fun AverageTimeInBedCard(modifier: Modifier = Modifier) { … }
```

Its compiled signature carries the real parameters ahead of the synthetic tail, the exact-signature lookup misses, and the render fails with a bare `NoSuchMethodException` naming a function that is plainly there:

```
java.lang.NoSuchMethodException: com.example.jetlagged.HomeScreenCardsKt.AverageTimeInBedCard
	at androidx.compose.runtime.reflect.ComposableMethodKt.getDeclaredComposableMethod(ComposableMethod.jvmAndAndroid.kt:202)
	at ee.schimke.composeai.renderer.ComposePreviewStrategy.Render(PreviewRenderStrategy.kt:133)
```

All 11 JetLagged failures are this one shape, `JetLaggedScreen`'s mangled `-uVTuf4s` name (a `WindowWidthSizeClass` value-class parameter) included.

**Fix.** Try the officially supported lookup first; only when it misses, scan `declaredMethods` for the name and take the composable overload that carries a defaults mask. `ComposableMethod.invoke` already knows how to call one — it fills every unsupplied parameter with the type's zero value and sets that parameter's bit in the mask, so the callee substitutes its own default expression. An overload *without* a mask is deliberately skipped: those zero values would go through as real arguments (a null `Modifier`, straight into an NPE), which is worse than reporting the miss.

## D — Firebase's headless activities (4)

`AppTourDiscovery` already drops library-injected activities by class-name prefix, but the list stopped at `com.google.android.`. Firebase Auth's `GenericIdpActivity` and `RecaptchaActivity` sit under `com.google.firebase.`, so manifest-merger's copies reached both Confetti catalogs as tour cards — and NPE'd inside `onResume` the moment they launched off a real device:

```
java.lang.NullPointerException: Cannot read the array length because "bytes" is null
	at com.google.android.gms.common.util.Hex.bytesToStringUppercase(play-services-basement@@18.9.0:2)
	at com.google.firebase.auth.internal.GenericIdpActivity.onResume(firebase-auth@@24.2.0:242)
```

Widening the prefix to `com.google.` subsumes the old entry and covers both. The list stays evidence-led rather than pre-emptive — every prefix is also a way to silently drop an app's own screen, so an SDK earns one once it has been seen producing a dead card.

## Not fixed here, and why

**A/B/C — 39 activity tours blocked by app-level DI.** Not one activity tour renders anywhere in the fleet except meshcore-mobile's; every DI-using app fails identically. The cause is the one `docs/APP_TOURS.md` already lists as a v1 limitation: the generated `robolectric.properties` pins `application=android.app.Application` for the whole render run, so an Activity that needs its `@HiltAndroidApp` Application never gets one. `composePreview.useConsumerApplication = true` restores it, but it is a *per-module* switch — flipping it would also push every composable preview in that module through the consumer's `Application.onCreate()`, which is the exact platform-init minefield the stub default exists to dodge. Doing this properly means giving ACTIVITY/APP_TOUR previews their own Robolectric config (a sibling package with its own properties file and test class), and that is a feature, not a triage fix. It also cannot be validated from here — Home Assistant's real `Application` under Robolectric may simply fail differently. Worth a decision before anyone builds it.

**I — 5 pocketcasts renders** are a one-line consumer fix, not a bug: `:modules:services:compose` is a library module, so its merged manifest has no `<application android:theme>` and `HtmlText`'s `setTextAppearance(UR.style.H50)` can't resolve `?attr/primary_text_01`. That is precisely what `composePreview.hostTheme` (#2957) exists for — `hostTheme = "@style/ThemeLight"` on that module should clear all five.

**H, J, K, L** are upstream preview defects (a `hiltViewModel()` call in the tree, Glance composables annotated with the Compose `@Preview`, a composition that never idles, a material3 ABI skew) that fail in Studio too.

## Test plan

- `./gradlew :renderer-android:testDebugUnitTest` — 301 tests, 0 failures, including the new `DefaultedComposableLookupTest`: six cases reflecting over *compiled* `@Composable` fixtures, since the compiled signature is the whole point and a hand-written `Method` stub could only approximate it. Covers a single defaulted parameter, several defaulted parameters, a required parameter (must be skipped), a plain function that merely has defaults (must be skipped), a parameterless composable the primary lookup already handles (fallback stays out of the way), and an absent name.
- `./gradlew :gradle-plugin:preview-discovery:test` — 199 tests, 0 failures, including a new `AppTourDiscoveryTest` case that feeds a realistic merged manifest (app activities + ui-tooling's `PreviewActivity` + `GoogleApiActivity` + both Firebase trampolines) and asserts only the app's own two survive.
- `./gradlew :renderer-android:ktfmtFormat* :gradle-plugin:preview-discovery:ktfmtFormat*` — clean.

No visual evidence: neither change alters how anything is painted. G turns a hard failure into the render the preview always described, and D removes cards that never had pixels. The proof is the JetLagged and Confetti catalogs regenerating without those failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsnMASEm93V7HBUe89PhqQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsnMASEm93V7HBUe89PhqQ)_