### PR TITLE
fix(serve): make a catalog re-point atomic and its persistence retryable

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/CatalogLoadTracker.kt
@@ -161,6 +161,32 @@ class CatalogLoadTracker(
   /** The configured entry for [system], or null when it isn't served here. */
   fun configFor(system: String): Config? = states[system]?.config
 
+  /**
+   * The full tracked state for [system] — configuration **and** whether anything is actually
+   * serving it — or null when it isn't served here.
+   *
+   * [configFor] answers only half the question, and a caller that reports on a catalog needs the
+   * other half: a pending entry and one whose initial load failed both have a configuration, and
+   * neither has a session behind it. Describing either as "still serving" is reassuring and wrong.
+   */
+  fun stateFor(system: String): State? = states[system]
+
+  /**
+   * Whether a background pass queued for [system] against [repo] is still about the catalog it was
+   * queued for.
+   *
+   * The branch refresher captures each entry's repo when it snapshots this tracker, and can then
+   * sit on the server's registration monitor for the whole of an admin re-point. "Does the system
+   * still exist" was the only test it made afterwards, and it is not enough: reloading the captured
+   * OLD repo puts the old repo's host back in front of the new registration, and the provenance and
+   * `catalogs.json` then both name a repository the served bytes did not come from.
+   *
+   * Asked of the tracker rather than compared at the call site because the tracker is where the
+   * answer lives and where [ServeCatalogAdmin] writes it — under the same monitor the caller is
+   * holding when it asks.
+   */
+  fun stillPointsAt(system: String, repo: String): Boolean = configFor(system)?.repo == repo
+
   /** First currently usable catalog in configured order, or null while every catalog is pending. */
   fun firstAvailableSystem(): String? = snapshot().firstOrNull { it.available }?.config?.system
 

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdmin.kt
@@ -39,6 +39,22 @@ class ServeCatalogAdmin(
    * by default — a server with no sites is unaffected.
    */
   private val sites: ServeSiteRegistry = ServeSiteRegistry.empty(),
+  /**
+   * The server's catalog-registration monitor, so a re-point's **load and its provenance record**
+   * are one critical section rather than two.
+   *
+   * [load] already takes this lock internally; passing the same object here makes the wider section
+   * a reentrant nesting rather than a second lock with its own ordering. Defaulted to a private
+   * object for the tests and for any caller whose `load` takes no lock — there the swap serialises
+   * against nothing, which is exactly what it did before.
+   *
+   * What it closes: the branch refresher captures each entry's repo when it snapshots the tracker,
+   * then blocks on this monitor. With the load inside the lock and the [CatalogLoadTracker.repoint]
+   * outside it, the refresher could acquire the lock in between, see a tracker still naming the OLD
+   * repo, and reload it over the new registration — leaving the old repo's host serving while the
+   * provenance and `catalogs.json` both said the new one.
+   */
+  private val registrationLock: Any = Any(),
   /** Group table for resolving [ServeCatalogsConfig.Entry.group]; seeded from the config file. */
   groups: List<ServeCatalogsConfig.Group> = emptyList(),
   private val onLog: (String) -> Unit = { System.err.println(it) },
@@ -203,23 +219,46 @@ class ServeCatalogAdmin(
       // could not: `unregister` refuses those outright to keep a hostname from being stranded, and
       // a swap never strands one because the system never stops existing.
       if (current.repo != repo) {
-        val failure = runCatching {
-          load(entry.system, repo)
-        }
-          .getOrElse { it.message ?: "load failed" }
+        // ONE critical section, not two. The load takes this same monitor internally, so this is a
+        // reentrant nesting whose only effect is to hold it across the provenance record as well —
+        // and that is the whole fix: with `repoint` outside the lock, the branch refresher (which
+        // captured this system's repo when it snapshotted the tracker, then queued on the monitor)
+        // could get in between, still see the OLD repo in the tracker, and reload it straight over
+        // the new registration. The old repo's host would then be serving while the provenance and
+        // `catalogs.json` both named the new one. The refresher declines a stale capture too — see
+        // `ServeRunner.buildCatalogRefresher` — because either side alone leaves a window.
+        val failure =
+          synchronized(registrationLock) {
+            val loadFailure = runCatching {
+              load(entry.system, repo)
+            }
+              .getOrElse { it.message ?: "load failed" }
+            if (loadFailure == null) {
+              tracker.repoint(entry.system, repo = repo, branch = "$branchPrefix${entry.system}")
+              tracker.relist(
+                entry.system,
+                listed = entry.listed,
+                group = resolved,
+                loadPriority = entry.loadPriority,
+              )
+            }
+            loadFailure
+          }
         if (failure != null) {
+          // What the old catalog is actually doing, not what it is configured to do. `configFor`
+          // answers for a pending entry and for one whose initial load failed exactly as it does
+          // for a live one, so "still serving" was the reassuring half of a two-part answer that
+          // could be wrong — reconciliation during startup, or a persistent startup fetch failure,
+          // reaches here with nothing behind the old configuration at all.
+          val serving = tracker.stateFor(entry.system)?.available == true
+          val held =
+            if (serving) "still serving ${current.repo}"
+            else "kept the ${current.repo} configuration, which is not currently serving"
           return Result.Failed(
             entry.system,
-            "could not re-point '${entry.system}' to $repo, still serving ${current.repo}: $failure",
+            "could not re-point '${entry.system}' to $repo, $held: $failure",
           )
         }
-        tracker.repoint(entry.system, repo = repo, branch = "$branchPrefix${entry.system}")
-        tracker.relist(
-          entry.system,
-          listed = entry.listed,
-          group = resolved,
-          loadPriority = entry.loadPriority,
-        )
         onLog("serve: catalog ${entry.system} re-pointed ${current.repo} -> $repo via admin API")
         return Result.Ok(entry.system, persist { it.withEntry(entry.copy(repo = repo)) })
       }
@@ -228,7 +267,25 @@ class ServeCatalogAdmin(
           current.listed == entry.listed &&
           current.loadPriority == entry.loadPriority
       ) {
-        return Result.Conflict("catalog '${entry.system}' is already published")
+        // Everything the runtime tracks already matches — but the FILE may not, and this branch
+        // used to be the dead end that guaranteed it never would. A swap whose runtime half
+        // succeeded and whose `persist` failed transiently answers Ok-with-warning, leaving the
+        // tracker on the new repo and `catalogs.json` on the old one (or without the entry at all,
+        // after a retire-first caller). Every later POST of the same desired entry then arrives
+        // here, matches on every tracked field, and returns 409 before attempting persistence. The
+        // reconcile can never repair the file, and the next restart reverts or drops the catalog.
+        //
+        // So a mismatch between the file and what is running is a repair, not a conflict: persist
+        // and report it. In the ordinary steady state the file already agrees and this is the same
+        // 409 it always was.
+        if (persistedRepoMatches(entry.system, repo)) {
+          return Result.Conflict("catalog '${entry.system}' is already published")
+        }
+        onLog(
+          "serve: catalog ${entry.system} is running from $repo but the config file disagreed" +
+            " — rewriting it"
+        )
+        return Result.Ok(entry.system, persist { it.withEntry(entry.copy(repo = repo)) })
       }
       tracker.relist(
         entry.system,
@@ -288,6 +345,26 @@ class ServeCatalogAdmin(
       group = homeGroup(entry, repo, declaredGroups),
       loadPriority = entry.loadPriority,
     )
+
+  /**
+   * Whether the on-disk config already records [system] as coming from [repo].
+   *
+   * The question the unchanged-repo branch has to ask before answering 409, so a runtime swap whose
+   * persistence failed has somewhere to be retried from. True when there is no config file at all:
+   * registrations are then runtime-only by configuration and there is nothing that could disagree.
+   *
+   * A file that cannot be read answers **false**, so the caller attempts the write. That write will
+   * fail too and come back as a persistence warning naming the reason — which is a better answer
+   * than a 409 claiming the catalog is already published from a document nobody can parse.
+   */
+  private fun persistedRepoMatches(system: String, repo: String): Boolean {
+    val file = configFile ?: return true
+    return runCatching {
+        val persisted = file.load().catalogs.firstOrNull { it.system == system } ?: return false
+        (persisted.repo?.takeIf { it.isNotBlank() } ?: defaultRepo) == repo
+      }
+      .getOrDefault(false)
+  }
 
   /**
    * Apply [mutate] to the on-disk config. Returns null on success (or when no config file is

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
@@ -2924,6 +2924,9 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
       branchPrefix = catalogBranchPrefix,
       configFile = catalogsFile,
       groups = catalogsConfig.groups,
+      // The same monitor `load` takes below, so a re-point holds it across the provenance record
+      // too — see the parameter's doc for the interleaving that closes.
+      registrationLock = catalogRegistrationLock,
       load = { system, repo ->
         backgroundWork.whileLoadingCatalog {
           synchronized(catalogRegistrationLock) {
@@ -2990,7 +2993,18 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
       reload = { system, repo ->
         val result = backgroundWork.whileLoadingCatalog {
           synchronized(catalogRegistrationLock) {
-            if (loads.configFor(system) == null) return@synchronized null
+            // Both halves of "is this pass still about the catalog it was queued for". The system
+            // still existing was the only test, and it is not enough: a pass captures each entry's
+            // repo when it snapshots the tracker, and can then sit on this monitor for the whole of
+            // an admin re-point. Reloading the captured OLD repo afterwards would put the old
+            // repo's host back in front of the new registration, with the provenance and
+            // `catalogs.json` both naming the new one — a catalog served from a repository it had
+            // left, reporting that it had left it.
+            //
+            // Declining is the right answer rather than reloading the CURRENT repo: the admin has
+            // just fetched it, so there is nothing to refresh, and the next ordinary pass picks up
+            // the new provenance from the tracker anyway.
+            if (!loads.stillPointsAt(system, repo)) return@synchronized null
             val result = store.load(system, sourceRepo = repo)
             loads.record(result)
             result

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAdminRoutingTest.kt
@@ -321,7 +321,15 @@ class ServeAdminRoutingTest {
       502,
       send("/admin/catalogs", method = "POST", body = """{"system":"ghost"}""").first,
     )
-    // A duplicate of an already-served catalog is a conflict, not a silent overwrite.
+    // A duplicate of an already-served catalog is a conflict, not a silent overwrite — once the
+    // config file agrees with what is running. When it does NOT, the same request is the retry path
+    // that repairs a swap whose persistence failed, and answers 200; the fixture's tracker is
+    // seeded without a matching file entry, so this states the agreement it is testing.
+    configFile.save(
+      configFile
+        .load()
+        .withEntry(ServeCatalogsConfig.Entry("compose-m3", repo = "yschimke/compose-ai-tools"))
+    )
     assertEquals(
       409,
       send("/admin/catalogs", method = "POST", body = """{"system":"compose-m3"}""").first,

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogAdminTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli.serve
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -115,12 +116,16 @@ class ServeCatalogAdminTest {
 
   @Test
   fun `re-publishing a served catalog is a conflict, not a silent overwrite`() {
+    // Seeded, so this is a catalog that really is already published: the file and the runtime agree
+    // on the repo. When they DISAGREE the same request is a repair rather than a conflict — see
+    // `a swap whose persistence failed can be repaired by re-posting the same entry`.
+    seedConfig(ServeCatalogsConfig(catalogs = listOf(ServeCatalogsConfig.Entry("compose-m3"))))
     val tracker =
       tracker(CatalogLoadTracker.Config("compose-m3", true, "yschimke/compose-ai-tools", "b"))
 
     val result = admin(tracker).register(ServeCatalogsConfig.Entry("compose-m3"))
 
-    assertTrue(result is ServeCatalogAdmin.Result.Conflict)
+    assertTrue(result is ServeCatalogAdmin.Result.Conflict, "$result")
     assertEquals(emptyList(), loaded, "the running catalog is never re-fetched behind its back")
   }
 
@@ -292,6 +297,9 @@ class ServeCatalogAdminTest {
           "design-artifacts/remote-m3",
         )
       )
+    // Actually serving, which is what makes the message below true. See the sibling test for the
+    // case where it is not.
+    tracker.recordSuccess("remote-m3")
 
     val result =
       admin(tracker, failWith = "could not fetch catalog.json")
@@ -309,6 +317,164 @@ class ServeCatalogAdminTest {
     assertEquals(emptyList(), unloaded)
     assertEquals("yschimke/old-home", assertNotNull(tracker.configFor("remote-m3")).repo)
     assertEquals("yschimke/old-home", file.load().catalogs.single().repo)
+  }
+
+  @Test
+  fun `a failed re-point does not claim an unavailable old catalog is still serving`() {
+    // `configFor` answers for a pending entry and for one whose initial load failed exactly as it
+    // does for a live one, so the failure message was the reassuring half of a two-part answer that
+    // could be wrong: reconciliation during startup, or a persistent startup fetch failure, reaches
+    // here with nothing at all behind the old configuration.
+    seedConfig(
+      ServeCatalogsConfig(
+        catalogs = listOf(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/old-home"))
+      )
+    )
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config(
+          "remote-m3",
+          true,
+          "yschimke/old-home",
+          "design-artifacts/remote-m3",
+        )
+      )
+    // Never loaded — `available` is false and no session is behind it.
+    assertEquals("pending", assertNotNull(tracker.stateFor("remote-m3")).loadState)
+
+    val result =
+      admin(tracker, failWith = "could not fetch catalog.json")
+        .register(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/nowhere", listed = true))
+
+    val reason = (assertIs<ServeCatalogAdmin.Result.Failed>(result)).reason
+    assertFalse(reason.contains("still serving"), reason)
+    assertTrue(reason.contains("kept the yschimke/old-home configuration"), reason)
+    assertTrue(reason.contains("not currently serving"), reason)
+    // The old configuration IS preserved, which is the part that was true all along.
+    assertEquals("yschimke/old-home", assertNotNull(tracker.configFor("remote-m3")).repo)
+  }
+
+  @Test
+  fun `a swap whose persistence failed can be repaired by re-posting the same entry`() {
+    // The dead end this closes. A runtime swap whose `persist` failed transiently answers
+    // Ok-with-warning, leaving the tracker on the new repo and `catalogs.json` on the old one.
+    // Every later POST of the same desired entry then matched on every TRACKED field and returned
+    // 409 before attempting persistence — so reconciliation could never repair the file, and the
+    // next restart reverted the catalog to the repo it had left.
+    seedConfig(
+      ServeCatalogsConfig(
+        catalogs = listOf(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/old-home"))
+      )
+    )
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config(
+          "remote-m3",
+          true,
+          "yschimke/new-home",
+          "design-artifacts/remote-m3",
+        )
+      )
+    tracker.recordSuccess("remote-m3")
+
+    val entry = ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/new-home", listed = true)
+    val result = admin(tracker).register(entry)
+
+    assertEquals(ServeCatalogAdmin.Result.Ok("remote-m3", warning = null), result)
+    assertEquals("yschimke/new-home", file.load().catalogs.single().repo)
+    // Nothing was re-fetched: the runtime half was already correct and only the file was behind.
+    assertEquals(emptyList(), loaded)
+
+    // And now that the two agree, the same POST is the ordinary conflict again.
+    assertEquals(
+      ServeCatalogAdmin.Result.Conflict("catalog 'remote-m3' is already published"),
+      admin(tracker).register(entry),
+    )
+  }
+
+  @Test
+  fun `a refresh captured before a re-point no longer points at the tracked catalog`() {
+    // The refresher's half of the same race. It captures each entry's repo when it snapshots the
+    // tracker; "does the system still exist" was the only test it made after finally getting the
+    // registration monitor, and that is true either side of a re-point.
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config("remote-m3", true, "yschimke/old-home", "design-artifacts/x")
+      )
+    assertTrue(tracker.stillPointsAt("remote-m3", "yschimke/old-home"))
+
+    tracker.repoint("remote-m3", repo = "yschimke/new-home", branch = "design-artifacts/x")
+
+    assertFalse(
+      tracker.stillPointsAt("remote-m3", "yschimke/old-home"),
+      "a pass captured before the swap must not reload the repo the catalog has left",
+    )
+    assertTrue(tracker.stillPointsAt("remote-m3", "yschimke/new-home"))
+    assertFalse(tracker.stillPointsAt("gone", "yschimke/new-home"), "and a retired system is gone")
+  }
+
+  @Test
+  fun `a re-point holds the registration lock across its provenance record`() {
+    // The branch refresher captures each entry's repo when it snapshots the tracker, then queues on
+    // the registration monitor. With the load inside the lock and `repoint` outside it, the
+    // refresher could get in between, still read the OLD repo, and reload it over the new
+    // registration — the old repo's host serving while the provenance and `catalogs.json` both
+    // named the new one.
+    seedConfig(
+      ServeCatalogsConfig(
+        catalogs = listOf(ServeCatalogsConfig.Entry("remote-m3", repo = "yschimke/old-home"))
+      )
+    )
+    val tracker =
+      tracker(
+        CatalogLoadTracker.Config(
+          "remote-m3",
+          true,
+          "yschimke/old-home",
+          "design-artifacts/remote-m3",
+        )
+      )
+    tracker.recordSuccess("remote-m3")
+
+    val lock = Any()
+    // What the refresher reads once it finally gets the monitor.
+    val seenByRefresher = java.util.concurrent.LinkedBlockingQueue<String>()
+    val loadEntered = java.util.concurrent.CountDownLatch(1)
+    val admin =
+      ServeCatalogAdmin(
+        tracker = tracker,
+        defaultRepo = "yschimke/compose-ai-tools",
+        branchPrefix = "design-artifacts/",
+        configFile = file,
+        registrationLock = lock,
+        load = { _, _ ->
+          // The real `load` takes this same monitor; reentrancy is what makes the wider section
+          // legal at all.
+          synchronized(lock) {
+            loadEntered.countDown()
+            Thread.sleep(50)
+            null
+          }
+        },
+        unload = {},
+        onLog = {},
+      )
+
+    val refresher = Thread {
+      loadEntered.await()
+      synchronized(lock) { seenByRefresher.add(assertNotNull(tracker.configFor("remote-m3")).repo) }
+    }
+      .apply { start() }
+
+    val result = admin.register(ServeCatalogsConfig.Entry("remote-m3", "yschimke/new-home"))
+    refresher.join(5_000)
+
+    assertEquals(ServeCatalogAdmin.Result.Ok("remote-m3", warning = null), result)
+    assertEquals(
+      "yschimke/new-home",
+      seenByRefresher.poll(),
+      "the first read that gets the monitor after the load must already see the new provenance",
+    )
   }
 
   @Test


### PR DESCRIPTION
Closes the three unaddressed review findings left on #4596 after it merged.

## The refresher could reload the repo a catalog had just left (P1)

`ServeCatalogRefresher` captures each entry's repo when it snapshots the tracker, then queues on `catalogRegistrationLock`. The re-point held that monitor for its `load` and **released it before** `tracker.repoint`, so:

1. the refresher captures `repo = OLD` and blocks on the monitor;
2. the admin's `load(system, NEW)` runs under it and releases;
3. the refresher gets the monitor, sees a tracker still naming `OLD`, passes its only test — `loads.configFor(system) == null` — and reloads `OLD` over the new registration;
4. the admin then records `NEW` and persists `NEW`.

The old repo's host is serving; the provenance and `catalogs.json` both name the new one.

Both halves are closed, because either alone leaves a window:

- **The swap is one critical section.** `ServeCatalogAdmin` takes a `registrationLock` and holds it across the load *and* the `repoint`/`relist`. The `load` lambda takes the same monitor internally, so this is a reentrant nesting, not a second lock with its own ordering. It defaults to a private object, so a caller whose `load` takes no lock behaves exactly as before.
- **The refresher declines a stale capture.** `CatalogLoadTracker.stillPointsAt(system, repo)` replaces the existence-only check. Declining is right rather than reloading the *current* repo: the admin has just fetched it, so there is nothing to refresh, and the next ordinary pass picks up the new provenance from the tracker.

## A successful swap whose persistence failed was a dead end (P1)

If the new repo loads but `persist` fails transiently, `register` returns `Ok` with a warning — tracker on the new repo, `catalogs.json` on the old one (or without the entry at all, after a retire-first caller). Every later POST of the same desired entry then reached the unchanged-repo branch, matched on every **tracked** field, and returned `409` before attempting persistence. Reconciliation could never repair the file, and the next restart reverted or dropped the catalog.

A file that disagrees with what is running is now a repair, not a conflict: the branch checks `persistedRepoMatches` before conflicting, and rewrites the entry when it does not. In the ordinary steady state the two agree and this is the same `409` it always was. An unreadable file answers "does not match", so the caller attempts the write and comes back with a persistence warning naming the reason — better than a `409` claiming the catalog is already published from a document nobody can parse.

## A failed re-point claimed an unavailable catalog was "still serving" (P2)

`configFor` answers for a pending entry and for one whose initial load failed exactly as it does for a live one, so the failure message was the reassuring half of a two-part answer that could be wrong — reachable from reconciliation during startup, or after a persistent startup fetch failure.

New `CatalogLoadTracker.stateFor` gives the caller the other half. The message now follows tracked availability, and otherwise says only that the old configuration was preserved — which is the part that was true all along.

## Two existing tests were asserting the wrong thing

Both had fixtures tracking a catalog the config file did not carry — exactly the divergence the repair path now heals — so they passed for a reason other than the one they stated:

- `re-publishing a served catalog is a conflict, not a silent overwrite` and the routing-level `a duplicate … is a conflict` now **seed the file**, so "already published" means the file and the runtime agree.
- `a repo change that cannot be fetched leaves the old catalog serving` now calls `recordSuccess`, so the catalog it asserts is "still serving" actually is.

## Test plan

Four new tests in `ServeCatalogAdminTest` (`:cli:serve:test`, 20 tests, 0 failures):

- **`a re-point holds the registration lock across its provenance record`** — a second thread waits on the same monitor (released by a `CountDownLatch` once the load is inside it) and asserts the first read to get the monitor after the load already sees the **new** repo. The interleaving is forced, not hoped for.
- **`a refresh captured before a re-point no longer points at the tracked catalog`** — `stillPointsAt` before and after a `repoint`, plus the retired-system case.
- **`a swap whose persistence failed can be repaired by re-posting the same entry`** — tracker on the new repo, file on the old: the POST rewrites the file, re-fetches nothing, and the *next* identical POST is the ordinary conflict again.
- **`a failed re-point does not claim an unavailable old catalog is still serving`** — a `pending` tracker entry: the message drops "still serving" and says the configuration was preserved.

Gates run locally on the pushed head:

- `./gradlew :cli:serve:test :cli:test` — BUILD SUCCESSFUL
- `./gradlew :cli:checkServeSeam` — `OK — 33 crossing symbol(s), all on the allowlist`
- `python3 scripts/test_check_serve_seam.py` — 45 tests, OK
- `./gradlew ktfmtCheckAll` — clean

Non-visual: a lock scope, a staleness check and a persistence retry path, none of which reach a rendered page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_