### PR TITLE
ci: check every contract-package mapping against the module that ships it

### DIFF
--- a/scripts/check-contract-registration.py
+++ b/scripts/check-contract-registration.py
@@ -87,12 +87,19 @@ def contract_packages(root: pathlib.Path) -> dict[str, str]:
 
 
 def module_packages(root: pathlib.Path, directory: str) -> set[str]:
-    """Every package declared in a module's main source set."""
+    """Every package declared in a module's main source set.
+
+    Java as well as Kotlin: a JVM consumer imports a Java declaration exactly like a Kotlin
+    one, so a Java-only package in a contract is as much part of the seam. No contract module
+    has Java sources today — which is the reason to include them now, while it costs a glob.
+    """
     packages: set[str] = set()
-    for source in (root / directory / "src" / "main").rglob("*.kt"):
-        match = re.search(r"^package\s+([\w.]+)", source.read_text(), re.M)
-        if match:
-            packages.add(match.group(1))
+    main = root / directory / "src" / "main"
+    for pattern in ("*.kt", "*.java"):
+        for source in main.rglob(pattern):
+            match = re.search(r"^\s*package\s+([\w.]+)", source.read_text(), re.M)
+            if match:
+                packages.add(match.group(1))
     return packages
 
 
@@ -125,8 +132,16 @@ def covered(directory: str, globs: list[str]) -> bool:
     A prefix test rather than an equality test on purpose: `render-session/**` legitimately
     covers both `render-session/api` and `render-session/subprocess`, and demanding an exact
     entry per project would fail a correct file.
