### PR TITLE
fix(deploy): size the live-seat budget from the CPU quota, not just nproc

### DIFF
--- a/deploy/image/docker-compose.yml
+++ b/deploy/image/docker-compose.yml
@@ -319,11 +319,14 @@ services:
     # Container memory limit. Default UNBOUNDED (0 = no cgroup cap) so the box's full RAM is
     # available and the live-seat budget auto-sizes to it: the entrypoint reads the container's
     # memory limit and, finding none, falls back to physical RAM (~1 GB reserved for the host,
-    # ~1.2 GB per live-seat permit, clamped [2, 8]). So a bigger dedicated box scales on its own —
-    # redeploy and it uses the whole machine, no compose edit. Admission control (the live-seat
-    # budget + the per-render concurrency limiter) is the memory guard here, not a hard cgroup kill.
-    # Set PREVIEW_MEM_LIMIT in .env (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap it on a shared host, which
-    # also lowers the derived seat budget to match.
+    # ~1.2 GB per live-seat permit). It sizes from CPU as well and takes the smaller of the two —
+    # 2 permits per core, from the cgroup CPU quota where one is set rather than from `nproc`,
+    # which reports the host's cores inside a `--cpus`-constrained container. Clamped [2, 32].
+    # So a bigger dedicated box scales on its own — redeploy and it uses the whole machine, no
+    # compose edit. Admission control (the live-seat budget + the per-render concurrency limiter)
+    # is the memory guard here, not a hard cgroup kill. Set PREVIEW_MEM_LIMIT in .env (e.g.
+    # `PREVIEW_MEM_LIMIT=4g`) to cap it on a shared host, which also lowers the derived seat budget
+    # to match; `cpus:` (or `--cpus`) now lowers it too.
     mem_limit: "${PREVIEW_MEM_LIMIT:-0}"
     # Readiness gate for the rolling update. docker-rollout (driven by the `rollout`
     # service) waits for a freshly-started replica to report `healthy` BEFORE it

--- a/deploy/image/entrypoint.sh
+++ b/deploy/image/entrypoint.sh
@@ -316,6 +316,49 @@ derive_live_seats() {
   echo "${seats}"
 }
 
+# The CPU budget this container may actually use.
+#
+# `nproc` does not answer that. It reports the processors *visible* to this process — the affinity
+# mask — so a container constrained with `docker --cpus 2` (or any equivalent CFS quota) that has
+# not also had its cpuset narrowed reports the host's core count. On a 16-core host that derived up
+# to the 32-seat ceiling for a container entitled to two CPUs' worth of work, which is the same
+# class of mistake as sizing from memory alone: a budget the box cannot work.
+#
+# So read the quota the way the memory path already reads its limit, and take the tighter of the
+# two. cgroup v2 puts `<quota|max> <period>` in one file; v1 splits it across two, with `-1` for
+# unlimited. Anything unreadable or non-numeric — including the literal `max` — leaves the visible
+# count as the answer, which is the pre-existing behaviour and the right one when the input is
+# missing rather than permissive.
+#
+# The file paths are parameters so the tests can drive both cgroup versions without a container.
+effective_cpus() {
+  local visible="${1:-0}" quota="" period="" quota_cpus=0
+  local v2="${CPU_MAX_FILE:-/sys/fs/cgroup/cpu.max}"
+  local v1_quota="${CPU_QUOTA_FILE:-/sys/fs/cgroup/cpu/cpu.cfs_quota_us}"
+  local v1_period="${CPU_PERIOD_FILE:-/sys/fs/cgroup/cpu/cpu.cfs_period_us}"
+  if [[ -r "${v2}" ]]; then
+    read -r quota period < "${v2}" 2>/dev/null || true
+  elif [[ -r "${v1_quota}" && -r "${v1_period}" ]]; then
+    quota="$(cat "${v1_quota}" 2>/dev/null || true)"
+    period="$(cat "${v1_period}" 2>/dev/null || true)"
+  fi
+  if [[ "${quota}" =~ ^[0-9]+$ && "${period}" =~ ^[0-9]+$ ]] && (( period > 0 )); then
+    # Rounded DOWN, then floored at 1. Down because this figure exists to BOUND the budget and the
+    # smaller answer is the safe one; floored at 1 because a sub-single-CPU quota is still a
+    # container that renders, and 0 would read as "unknown" and be ignored entirely. The seat floor
+    # in `derive_live_seats` is what actually decides the low end.
+    quota_cpus=$(( quota / period ))
+    (( quota_cpus < 1 )) && quota_cpus=1
+  fi
+  if (( quota_cpus > 0 && visible > 0 && quota_cpus < visible )); then
+    echo "${quota_cpus}"
+  elif (( quota_cpus > 0 && visible <= 0 )); then
+    echo "${quota_cpus}"
+  else
+    echo "${visible}"
+  fi
+}
+
 # When SERVE_LIVE_SEATS is unset we AUTO-DERIVE the budget from the box: reserve ~1 GB for the serve
 # host + OS, budget ~1.2 GB of headroom per permit, and take the SMALLER of what memory affords and
 # what the CPUs afford.
