### PR TITLE
fix(deploy): read .env the way Compose does before advising a deletion

### DIFF
--- a/deploy/image/README.md
+++ b/deploy/image/README.md
@@ -232,10 +232,26 @@ genuinely explain why this box differs from stock are buried.
 
 It first refuses any line ending in a backslash — `.env` is not a shell script, and that typo takes
 the box down with a 502 and no explanation. Then it reports which entries restate a compose or
-entrypoint default and which are set but empty (the same
-as unset), then lists the keys that genuinely differ — **by name only**. It never prints a value:
-the file holds `SERVE_TOKEN`, `SERVE_ADMIN_TOKEN`, the GitHub OAuth secret and the deploy hook
-token, and the output is meant to be safe to paste into an issue or a chat.
+entrypoint default and which are set but empty (the same as unset), then lists the keys that
+genuinely differ — **by name only**. It never prints a value: the file holds `SERVE_TOKEN`,
+`SERVE_ADMIN_TOKEN`, the GitHub OAuth secret and the deploy hook token, and the output is meant to
+be safe to paste into an issue or a chat. A malformed line is located by **line number**, for the
+same reason — a broken continuation's second line is a value fragment, not a key.
+
+Its advice is acted on by deleting a line, so it follows Compose's own reading rather than
+approximating it, and two of its sections exist because deleting is not always reversible:
+
+- **`DUPLICATED`** comes first when a key is assigned twice. Compose uses the last assignment, so
+  deleting the winning line exposes an earlier one — `SERVE_PUBLIC=1` over `SERVE_PUBLIC=0` takes a
+  public box token-gated. Resolve those before acting on anything below.
+- **"Set but empty, and NOT the same as unset"** covers keys whose `setup.sh` migration
+  distinguishes missing from empty. `DEPLOY_HOOK_TOKEN=` left deliberately empty disarms the
+  instant-roll webhook; deleting the line has `setup.sh` generate a token and arm it again.
+
+It reads every compose file `COMPOSE_FILE` selects, so the deploy overlay's defaults count as stock;
+it strips an inline comment from an unquoted value the way Compose does, so a line copied from this
+README complete with its `# the default` still reads as redundant; and where a compose file only
+passes a variable through (`${VAR:-}`), the entrypoint's default is the one compared against.
 
 ### Warming the theme cache aggressively
 

--- a/deploy/image/env-redundant.sh
+++ b/deploy/image/env-redundant.sh
@@ -10,13 +10,17 @@
 #
 # Values are never printed. The file holds SERVE_TOKEN, SERVE_ADMIN_TOKEN, the GitHub OAuth secret
 # and the deploy hook token; a tidy-up tool that pastes those into a terminal (and from there into
-# an issue, or a chat with an agent) would be a poor trade for the tidiness. Only key names, and
-# defaults that are already public in this repo, reach stdout.
+# an issue, or a chat with an agent) would be a poor trade for the tidiness. Only key names, line
+# numbers, and defaults that are already public in this repo, reach stdout.
+#
+# **Advice this tool gives is acted on by deleting a line, so a wrong answer is a config change.**
+# That is why the parsing below tracks Compose's own rules rather than approximating them: which
+# file's default actually applies, which assignment actually wins, and where a value actually ends.
+# Each of those, got wrong, turns "safe to delete" into a silent behaviour change on the next roll.
 set -euo pipefail
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file="${ENV_FILE:-${here}/.env}"
-compose="${COMPOSE_FILE_UNDER_TEST:-${here}/docker-compose.yml}"
 entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
 
 [[ -f "${env_file}" ]] || {
@@ -24,29 +28,137 @@ entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
   exit 0
 }
 
-# Collect VAR -> default from both files. The compose file decides what reaches the container at
-# all, so it wins where the two disagree; the entrypoint's defaults apply to what compose passed
-# through empty.
-declare -A default_of
-while IFS= read -r pair; do
-  key="${pair%%:-*}"
-  value="${pair#*:-}"
-  [[ -n "${default_of[$key]+set}" ]] || default_of["$key"]="$value"
-done < <(
-  { grep -oE '\$\{[A-Z_][A-Z0-9_]*:-[^}]*\}' "${compose}" || true
-    grep -oE '\$\{[A-Z_][A-Z0-9_]*:-[^}]*\}' "${entrypoint}" || true
-  } | sed 's/^\${//; s/}$//'
-)
+# ---------------------------------------------------------------------------------------------
+# Value parsing, shared by every reader below so they cannot disagree about where a value ends.
+# ---------------------------------------------------------------------------------------------
 
