### PR TITLE
fix(deploy): bound the branch probe and stop calling a raced catalog unpublished

### DIFF
--- a/.github/scripts/publish-config-to-box.sh
+++ b/.github/scripts/publish-config-to-box.sh
@@ -41,6 +41,17 @@ CATALOGS_FILE="${CATALOGS_FILE:-${DEPLOY_CONFIG_DIR}/catalogs.json}"
 TRUST_FILE="${TRUST_FILE:-${DEPLOY_CONFIG_DIR}/producers.json}"
 ADMIN_TOKEN_HEADER="X-Compose-Preview-Admin-Token"
 
+# How long the replacement-branch probe below may take. Injectable so the self-test can drive the
+# stall path in a second instead of thirty; nothing else should set it. `timeout` is coreutils and
+# present on every runner this executes on — on a host without it the probe runs unbounded, which
+# is the behaviour that existed before this line.
+LS_REMOTE_TIMEOUT_SECONDS="${LS_REMOTE_TIMEOUT_SECONDS:-30}"
+if command -v timeout > /dev/null 2>&1; then
+  LS_REMOTE=(timeout "${LS_REMOTE_TIMEOUT_SECONDS}" git ls-remote)
+else
+  LS_REMOTE=(git ls-remote)
+fi
+
 DRY_RUN=0
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
 
@@ -239,12 +250,37 @@ box_field_for() {
 # where it was. This is the cheap half of closing that window: refuse to retire anything until the
 # replacement branch is known to exist. It does not prove the box can load it, which is why the
 # caller still shouts if the re-post fails.
+#
+# BOUNDED, because `git ls-remote` has no timeout of its own and this is a synchronous call in the
+# middle of the reconcile. A connection GitHub accepts and then stalls would hold the entire run —
+# every remaining catalog, every site — until the job's own five-minute limit killed it
+# (.github/workflows/publish-preview-config.yml), which is a far worse outcome than the error path
+# this probe exists to take. Every HTTP call around it already carries `-m 30`; so does this.
+# `timeout` exits 124, which is non-zero like any other failure, so a stall lands on the same
+# `return 2` and is reported as "could not reach github.com" rather than "no such branch".
+#
+# GIT_TERMINAL_PROMPT=0 closes the second way this hangs: a repository that 404s to an
+# unauthenticated fetch makes git ASK for a username, and a runner has no one to answer.
 delivery_branch_exists() {
   local repo="$1" branch="$2" heads
   [[ -n "${repo}" && -n "${branch}" ]] || return 1
-  heads=$(git ls-remote --heads "https://github.com/${repo}.git" "refs/heads/${branch}" 2>/dev/null) ||
+  heads=$(GIT_TERMINAL_PROMPT=0 "${LS_REMOTE[@]}" --heads \
+    "https://github.com/${repo}.git" "refs/heads/${branch}" 2>/dev/null) ||
     return 2
   [[ -n "${heads}" ]]
+}
+
+# The box's registration for one system read FRESH, rather than from the startup snapshot — used
+# only to tell a lost catalog from a raced one, where a stale answer is the whole problem. Prints
+# the repo, or fails if the listing cannot be read.
+live_repo_for() {
+  local system="$1" latest
+  latest=$(curl -sS -m 30 -H "${ADMIN_TOKEN_HEADER}: ${ADMIN_TOKEN}" \
+    "${BASE_URL}/admin/catalogs" 2>/dev/null) || return 1
+  [[ -n "${latest}" ]] || return 1
+  printf '%s' "${latest}" |
+    jq -er --arg s "${system}" \
+      '.catalogs // [] | map(select(.system == $s)) | .[0].repo // ""' 2>/dev/null
 }
 
 echo "Reconciling catalogs from ${CATALOGS_FILE#"${REPO_ROOT}/"}"
@@ -256,9 +292,17 @@ while IFS= read -r entry; do
   moved=0
   if [[ -n "${current_repo}" && -z "${declared_repo}" ]]; then
     # No `repo` here means "the box's own --catalog-repo default", which this file cannot see. The
-    # POST would resolve it, find a mismatch, 409, and be logged as success. Say so rather than
-    # letting that read green; every entry in this repository's config names its repo explicitly.
-    echo "::warning::catalog ${system}: no repo declared, so a move away from ${current_repo} cannot be detected here — declare the repo explicitly."
+    # POST resolves it, finds a mismatch, 409s, and `post` logs that as "already present" — so a
+    # catalog that should have moved to the default keeps serving ${current_repo} and the run ends
+    # green. A warning was not enough: nobody reads a warning in a passing job, which is the whole
+    # reason this script counts rejections at all.
+    #
+    # So this reconcile REQUIRES an explicit repo for any catalog the box already serves, which is
+    # the cheaper half of Codex's two options — comparing against the server's resolved default
+    # would mean reading a flag this file has no route to. Every entry in this repository's config
+    # names its repo, so the requirement costs nothing and the failure is loud.
+    rejected=$((rejected + 1))
+    echo "::error::catalog ${system}: no repo declared, so a move away from ${current_repo} cannot be detected here — declare the repo explicitly in ${CATALOGS_FILE#"${REPO_ROOT}/"}."
   elif [[ -n "${current_repo}" && "${current_repo}" != "${declared_repo}" ]]; then
     echo "  catalog ${system}: repo moved ${current_repo} -> ${declared_repo}"
     # The branch name does not depend on the repo — it is `<branchPrefix><system>` either way — so
@@ -289,11 +333,34 @@ while IFS= read -r entry; do
     fi
   }
   if [[ "${moved}" == 1 && "${last_post}" != ok ]]; then