@@ -360,10 +403,14 @@ if [[ -z "${SERVE_LIVE_SEATS:-}" ]]; then
   else
     eff_mb=${mem_total_mb}
   fi
-  cpus=$(nproc 2>/dev/null || echo 0)
+  visible_cpus=$(nproc 2>/dev/null || echo 0)
+  # The quota, not just the affinity mask — see [effective_cpus].
+  cpus="$(effective_cpus "${visible_cpus}")"
   SERVE_LIVE_SEATS="$(derive_live_seats "${eff_mb}" "${cpus}")"
+  quota_note=""
+  (( cpus < visible_cpus )) && quota_note=" quota-limited from ${visible_cpus}"
   echo "entrypoint: auto live-seat budget ${SERVE_LIVE_SEATS}" \
-    "(effective mem ${eff_mb} MB, ${cpus} cpus)" >&2
+    "(effective mem ${eff_mb} MB, ${cpus} cpus${quota_note})" >&2
 fi
 [[ -n "${SERVE_LIVE_SEATS}" ]] && args+=(--live-seats "${SERVE_LIVE_SEATS}")
 # Background (theme-optimizer) renders admitted at once, server-wide. Unset leaves the server's own

--- a/deploy/image/test-derive-live-seats.sh
+++ b/deploy/image/test-derive-live-seats.sh
@@ -13,10 +13,13 @@ entrypoint="${ENTRYPOINT_FILE:-${here}/entrypoint.sh}"
 # Pull just the constants and the function out, so this exercises the real arithmetic without
 # running an entrypoint that expects to be inside the container.
 eval "$(sed -n '/^SEATS_PER_CPU=/,/^}$/p' "${entrypoint}")"
