### PR TITLE
docs: correct the force-bump routes and the "every body is discarded" claim

### DIFF
--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -17,20 +17,24 @@ name: No Agent Attribution
 #
 # Why this lives at the PR layer (not just the local .githooks/commit-msg
 # hook): PRs are squash-merged, and GitHub builds the squash commit *message*
-# from the **PR title + PR body**, NOT the branch commit messages. A
-# `Co-authored-by:` trailer at the start of a line in the PR description
-# therefore becomes a real trailer on `main`, bypassing every local hook. So we
+# from the PR title and body rather than from the branch commit messages, so
+# neither local hook ever sees the text that becomes the commit. This repo also
+# sets `squash_merge_commit_message=BLANK`, which drops the body — so a
+# `Co-authored-by:` line in a PR description does not in fact reach `main` today.
+# It is scanned anyway, and deliberately: that is a repository *setting*, not
+# anything a diff can guarantee, and a merger can edit the message by hand. So we
 # scan the PR title, the PR body, and every commit message in the range — but
 # only at trailer position (start of line), so prose that merely *mentions* a
 # trailer (like this very PR) does not trip the gate.
 #
-# There is a SECOND path to a trailer on `main`, and it is the one that actually
-# bit us: GitHub's squash credits every distinct **commit author** of the branch
-# as a co-author. So a branch commit authored by an agent lands
-# `Co-authored-by: Claude <noreply@anthropic.com>` on `main` even when the PR
-# title and body are clean. That is how 5aacb786 got its trailer. The identity
-# check below is therefore not just about the branch — it is what keeps the
-# trailer off `main`, and the failure message says so.
+# The path that DOES reach `main`, and the one that actually bit us: GitHub's
+# squash credits every distinct **commit author** of the branch as a co-author,
+# writing that into the body BLANK would otherwise leave empty. So a branch commit
+# authored by an agent lands `Co-authored-by: Claude <noreply@anthropic.com>` on
+# `main` even when the PR title and body are clean. That is how 5aacb786 got its
+# trailer, and why 8f5fcce and f82b02a carry a bot one. The identity check below
+# is therefore not just about the branch — it is what keeps the trailer off
+# `main`, and the failure message says so.
 #
 # Untrusted text (title/body) is passed through env: and never interpolated
 # into the shell, per the repo zizmor policy.

--- a/.github/workflows/no-agent-attribution.yml
+++ b/.github/workflows/no-agent-attribution.yml
@@ -21,11 +21,17 @@ name: No Agent Attribution
 # neither local hook ever sees the text that becomes the commit. This repo also
 # sets `squash_merge_commit_message=BLANK`, which drops the body — so a
 # `Co-authored-by:` line in a PR description does not in fact reach `main` today.
-# It is scanned anyway, and deliberately: that is a repository *setting*, not
-# anything a diff can guarantee, and a merger can edit the message by hand. So we
+# It is scanned anyway, and deliberately: BLANK is a repository *setting* that no
+# diff can guarantee, so the scan holds whether or not it is still set. So we
 # scan the PR title, the PR body, and every commit message in the range — but
 # only at trailer position (start of line), so prose that merely *mentions* a
 # trailer (like this very PR) does not trip the gate.
+#
+# What this job CANNOT cover is a merger editing the squash message by hand:
+# that happens after the required check has read the title, the body and the
+# commit range, so none of its inputs contain the new text. `drift` below is
+# what catches that, on the push to `main` — after the fact rather than before,
+# which is the honest boundary between the two jobs.
 #
 # The path that DOES reach `main`, and the one that actually bit us: GitHub's
 # squash credits every distinct **commit author** of the branch as a co-author,

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -167,16 +167,22 @@ that file deliberately leaves out.
 **Why the attribution gate scans the PR description, and why it caught something
 the hooks could not.** PRs here are squash-merged with
 `squash_merge_commit_message=BLANK`, so the squashed commit carries the **PR title
