### PR TITLE
fix(layout-inspector): advertise v18 for the vector-path transform

### DIFF
--- a/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
+++ b/data/layoutinspector/core/src/main/kotlin/ee/schimke/composeai/data/layoutinspector/ComposeSemanticsModels.kt
@@ -158,7 +158,15 @@ public object LayoutInspectorProduct {
   // rather than the drawn rect (Wear's `AlertDialog` confirm button: a 126x108 pill turned -45
   // degrees reports 166x166), so a consumer that places by `bounds` alone draws the node too big
   // and un-turned. Additive — older entries decode with `rotationDegrees = 0f`.
-  public const val SCHEMA_VERSION: Int = 17
+  // v18: a `vectorGraphic` path may carry a `transform` — the composed SVG transform list of every
+  // `ImageVector` group above it, so a grouped icon exports as paths rather than falling back to a
+  // raster. Additive — older entries decode with `transform = null`, which is what a path no group
+  // transforms carries anyway, so they export exactly as before.
+  //
+  // Bumped because the advertised integer is what a client gates payload support on: without it, a
+  // v17 capture that predates group transforms and a v18 one that has them are indistinguishable,
+  // and an archived artifact is labelled as the schema it is not.
+  public const val SCHEMA_VERSION: Int = 18
   public const val FILE: String = "layout-inspector.json"
 }
 


### PR DESCRIPTION
Closes the P2 review finding left on #4635 after it merged. **The P1 on the same PR — the JVM ABI break — is deliberately not in this diff; see below.**

## The bump

#4635 added `transform` to `LayoutInspectorVectorPath`, an additive serialized field on the layout-inspector payload, and left `LayoutInspectorProduct.SCHEMA_VERSION` at `17`.

That integer is what the daemon advertises through `DataProductCapability` and what clients gate per-kind payload support on, so leaving it means a v17 capture that predates group transforms and a v18 one that carries them are indistinguishable, and an archived artifact is labelled as a schema it is not.

Every previous additive field on this payload bumped it with a `// vN:` note saying what was added and how an older entry decodes — v15 `vectorName`, v16 `drawsContent`, v17 `rotationDegrees`, each ending "Additive — older entries decode…". This follows that shape exactly: older entries decode with `transform = null`, which is what a path no group transforms carries anyway, so they export exactly as before.

## Test plan

- `./gradlew :data-layoutinspector-core:compileKotlin :data-layoutinspector-connector:test` — BUILD SUCCESSFUL
- `./gradlew :data-layoutinspector-core:checkKotlinAbi` — BUILD SUCCESSFUL
- `./gradlew ktfmtCheckAll` — clean

No test pins the literal `17`: `ComposeSemanticsDataProductRegistryTest` asserts the advertised capability equals the constant, and both `ComposeSemanticsDataProducer.SCHEMA_VERSION` and `LayoutInspectorDataProducer.SCHEMA_VERSION` derive from the product objects, so the bump propagates through one edit.

Non-visual: an advertised integer and its schema note.

## What is *not* here, and why

The other finding on #4635 is a P1: adding the property changed the JVM descriptors of `LayoutInspectorVectorPath` and `FigmaSvgVectorPath`, replacing the 9-arg constructor and `copy` with 10-arg ones. The committed dump confirms it — `data/layoutinspector/core/api/data-layoutinspector-core.api:1390` now reads `<init> (…;Z;Ljava/lang/String;)V`.

I have not "fixed" that here, because the obvious fix does not do what it appears to. A 9-arg secondary constructor and a 9-arg `copy` overload restore the *all-arguments* call path, but the synthetic `<init>$default` / `copy$default` a Kotlin caller uses when it omits any parameter cannot be hand-restored — its descriptor gains the same argument. So a consumer compiled against the old JAR that wrote `LayoutInspectorVectorPath(pathData = d)` still gets `NoSuchMethodError`, while the module now *looks* binary compatible. Partial restoration that reads as complete is worse than a break that is recorded, and it is a permanent obligation on every future field this payload gains.

The alternative — treat it as a recorded ABI change, which the `checkKotlinAbi` gate and the updated dump already make deliberate rather than silent — needs a decision about what this artifact promises, and `docs/VERSIONING.md` does not currently answer it (§3 enumerates breaking surfaces and the published payload classes' JVM ABI is not among them; §9's table also still says Kotlin BCV is wired only on `:rc-player-*`, which this module contradicts).

That is a call for the repo owner, not something to settle in a follow-up PR. Raised with @yschimke separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_