-    # The retire succeeded and the re-publish did not, so this catalog is now published NOWHERE —
-    # `register` drops the entry it added when the fetch fails. Never let that end up in a green
-    # log: it is the one outcome an operator has to act on immediately.
-    rejected=$((rejected + 1))
-    echo "::error::catalog ${system} was retired from ${current_repo} but could not be re-published from ${declared_repo} — it is currently unpublished. Re-run this workflow once ${declared_repo} serves ${target_branch}, or re-post the old entry to restore it."
+    # The retire succeeded and the re-publish did not. Usually that means the catalog is published
+    # NOWHERE — `register` drops the entry it added when the fetch fails — and that is the one
+    # outcome an operator has to act on immediately, so it must never end in a green log.
+    #
+    # But a 409 says the opposite of "nowhere": the server has a registration under this id. It can
+    # only have arrived between our DELETE and our POST — a concurrent reconcile, or an operator
+    # registering it by hand — and if it came from the repository we were moving TO, the move
+    # happened and there is nothing to report. Declaring an outage there is a false alarm that
+    # fails the standalone publish workflow for a race that converged.
+    #
+    # So read the live registration back before saying anything. Only the `present` case can be
+    # rescued; anything else genuinely lost the catalog.
+    raced_repo=""
+    if [[ "${last_post}" == present ]]; then
+      raced_repo=$(live_repo_for "${system}") || raced_repo=""
+    fi
+    if [[ -n "${raced_repo}" && "${raced_repo}" == "${declared_repo}" ]]; then
+      echo "  catalog ${system}: re-registered from ${declared_repo} by a concurrent publish — the move stands"
+    elif [[ -n "${raced_repo}" ]]; then
+      rejected=$((rejected + 1))
+      echo "::error::catalog ${system} was retired from ${current_repo} and is now registered from ${raced_repo}, not the declared ${declared_repo} — something else re-registered it mid-publish. Re-run this workflow, and check who else is publishing to this box."
+    elif [[ "${last_post}" == present ]]; then
+      rejected=$((rejected + 1))
+      echo "::error::catalog ${system} was retired from ${current_repo} and the re-publish came back 409, but the live registration could not be read back — it is registered as SOMETHING, and possibly not ${declared_repo}. Check /admin/catalogs on the box."
+    else
+      rejected=$((rejected + 1))
+      echo "::error::catalog ${system} was retired from ${current_repo} but could not be re-published from ${declared_repo} — it is currently unpublished. Re-run this workflow once ${declared_repo} serves ${target_branch}, or re-post the old entry to restore it."
+    fi
   fi
 done < <(jq -c '.catalogs // [] | .[]' "${CATALOGS_FILE}")
 