-only** and every body — PR and commit alike — is discarded. Verify in one
-command: `git log --format='%b' -5 origin/main` prints nothing. That also means a
-`Co-authored-by:` trailer in a *branch* commit never lands on `main` either; the
-CI gate, not the merge, is what makes scrubbing necessary. There is a second path
-to a trailer on `main`, and it is the one that actually bit us: GitHub's squash
-credits every distinct **commit author** of the branch as a co-author, so a branch
-commit authored by an agent lands `Co-authored-by: Claude <noreply@anthropic.com>`
-on `main` even when the title and body are clean (commit `5aacb786`). The identity
-check is therefore not just about the branch — it is what keeps the trailer off
-`main`.
+only** and every body a human *writes* — PR and commit alike — is discarded. That
+also means a `Co-authored-by:` trailer in a *branch* commit never lands on `main`
+that way; the CI gate, not the merge, is what makes scrubbing necessary. There is
+a second path to a trailer on `main`, and it is the one that actually bit us:
+GitHub's squash credits every distinct **commit author** of the branch as a
+co-author, so a branch commit authored by an agent lands
+`Co-authored-by: Claude <noreply@anthropic.com>` on `main` even when the title and
+body are clean (commit `5aacb786`). The identity check is therefore not just about
+the branch — it is what keeps the trailer off `main`.
+
+`git log --format='%b' -5 origin/main` usually prints nothing, and that is the
+quick confirmation of the first half — but **an empty `%b` is not the rule**, and
+reading it as one hides the second half entirely. BLANK discards the body you
+wrote; it does not stop GitHub synthesizing one. `8f5fcce` and `f82b02a` both
+carry a `github-actions[bot]` co-author trailer in their bodies, and `5aacb786`
+carries an agent's. Branch author identities do reach `main`.
 
 The detector has its own tests — [`scripts/test-agent-attribution.sh`](../scripts/test-agent-attribution.sh),
 run by CI on every PR — so change it only with those passing, and keep the shared

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,9 +12,15 @@ In **Settings → Actions → General → Workflow permissions**, tick **"Allow 
 
 [release-please](https://github.com/googleapis/release-please) watches `main` for conventional-commit history and keeps a release PR up to date. Merging the PR is the only manual step.
 
-1. **Land conventional-commit PRs to `main`.** `fix:`, `feat:`, and `feat!:` / `BREAKING CHANGE` trigger a release. `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. To force a bump, run the `Release PR` workflow via `workflow_dispatch`, or set `"release-as": "0.3.4"` in `release-please-config.json`, let the release land, then revert that key in a follow-up PR.
+1. **Land conventional-commit PRs to `main`.** `fix:` and `feat:` trigger a release, and a `!` in the PR title (`feat!:`) cuts a major. `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. To force a bump with no releasable commit, set `"release-as": "0.3.4"` in `release-please-config.json`, let the release land, then revert that key in a follow-up PR — that is the **only** route.
 
-   > **A `Release-As:` footer does not work here.** release-please parses it from a commit's body, and this repo squash-merges with `squash_merge_commit_message=BLANK` — the squashed commit on `main` keeps the **PR title only**, so every body is discarded and the footer never arrives. Confirm with `git log --format='%b' -5 origin/main`, which prints nothing. Putting the footer in a branch commit, in the PR description, or in an empty commit all fail for the same reason (an empty commit additionally contributes no commit at all to a squash). The two routes above are the ones that survive.
+   > **Dispatching `Release PR` does not force a bump.** [`release-please.yml`](../.github/workflows/release-please.yml) declares `workflow_dispatch` with no inputs and runs the same release-please invocation, against the same config, that a push to `main` runs. It re-computes the answer; it cannot change it. Dispatch it to re-run a calculation that failed or raced — not to manufacture a release out of a history that warrants none, which just produces the same no-op however many times it is pressed.
+
+   > **A `BREAKING CHANGE:` footer does not reach release-please either**, for the reason below: it is a *body* footer, and the body is discarded. Only the `!` in the PR title survives the squash, so a breaking change has to be spelled `feat!:` / `fix!:` in the title. Writing `BREAKING CHANGE:` in the body and a plain `feat:` in the title yields a **minor** bump.
+
+   > **A `Release-As:` footer does not work here.** release-please parses it from a commit's body, and this repo squash-merges with `squash_merge_commit_message=BLANK` — the squashed commit on `main` keeps the **PR title only**, so every body a human writes is discarded and the footer never arrives. Putting it in a branch commit, in the PR description, or in an empty commit all fail for the same reason (an empty commit additionally contributes no commit at all to a squash). `release-as` is the one route that survives.
+   >
+   > `git log --format='%b' -5 origin/main` usually prints nothing, which is the quick confirmation — but do not read an empty `%b` as a rule. GitHub still *synthesizes* a body when the branch has distinct commit authors, crediting each as `Co-authored-by:` (`8f5fcce`, `f82b02a`, `5aacb786`). What BLANK discards is the body you wrote, not the metadata GitHub adds — which is exactly why the attribution gate cares who authored a branch commit. See [`docs/AGENTS.md` → Git conventions](AGENTS.md#git-conventions).
 
    > **PR titles are the commit headlines.** Squash-merge uses the PR title as the commit headline, which is what release-please parses. The [PR Title](../.github/workflows/pr-title.yml) workflow enforces conventional-commit format on every PR so mis-titled PRs can't silently skip a release (as PR #94 did before the 0.6.0 cut). If you _do_ ever end up with a non-conforming commit on `main`, push an empty conventional-commit marker with `git commit --allow-empty -m "feat(...)…"` and release-please will re-scan.
 
@@ -103,7 +109,7 @@ Removed alongside it: `bump-minor-pre-major` and `bump-patch-for-minor-pre-major
 |---|---|
 | `fix:` | patch |
 | `feat:` | minor |
-| `feat!:` / `BREAKING CHANGE` | **major** |
+| `feat!:` (the `!`, in the **PR title**) | **major** |
 
 So a PR titled `feat!:` now cuts **2.0.0**, not 1.0.1. Watch PR titles accordingly — this is the single most likely way to cut an unintended major.
 


### PR DESCRIPTION
The four substantive findings left on #4579. Each was checked against the repository, not against the docs. (The fifth was the agent-commit-identity P1, already answered on that thread — `447b99af` is authored and committed as Yuri Schimke.)

## `workflow_dispatch` is not a force-bump route

`docs/RELEASING.md` offered two ways to force a bump. The first does not exist: [`release-please.yml`](https://github.com/yschimke/compose-ai-tools/blob/main/.github/workflows/release-please.yml) declares `workflow_dispatch` with **no inputs** and runs the same `release-please-action` step, against the same `release-please-config.json`, that a push to `main` runs. It re-computes the answer; it cannot change it. A maintainer with no releasable commit would press it and get the same no-op however many times.

`release-as` is the only route, and the doc now says so — with a note that dispatch is for re-running a calculation that failed or raced.

## A body-only breaking-change footer cannot cut a major

`feat!:` and the `BREAKING CHANGE` footer were presented as equivalent, two paragraphs above the explanation of why the body is discarded. That footer lives in the *body*, so `squash_merge_commit_message=BLANK` drops it before release-please ever sees it: only the `!` in the PR title survives. A `feat:` title with such a footer yields a **minor** bump — silently, which is the bad kind. Corrected in the prose and in the bump table (`feat!:` (the `!`, in the **PR title**)).

## "Every body is discarded — `%b` prints nothing" is too broad

Stated in both `docs/RELEASING.md` and `docs/AGENTS.md`, and wrong in the direction that hides the thing the attribution gate exists for. BLANK discards the body a human *writes*; it does not stop GitHub *synthesizing* one for distinct branch commit authors. This repository has the examples:

| commit | subject | synthesized co-author |
| --- | --- | --- |
| `8f5fcce` | chore(ci): refresh the design-artifacts driver pin to v1.37.1 (#4566) | `github-actions[bot]` |
| `f82b02a` | chore(main): release 1.37.1 (#4551) | `github-actions[bot]` |
| `5aacb786` | fix: treat renderFailed as terminal in the daemon wait loops (#2749) | an agent identity |

`git log --format='%b' -5 origin/main` does print nothing right now, so it stays as the quick confirmation — but it is no longer offered as a rule. Both copies now separate what BLANK discards from what GitHub adds, which is exactly why the gate checks *who authored a branch commit* rather than only what the messages say.

> The first revision of this description quoted those three trailers verbatim, in a fenced block. `Reject agent attribution` matches `^[[:space:]]*Co-authored-by:` — a fence and eight spaces of indent are still start-of-line to it — so the gate failed this PR on its own evidence. Correctly: the rule is about trailer position, not about intent, and a table carries the same facts without occupying it.

## The workflow comment contradicted `docs/AGENTS.md`

`no-agent-attribution.yml` explained that GitHub builds the squash message "from the **PR title + PR body**", so a trailer in the PR description "becomes a real trailer on `main`". BLANK has made that false, and `docs/AGENTS.md` says the opposite — so which behaviour a contributor believed depended on which file they opened.

The comment now states the real reason the body is still scanned: BLANK is a repository *setting* that no diff can guarantee, so the scan holds whether or not it is still set. It also names the boundary between the two jobs — a merger editing the squash message by hand happens *after* every input this check reads, so that case belongs to `drift` on the push to `main`, not to the PR scan.

## Test plan

Documentation and one workflow comment — no behaviour changes.

- `scripts/test-agent-attribution.sh` — 44 passed, 0 failed.
- `scripts/check-agent-entrypoints.sh` — all invariants reachable from every agent.
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD` — clean.
- The workflow still parses as YAML; only comment lines changed.
- Every claim verified directly: `release-please.yml`'s dispatch inputs read from the file, and the three co-author commits read with `git log`.