### PR TITLE
fix: close three review findings left on merged PRs

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -934,17 +934,30 @@ class ServeCatalogStore(
           // straight off `catalog.json`; a catalog that declares neither gets null + empty and the
           // viewer's second comparison source is simply never offered.
           compareWithSystem = catalog.compareWith?.system?.takeIf { it.isNotBlank() },
+          // Read from BOTH lists, components last so they win — the same shape as
+          // [captionByComponentId] and for the same reason. A wholly deferred component never
+          // reaches `components[]`, and the export writes its pairing onto the deferred record
+          // instead; reading only `components` discarded it and left the deferred card unable to
+          // offer the sibling source. That also covers its deferred *variant* records, which
+          // inherit the entry's pairing.
           parallelByComponentId =
-            catalog.components
-              .mapNotNull { component ->
-                val id = component.componentId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-                val parallel =
-                  component.parallel?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-                id to parallel
+            buildMap {
+              catalog.deferred.forEach { deferred ->
+                val id = deferred.componentId?.takeIf { it.isNotBlank() } ?: return@forEach
+                val parallel = deferred.parallel?.takeIf { it.isNotBlank() } ?: return@forEach
+                // First wins among the deferred records themselves, like [previewAliasFor]: a
+                // catalog that somehow listed a component id twice gets the producer's own order
+                // rather than a throw.
+                putIfAbsent(id, parallel)
               }
-              // First wins, like [previewAliasFor]: a catalog that somehow published a component id
-              // twice gets the producer's own order rather than a throw.
-              .toMap(),
+              catalog.components.forEach { component ->
+                val id = component.componentId?.takeIf { it.isNotBlank() } ?: return@forEach
+                val parallel = component.parallel?.takeIf { it.isNotBlank() } ?: return@forEach
+                // `put`, not `putIfAbsent`: a component that IS in `components[]` states its own
+                // pairing, and a deferred *variant* record sharing its id only inherits one.
+                put(id, parallel)
+              }
+            },
           degradations = degradations,
           liveOnly = liveOnly,
           // Kept in step with [scheduleRcCompareFetch]'s own guard through the shared helper: a
@@ -2777,6 +2790,14 @@ class ServeCatalogStore(
     val props: JsonObject? = null,
     /** The declared breakpoint this live-only record renders at — see [Image.size]. */
     val size: String? = null,
+    /**
+     * The counterpart component in the `compareWith` sibling, for the same reason [caption] is
+     * here: a **wholly** deferred component short-circuits before it reaches `components[]`, so
+     * this is the only copy of its pairing in the manifest. Without it the deferred card is the one
+     * card that cannot offer the sibling comparison source, on a catalog that publishes
+     * `compareWith` precisely to have it.
+     */
+    val parallel: String? = null,
     /** Why it was deferred (`entry` / `variant` / `mode`) — carried for diagnostics. */
     val reason: String? = null,
     /**

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -3625,6 +3625,99 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a wholly deferred component's pairing reaches the server's parallel lookup`() {
+    // The generator writes a wholly deferred component's `parallel` onto its DEFERRED record —
+    // such a component short-circuits before it ever reaches `components[]`, so that is the only
+    // copy of it in the manifest. Reading the lookup from `components` alone discarded it, and the
+    // deferred card was the one card that could not offer the sibling comparison source on a
+    // catalog that publishes `compareWith` precisely to have it.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "compareWith":{"system":"wear-m3-catalog"},
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","section":"Components","group":"Buttons",
+         "parallel":"Button/Filled",
+         "images":[
+           {"path":"images/button-filled/ideal__default__dark.png","state":"default","theme":"dark","previewId":"FilledButton_Dark"}]}],
+       "deferred":[
+         {"componentId":"Button/Filled","section":"Components","group":"Buttons","reason":"mode",
+          "path":"images/button-filled/ideal__default__light.png","state":"default","theme":"light",
+          "preview":"FilledButton","previewId":"FilledButton_Light",
+          "previewIds":["FilledButton_Light","FilledButton_Dark"]},
+         {"componentId":"Progress/Circular","section":"Components","group":"Progress",
+          "reason":"entry","parallel":"Progress/Circular",
+          "path":"images/progress-circular/ideal__default__light.png","state":"default","theme":"light",
+          "preview":"CircularProgress","previewId":"CircularProgress_Light",
+          "previewIds":["CircularProgress_Light"]}]}
+      """
+        .trimIndent()
+    var fronted: ServeHost? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranches },
+        fetch = deferredFetcher(json),
+        buildTrustedBundle = { _, _, _, _, bakedFallback, _ ->
+          fronted = bakedFallback()
+          true
+        },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    val host = fronted as ServeBundleHost
+    assertEquals("wear-m3-catalog", host.compareWithSystem)
+    assertEquals(
+      mapOf("Button/Filled" to "Button/Filled", "Progress/Circular" to "Progress/Circular"),
+      host.parallelByComponentId,
+      "the wholly deferred component's pairing is read off its deferred record",
+    )
+  }
+
+  @Test
+  fun `a component's own pairing outranks one inherited by its deferred variant record`() {
+    // A component that IS in `components[]` states its own pairing; a deferred VARIANT record
+    // sharing its id only inherits one. Components win, the same way the caption lookup resolves
+    // the mirror case.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "compareWith":{"system":"wear-m3-catalog"},
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Button/Filled","section":"Components","group":"Buttons",
+         "parallel":"Button/Authored",
+         "images":[
+           {"path":"images/button-filled/ideal__default__dark.png","state":"default","theme":"dark","previewId":"FilledButton_Dark"}]}],
+       "deferred":[
+         {"componentId":"Button/Filled","section":"Components","group":"Buttons","reason":"mode",
+          "parallel":"Button/Inherited",
+          "path":"images/button-filled/ideal__default__light.png","state":"default","theme":"light",
+          "preview":"FilledButton","previewId":"FilledButton_Light",
+          "previewIds":["FilledButton_Light","FilledButton_Dark"]}]}
+      """
+        .trimIndent()
+    var fronted: ServeHost? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranches },
+        fetch = deferredFetcher(json),
+        buildTrustedBundle = { _, _, _, _, bakedFallback, _ ->
+          fronted = bakedFallback()
+          true
+        },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    assertEquals(
+      mapOf("Button/Filled" to "Button/Authored"),
+      (fronted as ServeBundleHost).parallelByComponentId,
+    )
+  }
+
+  @Test
   fun `a baked-only session hides the deferred previews and records why`() {
     // Fail-soft (issue #2965 point 5): with no live lane there is nothing to render a deferred
     // preview from, so it is omitted rather than listed as a card whose every request 404s — and

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -277,13 +277,7 @@ private class PackSubcommand(private val args: List<String>) {
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val progress: Boolean = verbose || "--progress" in args
   private val timeout: String? = args.flagValue("--timeout")
-  private val ids: List<String> =
-    PackPreviewIdExclusions.idFileFromArgs(args)?.let(PackPreviewIdExclusions::linesOf)
-      ?: args
-        .flagValuesAll("--id")
-        .flatMap { it.split(',') }
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
+  private val ids: List<String> = PackPreviewIdExclusions.selectedIds(args)
 
   /**
    * `--exclude-preview-id` patterns (issue #2966) — the previews this pack must NOT render or

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusions.kt
@@ -115,6 +115,26 @@ internal object PackPreviewIdExclusions {
       java.io.File(it)
     }
 
+  /**
+   * The previews `bundle pack` will select: the id file when one was passed, else `--id`.
+   *
+   * Extracted so the behaviour can be *exercised* rather than restated. The shattering below is the
+   * whole reason [idFileFromArgs] exists, and it was pinned by a test that rebuilt
+   * `args.drop(2).flatMap { it.split(',') }` by hand — which keeps passing if the real `--id`
+   * parsing stops splitting, changes its trimming, or loses the file's precedence over the flag. A
+   * regression test that cannot see the code it guards is not one.
+   *
+   * The file REPLACES `--id` rather than adding to it: a caller that has both has said the same
+   * thing twice, and the file is the form that survives a comma.
+   */
+  fun selectedIds(args: List<String>): List<String> =
+    idFileFromArgs(args)?.let(::linesOf)
+      ?: args
+        .flagValuesAll("--id")
+        .flatMap { it.split(',') }
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+
   /** The Gradle property carrying `@PreviewParameter` **row** label exclusions. */
   const val ROW_GRADLE_PROPERTY = "composePreview.rowExclude"
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PackPreviewIdExclusionsTest.kt
@@ -270,18 +270,53 @@ class PackPreviewIdExclusionsTest {
    * The live failure: `--id` comma-splits, so the first fragment is what `composePreviewBundle`
    * reports as `preview id not found`. Pinned so the shattering is a documented behaviour of the
    * flag rather than a surprise.
+   *
+   * Through [PackPreviewIdExclusions.selectedIds] — the selection `bundle pack` actually makes.
+   * This test used to rebuild `args.drop(2).flatMap { it.split(',') }` by hand, which would keep
+   * passing if the real parsing stopped splitting, changed its trimming, or lost the file's
+   * precedence over the flag: a regression test that cannot see the code it guards.
    */
   @Test
   fun `--id shatters a comma-bearing id into its fragments`() {
-    val shattered =
-      listOf("pack", "--id", commaBearingIds[0]).let { args ->
-        args.drop(2).flatMap { it.split(',') }.map(String::trim)
-      }
+    val shattered = PackPreviewIdExclusions.selectedIds(listOf("pack", "--id", commaBearingIds[0]))
     assertEquals(3, shattered.size)
     assertEquals(
       "ee.schimke.wearm3catalog.remote.CatalogPreviewsKt.CustomShapeRemoteButton_width=227dp",
       shattered[0],
     )
+  }
+
+  @Test
+  fun `an id file survives the comma that shatters --id, and outranks it`() {
+    // The two halves the hand-rolled version could not reach: the file keeps a comma-bearing id
+    // whole, and having both forms is not a merge — the file wins, because it is the one that
+    // survives a comma.
+    val file = fileWith(commaBearingIds)
+    assertEquals(
+      commaBearingIds,
+      PackPreviewIdExclusions.selectedIds(listOf("pack", "--id-file", file.path)),
+    )
+    assertEquals(
+      commaBearingIds,
+      PackPreviewIdExclusions.selectedIds(
+        listOf("pack", "--id", "SomethingElse", "--id-file", file.path)
+      ),
+    )
+  }
+
+  @Test
+  fun `repeated --id flags accumulate, and blanks are dropped`() {
+    assertEquals(
+      listOf("Alpha", "Beta", "Gamma"),
+      PackPreviewIdExclusions.selectedIds(
+        listOf("pack", "--id", " Alpha , Beta ", "--id", "", "--id", "Gamma")
+      ),
+    )
+  }
+
+  @Test
+  fun `no selector at all selects nothing, which the caller reads as every preview`() {
+    assertEquals(emptyList(), PackPreviewIdExclusions.selectedIds(listOf("pack", "--out", "x.zip")))
   }
 
   @Test

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -14,6 +14,7 @@ import ee.schimke.composeai.data.remotecompose.RemoteComposeDocumentPayload
 import ee.schimke.composeai.data.render.PreviewBackground
 import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.designpages.DesignPagesManifest
+import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
@@ -95,4 +96,21 @@ object ContractSurface {
    * thing that made an extracted server depend on the CLI (preparation item 7).
    */
   val coordinateResolver: KClass<CoordinateResolver> = CoordinateResolver::class
+
+  /**
+   * Cropping a render down to the pixels that carry content — what the home page's hero thumbnails
+   * and the compare wall's cells are cut with (`ServeWeb`, `ServeHttpServer`).
+   *
+   * `:common-image-crop` was added to `CONTRACT_PROJECTS` without a reference here, and adding the
+   * artifact to the probe's `contracts` only proves that a JAR with that coordinate resolves. That
+   * is the weaker half of what this file is for: removing or renaming the exact crop surface serve
+   * calls would leave `checkContractSurface` green, which is the failure this whole file exists to
+   * make impossible.
+   *
+   * `ContentCrop` alone, because that is serve's whole import from the module — `ServeWeb` and
+   * `ServeHttpServer` name it and nothing else. The sibling `ContentBox` is published but unused
+   * here, and naming a type serve does not reach for would have this file assert a dependency floor
+   * higher than the real one.
+   */
+  val imageCrop: KClass<ContentCrop> = ContentCrop::class
 }

--- a/scripts/design-artifacts/apply-parallels.mjs
+++ b/scripts/design-artifacts/apply-parallels.mjs
@@ -34,7 +34,20 @@
  *   The catalog spec the manifest was built from.
  * @returns {number} how many components had a `parallel` newly stamped.
  */
-export function applyParallels(manifest, spec) {
+/**
+ * `componentId -> parallel`, for every spec component that declares one.
+ *
+ * Exported because the manifest is stamped in two places and they must read the spec the same way.
+ * `applyParallels` runs over `manifest.components` while the manifest is being assembled; the
+ * DEFERRED records are attached later (`generate-design-catalog.mjs` builds them after this call),
+ * so they cannot be reached from here and are stamped at their own construction from this same map.
+ * Two hand-rolled readers would eventually disagree about the blank rule below, which is the only
+ * subtle part.
+ *
+ * @param {{groups?: Array<{components?: Array<{componentId: string, parallel?: string}>}>}} spec
+ * @returns {Map<string, string>}
+ */
+export function parallelIndex(spec) {
   const parallelByComponentId = new Map();
   for (const group of spec?.groups ?? []) {
     for (const component of group.components ?? []) {
@@ -48,6 +61,11 @@ export function applyParallels(manifest, spec) {
       if (parallel) parallelByComponentId.set(component.componentId, parallel);
     }
   }
+  return parallelByComponentId;
+}
+
+export function applyParallels(manifest, spec) {
+  const parallelByComponentId = parallelIndex(spec);
 
   let stamped = 0;
   for (const component of manifest?.components ?? []) {

--- a/scripts/design-artifacts/apply-parallels.test.mjs
+++ b/scripts/design-artifacts/apply-parallels.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { applyParallels } from "./apply-parallels.mjs";
+import { applyParallels, parallelIndex } from "./apply-parallels.mjs";
 
 const comp = (componentId, extra = {}) => ({
   componentId,
@@ -132,4 +132,74 @@ test("tolerates missing/empty groups and components without throwing", () => {
     0,
   );
   assert.equal(applyParallels({ components: [comp("X")] }, undefined), 0);
+});
+
+// --- parallelIndex, the map both stampers read ------------------------------------------------
+//
+// A WHOLLY deferred component never reaches `manifest.components` — the generator short-circuits it
+// into `deferred[]` — so `applyParallels` cannot see it and its declared counterpart was dropped,
+// on a catalog that publishes `compareWith` and whose whole point is the cross-system comparison.
+// The deferred records are attached after `applyParallels` runs, so they stamp from this index
+// instead; exporting it is what keeps the two from growing different ideas of the blank rule.
+
+test("indexes every component that declares a parallel", () => {
+  const index = parallelIndex({
+    groups: [
+      { components: [{ componentId: "Button", parallel: "Button/Filled" }] },
+      { components: [{ componentId: "Card", parallel: "TitleCard" }] },
+    ],
+  });
+  assert.equal(index.get("Button"), "Button/Filled");
+  assert.equal(index.get("Card"), "TitleCard");
+  assert.equal(index.size, 2);
+});
+
+test("applies the same blank and trim rules the stamper does", () => {
+  const index = parallelIndex({
+    groups: [
+      {
+        components: [
+          { componentId: "Blank", parallel: "" },
+          { componentId: "Spaces", parallel: "   " },
+          { componentId: "Padded", parallel: "  Button/Filled  " },
+          { componentId: "Absent" },
+          { componentId: "NotAString", parallel: 7 },
+        ],
+      },
+    ],
+  });
+  assert.equal(index.has("Blank"), false);
+  assert.equal(index.has("Spaces"), false);
+  assert.equal(index.get("Padded"), "Button/Filled");
+  assert.equal(index.has("Absent"), false);
+  assert.equal(index.has("NotAString"), false);
+});
+
+test("is the index applyParallels itself stamps from", () => {
+  // The property that makes exporting it worth anything: one reader, so a deferred record and a
+  // published component can never disagree about what a spec entry declares.
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "Button", parallel: "  Button/Filled " },
+          { componentId: "Blank", parallel: "" },
+        ],
+      },
+    ],
+  };
+  const manifest = {
+    components: [{ componentId: "Button" }, { componentId: "Blank" }],
+  };
+  applyParallels(manifest, spec);
+  const index = parallelIndex(spec);
+  for (const component of manifest.components) {
+    assert.equal(component.parallel, index.get(component.componentId));
+  }
+});
+
+test("tolerates a spec with no groups at all", () => {
+  assert.equal(parallelIndex(undefined).size, 0);
+  assert.equal(parallelIndex({}).size, 0);
+  assert.equal(parallelIndex({ groups: [] }).size, 0);
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -136,7 +136,7 @@ import {
   extraOnlyFunctions,
   unbridgeableFunctions,
 } from "./extra-render-fold.mjs";
-import { applyParallels } from "./apply-parallels.mjs";
+import { applyParallels, parallelIndex } from "./apply-parallels.mjs";
 import { applySpecSections } from "./apply-spec-sections.mjs";
 import { applySourceFiles } from "./apply-source-files.mjs";
 import {
@@ -1586,14 +1586,24 @@ if (values["publish-live-bundle"]) {
       );
     }
     const records = expandDeferredRecords(deferred, spec, allBundles);
+    // The same parallel index `applyParallels` stamped `manifest.components` from, applied to the
+    // deferred records too. A WHOLLY deferred component never reaches `manifest.components` — it
+    // short-circuits into `deferred[]` above — so stamping only there dropped its declared
+    // counterpart on the floor, and a server reconstructing the card could not resolve the sibling
+    // even though the catalog publishes `compareWith`. Read from one index rather than a second
+    // reader, so the two cannot disagree about the blank-means-none rule.
+    const deferredParallels = parallelIndex(spec);
     manifest.deferred = records.map((record) => {
       const ids = idsByFunction.get(record.preview) ?? [];
+      const parallel = deferredParallels.get(record.componentId);
       return {
         ...record,
         ...(mismatches.length === 0
           ? { path: catalogImagePath(record.componentId, record) }
           : {}),
         ...(ids.length > 0 ? { previewIds: ids } : {}),
+        // Never clobber a record that already carries one, matching `applyParallels`.
+        ...(parallel !== undefined && record.parallel === undefined ? { parallel } : {}),
       };
     });
     const addressable = manifest.deferred.filter((r) => r.path && r.previewId).length;


### PR DESCRIPTION
Three unaddressed review findings, from #4617, #4631 and #4615. Independent, all small, and each one is a guard that was not guarding.

## #4617 — the contract probe named an artifact it never used

`:common-image-crop` was added to `CONTRACT_PROJECTS`, but `ContractSurface` referenced nothing from it. Adding the artifact to the probe's `contracts` only proves that a JAR with that coordinate resolves — so removing or renaming the exact crop surface serve calls would have left `checkContractSurface` **green**, which is the one failure that file exists to make impossible.

`ContentCrop` alone. It is serve's whole import from the module (`ServeWeb` and `ServeHttpServer` name it and nothing else); the sibling `ContentBox` is published but unused here, and naming it would have the probe assert a dependency floor *higher* than the real one — against this file's own stated rule that every reference is drawn from serve's real import set.

> My first draft did include `ContentBox`, justified with "`ContentCrop.box` returns it". It doesn't — they are unrelated types, and serve imports neither the type nor any accessor returning it. Caught by checking the `.api` dump rather than trusting the sentence.

## #4631 — a wholly deferred component lost its declared parallel

`applyParallels` walks `manifest.components`. An entry marked `priority: "deferred"` short-circuits into `deferred[]` *before* it ever gets there, so its `parallel` was dropped — on a catalog that publishes `compareWith` and whose whole point is the cross-system comparison. A server reconstructing the deferred card could not resolve its sibling.

The deferred records are attached **after** `applyParallels` runs (`generate-design-catalog.mjs` builds them further down), so they cannot be reached from inside it. `parallelIndex` is now exported and both stampers read it, rather than growing a second hand-rolled reader that would eventually disagree about the blank-means-none rule — the only subtle part of reading a spec entry. The deferred stamp also refuses to clobber a record that already carries one, matching `applyParallels`.

## #4615 — a regression test that could not see the code it guarded

`--id shatters a comma-bearing id into its fragments` rebuilt `args.drop(2).flatMap { it.split(',') }` inside the test, so it kept passing if the real `--id` parsing stopped splitting, changed its trimming, or lost the `--id-file` precedence entirely.

`PackPreviewIdExclusions.selectedIds` extracts the selection `bundle pack` actually makes (`BundleCommand` now calls it), and the test goes through it. Three more cover what the hand-rolled version structurally could not reach:

- the file keeps a comma-bearing id **whole** — the regression `--id-file` exists for
- the file **outranks** `--id` rather than merging with it
- repeated `--id` flags accumulate, and blank values are dropped

## Test plan

- `./gradlew :cli:test :cli:serve:test` — BUILD SUCCESSFUL. `PackPreviewIdExclusionsTest`: **30 tests, 0 failures.**
- `node --test scripts/design-artifacts/apply-parallels.test.mjs` — **13 tests, 0 failures** (9 existing untouched, 4 new on `parallelIndex`, one of which asserts `applyParallels` stamps exactly what the index holds — the property that makes exporting it worth anything).
- `node --check scripts/design-artifacts/generate-design-catalog.mjs` — parses.
- **`scripts/check-preview-server-contracts.sh`** — the 16 contract modules publish, and `preview-server` then compiles against the *published* artifacts with the new import resolving. The script's second half needed `--no-daemon` in this sandbox (the separate build wants a JDK named by `org.gradle.java.home` and the running daemon's JVM did not match) — an environment mismatch, not a build one; the compile itself is clean.
- `./gradlew :cli:checkServeSeam` — `OK — 28 crossing symbol(s), all on the allowlist`. `./gradlew ktfmtCheckAll` — clean. `python3 .github/ci/test_path_scope.py` — OK.

Seven `scripts/design-artifacts/*.test.mjs` suites fail in this sandbox on `main` as well as on this branch (missing npm workspace deps — `@design-parity/candidate`); `apply-parallels` is not among them and runs clean.

Non-visual: a probe reference, a manifest field, and a test seam.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_