### PR TITLE
fix(serve): budget the parity verdict per comparison, and keep what a clean run said

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
@@ -227,9 +227,17 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
   /**
    * The sets that describe the comparison on screen: those naming [referenceId], plus the unscoped
    * ones that describe the render whichever reference it is being read against.
+   *
+   * The page budgets are spent HERE, not at load, because they describe a page and only this
+   * selection is one. Reference-scoped sets are mutually exclusive on screen — a preview with three
+   * boards shows one of them at a time — so charging them against a shared allowance let the first
+   * two exhaust it and left the third comparison with no verdict at all, for a page that was never
+   * going to render the other two.
    */
   fun forComparison(previewId: String, referenceId: String): List<ParityFindingSet> =
-    forPreview(previewId).filter { it.referenceId == null || it.referenceId == referenceId }
+    spendPageBudget(
+      forPreview(previewId).filter { it.referenceId == null || it.referenceId == referenceId }
+    )
 
   companion object {
     private const val MAX_PREVIEWS = 5000
@@ -258,6 +266,9 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
     private const val MAX_ANCHORS_PER_PREVIEW = 600
     private const val MAX_DETAIL_KEYS = 24
     private const val MAX_MESSAGE = 400
+
+    /** An anchor caption names an element; anything longer is not a name. */
+    private const val MAX_LABEL = 120
     private const val MAX_DETAIL_VALUE = 200
     private val STATUSES = setOf("pass", "warn", "fail")
     private val ID = Regex("[^\\p{Cc}]{1,300}")
@@ -347,34 +358,21 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
     }
 
     /**
-     * One preview's sets, held to what a single comparison may show and draw.
-     *
-     * Trimmed rather than dropped: the budget is exhausted in the order the producer wrote, and a
-     * verdict past it has already said far more than a reader will get through. Findings are
-     * severity-ordered within a set before the trim, so what survives is the worst of what was
-     * published rather than whatever happened to be written first.
+     * One preview's sets, each validated on its own. The page budgets are spent in [forComparison],
+     * which is the only place that knows what one page will show.
      */
     private fun sanitizePreview(sets: JsonArray): List<ParityFindingSet>? {
-      var findingBudget = MAX_FINDINGS_PER_PREVIEW
-      var anchorBudget = MAX_ANCHORS_PER_PREVIEW
-      val kept = mutableListOf<ParityFindingSet>()
-      for (element in sets.take(MAX_SETS_PER_PREVIEW)) {
-        if (findingBudget <= 0) break
-        val set =
-          runCatching { JSON.decodeFromJsonElement<RawSet>(element) }.getOrNull() ?: continue
-        val sanitized = sanitizeSet(set, findingBudget, anchorBudget) ?: continue
-        findingBudget -= sanitized.findings.size
-        anchorBudget -= sanitized.findings.sumOf { it.anchors.size }
-        kept += sanitized
-      }
+      val kept =
+        sets
+          .take(MAX_SETS_PER_PREVIEW)
+          .mapNotNull { element ->
+            runCatching { JSON.decodeFromJsonElement<RawSet>(element) }.getOrNull()
+          }
+          .mapNotNull(::sanitizeSet)
       return kept.takeIf { it.isNotEmpty() }
     }
 
-    private fun sanitizeSet(
-      raw: RawSet,
-      findingBudget: Int,
-      anchorBudget: Int,
-    ): ParityFindingSet? {
+    private fun sanitizeSet(raw: RawSet): ParityFindingSet? {
       // A supplied id that does not validate is NOT the same as an absent one, and treating it as
       // one is the worst reading available: `forComparison` takes null as "describes the render
       // whichever reference it is read against", so a producer's malformed scope would print this
@@ -390,7 +388,6 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
             text
           }
         }
-      var anchorsLeft = anchorBudget
       val findings =
         raw.findings
           .take(MAX_FINDINGS_PER_SET)
@@ -399,17 +396,15 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
           }
           .mapNotNull(::sanitizeFinding)
           .sortedBy { ParityFindingSeverity.rank(it.severity) }