--- a/.github/scripts/test-publish-config-to-box.sh
+++ b/.github/scripts/test-publish-config-to-box.sh
@@ -415,6 +415,177 @@ stranded=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t
 printf '%s' "${stranded}" | grep -q 'it is currently unpublished' ||
   fail "a retire that could not be re-published must be a loud error:\n${stranded}"
 
+# 10f. The retire succeeded, the re-post came back 409 — and the live registration says the box is
+#      already serving the repository we were moving TO. Something else (a concurrent reconcile, an
+#      operator) registered it between our DELETE and our POST. The move happened; calling that an
+#      outage fails the standalone publish workflow for a race that converged.
+race_curl() {
+  # $1 = the repo the SECOND and later listings report. The first still reports the old one, so the
+  # move is detected exactly as it would be in the field.
+  cat > "${shim}/curl" <<SH
+#!/usr/bin/env bash
+method=GET
+for a in "\$@"; do
+  case "\$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+if [[ "\$method" == GET ]]; then
+  for a in "\$@"; do
+    case "\$a" in
+      */admin/catalogs)
+        n=0
+        [[ -f "${tmp}/gets" ]] && n=\$(cat "${tmp}/gets")
+        echo \$((n + 1)) > "${tmp}/gets"
+        if [[ "\$n" == 0 ]]; then
+          printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+        else
+          printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"$1","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+        fi
+        exit 0 ;;
+    esac
+  done
+  exit 0
+fi
+if [[ "\$method" == DELETE ]]; then printf 'ok\n200'; exit 0; fi
+for a in "\$@"; do
+  case "\$a" in
+    *compose-m3*) printf "catalog 'compose-m3' is already registered\n409"; exit 0 ;;
+  esac
+done
+printf 'ok\n200'
+SH
+  chmod +x "${shim}/curl"
+  rm -f "${tmp}/gets"
+}
+
+race_curl yschimke/compose-ai-tools
+git_stub present
+
+raced=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+raced_status=$?
+
+printf '%s' "${raced}" | grep -q 'it is currently unpublished' &&
+  fail "a 409 whose live registration matches the declared repo is not an outage:\n${raced}"
+printf '%s' "${raced}" | grep -q 'catalog compose-m3: re-registered from yschimke/compose-ai-tools by a concurrent publish' ||
+  fail "a converged race must be reported as converged:\n${raced}"
+[[ "${raced_status}" == 0 ]] ||
+  fail "a converged race must not fail the publish (exit ${raced_status}):\n${raced}"
+
+# 10g. The same race, but whatever re-registered the catalog pointed it somewhere ELSE. That is a
+#      real problem and must stay loud — just not under the word "unpublished", which would send an
+#      operator looking for a catalog that is right there.
+race_curl yschimke/somewhere-else
+git_stub present
+
+hijacked=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+hijacked_status=$?
+
+printf '%s' "${hijacked}" | grep -q '::error::catalog compose-m3 was retired from yschimke/old-home and is now registered from yschimke/somewhere-else' ||
+  fail "a race onto the wrong repo must name that repo:\n${hijacked}"
+printf '%s' "${hijacked}" | grep -q 'it is currently unpublished' &&
+  fail "a catalog the server reports registered must not be called unpublished:\n${hijacked}"
+[[ "${hijacked_status}" != 0 ]] ||
+  fail "a race onto the wrong repo must fail the publish:\n${hijacked}"
+
+# 10h. An entry that declares NO repo for a catalog the box already serves. The POST resolves the
+#      omitted field to the server's own --catalog-repo default, 409s on the mismatch, and `post`
+#      logs that as "already present" — so the old repository keeps serving and the run reads green.
+#      This reconcile cannot see the box's default, so it requires the repo to be declared.
+cat > "${tmp}/catalogs-norepo.json" <<'JSON'
+{
+  "catalogs": [{ "system": "compose-m3", "listed": true }]
+}
+JSON
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+method=GET
+for a in "$@"; do
+  case "$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+if [[ "$method" == GET ]]; then
+  for a in "$@"; do
+    case "$a" in
+      */admin/catalogs)
+        printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+        exit 0 ;;
+    esac
+  done
+  exit 0
+fi
+printf 'ok\n200'
+SH
+chmod +x "${shim}/curl"
+
+norepo=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs-norepo.json" \
+  bash "${UNDER_TEST}" 2>&1)
+norepo_status=$?
+
+printf '%s' "${norepo}" | grep -q '::error::catalog compose-m3: no repo declared' ||
+  fail "an undeclarable move must be an error, not a warning:\n${norepo}"
+[[ "${norepo_status}" != 0 ]] ||
+  fail "an undeclarable move must fail the publish:\n${norepo}"
+
+# 10i. The replacement-branch probe is BOUNDED. `git ls-remote` has no timeout of its own, so a
+#      connection GitHub accepts and then stalls would hold the whole reconcile — every remaining
+#      catalog and every site — until the workflow's own limit killed it. A stall must instead take
+#      the same path as any other unreachable remote: report it, and retire nothing.
+cat > "${shim}/curl" <<'SH'
+#!/usr/bin/env bash
+method=GET
+for a in "$@"; do
+  case "$a" in
+    POST) method=POST ;;
+    DELETE) method=DELETE ;;
+  esac
+done
+if [[ "$method" == GET ]]; then
+  for a in "$@"; do
+    case "$a" in
+      */admin/catalogs)
+        printf '%s' '{"catalogs":[{"system":"compose-m3","repo":"yschimke/old-home","branch":"design-artifacts/compose-m3","listed":true,"state":"loaded"}]}'
+        exit 0 ;;
+    esac
+  done
+  exit 0
+fi
+printf 'ok\n200'
+SH
+chmod +x "${shim}/curl"
+cat > "${shim}/git" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == ls-remote ]]; then
+  sleep 30
+  exit 0
+fi
+exec /usr/bin/git "$@"
+SH
+chmod +x "${shim}/git"
+
+started=$(date +%s)
+stalled=$(PATH="${shim}:${PATH}" BASE_URL=https://example.invalid ADMIN_TOKEN=t \
+  LS_REMOTE_TIMEOUT_SECONDS=1 \
+  TRUST_FILE="${tmp}/producers.json" CATALOGS_FILE="${tmp}/catalogs.json" \
+  bash "${UNDER_TEST}" 2>&1)
+elapsed=$(($(date +%s) - started))
+
+printf '%s' "${stalled}" | grep -q 'could not reach github.com' ||
+  fail "a stalled probe must report the remote as unreachable:\n${stalled}"
+printf '%s' "${stalled}" | grep -q 'retired the stale registration' &&
+  fail "a stalled probe must retire nothing:\n${stalled}"
+# Three catalogs, one of which probes: without the bound this sleeps 30s per probe.
+[[ "${elapsed}" -lt 20 ]] ||
+  fail "the probe is not bounded — the run took ${elapsed}s with a 1s timeout"
+
 rm -f "${shim}/git"
 
 if [[ "${failures}" -gt 0 ]]; then

