### PR TITLE
fix(serve): never print a clean parity verdict over a report this build could not read

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
@@ -264,6 +264,24 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
      * the row count.
      */
     private const val MAX_ANCHORS_PER_PREVIEW = 600
+
+    /**
+     * What one preview may KEEP, across every reference it publishes a verdict for.
+     *
+     * A second budget, because it bounds a different thing. The page allowance above has to be
+     * spent at READ time — reference-scoped sets are mutually exclusive on screen, so charging them
+     * against one allowance at load blanks boards a page was never going to show together — and
+     * that leaves the store itself unbounded. The store is not free: it is held in memory by
+     * `ServeBundleHost` and reserialized into the staging tree by `ServeCatalogStore`, so the
+     * nested ceilings alone let one preview keep four thousand findings and a hundred and sixty
+     * thousand anchors no page can ever reach.
+     *
+     * Deliberately far above the page budget: several boards' worth of a real verdict passes
+     * untouched, since which of them a reader asks for is not known here. This bounds disk and
+     * heap, not what anyone reads.
+     */
+    private const val MAX_STORED_FINDINGS_PER_PREVIEW = 1000
+    private const val MAX_STORED_ANCHORS_PER_PREVIEW = 2000
     private const val MAX_DETAIL_KEYS = 24
     private const val MAX_MESSAGE = 400
 
@@ -369,7 +387,10 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
             runCatching { JSON.decodeFromJsonElement<RawSet>(element) }.getOrNull()
           }
           .mapNotNull(::sanitizeSet)
