### PR TITLE
fix(figma-svg): drive the interaction a variant names before the capture

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -795,11 +795,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
   // inbound live `renderNow.overrides` is layered OVER this in
   // `RobolectricHost.reshapeRenderPayload`
   // so live wins per key; the baked seed applies even with zero live overrides.
-  val bakedOverrides =
-    info.overrides
-      ?.toNamedOverrides()
-      ?.takeIf { it.isNotEmpty() }
-      ?.let { ee.schimke.composeai.daemon.protocol.PreviewOverrides(namedOverrides = it) }
+  val bakedOverrides = info.overrides?.toPreviewOverrides()
   val defaults =
     RenderSpec(
       previewId = info.id,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -512,11 +512,8 @@ data class PreviewManifestEntry(
     val showBackground = showBackground ?: p?.showBackground ?: true
     val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
     val wrapperClassName = p?.wrapperClassName
-    val bakedOverrides =
-      overrides
-        ?.toNamedOverrides()
-        ?.takeIf { it.isNotEmpty() }
-        ?.let { PreviewOverrides(namedOverrides = it) }
+    // Seeds AND the harness interaction, in one shared translation — see `toPreviewOverrides`.
+    val bakedOverrides = overrides?.toPreviewOverrides()
     return ResolvedRenderParams(
       widthPx = resolvedWidthPx,
       heightPx = resolvedHeightPx,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -786,6 +786,41 @@ class RenderEngine(
               }
             }
 
+            // `@OverrideVariant(interaction = Hovered)`: move a mouse onto the target and let its
+            // state layer settle, for exactly the reason the scroll drive above runs here — the
+            // PNG, the semantics / layout trees and the `compose/figma-svg` built from them all
+            // read the composition as it stands at this point, so a missing drive publishes a
+            // hovered sticker that is byte-identical to its resting sibling (issue #4639).
+            //
+            // `driveHoverPreview` is `:renderer-android`'s, not a copy: the index has to name the
+            // same node on both lanes or the two pictures of "hover the second chip" differ.
+            environment.staticHover?.let { hoverIndex ->
+              trace.section("compose:hover") {
+                ee.schimke.composeai.renderer.driveHoverPreview(rule, hoverIndex)
+              }
+            }
+
+            // `@OverrideVariant(interaction = Focused | Pressed)`, and every other daemon caller of
+            // `renderNow.overrides.focus`. The connector's `FocusOverrideExtension` supplies the
+            // half that has to happen inside composition — the `LocalInputModeManager` flip — but
+            // its `moveFocus` walk does not land in a daemon render, so the host addresses the
+            // target instead. See `driveFocusPreview`.
+            //
+            // A direction-addressed override is a traversal script rather than a target this can
+            // name, so it is left to the extension exactly as before.
+            spec.overrides
+              ?.focus
+              ?.takeIf { it.direction == null }
+              ?.let { focus ->
+                trace.section("compose:focus") {
+                  ee.schimke.composeai.renderer.driveFocusPreview(
+                    rule = rule,
+                    tabIndex = focus.tabIndex ?: 0,
+                    pressed = focus.pressed,
+                  )
+                }
+              }
+
             outputFile.parentFile?.mkdirs()
             // `applyDeviceCrop = true` is what produces the circular alpha mask Roborazzi paints
             // over the captured bitmap; the `round` resource qualifier set above only affects
@@ -2269,6 +2304,19 @@ class RenderEngine(
      * with motion enabled.
      */
     val staticScroll: ScrollCaptureDto?,
+    /**
+     * `@OverrideVariant(interaction = Hovered)` — the interactive-node index this render owes a
+     * mouse-hover before it captures, resolved from the preview index (see
+     * [PreviewIndex.staticHoverFor]).
+     *
+     * Hover is the one interaction with nothing on the wire to carry it. Focus and press ride
+     * `spec.overrides.focus`, which exists because the connector's `FocusOverrideExtension` has an
+     * in-composition half to perform (the `LocalInputModeManager` flip); a hover has no such half,
+     * so the intent has no reason to be in the override bag and is read off the index instead.
+     * Resolved here beside [staticScroll] for symmetry — unlike the scroll it carries no
+     * composition local, so it could equally be read at the drive site.
+     */
+    val staticHover: Int?,
     val sizeOverrides: PreviewOverrides?,
     val sandboxWidthPx: Int,
     val sandboxHeightPx: Int,
@@ -2300,6 +2348,7 @@ class RenderEngine(
     // `RobolectricRenderTest`, which reads the same flag off the preview's captures and wraps
     // `setContent` in the provider.
     val staticScroll = spec.previewId?.let { loadPreviewIndexLazily().staticScrollFor(it) }
+    val staticHover = spec.previewId?.let { loadPreviewIndexLazily().staticHoverFor(it) }
     val wearReduceMotionLocal =
       if (flattenWearScroll || staticScroll?.reduceMotion == true)
         ee.schimke.composeai.renderer.WearReduceMotionLocal.get(classLoader)
@@ -2361,6 +2410,7 @@ class RenderEngine(
       flattenWearScroll = flattenWearScroll,
       wearReduceMotionLocal = wearReduceMotionLocal,
       staticScroll = staticScroll,
+      staticHover = staticHover,
       sizeOverrides = sizeOverrides,
       sandboxWidthPx = sandboxWidthPx,
       sandboxHeightPx = sandboxHeightPx,

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.overrides.OverrideVariantInteraction
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -63,6 +65,91 @@ class OverrideIntegrationTest {
       assertEquals("heightPx override should reach the RenderSpec", 128, large.height)
     } finally {
       host.shutdown()
+    }
+  }
+
+  /**
+   * Issue #4639 — a `_VARIANT_hovered` / `_VARIANT_focused` / `_VARIANT_pressed` preview must
+   * render the state it names, not the resting one.
+   *
+   * The seed half of an `@OverrideVariant` reaches the composition as data (#3652 / #4638); an
+   * interaction is something that has to be *done* to the composition, and the daemon's
+   * one-frame-per-id path did nothing at all. Everything read off that render — the PNG, the
+   * semantics and layout trees, the `compose/figma-svg` built from them — therefore described the
+   * resting state under a filename claiming otherwise.
+   *
+   * The two halves arrive by different routes and this covers both: focus and press ride
+   * `spec.overrides.focus` (via `OverrideVariantSpec.toPreviewOverrides`) into the connector's
+   * `FocusOverrideExtension`, which does its work inside composition; hover is dispatched by the
+   * host from [RenderEngine], because positional input has no in-composition half.
+   *
+   * Pixels rather than the exported vector, matching this file's idiom — and the stronger assertion
+   * of the two, since every structured product is projected from the same composition these pixels
+   * were captured from.
+   */
+  @Test
+  fun interactionVariantsRenderTheStateTheyName() {
+    val outputDir = tempFolder.newFolder("renders-interaction")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val previewsJson = tempFolder.newFile("previews-interaction.json")
+    // `staticHoverFor` reads the hover intent off the preview index, so the engine needs one on
+    // disk — the same sysprop the gradle plugin sets on a production daemon JVM.
+    previewsJson.writeText(
+      """
+      {"previews":[
+        {"id":"interaction-hovered","functionName":"InteractionStateSquare",
+         "className":"ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+         "overrides":{"name":"hovered","seeds":[],"interaction":"Hovered"}}
+      ]}
+      """
+        .trimIndent()
+    )
+    val previousPreviewsJson = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previewsJson.absolutePath)
+    fun entry(id: String, interaction: OverrideVariantInteraction? = null) =
+      PreviewManifestEntry(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "InteractionStateSquare",
+        widthPx = 48,
+        heightPx = 48,
+        density = 1.0f,
+        outputBaseName = id,
+        overrides =
+          interaction?.let { OverrideVariantSpec(name = it.name.lowercase(), interaction = it) },
+      )
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                entry("interaction-base"),
+                entry("interaction-hovered", OverrideVariantInteraction.Hovered),
+                entry("interaction-focused", OverrideVariantInteraction.Focused),
+                entry("interaction-pressed", OverrideVariantInteraction.Pressed),
+              )
+          )
+      )
+    host.start()
+    try {
+      fun renderedIs(id: String, rgb: Int): Double =
+        pixelMatchPct(renderAndDecode(host, "previewId=$id", id), rgb, 8)
+      assertTrue("resting render must stay red", renderedIs("interaction-base", 0xEF5350) > 0.9)
+      assertTrue("hovered render must be blue", renderedIs("interaction-hovered", 0x42A5F5) > 0.9)
+      assertTrue(
+        "focused render must be orange",
+        renderedIs("interaction-focused", 0xFFA726) > 0.9,
+      )
+      assertTrue("pressed render must be green", renderedIs("interaction-pressed", 0x66BB6A) > 0.9)
+    } finally {
+      host.shutdown()
+      if (previousPreviewsJson == null) {
+        System.clearProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+      } else {
+        System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previousPreviewsJson)
+      }
     }
   }
 

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -11,6 +11,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -221,6 +226,40 @@ fun OverridableSquare() {
     ee.schimke.composeai.overrides.previewOverrideColor("fill", default = Color(0xFFEF5350))
   ee.schimke.composeai.overrides.previewOverrideString("label", default = "hi")
   Box(modifier = Modifier.fillMaxSize().background(fill))
+}
+
+/**
+ * A clickable square that paints its own **interaction state**: red at rest, blue hovered, orange
+ * focused, green pressed. Android twin of `:daemon:desktop`'s fixture of the same name.
+ *
+ * The colours come off the interaction source it hands `Modifier.clickable`, so each one appears
+ * only when a **real** event reaches that source — a mouse hover dispatched by the render host, or
+ * a focus walk the connector's `FocusOverrideExtension` performed. A fixture that emitted into the
+ * source itself would report every state whether or not the harness drove one, which is the
+ * distinction issue #3672 drew and the reason this fixture is worth having at all.
+ *
+ * Pinned by [OverrideIntegrationTest.interactionVariantsRenderTheStateTheyName].
+ */
+@Composable
+fun InteractionStateSquare() {
+  val interactionSource = remember { MutableInteractionSource() }
+  val hovered by interactionSource.collectIsHoveredAsState()
+  val pressed by interactionSource.collectIsPressedAsState()
+  val focused by interactionSource.collectIsFocusedAsState()
+  val fill =
+    when {
+      pressed -> Color(0xFF66BB6A)
+      hovered -> Color(0xFF42A5F5)
+      focused -> Color(0xFFFFA726)
+      else -> Color(0xFFEF5350)
+    }
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(fill).hoverable(interactionSource).clickable(
+        interactionSource = interactionSource,
+        indication = null,
+      ) {}
+  )
 }
 
 @Composable

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/OverrideVariantSeed.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/OverrideVariantSeed.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.FocusOverride
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.overrides.OverrideVariantInteraction
+import ee.schimke.composeai.data.overrides.OverrideVariantSpec
+
+/**
+ * The **whole** of what a synthetic `_VARIANT_` preview's `@OverrideVariant` asks a daemon render
+ * to do, as one [PreviewOverrides] bag: the knob seeds *and* the harness interaction.
+ *
+ * One function, called from four places — `renderSpecFromInfo` and `PreviewManifestEntry.resolved`
+ * on each of the two backends. That is not tidiness. Each of those four used to compute
+ * `overrides?.toNamedOverrides()` inline, and the seed half reached them one backend at a
+ * time: #3652 wired the two android sites and left the desktop router forwarding nothing, so every
+ * desktop-rendered catalog exported base-state vectors for two more weeks (#4638, and
+ * yschimke/m3-catalog#201 that reported it). A translation with one home cannot land on half the
+ * backends.
+ *
+ * ### The two halves are carried differently, and that is not an accident
+ *
+ * A **seed** is data: `state=disabled` is a value the composable reads out of
+ * `PreviewOverrideController` on its first pass, so it rides `namedOverrides` and needs nothing
+ * from the render host.
+ *
+ * An **interaction** is a state something else has to put the composition into. Two of the three
+ * are expressible as a `FocusOverride`, because `FocusOverrideExtension` (both backends) already
+ * owns the in-composition half of that: it flips `LocalInputModeManager` to keyboard mode — which
+ * nothing outside composition can do, and without which the focus indication does not draw at all —
+ * and walks `FocusManager.moveFocus(...)` to the requested index.
+ *
+ * * [OverrideVariantInteraction.Focused] → the flip, plus the target index.
+ * * [OverrideVariantInteraction.Pressed] → the same, plus [FocusOverride.pressed], matching what
+ *   discovery hands the standalone renderers (`FocusCapture(tabIndex, pressed = true)`): a pressed
+ *   sticker is focused *and* pressed, so a press with no focus indication under it would disagree
+ *   with the baked PNG beside it.
+ * * [OverrideVariantInteraction.Hovered] is **not** here. A hover has no in-composition half at all
+ *   — no input-mode flip, no manager to walk — so there is nothing for this bag to carry and each
+ *   engine reads the intent off the preview index instead ([PreviewIndex.staticHoverFor]), exactly
+ *   as the `@ScrollingPreview(END)` drive already does. Returning a `FocusOverride` for it would
+ *   draw a focus indication and call it hover: a plausible picture of the wrong state, which is
+ *   worse than the honest duplicate this whole change is about.
+ *
+ * What this bag does **not** carry for focus and press is the *targeting*. Both engines address the
+ * node themselves, because `FocusOverrideExtension`'s `moveFocus` walk does not land inside a
+ * daemon render on either backend — see `driveFocusPreview` (android) and
+ * `RenderEngine.driveStaticInteraction` (desktop) for the evidence and the mechanism. The bag is
+ * still what turns the extension on, and the extension is still what makes focus possible at all.
+ *
+ * Returns null when the variant asks for nothing this bag can carry — an all-unparseable seed set
+ * with no interaction — so a caller can leave a live per-call token untouched rather than layering
+ * an empty bag under it.
+ */
+public fun OverrideVariantSpec.toPreviewOverrides(): PreviewOverrides? {
+  val named = toNamedOverrides().takeIf { it.isNotEmpty() }
+  val focus =
+    when (interaction) {
+      OverrideVariantInteraction.Focused -> FocusOverride(tabIndex = interactionIndex)
+      OverrideVariantInteraction.Pressed ->
+        FocusOverride(tabIndex = interactionIndex, pressed = true)
+      // Host-driven; see the KDoc.
+      OverrideVariantInteraction.Hovered -> null
+      null -> null
+    }
+  if (named == null && focus == null) return null
+  return PreviewOverrides(namedOverrides = named, focus = focus)
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.overrides.OverrideVariantInteraction
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.locks.ReentrantReadWriteLock
@@ -436,6 +437,26 @@ internal constructor(
 
   /** A previewId resolved by [rowResolved]: the entry, and the `@PreviewParameter` row it named. */
   public data class Resolved(val info: PreviewInfoDto, val row: String?)
+
+  /**
+   * The **hover** target index a synthetic `_VARIANT_hovered` preview asks its render host to move
+   * a mouse onto, or null for every other preview.
+   *
+   * Hover is the one `@OverrideVariant` interaction with no in-composition half. Focus and press
+   * ride `RenderSpec.overrides.focus` — `FocusOverrideExtension` has to flip
+   * `LocalInputModeManager` from inside composition or the indication never draws — but a hover is
+   * pure positional input, so it is the render host that owns it end to end. That leaves the intent
+   * with nowhere on the wire to travel, and the engine reads it off the index here instead, exactly
+   * as [staticScrollFor] does for `@ScrollingPreview(END)`.
+   *
+   * Row-aware for the same reason [scrollCaptureFor] is: a `@PreviewParameter` row carries its
+   * base's variant.
+   */
+  public fun staticHoverFor(previewId: String): Int? {
+    val spec = rowResolved(previewId)?.info?.overrides ?: return null
+    if (spec.interaction != OverrideVariantInteraction.Hovered) return null
+    return spec.interactionIndex.coerceAtLeast(0)
+  }
 
   /**
    * Issue #1528 — resolves the [ScrollCaptureDto] for a given `(previewId, renderMode)` pair so the

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -508,11 +508,7 @@ internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
   // `@OverrideVariant` baked seed for a synthetic variant preview → the base override layer. A live
   // per-render `renderNow.overrides` is layered OVER this by `DesktopHost.specFromPreviewIdPayload`
   // (`layeredOver`), so live wins per key and the baked seed applies even with zero live overrides.
-  val bakedOverrides =
-    info.overrides
-      ?.toNamedOverrides()
-      ?.takeIf { it.isNotEmpty() }
-      ?.let { ee.schimke.composeai.daemon.protocol.PreviewOverrides(namedOverrides = it) }
+  val bakedOverrides = info.overrides?.toPreviewOverrides()
   val defaults =
     RenderSpec(
       previewId = info.id,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -515,13 +515,10 @@ data class PreviewManifestEntry(
     val previewParameterProviderClassName =
       previewParameterProviderClassName ?: p?.previewParameterProviderClassName
     val previewParameterLimit = previewParameterLimit ?: p?.previewParameterLimit ?: Int.MAX_VALUE
-    // An all-unparseable seed set yields an empty map, which is "no seed" rather than "seed
-    // nothing" — `takeIf` keeps it null so the router forwards the inbound token untouched.
-    val bakedOverrides =
-      overrides
-        ?.toNamedOverrides()
-        ?.takeIf { it.isNotEmpty() }
-        ?.let { PreviewOverrides(namedOverrides = it) }
+    // Seeds AND the harness interaction, in one shared translation — see `toPreviewOverrides`
+    // for why that function has exactly one home. Null when the variant asks for nothing this bag
+    // can carry, so the router forwards the inbound token untouched.
+    val bakedOverrides = overrides?.toPreviewOverrides()
     return ResolvedRenderParams(
       widthPx = widthPx,
       heightPx = heightPx,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.ScrollAxisRange
@@ -255,6 +257,12 @@ class RenderEngine(
         // nothing to scroll until it has arrived.
         trace.section("render:settle") { applyStaticSettle(state) }
         trace.section("render:scrollToEnd") { driveStaticScrollToEnd(state) }
+        // `@OverrideVariant(interaction = …)` — put the composition into the hovered / pressed
+        // state before the capture, for the same reason the scroll drive runs here: the PNG *and*
+        // every tree read off the same scene (semantics, layout, figma-svg) have to describe the
+        // state the sticker claims. After the scroll, because a hover target has to be where the
+        // settled frame put it.
+        trace.section("render:interaction") { driveStaticInteraction(state) }
         val driveNs = System.nanoTime() - driveStartNs
         trace.section("render:once") {
           renderOnce(
@@ -1822,6 +1830,213 @@ class RenderEngine(
   }
 
   /**
+   * `@OverrideVariant(interaction = Hovered | Focused | Pressed)` — put the scene into the
+   * interaction state the sticker names, before the capture.
+   *
+   * An interaction has two halves and this is the **host** half. `FocusOverrideExtension` keeps the
+   * other one, and it is not optional: it flips `LocalInputModeManager` to keyboard mode from
+   * inside composition, and without that `Focusability.SystemDefined` refuses focus outright, so
+   * nothing here would land. The bag that turns it on is `spec.overrides.focus` (see
+   * `OverrideVariantSpec.toPreviewOverrides`).
+   *
+   * What the extension does **not** manage to do is land the walk. `moveFocus(Enter)` + N × `Next`
+   * does not take inside an [ImageComposeScene] — a probe for issue #4639 left the target reporting
+   * `Focused=false` after forty frames, while a `FocusRequester` on that same node in that same
+   * scene landed on the first. So focus is *targeted* here instead, through the public
+   * `SemanticsActions.RequestFocus`, the same way [driveStaticScrollToEnd] reaches
+   * `SemanticsActions.ScrollBy`. `:renderer-android`'s `driveFocusPreview` does the same for the
+   * other backend and for the same reason.
+   *
+   * * **Hovered** moves a mouse to the centre of the `interactionIndex`-th *interactive* node.
+   * * **Focused** requests focus on the `tabIndex`-th *focusable* node — a narrower set, and
+   *   deliberately so: `tabIndex` is a focus-order index on both lanes, and hover's is not.
+   * * **Pressed** is focus plus a press on whatever took it. That is what discovery asks for (a
+   *   pressed variant is `FocusCapture(tabIndex, pressed = true)`), so pressing without focusing
+   *   would publish a press with no indication under it and disagree with the baked PNG.
+   *
+   * The press is a touch, not a mouse: a mouse press also raises `HoverInteraction.Enter`, and a
+   * sticker labelled "pressed" should not be documenting hover as well. It is never released — a
+   * release would end the press before the frame is captured and catch the ripple mid-retreat, and
+   * the held state is the one this render exists to show. [tearDown] disposes the scene, so nothing
+   * outlives the capture.
+   *
+   * Every failure is a **decline with a reason on stderr**, never a silent fallback: a sticker of a
+   * component that refused the state is the plausible-but-wrong picture this whole change is
+   * against, and is harder to notice than the honest duplicate it replaces.
+   *
+   * No-ops — leaving the frame clock exactly where the scroll drive left it, so an ordinary
+   * preview's capture stays bit-for-bit what it was — when the preview asks for no interaction.
+   */
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  internal fun driveStaticInteraction(state: SceneState) {
+    val hoverIndex = state.spec.previewId?.let { loadPreviewIndexLazily().staticHoverFor(it) }
+    val focus = state.spec.overrides?.focus
+    // A direction-addressed override is a traversal script, which is the extension's walk to run
+    // and not a target this can name. Left exactly as it was.
+    val focusIndex = if (focus != null && focus.direction == null) focus.tabIndex ?: 0 else null
+    if (hoverIndex == null && focusIndex == null) return
+    // Under the same JVM-default-`Locale` override every other frame-driving pass runs in: a press
+    // can compose new content, and `rememberResourceEnvironment` caches what it resolves.
+    withPreviewLocale(state.spec.localeTag) {
+      driveStaticInteractionLocalized(state, hoverIndex, focusIndex, focus?.pressed == true)
+    }
+  }
+
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  private fun driveStaticInteractionLocalized(
+    state: SceneState,
+    hoverIndex: Int?,
+    focusIndex: Int?,
+    pressFocused: Boolean,
+  ) {
+    // Semantics only exist once the scene has laid out, and `setUp` deliberately doesn't render.
+    // At the cursor's current position and without moving it — same guarantee (and the same reason)
+    // as the scroll drive's probe render.
+    if (state.virtualFrameNanos > 0L) state.scene.render(nanoTime = state.virtualFrameNanos)
+    else state.scene.render()
+
+    if (hoverIndex != null) {
+      val target = interactiveNodes(state).getOrNull(hoverIndex)
+      if (target == null) {
+        System.err.println(
+          "@OverrideVariant hover on ${state.spec.outputBaseName}: no interactive node at index " +
+            "$hoverIndex — capturing the undriven state."
+        )
+        return
+      }
+      state.scene.sendPointerEvent(
+        eventType = PointerEventType.Move,
+        position = target.boundsInRoot.center,
+        type = PointerType.Mouse,
+      )
+      settleInteraction(state)
+      return
+    }
+
+    val label = if (pressFocused) "pressed" else "focused"
+    val target = focusableNodes(state).getOrNull(focusIndex!!)
+    if (target == null) {
+      System.err.println(
+        "@OverrideVariant $label on ${state.spec.outputBaseName}: no focusable node at index " +
+          "$focusIndex — capturing the undriven state."
+      )
+      return
+    }
+    target.config.getOrNull(SemanticsActions.RequestFocus)?.action?.invoke()
+    settleInteraction(state)
+
+    // Verify rather than assume. `RequestFocus` returns before the focus state has propagated, and
+    // a component can refuse focus outright — publishing a "focused" sticker of a component that
+    // declined is the class of plausible-but-wrong picture this whole change is against.
+    val focused = focusedNode(state)
+    if (focused == null) {
+      System.err.println(
+        "@OverrideVariant $label on ${state.spec.outputBaseName}: nothing took focus — " +
+          "capturing the undriven state."
+      )
+      return
+    }
+    if (pressFocused) {
+      state.scene.sendPointerEvent(
+        eventType = PointerEventType.Press,
+        position = focused.boundsInRoot.center,
+        type = PointerType.Touch,
+      )
+      settleInteraction(state)
+    }
+  }
+
+  /**
+   * Every node carrying an interactive action, in traversal order — the hover addressing space.
+   *
+   * The same predicate `:renderer-desktop`'s `interactiveNodeMatcher` and `RobolectricRenderTest`'s
+   * namesake apply, reproduced against the raw semantics tree because [ImageComposeScene] has no
+   * `onAllNodes`. An index that means a different element on the two lanes would be worse than no
+   * hover at all, so the predicate is duplicated deliberately rather than approximated.
+   */
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  private fun interactiveNodes(state: SceneState): List<SemanticsNode> {
+    val root =
+      state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return emptyList()
+    val out = mutableListOf<SemanticsNode>()
+    fun walk(node: SemanticsNode) {
+      val config = node.config
+      if (
+        config.getOrNull(SemanticsActions.OnClick) != null ||
+          config.getOrNull(SemanticsActions.SetProgress) != null ||
+          config.getOrNull(SemanticsActions.SetText) != null ||
+          config.getOrNull(SemanticsActions.RequestFocus) != null
+      ) {
+        out.add(node)
+      }
+      node.children.forEach(::walk)
+    }
+    walk(root)
+    return out
+  }
+
+  /** Every node that can take focus, in traversal order — the `tabIndex` addressing space. */
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  private fun focusableNodes(state: SceneState): List<SemanticsNode> {
+    val root =
+      state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return emptyList()
+    val out = mutableListOf<SemanticsNode>()
+    fun walk(node: SemanticsNode) {
+      if (node.config.getOrNull(SemanticsActions.RequestFocus) != null) out.add(node)
+      node.children.forEach(::walk)
+    }
+    walk(root)
+    return out
+  }
+
+  @OptIn(
+    androidx.compose.ui.InternalComposeUiApi::class,
+    androidx.compose.ui.ExperimentalComposeUiApi::class,
+  )
+  private fun focusedNode(state: SceneState): SemanticsNode? {
+    val root = state.scene.semanticsOwners.firstOrNull()?.unmergedRootSemanticsNode ?: return null
+    var found: SemanticsNode? = null
+    fun walk(node: SemanticsNode) {
+      if (found != null) return
+      if (node.config.getOrNull(SemanticsProperties.Focused) == true) {
+        found = node
+        return
+      }
+      node.children.forEach(::walk)
+    }
+    walk(root)
+    return found
+  }
+
+  /**
+   * Frames for the indication the pointer event started — a Material state layer crossfade, or a
+   * ripple — to reach its resting opacity before the capture.
+   *
+   * [INTERACTION_SETTLE_FRAMES] is `FocusController.SETTLE_MS` worth of frames, which is the window
+   * both standalone renderers give the same crossfade. A capture taken mid-fade is a picture of an
+   * animation rather than of a state, and would differ from the baked PNG by however much of the
+   * fade each lane happened to catch.
+   */
+  @OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+  private fun settleInteraction(state: SceneState) {
+    repeat(INTERACTION_SETTLE_FRAMES) {
+      state.scene.render(nanoTime = state.nextVirtualFrameNanos())
+    }
+  }
+
+  /**
    * Measures the tallest vertically-scrollable node in [scene] and how far its composed content
    * reaches, or null when nothing is vertically scrollable. Used by [runScrollSvgScenario] to size
    * the full-page render by *geometry* rather than the LazyList scroll-range estimate (which is
@@ -1958,6 +2173,13 @@ class RenderEngine(
 
     /** Sub-pixel scroll movement that counts as "didn't move". */
     private const val SCROLL_SETTLED_EPSILON_PX: Float = 0.5f
+
+    /**
+     * Frames [driveStaticInteraction] lets a state-layer / ripple crossfade run for before the
+     * capture — `FocusController.SETTLE_MS` (250 ms) at [FRAME_INTERVAL_NANOS], the same window
+     * both standalone renderers give it.
+     */
+    private const val INTERACTION_SETTLE_FRAMES: Int = 15
 
     /**
      * Frames [driveStaticScrollToEnd] lets an animated `ScrollBy` run for before re-reading the

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.WallpaperOverride
 import ee.schimke.composeai.data.overrides.OverrideSeed
 import ee.schimke.composeai.data.overrides.OverrideSeedKind
+import ee.schimke.composeai.data.overrides.OverrideVariantInteraction
 import ee.schimke.composeai.data.overrides.OverrideVariantSpec
 import ee.schimke.composeai.data.overrides.PreviewOverrideValue
 import java.io.ByteArrayInputStream
@@ -157,6 +158,104 @@ class OverrideIntegrationTest {
       assertNotEquals("base and variant SVGs must not collide", baseSvg, variantSvg)
     } finally {
       host.shutdown()
+    }
+  }
+
+  /**
+   * Issue #4639 — a `_VARIANT_hovered` / `_VARIANT_pressed` preview must export the state it names,
+   * not the resting one.
+   *
+   * The seed half of an `@OverrideVariant` reaches the composition as data (#4638). An interaction
+   * does not: it is something the render **host** has to do to the scene, and the daemon's
+   * one-frame-per-id path did nothing at all — so every published catalog's hovered / focused /
+   * pressed vectors were byte-identical to their base beside a correct PNG.
+   *
+   * [InteractionStateSquare] paints red / blue / green off the interaction source it hands
+   * `Modifier.clickable`, so these assertions fail unless a real pointer event reached that source.
+   * Driven through [PreviewManifestRouter] — the production lane on this backend — so the whole
+   * chain is under test: manifest entry → `toPreviewOverrides` → routed payload → engine drive.
+   */
+  @Test
+  fun interactionVariantsExportTheStateTheyName() {
+    val outputDir = tempFolder.newFolder("renders-interaction-variants")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val previewsJson = tempFolder.newFile("previews-interaction.json")
+    val baseId = "InteractionSquare_Light"
+    val hoveredId = "InteractionSquare_Light_VARIANT_hovered"
+    val focusedId = "InteractionSquare_Light_VARIANT_focused"
+    val pressedId = "InteractionSquare_Light_VARIANT_pressed"
+    // `staticHoverFor` reads the hover intent off the preview index, so the engine needs one on
+    // disk — the same sysprop the gradle plugin sets on a production daemon JVM.
+    previewsJson.writeText(
+      """
+      {"previews":[
+        {"id":"$baseId","functionName":"InteractionStateSquare",
+         "className":"ee.schimke.composeai.daemon.RedFixturePreviewsKt"},
+        {"id":"$hoveredId","functionName":"InteractionStateSquare",
+         "className":"ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+         "overrides":{"name":"hovered","seeds":[],"interaction":"Hovered"}},
+        {"id":"$focusedId","functionName":"InteractionStateSquare",
+         "className":"ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+         "overrides":{"name":"focused","seeds":[],"interaction":"Focused"}},
+        {"id":"$pressedId","functionName":"InteractionStateSquare",
+         "className":"ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+         "overrides":{"name":"pressed","seeds":[],"interaction":"Pressed"}}
+      ]}
+      """
+        .trimIndent()
+    )
+    val previousPreviewsJson = System.getProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+    System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previewsJson.absolutePath)
+    fun entry(id: String, interaction: OverrideVariantInteraction? = null) =
+      PreviewManifestEntry(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "InteractionStateSquare",
+        widthPx = 32,
+        heightPx = 32,
+        density = 1.0f,
+        outputBaseName = id,
+        overrides =
+          interaction?.let { OverrideVariantSpec(name = it.name.lowercase(), interaction = it) },
+      )
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                entry(baseId),
+                entry(hoveredId, OverrideVariantInteraction.Hovered),
+                entry(focusedId, OverrideVariantInteraction.Focused),
+                entry(pressedId, OverrideVariantInteraction.Pressed),
+              )
+          ),
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(
+                listOf(PreviewOverridesPreviewOverrideExtension(), FocusPreviewOverrideExtension())
+              )
+          ),
+      )
+    host.start()
+    try {
+      for (id in listOf(baseId, hoveredId, focusedId, pressedId)) {
+        host.submit(RenderRequest.Render(payload = "previewId=$id"), timeoutMs = 60_000)
+      }
+      val dataDir = outputDir.parentFile!!.resolve("data")
+      fun svg(id: String) = dataDir.resolve(id).resolve("compose-figma.svg").readText()
+      assertTrue("resting export must stay red", svg(baseId).contains("#EF5350"))
+      assertTrue("hovered export must be blue", svg(hoveredId).contains("#42A5F5"))
+      assertTrue("focused export must be orange", svg(focusedId).contains("#FFA726"))
+      assertTrue("pressed export must be green", svg(pressedId).contains("#66BB6A"))
+    } finally {
+      host.shutdown()
+      if (previousPreviewsJson == null) {
+        System.clearProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP)
+      } else {
+        System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previousPreviewsJson)
+      }
     }
   }
 

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -2,8 +2,14 @@ package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -1686,3 +1692,41 @@ fun TimedRevealPreview() {
 
 /** When [TimedRevealPreview]'s square lands, in milliseconds of composition time. */
 const val TIMED_REVEAL_DELAY_MS: Long = 200L
+
+/**
+ * A clickable square that paints its own **interaction state**: red at rest, blue hovered, green
+ * pressed.
+ *
+ * The fixture for `@OverrideVariant(interaction = …)` on the daemon lane. It reads
+ * `collectIsHoveredAsState` / `collectIsPressedAsState` off the interaction source it hands
+ * `Modifier.clickable`, so the colour flips only when a **real** pointer event reaches that source
+ * — the harness has to actually deliver the hover or the press. That is the distinction issue #3672
+ * drew: a fixture that emitted into the interaction source itself would report a state layer
+ * whether or not the component could receive the state, and would pass against a renderer that
+ * drives nothing.
+ *
+ * A colour rather than a Material state layer because the assertion is about *whether* the state
+ * arrived, and an 8%-alpha overlay in an exported vector is a much weaker signal than a fill that
+ * changed outright. Pinned by [OverrideIntegrationTest.interactionVariantsExportTheStateTheyName].
+ */
+@Composable
+fun InteractionStateSquare() {
+  val interactionSource = remember { MutableInteractionSource() }
+  val hovered by interactionSource.collectIsHoveredAsState()
+  val pressed by interactionSource.collectIsPressedAsState()
+  val focused by interactionSource.collectIsFocusedAsState()
+  val fill =
+    when {
+      pressed -> Color(0xFF66BB6A)
+      hovered -> Color(0xFF42A5F5)
+      focused -> Color(0xFFFFA726)
+      else -> Color(0xFFEF5350)
+    }
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(fill).hoverable(interactionSource).clickable(
+        interactionSource = interactionSource,
+        indication = null,
+      ) {}
+  )
+}

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -13,8 +13,12 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -101,7 +105,22 @@ private fun ScrollAxis.toProductAxis(): ProductScrollAxis =
     ScrollAxis.HORIZONTAL -> ProductScrollAxis.HORIZONTAL
   }
 
