### PR TITLE
refactor(serve): split the build out of ServeOptions into ServeBuildHost

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBuildHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBuildHost.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.cli.serve
+
+import ee.schimke.composeai.previewdata.PreviewModule
+import java.io.File
+
+/**
+ * The build the server asks for, without naming a single Gradle type.
+ *
+ * Split out of [ServeOptions], which had grown to 99 members carrying two different things. Ninety-
+ * one of those are flags — values the command parsed. These seven are not options at all: they are
+ * work the CLI does *on the server's behalf*, and the difference matters more than the member
+ * count. An option is answered once at startup; a build is invoked, can fail, and takes time.
+ *
+ * Saying so separately also makes the real question visible. A preview server that no longer has a
+ * Gradle build behind it — one serving only fetched bundles and catalogs, which is already a
+ * supported mode — does not need a different `ServeOptions`; it needs a different implementation of
+ * *this*, and there are seven methods to write rather than ninety-nine to read.
+ *
+ * **Nothing here names a Gradle type, and that is load-bearing.** The obvious seam would be to hand
+ * the server `Command.withGradle` / `runGradle`, but both expose `GradleConnection`, which lives in
+ * `:gradle-preview-driver` behind `api("org.gradle:gradle-tooling-api")`. Either on this interface
+ * would drop the Gradle Tooling API onto the preview server's floor — exactly the dependency #4599
+ * removed, and exactly what would stop the server being separable. So this is the *operations*, not
+ * the connection: every type below is already on the server's floor (`File`, `String`, and
+ * `PreviewModule` from `:preview-data-api`), and the Tooling API stays on the `:cli` side.
+ *
+ * The names differ from `Command`'s protected `findProjectRoot` / `variantGradleArgs` /
+ * `gradleArgsWithForce` on purpose: `ServeCommand` inherits both sets, and a public interface
+ * member cannot implement a protected one of the same name. The rename is what lets the command
+ * satisfy this contract by *delegating* to its own base class rather than re-exposing it.
+ */
+public interface ServeBuildHost {
+
+  /**
+   * The init-script arguments to add for [projectRoot], if any.
+   *
+   * Build work, despite reading like a flag: it decides whether to inject the preview plugin into a
+   * project that does not declare it. `:cli` binds the raw `args` here so it can tell an explicit
+   * `--init-script` from an injected one, which is why the server cannot compute it itself.
+   */
+  public fun autoInjectInitScriptArgs(projectRoot: File): List<String>
+
+  /** The Gradle project root for this invocation, or null when there is no `gradlew` above us. */
+  public fun gradleProjectRoot(): File?
+
+  /** `-PcomposePreview.variant=…`, if `--variant` was given. */
+  public fun gradleVariantArgs(): List<String>
+
+  /** The build arguments this invocation implies, including `--force` and data extensions. */
+  public fun gradleBuildArgs(extra: List<String> = emptyList()): List<String>
+
+  /** Every Gradle project in the build that declares previews. */
+  public fun gradleProjects(): List<PreviewModule>
+
+  /** Run [tasks] in the project's Gradle build; true when the build succeeded. */
+  public fun runGradleTasks(
+    vararg tasks: String,
+    arguments: List<String> = emptyList(),
+    silenceStdout: Boolean = false,
+  ): Boolean
+
+  /** Discover and build the selected modules so their manifests exist on disk. */
+  public fun discoverAndBuild(silenceStdout: Boolean): ServeDiscovery
+}

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeOptions.kt
@@ -590,13 +590,10 @@ public interface ServeOptions {
    */
   public val browseProject: Boolean
 
-  // ---- the two rules that need the raw `args`, bound on the `:cli` side ----
+  // ---- the one rule that needs the raw `args`, bound on the `:cli` side ----
   //
-  // `args` is the one thing that must not cross: a server that can read the command line is a
-  // server that still has a CLI in it. Both rules below need it, so both are bound where it lives.
-
-  /** The init-script arguments to add for [projectRoot], if any. */
-  public fun autoInjectInitScriptArgs(projectRoot: File): List<String>
+  // `args` is the thing that must not cross: a server that can read the command line is a server
+  // that still has a CLI in it. This rule needs it, so it is bound where `args` lives.
 
   /** The shared preview-id selector rule, so `serve` and the other commands agree on a match. */
   public fun previewIdMatchesRequest(
@@ -607,47 +604,6 @@ public interface ServeOptions {
     className: String? = null,
     functionName: String? = null,
   ): Boolean
-
-  // ---- the build side, expressed without a single Gradle type ----
-  //
-  // Six of the server's members need Gradle work done: discovery, a daemon start, a worktree
-  // build. The obvious seam — hand the server `Command.withGradle`/`runGradle` — is the one that
-  // must not be taken: both expose `GradleConnection`, which lives in `:gradle-preview-driver`
-  // behind `api("org.gradle:gradle-tooling-api")`. Putting either on this interface would drop the
-  // Gradle Tooling API onto the preview server's floor, which is exactly the dependency #4599
-  // removed and exactly what stops the server being separable.
-  //
-  // So the seam is the *operations*, not the connection. Every type below is already on the
-  // server's floor: `File`, `String`, and `PreviewModule` / `PreviewManifest` from
-  // `:preview-data-api`. The Tooling API stays on the `:cli` side of the boundary, where the build
-  // actually happens.
-
-  // Named apart from `Command`'s protected `findProjectRoot` / `variantGradleArgs` /
-  // `gradleArgsWithForce` on purpose: `ServeCommand` inherits both sets, and a public interface
-  // member cannot implement a protected one of the same name. The rename is what lets the command
-  // satisfy the contract by *delegating* to its own base class rather than re-exposing it.
-
-  /** The Gradle project root for this invocation, or null when there is no `gradlew` above us. */
-  public fun gradleProjectRoot(): File?
-
-  /** `-PcomposePreview.variant=…`, if `--variant` was given. */
-  public fun gradleVariantArgs(): List<String>
-
-  /** The build arguments this invocation implies, including `--force` and data extensions. */
-  public fun gradleBuildArgs(extra: List<String> = emptyList()): List<String>
-
-  /** Every Gradle project in the build that declares previews. */
-  public fun gradleProjects(): List<PreviewModule>
-
-  /** Run [tasks] in the project's Gradle build; true when the build succeeded. */
-  public fun runGradleTasks(
-    vararg tasks: String,
-    arguments: List<String> = emptyList(),
-    silenceStdout: Boolean = false,
-  ): Boolean
-
-  /** Discover and build the selected modules so their manifests exist on disk. */
-  public fun discoverAndBuild(silenceStdout: Boolean): ServeDiscovery
 }
 
 /**

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRunner.kt
@@ -29,17 +29,20 @@ import okio.Path.Companion.toPath
 /**
  * `compose-preview serve`, from the first port bind to the last shutdown hook.
  *
- * This is the body that used to live in `:cli`'s `ServeCommand`. It reaches its configuration and
- * its build through [ServeOptions] — `by options`, so every flag reads exactly as it did when it
- * was a private val on the command — and it never sees `args`, `--help`, the usage text, or a
- * Gradle type.
+ * This is the body that used to live in `:cli`'s `ServeCommand`. It reaches its configuration
+ * through [ServeOptions] and its build through [ServeBuildHost] — `by options`, so every flag reads
+ * exactly as it did when it was a private val on the command — and it never sees `args`, `--help`,
+ * the usage text, or a Gradle type.
  *
  * The point is not tidiness. While this code sat in `:cli`, the module boundary #4599 drew was true
  * of every serve file *except* the one that starts the server, and the seam register carried 92
  * symbols for this file alone. A preview server you cannot start without the CLI is not separable,
  * whatever the build files say.
  */
-public class ServeRunner(private val options: ServeOptions) : ServeOptions by options {
+public class ServeRunner(
+  private val options: ServeOptions,
+  private val build: ServeBuildHost,
+) : ServeOptions by options, ServeBuildHost by build {
 
   private val catalogBlobPool: CatalogBlobPool by lazy {
     val requested = catalogCacheDirFlag

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ServeCommand.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.bundle.TrustStore
+import ee.schimke.composeai.cli.serve.ServeBuildHost
 import ee.schimke.composeai.cli.serve.ServeDefaults
 import ee.schimke.composeai.cli.serve.ServeDiscovery
 import ee.schimke.composeai.cli.serve.ServeOptions
@@ -21,7 +22,7 @@ import java.io.File
  * serves the module's whole preview set, so switching previews is just navigation.
  */
 class ServeCommand(args: List<String>, override val browseProject: Boolean = false) :
-  Command(args), ServeOptions {
+  Command(args), ServeOptions, ServeBuildHost {
 
   override val lan: Boolean = "--lan" in args
 
@@ -1020,7 +1021,7 @@ class ServeCommand(args: List<String>, override val browseProject: Boolean = fal
       printUsage()
       return
     }
-    ServeRunner(this).run()
+    ServeRunner(this, this).run()
   }
 
   // ---- the ServeOptions members that need something `:cli` has and the server must not ----

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ServeCommandTest.kt
@@ -83,7 +83,7 @@ class ServeCommandTest {
    */
   @Suppress("UNCHECKED_CAST")
   private fun ServeCommand.backgroundWork(): ServeBackgroundWork {
-    val runner = ServeRunner(this)
+    val runner = ServeRunner(this, this)
     return (runner.javaClass
         .getDeclaredField("backgroundWork\$delegate")
         .apply { isAccessible = true }

--- a/scripts/serve-seam-allowlist.json
+++ b/scripts/serve-seam-allowlist.json
@@ -134,6 +134,7 @@
       "serve.PreviewHistoryManifest",
       "serve.RenderFailureFrame",
       "serve.RenderOutcome",
+      "serve.ServeBuildHost",
       "serve.ServeBundleDaemon",
       "serve.ServeDefaults",
       "serve.ServeDiscovery",


### PR DESCRIPTION
API-review follow-up, the second of the two findings I flagged in #4651. Independent of #4641, #4648 and #4651.

`ServeOptions` had grown to 99 members carrying two different kinds of thing — and the member count was the least of it.

**Ninety-one are flags**: values the command parsed once. **Seven were not options at all** — `autoInjectInitScriptArgs`, `gradleProjectRoot`, `gradleVariantArgs`, `gradleBuildArgs`, `gradleProjects`, `runGradleTasks`, `discoverAndBuild` are work the CLI does *on the server's behalf*. An option is answered at startup; a build is invoked, can fail, and takes time. One interface was claiming to be both.

| | before | after |
|---|---|---|
| `ServeOptions` | 91 vals + 8 funs | 91 vals + 1 fun |
| `ServeBuildHost` | — | 7 funs |

## Why it is worth separating, beyond tidiness

It makes the interesting question visible. **A preview server with no Gradle build behind it — serving only fetched bundles and catalogs — is already a supported mode** (`serve` without `--module`/`--discover`). Such a host does not need a different `ServeOptions`; it needs a different `ServeBuildHost`. That is seven methods to write, rather than ninety-nine members to read past while working out which ones matter.

For #3824 that is the shape of the eventual question: what does the extracted server require of whoever runs it? Ninety-one values it reads, and seven things it asks for.

## Placement calls

- **`autoInjectInitScriptArgs` moves with the build half**, despite reading like a flag. It decides whether to inject the preview plugin into a project that doesn't declare it — a build decision. It still binds `args` on the `:cli` side, for the same reason as before.
- **`previewIdMatchesRequest` stays on `ServeOptions`.** A selector rule belongs with the selectors it reads.

## The Gradle argument is unchanged, and better placed

`ServeBuildHost` names `File`, `String` and `PreviewModule` — no Gradle type — so the Tooling API stays on the `:cli` side of the boundary, exactly as before. That reasoning now lives in the new file, where it is the file's whole subject rather than a comment halfway down a 99-member interface. It is the single most important constraint on this seam and it was easy to miss where it was.

## Cost

`serveInternalsUsedByCli` goes **12 → 13**: `ServeCommand` names one more serve type because it implements one more interface. The register grows by exactly the seam this splits in two, which is the trade — and it is the honest direction for the number to move, since the coupling is now described by two names instead of one.

## Test plan

- `:cli:serve:test`, `:cli:test` — green under **`--rerun-tasks`**. Forced deliberately: an ordinary run reported `UP-TO-DATE` immediately after an earlier `:cli:serve:test FAILED`, and an ambiguous green is not a green. The forced run took 4m47s and passed.
- All four compile tasks across both modules — clean.
- `check-serve-seam.py` OK at `main.serveInternalsUsedByCli=13`, `cliInternalsUsedByServe=0`, `test=16`.
- `ktfmtCheck` clean.

Non-visual: an interface split. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_