### PR TITLE
fix(bundle-format): record appTourRobolectricPropertiesBody in the ABI dump

### DIFF
--- a/bundle/format/api/bundle-format.api
+++ b/bundle/format/api/bundle-format.api
@@ -6,6 +6,7 @@ public final class ee/schimke/composeai/bundle/AndroidBundleLaunch {
 	public fun <init> ()V
 	public fun <init> (IZLokio/FileSystem;Ljava/lang/String;)V
 	public synthetic fun <init> (IZLokio/FileSystem;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun appTourRobolectricPropertiesBody ()Ljava/lang/String;
 	public final fun getSdkLevel ()I
 	public final fun jvmArgs ()Ljava/util/List;
 	public final fun robolectricPropertiesBody ()Ljava/lang/String;


### PR DESCRIPTION
`main` is red on `:bundle-format:checkKotlinAbi`.

#4662 added `AndroidBundleLaunch.appTourRobolectricPropertiesBody` without regenerating the dump. The method appears in no recorded `.api` file, so the check fails on `main` and on every branch that merges it — I hit it on #4666 and only then went looking.

Reproduced on a pristine checkout of `origin/main` before attributing it, rather than assuming it belonged to the branch that surfaced it:

```
<<<ABI has changed>>>
--- bundle/format/api/bundle-format.api
+++ bundle/format/build/kotlin/abi/bundle-format.api
+	public final fun appTourRobolectricPropertiesBody ()Ljava/lang/String;
BUILD FAILED
```

One line, generated by `:bundle-format:updateLegacyAbi`, not written by hand.

## Why it reached main

`#4662` changed `bundle/format/src` and `checkKotlinAbi` did not run for it. That is the same shape as the two `ci-paths.json` omissions #4663 was written for — a gate that exists without running — in a different path group. Worth a follow-up to check which module `check` tasks are actually scheduled by changes to their own sources; I've not touched that here, to keep this to the red build.

## Test plan

- `:bundle-format:checkKotlinAbi` — reproduced failing on pristine `origin/main`, passing on this branch (`BUILD SUCCESSFUL`).

Non-visual: a generated ABI dump. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_