### PR TITLE
refactor(serve): extract the agent-grant protocol into a published contract

### DIFF
--- a/api/agent-grant-protocol/api/agent-grant-protocol.api
+++ b/api/agent-grant-protocol/api/agent-grant-protocol.api
@@ -1,0 +1,45 @@
+public final class ee/schimke/composeai/agentgrants/AgentGrantCapability : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/agentgrants/AgentGrantCapability$Companion;
+	public static final field IMAGES Lee/schimke/composeai/agentgrants/AgentGrantCapability;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getHumanDescription ()Ljava/lang/String;
+	public final fun getWire ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/agentgrants/AgentGrantCapability;
+	public static fun values ()[Lee/schimke/composeai/agentgrants/AgentGrantCapability;
+}
+
+public final class ee/schimke/composeai/agentgrants/AgentGrantCapability$Companion {
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/agentgrants/AgentGrantCapability;
+	public final fun parseAll (Ljava/lang/String;)Ljava/util/Set;
+	public final fun wireNames (Ljava/util/Set;)Ljava/util/List;
+}
+
+public final class ee/schimke/composeai/agentgrants/AgentGrantProtocol {
+	public static final field HARD_MAX_GRANT_TTL_SECONDS J
+	public static final field INSTANCE Lee/schimke/composeai/agentgrants/AgentGrantProtocol;
+	public final fun fingerprintOf (Ljava/lang/String;)Ljava/lang/String;
+	public final fun formatDuration (J)Ljava/lang/String;
+	public final fun parseDurationSeconds (Ljava/lang/String;)Ljava/lang/Long;
+}
+
+public final class ee/schimke/composeai/agentgrants/AgentGrantScope : java/lang/Enum {
+	public static final field Companion Lee/schimke/composeai/agentgrants/AgentGrantScope$Companion;
+	public static final field LIVE Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public static final field PLAYGROUND Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public static final field PREVIEW Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getHumanDescription ()Ljava/lang/String;
+	public final fun getWire ()Ljava/lang/String;
+	public final fun implies (Lee/schimke/composeai/agentgrants/AgentGrantScope;)Z
+	public static fun valueOf (Ljava/lang/String;)Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public static fun values ()[Lee/schimke/composeai/agentgrants/AgentGrantScope;
+}
+
+public final class ee/schimke/composeai/agentgrants/AgentGrantScope$Companion {
+	public final fun getDEFAULT_MAX ()Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public final fun getDEFAULT_REQUEST ()Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public final fun parse (Ljava/lang/String;)Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public final fun parseHighest (Ljava/lang/String;)Lee/schimke/composeai/agentgrants/AgentGrantScope;
+	public final fun upTo (Lee/schimke/composeai/agentgrants/AgentGrantScope;)Ljava/util/List;
+}
+

--- a/api/agent-grant-protocol/build.gradle.kts
+++ b/api/agent-grant-protocol/build.gradle.kts
@@ -1,0 +1,44 @@
+// The vocabulary a `serve` box and an agent-access client must agree on.
+//
+// `--agent-grants` is a two-party protocol: the CLI's `auth` command asks for a grant and polls for
+// it, the preview server mints and revokes. Both ends therefore need the same scope and capability
+// names, the same duration grammar, and the same token fingerprint — and while those lived in
+// `:cli:serve`, the client half was reaching into the server to parse its own `--ttl`.
+//
+// Deliberately small. It carries what the two ends must share and nothing about how either behaves:
+// no store, no routes, no HTTP. `ServeAgentGrantStore` — minting, expiry, persistence, rate limits
+// —
+// stays in the server, which is where the policy belongs.
+plugins {
+  id("composeai.base-conventions")
+  id("composeai.maven-publishing")
+  alias(libs.plugins.kotlin.jvm)
+}
+
+dependencies {
+  testImplementation(libs.junit)
+  testImplementation(kotlin("test"))
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "agent-grant-protocol",
+    displayName = "Compose Preview — Agent Grant Protocol",
+    description =
+      "Scopes, capabilities, duration grammar and token fingerprinting shared by the " +
+        "compose-preview server that mints agent access grants and the client that asks for them.",
+  )
+  inceptionYear.set("2026")
+}
+
+kotlin {
+  // `explicitApi()` — this is a published contract both halves of the #3824 split compile against
+  // across a repo boundary, so an implicitly-public declaration is an API decision nobody made.
+  explicitApi()
+
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
+}
+
+// `checkKotlinAbi` is not wired into `check` by the Kotlin Gradle plugin, so an unrecorded surface
+// change would pass CI silently. Wire it explicitly — the gate is only worth having if it runs.
+tasks.named("check") { dependsOn("checkKotlinAbi") }

--- a/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantCapability.kt
+++ b/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantCapability.kt
@@ -1,13 +1,12 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.agentgrants
 
 /**
  * What a grant may do **beside** its scope rung — see
  * [docs/design/AGENT_ACCESS_GRANTS.md](../../../../../../../../docs/design/AGENT_ACCESS_GRANTS.md).
  *
- * [ServeAgentGrantScope] is a ladder: each rung implies the ones below it, because each names a
- * strictly larger amount of this box's CPU and trust. A capability is the other shape — an
- * **independent** permission that does not sit anywhere on that ladder and must not be dragged
- * along by it.
+ * [AgentGrantScope] is a ladder: each rung implies the ones below it, because each names a strictly
+ * larger amount of this box's CPU and trust. A capability is the other shape — an **independent**
+ * permission that does not sit anywhere on that ladder and must not be dragged along by it.
  *
  * [IMAGES] is the worked example, and the reason this type exists rather than a fourth rung.
  * Uploading a PNG is not "more" than opening a render daemon and not "less" than running a Kotlin
@@ -21,11 +20,11 @@ package ee.schimke.composeai.cli.serve
  * these as checkboxes where the scopes are radios: independent boxes describe independent
  * permissions honestly.
  */