-private fun driveHover(rule: AndroidComposeTestRule<*, ComponentActivity>, targetIndex: Int) {
+/**
+ * `@OverrideVariant(interaction = Hovered)` — move a mouse onto the [targetIndex]-th interactive
+ * node and let its state layer settle. Returns whether a target was found.
+ *
+ * Public because the **daemon** needs the same drive (issue #4639), and calls this rather than
+ * growing a second copy: a copy is what would let the two lanes disagree about which node index 0
+ * names, and the whole point of an index is that both lanes resolve it the same way.
+ *
+ * A hover is positional input with no in-composition half at all — no input-mode flip, no manager
+ * to walk — so unlike focus it never had a `renderNow.overrides` field, and only the render host
+ * can synthesise it. See [driveFocusPreview] for the other two.
+ */
+public fun driveHoverPreview(
+  rule: AndroidComposeTestRule<*, ComponentActivity>,
+  targetIndex: Int,
+): Boolean {
   val targets = rule.onAllNodes(interactiveNodeMatcher()).fetchSemanticsNodes()
   val target = targets.getOrNull(targetIndex)
   if (target == null) {
@@ -109,7 +128,7 @@ private fun driveHover(rule: AndroidComposeTestRule<*, ComponentActivity>, targe
       "@OverrideVariant hover: no interactive node at index $targetIndex; " +
         "capturing the undriven state."
     )
-    return
+    return false
   }
   val bounds = target.boundsInRoot
   val x = bounds.center.x
@@ -139,7 +158,69 @@ private fun driveHover(rule: AndroidComposeTestRule<*, ComponentActivity>, targe
   }
   org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
     .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+  return true
 }
+
+/**
+ * `@OverrideVariant(interaction = Focused | Pressed)` — put focus on the [tabIndex]-th focusable
+ * node and, for a pressed variant, hold a pointer down on it. Returns whether focus landed.
+ *
+ * **Why the host does this and not `FocusOverrideExtension`.** The connector's `LaunchedEffect`
+ * walk (`moveFocus(Enter)` then N × `Next`) is the documented daemon path for
+ * `renderNow.overrides.focus`, and it does not land inside a daemon render on either backend — the
+ * probe for issue #4639 found the target node reporting `Focused=false` after forty frames on
+ * desktop, and the android daemon renders the resting state too. A `FocusRequester` on the same
+ * node in the same scene lands immediately, so what fails is the traversal, not focus itself. This
+ * addresses the node instead: `requestFocus()` on the index, which is a public semantics action and
+ * cannot be defeated by whatever leaves the root focus node inactive.
+ *
+ * The extension is still required and still installed — it provides `LocalInputModeManager` in
+ * keyboard mode, without which `Focusability.SystemDefined` refuses focus outright and the
+ * indication never draws. Only the *targeting* moves out here.
+ *
+ * The press is a touch down that is never released: releasing it would end the press before the
+ * capture and catch the ripple mid-retreat, and the held state is the one a "pressed" sticker
+ * exists to show. Touch rather than mouse because a mouse press also raises
+ * `HoverInteraction.Enter`. Both choices match `:renderer-desktop`'s `renderFocusPreview`.
+ */
+public fun driveFocusPreview(
+  rule: AndroidComposeTestRule<*, ComponentActivity>,
+  tabIndex: Int,
+  pressed: Boolean,
+): Boolean {
+  val focusables = rule.onAllNodes(focusableNodeMatcher()).fetchSemanticsNodes()
+  if (tabIndex !in focusables.indices) {
+    System.err.println(
+      "@OverrideVariant focus: no focusable node at index $tabIndex; capturing the undriven state."
+    )
+    return false
+  }
+  rule.onAllNodes(focusableNodeMatcher())[tabIndex].requestFocus()
+  rule.waitForIdle()
+  org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+    .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+  // Verify rather than assume: a component can refuse focus, and publishing a "focused" sticker of
+  // one that declined is the plausible-but-wrong picture this change exists to remove.
+  if (rule.onAllNodes(isFocused()).fetchSemanticsNodes().isEmpty()) {
+    System.err.println(
+      "@OverrideVariant focus: nothing took focus at index $tabIndex; capturing the undriven state."
+    )
+    return false
+  }
+  if (pressed) {
+    rule.onAllNodes(isFocused()).onFirst().performTouchInput { down(center) }
+    rule.waitForIdle()
+    org.robolectric.Shadows.shadowOf(android.os.Looper.getMainLooper())
+      .idleFor(java.time.Duration.ofMillis(FocusController.SETTLE_MS))
+  }
+  return true
+}
+
+/** The `tabIndex` addressing space: every node that can take focus, in traversal order. */
+private fun focusableNodeMatcher() =
+  SemanticsMatcher("can take focus") { node ->
+    node.config.getOrNull(SemanticsActions.RequestFocus) != null
+  }
 
 private fun interactiveNodeMatcher() =
   SemanticsMatcher("has an interactive action") { node ->
@@ -1870,7 +1951,7 @@ abstract class RobolectricRenderTestBase(
             // it would combine Hovered and Pressed, and focusing merely to find the target would
             // combine Hovered and Focused.
             capture?.hover?.let { hover ->
-              driveHover(rule, hover.targetIndex)
+              driveHoverPreview(rule, hover.targetIndex)
               rule.mainClock.advanceTimeBy(FocusController.SETTLE_MS)
               currentTime += FocusController.SETTLE_MS
             }


### PR DESCRIPTION
Closes #4639 — the half of #3616 that #4638 left. Reported as [yschimke/m3-catalog#201](https://github.com/yschimke/m3-catalog/issues/201).

## What was wrong

A `_VARIANT_hovered` / `_VARIANT_focused` / `_VARIANT_pressed` preview exported its **resting** state on both backends. On the published `m3-catalog` branch every one of those vectors is byte-identical to the base beside a correct PNG — the PNG comes from the standalone renderer, which drives the interaction itself.

#4638 fixed the *seed* half: `state=disabled` is data, so it rides `namedOverrides` and the composable reads it. An interaction is not data — it is something that has to be done **to** the composition — and the daemon's one-frame-per-id path did nothing at all. `PreviewCaptureDto` says so in as many words: it mirrors only `scroll` and `settle`, because every other field on the plugin's `Capture` "drives outputs the daemon's one-frame-per-id surface doesn't produce".

## What changed

**One home for the variant translation.** `OverrideVariantSpec.toPreviewOverrides` in `:daemon:core` replaces four inline copies of `overrides?.toNamedOverrides()` — `renderSpecFromInfo` and `PreviewManifestEntry.resolved`, on each backend — and folds the interaction in beside the seeds. Those four copies are exactly how #3652 landed the seed half on android alone and left desktop broken for two weeks; a translation with one home cannot land on half the backends.

**Focus and press are host-driven, not walked.** `FocusOverrideExtension` is still required and still installed: it flips `LocalInputModeManager` to keyboard mode from inside composition, and without that `Focusability.SystemDefined` refuses focus outright. What it does *not* manage is landing the walk — `moveFocus(Enter)` + N × `Next` takes on neither backend inside a daemon render. A probe left the target reporting `Focused=false` after forty frames in an `ImageComposeScene`, while a `FocusRequester` on that same node in that same scene landed on the first frame, so what fails is the traversal and not focus itself. Both engines now address the node through the public `SemanticsActions.RequestFocus` — the same way the `@ScrollingPreview(END)` drive already reaches `SemanticsActions.ScrollBy` — and press is a held touch on whatever took focus.

That also means `renderNow.overrides.focus` works on the daemon lane for the first time, for every caller, not just for variants.

**Hover is host-driven end to end.** It has no in-composition half — no input-mode flip, no manager to walk — so it never had an overrides field and there is nothing on the wire to carry it. Each engine reads the intent off the preview index (`PreviewIndex.staticHoverFor`), exactly as the scroll drive does. Android calls `:renderer-android`'s `driveHoverPreview`, promoted from private rather than copied: a copy is how the two lanes would come to disagree about which node index 0 names.

Three deliberate choices, all matching `:renderer-desktop`'s `renderFocusPreview` so the daemon and the baked PNG describe the same picture:

- press is a **touch**, not a mouse — a mouse press also raises `HoverInteraction.Enter`, and a sticker labelled "pressed" should not be documenting hover as well;
- the pointer is **never released** — a release would catch the ripple mid-retreat, and the held state is the one the render exists to show;
- a pressed variant is focused **and** pressed, because that is what discovery hands the standalone renderers (`FocusCapture(tabIndex, pressed = true)`).

Every failure declines with a reason on stderr rather than falling back. A sticker of a component that refused the state is a plausible-but-wrong picture, and harder to notice than the honest duplicate it replaces.

## Test plan

A new fixture on each backend — `InteractionStateSquare`, red at rest / blue hovered / orange focused / green pressed — reads its colours off the interaction source it hands `Modifier.clickable`, so a colour appears only when a **real** event reaches that source. That is the distinction #3672 drew: a fixture that emitted into the source itself would pass against a renderer that drives nothing.

- `:daemon:desktop` — `OverrideIntegrationTest.interactionVariantsExportTheStateTheyName` renders base + all three variants through `PreviewManifestRouter` (the production lane) and asserts on the exported `compose-figma.svg`, which is the artifact the issue is about.
- `:daemon:android` — `OverrideIntegrationTest.interactionVariantsRenderTheStateTheyName` does the same and asserts on the rendered pixels, matching that file's idiom and the stronger assertion of the two, since every structured product is projected from the composition those pixels came from.

Both fail on `main`: I built the desktop test up in stages against the unfixed engine and watched hovered pass while focused and pressed stayed red, which is what surfaced the `moveFocus` finding above rather than my assuming the walk worked.

```
./gradlew :daemon:core:test :daemon:desktop:test :renderer-android:test          # BUILD SUCCESSFUL
./gradlew :daemon:android:testDebugUnitTest                                      # BUILD SUCCESSFUL (full suite, 12m)
./gradlew :daemon:core:ktfmtCheckMain :daemon:desktop:ktfmtCheck* :daemon:android:ktfmtCheck* :renderer-android:ktfmtCheckMain
```

Text-only PR body is correct here: nothing in this repo's own rendered surfaces changes. The visible effect is on consumers' delivery branches and needs a release plus a version bump before it can be captured — m3-catalog's `figma/button-filled/ideal__{hovered,focused,pressed}.svg` are the pixels this is for.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7nWo74vAVUg2rURVm3y3m)_