### PR TITLE
fix(cli): stop doctor's probes following a captive portal's redirect

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1446,7 +1446,16 @@ class DoctorCommand(
   private fun checkNetworkReach() {
     NETWORK_HOSTS.forEach { probe ->
       val (code, headers) = headPlain(probe.url)
-      addCheck(networkCheck(probe, code, headers["error"], inClaudeCloud))
+      addCheck(
+        networkCheck(
+          probe,
+          code,
+          headers["error"],
+          inClaudeCloud,
+          // Header lookup is case-insensitive at the source; Ktor lowercases nothing, so try both.
+          redirectTarget = headers["Location"] ?: headers["location"],
+        )
+      )
     }
   }
 
@@ -1458,7 +1467,11 @@ class DoctorCommand(
    */
   internal fun headPlain(url: String): Pair<Int, Map<String, String>> =
     try {
-      httpProbeClient().use { client ->
+      // NOT following redirects. A captive portal or filtering proxy that redirects to a 200 login
+      // page is the case these probes exist to catch, and following it reports that page's status
+      // as the host's — "reachable (HTTP 200)" for an endpoint that never answered. The 3xx and its
+      // `Location` reach [networkCheck] instead, which names it for what it is.
+      httpProbeClient(followRedirects = false).use { client ->
         runBlocking {
           val response = client.head(url) { header("User-Agent", USER_AGENT) }
           val headers = response.headers.entries().associate { (k, v) -> k to v.joinToString(", ") }
@@ -1475,8 +1488,18 @@ class DoctorCommand(
    * path, and `use {}` tears the connection pool down immediately. Mirrors the Ktor/OkHttp client
    * the rest of the CLI already uses (see [BundleSource]).
    */
-  private fun httpProbeClient(): HttpClient =
+  private fun httpProbeClient(followRedirects: Boolean = true): HttpClient =
     HttpClient(OkHttp) {
+      // Off for the reachability probes, on for the version check — which reads the FINAL url of
+      // `releases/latest` and exists to be redirected. Set on the Ktor config and on the engine,
+      // because either one left following would hide the case the caller is asking about.
+      this.followRedirects = followRedirects
+      engine {
+        config {
+          followRedirects(followRedirects)
+          followSslRedirects(followRedirects)
+        }
+      }
       install(HttpTimeout) {
         connectTimeoutMillis = 3_000
         requestTimeoutMillis = 3_000
@@ -1665,6 +1688,8 @@ class DoctorCommand(
       code: Int,
       error: String?,
       inClaudeCloud: Boolean,
+      /** The `Location` a 3xx pointed at, when there was one — named in the detail. */
+      redirectTarget: String? = null,
     ): DoctorCheck {
       val id = "env.network.${probe.id}"
       val expectedNote = probe.expected[code]
@@ -1697,13 +1722,41 @@ class DoctorCommand(
           remediation = remediation,
         )
       }
+      // What THIS url answers with when egress is healthy, read off the probe rather than assumed.
+      // `fonts.gstatic.com` documents a 404 on `/` — it serves versioned asset paths only — so
+      // telling its operator "returns 2xx when egress is healthy" contradicted the probe's own
+      // configuration, in the one message they have to reason from.
+      val healthy =
+        (listOf("2xx") + probe.expected.keys.sorted().map { "HTTP $it" }).let {
+          if (it.size == 1) it.single() else it.dropLast(1).joinToString(", ") + " or " + it.last()
+        }
+      // A REDIRECT is its own diagnosis. The probes do not follow them (see [headPlain]) precisely
+      // so this case stays visible: a captive portal or filtering proxy that redirects to a 200
+      // login page would otherwise be followed to that page and reported as the host answering
+      // healthily, which is the opposite of the truth.
+      if (code in 300..399) {
+        val target = redirectTarget?.takeIf { it.isNotBlank() }
+        return DoctorCheck(
+          id = id,
+          category = "env",
+          status = "warning",
+          message = "${probe.host} redirected (HTTP $code) instead of answering",
+          detail =
+            "${probe.purpose}. ${probe.url} answers $healthy when egress is healthy; a redirect" +
+              (target?.let { " to $it" } ?: "") +
+              " is a captive portal or filtering proxy answering on the host's behalf. The probe" +
+              " does not follow it, because the page at the other end can be a 200 that proves" +
+              " nothing about ${probe.host}.",
+          remediation = remediation,
+        )
+      }
       return DoctorCheck(
         id = id,
         category = "env",
         status = "warning",
         message = "${probe.host} answered HTTP $code, not a success",
         detail =
-          "${probe.purpose}. ${probe.url} returns 2xx when egress is healthy; a $code usually means a proxy or sandbox answered instead of the host.",
+          "${probe.purpose}. ${probe.url} answers $healthy when egress is healthy; a $code usually means a proxy or sandbox answered instead of the host.",
         remediation = remediation,
       )
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorNetworkProbeTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorNetworkProbeTest.kt
@@ -55,6 +55,42 @@ class DoctorNetworkProbeTest {
     assertEquals(404, code)
   }
 
+  /**
+   * A captive portal's shape: `/` redirects to a login page that answers 200.
+   *
+   * Following it reports the LOGIN PAGE's status as the probed host's, so an endpoint that never
+   * answered reads as `reachable (HTTP 200)` — the exact opposite of the truth, from the check
+   * whose whole job is to notice that egress is intercepted.
+   */
+  private fun startPortal(): String {
+    val s = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    s.createContext("/login") { exchange ->
+      exchange.sendResponseHeaders(200, -1)
+      exchange.close()
+    }
+    s.createContext("/") { exchange ->
+      exchange.responseHeaders.add("Location", "/login")
+      exchange.sendResponseHeaders(302, -1)
+      exchange.close()
+    }
+    s.start()
+    server = s
+    return "http://127.0.0.1:${s.address.port}/"
+  }
+
+  @Test
+  fun `a redirect is reported, not followed to whatever answers at the other end`() {
+    val url = startPortal()
+
+    val (code, headers) = DoctorCommand(emptyList()).headPlain(url)
+
+    assertEquals(302, code, "the probe stops at the redirect rather than reporting the login page")
+    assertTrue(
+      headers.entries.any { (k, v) -> k.equals("Location", ignoreCase = true) && v == "/login" },
+      "the redirect target is carried through for the check to name: $headers",
+    )
+  }
+
   @Test
   fun `an unreachable host returns -1 and an error, never throws`() {
     // Nothing is listening on port 1 — the connection is refused fast, well inside the 3s timeout.
@@ -107,6 +143,38 @@ class DoctorNetworkCheckTest {
     assertEquals("warning", check.status)
     assertTrue("proxy or sandbox" in (check.detail ?: ""), check.detail.orEmpty())
     assertTrue("Custom" in (check.remediation?.summary ?: ""), check.remediation?.summary.orEmpty())
+  }
+
+  @Test
+  fun `a redirect is named as an interception, with where it pointed`() {
+    val check =
+      DoctorCommand.networkCheck(
+        gstatic,
+        302,
+        null,
+        inClaudeCloud = false,
+        redirectTarget = "http://portal.example/login",
+      )
+
+    assertEquals("warning", check.status)
+    assertTrue("redirected" in check.message, check.message)
+    assertTrue("reachable" !in check.message, check.message)
+    assertTrue("portal.example/login" in (check.detail ?: ""), check.detail.orEmpty())
+    assertTrue("captive portal" in (check.detail ?: ""), check.detail.orEmpty())
+  }
+
+  @Test
+  fun `the healthy-response wording follows the probe, not a blanket 2xx`() {
+    // `fonts.gstatic.com` documents a 404 on `/` — it serves versioned asset paths only — so
+    // telling its operator the url "returns 2xx when egress is healthy" contradicted the probe's
+    // own configuration, in the one message they have to reason from.
+    val intercepted = DoctorCommand.networkCheck(gstatic, 403, null, inClaudeCloud = false)
+    assertTrue("2xx or HTTP 404" in (intercepted.detail ?: ""), intercepted.detail.orEmpty())
+
+    // A probe with no documented exception still says plain 2xx.
+    val plain = DoctorCommand.networkCheck(googleapis, 403, null, inClaudeCloud = false)
+    assertTrue("answers 2xx when egress is healthy" in (plain.detail ?: ""), plain.detail.orEmpty())
+    assertTrue("404" !in (plain.detail ?: ""), plain.detail.orEmpty())
   }
 
   @Test


### PR DESCRIPTION
Closes the two unaddressed review findings left on #4632 after it merged.

## A captive portal was reported as a healthy host

`httpProbeClient()` followed redirects. So a captive portal or filtering proxy that redirects to a 200 login page had doctor report the probed Google host as **`reachable (HTTP 200)`** — the login page's status presented as the host's, for an endpoint that never answered.

That is the exact inversion of what these probes are for. #4632's own reasoning was that "we got bytes back" is not the same as "this host works", and it fixed the 403/407 case; a redirect walks straight past that fix, because the status it lands on genuinely *is* a 2xx.

The probes no longer follow them. The **version check still does** — it reads the final URL of `releases/latest` and exists to be redirected — so `httpProbeClient` takes the flag rather than turning it off globally. It is set on both the Ktor config and the OkHttp engine, because either one left following would hide the case the caller is asking about.

A 3xx now reaches `networkCheck` with its `Location` and is named for what it is:

```
⚠ fonts.gstatic.com redirected (HTTP 302) instead of answering
  …a redirect to http://portal.example/login is a captive portal or filtering proxy
  answering on the host's behalf. The probe does not follow it, because the page at
  the other end can be a 200 that proves nothing about fonts.gstatic.com.
```

## The detail contradicted the probe's own configuration

The unexpected-positive path asserted that the url "returns 2xx when egress is healthy" for **every** probe. `fonts.gstatic.com` documents a 404 on `/` — it serves versioned asset paths only, which is why `NetworkHost.expected` exists — so its operator was told something the probe's own configuration denies, in the one message they have to reason from.

The wording is derived from `probe.expected` now: `2xx or HTTP 404` there, plain `2xx` everywhere else.

## Test plan

Four tests (`DoctorNetworkProbeTest` 4, `DoctorNetworkCheckTest` 8, all passing):

- **`a redirect is reported, not followed to whatever answers at the other end`** — a loopback server shaped like a captive portal: `/` 302s to `/login`, which answers 200. Asserts `headPlain` returns **302** and carries the `Location` through.
- **`a redirect is named as an interception, with where it pointed`** — the check says "redirected", never "reachable", and names the target.
- **`the healthy-response wording follows the probe, not a blanket 2xx`** — gstatic's detail reads `2xx or HTTP 404`; a probe with no documented exception says plain `2xx` and mentions no 404.

**Verified non-vacuous** by flipping the flag back to `followRedirects = true` and re-running:

```
DoctorNetworkProbeTest > a redirect is reported, not followed … FAILED
  expected: <302> but was: <200>
```

That is the reported failure exactly — the probe reporting the login page's 200 as the host's.

The two `networkCheck` tests cannot be run against the pre-fix code directly, since it has no `redirectTarget` parameter; the behavioural one above is what pins the change.

`./gradlew :cli:test :cli:checkServeSeam ktfmtCheckAll` — BUILD SUCCESSFUL, seam `OK — 29 crossing symbol(s), all on the allowlist`.

Non-visual: a diagnostic's client configuration and its wording.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_