-# A trailing backslash is not a continuation here, it is a fatal typo — and a silent one. Compose
-# reads every line as its own KEY=VALUE, so the backslash becomes part of the value and the lines
-# below it are parsed as junk keys. When the value is SERVE_JAVA_OPTS that backslash reaches
-# JAVA_TOOL_OPTIONS, the JVM refuses to start on an unrecognised option, and the box serves 502
-# behind a restart-looping container with nothing in the compose output naming the cause.
+# Compose's reading of one .env value: one layer of surrounding quotes stripped, and — for an
+# UNQUOTED value only — an inline comment removed from the first whitespace-preceded `#` onward.
+#
+# The comment rule is not a nicety. `deploy/image/README.md` hands out copyable lines of the form
+# `SERVE_THEME_CACHE_DIR=/theme-cache # the default`, and a reader that keeps the comment compares
+# `/theme-cache # the default` against `/theme-cache`, calls the entry live, and tells the operator
+# the one line that IS pure decoration is the one worth keeping.
+# https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/
+compose_value() {
+  local raw="$1"
+  case "${raw}" in
+    \"*\") printf '%s' "${raw:1:${#raw}-2}"; return 0 ;;
+    \'*\') printf '%s' "${raw:1:${#raw}-2}"; return 0 ;;
+  esac
+  local v="${raw}"
+  [[ "${v}" == *" #"* ]] && v="${v%% #*}"
+  [[ "${v}" == *$'\t#'* ]] && v="${v%%$'\t'#*}"
+  # Trailing whitespace before a stripped comment is not part of the value either.
+  while [[ "${v}" == *[[:space:]] ]]; do v="${v%[[:space:]]}"; done
+  printf '%s' "${v}"
+}
+
+# ---------------------------------------------------------------------------------------------
+# Which compose files are actually in play.
+# ---------------------------------------------------------------------------------------------
+
+# `COMPOSE_FILE` selects them, and this deployment documents an overlay
+# (`docker-compose.yml:docker-compose.deploy-config.yml`) that carries defaults of its own —
+# `${DEPLOY_CONFIG_DIR:-../preview.coo.ee}` among them. Reading only the base file tells an operator
+# who set exactly the overlay's default that their line genuinely differs from stock.
+#
+# Compose reads `COMPOSE_FILE` from the environment or from the .env itself, so both are honoured
+# here, in that order.
+compose_file_selector="${COMPOSE_FILE:-}"
+if [[ -z "${compose_file_selector}" ]]; then
+  compose_file_selector="$(
+    sed -n 's/^[[:space:]]*COMPOSE_FILE=//p' "${env_file}" | tail -n 1
+  )"
+  [[ -n "${compose_file_selector}" ]] &&
+    compose_file_selector="$(compose_value "${compose_file_selector}")"
+fi
+
+compose_files=()
+if [[ -n "${COMPOSE_FILE_UNDER_TEST:-}" ]]; then
+  # The tests name their fixtures directly; honoured ahead of everything else.
+  IFS=':' read -r -a compose_files <<<"${COMPOSE_FILE_UNDER_TEST}"
+elif [[ -n "${compose_file_selector}" ]]; then
+  IFS="${COMPOSE_PATH_SEPARATOR:-:}" read -r -a selected <<<"${compose_file_selector}"
+  for name in "${selected[@]}"; do
+    [[ -z "${name}" ]] && continue
+    [[ "${name}" == /* ]] && compose_files+=("${name}") || compose_files+=("${here}/${name}")
+  done
+else
+  compose_files=("${here}/docker-compose.yml")
+fi
+
+# ---------------------------------------------------------------------------------------------
+# VAR -> default, from the compose files and then the entrypoint.
+# ---------------------------------------------------------------------------------------------
+
+# Within the compose files, LATER wins — that is what an overlay is for. The entrypoint then fills
+# in behind them, and it also **replaces an empty compose default**: a compose file that passes a
+# variable through as `${SERVE_TIMEOUT:-}` is declaring a pass-through, not a value, and the
+# effective default is whatever the entrypoint supplies. First-wins across both files recorded the
+# empty string and reported `SERVE_TIMEOUT=1800`, `SERVE_CATALOG_SOURCE_REF=main` and
+# `SERVE_CATALOG_SOURCE_ROOT=/catalog-src` as genuine deviations when each is exactly stock.
+declare -A default_of
+record_defaults() {
+  local file="$1" replace_empty="$2" pair key value
+  [[ -f "${file}" ]] || return 0
+  while IFS= read -r pair; do
+    key="${pair%%:-*}"
+    value="${pair#*:-}"
+    if [[ -z "${default_of[$key]+set}" ]]; then
+      default_of["$key"]="${value}"
+    elif [[ "${replace_empty}" == "replace-empty" && -z "${default_of[$key]}" && -n "${value}" ]]; then
+      default_of["$key"]="${value}"
+    elif [[ "${replace_empty}" == "later-wins" ]]; then
+      default_of["$key"]="${value}"
+    fi
+  done < <(grep -oE '\$\{[A-Z_][A-Z0-9_]*:-[^}]*\}' "${file}" 2>/dev/null | sed 's/^\${//; s/}$//' || true)
+}
+for f in "${compose_files[@]}"; do record_defaults "${f}" later-wins; done
+record_defaults "${entrypoint}" replace-empty
+
+# ---------------------------------------------------------------------------------------------
+# Read the .env once: line numbers, the effective assignment per key, and the malformed lines.
+# ---------------------------------------------------------------------------------------------
+
+# `|| [[ -n "${line}" ]]` because a final line with no terminating newline is assigned by `read`
+# and then reported as failure, so the loop body never sees it. A file ending in
+# `SERVE_JAVA_OPTS=…\` — the exact fatal typo the continuation check exists to catch — otherwise
+# exits 0 with nothing said.
 continuations=()
-while IFS= read -r line; do
+order=()
+declare -A value_of last_line_of occurrences
+lineno=0
+while IFS= read -r line || [[ -n "${line}" ]]; do
+  lineno=$((lineno + 1))
   [[ "${line}" =~ ^[[:space:]]*# ]] && continue
-  [[ "${line}" == *\\ ]] && continuations+=("${line%%=*}")
+  [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
+  if [[ "${line}" == *\\ ]]; then
+    # Named by LINE NUMBER, and by key only when the line is a well-formed assignment. A malformed
+    # continuation's second line — `--token secret\`, or a split value fragment — has no `=`, so
+    # `${line%%=*}` was the whole line: this tool's one guarantee is that its output can be pasted
+    # into an issue, and that path printed a value fragment straight to stderr.
+    if [[ "${line}" =~ ^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      key="${line%%=*}"; key="${key#*export }"; key="${key//[[:space:]]/}"
+      continuations+=("line ${lineno}: ${key}")
+    else
+      continuations+=("line ${lineno}: (continuation of the line above; value not shown)")
+    fi
+    continue
+  fi
+  [[ "${line}" == *=* ]] || continue
+  key="${line%%=*}"
+  key="${key#export }"
+  key="${key//[[:space:]]/}"
+  raw="${line#*=}"
+  # LAST assignment wins, exactly as Compose reads it. Classifying each line independently told an
+  # operator that the final `SERVE_PUBLIC=1` was safe to delete when an earlier `SERVE_PUBLIC=0`
+  # was still in the file — deleting it exposes the 0, and the box goes from public to token-gated
+  # and fails to start if no token is configured.
+  [[ -n "${value_of[$key]+set}" ]] || order+=("${key}")
+  value_of["$key"]="$(compose_value "${raw}")"
+  last_line_of["$key"]="${lineno}"
+  occurrences["$key"]=$(( ${occurrences[$key]:-0} + 1 ))
 done < "${env_file}"
 
 if ((${#continuations[@]})); then
@@ -56,28 +168,53 @@ if ((${#continuations[@]})); then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------------------------
+# Classify.
+# ---------------------------------------------------------------------------------------------
+
+# Keys whose setup migration distinguishes MISSING from EMPTY. `setup.sh` backfills a generated
+# DEPLOY_HOOK_TOKEN only when no assignment is present, so an operator who deliberately keeps the
+# line empty has disarmed the instant-roll webhook — and deleting the line re-arms it on the next
+# `setup.sh`. Removing an empty assignment is equivalent to leaving it unset for every OTHER key;
+# for these it is a behaviour change, so they are reported separately rather than as deletable.
+migration_sensitive=(DEPLOY_HOOK_TOKEN)
+
 redundant=()
 empty=()
+empty_load_bearing=()
 active=()
-while IFS= read -r line; do
-  [[ "${line}" =~ ^[[:space:]]*# ]] && continue
-  [[ "${line}" =~ ^[[:space:]]*$ ]] && continue
-  [[ "${line}" == *=* ]] || continue
-  key="${line%%=*}"
-  key="${key#export }"
-  key="${key//[[:space:]]/}"
-  value="${line#*=}"
-  # Strip one layer of surrounding quotes, the way compose does.
-  value="${value%\"}"; value="${value#\"}"
-  value="${value%\'}"; value="${value#\'}"
+duplicates=()
+
+for key in "${order[@]}"; do
+  if (( ${occurrences[$key]} > 1 )); then
+    duplicates+=("${key} (${occurrences[$key]} assignments; the one on line ${last_line_of[$key]} is the one Compose uses)")
+  fi
+  value="${value_of[$key]}"
   if [[ -z "${value}" ]]; then
-    empty+=("${key}")
+    exempt=no
+    for sensitive in "${migration_sensitive[@]}"; do
+      [[ "${key}" == "${sensitive}" ]] && exempt=yes && break
+    done
+    if [[ "${exempt}" == yes ]]; then
+      empty_load_bearing+=("${key}")
+    else
+      empty+=("${key}")
+    fi
   elif [[ -n "${default_of[$key]+set}" && "${value}" == "${default_of[$key]}" ]]; then
     redundant+=("${key}=${default_of[$key]}")
   else
     active+=("${key}")
   fi
-done < "${env_file}"
+done
+
+# Duplicates first: everything below is advice about deleting a line, and a duplicated key makes
+# "delete this one" mean something different from what the reader will assume.
+if ((${#duplicates[@]})); then
+  echo "DUPLICATED — resolve these before deleting anything:"
+  printf '  %s\n' "${duplicates[@]}"
+  echo "  Deleting the winning line exposes an earlier one; the advice below is about the winner only."
+  echo
+fi
 
 if ((${#redundant[@]})); then
   echo "Restating a default — safe to delete:"
@@ -90,6 +227,14 @@ if ((${#empty[@]})); then
   echo
   echo "Set but empty — same as unset, safe to delete:"
   printf '  %s\n' "${empty[@]}"
+fi
+
+if ((${#empty_load_bearing[@]})); then
+  echo
+  echo "Set but empty, and NOT the same as unset — leave these alone:"
+  printf '  %s\n' "${empty_load_bearing[@]}"
+  echo "  setup.sh generates a value when the assignment is absent, so deleting the line changes"
+  echo "  behaviour on the next run rather than restoring the default."
 fi
 
 echo

--- a/deploy/image/test-env-redundant.sh
+++ b/deploy/image/test-env-redundant.sh
@@ -103,4 +103,173 @@ ENV_FILE="${tmp}/.env" "${here}/env-redundant.sh" >/dev/null || {
 }
 echo "PASS: a well-formed .env is unaffected"
 
+# 9. A DUPLICATED key: Compose uses the last assignment, so classifying each line independently
+#    told an operator the final SERVE_PUBLIC=1 was safe to delete while an earlier SERVE_PUBLIC=0
+#    was still in the file. Deleting it exposes the 0 — the box goes from public to token-gated,
+#    and fails to start if no token is configured. This is a config change dressed as tidying.
+cat > "${tmp}/.env-dup" <<'ENV'
+SERVE_PUBLIC=0
+SERVE_LIVE_SEATS=8
+SERVE_PUBLIC=1
+ENV
+dup_out="$(ENV_FILE="${tmp}/.env-dup" "${here}/env-redundant.sh")"
+grep -q "^DUPLICATED" <<<"${dup_out}" || {
+  echo "FAIL: a duplicated key was not reported before the deletion advice" >&2
+  echo "${dup_out}" >&2
+  exit 1
+}
+grep -q "SERVE_PUBLIC (2 assignments" <<<"${dup_out}" || {
+  echo "FAIL: the duplicate report does not name the key and its count" >&2
+  echo "${dup_out}" >&2
+  exit 1
+}
+# And the classification follows the WINNER (=1, the compose default), not the first line.
+grep -q "^  SERVE_PUBLIC=1$" <<<"${dup_out}" || {
+  echo "FAIL: the effective (last) assignment is not the one classified" >&2
+  echo "${dup_out}" >&2
+  exit 1
+}
+echo "PASS: a duplicated key is reported, and the last assignment is the one classified"
+
+# 10. An inline comment on an unquoted value. The README hands out copyable lines in exactly this
+#     form, and keeping the comment made the one line that IS pure decoration read as live config.
+cat > "${tmp}/.env-comment" <<'ENV'
+SERVE_THEME_CACHE_DIR=/theme-cache # the default
+SERVE_ADMIN_TOKEN="a value # with a hash inside it"
+ENV
+com_out="$(ENV_FILE="${tmp}/.env-comment" "${here}/env-redundant.sh")"
+grep -q "^  SERVE_THEME_CACHE_DIR=/theme-cache$" <<<"${com_out}" || {
+  echo "FAIL: an inline comment was not stripped before comparing" >&2
+  echo "${com_out}" >&2
+  exit 1
+}
+# A quoted value keeps its hash — it is not a comment inside quotes — and stays active, by name.
+grep -q "  SERVE_ADMIN_TOKEN$" <<<"${com_out}" || {
+  echo "FAIL: a hash inside a quoted value must not be treated as a comment" >&2
+  echo "${com_out}" >&2
+  exit 1
+}
+if grep -qF "with a hash inside it" <<<"${com_out}"; then
+  echo "FAIL: a quoted value reached stdout" >&2
+  exit 1
+fi
+echo "PASS: inline comments are stripped, and a hash inside quotes is not one"
+
+# 11. The entrypoint's default beats an EMPTY compose pass-through. `${VAR:-}` in the compose file
+#     declares a pass-through, not a value; first-wins recorded the empty string and reported the
+#     entrypoint's own default as a genuine deviation.
+cat > "${tmp}/compose-passthrough.yml" <<'YML'
+services:
+  preview:
+    environment:
+      SERVE_TIMEOUT: ${SERVE_TIMEOUT:-}
+YML
+cat > "${tmp}/entrypoint-defaults.sh" <<'SH'
+: "${SERVE_TIMEOUT:-1800}"
+SH
+printf 'SERVE_TIMEOUT=1800\n' > "${tmp}/.env-passthrough"
+pass_out="$(
+  ENV_FILE="${tmp}/.env-passthrough" \
+  COMPOSE_FILE_UNDER_TEST="${tmp}/compose-passthrough.yml" \
+  ENTRYPOINT_FILE="${tmp}/entrypoint-defaults.sh" \
+  "${here}/env-redundant.sh"
+)"
+grep -q "^  SERVE_TIMEOUT=1800$" <<<"${pass_out}" || {
+  echo "FAIL: an empty compose pass-through must not shadow the entrypoint's default" >&2
+  echo "${pass_out}" >&2
+  exit 1
+}
+echo "PASS: the entrypoint's default replaces an empty compose pass-through"
+
+# 12. COMPOSE_FILE selects the overlay too. The documented deployment enables
+#     docker-compose.deploy-config.yml, whose own defaults are invisible to a reader pinned to the
+#     base file — so an operator restating one was told it differed from stock.
+cat > "${tmp}/base.yml" <<'YML'
+services:
+  preview:
+    environment:
+      SERVE_LIVE_SEATS: ${SERVE_LIVE_SEATS:-4}
+YML
+cat > "${tmp}/overlay.yml" <<'YML'
+services:
+  preview:
+    environment:
+      DEPLOY_CONFIG_DIR: ${DEPLOY_CONFIG_DIR:-../preview.coo.ee}
+YML
+printf 'DEPLOY_CONFIG_DIR=../preview.coo.ee\n' > "${tmp}/.env-overlay"
+ovl_out="$(
+  ENV_FILE="${tmp}/.env-overlay" \
+  COMPOSE_FILE_UNDER_TEST="${tmp}/base.yml:${tmp}/overlay.yml" \
+  ENTRYPOINT_FILE="${tmp}/entrypoint-defaults.sh" \
+  "${here}/env-redundant.sh"
+)"
+grep -q "DEPLOY_CONFIG_DIR=../preview.coo.ee" <<<"${ovl_out}" || {
+  echo "FAIL: an overlay's default was not read" >&2
+  echo "${ovl_out}" >&2
+  exit 1
+}
+echo "PASS: every compose file COMPOSE_FILE selects is read"
+
+# 13. An empty DEPLOY_HOOK_TOKEN is NOT the same as unset: setup.sh backfills a generated token
+#     when no assignment is present, so deleting the line arms the instant-roll webhook an operator
+#     deliberately disarmed.
+printf 'DEPLOY_HOOK_TOKEN=\nSERVE_CATALOG_MAX_IMAGES=\n' > "${tmp}/.env-hook"
+hook_out="$(ENV_FILE="${tmp}/.env-hook" "${here}/env-redundant.sh")"
+grep -q "NOT the same as unset" <<<"${hook_out}" || {
+  echo "FAIL: an empty migration-sensitive key was not separated from the deletable ones" >&2
+  echo "${hook_out}" >&2
+  exit 1
+}
+awk '/^Set but empty — same as unset/,/^$/' <<<"${hook_out}" | grep -q "DEPLOY_HOOK_TOKEN" && {
+  echo "FAIL: DEPLOY_HOOK_TOKEN was listed as safe to delete" >&2
+  echo "${hook_out}" >&2
+  exit 1
+}
+awk '/^Set but empty — same as unset/,/^$/' <<<"${hook_out}" | grep -q "SERVE_CATALOG_MAX_IMAGES" || {
+  echo "FAIL: an ordinary empty key must still be reported as deletable" >&2
+  echo "${hook_out}" >&2
+  exit 1
+}
+echo "PASS: an empty migration-sensitive key is not advertised as deletable"
+
+# 14. A malformed continuation's second line has no `=`, so naming "the key" printed the whole
+#     line — a value fragment on stderr, from the one tool whose output is meant to be pasteable.
+cat > "${tmp}/.env-frag" <<'ENV'
+SERVE_JAVA_OPTS=-Dfirst=1 \
+  --token sup3rs3cr3t-fragment \
+ENV
+frag_out="$(ENV_FILE="${tmp}/.env-frag" "${here}/env-redundant.sh" 2>&1 || true)"
+if grep -qF "sup3rs3cr3t-fragment" <<<"${frag_out}"; then
+  echo "FAIL: a value fragment from a malformed continuation reached the output" >&2
+  echo "${frag_out}" >&2
+  exit 1
+fi
+grep -q "line 1: SERVE_JAVA_OPTS" <<<"${frag_out}" || {
+  echo "FAIL: the offending line number and key were not named" >&2
+  echo "${frag_out}" >&2
+  exit 1
+}
+grep -q "line 2:" <<<"${frag_out}" || {
+  echo "FAIL: the second offending line was not reported at all" >&2
+  echo "${frag_out}" >&2
+  exit 1
+}
+echo "PASS: a malformed continuation is located by line, never by value"
+
+# 15. A final line with no terminating newline. `read` assigns it and then returns failure, so the
+#     loop body never saw it — a file ending in exactly the fatal typo this guard exists for exited
+#     0 with nothing said.
+printf 'SERVE_JAVA_OPTS=-Dfirst=1 \\' > "${tmp}/.env-noeol"
+if ENV_FILE="${tmp}/.env-noeol" "${here}/env-redundant.sh" >/dev/null 2>&1; then
+  echo "FAIL: an unterminated final line ending in a backslash must still be fatal" >&2
+  exit 1
+fi
+noeol_out="$(ENV_FILE="${tmp}/.env-noeol" "${here}/env-redundant.sh" 2>&1 || true)"
+grep -q "line 1: SERVE_JAVA_OPTS" <<<"${noeol_out}" || {
+  echo "FAIL: the unterminated final line was not named" >&2
+  echo "${noeol_out}" >&2
+  exit 1
+}
+echo "PASS: an unterminated final line is still examined"
+
 echo "PASS: all env-redundant checks"


### PR DESCRIPTION
Closes the seven unaddressed review findings left on #4633 and #4640 after they merged.

They share a root worth stating once: **this tool's advice is acted on by deleting a line**, so an approximation of Compose's parsing turns "safe to delete" into a silent config change on the next roll. Every fix below is that same correction applied to a different rule.

## The one that could take a box down

**Duplicate keys were classified independently** (#4633, P1). Compose uses the last assignment, so with `SERVE_PUBLIC=0` earlier in the file the tool labelled the winning `SERVE_PUBLIC=1` *safe to delete*. Deleting it exposes the `0` — a public box goes token-gated, and fails to start if no token is configured.

The effective last assignment is now what gets classified, and a duplicated key is reported **first**, above every other section, because the advice below it means something different when a key is assigned twice:

```
DUPLICATED — resolve these before deleting anything:
  SERVE_PUBLIC (2 assignments; the one on line 3 is the one Compose uses)
  Deleting the winning line exposes an earlier one; the advice below is about the winner only.
```

**An empty `DEPLOY_HOOK_TOKEN=` was advertised as deletable** (#4633, P2). `setup.sh:43` backfills a generated token only when no assignment is present (`grep -q '^DEPLOY_HOOK_TOKEN='`), so an operator who deliberately emptied the line to disarm the instant-roll webhook would have it armed again on the next run. Keys whose migration distinguishes missing from empty now get their own section saying exactly that, rather than sitting among the deletable ones.

## Three that reported decoration as live config

- **Inline comments were kept** (#4633, P2). Compose strips a whitespace-preceded `#` from an unquoted value; this didn't, so `SERVE_THEME_CACHE_DIR=/theme-cache # the default` — a line this repo's own README hands out as copyable — compared unequal to the default it restates. A `#` *inside* quotes is still part of the value.
- **Only `docker-compose.yml` was read** (#4633, P2). The documented deployment enables `COMPOSE_FILE=docker-compose.yml:docker-compose.deploy-config.yml`, whose overlay carries `${DEPLOY_CONFIG_DIR:-../preview.coo.ee}`. Every file `COMPOSE_FILE` selects is now read (from the environment, or from the `.env` itself — Compose reads it from both), later files winning as overlay semantics require.
- **An empty compose pass-through shadowed the entrypoint's default** (#4633, P2). `${VAR:-}` in a compose file declares a pass-through, not a value; first-wins recorded the empty string, which is what made `SERVE_TIMEOUT=1800`, `SERVE_CATALOG_SOURCE_REF=main` and `SERVE_CATALOG_SOURCE_ROOT=/catalog-src` all read as deliberate deviations when each is exactly stock.

## Two on the continuation guard

Both matter more than their P2 badge, because this guard's entire premise is that its output is safe to paste into an issue or a chat:

- **A value fragment reached the output** (#4640). A malformed continuation's second line has no `=`, so `${line%%=*}` was the whole line — `--token secret\` printed verbatim to stderr. Lines are now located by **number**, with a key named only when the line is a well-formed assignment.
- **An unterminated final line was never examined** (#4640). `read` assigns it and then returns failure, so the loop body never saw it: a file ending in `SERVE_JAVA_OPTS=…\` — the exact fatal typo this guard exists for, the one that took `preview.coo.ee` down behind a 502 — exited 0 in silence.

## Test plan

Seven regression checks added to `test-env-redundant.sh` (15 total, all passing), and **each verified non-vacuous against the pre-fix script**:

| check | pre-fix behaviour |
| --- | --- |
| duplicated key | no `DUPLICATED` section at all |
| inline comment | `SERVE_THEME_CACHE_DIR` reported as genuinely differing |
| empty pass-through | `SERVE_TIMEOUT` reported as genuinely differing |
| `COMPOSE_FILE` overlay | `DEPLOY_CONFIG_DIR` reported as genuinely differing |
| empty `DEPLOY_HOOK_TOKEN` | listed under "safe to delete" |
| continuation fragment | `sup3rs3cr3t-fragment` present in the output |
| unterminated final line | exited **0**, said nothing |

The overlay case cannot even be expressed against the old script, which takes a single file — that is the finding.

Also run:

- `deploy/image/test-env-migrations.sh` — OK
- `deploy/image/test-compose-env-passthrough.sh` — OK
- `bash -n` on both changed scripts

The existing eight checks are unchanged and still pass, including the two that matter most: no value reaches stdout, and a well-formed `.env` is unaffected.

`deploy/image/README.md` gains the two new sections and the parsing rules, since an operator reading `DUPLICATED` or "NOT the same as unset" needs to know why they are being told to stop.

Non-visual: a shell tool and its tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_