### PR TITLE
fix(agents): cap fence indentation at three spaces in the entrypoint gate

### DIFF
--- a/scripts/check-agent-entrypoints.sh
+++ b/scripts/check-agent-entrypoints.sh
@@ -135,17 +135,25 @@ fi
 #
 # The fence state tracks the OPENING delimiter, not just "a fence marker seen".
 # CommonMark closes a fence only on the same character, at least as long as the
-# opener, with nothing after it — so a literal ~~~ line inside a ``` block is
-# content, and treating it as a close would re-open the file to the `@AGENTS.md`
-# on the next line. An inert pointer certified as reachable is the exact failure
-# this gate exists to prevent, so it is worth the extra state.
+# opener, indented at most three spaces, with nothing after it. Each of those
+# three conditions has the same failure if dropped: a line that is fence CONTENT
+# reads as a close, the file re-opens, and the still-fenced `@AGENTS.md` on the
+# next line certifies as an import. An inert pointer certified as reachable is
+# the exact failure this gate exists to prevent, so it is worth the state.
+#
+# Three spaces, not "any indentation": at four a fence marker is an indented
+# code block, i.e. content. A leading TAB is four columns and so is over the
+# limit already, which is why only spaces are allowed here.
 strip_fenced_blocks() {
   awk '
     {
       marker = ""
-      if (match($0, /^[ \t]*(`+|~+)/)) {
+      # Three optional spaces spelled out rather than {0,3}: mawk 1.3.4 panics
+      # compiling an interval next to this alternation ("values still on machine
+      # stack"), and this script has to run under whatever awk the host has.
+      if (match($0, /^ ? ? ?(`+|~+)/)) {
         marker = substr($0, RSTART, RLENGTH)
-        gsub(/^[ \t]*/, "", marker)
+        gsub(/^ */, "", marker)
       }
       len = length(marker)
       if (len >= 3) {

--- a/scripts/test-check-agent-entrypoints.sh
+++ b/scripts/test-check-agent-entrypoints.sh
@@ -123,6 +123,19 @@ printf '@xAGENTSymd\n' > "$d/CLAUDE.md"
 printf '@xAGENTSymd\n' > "$d/GEMINI.md"
 check "a pointer matching only via wildcarded dots is rejected" 1 "$(run "$d")"
 
+# CommonMark caps fence indentation at three spaces: at four, a same-delimiter
+# line is an indented code block — content — not a closer. Accepting unlimited
+# leading whitespace re-opened the document at that line and certified the still
+# fenced @AGENTS.md below it.
+d="$tmp/overindented-fence"; make_good "$d"
+printf '```\n    ```\n@AGENTS.md\n```\n' > "$d/CLAUDE.md"
+check "a four-space-indented fence marker does not close the block" 1 "$(run "$d")"
+
+# ...and three spaces still does, so the limit does not simply reject everything.
+d="$tmp/indented-fence-ok"; make_good "$d"
+printf '@AGENTS.md\n\n   ```\nfenced\n   ```\n' > "$d/CLAUDE.md"
+check "a three-space-indented fence still opens and closes" 0 "$(run "$d")"
+
 d="$tmp/no-copilot"; make_good "$d"; rm "$d/.github/copilot-instructions.md"
 check "missing copilot-instructions.md is rejected" 1 "$(run "$d")"
 


### PR DESCRIPTION
Follow-up to #4671, which merged about seven minutes after Codex posted this finding on it — so it landed unaddressed. Fresh branch off `main` rather than commits onto the merged one.

## The finding

CommonMark caps a fence marker's indentation at three spaces; at four it is an indented code block, i.e. block **content**. The fence tracker `strip_fenced_blocks` accepted unlimited leading whitespace, so this file passed the gate:

````
```
    ```
@AGENTS.md
```
````

The four-space-indented marker read as a close, the document re-opened, and the still-fenced `@AGENTS.md` on the next line certified as an import. That is the same "inert pointer certified as reachable" failure the delimiter tracking in #4671 was added to prevent, reached by indentation instead of by delimiter — and it is the failure this gate exists for: an agent that never sees the invariants, going red on a rule it was never shown.

A leading **tab** is four columns and so is over the limit already, which is why only spaces are permitted before the marker now.

The three spaces are spelled out (`^ ? ? ?`) rather than written `{0,3}`: mawk 1.3.4 panics compiling an interval next to that alternation — `REcompile() - panic: values still on machine stack` — and this script runs under whatever awk the host has, so the pattern has to be portable rather than merely correct on gawk.

## Test plan

`scripts/test-check-agent-entrypoints.sh` — 21 passed, 0 failed (19 before). Two new cases:

- `a four-space-indented fence marker does not close the block` — the reproduction above; **passes** against `main`'s script, which is the hole, so it is non-vacuous
- `a three-space-indented fence still opens and closes` — the limit does not simply reject every indented fence

`scripts/check-agent-entrypoints.sh` against the real repository: all invariants reachable from every agent.

Also on that review, and deliberately not acted on: the P1 reporting the reviewed commit as authored by `Codex <codex@openai.com>`. `git log --format=fuller` on this branch and on #4671's head shows Yuri Schimke as both author and committer, and the SHA the finding cites is not in the repository. `Reject agent attribution` runs on every PR with no path filter and is the authority here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_