-declare -F derive_live_seats >/dev/null || {
-  echo "FAIL: derive_live_seats not found in ${entrypoint} — the extractor is broken." >&2
-  exit 1
-}
+eval "$(sed -n '/^effective_cpus() {$/,/^}$/p' "${entrypoint}")"
+for fn in derive_live_seats effective_cpus; do
+  declare -F "${fn}" >/dev/null || {
+    echo "FAIL: ${fn} not found in ${entrypoint} — the extractor is broken." >&2
+    exit 1
+  }
+done
 
 check() { # eff_mb cpus expected why
   local got; got="$(derive_live_seats "$1" "$2")"
@@ -61,3 +64,74 @@ check 8192 0 5 "an unknown core count on a small box matches the old derivation"
 check 0 8 2 "unknown memory falls back to the floor, not a negative"
 
 echo "PASS: all derive_live_seats checks"
+
+# ---------------------------------------------------------------------------------------------
+# effective_cpus: the quota, not just the affinity mask.
+# ---------------------------------------------------------------------------------------------
+#
+# `nproc` reports the processors VISIBLE to this process. A container constrained with
+# `docker --cpus 2` whose cpuset was not also narrowed sees the host's cores, so a 16-core host
+# derived up to the 32-seat ceiling for a container entitled to two CPUs' worth of work — the same
+# class of mistake as sizing from memory alone.
+
+cpu_tmp="$(mktemp -d)"
+trap 'rm -rf "${cpu_tmp}"' EXIT
+
+cpucheck() { # expected visible why
+  local got; got="$(effective_cpus "$2")"
+  [[ "${got}" == "$1" ]] || {
+    echo "FAIL: ${3} — visible ${2} gave ${got}, expected ${1}" >&2
+    exit 1
+  }
+  echo "PASS: ${3} (visible ${2} -> ${got})"
+}
+
+# cgroup v2, the case from the review: cpu.max "200000 100000" is 2 CPUs, with 3 visible.
+printf '200000 100000\n' > "${cpu_tmp}/cpu.max"
+CPU_MAX_FILE="${cpu_tmp}/cpu.max" cpucheck 2 3 "a v2 quota bounds the visible count"
+CPU_MAX_FILE="${cpu_tmp}/cpu.max" cpucheck 2 16 "and bounds a big host just as hard"
+
+# A quota LOOSER than the affinity mask must not inflate the answer.
+printf '3200000 100000\n' > "${cpu_tmp}/cpu.wide"
+CPU_MAX_FILE="${cpu_tmp}/cpu.wide" cpucheck 4 4 "a quota wider than the cores changes nothing"
+
+# `max` is unlimited, not a number — the visible count stands.
+printf 'max 100000\n' > "${cpu_tmp}/cpu.unlimited"
+CPU_MAX_FILE="${cpu_tmp}/cpu.unlimited" cpucheck 8 8 "an unlimited v2 quota leaves nproc alone"
+
+# Sub-single-CPU quota floors at 1 rather than reading as unknown and being ignored.
+printf '50000 100000\n' > "${cpu_tmp}/cpu.half"
+CPU_MAX_FILE="${cpu_tmp}/cpu.half" cpucheck 1 8 "half a CPU floors at 1, it does not vanish"
+
+# cgroup v1 splits it across two files, with -1 for unlimited.
+printf '200000\n' > "${cpu_tmp}/quota"
+printf '100000\n' > "${cpu_tmp}/period"
+CPU_MAX_FILE="${cpu_tmp}/absent" CPU_QUOTA_FILE="${cpu_tmp}/quota" CPU_PERIOD_FILE="${cpu_tmp}/period" \
+  cpucheck 2 6 "a v1 quota is read too"
+printf -- '-1\n' > "${cpu_tmp}/quota-unlimited"
+CPU_MAX_FILE="${cpu_tmp}/absent" CPU_QUOTA_FILE="${cpu_tmp}/quota-unlimited" CPU_PERIOD_FILE="${cpu_tmp}/period" \
+  cpucheck 6 6 "an unlimited v1 quota leaves nproc alone"
+
+# No cgroup files at all — a developer laptop, and the pre-existing behaviour.
+CPU_MAX_FILE="${cpu_tmp}/absent" CPU_QUOTA_FILE="${cpu_tmp}/absent" CPU_PERIOD_FILE="${cpu_tmp}/absent" \
+  cpucheck 4 4 "no cgroup files leaves the visible count untouched"
+
+# A garbled file is missing input, not permission to invent a number.
+printf 'not-a-quota\n' > "${cpu_tmp}/cpu.garbage"
+CPU_MAX_FILE="${cpu_tmp}/cpu.garbage" cpucheck 4 4 "an unparseable quota is ignored"
+
+# End to end: the quota is what reaches the seat budget. 16 visible cores would have derived the
+# 32-seat ceiling on a RAM-rich box; a 2-CPU quota derives 4.
+seats_visible="$(derive_live_seats 49152 16)"
+seats_quota="$(derive_live_seats 49152 "$(CPU_MAX_FILE="${cpu_tmp}/cpu.max" effective_cpus 16)")"
+[[ "${seats_visible}" == "32" ]] || {
+  echo "FAIL: 16 visible cores on a 48 GB box should reach the ceiling, got ${seats_visible}" >&2
+  exit 1
+}
+[[ "${seats_quota}" == "4" ]] || {
+  echo "FAIL: a 2-CPU quota should derive 4 seats, got ${seats_quota}" >&2
+  exit 1
+}
+echo "PASS: the quota reaches the seat budget (32 -> 4 on a 2-CPU quota)"
+
+echo "PASS: all effective-cpu checks"

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -4005,15 +4005,26 @@ hog a single seat and starve the cheap `compose-m3` CMP lanes. A session that ca
 is refused with WebSocket close `1013` (*Try Again Later*) instead of spawning a daemon that risks
 the OOM killer; `0` is unbounded, and snapshot + Wasm sessions never consume a permit.
 
-**Auto-sizing.** When `SERVE_LIVE_SEATS` is unset, the prebuilt image derives the budget from the
-container's memory (reserve ~1 GB for the host + OS, ~1.2 GB per permit, clamped to **[2, 8]**), so a
-bigger box scales up on its own with no compose edit: an 8 GB box gets **5** permits, a 4 GB box gets
-**2** (two concurrent CMP sessions, or one Android). `preview.coo.ee` runs on an **8 GB host**, so it
-derives **5** permits — enough for the heavier Wear/Android daemon (2 permits) plus concurrent CMP
-lanes. The `preview` container is **unbounded by default** (`mem_limit: ${PREVIEW_MEM_LIMIT:-0}`), so
-it uses the box's full RAM and the entrypoint
-falls back to physical RAM when there's no cgroup cap — redeploy onto a larger dedicated box and it
-scales automatically. Admission control (the live-seat budget + the per-render concurrency limiter)
+**Auto-sizing.** When `SERVE_LIVE_SEATS` is unset, the prebuilt image derives the budget from
+**both** memory and CPU and takes the smaller: memory affords `(effective MB − 1024) / 1200` permits
+(~1 GB reserved for the host + OS, ~1.2 GB per permit), CPU affords **2 per core** (one Android
+daemon per core, since Android costs two permits and is the heaviest backend), and the result is
+clamped to **[2, 32]**. A 4 GB box gets **2** (two concurrent CMP sessions, or one Android); an 8 GB
+/ 4-core box gets **5**, memory governing; a 48 GB / 8-core box gets **16**, the cores governing.
+
+Memory alone was the wrong input, and so is `nproc` alone. A permit buys a render daemon and a
+render is CPU-bound, so a RAM-rich, core-poor box derived a budget it could not work — and the old
+`[2, 8]` clamp meant a large box stopped scaling entirely. The CPU figure is the **cgroup quota**
+where one is set, not the visible core count: `nproc` reports the processors visible to the process,
+so a container constrained with `docker --cpus 2` whose cpuset was not also narrowed reports the
+host's cores. The entrypoint reads `cpu.max` (cgroup v2) or `cpu.cfs_quota_us`/`cpu.cfs_period_us`
+(v1) and takes the tighter of quota and `nproc`; an absent, unlimited or unparseable quota leaves
+the visible count as the answer. The startup line says which applied — `8 cpus quota-limited from
+16` when the quota bound it.
+
+The `preview` container is **unbounded by default** (`mem_limit: ${PREVIEW_MEM_LIMIT:-0}`), so it
+uses the box's full RAM and the entrypoint falls back to physical RAM when there's no cgroup cap —
+redeploy onto a larger dedicated box and it scales automatically. Admission control (the live-seat budget + the per-render concurrency limiter)
 is the memory guard, rather than a hard cgroup kill. On a **shared** host, set `PREVIEW_MEM_LIMIT` in
 `.env` (e.g. `PREVIEW_MEM_LIMIT=4g`) to cap the container — which also lowers the derived seat budget
 to match. Set `SERVE_LIVE_SEATS` explicitly to override the budget directly, or `0` for unbounded.


### PR DESCRIPTION
Closes the two unaddressed review findings left on #4637 after it merged.

## `nproc` is not the CPU budget (P2, but it re-opens the bug #4637 fixed)

`nproc` reports the processors **visible** to the process — the affinity mask — not what the container may use. A container constrained with `docker --cpus 2`, or any equivalent CFS quota, whose cpuset was *not* also narrowed reports the host's core count. On a 16-core host that derived up to the **32-seat ceiling for a container entitled to two CPUs' worth of work**.

That is the same class of mistake #4637 set out to fix. Its own reasoning — "a permit buys a render daemon and a render is CPU-bound, so a RAM-rich, core-poor box derives a budget it cannot work" — applies unchanged to a quota-constrained box, which is core-poor in every way that matters and reports otherwise.

`effective_cpus` reads the quota the way the memory path beside it already reads its limit:

| source | file | unlimited sentinel |
| --- | --- | --- |
| cgroup v2 | `cpu.max` — `"<quota\|max> <period>"` | `max` |
| cgroup v1 | `cpu.cfs_quota_us` + `cpu.cfs_period_us` | `-1` |

and takes the tighter of quota and `nproc`. An absent, unlimited or unparseable quota leaves the visible count as the answer — the pre-existing behaviour, and the right one when the input is missing rather than permissive.

The quota is rounded **down** and floored at **1**: down because this figure exists to *bound* the budget and the smaller answer is the safe one; floored because a sub-single-CPU quota is still a container that renders, and `0` would read as "unknown" and be ignored entirely. The seat floor in `derive_live_seats` still decides the low end.

The startup line says when it applied: `(effective mem 49152 MB, 2 cpus quota-limited from 16)`.

## Two operator-facing descriptions still stated the pre-#4637 rule (P2)

`docs/public-preview-server.md:4009` said sizing was memory alone, "clamped to **[2, 8]**"; `deploy/image/docker-compose.yml:319-327` repeated the same formula. An operator following either would calculate the wrong capacity and add overrides they do not need. Both now state the smaller-of-two rule, the `[2, 32]` clamp, and the quota behaviour — including that `cpus:` now lowers the derived budget the way `PREVIEW_MEM_LIMIT` already did.

## Test plan

Nine checks added to `test-derive-live-seats.sh`, driving both cgroup versions through injected file paths (`CPU_MAX_FILE`, `CPU_QUOTA_FILE`, `CPU_PERIOD_FILE`) so no container is needed:

- a v2 quota bounds a larger visible count (`200000 100000` with 3 visible → 2; with 16 visible → 2)
- a quota **wider** than the cores changes nothing
- `max` (v2) and `-1` (v1) leave `nproc` alone
- half a CPU floors at 1 rather than vanishing
- v1's two-file form is read
- no cgroup files at all — a developer laptop — leaves the visible count untouched
- an unparseable file is ignored, not invented from
- **end to end**: 16 visible cores on a 48 GB box derive the 32-seat ceiling; the same box under a 2-CPU quota derives **4**

Verified non-vacuous by pointing the suite at the pre-fix entrypoint (`ENTRYPOINT_FILE=…`), which fails immediately — `effective_cpus` does not exist there. The eight existing `derive_live_seats` checks are untouched and still pass, including the two that pin #4637's own behaviour (the old 8-seat clamp is gone; a RAM-rich box is bounded by cores).

Also run: `test-env-redundant.sh`, `test-env-migrations.sh`, `test-compose-env-passthrough.sh` — all OK; `bash -n` on both changed scripts; the compose file parses as YAML.

Non-visual: a capacity derivation and its documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_