-      return kept.takeIf { it.isNotEmpty() }
+      return spendBudget(kept, MAX_STORED_FINDINGS_PER_PREVIEW, MAX_STORED_ANCHORS_PER_PREVIEW)
+        // A set trimmed to nothing that never declared a status has stopped saying anything.
+        .filter { it.findings.isNotEmpty() || it.status != null }
+        .takeIf { it.isNotEmpty() }
     }
 
     private fun sanitizeSet(raw: RawSet): ParityFindingSet? {
@@ -401,7 +422,13 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
       // run that looked and found nothing is a different fact from a catalog nobody ran, and only
       // the first can say "Pass". Dropping it made the two indistinguishable on the page. With
       // neither findings nor a status there is nothing to say, and the set goes.
-      if (findings.isEmpty() && status == null) return null
+      // …but only when the producer's array was ALSO empty. A set whose findings were all
+      // rejected here — a message this reader could not use, a kind it does not know — has a
+      // report behind it that this build cannot show, and printing "Pass · No findings." over it
+      // would turn a manifest we failed to read into a reassuring clean verdict. That is the one
+      // direction this panel must never fail in: silence says "unknown", a green chip says
+      // "checked".
+      if (findings.isEmpty() && (status == null || raw.findings.isNotEmpty())) return null
       return ParityFindingSet(
         referenceId = referenceId,
         status = status,
@@ -471,9 +498,17 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
      * severity-ordered within a set before this runs, so what survives is the worst of what was
      * published rather than whatever happened to be written first.
      */
-    private fun spendPageBudget(sets: List<ParityFindingSet>): List<ParityFindingSet> {
-      var findingsLeft = MAX_FINDINGS_PER_PREVIEW
-      var anchorsLeft = MAX_ANCHORS_PER_PREVIEW
+    private fun spendPageBudget(sets: List<ParityFindingSet>): List<ParityFindingSet> =
+      spendBudget(sets, MAX_FINDINGS_PER_PREVIEW, MAX_ANCHORS_PER_PREVIEW)
+
+    /** Hold a list of sets to a finding and anchor allowance, worst-severity-first. */
+    private fun spendBudget(
+      sets: List<ParityFindingSet>,
+      maxFindings: Int,
+      maxAnchors: Int,
+    ): List<ParityFindingSet> {
+      var findingsLeft = maxFindings
+      var anchorsLeft = maxAnchors
       // Nothing to spend against: the common shape, and worth not rebuilding every set for.
       if (
         sets.sumOf { it.findings.size } <= findingsLeft &&

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindings.kt
@@ -388,8 +388,6 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
           }
           .mapNotNull(::sanitizeSet)
       return spendBudget(kept, MAX_STORED_FINDINGS_PER_PREVIEW, MAX_STORED_ANCHORS_PER_PREVIEW)
-        // A set trimmed to nothing that never declared a status has stopped saying anything.
-        .filter { it.findings.isNotEmpty() || it.status != null }
         .takeIf { it.isNotEmpty() }
     }
 
@@ -516,7 +514,7 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
       ) {
         return sets
       }
-      return sets.map { set ->
+      return sets.mapNotNull { set ->
         val findings =
           set.findings.take(findingsLeft.coerceAtLeast(0)).map { finding ->
             val room = anchorsLeft.coerceAtLeast(0)
@@ -525,7 +523,12 @@ private constructor(private val byPreview: Map<String, List<ParityFindingSet>>) 
             else finding.copy(anchors = finding.anchors.take(room))
           }
         findingsLeft -= findings.size
-        set.copy(findings = findings)
+        // A set this budget emptied is DROPPED, never trimmed to a status-only record. It reached
+        // here carrying findings, so its "Pass" would be printed over a report that exists and
+        // that this build then discarded — the same false-clean verdict a rejected findings array
+        // produces, arriving one level up. Only a set the producer wrote empty may say "Pass" with
+        // nothing under it, and such a set is empty before this runs rather than because of it.
+        if (findings.isEmpty() && set.findings.isNotEmpty()) null else set.copy(findings = findings)
       }
     }
 

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
@@ -213,6 +213,54 @@ class ServeParityFindingStoreTest {
   }
 
   @Test
+  fun `a report this build could not read never reads as a clean run`() {
+    // The sharpest failure available to this panel: a producer says `pass` over findings that all
+    // get rejected here, and the page prints "Pass · No findings." over a report nobody could
+    // read. Silence says "unknown"; a green chip says "checked", and only one of those is honest.
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         {"referenceId":"a","status":"pass","findings":[
+           {"kind":"token","severity":"warn"},
+           {"kind":"invented","severity":"warn","message":"m"}]}]}}"""
+    assertTrue(store(json).isEmpty)
+  }
+
+  @Test
+  fun `one preview cannot store more than disk and heap should hold`() {
+    // The page budget is spent at read time, so it bounds a comparison and not the store. This
+    // bounds the store, which is held in memory and reserialized into the staging tree.
+    fun finding(index: Int) =
+      """{"kind":"layout","severity":"warn","message":"m$index","anchors":[
+         {"side":"actual","bounds":{"x":0,"y":0,"width":4,"height":4}},
+         {"side":"reference","bounds":{"x":0,"y":0,"width":4,"height":4}}]}"""
+    fun set(reference: Int) =
+      """{"referenceId":"r$reference","findings":[
+         ${(1..200).joinToString(",") { finding(it) }}]}"""
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         ${(1..20).joinToString(",") { set(it) }}]}}"""
+    val stored = store(json).forPreview("p").flatMap { it.findings }
+    assertEquals(1000, stored.size)
+    assertEquals(2000, stored.sumOf { it.anchors.size })
+  }
+
+  @Test
+  fun `a real multi-board verdict passes the storage ceiling untouched`() {
+    // The ceiling must not trim anything a genuine run publishes, or it would silently answer a
+    // later comparison with less than its board said.
+    fun finding(index: Int) = """{"kind":"layout","severity":"warn","message":"m$index"}"""
+    fun set(reference: String) =
+      """{"referenceId":"$reference","findings":[${(1..150).joinToString(",") { finding(it) }}]}"""
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         ${listOf("ideal", "layout", "dark", "large").joinToString(",") { set(it) }}]}}"""
+    val loaded = store(json)
+    for (reference in listOf("ideal", "layout", "dark", "large")) {
+      assertEquals(150, loaded.forComparison("p", reference).single().findings.size, reference)
+    }
+  }
+
+  @Test
   fun `the page budget is spent per comparison, not across references a page never shows`() {
     // Reference-scoped sets are mutually exclusive on screen. Charging them against one shared
     // allowance let the first two boards exhaust it and left the third comparison blank, for a

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeParityFindingStoreTest.kt
@@ -245,6 +245,26 @@ class ServeParityFindingStoreTest {
   }
 
   @Test
+  fun `a board the storage ceiling emptied never reads as a clean run`() {
+    // The same false-clean verdict as a rejected findings array, arriving one level up: five full
+    // boards exhaust the store's allowance, the sixth is trimmed to nothing, and its declared
+    // `pass` would print "Pass · No findings." over findings this build discarded.
+    fun finding(index: Int) = """{"kind":"layout","severity":"warn","message":"m$index"}"""
+    fun set(reference: String, status: String? = null) =
+      """{"referenceId":"$reference",${status?.let { "\"status\":\"$it\"," } ?: ""}
+         "findings":[${(1..200).joinToString(",") { finding(it) }}]}"""
+    val json =
+      """{"schema":"compose-preview-parity-findings/v1","previews":{"p":[
+         ${(1..5).joinToString(",") { set("r$it") }},
+         ${set("last", status = "pass")}]}}"""
+    val loaded = store(json)
+    // Five boards fit within the 1000-finding ceiling; the sixth is dropped whole rather than
+    // kept as a reassuring empty record.
+    assertTrue(loaded.forComparison("p", "last").isEmpty(), "the trimmed board is dropped")
+    assertEquals(200, loaded.forComparison("p", "r1").single().findings.size)
+  }
+
+  @Test
   fun `a real multi-board verdict passes the storage ceiling untouched`() {
     // The ceiling must not trim anything a genuine run publishes, or it would silently answer a
     // later comparison with less than its board said.


### PR DESCRIPTION
Follow-up to #4672, which merged while this round of review fixes was in flight — same as #4664 before it. Two findings from Codex's third pass, both against code that landed in #4672.

## A rejected findings array was becoming a reassuring "Pass"

#4672 taught the store to keep a set that declares a status with no findings, so a clean run could say so instead of looking like a catalog nobody ever checked. That was right, and it was too broad: it also kept a set whose findings were *all rejected during sanitization* — a message this reader could not use, a kind it does not know — and the page then printed `Pass · No findings.` over a report nobody could read.

That is the one direction this panel must never fail in. Silence says *unknown*; a green chip says *checked*, and only one of those is honest about a manifest we failed to parse. A set now survives on its status alone only when the producer's array was **also** empty.

## Moving the page budget to read time left the store unbounded

Also from #4672, and the two budgets bound genuinely different things:

- The **page** allowance has to be spent in `forComparison`. Reference-scoped sets are mutually exclusive on screen, so charging them against one allowance at load blanks boards a page was never going to show together — that was the bug #4672 fixed.
- That leaves the **store** unbounded, and the store is not free: it is held in memory by `ServeBundleHost` and reserialized into the staging tree by `ServeCatalogStore`. The nested per-set ceilings alone let one preview keep 4,000 findings and 160,000 anchors that no page can ever reach.

So a storage ceiling now runs at load, deliberately far above the page budget — a four-board verdict of 150 findings each passes through untouched, pinned by its own test, because which board a reader asks for is not known at load time. It bounds disk and heap, not what anyone reads.

## Test plan

- `:cli:serve:test` green, `ktfmtCheckMain` / `ktfmtCheckTest` clean, on a branch freshly based on `main` (`58504d2`).
- New `ServeParityFindingStoreTest` cases: `a report this build could not read never reads as a clean run`; `one preview cannot store more than disk and heap should hold` (20 boards × 200 findings → 1000/2000 retained); `a real multi-board verdict passes the storage ceiling untouched` (4 boards × 150 findings, each intact through `forComparison`).
- The existing `a run that looked and found nothing keeps its verdict` still passes — a genuinely empty array with a declared status is unaffected.

## Note on the recurring identity finding

Codex has now raised "recreate the commit with a human identity" on all three PRs in this series. It is a false positive each time: `.github/scripts/agent-attribution-scan.sh --range HEAD~1..HEAD` reports no finding, both identities on the commit are `Yuri Schimke <yuri@schimke.ee>`, and the `Reject agent attribution` gate has been green throughout. `.claude/skills/steward/SKILL.md` documents this exact pattern and says to skip it, so I have not acted on it.


---
_Generated by [Claude Code](https://claude.ai/code/session_0182LfFspu62Vogm1ezszybP)_