--- a/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
+++ b/docs/design/evidence/rc-compare-cmp-jvm-lane/README.md
@@ -34,7 +34,8 @@ git show FETCH_HEAD:bundle/bundle.png > bundle.png
 #     live in THIS repository.)
 
 # 2. stage the documents once (shared by both embedded lanes)
-node rc-compare.mjs --bundle bundle.png --player <rc-player>/bundle.js --out out --stage-embedded rc-in
+node scripts/design-artifacts/rc-compare.mjs --bundle bundle.png \
+  --player cli/serve/src/main/resources/rc-player/bundle.js --out out --stage-embedded rc-in
 #    -> rc-compare: staged 24 document(s)
 
 # 3. Android embedded lane
@@ -46,7 +47,8 @@ node rc-compare.mjs --bundle bundle.png --player <rc-player>/bundle.js --out out
   -Prc.jvm.input=rc-in -Prc.jvm.output=rc-jvm-out                  # BUILD SUCCESSFUL; 24 PNGs, 0 errors
 
 # 5. render the four-lane page
-node rc-compare.mjs --bundle bundle.png --player <rc-player>/bundle.js --out out \
+node scripts/design-artifacts/rc-compare.mjs --bundle bundle.png \
+  --player cli/serve/src/main/resources/rc-player/bundle.js --out out \
   --system remote-m3 --title remote-m3 --embedded rc-out --embedded-jvm rc-jvm-out
 #    -> 24/24 rendered, mean mismatch 1.16%
 ```


### PR DESCRIPTION
Unaddressed review findings from #4592 and #4595. Nine were left on those two PRs; five were already closed by the follow-ups themselves (the DELETE-409 site discrimination, and both `rc-outlined-card-double-draw` recipe findings — `(b)` already stages a `manifest.json` and `(a)` is already annotated as not producing one). Each finding below was re-verified against `main` before being fixed.

## The replacement-branch probe was unbounded

`git ls-remote` has no timeout of its own, and it is a synchronous call in the middle of the reconcile. A connection GitHub accepts and then stalls holds the whole run — every remaining catalog and every site — until the workflow's own five-minute limit kills it, which is a far worse outcome than the error path the probe exists to take. Every HTTP call around it already carries `-m 30`; the probe now matches, through `timeout`, whose exit 124 is non-zero like any other failure and so lands on the existing "could not reach github.com" path rather than the "no such branch" one.

`GIT_TERMINAL_PROMPT=0` closes the second way this hangs: a repository that 404s to an unauthenticated fetch makes git *ask for a username*, and a runner has no one to answer.

The duration is injectable (`LS_REMOTE_TIMEOUT_SECONDS`) so the self-test can drive the stall in a second instead of thirty.

## A 409 on the re-post was reported as an outage

After a successful retire, `last_post=present` says the opposite of "published nowhere": the server has a registration under this id, and it can only have arrived between our DELETE and our POST — a concurrent reconcile, or an operator. If it came from the repository we were moving *to*, the move happened and there is nothing to report; declaring an outage there fails the standalone publish workflow for a race that converged.

The live registration is now read back before anything is said:

| what the box reports | what this says now |
| --- | --- |
| registered from the declared repo | `re-registered … by a concurrent publish — the move stands`, no rejection |
| registered from some other repo | error naming that repo — loud, but not "unpublished" |
| 409 but the listing can't be read | error saying it is registered as *something*, possibly not the declared repo |
| anything else | the existing "currently unpublished" error, unchanged |

## A repo-less entry could not be reconciled, and only warned

The POST resolves the omitted field to the box's own `--catalog-repo`, 409s on the mismatch, and `post` logs that as "already present" — so a catalog that should have moved to the default keeps serving the old repository and the run ends green. A warning was not enough: nobody reads a warning in a passing job, which is the reason this script counts rejections at all.

This takes the cheaper of Codex's two options — require an explicit repo for any catalog the box already serves. Comparing against the server's resolved default would mean reading a flag this file has no route to, and every entry in this repository's config names its repo already, so the requirement costs nothing.

## The rc-compare evidence recipe named a script that isn't there

`node rc-compare.mjs` from the compose-ai-tools root is `MODULE_NOT_FOUND` — the script is `scripts/design-artifacts/rc-compare.mjs`. Both invocations now carry the real path, and `--player <rc-player>/bundle.js` is replaced by the concrete `cli/serve/src/main/resources/rc-player/bundle.js` its sibling README already uses.

## Test plan

`.github/scripts/test-publish-config-to-box.sh` — all checks pass, in 3.4s. Four new cases, each confirmed non-vacuous by reverting its fix and watching it go red:

- **10f** the re-post 409s and the live listing shows the declared repo → reported as converged, exit 0
- **10g** the re-post 409s and the live listing shows a *third* repo → names it, fails the publish, and does not say "unpublished"
- **10h** a repo-less entry for a catalog the box serves → error, non-zero exit
- **10i** a `git ls-remote` that hangs → reports the remote unreachable, retires nothing, and the run finishes in under 20s (30s per probe without the bound — this case is what fails when the `timeout` is removed)

10f/10g need a stateful `curl` shim: the first `/admin/catalogs` GET reports the old repo so the move is detected exactly as in the field, and later GETs report what the race left behind.

`bash -n` clean on both scripts. Non-visual — a deploy script and an evidence recipe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_