-          .take(findingBudget.coerceAtLeast(0))
-          .map { finding ->
-            val room = anchorsLeft.coerceAtLeast(0)
-            anchorsLeft -= finding.anchors.size.coerceAtMost(room)
-            if (finding.anchors.size <= room) finding
-            else finding.copy(anchors = finding.anchors.take(room))
-          }
-      if (findings.isEmpty()) return null
+      val status = raw.status?.trim()?.lowercase()?.takeIf(STATUSES::contains)
+      // A set with no findings is KEPT when it declares a status, and it is not an empty record: a
+      // run that looked and found nothing is a different fact from a catalog nobody ran, and only
+      // the first can say "Pass". Dropping it made the two indistinguishable on the page. With
+      // neither findings nor a status there is nothing to say, and the set goes.
+      if (findings.isEmpty() && status == null) return null
       return ParityFindingSet(
         referenceId = referenceId,
-        status = raw.status?.trim()?.lowercase()?.takeIf(STATUSES::contains),
+        status = status,
         // Only an absolute https link, and only as a link: this string is written by another
         // repository and lands in an `href`, so a `javascript:` or a protocol-relative host would
         // be a stored redirect out of the catalog on a page the reader trusts.
@@ -441,7 +436,17 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
           raw.anchors
             .take(MAX_ANCHORS_PER_FINDING)
             .mapNotNull { runCatching { JSON.decodeFromJsonElement<ParityAnchor>(it) }.getOrNull() }
-            .filter(::isUsable),
+            .filter(::isUsable)
+            // Clamped like a message and a detail value, and for a sharper reason than either:
+            // this string is serialized into every comparison page AND drawn by the client as a
+            // `white-space: nowrap` caption, so an unbounded one is both a multi-megabyte response
+            // and a label wider than the screen it is meant to annotate.
+            .map { anchor ->
+              anchor.copy(
+                label =
+                  anchor.label?.trim()?.takeIf { it.isNotEmpty() }?.let { clamp(it, MAX_LABEL) }
+              )
+            },
       )
     }
 
@@ -456,6 +461,37 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
       val primitive = value as? JsonPrimitive ?: return null
       if (primitive is JsonNull) return null
       return clamp(primitive.content.trim(), MAX_DETAIL_VALUE).takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Hold one comparison's sets to what a page can show and draw, worst-severity-first.
+     *
+     * Trimmed rather than dropped: the budget is spent in the order the producer wrote, and a
+     * verdict past it has already said far more than a reader will get through. Findings are
+     * severity-ordered within a set before this runs, so what survives is the worst of what was
+     * published rather than whatever happened to be written first.
+     */
+    private fun spendPageBudget(sets: List<ParityFindingSet>): List<ParityFindingSet> {
+      var findingsLeft = MAX_FINDINGS_PER_PREVIEW
+      var anchorsLeft = MAX_ANCHORS_PER_PREVIEW
+      // Nothing to spend against: the common shape, and worth not rebuilding every set for.
+      if (
+        sets.sumOf { it.findings.size } <= findingsLeft &&
+          sets.sumOf { set -> set.findings.sumOf { it.anchors.size } } <= anchorsLeft
+      ) {
+        return sets
+      }
+      return sets.map { set ->
+        val findings =
+          set.findings.take(findingsLeft.coerceAtLeast(0)).map { finding ->
+            val room = anchorsLeft.coerceAtLeast(0)
+            anchorsLeft -= finding.anchors.size.coerceAtMost(room)
+            if (finding.anchors.size <= room) finding
+            else finding.copy(anchors = finding.anchors.take(room))
+          }
+        findingsLeft -= findings.size
+        set.copy(findings = findings)
+      }
     }
 
     /**

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -1284,7 +1284,10 @@ ${captureControlsHtml().prependIndent("          ")}
    */
   private fun parityVerdictHtml(sets: List<ParityFindingSet>): String {
     val findings = sets.flatMap { it.findings }
-    if (findings.isEmpty()) return ""
+    // A run that looked and found nothing still has something to say, and it is not the same fact
+    // as a catalog nobody ran: only the first can print "Pass". So a set survives on its declared
+    // status alone, and renders as the head with no groups under it.
+    if (findings.isEmpty() && sets.none { it.status != null }) return ""
     // Worst declared status wins. A run that declared none at all is read off its own findings,
     // which is the same rule the producing engine applies and keeps a hand-written manifest honest.
     val declared = sets.mapNotNull { it.status }
@@ -1359,9 +1362,8 @@ ${captureControlsHtml().prependIndent("          ")}
         report +
         "\n  </div>" +
         hint +
-        "\n  <div class=\"cp-parity-groups\">\n" +
-        groups.joinToString("\n") +
-        "\n  </div>"
+        (if (groups.isEmpty()) "\n  <p class=\"cp-parity-clean\">No findings.</p>"
+        else "\n  <div class=\"cp-parity-groups\">\n" + groups.joinToString("\n") + "\n  </div>")
     val payload =
       if (anchors.isEmpty()) ""
       else
@@ -1390,8 +1392,13 @@ ${captureControlsHtml().prependIndent("          ")}
     val expected = finding.detail["expected"]
     val actual = finding.detail["actual"]
     val token = finding.detail["token"] ?: finding.detail["property"]
+    // The token is printed whenever the finding names one — a spec token IS the finding's subject,
+    // and a check reporting "radius: candidate resolved none" carries the identity with no numeric
+    // delta. Gating the row on expected/actual dropped that identity from the page while the
+    // sanitizer had faithfully kept it, and the `rest` filter below excludes the key too, so it
+    // reached nowhere at all.
     val delta =
-      if (expected == null && actual == null) ""
+      if (expected == null && actual == null && token == null) ""
       else
         "<span class=\"cp-parity-delta\">" +
           (token?.let { "<code>${WebEscaping.htmlEscape(it)}</code>" } ?: "") +

--- a/cli/serve/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
+++ b/cli/serve/src/main/resources/ee/schimke/composeai/cli/serve/assets/serve.css
@@ -2907,6 +2907,9 @@ html:not(.cp-bg-transparent) #cp-reference-compare[data-cp-stage-clip] .cp-refer
   font-variant-numeric: tabular-nums; }
 .cp-parity-report { margin-left: auto; font-size: 0.74rem; }
 .cp-parity-hint { margin: 8px 0 0; color: var(--cp-fg-faint); font-size: 0.72rem; }
