### PR TITLE
refactor(image-crop): name the box for the rectangle, not for one producer

### DIFF
--- a/common/image-crop/api/common-image-crop.api
+++ b/common/image-crop/api/common-image-crop.api
@@ -1,3 +1,20 @@
+public final class ee/schimke/composeai/imagecrop/ContentBox {
+	public fun <init> (IIII)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (IIII)Lee/schimke/composeai/imagecrop/ContentBox;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentBox;IIIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentBox;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getH ()I
+	public final fun getW ()I
+	public final fun getX ()I
+	public final fun getY ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class ee/schimke/composeai/imagecrop/ContentCrop {
 	public fun <init> (IIIIIIZII)V
 	public synthetic fun <init> (IIIIIIZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -27,32 +44,15 @@ public final class ee/schimke/composeai/imagecrop/ContentCrop {
 }
 
 public final class ee/schimke/composeai/imagecrop/ContentCropGeometryKt {
-	public static final fun clampTo (Lee/schimke/composeai/imagecrop/SvgContentBox;II)Lee/schimke/composeai/imagecrop/SvgContentBox;
+	public static final fun clampTo (Lee/schimke/composeai/imagecrop/ContentBox;II)Lee/schimke/composeai/imagecrop/ContentBox;
 	public static final fun computeGutterCrop (IIIIIII)Lee/schimke/composeai/imagecrop/ContentCrop;
 	public static synthetic fun computeGutterCrop$default (IIIIIIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
-	public static final fun computeThumbCrop (Ljava/lang/String;IILee/schimke/composeai/imagecrop/SvgContentBox;I)Lee/schimke/composeai/imagecrop/ContentCrop;
-	public static synthetic fun computeThumbCrop$default (Ljava/lang/String;IILee/schimke/composeai/imagecrop/SvgContentBox;IILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
-	public static final fun contentBoxFillsRender (Lee/schimke/composeai/imagecrop/SvgContentBox;II)Z
-	public static final fun pngAlphaBounds ([BI)Lee/schimke/composeai/imagecrop/SvgContentBox;
-	public static synthetic fun pngAlphaBounds$default ([BIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/SvgContentBox;
-	public static final fun svgContentBox (Ljava/lang/String;)Lee/schimke/composeai/imagecrop/SvgContentBox;
-	public static final fun union (Lee/schimke/composeai/imagecrop/SvgContentBox;Lee/schimke/composeai/imagecrop/SvgContentBox;)Lee/schimke/composeai/imagecrop/SvgContentBox;
-}
-
-public final class ee/schimke/composeai/imagecrop/SvgContentBox {
-	public fun <init> (IIII)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()I
-	public final fun copy (IIII)Lee/schimke/composeai/imagecrop/SvgContentBox;
-	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/SvgContentBox;IIIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/SvgContentBox;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getH ()I
-	public final fun getW ()I
-	public final fun getX ()I
-	public final fun getY ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+	public static final fun computeThumbCrop (Ljava/lang/String;IILee/schimke/composeai/imagecrop/ContentBox;I)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun computeThumbCrop$default (Ljava/lang/String;IILee/schimke/composeai/imagecrop/ContentBox;IILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static final fun contentBoxFillsRender (Lee/schimke/composeai/imagecrop/ContentBox;II)Z
+	public static final fun pngAlphaBounds ([BI)Lee/schimke/composeai/imagecrop/ContentBox;
+	public static synthetic fun pngAlphaBounds$default ([BIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentBox;
+	public static final fun svgContentBox (Ljava/lang/String;)Lee/schimke/composeai/imagecrop/ContentBox;
+	public static final fun union (Lee/schimke/composeai/imagecrop/ContentBox;Lee/schimke/composeai/imagecrop/ContentBox;)Lee/schimke/composeai/imagecrop/ContentBox;
 }
 

--- a/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
+++ b/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
@@ -65,20 +65,24 @@ private val VIEWBOX_RE = Regex("""viewBox="0 0 (\d+(?:\.\d+)?) (\d+(?:\.\d+)?)""
 
 /**
  * The component's content box in the render's native pixel space, read from a figma-svg: crop
- * origin ([x],[y]) and size ([w]×[h]). The figma-svg is content-cropped — its root `viewBox` is the
- * box size and its root `<g transform="translate(tx,ty)">` places it, so the component's top-left
- * in the render is `(-tx, -ty)`. This is the *unscaled* box (native render pixels);
- * [computeThumbCrop] adds the display scaling on top, while the bundle PNG crop
- * ([ee.schimke.composeai.cli] `bundle split`) uses it at full resolution.
+ * origin ([x],[y]) and size ([w]×[h]), in native render pixels.
+ *
+ * Not SVG-specific despite where it is first read: [pngAlphaBounds] returns one for a PNG's drawn
+ * extent, and [union] combines the two. It was called `SvgContentBox` while it lived beside the one
+ * producer that parses an SVG, which read as a claim about the format rather than about the
+ * rectangle. The figma-svg is content-cropped — its root `viewBox` is the box size and its root `<g
+ * transform="translate(tx,ty)">` places it, so the component's top-left in the render is `(-tx,
+ * -ty)`. This is the *unscaled* box (native render pixels); [computeThumbCrop] adds the display
+ * scaling on top, while a full-resolution consumer (the CLI's `bundle split`) uses it as-is.
  */
-public data class SvgContentBox(val x: Int, val y: Int, val w: Int, val h: Int)
+public data class ContentBox(val x: Int, val y: Int, val w: Int, val h: Int)
 
 /**
  * Parse a figma-svg's content box (root `viewBox` size + `translate` origin) in render pixels, or
  * `null` when the svg carries no parseable `viewBox`. A missing `translate` places the box at the
  * origin.
  */
-public fun svgContentBox(svgText: String): SvgContentBox? {
+public fun svgContentBox(svgText: String): ContentBox? {
   val vb = VIEWBOX_RE.find(svgText) ?: return null
   val w = vb.groupValues[1].toDouble()
   val h = vb.groupValues[2].toDouble()
@@ -86,7 +90,7 @@ public fun svgContentBox(svgText: String): SvgContentBox? {
   val tr = TRANSLATE_RE.find(svgText)
   val tx = tr?.groupValues?.get(1)?.toInt() ?: 0
   val ty = tr?.groupValues?.get(2)?.toInt() ?: 0
-  return SvgContentBox(x = -tx, y = -ty, w = w.roundToInt(), h = h.roundToInt())
+  return ContentBox(x = -tx, y = -ty, w = w.roundToInt(), h = h.roundToInt())
 }
 
 /**
@@ -95,23 +99,23 @@ public fun svgContentBox(svgText: String): SvgContentBox? {
  * canvas) — the shared "within 10% on both axes" no-op guard. Consumers that read a pre-cropped PNG
  * then find their box ≈ the image and no-op via this same test.
  */
-public fun contentBoxFillsRender(box: SvgContentBox, renderW: Int, renderH: Int): Boolean =
+public fun contentBoxFillsRender(box: ContentBox, renderW: Int, renderH: Int): Boolean =
   box.w >= renderW * 0.9 && box.h >= renderH * 0.9
 
 /** The smallest box covering both [this] and [other]. */
-public fun SvgContentBox.union(other: SvgContentBox): SvgContentBox {
+public fun ContentBox.union(other: ContentBox): ContentBox {
   val x1 = min(x, other.x)
   val y1 = min(y, other.y)
   val x2 = max(x + w, other.x + other.w)
   val y2 = max(y + h, other.y + other.h)
-  return SvgContentBox(x1, y1, x2 - x1, y2 - y1)
+  return ContentBox(x1, y1, x2 - x1, y2 - y1)
 }
 
 /** Clamp [this] to a [renderW]×[renderH] canvas (origin ≥ 0, extent within bounds). */
-public fun SvgContentBox.clampTo(renderW: Int, renderH: Int): SvgContentBox {
+public fun ContentBox.clampTo(renderW: Int, renderH: Int): ContentBox {
   val nx = x.coerceIn(0, renderW)
   val ny = y.coerceIn(0, renderH)
-  return SvgContentBox(nx, ny, max(1, min(x + w, renderW) - nx), max(1, min(y + h, renderH) - ny))
+  return ContentBox(nx, ny, max(1, min(x + w, renderW) - nx), max(1, min(y + h, renderH) - ny))
 }
 
 /**
@@ -122,7 +126,7 @@ public fun SvgContentBox.clampTo(renderW: Int, renderH: Int): SvgContentBox {
  * (see [computeThumbCrop]) guarantees the crop never clips real pixels, self-correcting per variant
  * without needing a per-variant figma-svg.
  */
-public fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): SvgContentBox? {
+public fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): ContentBox? {
   val img = runCatching { ImageIO.read(ByteArrayInputStream(pngBytes)) }.getOrNull() ?: return null
   val w = img.width
   val h = img.height
@@ -141,7 +145,7 @@ public fun pngAlphaBounds(pngBytes: ByteArray, threshold: Int = 16): SvgContentB
     }
   }
   if (maxX < 0) return null // fully transparent
-  return SvgContentBox(minX, minY, maxX - minX + 1, maxY - minY + 1)
+  return ContentBox(minX, minY, maxX - minX + 1, maxY - minY + 1)
 }
 
 /**
@@ -215,7 +219,7 @@ public fun computeThumbCrop(
   svgText: String,
   renderW: Int,
   renderH: Int,
-  contentBounds: SvgContentBox? = null,
+  contentBounds: ContentBox? = null,
   cap: Int = CAP,
 ): ContentCrop? {
   if (renderW <= 0 || renderH <= 0) return null


### PR DESCRIPTION
API review of what #4617 published. **Time-sensitive: free today, an ABI break once 1.42.0 publishes.**

`SvgContentBox` is the type every crop computation passes around — and `pngAlphaBounds` returns one for a **PNG's** drawn extent, which has nothing to do with SVG. `union` combines an SVG-derived box with a PNG-derived one. The name was accurate only about where the type was first read, not about what it is, and it put "SVG" in the public surface of a module whose entire job is rectangles in native render pixels.

`ContentBox` now, with KDoc that says it is not SVG-specific and names both producers.

## Why this is urgent rather than tidy-up

`common-image-crop` is in the 1.42.0 tree, but not yet on Maven Central:

```
preview-annotations   200
common-io             200
common-image-crop     404     <- nothing consumes the old name
agent-grant-protocol  404
compose-preview-serve 404
```

I checked the two known-published artifacts precisely so a 404 could be read as *the artifact's absence* rather than a broken endpoint or a proxy quirk — a false negative from a failed request looks identical to a true one, and that has already caught me once today.

The `v1.42.0` tag exists and `common-io`'s metadata still tops out at 1.41.0, so the publish is in flight. **If 1.42.0 lands before this merges, the rename stops being free** and should be reconsidered rather than merged — say the word and I'll close it.

## Also fixed

A `[ee.schimke.composeai.cli]` KDoc reference inside the module. A contract pointing back at one of its consumers is the wrong direction, and after the repo split it would not resolve at all.

## Test plan

- `:common-image-crop:check`, including the regenerated ABI dump — green.
- `:cli:serve:test`, `:cli:test` — green.
- All four compile tasks across `:cli` and `:cli:serve` — clean.
- `ktfmtCheck` clean.

## Two more findings from the same review, not in this PR

Reporting rather than fixing, because both are judgement calls rather than mistakes:

1. **`ServeDefaults` carries two naming conventions.** Its original companion constants use a `DEFAULT_` prefix (`DEFAULT_PORT`, `DEFAULT_IDLE_EXIT_SECONDS`); the re-exports added in #4625 mostly dropped it (`IMAGE_TTL_SECONDS`, `CATALOG_REPO`). The prefix does carry meaning — it distinguishes "what an unset flag becomes" from a plain constant like `AGENT_GRANT_CALLER_CONCURRENCY` — so the inconsistency is real, just cosmetic.

2. **`ServeOptions` is 99 members (91 vals, 8 functions), and the functions are two different things.** Six of them (`gradleProjectRoot`, `gradleBuildArgs`, `gradleProjects`, `runGradleTasks`, `discoverAndBuild`, plus `variantGradleArgs`) are not options at all — they are a *build service* the CLI provides to the server. Splitting them into a second interface (`ServeBuildHost`?) would say that, and would make it obvious that a future non-Gradle host only has to implement six methods. I'd rather propose it than reshape a seam that landed hours ago.

Non-visual: a rename in a not-yet-published module. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_