### PR TITLE
fix(ci): schedule the contract probe for agent-grant-protocol sources

### DIFF
--- a/.github/ci/ci-paths.json
+++ b/.github/ci/ci-paths.json
@@ -136,6 +136,7 @@
       "api/preview-data-api/**",
       "common/io/**",
       "common/image-crop/**",
+      "api/agent-grant-protocol/**",
       "render-session/**",
       "data/layoutinspector/core/**",
       "data/preview-overrides/core/**",


### PR DESCRIPTION
**`main` is red.** `Actions Script Tests` fails on every PR until this lands.

## The failure

#4648 added `:agent-grant-protocol` to `CONTRACT_PROJECTS` in `scripts/check-preview-server-contracts.sh` without adding a path covering its sources to `groups.preview_server_contracts` in `.github/ci/ci-paths.json`, so `RepositoryConfigsTest.test_every_contract_project_reaches_the_probe_job` fails:

```
AssertionError: Lists differ: [':agent-grant-protocol (api/agent-grant-protocol)'] != []
  : contract project(s) whose sources do not schedule preview-server-contracts:
    :agent-grant-protocol (api/agent-grant-protocol)
```

Reproduced on `main` at `3568d90ffe` before touching anything, and confirmed green after.

I found it as a red check on my own #4649 (`Actions Script Tests`, head `c0375a034`) — that PR's diff is `deploy/image/*` only, so it was inherited, and it merged with the check red, which is why `main` carries it now.

## The fix

One path, `api/agent-grant-protocol/**`, inserted where the group already follows `CONTRACT_PROJECTS`' own order (right after `common/image-crop/**`, matching the script).

Same shape as the `common/image-crop` gap #4634 closed a few hours earlier, and the guard exists for the consequence rather than the tidiness: without the path, a later PR touching only that module skips `preview-server-contracts` — the sole job that publishes the contract and resolves it from the separate `preview-server` build — so a break in the published surface would land green. The two lists are checked against each other by the build itself; the CI path group is not, which is what this test is for.

## Test plan

- `python3 .github/ci/test_path_scope.py` — **22 tests, OK** (was `FAILED (failures=1)` on `main`)
- `python3 -c "import json; json.load(open('.github/ci/ci-paths.json'))"` — parses
- `python3 scripts/test_check_serve_seam.py` — OK, unaffected

The guard's own self-test, `test_a_contract_added_without_a_path_is_caught`, still passes — it asserts the check fails when a contract is missing its path, so it proves this fix is not just silencing the assertion.

Non-visual: one CI path-scope entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_