+/* A run that looked and found nothing. Worth a line rather than an absent panel: "checked, clean"
+   and "nobody ran this" are different facts, and only one of them is reassuring. */
+.cp-parity-clean { margin: 10px 0 0; color: var(--cp-fg-muted); font-size: 0.76rem; }
 .cp-parity-groups { display: grid; gap: 12px; margin-top: 12px; }
 .cp-parity-group h3 { display: flex; align-items: center; gap: 7px; margin: 0 0 6px;
   font-size: 0.72rem; color: var(--cp-fg-muted); text-transform: uppercase;

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
@@ -197,6 +197,57 @@ class ServeParityFindingStoreTest {
   }
 
   @Test
+  fun `a run that looked and found nothing keeps its verdict`() {
+    // `{"status":"pass","findings":[]}` is the natural shape of a clean run, and dropping it made
+    // the comparison indistinguishable from a catalog nobody ran a parity check against.
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         {"referenceId":"a","status":"pass","findings":[]}]}}"""
+    val set = store(json).forComparison("p", "a").single()
+    assertEquals("pass", set.status)
+    assertTrue(set.findings.isEmpty())
+    // …but a set with neither findings nor a status says nothing at all, and still goes.
+    val silent =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[{"findings":[]}]}}"""
+    assertTrue(store(silent).isEmpty)
+  }
+
+  @Test
+  fun `the page budget is spent per comparison, not across references a page never shows`() {
+    // Reference-scoped sets are mutually exclusive on screen. Charging them against one shared
+    // allowance let the first two boards exhaust it and left the third comparison blank, for a
+    // page that was never going to render the other two.
+    fun finding(index: Int) =
+      """{"kind":"layout","severity":"warn","message":"m$index","anchors":[
+         {"side":"actual","bounds":{"x":0,"y":0,"width":4,"height":4}}]}"""
+    fun set(reference: String) =
+      """{"referenceId":"$reference","findings":[${(1..200).joinToString(",") { finding(it) }}]}"""
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         ${listOf("a", "b", "c").joinToString(",") { set(it) }}]}}"""
+    val loaded = store(json)
+    for (reference in listOf("a", "b", "c")) {
+      assertEquals(
+        200,
+        loaded.forComparison("p", reference).single().findings.size,
+        "board $reference keeps its own verdict",
+      )
+    }
+  }
+
+  @Test
+  fun `an anchor label is clamped, not carried whole into every page`() {
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[{"findings":[
+         {"kind":"layout","severity":"warn","message":"m","anchors":[
+           {"side":"actual","bounds":{"x":0,"y":0,"width":4,"height":4},
+            "label":"${"x".repeat(900)}"}]}]}]}}"""
+    val label = store(json).forPreview("p").single().findings.single().anchors.single().label
+    assertEquals(120, label?.length)
+    assertTrue(label!!.endsWith("…"))
+  }
+
+  @Test
   fun `one comparison cannot publish more than a page can hold`() {
     // Nested ceilings multiply — twenty sets of two hundred findings is four thousand rows and a
     // browser that stops responding while their boxes are placed. The aggregate is the one that
@@ -209,7 +260,7 @@ class ServeParityFindingStoreTest {
     val json =
       """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
          ${(1..20).joinToString(",") { set }}]}}"""
-    val findings = store(json).forPreview("p").flatMap { it.findings }
+    val findings = store(json).forComparison("p", "any").flatMap { it.findings }
     assertEquals(300, findings.size)
     assertEquals(600, findings.sumOf { it.anchors.size })
   }

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebParityVerdictTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebParityVerdictTest.kt
@@ -140,6 +140,39 @@ class ServeWebParityVerdictTest {
   }
 
   @Test
+  fun `a clean run says so rather than looking like a catalog nobody checked`() {
+    val html = page(listOf(ParityFindingSet(status = "pass", findings = emptyList())))
+    assertTrue("cp-parity-verdict" in html, html)
+    assertTrue("cp-parity-status--pass" in html, html)
+    assertTrue("No findings." in html, html)
+    // No empty groups container behind it.
+    assertFalse("cp-parity-groups" in html, html)
+  }
+
+  @Test
+  fun `a finding that names a token prints it even with no numeric delta`() {
+    val html =
+      page(
+        listOf(
+          ParityFindingSet(
+            findings =
+              listOf(
+                finding(
+                  "token",
+                  severity = "info",
+                  message = "radius: candidate resolved no radius tokens",
+                  detail = mapOf("token" to "shape.corner", "unverified" to "true"),
+                )
+              )
+          )
+        )
+      )
+    // The spec token IS the finding's subject; the delta row is optional metadata around it.
+    assertTrue("shape.corner" in html, html)
+    assertFalse("expected" in html, html)
+  }
+
+  @Test
   fun `a verdict with no geometry gets the panel without the invitation`() {
     val html = page(listOf(ParityFindingSet(findings = listOf(finding("a11y")))))
     assertTrue("cp-parity-verdict" in html, html)


### PR DESCRIPTION
Follow-up to #4664, which auto-merged while this round of review fixes was still in flight. Four findings from Codex's second pass, all against code that landed in that PR.

**The page budgets were spent across sets a page never shows together.** Reference-scoped sets are mutually exclusive on screen — a preview with three boards shows one at a time — so charging them against one shared allowance let the first two exhaust it and left the third comparison with no verdict at all, for a page that was never going to render the other two. They are spent in `forComparison` now, which is the only place that knows what one page will render. The constant already said "what ONE comparison may put on a page"; the implementation did not.

**A clean run's verdict was thrown away.** `{"status":"pass","findings":[]}` is the natural shape of a run that looked and found nothing, and dropping it made the comparison indistinguishable from a catalog nobody ever checked. Those are different facts and only one of them is reassuring, so a set now survives on its declared status alone and renders as the head over "No findings." A set with neither findings nor a status still says nothing, and still goes.

**A finding's token identity vanished without a numeric delta.** A spec token is the finding's subject, not decoration around a delta — a check reporting `radius: candidate resolved no radius tokens` names one and has no expected/actual. The row was gated on the delta and the remaining-detail filter excludes the key, so it reached nowhere at all.

**An anchor label was the one producer string with no ceiling**, while being serialized into every comparison page and drawn by the client as a `white-space: nowrap` caption — both a multi-megabyte response and a label wider than the frame it annotates. Clamped to 120 like a message and a detail value.

## Not fixed here: the cache coupling

Codex's remaining P1 is that the page HTML (`max-age=60`) and `/render/<id>.png` (`max-age=300`) have independent cache lifetimes, so after a catalog refresh a client can pair one generation's verdict prose and anchors with another generation's pixels. The finding is correct, and it is deliberately not fixed in this PR:

- Closing it means giving the page, the verdict and the rendered frame **one generation identity**, which moves the render lane's published URL and caching contract for every surface that builds a render URL — the viewer, the wall, the compare page, the acceptance engine's `candidateUrl`, the tag-index gate, the issue reporter's embedded `renderUrl`.
- That work is already named as deferred in this exact handler (the `frameIsReplayedBaked` comment: *"the gap is caching … closing it needs the image and the index to carry a shared generation — batch 05's coupling, which also moves the render lane's URL and caching contract"*).
- The exposure is not new. The annotation redline that ships today is drawn from bounds in the same pixel space, over the same panels, behind the same two caches.
- A partial fix — generation-scoping only the `<img>` on this page — would put the acceptance engine's `candidateUrl` and the displayed pixels on different URLs, which is a worse inconsistency than the one it closes.

Happy to take it as its own change if you'd rather not wait for batch 05; it wants to be scoped as the render-lane URL change, not bolted to the verdict panel.

## Test plan

- `:cli:serve:test` green, `ktfmtCheckMain` / `ktfmtCheckTest` clean.
- New `ServeParityFindingStoreTest` cases: `a run that looked and found nothing keeps its verdict` (and that a set with neither findings nor status still goes), `the page budget is spent per comparison, not across references a page never shows` (three boards × 200 findings, each keeping its own 200), `an anchor label is clamped, not carried whole into every page`.
- New `ServeWebParityVerdictTest` cases: `a clean run says so rather than looking like a catalog nobody checked` (status chip + "No findings.", no empty groups container), `a finding that names a token prints it even with no numeric delta`.
- All 8 `serve-reference-compare` harness captures pass; the committed golden is unchanged, since the fixture's findings all carry a delta or no token.
- `check-committed-bundle.mjs` green — no client change in this round.


---
_Generated by [Claude Code](https://claude.ai/code/session_0182LfFspu62Vogm1ezszybP)_