### PR TITLE
test(serve): assert the escaped provenance the lane actually emits

### DIFF
--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -1530,7 +1530,7 @@ class ServeWebTest {
       "the sibling's own render is same-origin on this server: $html",
     )
     assertTrue(
-      html.contains("under that catalog's theme and knobs"),
+      html.contains("under that catalog&#39;s theme and knobs"),
       "the panel says whose render it is, rather than implying symmetry: $html",
     )
     // The kit leads, so the pair the lane opens on does not move for a paired catalog.


### PR DESCRIPTION
## main is red, and it is mine

`ServeWebTest.the spec lane offers the compareWith sibling as a second source` fails on `origin/main`. Reproduced on a clean checkout of the current tip:

```
$ ./gradlew :cli:serve:test --tests "*ServeWebTest*"
65 tests completed, 1 failed
```

Introduced by #4652.

## What is wrong — the assertion, not the markup

The test asserts the panel names whose render it is showing. It looked for the raw apostrophe:

```kotlin
html.contains("under that catalog's theme and knobs")
```

But `data-spec-provenance` is HTML-escaped like every other attribute the lane writes, so what is actually emitted — correctly — is:

```html
data-spec-provenance="wear-m3-catalog&#39;s own render, under that catalog&#39;s theme and knobs."
```

So the markup was right and the assertion was not. The escaped form is also the better thing to assert: matching the raw text would only pass if the escaping had gone missing, which is precisely the regression worth catching.

One line. The raw string on line 1522 is the test's *input* and stays as it is.

## How it reached main

I caught this locally and pushed the fix to the PR branch, but #4652 was squash-merged in between, so the merge carried the first commit only. Following AGENTS.md, the follow-up goes on a fresh branch off `origin/main` rather than stacking onto the merged one.

## Test plan

- `./gradlew :cli:serve:test --tests "*ServeWebTest*"` — was `65 tests completed, 1 failed` on `origin/main`, now green.
- `./gradlew :cli:serve:test` — the whole module green.
- ktfmt (Google style) clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_