+
+    But only a glob that takes the *whole* subtree counts. `daemon/core/**/*.kt` has the same
+    directory prefix and does not schedule the job for a change to that module's build file or
+    to a Java source under it — and those paths are classified by other groups, so the
+    classifier does not fail open and the probe is simply skipped. A partial glob is worse than
+    a missing one: it reads as coverage.
     """
     for glob in globs:
+        if glob != "**" and not glob.endswith("/**") and not glob.endswith("/"):
+            continue  # not whole-subtree coverage; see above
         prefix = glob.split("*", 1)[0].rstrip("/")
         if prefix and (directory == prefix or directory.startswith(prefix + "/")):
             return True
@@ -163,6 +178,28 @@ def check(root: pathlib.Path = REPO) -> int:
             f"project in {SHELL} publishes — the seam checker would credit those imports to a "
             "contract that does not exist"
         )
+
+    # Every mapping key names a package; the artifact it names must be the one that ships it.
+    # The per-module loop below only reaches a module's *root* packages, so a nested entry —
+    # `…daemon.bta` pointed at `daemon-client` while its sources sit in `daemon-core` — is
+    # invisible there: `daemon-core` reduces to `…daemon`, and the value check only asks
+    # whether `daemon-client` exists at all.
+    owned: dict[str, set[str]] = {}
+    for path, directory in resolved.items():
+        artifact = ids[path]
+        if artifact is not None:
+            owned.setdefault(artifact, set()).update(module_packages(root, directory))
+    for package, artifact in sorted(mapping.items()):
+        if artifact not in named:
+            continue  # already reported above, with a better message
+        packages = owned.get(artifact, set())
+        if not any(p == package or p.startswith(package + ".") for p in packages):
+            elsewhere = sorted(a for a, ps in owned.items() if any(p == package for p in ps))
+            hint = f" — it ships in {', '.join(elsewhere)}" if elsewhere else ""
+            problems.append(
+                f"{ALLOWLIST}: `contractPackages` maps '{package}' to '{artifact}', which "
+                f"declares no such package{hint}"
+            )
 
     for path, directory in sorted(resolved.items()):
         artifact = ids[path]

--- a/scripts/test_check_contract_registration.py
+++ b/scripts/test_check_contract_registration.py
@@ -46,8 +46,27 @@ class Covered(unittest.TestCase):
         # `bundle/format2` is not covered by `bundle/format/**`.
         self.assertFalse(mod.covered("bundle/format2", ["bundle/format/**"]))
 
+    def test_a_selective_glob_is_not_whole_module_coverage(self):
+        # Same directory prefix, but a change to the module's build file or a Java source under
+        # it would not select the group — and other groups classify those paths, so the
+        # classifier does not fail open. A partial glob reads as coverage without being it.
+        self.assertFalse(mod.covered("daemon/core", ["daemon/core/**/*.kt"]))
+        self.assertTrue(mod.covered("daemon/core", ["daemon/core/**"]))
+
     def test_no_globs_covers_nothing(self):
         self.assertFalse(mod.covered("common/io", []))
+
+
+class ModulePackages(unittest.TestCase):
+    def test_java_sources_are_scanned(self):
+        # No contract module has Java sources today; the point is that adding one cannot open a
+        # hole. A JVM consumer imports a Java declaration exactly like a Kotlin one.
+        tmp = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        main = tmp / "m" / "src" / "main" / "java" / "ee" / "x"
+        main.mkdir(parents=True)
+        (main / "T.java").write_text("package ee.x;\n\npublic final class T {}\n")
+        self.assertEqual(mod.module_packages(tmp, "m"), {"ee.x"})
 
 
 class RealTree(unittest.TestCase):
@@ -83,7 +102,9 @@ class Omissions(unittest.TestCase):
             # One stub per declared package instead of the real sources: the checker only
             # reads `package` lines, and copying every module's main source set to run a
             # regex over it would make the fixture cost more than the gate it tests.
-            for i, package in enumerate(mod.package_roots(mod.module_packages(REPO, d))):
+            # Every package, not just the roots — the key-ownership check resolves nested
+            # entries like `…daemon.bta` against the module that declares them.
+            for i, package in enumerate(sorted(mod.module_packages(REPO, d))):
                 stub = self.root / d / "src" / "main" / "kotlin" / f"Stub{i}.kt"
                 stub.parent.mkdir(parents=True, exist_ok=True)
                 stub.write_text(f"package {package}\n")
@@ -138,6 +159,19 @@ class Omissions(unittest.TestCase):
             lambda m: m.__setitem__("ee.schimke.composeai.imagecrop", "common-image-kropp")
         )
         self.assertIn("which no project in", self._failure())
+
+    def test_a_nested_package_mapped_to_the_wrong_contract_fails(self):
+        # The per-module check below only reaches a module's *root* packages, so a nested entry
+        # is invisible to it: `daemon-core` reduces to `…daemon`, and the value check only asks
+        # whether `daemon-client` exists at all. This is the key-ownership check instead.
+        self._rewrite_allowlist(
+            lambda m: m.__setitem__("ee.schimke.composeai.daemon.bta", "daemon-client")
+        )
+        self.assertIn(
+            "maps 'ee.schimke.composeai.daemon.bta' to 'daemon-client', which declares no such "
+            "package",
+            self._failure(),
+        )
 
     def test_contract_package_naming_the_wrong_contract_fails(self):
         # A parent entry swallowing a child module's package — `…daemon.client` reading as


### PR DESCRIPTION
Follow-up to #4663, which merged before I could act on its review. Three holes in the gate I wrote to close holes of exactly this kind — all three found by Codex, all three confirmed by mutation before fixing.

## A nested mapping was never checked

The per-module loop resolves a module's **root** packages, so `daemon-core` reduces to `ee.schimke.composeai.daemon` and an entry for `…daemon.bta` is never reached. The value check only asked whether the named artifact exists at all. So this passed both gates:

```
"ee.schimke.composeai.daemon.bta": "daemon-client"     # sources are in daemon-core
```

Now every key is resolved against the packages its named module actually declares, which **subsumes** the root check rather than sitting beside it:

```
contractPackages maps 'ee.schimke.composeai.daemon.bta' to 'daemon-client',
which declares no such package — it ships in daemon-core
```

## A selective glob read as whole-module coverage

`daemon/core/**/*.kt` has the same directory prefix as `daemon/core/**`, so the prefix test accepted it — but it does not schedule the probe for a change to that module's build file. Those paths are classified by other groups, so the classifier does not fail open and the job is simply skipped. No such glob exists in `ci-paths.json` today; the check accepted one. Only a whole-subtree glob counts now.

## Java packages were invisible

The scan read `*.kt` only, so a Java-only package in a contract could be left unmapped while the gate reported success. No contract module has Java sources — which is exactly why it costs one glob to close now rather than a debug session later.

## Test plan

- 16 tests green. Each new case asserts the **failure message**, not just the exit code, so it fails for the reason it claims.
- Falsified each fix by mutation on the real tree first: the `daemon.bta` remap and a `daemon/core/**/*.kt` substitution both passed before and are caught after.
- The fixture now stubs every declared package rather than only the roots. It failed first on the *baseline* case when I changed the checker — that guard doing its job is why the new cases can be trusted.
- `check-contract-registration.py` and `check-serve-seam.py` both OK on the real tree.

Non-visual: a CI script and its tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_