### PR TITLE
fix(design-artifacts): resolve RTL previews by locale and stop guessing a gutter density

### DIFF
--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -174,6 +174,7 @@ function pickVariantId(candidates, image, breakpointForSize) {
   const wantDevice = wantBreakpoint.device ?? null;
   const wantWidth = wantBreakpoint.widthDp ?? null;
   const wantFontScale = requestedFontScale(image.props);
+  const wantLocale = normalizedLocale(image.props?.locale);
   let best;
   let bestConstraint = -Infinity;
   let bestPreference = -Infinity;
@@ -222,6 +223,20 @@ function pickVariantId(candidates, image, breakpointForSize) {
     } else {
       preference += candidate.fontScale === null ? 1 : -1;
     }
+    // The LOCALE, in the same two tiers and for the same reason. `variantIdentity` has carried it
+    // since gutters started publishing physical edges, but nothing scored it — so one function with
+    // separate LTR and RTL `@Preview` annotations resolved BOTH images to whichever appears first,
+    // and an asymmetric gutter was published with its left and right edges swapped for one of them.
+    // That is a wrong crop rather than a missing one, which is the worse of the two.
+    //
+    // Compared normalised, because a catalog spells a locale the way its annotation did and `ar_XB`
+    // and `ar-XB` are the same render — the same normalisation `rendersRightToLeft` applies before
+    // it asks about direction.
+    if (wantLocale !== null) {
+      constraint += normalizedLocale(candidate.locale) === wantLocale ? 2 : -2;
+    } else {
+      preference += candidate.locale === null ? 1 : -1;
+    }
     if (
       constraint > bestConstraint ||
       (constraint === bestConstraint && preference > bestPreference)
@@ -246,6 +261,20 @@ function requestedFontScale(props) {
     typeof raw === "number" ? raw : Number.parseFloat(String(raw).replace(/x$/i, ""));
   if (!Number.isFinite(value) || value === 1) return null;
   return value;
+}
+
+/**
+ * A locale tag reduced to what makes two of them the same render: trimmed, `_` separators turned
+ * into `-`, and lower-cased. Null for anything that is not a non-empty string, so an image stating
+ * no locale constrains nothing.
+ *
+ * The renderer normalises the same way (`Pseudolocale.fromTag`, `LocaleDirection.isRtl`), and a
+ * comparison that did not would rank `ar_XB` and `ar-XB` as different annotations.
+ */
+function normalizedLocale(locale) {
+  if (typeof locale !== "string") return null;
+  const trimmed = locale.trim();
+  return trimmed === "" ? null : trimmed.replace(/_/g, "-").toLowerCase();
 }
 
 /**

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -1448,3 +1448,63 @@ test("a Wear catalog that declares no breakpoints still resolves through the def
     ],
   );
 });
+
+test("separate LTR and RTL annotations resolve to their own preview, not the first listed", () => {
+  // `variantIdentity` has carried `locale` since gutters started publishing physical edges, but
+  // nothing SCORED it — so one function with an LTR and an RTL `@Preview` resolved both images to
+  // whichever annotation came first, and an asymmetric gutter went out with its left and right
+  // edges swapped for one of them. A wrong crop, not a missing one.
+  const spec = {
+    system: "m3",
+    groups: [
+      {
+        components: [
+          {
+            componentId: "Button/Filled",
+            preview: "FilledButton",
+            // Both stickers come off the SAME function; the locale is a props variant, exactly the
+            // shape a font-scale fan-out takes, so the pick has to score it.
+            variants: [
+              { state: "default", props: { locale: "en" }, preview: "FilledButton" },
+              { state: "rtl", props: { locale: "ar-XB" }, preview: "FilledButton" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      {
+        id: "pkg.CatalogKt.FilledButton_en",
+        functionName: "FilledButton",
+        params: { locale: "en" },
+      },
+      {
+        // The underscore spelling a catalog actually carries, against a hyphenated request.
+        id: "pkg.CatalogKt.FilledButton_ar",
+        functionName: "FilledButton",
+        params: { locale: "ar_XB" },
+      },
+    ],
+  };
+  const manifest = {
+    system: "m3",
+    components: [
+      {
+        componentId: "Button/Filled",
+        images: [
+          { state: "default", props: { locale: "en" } },
+          { state: "rtl", props: { locale: "ar-XB" } },
+        ],
+      },
+    ],
+  };
+
+  bridgeLivePreviewIds(manifest, spec, bundle, new Set());
+
+  assert.deepEqual(mapped(manifest), {
+    default: "pkg.CatalogKt.FilledButton_en",
+    rtl: "pkg.CatalogKt.FilledButton_ar",
+  });
+});

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -32,7 +32,13 @@ function sidecarDeclarations(bundle, previewId, suffix) {
 function rendersRightToLeft(locale) {
   if (typeof locale !== "string" || locale.trim() === "") return false;
   try {
-    return new Intl.Locale(locale).textInfo?.direction === "rtl";
+    // `_` to `-` first. A catalog spells a locale the way the annotation did, and `ar_XB` / `ar_EG`
+    // are supported spellings — `Intl.Locale` throws on them, the catch below reads that as LTR,
+    // and an asymmetric gutter is then published with its left and right edges swapped. The
+    // renderer does not have this problem because `Pseudolocale.fromTag` and
+    // `LocaleDirection.isRtl` both normalise the separator before they look; this is the publisher
+    // agreeing with the pixels rather than with the string it was handed.
+    return new Intl.Locale(locale.trim().replace(/_/g, "-")).textInfo?.direction === "rtl";
   } catch {
     return false;
   }
@@ -57,7 +63,19 @@ function rendersRightToLeft(locale) {
  */
 export function captureGutterPx(gutter, { density, locale } = {}) {
   if (!gutter) return null;
-  const scale = Number.isFinite(density) && density > 0 ? density : 1;
+  // **No density, no record.** This converts dp to render pixels, and a render whose manifest
+  // leaves `density` null did not use 1x: the Android gutter path falls back to `2.0f`
+  // (`RobolectricRenderTest`) and the ordinary render spec to `DeviceDimensions.DEFAULT_DENSITY`,
+  // 2.625f. Publishing as though it were 1x subtracts a third to a half of the real margin, and a
+  // consumer cannot tell a wrong crop from a right one — it just draws the component at the wrong
+  // size, which is the complaint the gutter exists to answer.
+  //
+  // Guessing is not available either: the two backends fall back differently and this publisher
+  // does not reliably know which produced the PNG. So it declines. A preview with no density keeps
+  // the behaviour it had before gutters existed — the whole canvas, un-cropped — rather than a
+  // cropped one that is confidently off by 2x.
+  if (!(Number.isFinite(density) && density > 0)) return null;
+  const scale = density;
   const px = (dp) => Math.round(Math.max(0, Number(dp) || 0) * scale);
   const rtl = rendersRightToLeft(locale);
   const out = {

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -290,12 +290,68 @@ test("records no gutter for a preview that declares none, or declares an empty o
   assert.equal(declarations.get("Zeroed"), undefined);
 });
 
-test("falls back to 1x when a manifest states no density, rather than inventing one", () => {
+test("publishes no gutter when a manifest states no density, rather than assuming 1x", () => {
+  // This replaces a test that pinned the 1x fallback as "not inventing one". It is: a render whose
+  // manifest leaves `density` null did not use 1x. The Android gutter path falls back to `2.0f`
+  // (`RobolectricRenderTest`) and the ordinary render spec to `DeviceDimensions.DEFAULT_DENSITY`,
+  // 2.625f — so publishing dp values as pixels subtracted a third to a half of the real margin, and
+  // a consumer cannot tell a wrong crop from a right one. It just draws the component at the wrong
+  // size, which is what the gutter exists to fix.
+  //
+  // Guessing is not available: the two backends fall back differently and this publisher does not
+  // reliably know which produced the PNG. Declining leaves the preview with the behaviour it had
+  // before gutters existed — the whole canvas, un-cropped — which is recoverable in a way a
+  // confidently-wrong crop is not.
   const bundle = {
     previews: [{ id: "Densityless", params: { captureGutter: { start: 4, top: 4, end: 4, bottom: 5 } } }],
     entries: {},
   };
-  assert.deepEqual(declarationsByPreviewId(bundle).get("Densityless"), {
-    previewParams: { captureGutter: { left: 4, top: 4, right: 4, bottom: 5 } },
+  assert.equal(declarationsByPreviewId(bundle).get("Densityless"), undefined);
+});
+
+test("publishes the gutter as soon as a density is stated", () => {
+  // The other side of the refusal above: it is about the missing input, not about the feature.
+  const bundle = {
+    previews: [
+      {
+        id: "Dense",
+        params: { density: 2, captureGutter: { start: 4, top: 4, end: 4, bottom: 5 } },
+      },
+    ],
+    entries: {},
+  };
+  assert.deepEqual(declarationsByPreviewId(bundle).get("Dense"), {
+    previewParams: { captureGutter: { left: 8, top: 8, right: 8, bottom: 10 } },
+  });
+});
+
+test("an underscore-separated RTL locale still swaps the physical edges", () => {
+  // `ar_XB` and `ar_EG` are supported spellings — a catalog spells a locale the way its annotation
+  // did. `Intl.Locale` throws on the underscore form, the catch read that as LTR, and the gutter
+  // was published with its left and right edges the wrong way round. The renderer has no such
+  // problem: `Pseudolocale.fromTag` and `LocaleDirection.isRtl` normalise the separator first.
+  const asymmetric = { start: 4, top: 4, end: 12, bottom: 5 };
+  for (const tag of ["ar-XB", "ar_XB", "ar_EG", "AR_eg"]) {
+    const bundle = {
+      previews: [
+        { id: "Rtl", params: { density: 1, locale: tag, captureGutter: asymmetric } },
+      ],
+      entries: {},
+    };
+    assert.deepEqual(
+      declarationsByPreviewId(bundle).get("Rtl"),
+      { previewParams: { captureGutter: { left: 12, top: 4, right: 4, bottom: 5 } } },
+      `${tag} renders right-to-left, so start (4) is the RIGHT margin`,
+    );
+  }
+  // …and the LTR spelling of the same pseudolocale is untouched.
+  const ltr = {
+    previews: [
+      { id: "Ltr", params: { density: 1, locale: "en_XA", captureGutter: asymmetric } },
+    ],
+    entries: {},
+  };
+  assert.deepEqual(declarationsByPreviewId(ltr).get("Ltr"), {
+    previewParams: { captureGutter: { left: 4, top: 4, right: 12, bottom: 5 } },
   });
 });


### PR DESCRIPTION
Three findings from the review on #4542, all on the metadata that tells a sheet how much of a `@CaptureGutter` canvas to crop. Each was verified still open on `main` before fixing.

## The underscore spellings read as LTR

`rendersRightToLeft` handed the tag straight to `Intl.Locale`, which throws on `ar_XB` / `ar_EG` — spellings a catalog actually carries, because it spells a locale the way the annotation did. The `catch` read the throw as LTR, so an asymmetric gutter was published with its left and right edges swapped. The separator is now normalised first, the way `Pseudolocale.fromTag` and `LocaleDirection.isRtl` already do on the renderer side.

## `pickVariantId` never scored the locale

`variantIdentity` has carried `locale` since gutters started publishing physical edges, but nothing compared it. One function with a separate LTR and RTL `@Preview` resolved *both* images to whichever annotation the bundle listed first — the same class of bug as #2883, and a wrong crop rather than a missing one. Now scored in the same two tiers as theme and font scale (constraint when the image names a locale, preference otherwise), compared normalised so `ar_XB` and `ar-XB` rank as the same annotation.

## No density is not 1x

`captureGutterPx` fell back to `scale = 1` when a manifest stated no density. No render uses 1x: the Android gutter path falls back to `params.density ?: 2.0f`, and the ordinary render spec to `DeviceDimensions.DEFAULT_DENSITY` (2.625f). So the published margin was a third to a half of the real one, and a consumer cannot tell a wrong crop from a right one — it just draws the component at the wrong size, which is the complaint the gutter exists to answer.

Guessing is not available either: the two backends fall back differently and this publisher does not reliably know which produced the PNG. It now declines, leaving the preview with the behaviour it had before gutters existed — the whole canvas, un-cropped — rather than a crop that is confidently off by 2x. Both call sites were already null-safe.

This replaces the test that pinned the old behaviour as "not inventing" a density; 1x *is* an invention, so the test encoded the bug.

## Test plan

- `node --test scripts/design-artifacts/bridge-live-preview-ids.test.mjs` — 39 pass. New: `separate LTR and RTL annotations resolve to their own preview, not the first listed`.
- `node --test scripts/design-artifacts/catalog-preview-declarations.test.mjs` — 16 pass. New: `publishes no gutter when a manifest states no density`, `publishes the gutter as soon as a density is stated`, `an underscore-separated RTL locale still swaps the physical edges` (covers `ar-XB`, `ar_XB`, `ar_EG`, `AR_eg`, and the LTR `en_XA` control).
- Each new test confirmed non-vacuous by reverting its fix and watching it go red.
- Dependent suites green: `tag-index.test.mjs` (23), `render-index-html.test.mjs` (10).

No visual surface changes — this is publisher metadata, and the correctness it restores shows up as a sheet cropping the right margin rather than as a different render.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_