-enum class ServeAgentGrantCapability(
+public enum class AgentGrantCapability(
   /** The wire/CLI name — lowercase, stable, what `--capability` and the JSON carry. */
-  val wire: String,
+  public val wire: String,
   /** One line for the approval page: what the human is actually agreeing to. */
-  val humanDescription: String,
+  public val humanDescription: String,
 ) {
   /**
    * Upload rendered images through the image lane (`POST /images`), so the returned URLs can be
@@ -47,9 +46,9 @@ enum class ServeAgentGrantCapability(
     "Upload rendered preview images, published at unlisted URLs on this server until they expire",
   );
 
-  companion object {
+  public companion object {
     /** Parse one wire name, case-insensitively; null when it names nothing. */
-    fun parse(value: String?): ServeAgentGrantCapability? {
+    public fun parse(value: String?): AgentGrantCapability? {
       val wanted = value?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
       return entries.firstOrNull { it.wire == wanted }
     }
@@ -59,9 +58,9 @@ enum class ServeAgentGrantCapability(
      *
      * **Throws** on a name that means nothing, so a typo in `--agent-grant-capabilities` fails the
      * server's startup instead of silently withholding a capability the operator believes they
-     * enabled — the same trade [ServeAgentGrantScope.parseHighest] makes, for the same reason.
+     * enabled — the same trade [AgentGrantScope.parseHighest] makes, for the same reason.
      */
-    fun parseAll(list: String?): Set<ServeAgentGrantCapability> {
+    public fun parseAll(list: String?): Set<AgentGrantCapability> {
       val names =
         list
           ?.split(',', ' ')
@@ -82,7 +81,7 @@ enum class ServeAgentGrantCapability(
     }
 
     /** Wire names, in declaration order — for JSON, the CLI and the audit line. */
-    fun wireNames(capabilities: Set<ServeAgentGrantCapability>): List<String> =
+    public fun wireNames(capabilities: Set<AgentGrantCapability>): List<String> =
       entries.filter { it in capabilities }.map { it.wire }
   }
 }

--- a/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantProtocol.kt
+++ b/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantProtocol.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.agentgrants
+
+import java.security.MessageDigest
+
+/**
+ * The parts of the agent-grant lane both ends have to agree on.
+ *
+ * The duration grammar is the clearest case for this module existing: the CLI's `--ttl` and the
+ * server's `--agent-grant-max-ttl` accept the same `2h` / `45m` / `90s` spellings, and they have
+ * to, because the client asks in that grammar and the server clamps in it. While
+ * `parseDurationSeconds` lived in `:cli:serve`, `auth` reached into the preview server to read its
+ * own flag.
+ *
+ * The fingerprint is here for the same reason from the other direction: a grant token is only ever
+ * *displayed* as its fingerprint, and a client that computed a different one would show the
+ * operator a value that matches nothing on the box.
+ *
+ * What is deliberately NOT here: minting, expiry, revocation, persistence and rate limiting. Those
+ * are `ServeAgentGrantStore`'s, and they are policy rather than protocol.
+ */
+public object AgentGrantProtocol {
+
+  /**
+   * The longest grant any box will mint, whatever the operator asks for.
+   *
+   * A ceiling rather than a default: beyond a day this stops being temporary access. Shared because
+   * the client prints it when explaining why a requested TTL was cut.
+   */
+  public const val HARD_MAX_GRANT_TTL_SECONDS: Long = 24 * 60 * 60L
+
+  /**
+   * Turn `"2h"`, `"45m"`, `"90s"`, or a bare number of seconds into seconds. Null for anything
+   * unparseable, so a caller can fall back rather than silently granting a duration nobody chose.
+   */
+  public fun parseDurationSeconds(raw: String?): Long? {
+    val text = raw?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
+    val match = DURATION.matchEntire(text) ?: return null
+    val value = match.groupValues[1].toLongOrNull() ?: return null
+    if (value <= 0) return null
+    return when (match.groupValues[2]) {
+      "h" -> value * 3600
+      "m" -> value * 60
+      else -> value
+    }
+  }
+
+  /** `2h 15m`, `45m`, `30s` — how a duration is shown on the page and in the CLI's output. */
+  public fun formatDuration(seconds: Long): String {
+    if (seconds < 60) return "${seconds}s"
+    val hours = seconds / 3600
+    val minutes = (seconds % 3600) / 60
+    return when {
+      hours == 0L -> "${minutes}m"
+      minutes == 0L -> "${hours}h"
+      else -> "${hours}h ${minutes}m"
+    }
+  }
+
+  /** SHA-256, first 12 hex characters — the only form of a token that is ever displayed. */
+  public fun fingerprintOf(token: String): String =
+    MessageDigest.getInstance("SHA-256")
+      .digest(token.toByteArray(Charsets.UTF_8))
+      .joinToString("") { "%02x".format(it) }
+      .take(12)
+
+  private val DURATION = Regex("(\\d+)\\s*([hms]?)(?:ec|in|our)?s?")
+}

--- a/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantScope.kt
+++ b/api/agent-grant-protocol/src/main/kotlin/ee/schimke/composeai/agentgrants/AgentGrantScope.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.agentgrants
 
 /**
  * What an agent grant ([ServeAgentGrantStore]) may unlock, and nothing else — see
@@ -14,22 +14,22 @@ package ee.schimke.composeai.cli.serve
  * matching a set. Adding a value in the middle re-orders the lattice, which is why the ordinal is
  * load-bearing and the enum is not alphabetised.
  */
-enum class ServeAgentGrantScope(
+public enum class AgentGrantScope(
   /** The wire/CLI name — lowercase, stable, what `--scope` and the JSON carry. */
-  val wire: String,
+  public val wire: String,
   /** One line for the approval page: what the human is actually agreeing to. */
-  val humanDescription: String,
+  public val humanDescription: String,
 ) {
   /**
    * Read the published catalogs: browse pages, baked renders, `/status`. Satisfies the token gate
-   * ([ServeHttpServer.rejectBadToken]) and nothing further, so on a `--public` box this scope is
+   * (`ServeHttpServer.rejectBadToken`) and nothing further, so on a `--public` box this scope is
    * already what an anonymous visitor has.
    */
   PREVIEW("preview", "Browse this server's catalogs and their rendered previews"),
 
   /**
    * Open a live daemon-backed session — the viewer WebSocket, on-demand renders, theme switching.
-   * Satisfies [ServeHttpServer.rejectMissingGithubAuth], the gate a signed-in GitHub visitor
+   * Satisfies `ServeHttpServer.rejectMissingGithubAuth`, the gate a signed-in GitHub visitor
    * passes. Costs the box real CPU (a render daemon), which is why it is a step above [PREVIEW]
    * rather than part of it.
    */
@@ -37,7 +37,7 @@ enum class ServeAgentGrantScope(
 
   /**
    * Compile and run a Kotlin snippet on this host (the playground lane). Satisfies
-   * [ServeHttpServer.rejectMissingGithubRepoAccess].
+   * `ServeHttpServer.rejectMissingGithubRepoAccess`.
    *
    * This is arbitrary code execution on the box, inside the playground's sandbox and nothing more.
    * It is deliberately absent from [DEFAULT_MAX], and an approver who does not themselves hold
@@ -46,24 +46,24 @@ enum class ServeAgentGrantScope(
   PLAYGROUND("playground", "Compile and run Kotlin snippets on this machine (the playground)");
 
   /** True when holding `this` also confers [other] — i.e. [other] is at or below this rung. */
-  fun implies(other: ServeAgentGrantScope): Boolean = ordinal >= other.ordinal
+  public fun implies(other: AgentGrantScope): Boolean = ordinal >= other.ordinal
 
-  companion object {
+  public companion object {
     /**
      * What a grant carries when the agent asked for nothing in particular: enough to look, not
      * enough to spend the box's CPU. An agent that wants [LIVE] says so.
      */
-    val DEFAULT_REQUEST: ServeAgentGrantScope = PREVIEW
+    public val DEFAULT_REQUEST: AgentGrantScope = PREVIEW
 
     /**
      * The operator's ceiling when `--agent-grant-scopes` is unset. [PLAYGROUND] is out because it
      * runs code; opting into it must be a deliberate, typed decision rather than a default an
      * operator inherits by upgrading.
      */
-    val DEFAULT_MAX: ServeAgentGrantScope = LIVE
+    public val DEFAULT_MAX: AgentGrantScope = LIVE
 
     /** Parse one wire name, case-insensitively; null when it names nothing. */
-    fun parse(value: String?): ServeAgentGrantScope? {
+    public fun parse(value: String?): AgentGrantScope? {
       val wanted = value?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
       return entries.firstOrNull { it.wire == wanted }
     }
@@ -76,7 +76,7 @@ enum class ServeAgentGrantScope(
      * `--agent-grant-scopes` fails the server's startup instead of silently narrowing every future
      * grant to `preview` and leaving the operator to wonder why live never works.
      */
-    fun parseHighest(list: String?): ServeAgentGrantScope? {
+    public fun parseHighest(list: String?): AgentGrantScope? {
       val names =
         list?.split(',', ' ')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: return null
       if (names.isEmpty()) return null
@@ -91,7 +91,7 @@ enum class ServeAgentGrantScope(
     }
 
     /** Every scope up to and including [highest], least-privileged first — what a grant lists. */
-    fun upTo(highest: ServeAgentGrantScope): List<ServeAgentGrantScope> = entries.filter {
+    public fun upTo(highest: AgentGrantScope): List<AgentGrantScope> = entries.filter {
       highest.implies(it)
     }
   }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -213,6 +213,7 @@ dependencies {
   // subcommands stay here. `api` for source-compat: the types kept their `ee.schimke.composeai.cli`
   // package, so every existing call site (including `serve`) resolves them unchanged.
   api(project(":bundle-format"))
+  api(project(":agent-grant-protocol"))
 
   // Turning a bundle's recorded Maven coordinates back into local jars — the `bundle daemon` and
   // `bundle render` subcommands and `serve` all need it. Split out of this module for #3824

--- a/cli/serve/build.gradle.kts
+++ b/cli/serve/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
   api(project(":preview-data-api"))
   implementation(project(":common-image-crop"))
   api(project(":bundle-format"))
+  api(project(":agent-grant-protocol"))
   api(project(":bundle-coordinates"))
   api(project(":daemon:core"))
   api(project(":daemon-client"))

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStore.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
-import java.security.MessageDigest
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
@@ -30,14 +32,14 @@ class ServeAgentGrantStore(
   /** The longest grant this box will mint, whatever the agent asked for or the approver chose. */
   val maxGrantTtlSeconds: Long = DEFAULT_MAX_GRANT_TTL_SECONDS,
   /** The most privileged scope any grant here may carry — the operator's ceiling. */
-  val maxScope: ServeAgentGrantScope = ServeAgentGrantScope.DEFAULT_MAX,
+  val maxScope: AgentGrantScope = AgentGrantScope.DEFAULT_MAX,
   /**
-   * The capabilities ([ServeAgentGrantCapability]) any grant here may carry — the operator's other
+   * The capabilities ([AgentGrantCapability]) any grant here may carry — the operator's other
    * ceiling, and empty by default. Separate from [maxScope] because capabilities are not rungs: a
    * box that grants `live` has said nothing about whether an agent may also publish an image on its
    * origin, and must not be read as having said yes.
    */
-  val maxCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+  val maxCapabilities: Set<AgentGrantCapability> = emptySet(),
   private val maxActiveGrants: Int = DEFAULT_MAX_ACTIVE_GRANTS,
   private val maxPendingRequests: Int = DEFAULT_MAX_PENDING_REQUESTS,
   private val clock: () -> Long = System::currentTimeMillis,
@@ -75,14 +77,14 @@ class ServeAgentGrantStore(
     /** Where the request came from, for the approval page's "who is asking". Also untrusted. */
     val client: String,
     /** The most privileged scope the agent asked for; the approver may grant this or less. */
-    val requestedScope: ServeAgentGrantScope,
+    val requestedScope: AgentGrantScope,
     /** Seconds of access the agent asked for; the approver may grant this or less. */
     val requestedTtlSeconds: Long,
     /**
      * The capabilities the agent asked for, already narrowed to this box's ceiling. The approver
      * may grant these or fewer — never more, for the same reason the scope can only be narrowed.
      */
-    val requestedCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+    val requestedCapabilities: Set<AgentGrantCapability> = emptySet(),
     val createdAtMillis: Long,
     val expiresAtMillis: Long,
     @Volatile var state: State = State.PENDING,
@@ -125,9 +127,9 @@ class ServeAgentGrantStore(
     val id: String,
     /** The bearer. Returned exactly once (the poll response) and never rendered again. */
     val token: String,
-    val scope: ServeAgentGrantScope,
+    val scope: AgentGrantScope,
     /** The independent permissions this grant carries beside its rung. Usually empty. */
-    val capabilities: Set<ServeAgentGrantCapability> = emptySet(),
+    val capabilities: Set<AgentGrantCapability> = emptySet(),
     /** The label from the request, carried through so `/status` says what this is for. */
     val label: String,
     /** GitHub login, or `operator (token)` — see [ServeAgentGrants]. */
@@ -136,24 +138,24 @@ class ServeAgentGrantStore(
     val expiresAtMillis: Long,
   ) {
     /** Every scope this grant confers, least-privileged first — the poll response's `scopes`. */
-    val scopes: List<ServeAgentGrantScope>
-      get() = ServeAgentGrantScope.upTo(scope)
+    val scopes: List<AgentGrantScope>
+      get() = AgentGrantScope.upTo(scope)
 
     /** True when this grant is at or above [wanted]. The one question every gate asks. */
-    fun allows(wanted: ServeAgentGrantScope): Boolean = scope.implies(wanted)
+    fun allows(wanted: AgentGrantScope): Boolean = scope.implies(wanted)
 
     /**
      * True when this grant carries [wanted]. Deliberately **not** implied by any scope: the rung
      * says how much of the machine the agent may spend, and a capability is a separate yes.
      */
-    fun allows(wanted: ServeAgentGrantCapability): Boolean = wanted in capabilities
+    fun allows(wanted: AgentGrantCapability): Boolean = wanted in capabilities
 
     /**
      * A short, stable, non-reversible handle on the token, for `/status` and the audit log. SHA-256
      * truncated to 12 hex characters: enough to tell two live grants apart and to match a log line
      * to a row, and useless to anyone who reads it.
      */
-    val fingerprint: String by lazy { fingerprintOf(token) }
+    val fingerprint: String by lazy { AgentGrantProtocol.fingerprintOf(token) }
 
     fun secondsUntilExpiry(nowMillis: Long): Long =
       ((expiresAtMillis - nowMillis) / 1000).coerceAtLeast(0)
@@ -182,9 +184,9 @@ class ServeAgentGrantStore(
   fun openRequest(
     label: String,
     client: String,
-    requestedScope: ServeAgentGrantScope,
+    requestedScope: AgentGrantScope,
     requestedTtlSeconds: Long,
-    requestedCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+    requestedCapabilities: Set<AgentGrantCapability> = emptySet(),
   ): Request? =
     synchronized(this) {
       openRequestLocked(label, client, requestedScope, requestedTtlSeconds, requestedCapabilities)
@@ -202,9 +204,9 @@ class ServeAgentGrantStore(
   private fun openRequestLocked(
     label: String,
     client: String,
-    requestedScope: ServeAgentGrantScope,
+    requestedScope: AgentGrantScope,
     requestedTtlSeconds: Long,
-    requestedCapabilities: Set<ServeAgentGrantCapability>,
+    requestedCapabilities: Set<AgentGrantCapability>,
   ): Request? {
     val now = clock()
     purge(now)
@@ -277,9 +279,9 @@ class ServeAgentGrantStore(
   fun approve(
     id: String,
     approvedBy: String,
-    scope: ServeAgentGrantScope,
+    scope: AgentGrantScope,
     ttlSeconds: Long,
-    capabilities: Set<ServeAgentGrantCapability> = emptySet(),
+    capabilities: Set<AgentGrantCapability> = emptySet(),
   ): Grant? {
     synchronized(this) {
       // Lookup, expiry validation and the state transition all inside the lock. Split across it,
@@ -506,9 +508,9 @@ class ServeAgentGrantStore(
    * overwhelmingly common case, and a trailing `caps=` on every line would be noise that trains the
    * reader to skip the field on the lines where it matters.
    */
-  private fun capabilityAuditField(capabilities: Set<ServeAgentGrantCapability>): String =
+  private fun capabilityAuditField(capabilities: Set<AgentGrantCapability>): String =
     if (capabilities.isEmpty()) ""
-    else "caps=${ServeAgentGrantCapability.wireNames(capabilities).joinToString(",")} "
+    else "caps=${AgentGrantCapability.wireNames(capabilities).joinToString(",")} "
 
   private fun evictOverflow(keep: Grant) {
     while (grants.size > maxActiveGrants) {
@@ -531,7 +533,6 @@ class ServeAgentGrantStore(
      * a day stops being "temporary access for this task" and becomes a credential nobody remembers
      * issuing, which is the thing this feature exists to replace.
      */
-    const val HARD_MAX_GRANT_TTL_SECONDS = 24 * 60 * 60L
 
     /** What an agent gets when it names no TTL: long enough for one task. */
     const val DEFAULT_GRANT_TTL_SECONDS = 60 * 60L
@@ -635,13 +636,6 @@ class ServeAgentGrantStore(
 
     /** Cheap shape check on a presented bearer, so an ordinary `--token` never reaches the map. */
     fun isWellFormedToken(token: String): Boolean = token.matches(TOKEN_SHAPE)
-
-    /** SHA-256, first 12 hex characters — the only form of a token that is ever displayed. */
-    fun fingerprintOf(token: String): String =
-      MessageDigest.getInstance("SHA-256")
-        .digest(token.toByteArray(Charsets.UTF_8))
-        .joinToString("") { "%02x".format(it) }
-        .take(12)
 
     private val ID_SHAPE = Regex("[A-Za-z0-9_-]{16,64}")
     private val TOKEN_SHAPE = Regex("${Regex.escape(TOKEN_PREFIX)}[A-Za-z0-9_-]{16,64}")

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrants.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrants.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import java.security.SecureRandom
 import java.util.Base64
 import javax.crypto.Mac
@@ -41,17 +43,15 @@ object ServeAgentGrants {
   data class OpenRequest(
     /** What the access is for, shown to the approver. Free text; displayed escaped. */
     val label: String = "",
-    /**
-     * Highest scope wanted, by wire name. Unknown/absent ⇒ [ServeAgentGrantScope.DEFAULT_REQUEST].
-     */
+    /** Highest scope wanted, by wire name. Unknown/absent ⇒ [AgentGrantScope.DEFAULT_REQUEST]. */
     val scope: String = "",
     /** Requested lifetime. Clamped to the box's `--agent-grant-max-ttl`. */
     @SerialName("ttlSeconds") val ttlSeconds: Long = 0,
     /**
-     * Independent permissions wanted beside [scope], by wire name ([ServeAgentGrantCapability]).
-     * Unknown names are ignored rather than refused: this is an agent describing what it would
-     * like, and a newer client naming a capability this server has never heard of should get the
-     * rest of its request honoured, not a 400.
+     * Independent permissions wanted beside [scope], by wire name ([AgentGrantCapability]). Unknown
+     * names are ignored rather than refused: this is an agent describing what it would like, and a
+     * newer client naming a capability this server has never heard of should get the rest of its
+     * request honoured, not a 400.
      */
     val capabilities: List<String> = emptyList(),
   )
@@ -138,7 +138,7 @@ object ServeAgentGrants {
    * Who is approving, and what they are themselves allowed to pass on.
    *
    * The second half is the rule that matters: **an approver may never grant a capability they do
-   * not hold**. On a GitHub-gated box, [ceiling] drops to [ServeAgentGrantScope.LIVE] for a visitor
+   * not hold**. On a GitHub-gated box, [ceiling] drops to [AgentGrantScope.LIVE] for a visitor
    * without access to `--github-auth-repo`, because that repo check is exactly the playground's own
    * gate — letting them tick the playground box would be a privilege escalation dressed as a
    * delegation.
@@ -146,36 +146,36 @@ object ServeAgentGrants {
   data class Approver(
     /** Display name, and what the audit line records: a GitHub login, or `operator (token)`. */
     val name: String,
-    val ceiling: ServeAgentGrantScope,
+    val ceiling: AgentGrantScope,
     /**
      * The capabilities this approver may pass on — the same "never grant what you do not hold"
      * rule, applied to the half of a grant that is not a rung.
      *
-     * [ServeAgentGrantCapability.IMAGES] is the case that makes it concrete. The image lane admits
-     * a caller who has **write access to the gating repository**, so a signed-in visitor without
-     * that access cannot upload — and must not be able to hand an agent a token that does. It is
-     * the identical argument to the playground's, which is why the two are computed from the same
+     * [AgentGrantCapability.IMAGES] is the case that makes it concrete. The image lane admits a
+     * caller who has **write access to the gating repository**, so a signed-in visitor without that
+     * access cannot upload — and must not be able to hand an agent a token that does. It is the
+     * identical argument to the playground's, which is why the two are computed from the same
      * `repositoryAccess` bit.
      */
-    val capabilityCeiling: Set<ServeAgentGrantCapability> = emptySet(),
+    val capabilityCeiling: Set<AgentGrantCapability> = emptySet(),
   ) {
     companion object {
       /** The holder of `--token` on a box with no GitHub auth: the operator, so no narrowing. */
       fun operator(
-        storeCeiling: ServeAgentGrantScope,
-        storeCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+        storeCeiling: AgentGrantScope,
+        storeCapabilities: Set<AgentGrantCapability> = emptySet(),
       ): Approver = Approver("operator (token)", storeCeiling, storeCapabilities)
 
       fun github(
         login: String,
         repositoryAccess: Boolean,
-        storeCeiling: ServeAgentGrantScope,
-        storeCapabilities: Set<ServeAgentGrantCapability> = emptySet(),
+        storeCeiling: AgentGrantScope,
+        storeCapabilities: Set<AgentGrantCapability> = emptySet(),
       ) =
         Approver(
           name = "@$login",
           ceiling =
-            if (repositoryAccess) storeCeiling else minOf(storeCeiling, ServeAgentGrantScope.LIVE),
+            if (repositoryAccess) storeCeiling else minOf(storeCeiling, AgentGrantScope.LIVE),
           capabilityCeiling = if (repositoryAccess) storeCapabilities else emptySet(),
         )
     }
@@ -235,46 +235,15 @@ object ServeAgentGrants {
    * never offer something the POST would then refuse.
    */
   fun selectableCapabilities(
-    requested: Set<ServeAgentGrantCapability>,
+    requested: Set<AgentGrantCapability>,
     approver: Approver,
-    storeCeiling: Set<ServeAgentGrantCapability>,
-  ): Set<ServeAgentGrantCapability> =
+    storeCeiling: Set<AgentGrantCapability>,
+  ): Set<AgentGrantCapability> =
     requested intersect approver.capabilityCeiling intersect storeCeiling
 
   fun selectableScopes(
-    requested: ServeAgentGrantScope,
+    requested: AgentGrantScope,
     approver: Approver,
-    storeCeiling: ServeAgentGrantScope,
-  ): List<ServeAgentGrantScope> =
-    ServeAgentGrantScope.upTo(minOf(requested, approver.ceiling, storeCeiling))
-
-  /**
-   * Turn `"2h"`, `"45m"`, `"90s"`, or a bare number of seconds into seconds. Null for anything
-   * unparseable, so a caller can fall back rather than silently granting a duration nobody chose.
-   */
-  fun parseDurationSeconds(raw: String?): Long? {
-    val text = raw?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
-    val match = DURATION.matchEntire(text) ?: return null
-    val value = match.groupValues[1].toLongOrNull() ?: return null
-    if (value <= 0) return null
-    return when (match.groupValues[2]) {
-      "h" -> value * 3600
-      "m" -> value * 60
-      else -> value
-    }
-  }
-
-  /** `2h 15m`, `45m`, `30s` — how a duration is shown on the page and in the CLI's output. */
-  fun formatDuration(seconds: Long): String {
-    if (seconds < 60) return "${seconds}s"
-    val hours = seconds / 3600
-    val minutes = (seconds % 3600) / 60
-    return when {
-      hours == 0L -> "${minutes}m"
-      minutes == 0L -> "${hours}h"
-      else -> "${hours}h ${minutes}m"
-    }
-  }
-
-  private val DURATION = Regex("(\\d+)\\s*([hms]?)(?:ec|in|our)?s?")
+    storeCeiling: AgentGrantScope,
+  ): List<AgentGrantScope> = AgentGrantScope.upTo(minOf(requested, approver.ceiling, storeCeiling))
 }

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDefaults.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeDefaults.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+
 /**
  * Server defaults shared by the two halves of `serve`.
  *
@@ -98,7 +100,7 @@ public object ServeDefaults {
   public const val MAX_DERIVED_CONCURRENT_RENDERS: Int =
     ServeBackgroundWork.MAX_DERIVED_CONCURRENT_RENDERS
   public const val AGENT_GRANT_HARD_MAX_TTL_SECONDS: Long =
-    ServeAgentGrantStore.HARD_MAX_GRANT_TTL_SECONDS
+    AgentGrantProtocol.HARD_MAX_GRANT_TTL_SECONDS
   public const val AGENT_GRANT_MAX_ACTIVE: Int = ServeAgentGrantStore.DEFAULT_MAX_ACTIVE_GRANTS
   public const val AGENT_GRANT_MAX_TTL_SECONDS: Long =
     ServeAgentGrantStore.DEFAULT_MAX_GRANT_TTL_SECONDS

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
@@ -2567,8 +2570,8 @@ class ServeHttpServer(
   }
 
   /**
-   * The upload identity of a live agent grant carrying [ServeAgentGrantCapability.IMAGES], or null
-   * when this call presents no such grant (in which case the GitHub gate has its say as before).
+   * The upload identity of a live agent grant carrying [AgentGrantCapability.IMAGES], or null when
+   * this call presents no such grant (in which case the GitHub gate has its say as before).
    *
    * This is the whole of the link between the grant lane and the image lane, and it is small on
    * purpose: a grant does not become a GitHub account here, it becomes *an admitted caller with a
@@ -2586,7 +2589,7 @@ class ServeHttpServer(
    */
   private fun RoutingContext.grantedImageIdentity(): ServeImageUploadAuth.Identity.Ok? {
     val grant = agentGrantFor(call) ?: return null
-    if (!grant.allows(ServeAgentGrantCapability.IMAGES)) return null
+    if (!grant.allows(AgentGrantCapability.IMAGES)) return null
     return ServeImageUploadAuth.Identity.Ok(
       login = "agent grant ${grant.fingerprint} (approved by ${grant.approvedBy})",
       budgetKey = "grant:${grant.id}",
@@ -3060,7 +3063,7 @@ class ServeHttpServer(
     // grant would be handed the lease and then refused every render it authorises, which is a
     // confusing way to say no; refuse the ticket instead. (The release counterpart is deliberately
     // ungated — handing capacity back is always welcome.)
-    if (rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api = true)) return
+    if (rejectGrantBelowScope(AgentGrantScope.LIVE, api = true)) return
     val sessionId = selectedSessionId(sessionInPath)
     withLeasedSession(sessionId) { renderHost ->
       val grant =
@@ -3105,7 +3108,7 @@ class ServeHttpServer(
     if (rejectBadToken()) return
     // `keepLiveWarm()` below starts or retains a daemon — the definition of `live`, however small
     // each individual ping looks.
-    if (rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api = true)) return
+    if (rejectGrantBelowScope(AgentGrantScope.LIVE, api = true)) return
     withLeasedSession(
       selectedSessionId(sessionInPath),
       onMissing = { call.respond(HttpStatusCode.NoContent) },
@@ -5696,13 +5699,13 @@ class ServeHttpServer(
                 pendingRequests = store.pendingRequests().size,
                 maxScope = store.maxScope.wire,
                 maxTtlSeconds = store.maxGrantTtlSeconds,
-                maxCapabilities = ServeAgentGrantCapability.wireNames(store.maxCapabilities),
+                maxCapabilities = AgentGrantCapability.wireNames(store.maxCapabilities),
                 grants =
                   live.map { grant ->
                     AgentGrantDto(
                       fingerprint = grant.fingerprint,
                       scopes = grant.scopes.map { it.wire },
-                      capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities),
+                      capabilities = AgentGrantCapability.wireNames(grant.capabilities),
                       approvedBy = grant.approvedBy,
                       expiresInSeconds = grant.secondsUntilExpiry(now),
                       label = grant.label,
@@ -6545,7 +6548,7 @@ class ServeHttpServer(
   private suspend fun RoutingContext.handleStorybookIframe(sessionInPath: Boolean) {
     if (rejectBadToken()) return
     // Renders unconditionally — there is no baked lane here at all, so every request is live work.
-    if (rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api = true)) return
+    if (rejectGrantBelowScope(AgentGrantScope.LIVE, api = true)) return
     // Renders a story unconditionally — there is no baked lane here. A chrome-less frame for
     // screenshot tools is never an unfurl target (and is robots-disallowed), so a bodyless probe
     // gets nothing but the render bill.
@@ -6714,7 +6717,7 @@ class ServeHttpServer(
     // …and by the same token the most expensive thing a grant could trigger, so it wants `live`.
     // Not named in the review that caught the `/render` case, but it is the same rule and the
     // larger bill: leaving the sibling hole open while closing the named one would be theatre.
-    if (rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api = true)) return
+    if (rejectGrantBelowScope(AgentGrantScope.LIVE, api = true)) return
     withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
       // Render the whole module once (cache-backed) into the portable WebEmbed gallery and stream
       // it
@@ -7344,7 +7347,7 @@ class ServeHttpServer(
     // time a session was not resident, which is not what anyone approved or withheld.
     if (
       (requestCarriesOverrides() || wantsDaemonOnlyRenderProduct()) &&
-        rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api = true)
+        rejectGrantBelowScope(AgentGrantScope.LIVE, api = true)
     )
       return
     // A bare `/render/<id>.png` replays a baked file and IS what an unfurler probes for `og:image`,
@@ -8587,7 +8590,7 @@ class ServeHttpServer(
     // scope whether or not this box configures GitHub auth.
     val socketGrant = agentGrantFor(call)
     if (socketGrant != null) {
-      if (!socketGrant.allows(ServeAgentGrantScope.LIVE)) {
+      if (!socketGrant.allows(AgentGrantScope.LIVE)) {
         close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "live not approved for this grant"))
         return
       }
@@ -8739,9 +8742,9 @@ class ServeHttpServer(
    * the request's `?token=` / `X-Compose-Preview-Token` doesn't match. Constant-time compare.
    *
    * A live **agent grant** ([ServeAgentGrantStore]) presented in the same place is the other way to
-   * pass, at [ServeAgentGrantScope.PREVIEW] — the lowest rung, which every grant carries. That is
-   * the whole integration: an agent presents its bearer exactly where the operator token goes, and
-   * no route learns anything new.
+   * pass, at [AgentGrantScope.PREVIEW] — the lowest rung, which every grant carries. That is the
+   * whole integration: an agent presents its bearer exactly where the operator token goes, and no
+   * route learns anything new.
    */
   private suspend fun RoutingContext.rejectBadToken(): Boolean {
     if (callIsAuthorized()) return false
@@ -8759,7 +8762,7 @@ class ServeHttpServer(
   private fun ApplicationCall.isAuthorizedCall(): Boolean {
     val provided = request.queryParameters["token"] ?: request.headers[TOKEN_HEADER]
     if (isAuthorized(serverToken, provided, isPublic)) return true
-    return agentGrantFor(this)?.allows(ServeAgentGrantScope.PREVIEW) == true
+    return agentGrantFor(this)?.allows(AgentGrantScope.PREVIEW) == true
   }
 
   /**
@@ -8796,13 +8799,13 @@ class ServeHttpServer(
 
   /**
    * Whether a credential arriving as a **path** segment (`/wasm-private/{access}/…`) is one this
-   * server accepts. The operator's token, or a live grant that reaches
-   * [ServeAgentGrantScope.PREVIEW] — the same two answers [linkToken] can produce, because the page
-   * that builds these URLs embeds whichever one its reader presented.
+   * server accepts. The operator's token, or a live grant that reaches [AgentGrantScope.PREVIEW] —
+   * the same two answers [linkToken] can produce, because the page that builds these URLs embeds
+   * whichever one its reader presented.
    */
   private fun isAuthorizedAccessParam(value: String?): Boolean =
     ServeUrls.tokensMatch(serverToken, value) ||
-      agentGrants?.grantForToken(value)?.allows(ServeAgentGrantScope.PREVIEW) == true
+      agentGrants?.grantForToken(value)?.allows(AgentGrantScope.PREVIEW) == true
 
   /**
    * The live grant this call presents, or null. Reads the same two places the operator token is
@@ -8915,10 +8918,10 @@ class ServeHttpServer(
         id = grant.id,
         fingerprint = grant.fingerprint,
         scopes = grant.scopes.joinToString(", ") { it.wire },
-        capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities).joinToString(", "),
+        capabilities = AgentGrantCapability.wireNames(grant.capabilities).joinToString(", "),
         label = grant.label,
         approvedBy = grant.approvedBy,
-        expiresInText = ServeAgentGrants.formatDuration(grant.secondsUntilExpiry(now)),
+        expiresInText = AgentGrantProtocol.formatDuration(grant.secondsUntilExpiry(now)),
         revokeCsrf =
           approver?.let {
             agentGrantCsrf.seal(grant.id, it.name, ServeAgentGrants.Csrf.ACTION_DENY)
@@ -8947,7 +8950,7 @@ class ServeHttpServer(
         label = request.label,
         client = request.client,
         requestedScope = request.requestedScope.wire,
-        expiresInText = ServeAgentGrants.formatDuration(request.secondsUntilExpiry(now)),
+        expiresInText = AgentGrantProtocol.formatDuration(request.secondsUntilExpiry(now)),
       )
     }
   }
@@ -8990,12 +8993,11 @@ class ServeHttpServer(
             call.respondText("invalid request: ${e.message}", status = HttpStatusCode.BadRequest)
             return
           }
-      val scope = ServeAgentGrantScope.parse(parsed.scope) ?: ServeAgentGrantScope.DEFAULT_REQUEST
+      val scope = AgentGrantScope.parse(parsed.scope) ?: AgentGrantScope.DEFAULT_REQUEST
       // Unknown names are dropped rather than refused — see [OpenRequest.capabilities]. The store
       // narrows what survives to this box's ceiling, so asking for `images` on a box that offers
       // none is not an error, it simply is not in the request that comes back.
-      val capabilities =
-        parsed.capabilities.mapNotNull { ServeAgentGrantCapability.parse(it) }.toSet()
+      val capabilities = parsed.capabilities.mapNotNull { AgentGrantCapability.parse(it) }.toSet()
       val ttl =
         parsed.ttlSeconds.takeIf { it > 0 } ?: ServeAgentGrantStore.DEFAULT_GRANT_TTL_SECONDS
       val request =
@@ -9037,9 +9039,8 @@ class ServeHttpServer(
             requestedTtlSeconds = request.requestedTtlSeconds,
             maxScope = store.maxScope.wire,
             maxTtlSeconds = store.maxGrantTtlSeconds,
-            requestedCapabilities =
-              ServeAgentGrantCapability.wireNames(request.requestedCapabilities),
-            maxCapabilities = ServeAgentGrantCapability.wireNames(store.maxCapabilities),
+            requestedCapabilities = AgentGrantCapability.wireNames(request.requestedCapabilities),
+            maxCapabilities = AgentGrantCapability.wireNames(store.maxCapabilities),
           ),
         ),
         ContentType.Application.Json,
@@ -9089,7 +9090,7 @@ class ServeHttpServer(
               token = outcome.grant.token,
               tokenHeader = TOKEN_HEADER,
               scopes = outcome.grant.scopes.map { it.wire },
-              capabilities = ServeAgentGrantCapability.wireNames(outcome.grant.capabilities),
+              capabilities = AgentGrantCapability.wireNames(outcome.grant.capabilities),
               expiresInSeconds = outcome.grant.secondsUntilExpiry(System.currentTimeMillis()),
               approvedBy = outcome.grant.approvedBy,
               message = "approved by ${outcome.grant.approvedBy}",
@@ -9135,7 +9136,7 @@ class ServeHttpServer(
         ServeAgentGrants.WhoamiResponse(
           active = true,
           scopes = grant.scopes.map { it.wire },
-          capabilities = ServeAgentGrantCapability.wireNames(grant.capabilities),
+          capabilities = AgentGrantCapability.wireNames(grant.capabilities),
           expiresInSeconds = grant.secondsUntilExpiry(System.currentTimeMillis()),
           approvedBy = grant.approvedBy,
           label = grant.label,
@@ -9208,7 +9209,7 @@ class ServeHttpServer(
     }
     val selectable =
       ServeAgentGrants.selectableScopes(request.requestedScope, approver, store.maxScope)
-    val withheld = ServeAgentGrantScope.upTo(request.requestedScope).filterNot { it in selectable }
+    val withheld = AgentGrantScope.upTo(request.requestedScope).filterNot { it in selectable }
     val selectableCapabilities =
       ServeAgentGrants.selectableCapabilities(
         request.requestedCapabilities,
@@ -9243,7 +9244,7 @@ class ServeHttpServer(
         siteName = skin.first,
         themeCss = skin.second,
         selectableCapabilities =
-          ServeAgentGrantCapability.entries.filter { it in selectableCapabilities },
+          AgentGrantCapability.entries.filter { it in selectableCapabilities },
         withheldScopes = withheld,
         withheldCapabilities = withheldCapabilities,
         withheldReason = "you do not hold it yourself on this server, so you cannot pass it on",
@@ -9314,17 +9315,17 @@ class ServeHttpServer(
     // set of checkboxes), but `maxOrNull` is kept rather than `single()`: the form is client state,
     // and a caller that posts several is asking for the highest, which the ceilings then clamp.
     val ticked =
-      form["scope"].orEmpty().mapNotNull { ServeAgentGrantScope.parse(it) }.maxOrNull()
-        ?: ServeAgentGrantScope.PREVIEW
+      form["scope"].orEmpty().mapNotNull { AgentGrantScope.parse(it) }.maxOrNull()
+        ?: AgentGrantScope.PREVIEW
     val chosen = minOf(ticked, approver.ceiling)
     // Capabilities ARE checkboxes — they are independent, so a box per capability describes the
     // outcome honestly (the scopes' radio is the opposite case, see above). Absent means unticked
     // means not granted, which is why nothing here defaults to the request.
     val tickedCapabilities =
-      form["capability"].orEmpty().mapNotNull { ServeAgentGrantCapability.parse(it) }.toSet()
+      form["capability"].orEmpty().mapNotNull { AgentGrantCapability.parse(it) }.toSet()
     val chosenCapabilities = tickedCapabilities intersect approver.capabilityCeiling
     val ttl =
-      form["ttl"]?.firstOrNull()?.let { ServeAgentGrants.parseDurationSeconds(it) }
+      form["ttl"]?.firstOrNull()?.let { AgentGrantProtocol.parseDurationSeconds(it) }
         ?: ServeAgentGrantStore.DEFAULT_GRANT_TTL_SECONDS
     val grant = store.approve(requestId, approver.name, chosen, ttl, chosenCapabilities)
     if (grant == null) {
@@ -9341,13 +9342,13 @@ class ServeHttpServer(
       heading = "Access granted",
       message =
         "The agent can now use this server for " +
-          ServeAgentGrants.formatDuration(grant.secondsUntilExpiry(System.currentTimeMillis())) +
+          AgentGrantProtocol.formatDuration(grant.secondsUntilExpiry(System.currentTimeMillis())) +
           ". You can end it early from the server status page at any time.",
       detail =
         buildString {
           append("Scopes: ${grant.scopes.joinToString(", ") { it.wire }}")
           if (grant.capabilities.isNotEmpty()) {
-            val names = ServeAgentGrantCapability.wireNames(grant.capabilities).joinToString(", ")
+            val names = AgentGrantCapability.wireNames(grant.capabilities).joinToString(", ")
             append(" · also: $names")
           }
           append(" · grant ${grant.fingerprint}")
@@ -9499,7 +9500,7 @@ class ServeHttpServer(
     // unread, so a `preview` grant opened live daemon sessions the human never agreed to. The gate
     // is "is this caller allowed to run this lane", and for a grant holder the answer comes from
     // the grant, on every deployment shape.
-    if (rejectGrantBelowScope(ServeAgentGrantScope.LIVE, api)) return true
+    if (rejectGrantBelowScope(AgentGrantScope.LIVE, api)) return true
     if (agentGrantFor(call) != null) return false
     val auth = githubAuth ?: return false
     if (auth.isAuthenticated(call)) return false
@@ -9520,7 +9521,7 @@ class ServeHttpServer(
    * browser to be redirected in, and its remedy is to ask for a wider grant, not to sign in.
    */
   private suspend fun RoutingContext.rejectGrantBelowScope(
-    required: ServeAgentGrantScope,
+    required: AgentGrantScope,
     api: Boolean,
   ): Boolean {
     val grant = agentGrantFor(call) ?: return false
@@ -9542,7 +9543,7 @@ class ServeHttpServer(
     // other order was a hole. `playground` is never in a default grant and can only be approved by
     // someone holding repository access themselves, so a grant that reaches it means a human with
     // this exact right said yes.
-    if (rejectGrantBelowScope(ServeAgentGrantScope.PLAYGROUND, api)) return true
+    if (rejectGrantBelowScope(AgentGrantScope.PLAYGROUND, api)) return true
     if (agentGrantFor(call) != null) return false
     val auth = githubAuth ?: return false
     if (auth.hasRepositoryAccess(call)) return false

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
@@ -460,8 +460,8 @@ public interface ServeOptions {
    * Raw `--agent-grant-capabilities`, unparsed.
    *
    * The CLI reads the flag; the server decides what the names mean. A capability list is a server
-   * policy, and parsing it here would put `ServeAgentGrantCapability` on the CLI's classpath for
-   * the sake of a string split.
+   * policy, and parsing it here would put `AgentGrantCapability` on the CLI's classpath for the
+   * sake of a string split.
    */
   public val agentGrantCapabilitiesFlag: String?
 

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import ee.schimke.composeai.bundle.AndroidBundleLaunch
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.BundleVerifier
@@ -116,7 +119,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
         // operator asking for half an hour and getting eight — sixteen times the ceiling they
         // meant, on the one setting that bounds how long a minted credential lives. The client's
         // `--ttl` already fails loudly; so does this.
-        ServeAgentGrants.parseDurationSeconds(it)
+        AgentGrantProtocol.parseDurationSeconds(it)
           ?: throw IllegalArgumentException(
             "--agent-grant-max-ttl '$it' is not a duration — try 90m, 2h, or a number of seconds"
           )
@@ -124,30 +127,30 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
       ?.coerceIn(60L, ServeDefaults.AGENT_GRANT_HARD_MAX_TTL_SECONDS)
       ?: ServeDefaults.AGENT_GRANT_MAX_TTL_SECONDS
 
-  private val agentGrantMaxScope: ServeAgentGrantScope =
+  private val agentGrantMaxScope: AgentGrantScope =
     agentGrantScopesFlag?.let {
       // The worst of this family to default silently: `--agent-grant-scopes preivew` is an operator
       // narrowing the box to read-only, and the default it would fall back to is `preview,live`. A
       // typo would have *widened* what every grant on the host may do, which is the opposite of the
       // intent that made them type the flag.
-      ServeAgentGrantScope.parseHighest(it)
+      AgentGrantScope.parseHighest(it)
         ?: throw IllegalArgumentException(
           "--agent-grant-scopes '$it' is not a scope list — use preview, live, or playground"
         )
-    } ?: ServeAgentGrantScope.DEFAULT_MAX
+    } ?: AgentGrantScope.DEFAULT_MAX
 
   // ---- flag values the server parses for itself ----
   //
   // Each of these arrived as a raw string from the CLI. Parsing them here rather than there is what
-  // keeps `ServeAgentGrantCapability`, `ServeAgentGrantScope`, `ServeStartupBundles.Spec` and the
+  // keeps `AgentGrantCapability`, `AgentGrantScope`, `ServeStartupBundles.Spec` and the
   // two cache stores off `:cli`'s classpath: the command reads flags, the server decides what they
   // mean. The operator-facing error messages are unchanged and still fire during startup.
-  private val agentGrantCapabilities: Set<ServeAgentGrantCapability> =
+  private val agentGrantCapabilities: Set<AgentGrantCapability> =
     agentGrantCapabilitiesFlag?.let {
       // Throws on an unknown name, same as `--agent-grant-scopes`: a typo here would silently
       // withhold a capability the operator believes they turned on, and they would go looking for
       // the bug in the agent.
-      ServeAgentGrantCapability.parseAll(it)
+      AgentGrantCapability.parseAll(it)
     } ?: emptySet()
 
   /**
@@ -1717,7 +1720,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
       )
       throw IllegalArgumentException("--agent-grants needs an approver identity")
     }
-    if (agentGrantMaxScope == ServeAgentGrantScope.PLAYGROUND) {
+    if (agentGrantMaxScope == AgentGrantScope.PLAYGROUND) {
       System.err.println(
         "serve: WARNING --agent-grant-scopes allows 'playground' — an approved agent can compile " +
           "and run Kotlin on this host."
@@ -1731,7 +1734,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
     // [imageLaneConfigured], not `acceptImages`: the flag alone is not a lane. Without a repository
     // to gate on, [openImageLane] declines to build one and says so — and a box that keeps starting
     // for some other reason would then have offered a capability whose every upload 404s.
-    if (ServeAgentGrantCapability.IMAGES in agentGrantCapabilities && !imageLaneConfigured) {
+    if (AgentGrantCapability.IMAGES in agentGrantCapabilities && !imageLaneConfigured) {
       System.err.println(
         "serve: --agent-grant-capabilities images refused — this server does not run the image " +
           "lane, so a granted upload would have nowhere to go. Add --accept-images AND a " +
@@ -1750,7 +1753,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
     // than to approximate the check.
     val imageRepository = imageUploadRepository
     if (
-      ServeAgentGrantCapability.IMAGES in agentGrantCapabilities &&
+      AgentGrantCapability.IMAGES in agentGrantCapabilities &&
         githubAuth != null &&
         !imageRepository.isNullOrBlank() &&
         !imageRepository.equals(githubAuthRepo, ignoreCase = true)
@@ -1769,7 +1772,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
     if (agentGrantCapabilities.isNotEmpty()) {
       System.err.println(
         "serve: agent grants may carry " +
-          ServeAgentGrantCapability.wireNames(agentGrantCapabilities).joinToString(", ") +
+          AgentGrantCapability.wireNames(agentGrantCapabilities).joinToString(", ") +
           " when a human ticks it — an approved agent can then upload without a GitHub credential."
       )
     }
@@ -2407,7 +2410,7 @@ public class ServeRunner(private val options: ServeOptions) : ServeOptions by op
     if (agentGrantStore != null) {
       System.err.println(
         "serve: agent access grants enabled at /agent-access — up to " +
-          "${ServeAgentGrants.formatDuration(agentGrantStore.maxGrantTtlSeconds)}, " +
+          "${AgentGrantProtocol.formatDuration(agentGrantStore.maxGrantTtlSeconds)}, " +
           "max scope ${agentGrantStore.maxScope.wire}, approved by " +
           (if (githubAuth != null) "a signed-in GitHub user" else "the holder of --token")
       )

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1,5 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import ee.schimke.composeai.bundle.BundleVerifier
 import ee.schimke.composeai.data.overrides.PreviewOverrideOption
 import ee.schimke.composeai.data.render.PreviewBackdrop
@@ -5502,17 +5505,17 @@ ${captureControlsHtml().prependIndent("          ")}
     userCode: String,
     label: String,
     client: String,
-    requestedScope: ServeAgentGrantScope,
+    requestedScope: AgentGrantScope,
     requestedTtlSeconds: Long,
     expiresInSeconds: Long,
     approver: String,
-    selectableScopes: List<ServeAgentGrantScope>,
+    selectableScopes: List<AgentGrantScope>,
     maxTtlSeconds: Long,
     /**
      * Independent permissions this approver may tick, already narrowed like [selectableScopes].
      * Empty on almost every box — the whole feature is opt-in twice over.
      */
-    selectableCapabilities: List<ServeAgentGrantCapability> = emptyList(),
+    selectableCapabilities: List<AgentGrantCapability> = emptyList(),
     approveCsrf: String,
     denyCsrf: String,
     /**
@@ -5527,9 +5530,9 @@ ${captureControlsHtml().prependIndent("          ")}
      * Named only when the approver's own rights are what capped [selectableScopes] — so the page
      * says "you can't grant this" rather than silently omitting a row the agent asked for.
      */
-    withheldScopes: List<ServeAgentGrantScope> = emptyList(),
+    withheldScopes: List<AgentGrantScope> = emptyList(),
     /** Capabilities the agent asked for that this approver may not pass on. Same treatment. */
-    withheldCapabilities: List<ServeAgentGrantCapability> = emptyList(),
+    withheldCapabilities: List<AgentGrantCapability> = emptyList(),
     withheldReason: String = "",
   ): String {
     val esc = WebEscaping::htmlEscape
@@ -5550,7 +5553,7 @@ ${captureControlsHtml().prependIndent("          ")}
       selectableScopes.joinToString("\n") { scope ->
         val checked = if (scope == defaultScope) " checked" else ""
         val includes =
-          ServeAgentGrantScope.upTo(scope).filter { it != scope }.joinToString(", ") { it.wire }
+          AgentGrantScope.upTo(scope).filter { it != scope }.joinToString(", ") { it.wire }
         val alsoIncludes =
           if (includes.isEmpty()) ""
           else "<span class=\"cp-grant-scope-implies\">also includes ${esc(includes)}</span>"
@@ -5613,7 +5616,7 @@ ${captureControlsHtml().prependIndent("          ")}
     val ttlOptions =
       ttlChoices(requestedTtlSeconds, maxTtlSeconds).joinToString("\n") { seconds ->
         val selected = if (seconds == requestedTtlSeconds) " selected" else ""
-        "<option value=\"$seconds\"$selected>${esc(ServeAgentGrants.formatDuration(seconds))}</option>"
+        "<option value=\"$seconds\"$selected>${esc(AgentGrantProtocol.formatDuration(seconds))}</option>"
       }
     return document(
       title = "Grant agent access — compose-preview",
@@ -5640,7 +5643,7 @@ ${captureControlsHtml().prependIndent("          ")}
           <dt>Purpose</dt><dd>${if (label.isBlank()) "<em>none given</em>" else esc(label)}</dd>
           <dt>Asked from</dt><dd>${esc(client)}</dd>
           <dt>Approving as</dt><dd>${esc(approver)}</dd>
-          <dt>This request expires in</dt><dd>${esc(ServeAgentGrants.formatDuration(expiresInSeconds))}</dd>
+          <dt>This request expires in</dt><dd>${esc(AgentGrantProtocol.formatDuration(expiresInSeconds))}</dd>
         </dl>
 
         <form class="cp-grant-form" method="post" action="${esc(formAction)}">

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantImageUploadTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -37,8 +39,8 @@ class ServeAgentGrantImageUploadTest {
 
   private val grants =
     ServeAgentGrantStore(
-      maxScope = ServeAgentGrantScope.LIVE,
-      maxCapabilities = setOf(ServeAgentGrantCapability.IMAGES),
+      maxScope = AgentGrantScope.LIVE,
+      maxCapabilities = setOf(AgentGrantCapability.IMAGES),
       maxGrantTtlSeconds = 3600,
     )
 
@@ -59,7 +61,7 @@ class ServeAgentGrantImageUploadTest {
 
   /** A second box whose operator never opted into the capability at all. */
   private val closedGrants =
-    ServeAgentGrantStore(maxScope = ServeAgentGrantScope.LIVE, maxGrantTtlSeconds = 3600)
+    ServeAgentGrantStore(maxScope = AgentGrantScope.LIVE, maxGrantTtlSeconds = 3600)
 
   private val closedServer: ServeHttpServer by lazy {
     ServeHttpServer(

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantRoutingTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
@@ -33,7 +34,7 @@ class ServeAgentGrantRoutingTest {
   private val registry = ServeSessionRegistry(open = { null })
 
   private val grants =
-    ServeAgentGrantStore(maxScope = ServeAgentGrantScope.PLAYGROUND, maxGrantTtlSeconds = 3600)
+    ServeAgentGrantStore(maxScope = AgentGrantScope.PLAYGROUND, maxGrantTtlSeconds = 3600)
 
   private val server: ServeHttpServer by lazy {
     val dir = Files.createTempDirectory("grants").toFile().also { it.deleteOnExit() }

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantStoreTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,7 +24,7 @@ class ServeAgentGrantStoreTest {
   private var now = 1_000_000L
 
   private fun store(
-    maxScope: ServeAgentGrantScope = ServeAgentGrantScope.PLAYGROUND,
+    maxScope: AgentGrantScope = AgentGrantScope.PLAYGROUND,
     maxGrantTtlSeconds: Long = 3600,
     maxActiveGrants: Int = 16,
     maxPendingRequests: Int = 32,
@@ -36,7 +38,7 @@ class ServeAgentGrantStoreTest {
     )
 
   private fun ServeAgentGrantStore.ask(
-    scope: ServeAgentGrantScope = ServeAgentGrantScope.LIVE,
+    scope: AgentGrantScope = AgentGrantScope.LIVE,
     ttl: Long = 1800,
   ) = openRequest("fix #1", "10.0.0.1", scope, ttl)!!
 
@@ -44,7 +46,7 @@ class ServeAgentGrantStoreTest {
   fun `the token goes to the device secret, not to the link`() {
     val store = store()
     val request = store.ask()
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
+    store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)
 
     // Someone holding the link but not the secret gets the same answer as someone holding neither.
     assertEquals(ServeAgentGrantStore.Poll.Unknown, store.poll(request.id, "not-the-secret"))
@@ -64,33 +66,33 @@ class ServeAgentGrantStoreTest {
 
   @Test
   fun `approval may narrow a request but never widen it`() {
-    val store = store(maxScope = ServeAgentGrantScope.PLAYGROUND)
-    val request = store.ask(scope = ServeAgentGrantScope.LIVE, ttl = 900)
+    val store = store(maxScope = AgentGrantScope.PLAYGROUND)
+    val request = store.ask(scope = AgentGrantScope.LIVE, ttl = 900)
 
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.PLAYGROUND, 99_999)!!
-    assertEquals(ServeAgentGrantScope.LIVE, grant.scope)
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.PLAYGROUND, 99_999)!!
+    assertEquals(AgentGrantScope.LIVE, grant.scope)
     assertEquals(900, (grant.expiresAtMillis - grant.issuedAtMillis) / 1000)
   }
 
   @Test
   fun `the operator ceiling clamps a request at the door`() {
-    val store = store(maxScope = ServeAgentGrantScope.PREVIEW)
-    val request = store.ask(scope = ServeAgentGrantScope.PLAYGROUND)
-    assertEquals(ServeAgentGrantScope.PREVIEW, request.requestedScope)
+    val store = store(maxScope = AgentGrantScope.PREVIEW)
+    val request = store.ask(scope = AgentGrantScope.PLAYGROUND)
+    assertEquals(AgentGrantScope.PREVIEW, request.requestedScope)
 
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.PLAYGROUND, 600)!!
-    assertEquals(ServeAgentGrantScope.PREVIEW, grant.scope)
-    assertFalse(grant.allows(ServeAgentGrantScope.LIVE))
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.PLAYGROUND, 600)!!
+    assertEquals(AgentGrantScope.PREVIEW, grant.scope)
+    assertFalse(grant.allows(AgentGrantScope.LIVE))
   }
 
   @Test
   fun `scopes are cumulative`() {
     val store = store()
-    val request = store.ask(scope = ServeAgentGrantScope.PLAYGROUND)
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.PLAYGROUND, 600)!!
-    assertTrue(grant.allows(ServeAgentGrantScope.PREVIEW))
-    assertTrue(grant.allows(ServeAgentGrantScope.LIVE))
-    assertTrue(grant.allows(ServeAgentGrantScope.PLAYGROUND))
+    val request = store.ask(scope = AgentGrantScope.PLAYGROUND)
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.PLAYGROUND, 600)!!
+    assertTrue(grant.allows(AgentGrantScope.PREVIEW))
+    assertTrue(grant.allows(AgentGrantScope.LIVE))
+    assertTrue(grant.allows(AgentGrantScope.PLAYGROUND))
     assertEquals(listOf("preview", "live", "playground"), grant.scopes.map { it.wire })
   }
 
@@ -98,8 +100,8 @@ class ServeAgentGrantStoreTest {
   fun `approving twice mints one grant, not two`() {
     val store = store()
     val request = store.ask()
-    val first = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)!!
-    val second = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)!!
+    val first = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)!!
+    val second = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)!!
     assertEquals(first.id, second.id)
     assertEquals(1, store.activeGrants().size)
   }
@@ -109,7 +111,7 @@ class ServeAgentGrantStoreTest {
     val store = store()
     val request = store.ask()
     assertTrue(store.deny(request.id, "@yuri"))
-    assertNull(store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600))
+    assertNull(store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600))
     val polled = store.poll(request.id, request.deviceSecret)
     assertTrue(polled is ServeAgentGrantStore.Poll.Denied)
   }
@@ -118,7 +120,7 @@ class ServeAgentGrantStoreTest {
   fun `an approved request cannot then be denied`() {
     val store = store()
     val request = store.ask()
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
+    store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)
     assertFalse(store.deny(request.id, "@someone-else"))
   }
 
@@ -135,7 +137,7 @@ class ServeAgentGrantStoreTest {
   fun `a grant expires and stops authorising`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 60)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 60)!!
     assertNotNull(store.grantForToken(grant.token))
     now += 61_000
     assertNull(store.grantForToken(grant.token))
@@ -146,7 +148,7 @@ class ServeAgentGrantStoreTest {
   fun `a revoked grant stops authorising immediately`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 3600)!!
     assertTrue(store.revoke(grant.id, "@yuri"))
     assertNull(store.grantForToken(grant.token))
     assertFalse(store.revoke(grant.id, "@yuri"))
@@ -156,7 +158,7 @@ class ServeAgentGrantStoreTest {
   fun `revoking by token is the agent handing its own access back`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 3600)!!
     assertTrue(store.revokeToken(grant.token, "the agent itself"))
     assertNull(store.grantForToken(grant.token))
   }
@@ -165,7 +167,7 @@ class ServeAgentGrantStoreTest {
   fun `polling after a revoke reports expired rather than handing back a dead token`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 3600)!!
     store.revoke(grant.id, "@yuri")
     assertEquals(ServeAgentGrantStore.Poll.Expired, store.poll(request.id, request.deviceSecret))
   }
@@ -175,7 +177,7 @@ class ServeAgentGrantStoreTest {
     val store = store(maxActiveGrants = 2)
     fun mint(ttl: Long): ServeAgentGrantStore.Grant {
       val request = store.ask(ttl = ttl)
-      return store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, ttl)!!
+      return store.approve(request.id, "@yuri", AgentGrantScope.LIVE, ttl)!!
     }
     val shortest = mint(60)
     val middle = mint(600)
@@ -193,7 +195,7 @@ class ServeAgentGrantStoreTest {
     val store = store(maxActiveGrants = 2)
     fun mint(ttl: Long): ServeAgentGrantStore.Grant {
       val request = store.ask(ttl = ttl)
-      return store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, ttl)!!
+      return store.approve(request.id, "@yuri", AgentGrantScope.LIVE, ttl)!!
     }
     mint(3600)
     mint(1800)
@@ -205,9 +207,9 @@ class ServeAgentGrantStoreTest {
   @Test
   fun `the pending-request cap refuses rather than growing without bound`() {
     val store = store(maxPendingRequests = 2)
-    assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
-    assertNotNull(store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600))
-    assertNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("a", "ip", AgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("b", "ip", AgentGrantScope.PREVIEW, 600))
+    assertNull(store.openRequest("c", "ip", AgentGrantScope.PREVIEW, 600))
   }
 
   @Test
@@ -217,7 +219,7 @@ class ServeAgentGrantStoreTest {
     val store = store(maxPendingRequests = 8)
     val threads =
       (1..32).map { i ->
-        Thread { store.openRequest("burst-$i", "ip-$i", ServeAgentGrantScope.PREVIEW, 600) }
+        Thread { store.openRequest("burst-$i", "ip-$i", AgentGrantScope.PREVIEW, 600) }
       }
     threads.forEach { it.start() }
     threads.forEach { it.join() }
@@ -234,21 +236,21 @@ class ServeAgentGrantStoreTest {
     // the sender a fresh slot with every click. A denial is kept (its owner must be able to learn
     // it was denied) and charged to whoever caused it; only its own expiry frees the space.
     val store = store(maxPendingRequests = 2)
-    val first = store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600)!!
-    store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
+    val first = store.openRequest("a", "ip", AgentGrantScope.PREVIEW, 600)!!
+    store.openRequest("b", "ip", AgentGrantScope.PREVIEW, 600)
     store.deny(first.id, "@yuri")
-    assertNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNull(store.openRequest("c", "ip", AgentGrantScope.PREVIEW, 600))
     // The denial is still readable by its owner while it holds that slot.
     assertTrue(store.poll(first.id, first.deviceSecret) is ServeAgentGrantStore.Poll.Denied)
     now += (store.requestTtlSeconds + 5) * 1000
-    assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("c", "ip", AgentGrantScope.PREVIEW, 600))
   }
 
   @Test
   fun `a token is never mistaken for the operator token, and vice versa`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)!!
     assertTrue(ServeAgentGrantStore.isWellFormedToken(grant.token))
     // An ordinary `--token` (no prefix) never reaches the map at all.
     assertFalse(ServeAgentGrantStore.isWellFormedToken("plain-operator-token-value"))
@@ -259,10 +261,10 @@ class ServeAgentGrantStoreTest {
   fun `the fingerprint identifies a grant without disclosing it`() {
     val store = store()
     val request = store.ask()
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)!!
     assertEquals(12, grant.fingerprint.length)
     assertFalse(grant.token.contains(grant.fingerprint))
-    assertEquals(grant.fingerprint, ServeAgentGrantStore.fingerprintOf(grant.token))
+    assertEquals(grant.fingerprint, AgentGrantProtocol.fingerprintOf(grant.token))
   }
 
   @Test
@@ -271,11 +273,11 @@ class ServeAgentGrantStoreTest {
     val store =
       ServeAgentGrantStore(
         clock = { now },
-        maxScope = ServeAgentGrantScope.PLAYGROUND,
+        maxScope = AgentGrantScope.PLAYGROUND,
         audit = { lines += it },
       )
-    val request = store.openRequest("fix #1", "10.0.0.1", ServeAgentGrantScope.LIVE, 600)!!
-    val grant = store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)!!
+    val request = store.openRequest("fix #1", "10.0.0.1", AgentGrantScope.LIVE, 600)!!
+    val grant = store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)!!
     store.revoke(grant.id, "@yuri")
     assertEquals(2, lines.size)
     assertTrue(lines.all { it.contains(grant.fingerprint) })
@@ -302,10 +304,10 @@ class ServeAgentGrantStoreTest {
     // arrives.
     val store = store(maxPendingRequests = 2)
     val approved = store.ask()
-    store.approve(approved.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
+    store.approve(approved.id, "@yuri", AgentGrantScope.LIVE, 600)
     // Saturate the pending budget, then keep asking — every one of these is refused or admitted on
     // its own merits, and none of them may cost the approval above its credential.
-    repeat(6) { store.openRequest("filler-$it", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600) }
+    repeat(6) { store.openRequest("filler-$it", "10.9.9.9", AgentGrantScope.PREVIEW, 600) }
     val polled = store.poll(approved.id, approved.deviceSecret)
     assertTrue(polled is ServeAgentGrantStore.Poll.Approved, "got $polled")
   }
@@ -317,7 +319,7 @@ class ServeAgentGrantStoreTest {
     // seconds of the window, because the agent's next poll landed after it.
     val store = store()
     val request = store.ask(ttl = 3600)
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+    store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 3600)
     now += (store.requestTtlSeconds + 5) * 1000
     val polled = store.poll(request.id, request.deviceSecret)
     assertTrue(polled is ServeAgentGrantStore.Poll.Approved, "got $polled")
@@ -333,7 +335,7 @@ class ServeAgentGrantStoreTest {
       val request = store.ask(ttl = 600)
       val results = java.util.concurrent.ConcurrentLinkedQueue<ServeAgentGrantStore.Grant?>()
       val approver = Thread {
-        results += store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
+        results += store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)
       }
       val purger = Thread { repeat(20) { store.purge() } }
       approver.start()
@@ -363,7 +365,7 @@ class ServeAgentGrantStoreTest {
       val seen = java.util.concurrent.ConcurrentLinkedQueue<ServeAgentGrantStore.Poll>()
       val poller = Thread { repeat(200) { seen += store.poll(request.id, request.deviceSecret) } }
       poller.start()
-      store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600)
+      store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600)
       poller.join()
       assertTrue(
         seen.none { it is ServeAgentGrantStore.Poll.Expired },
@@ -396,11 +398,11 @@ class ServeAgentGrantStoreTest {
     // anonymous caller can attempt.
     val store = store(maxPendingRequests = 2)
     val mine = store.ask(ttl = 3600)
-    store.approve(mine.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+    store.approve(mine.id, "@yuri", AgentGrantScope.LIVE, 3600)
     assertTrue(store.poll(mine.id, mine.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
     // …that response is lost. Now an anonymous caller tries to fill the map. `openRequest` rather
     // than the `!!` helper: being REFUSED is the correct outcome here, not an error.
-    repeat(4) { store.openRequest("spam", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600) }
+    repeat(4) { store.openRequest("spam", "10.9.9.9", AgentGrantScope.PREVIEW, 600) }
     assertTrue(
       store.poll(mine.id, mine.deviceSecret) is ServeAgentGrantStore.Poll.Approved,
       "a live grant was shed to admit an anonymous request",
@@ -414,7 +416,7 @@ class ServeAgentGrantStoreTest {
     // grant was still live.
     val store = store()
     val request = store.ask(ttl = 3600)
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+    store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 3600)
     assertTrue(store.poll(request.id, request.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
     now += (store.requestTtlSeconds + 5) * 1000 // past the request window, grant still alive
     assertTrue(
@@ -430,14 +432,14 @@ class ServeAgentGrantStoreTest {
     val request = store.ask()
     now += (store.requestTtlSeconds + 5) * 1000
     assertNull(store.request(request.id))
-    assertNull(store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 600))
+    assertNull(store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 600))
   }
 
   @Test
   fun `a retained approval is reclaimed once its grant is gone`() {
     val store = store()
     val request = store.ask(ttl = 60)
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
+    store.approve(request.id, "@yuri", AgentGrantScope.LIVE, 60)
     now += (store.requestTtlSeconds + 5) * 1000
     // The grant expired too, so the record owes nobody anything and goes.
     assertNull(store.request(request.id))
@@ -454,12 +456,12 @@ class ServeAgentGrantStoreTest {
     val approved =
       (1..5).map { i ->
         val r = store.ask(ttl = 3600)
-        store.approve(r.id, "@yuri", ServeAgentGrantScope.LIVE, 3600)
+        store.approve(r.id, "@yuri", AgentGrantScope.LIVE, 3600)
         r
       }
     // …and a fresh request still gets in, because none of those is pending.
     assertNotNull(
-      store.openRequest("new", "ip", ServeAgentGrantScope.PREVIEW, 600),
+      store.openRequest("new", "ip", AgentGrantScope.PREVIEW, 600),
       "retained approvals must not spend the pending budget",
     )
     // Every one of those grants is still collectable.
@@ -479,22 +481,20 @@ class ServeAgentGrantStoreTest {
     // another, forever, in an anonymously-controlled map that was supposed to be bounded.
     val store = store(maxPendingRequests = 3)
     val first =
-      (1..3).mapNotNull {
-        store.openRequest("spam-$it", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600)
-      }
+      (1..3).mapNotNull { store.openRequest("spam-$it", "10.9.9.9", AgentGrantScope.PREVIEW, 600) }
     assertEquals(3, first.size)
     // The operator denies every one of them.
     for (r in first) assertTrue(store.deny(r.id, "@yuri"))
     // The attacker immediately tries again, and gets nowhere.
     assertNull(
-      store.openRequest("spam-again", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600),
+      store.openRequest("spam-again", "10.9.9.9", AgentGrantScope.PREVIEW, 600),
       "a denied row must still be charged to whoever created it",
     )
     // …and the denials remain visible to their owners in the meantime.
     assertTrue(store.poll(first[0].id, first[0].deviceSecret) is ServeAgentGrantStore.Poll.Denied)
     // Only the passage of time frees the capacity.
     now += (store.requestTtlSeconds + 5) * 1000
-    assertNotNull(store.openRequest("later", "10.9.9.9", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("later", "10.9.9.9", AgentGrantScope.PREVIEW, 600))
   }
 
   @Test
@@ -503,19 +503,19 @@ class ServeAgentGrantStoreTest {
     // pushes someone over the cap.
     val store = store(maxPendingRequests = 2)
     val done = store.ask(ttl = 60)
-    store.approve(done.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
+    store.approve(done.id, "@yuri", AgentGrantScope.LIVE, 60)
     now += 61_000 // the grant is gone; the row owes nobody anything
-    assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
-    assertNotNull(store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("a", "ip", AgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("b", "ip", AgentGrantScope.PREVIEW, 600))
   }
 
   @Test
   fun `the pending cap still bounds what an anonymous caller can create`() {
     val store = store(maxPendingRequests = 2)
-    assertNotNull(store.openRequest("a", "ip", ServeAgentGrantScope.PREVIEW, 600))
-    assertNotNull(store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("a", "ip", AgentGrantScope.PREVIEW, 600))
+    assertNotNull(store.openRequest("b", "ip", AgentGrantScope.PREVIEW, 600))
     assertNull(
-      store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600),
+      store.openRequest("c", "ip", AgentGrantScope.PREVIEW, 600),
       "a third pending request must be refused",
     )
   }
@@ -528,11 +528,11 @@ class ServeAgentGrantStoreTest {
     // request that is genuinely finished with — here, one whose grant has since expired.
     val store = store(maxPendingRequests = 2)
     val done = store.ask(ttl = 60)
-    store.approve(done.id, "@yuri", ServeAgentGrantScope.LIVE, 60)
+    store.approve(done.id, "@yuri", AgentGrantScope.LIVE, 60)
     assertTrue(store.poll(done.id, done.deviceSecret) is ServeAgentGrantStore.Poll.Approved)
     now += 61_000 // its grant is gone, so the record owes nobody anything
-    store.openRequest("b", "ip", ServeAgentGrantScope.PREVIEW, 600)
-    assertNotNull(store.openRequest("c", "ip", ServeAgentGrantScope.PREVIEW, 600))
+    store.openRequest("b", "ip", AgentGrantScope.PREVIEW, 600)
+    assertNotNull(store.openRequest("c", "ip", AgentGrantScope.PREVIEW, 600))
   }
 
   @Test
@@ -540,10 +540,10 @@ class ServeAgentGrantStoreTest {
     val lines = mutableListOf<String>()
     val store = ServeAgentGrantStore(clock = { now }, audit = { lines += it })
     val hostile = "ok\nagent-grant: minted deadbeef scope=playground\u001b[2J"
-    val request = store.openRequest(hostile, "10.0.0.1", ServeAgentGrantScope.PREVIEW, 600)!!
+    val request = store.openRequest(hostile, "10.0.0.1", AgentGrantScope.PREVIEW, 600)!!
     assertFalse(request.label.contains('\n'))
     assertFalse(request.label.any { it.isISOControl() })
-    store.approve(request.id, "@yuri", ServeAgentGrantScope.PREVIEW, 600)
+    store.approve(request.id, "@yuri", AgentGrantScope.PREVIEW, 600)
     assertEquals(1, lines.size, "one label must not become two log lines")
     assertFalse(lines.single().contains('\n'))
   }
@@ -551,7 +551,7 @@ class ServeAgentGrantStoreTest {
   @Test
   fun `a label from an agent is capped rather than trusted to be short`() {
     val store = store()
-    val request = store.openRequest("x".repeat(5000), "ip", ServeAgentGrantScope.PREVIEW, 600)!!
+    val request = store.openRequest("x".repeat(5000), "ip", AgentGrantScope.PREVIEW, 600)!!
     assertEquals(ServeAgentGrantStore.MAX_LABEL_CHARS, request.label.length)
   }
 }

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantsTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeAgentGrantsTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -14,38 +16,36 @@ class ServeAgentGrantsTest {
 
   @Test
   fun `scopes imply everything below them and nothing above`() {
-    assertTrue(ServeAgentGrantScope.PLAYGROUND.implies(ServeAgentGrantScope.PREVIEW))
-    assertTrue(ServeAgentGrantScope.LIVE.implies(ServeAgentGrantScope.PREVIEW))
-    assertTrue(ServeAgentGrantScope.PREVIEW.implies(ServeAgentGrantScope.PREVIEW))
-    assertFalse(ServeAgentGrantScope.PREVIEW.implies(ServeAgentGrantScope.LIVE))
-    assertFalse(ServeAgentGrantScope.LIVE.implies(ServeAgentGrantScope.PLAYGROUND))
+    assertTrue(AgentGrantScope.PLAYGROUND.implies(AgentGrantScope.PREVIEW))
+    assertTrue(AgentGrantScope.LIVE.implies(AgentGrantScope.PREVIEW))
+    assertTrue(AgentGrantScope.PREVIEW.implies(AgentGrantScope.PREVIEW))
+    assertFalse(AgentGrantScope.PREVIEW.implies(AgentGrantScope.LIVE))
+    assertFalse(AgentGrantScope.LIVE.implies(AgentGrantScope.PLAYGROUND))
   }
 
   @Test
   fun `a scope list resolves to its highest rung`() {
-    assertEquals(ServeAgentGrantScope.LIVE, ServeAgentGrantScope.parseHighest("preview,live"))
-    assertEquals(ServeAgentGrantScope.LIVE, ServeAgentGrantScope.parseHighest("live"))
+    assertEquals(AgentGrantScope.LIVE, AgentGrantScope.parseHighest("preview,live"))
+    assertEquals(AgentGrantScope.LIVE, AgentGrantScope.parseHighest("live"))
     assertEquals(
-      ServeAgentGrantScope.PLAYGROUND,
-      ServeAgentGrantScope.parseHighest("preview playground"),
+      AgentGrantScope.PLAYGROUND,
+      AgentGrantScope.parseHighest("preview playground"),
     )
-    assertNull(ServeAgentGrantScope.parseHighest(null))
-    assertNull(ServeAgentGrantScope.parseHighest("   "))
+    assertNull(AgentGrantScope.parseHighest(null))
+    assertNull(AgentGrantScope.parseHighest("   "))
   }
 
   @Test
   fun `a typo in the scope list fails loudly instead of silently narrowing`() {
     val e =
-      assertFailsWith<IllegalArgumentException> {
-        ServeAgentGrantScope.parseHighest("preview,liev")
-      }
+      assertFailsWith<IllegalArgumentException> { AgentGrantScope.parseHighest("preview,liev") }
     assertTrue(e.message!!.contains("liev"))
   }
 
   @Test
   fun `playground is not in the default ceiling`() {
-    assertEquals(ServeAgentGrantScope.LIVE, ServeAgentGrantScope.DEFAULT_MAX)
-    assertFalse(ServeAgentGrantScope.DEFAULT_MAX.implies(ServeAgentGrantScope.PLAYGROUND))
+    assertEquals(AgentGrantScope.LIVE, AgentGrantScope.DEFAULT_MAX)
+    assertFalse(AgentGrantScope.DEFAULT_MAX.implies(AgentGrantScope.PLAYGROUND))
   }
 
   // ---------------------------------------------------------------- approver
@@ -56,15 +56,15 @@ class ServeAgentGrantsTest {
       ServeAgentGrants.Approver.github(
         login = "outsider",
         repositoryAccess = false,
-        storeCeiling = ServeAgentGrantScope.PLAYGROUND,
+        storeCeiling = AgentGrantScope.PLAYGROUND,
       )
-    assertEquals(ServeAgentGrantScope.LIVE, approver.ceiling)
+    assertEquals(AgentGrantScope.LIVE, approver.ceiling)
     assertEquals(
       listOf("preview", "live"),
       ServeAgentGrants.selectableScopes(
-          ServeAgentGrantScope.PLAYGROUND,
+          AgentGrantScope.PLAYGROUND,
           approver,
-          ServeAgentGrantScope.PLAYGROUND,
+          AgentGrantScope.PLAYGROUND,
         )
         .map { it.wire },
     )
@@ -72,21 +72,20 @@ class ServeAgentGrantsTest {
 
   @Test
   fun `an approver with repository access may pass playground on`() {
-    val approver =
-      ServeAgentGrants.Approver.github("maintainer", true, ServeAgentGrantScope.PLAYGROUND)
-    assertEquals(ServeAgentGrantScope.PLAYGROUND, approver.ceiling)
+    val approver = ServeAgentGrants.Approver.github("maintainer", true, AgentGrantScope.PLAYGROUND)
+    assertEquals(AgentGrantScope.PLAYGROUND, approver.ceiling)
     assertEquals("@maintainer", approver.name)
   }
 
   @Test
   fun `the page never offers more than the agent asked for`() {
-    val approver = ServeAgentGrants.Approver.operator(ServeAgentGrantScope.PLAYGROUND)
+    val approver = ServeAgentGrants.Approver.operator(AgentGrantScope.PLAYGROUND)
     assertEquals(
       listOf("preview"),
       ServeAgentGrants.selectableScopes(
-          ServeAgentGrantScope.PREVIEW,
+          AgentGrantScope.PREVIEW,
           approver,
-          ServeAgentGrantScope.PLAYGROUND,
+          AgentGrantScope.PLAYGROUND,
         )
         .map { it.wire },
     )
@@ -118,23 +117,23 @@ class ServeAgentGrantsTest {
 
   @Test
   fun `durations parse the forms a human types`() {
-    assertEquals(7200, ServeAgentGrants.parseDurationSeconds("2h"))
-    assertEquals(2700, ServeAgentGrants.parseDurationSeconds("45m"))
-    assertEquals(90, ServeAgentGrants.parseDurationSeconds("90s"))
-    assertEquals(3600, ServeAgentGrants.parseDurationSeconds("3600"))
-    assertEquals(7200, ServeAgentGrants.parseDurationSeconds(" 2 H "))
-    assertNull(ServeAgentGrants.parseDurationSeconds("soon"))
-    assertNull(ServeAgentGrants.parseDurationSeconds("0h"))
-    assertNull(ServeAgentGrants.parseDurationSeconds(""))
-    assertNull(ServeAgentGrants.parseDurationSeconds(null))
+    assertEquals(7200, AgentGrantProtocol.parseDurationSeconds("2h"))
+    assertEquals(2700, AgentGrantProtocol.parseDurationSeconds("45m"))
+    assertEquals(90, AgentGrantProtocol.parseDurationSeconds("90s"))
+    assertEquals(3600, AgentGrantProtocol.parseDurationSeconds("3600"))
+    assertEquals(7200, AgentGrantProtocol.parseDurationSeconds(" 2 H "))
+    assertNull(AgentGrantProtocol.parseDurationSeconds("soon"))
+    assertNull(AgentGrantProtocol.parseDurationSeconds("0h"))
+    assertNull(AgentGrantProtocol.parseDurationSeconds(""))
+    assertNull(AgentGrantProtocol.parseDurationSeconds(null))
   }
 
   @Test
   fun `durations format the way the page and the CLI print them`() {
-    assertEquals("30s", ServeAgentGrants.formatDuration(30))
-    assertEquals("15m", ServeAgentGrants.formatDuration(900))
-    assertEquals("2h", ServeAgentGrants.formatDuration(7200))
-    assertEquals("2h 30m", ServeAgentGrants.formatDuration(9000))
+    assertEquals("30s", AgentGrantProtocol.formatDuration(30))
+    assertEquals("15m", AgentGrantProtocol.formatDuration(900))
+    assertEquals("2h", AgentGrantProtocol.formatDuration(7200))
+    assertEquals("2h 30m", AgentGrantProtocol.formatDuration(9000))
   }
 
   @Test

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.cli.serve
 
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import ee.schimke.composeai.daemon.protocol.RemoteNamedValue
 import ee.schimke.composeai.data.overrides.PreviewOverrideDeclaration
 import ee.schimke.composeai.data.overrides.PreviewOverrideType
@@ -3039,17 +3041,17 @@ class ServeWebFixtureTest {
         userCode = "KX7M-9QD4",
         label = "fix wear-m3-catalog#68 <the focus ring>",
         client = "203.0.113.42",
-        requestedScope = ServeAgentGrantScope.PLAYGROUND,
+        requestedScope = AgentGrantScope.PLAYGROUND,
         requestedTtlSeconds = 7200,
         expiresInSeconds = 540,
         approver = "@yschimke",
-        selectableScopes = listOf(ServeAgentGrantScope.PREVIEW, ServeAgentGrantScope.LIVE),
+        selectableScopes = listOf(AgentGrantScope.PREVIEW, AgentGrantScope.LIVE),
         maxTtlSeconds = 8 * 3600,
         approveCsrf = "fixed-approve-seal",
         denyCsrf = "fixed-deny-seal",
         formAction = "/agent-access/9c2Qk1pTf0Xb7hLm4nRzQA",
         version = version,
-        withheldScopes = listOf(ServeAgentGrantScope.PLAYGROUND),
+        withheldScopes = listOf(AgentGrantScope.PLAYGROUND),
         withheldReason = "you do not hold it yourself on this server, so you cannot pass it on",
       )
 
@@ -3064,12 +3066,12 @@ class ServeWebFixtureTest {
         userCode = "KX7M-9QD4",
         label = "embed the before/after in the PR body",
         client = "203.0.113.42",
-        requestedScope = ServeAgentGrantScope.LIVE,
+        requestedScope = AgentGrantScope.LIVE,
         requestedTtlSeconds = 1800,
         expiresInSeconds = 540,
         approver = "@yschimke",
-        selectableScopes = listOf(ServeAgentGrantScope.PREVIEW, ServeAgentGrantScope.LIVE),
-        selectableCapabilities = listOf(ServeAgentGrantCapability.IMAGES),
+        selectableScopes = listOf(AgentGrantScope.PREVIEW, AgentGrantScope.LIVE),
+        selectableCapabilities = listOf(AgentGrantCapability.IMAGES),
         maxTtlSeconds = 8 * 3600,
         approveCsrf = "fixed-approve-seal",
         denyCsrf = "fixed-deny-seal",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AgentAccessStore.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.cli.serve.ServeAgentGrantStore
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
 import java.io.File
 import java.io.RandomAccessFile
 import java.nio.file.Files
@@ -51,8 +52,8 @@ internal open class AgentAccessStore(
     val token: String,
     val scopes: List<String> = emptyList(),
     /**
-     * Independent permissions the approver ticked ([ServeAgentGrantCapability]). Defaulted, so a
-     * file written by an older CLI reads back without complaint.
+     * Independent permissions the approver ticked ([AgentGrantCapability]). Defaulted, so a file
+     * written by an older CLI reads back without complaint.
      */
     val capabilities: List<String> = emptyList(),
     val approvedBy: String = "",
@@ -65,7 +66,7 @@ internal open class AgentAccessStore(
      * message here names a row a human can actually find. Never the token itself.
      */
     val fingerprint: String
-      get() = ServeAgentGrantStore.fingerprintOf(token)
+      get() = AgentGrantProtocol.fingerprintOf(token)
 
     fun secondsUntilExpiry(nowMillis: Long): Long =
       ((expiresAtMillis - nowMillis) / 1000).coerceAtLeast(0)
@@ -343,8 +344,8 @@ internal open class AgentAccessStore(
     /**
      * How long a remembered request stays worth polling **past the close of its approval window** —
      * the server's own hard ceiling on a grant's life
-     * ([ServeAgentGrantStore.HARD_MAX_GRANT_TTL_SECONDS]). Measured from the window's end rather
-     * than from the request's creation, because the server starts a grant's TTL at approval: past
+     * ([AgentGrantProtocol.HARD_MAX_GRANT_TTL_SECONDS]). Measured from the window's end rather than
+     * from the request's creation, because the server starts a grant's TTL at approval: past
      * window-end plus this, no grant the request could have produced can still be alive, so the
      * record owes nobody.
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AuthCommand.kt
@@ -1,8 +1,8 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.cli.serve.ServeAgentGrantCapability
-import ee.schimke.composeai.cli.serve.ServeAgentGrantScope
-import ee.schimke.composeai.cli.serve.ServeAgentGrants
+import ee.schimke.composeai.agentgrants.AgentGrantCapability
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import kotlin.system.exitProcess
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -138,10 +138,10 @@ internal class AuthCommand(
     // default, and the agent would spend a human's attention on a request for less access than it
     // meant to ask for.
     val scope = args.flagValue("--scope")?.trim().orEmpty()
-    if (scope.isNotEmpty() && ServeAgentGrantScope.parse(scope) == null) {
+    if (scope.isNotEmpty() && AgentGrantScope.parse(scope) == null) {
       fail(
         "unknown --scope '$scope' — expected one of " +
-          ServeAgentGrantScope.entries.joinToString(", ") { it.wire },
+          AgentGrantScope.entries.joinToString(", ") { it.wire },
         code = 64,
       )
     }
@@ -155,17 +155,17 @@ internal class AuthCommand(
         .map { it.trim() }
         .filter { it.isNotEmpty() }
         .map { raw ->
-          ServeAgentGrantCapability.parse(raw)?.wire
+          AgentGrantCapability.parse(raw)?.wire
             ?: fail(
               "unknown --capability '$raw' — expected one of " +
-                ServeAgentGrantCapability.entries.joinToString(", ") { it.wire },
+                AgentGrantCapability.entries.joinToString(", ") { it.wire },
               code = 64,
             )
         }
         .distinct()
     val ttlRaw = args.flagValue("--ttl")
     val ttl =
-      ServeAgentGrants.parseDurationSeconds(ttlRaw)
+      AgentGrantProtocol.parseDurationSeconds(ttlRaw)
         ?: if (ttlRaw.isNullOrBlank()) DEFAULT_TTL_SECONDS
         else fail("unrecognised --ttl '$ttlRaw' — try 45m, 2h, or a number of seconds", code = 64)
     val label = args.flagValue("--label")?.trim().orEmpty().ifEmpty { defaultLabel() }
@@ -223,7 +223,7 @@ internal class AuthCommand(
           "could collect the token once it was approved. Fix the credential file's directory and " +
           "run this again, or use --json, which prints the device secret for you to poll with. " +
           "The unsaved request expires on its own in " +
-          ServeAgentGrants.formatDuration(opened.expiresInSeconds) +
+          AgentGrantProtocol.formatDuration(opened.expiresInSeconds) +
           "; nobody has been asked to approve anything."
       )
     }
@@ -266,7 +266,7 @@ internal class AuthCommand(
         else " + ${opened.requestedCapabilities.joinToString(", ")}"
       println(
         "  They will be asked to grant: ${opened.requestedScope}$requestedCapabilities · " +
-          ServeAgentGrants.formatDuration(opened.requestedTtlSeconds) +
+          AgentGrantProtocol.formatDuration(opened.requestedTtlSeconds) +
           (if (label.isNotEmpty()) " · \"$label\"" else "")
       )
       println("  The code above must match what they see on that page.")
@@ -283,7 +283,7 @@ internal class AuthCommand(
       }
       println(
         "Waiting for approval (this request expires in " +
-          "${ServeAgentGrants.formatDuration(opened.expiresInSeconds)})…"
+          "${AgentGrantProtocol.formatDuration(opened.expiresInSeconds)})…"
       )
     }
 
@@ -328,7 +328,7 @@ internal class AuthCommand(
     println(
       "Access granted by ${outcome.approvedBy ?: "an approver"} — " +
         "${outcome.scopes.joinToString(", ")} for " +
-        ServeAgentGrants.formatDuration(outcome.expiresInSeconds ?: 0) +
+        AgentGrantProtocol.formatDuration(outcome.expiresInSeconds ?: 0) +
         "."
     )
     println(
@@ -489,7 +489,7 @@ internal class AuthCommand(
         if (entry.capabilities.isEmpty()) "" else " + ${entry.capabilities.joinToString(", ")}"
       println(
         "${entry.origin} — ${entry.scopes.joinToString(", ").ifEmpty { "preview" }}$capabilities · " +
-          "expires in ${ServeAgentGrants.formatDuration(left)}" +
+          "expires in ${AgentGrantProtocol.formatDuration(left)}" +
           (if (entry.approvedBy.isNotEmpty()) " · approved by ${entry.approvedBy}" else "") +
           (if (entry.label.isNotEmpty()) " · \"${entry.label}\"" else "") +
           suffix
@@ -505,7 +505,7 @@ internal class AuthCommand(
         continue
       }
       println(
-        "${p.origin} — waiting for approval (${ServeAgentGrants.formatDuration(
+        "${p.origin} — waiting for approval (${AgentGrantProtocol.formatDuration(
           p.secondsUntilExpiry(now)
         )} left)"
       )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessClientIntegrationTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AgentAccessClientIntegrationTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.cli.serve.ServeAgentGrantScope
+import ee.schimke.composeai.agentgrants.AgentGrantScope
 import ee.schimke.composeai.cli.serve.ServeAgentGrantStore
 import ee.schimke.composeai.cli.serve.ServeBundleHost
 import ee.schimke.composeai.cli.serve.ServeHttpServer
@@ -29,7 +29,7 @@ class AgentAccessClientIntegrationTest {
   private val registry = ServeSessionRegistry(open = { null })
 
   private val grants =
-    ServeAgentGrantStore(maxScope = ServeAgentGrantScope.PLAYGROUND, maxGrantTtlSeconds = 3600)
+    ServeAgentGrantStore(maxScope = AgentGrantScope.PLAYGROUND, maxGrantTtlSeconds = 3600)
 
   private val server: ServeHttpServer by lazy {
     val dir = Files.createTempDirectory("client-grants").toFile().also { it.deleteOnExit() }
@@ -113,7 +113,7 @@ class AgentAccessClientIntegrationTest {
     assertEquals("pending", ok(c.poll(opened.requestId, opened.deviceSecret)).status)
 
     // The human's half, driven directly — the browser flow itself is covered by the routing test.
-    grants.approve(opened.requestId, "@yuri", ServeAgentGrantScope.LIVE, 900)
+    grants.approve(opened.requestId, "@yuri", AgentGrantScope.LIVE, 900)
 
     val approved = ok(c.poll(opened.requestId, opened.deviceSecret))
     assertEquals("approved", approved.status)
@@ -143,7 +143,7 @@ class AgentAccessClientIntegrationTest {
   fun `a wrong device secret reads as unknown and carries no token`() {
     val c = client()
     val opened = ok(c.open(label = "", scope = "preview", ttlSeconds = 600))
-    grants.approve(opened.requestId, "@yuri", ServeAgentGrantScope.PREVIEW, 600)
+    grants.approve(opened.requestId, "@yuri", AgentGrantScope.PREVIEW, 600)
     val polled = ok(c.poll(opened.requestId, "not-the-secret"))
     assertEquals("unknown", polled.status)
     assertEquals(null, polled.token)
@@ -172,7 +172,7 @@ class AgentAccessClientIntegrationTest {
     assertNull(store.tokenFor(c.origin))
     assertNotNull(store.pendingFor(c.origin))
 
-    grants.approve(opened.requestId, "@yuri", ServeAgentGrantScope.LIVE, 900)
+    grants.approve(opened.requestId, "@yuri", AgentGrantScope.LIVE, 900)
 
     AuthCommand(listOf("status", "--server", c.origin), store).run()
     assertNotNull(store.tokenFor(c.origin), "the approved token should have been collected")
@@ -184,7 +184,7 @@ class AgentAccessClientIntegrationTest {
   fun `auth status drops a grant the server no longer honours`() {
     val c = client()
     val opened = ok(c.open(label = "revoked soon", scope = "live", ttlSeconds = 900))
-    grants.approve(opened.requestId, "@yuri", ServeAgentGrantScope.LIVE, 900)
+    grants.approve(opened.requestId, "@yuri", AgentGrantScope.LIVE, 900)
     val token = ok(c.poll(opened.requestId, opened.deviceSecret)).token!!
     val store = tempStore()
     store.save(
@@ -222,7 +222,7 @@ class AgentAccessClientIntegrationTest {
       )
     )
     assertNotNull(wedged.pendingFor(c.origin))
-    grants.approve(opened.requestId, "@yuri", ServeAgentGrantScope.LIVE, 900)
+    grants.approve(opened.requestId, "@yuri", AgentGrantScope.LIVE, 900)
 
     // The store cannot write, so collection fails — and must not take the secret down with it.
     AuthCommand(listOf("status", "--server", c.origin), wedged).run()

--- a/preview-server/contract-probe/build.gradle.kts
+++ b/preview-server/contract-probe/build.gradle.kts
@@ -54,6 +54,10 @@ val contracts =
     // Both halves need the same arithmetic — the server crops catalog thumbnails, `bundle split`
     // crops the same renders — so it is a contract rather than a thing to keep two copies of.
     "common-image-crop",
+    // The agent-grant vocabulary. Both ends of `--agent-grants` speak it — the server mints, the
+    // CLI's `auth` asks — so it is a contract rather than a thing for the client to reach into the
+    // server for.
+    "agent-grant-protocol",
     "data-layoutinspector-core",
     "data-preview-overrides-core",
     "data-remotecompose-core",

--- a/scripts/check-preview-server-contracts.sh
+++ b/scripts/check-preview-server-contracts.sh
@@ -37,6 +37,7 @@ CONTRACT_PROJECTS=(
   ":render-session-subprocess"
   ":common-io"
   ":common-image-crop"
+  ":agent-grant-protocol"
   ":data-layoutinspector-core"
   ":data-preview-overrides-core"
   ":data-remotecompose-core"

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -80,6 +80,7 @@
     "ee.schimke.composeai.plugin"
   ],
   "contractPackages": {
+    "ee.schimke.composeai.agentgrants": "agent-grant-protocol",
     "ee.schimke.composeai.bundle": "bundle-format",
     "ee.schimke.composeai.bundle.coordinates": "bundle-coordinates",
     "ee.schimke.composeai.daemon": "daemon-core",
@@ -133,10 +134,6 @@
       "serve.PreviewHistoryManifest",
       "serve.RenderFailureFrame",
       "serve.RenderOutcome",
-      "serve.ServeAgentGrantCapability",
-      "serve.ServeAgentGrantScope",
-      "serve.ServeAgentGrantStore",
-      "serve.ServeAgentGrants",
       "serve.ServeBundleDaemon",
       "serve.ServeDefaults",
       "serve.ServeDiscovery",
@@ -152,7 +149,6 @@
     "serveInternalsUsedByCli": [
       "serve.FakeRenderSession",
       "serve.PreviewHistoryManifest",
-      "serve.ServeAgentGrantScope",
       "serve.ServeAgentGrantStore",
       "serve.ServeBackgroundWork",
       "serve.ServeBundleHost",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -287,6 +287,13 @@ include(":common-image-crop")
 
 project(":common-image-crop").projectDir = file("common/image-crop")
 
+// The scope/capability vocabulary, duration grammar and token fingerprint shared by the preview
+// server that mints agent grants and the `auth` client that asks for them. Extracted from
+// `:cli:serve` so the client half stops reaching into the server to parse its own `--ttl`.
+include(":agent-grant-protocol")
+
+project(":agent-grant-protocol").projectDir = file("api/agent-grant-protocol")
+
 // Step B of the clean-API carve-out: the Gradle Tooling-API render pipeline that previously
 // lived inside `:cli`'s `Command` base class. Exposes a `GradlePreviewDriver` library so
 // external consumers (contrib scripting, third-party tooling) can render previews and read the


### PR DESCRIPTION
#3824 preparation. **`serveInternalsUsedByCli` 16 → 12**, test 17 → 16. Independent of #4641 (publishing) — they touch different files.

`--agent-grants` is a two-party protocol: the CLI's `auth` asks for a grant and polls for it, the preview server mints and revokes. Both ends need the same scope and capability names, the same duration grammar, and the same token fingerprint. While those lived in `:cli:serve`, **the client half was reaching into the server to parse its own `--ttl`**.

## What is and isn't in the contract

`:agent-grant-protocol` carries what the two ends must agree on and nothing about how either behaves: the two enums, `parseDurationSeconds` / `formatDuration`, `fingerprintOf`, and the hard TTL ceiling the client prints when explaining a clamp.

`ServeAgentGrantStore` — minting, expiry, persistence, rate limiting — stays in the server. That is policy, not protocol, and it is also the file with real server dependencies (`PlaygroundTokenStore`, `ServeUrls`).

The scope was measured, not guessed: `:cli` referenced **exactly two** members of `ServeAgentGrants` (`formatDuration`, `parseDurationSeconds`), which is why the contract is this small rather than the whole 280-line object. `AgentGrantScope`'s only references to server types were three KDoc links to `ServeHttpServer`, now backticked names.

## The types lose their `Serve` prefix

`ServeAgentGrantScope` → `AgentGrantScope`, `ServeAgentGrantCapability` → `AgentGrantCapability`, **in its own commit** so the move and the rename read apart.

Leaving them `Serve*` in a contract package next to `AgentGrantProtocol` would have shipped a name asserting they belong to the module they had just left — a mistake I'd have had to undo later, and cheapest to avoid while the files are already moving.

Safe because **the wire format is an explicit `wire: String` on each constant, not the class or constant name**, so the rename changes no JSON and no `--scope` spelling. I checked that before renaming rather than after, since the opposite finding would have made it a breaking change rather than a tidy-up. (Credit where due: that `wire` property is what makes this free — a design that had serialised the enum name would have locked the type name to the protocol forever.)

## Registration

All three places a contract has to be registered — the seam allowlist's `contractPackages`, the probe's `contracts`, and `check-preview-server-contracts.sh`'s publish list. `explicitApi()` + a committed ABI dump, matching `:common-io`, `:bundle-format` and `:common-image-crop`.

## Test plan

- `:agent-grant-protocol:check` (includes `checkKotlinAbi`), `:cli:serve:test`, `:cli:test` — green.
- All five compile tasks across the three modules — clean.
- `check-preview-server-contracts.sh` — green end to end, publishing the new module at the probe SNAPSHOT.
- `check-serve-seam.py` OK at `main.serveInternalsUsedByCli=12`, `cliInternalsUsedByServe=0`, `test=16`.
- `ktfmtCheck` clean.

Non-visual: a contract boundary. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_