### PR TITLE
fix(design-artifacts): publish each catalog's own components on a shared design page

### DIFF
--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -122,7 +122,12 @@ function resolveServePreviewId(
     const matches = matchesForPreviewId(byPreviewId, declared);
     return matches.length > 0 ? servePreviewId(matches[0].image?.path) : null;
   }
-  const fn = functionNameOf(node?.code);
+  // The function join is in the PRODUCING MODULE's namespace, so it is only offered for a node this
+  // catalog owns. A foreign node's `#Member` can collide with an unrelated local preview — a bare
+  // `DefaultPreview` is the obvious case — and taking it would pair one component's code (rewritten
+  // from the reference) with another component's render, corrupting the very score this surface
+  // publishes. A foreign node goes straight to the reference join.
+  const fn = ours ? functionNameOf(node?.code) : null;
   if (fn) {
     const matches = byFunction.get(fn) ?? [];
     // Refuse an AMBIGUOUS fallback. `byFunction` is keyed by the bare member name, so two
@@ -185,13 +190,14 @@ export function codeForNode(node, { byReference, classes, moduleDir }) {
     // to go back on — the same join the serve host makes to build a source link. Without a
     // directory to prefix there is nothing honest to say, so the claim is dropped rather than
     // published one namespace out.
-    const dir = moduleDir ? moduleDir(referenced.sourceModule) : "";
-    if (file !== "" && dir !== "") {
+    const dir = moduleDir ? moduleDir(referenced.sourceModule) : null;
+    if (file !== "" && dir !== null) {
       // OUR function, not the incoming one. Keeping the sibling's `#Member` beside our file names a
       // function that does not exist in it — `CatalogPreviews.kt#FilledButton` when the preview is
       // `FilledRemoteButton` — which is a worse link than no link, because it looks resolvable.
       const fn = previewFunctionOf(referenced);
-      const path = `${dir}/${file}`;
+      // The root project prefixes nothing — its files are already repository-relative.
+      const path = dir === "" ? file : `${dir}/${file}`;
       return fn ? `${path}#${fn}` : path;
     }
   }
@@ -210,11 +216,33 @@ export function previewFunctionOf(component) {
   for (const image of component?.images ?? []) {
     const previewId =
       typeof image?.previewId === "string" ? image.previewId : "";
+    if (!previewId.includes(".")) continue;
     const member = previewId.slice(previewId.lastIndexOf(".") + 1);
-    const fn = member.split("_")[0];
-    if (previewId.includes(".") && fn !== "") return fn;
+    const fn = stripPreviewSuffixes(member);
+    if (fn !== "") return fn;
   }
   return null;
+}
+
+/**
+ * The `@Preview` axes and variant markers discovery appends to a member name.
+ *
+ * Anchored to the axis VOCABULARY rather than to the first underscore, because a Kotlin function
+ * name may contain one: `Filled_Button_Light` truncated at the first `_` publishes `#Filled`, a
+ * handle that names no function at all. Only a recognised suffix is removed, so an unrecognised
+ * name survives whole — which is the safe direction, since a too-long name still points at the
+ * right file while a truncated one points nowhere.
+ */
+const PREVIEW_SUFFIX = new RegExp(
+  [
+    "_VARIANT_.*$",
+    "_(?:width|height|dpi|density|fontScale|locale|uiMode|device|apiLevel|group|showBackground|backgroundColor|wallpaper)_.*$",
+    "_(?:Light|Dark)$",
+  ].join("|"),
+);
+
+function stripPreviewSuffixes(member) {
+  return member.replace(PREVIEW_SUFFIX, "");
 }
 
 /**
@@ -222,8 +250,11 @@ export function previewFunctionOf(component) {
  *
  * Gradle's own default, and the same join the serve host makes to turn a component's module-relative
  * `sourceFile` into a link. A `settings.gradle.kts` may remap a project's directory, and nothing in
- * a published catalog records that — so this returns "" for anything it cannot derive plainly, and
- * the caller drops the claim instead of publishing a path that resolves to nothing.
+ * a published catalog records that — so this returns `null` for anything it cannot derive plainly,
+ * and the caller drops the claim instead of publishing a path that resolves to nothing.
+ *
+ * `":"` — the root project — returns `""`, which is a real answer and not a refusal: such a
+ * catalog's `sourceFile` is already repository-relative and needs no prefix.
  */
 export function moduleDirectory(modulePath, fallback) {
   const raw =
@@ -231,9 +262,12 @@ export function moduleDirectory(modulePath, fallback) {
       ? modulePath
       : fallback;
   const path = typeof raw === "string" ? raw.trim() : "";
-  if (path === "" || !path.startsWith(":")) return "";
+  if (path === "" || !path.startsWith(":")) return null;
   const segments = path.slice(1).split(":").filter(Boolean);
-  return segments.length > 0 ? segments.join("/") : "";
+  // `":"` is the ROOT project, and its answer is the empty prefix — a root-project catalog's
+  // `sourceFile` is already repository-relative. Distinct from `null`, which means the path could
+  // not be derived at all; conflating the two dropped every rewritable node of a root catalog.
+  return segments.join("/");
 }
 
 /**
@@ -331,6 +365,12 @@ export function declaringClasses(catalog) {
  * written for my sibling" exactly, and is a no-op for every single-catalog repo.
  */
 export function catalogOwnsNode(node, classes) {
+  // A catalog whose images carry NO discovery ids at all — everything folded in through the
+  // generator's `--extra-renders`, which deliberately publishes none (see
+  // [narrowToMappedPreviewId]) — cannot place any claim. That is ignorance, not evidence of
+  // foreignness: judging on it would unlink every node such a catalog has, which is the whole page
+  // surface. Unable to judge ⇒ keep, exactly as before this test existed.
+  if (!classes || classes.size === 0) return true;
   const previewId = typeof node?.previewId === "string" ? node.previewId : "";
   const lastDot = previewId.lastIndexOf(".");
   if (lastDot <= 0) {
@@ -461,17 +501,28 @@ export function planDesignPages({ manifest, spec, catalog }) {
       const declaredLink = LINK_METHODS.has(node?.link)
         ? node.link
         : "unlinked";
+      const ours = catalogOwnsNode(node, classes);
       const code =
         declaredLink === "unlinked"
           ? null
           : codeForNode(node, { byReference, classes, moduleDir });
+      // Whether the reference join REPLACED this node's mapping rather than inheriting it. None of
+      // the owner's provenance survives that swap: its `confidence` grades a link we did not make,
+      // and its `cell` says the id it declared is an override capture — a claim about a preview id
+      // in the sibling's namespace, not about ours. Republishing either would label our component
+      // with the other catalog's bookkeeping.
+      const rewritten = declaredLink !== "unlinked" && !ours && code !== null;
       // A claim this catalog cannot substantiate is not a link. Dropping the handle while keeping
       // `link` would publish a linked node with nothing behind it — the contradiction
       // `renderablePreviewId` already refuses to draw — so the two move together.
       const link =
         declaredLink !== "unlinked" && code === null
           ? "unlinked"
-          : declaredLink;
+          : rewritten
+            ? // Our own catalog metadata tied this node to a component — the `reference` handle on
+              // it — so the method is `manifest` however the owner came by its link.
+              "manifest"
+            : declaredLink;
       if (declaredLink !== "unlinked" && link === "unlinked") foreign += 1;
       const previewId =
         link === "unlinked"
@@ -514,7 +565,7 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // unrecognised value there is a parse failure for the WHOLE manifest — one bad string in
         // one node would hide every page the catalog publishes. Dropping the field costs only a
         // styling hint.
-        ...(CONFIDENCE_VALUES.has(node?.confidence)
+        ...(!rewritten && CONFIDENCE_VALUES.has(node?.confidence)
           ? { confidence: node.confidence }
           : {}),
         // A grouping whose contents are listed below it — a COMPONENT_SET, whose children are the
@@ -540,7 +591,9 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // actually linked: an unlinked node carries no claim about what is behind it, and a stale
         // `previewId` left beside `link: unlinked` is exactly the contradiction
         // `renderablePreviewId` refuses to draw.
-        ...(link !== "unlinked" && isCellNode(node) ? { cell: true } : {}),
+        ...(link !== "unlinked" && !rewritten && isCellNode(node)
+          ? { cell: true }
+          : {}),
       });
     }
     if (foreign > 0) {

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -339,14 +339,35 @@ export function componentForNodeReference(node, byReference) {
  * exactly what a `code` handle claims. A catalog either publishes previews out of that file or it
  * does not, and no ambiguity or bake-time choice can change the answer.
  */
+/**
+ * The declaring class inside a discovery id — `ee.app.sections.ButtonsKt` out of
+ * `ee.app.sections.ButtonsKt.TextAction`.
+ *
+ * NOT the last dot. `buildVariantSuffix` appends `@Preview(name = …)` / `group` through
+ * `sanitizeForPath`, which deliberately leaves DOTS INTACT so an id stays lossless — a preview
+ * named `Phone.v2` ends `…FooKt.Render_Phone.v2`. Splitting at the last dot would read that class
+ * as `…FooKt.Render_Phone`, putting two variants of ONE function in different "classes" and making
+ * a legitimate node read as foreign.
+ *
+ * The boundary is structural instead: a Kotlin package is lowercase by convention and the file
+ * class is the first segment that is not, so the class is the prefix up to and including the first
+ * capitalised segment. An id with no capitalised segment falls back to the last dot — the previous
+ * behaviour, and no worse than it.
+ */
+export function declaringClassOf(previewId) {
+  if (typeof previewId !== "string" || !previewId.includes(".")) return "";
+  const segments = previewId.split(".");
+  const classAt = segments.findIndex((segment) => /^[A-Z]/.test(segment));
+  if (classAt > 0) return segments.slice(0, classAt + 1).join(".");
+  return previewId.slice(0, previewId.lastIndexOf("."));
+}
+
 export function declaringClasses(catalog) {
   const classes = new Set();
   for (const component of catalog?.components ?? []) {
     for (const image of component?.images ?? []) {
-      const previewId =
-        typeof image?.previewId === "string" ? image.previewId : "";
-      const lastDot = previewId.lastIndexOf(".");
-      if (lastDot > 0) classes.add(previewId.slice(0, lastDot));
+      const declaring = declaringClassOf(image?.previewId);
+      if (declaring !== "") classes.add(declaring);
     }
   }
   return classes;
@@ -371,14 +392,13 @@ export function catalogOwnsNode(node, classes) {
   // foreignness: judging on it would unlink every node such a catalog has, which is the whole page
   // surface. Unable to judge ⇒ keep, exactly as before this test existed.
   if (!classes || classes.size === 0) return true;
-  const previewId = typeof node?.previewId === "string" ? node.previewId : "";
-  const lastDot = previewId.lastIndexOf(".");
-  if (lastDot <= 0) {
+  const declaring = declaringClassOf(node?.previewId);
+  if (declaring === "") {
     // No declared id to place. Nothing here can prove the claim foreign, so it is kept — the
     // pre-existing behaviour for every manifest that names no preview ids at all.
     return true;
   }
-  return classes.has(previewId.slice(0, lastDot));
+  return classes.has(declaring);
 }
 
 /**

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -69,7 +69,12 @@ const DOT_SEGMENT = /^\.{1,2}$/;
 /** The contract's `confidence` values. Anything else is dropped rather than republished. */
 const CONFIDENCE_VALUES = new Set(["high", "low"]);
 
-const LINK_METHODS = new Set(["code-connect", "manifest", "convention", "unlinked"]);
+const LINK_METHODS = new Set([
+  "code-connect",
+  "manifest",
+  "convention",
+  "unlinked",
+]);
 
 /** A finite number greater than zero — every dimension the server draws with. */
 function isPositive(value) {
@@ -97,9 +102,18 @@ export function pageImageName(pageId) {
  * sort first in a catalog's own image order, which is also the better default under a design sheet
  * exported in light mode.
  */
-function resolveServePreviewId(node, { byPreviewId, byFunction }) {
+function resolveServePreviewId(
+  node,
+  { byPreviewId, byFunction, byReference, classes },
+) {
   const declared = typeof node?.previewId === "string" ? node.previewId : "";
-  if (declared !== "") {
+  // A declared id is only a refusal when it is OURS. The terminal rule below reads an empty match
+  // as "the producer declined to name a sticker", which is true of an id in this catalog's own
+  // namespace and false of a sibling module's — that one never named anything of ours to begin
+  // with, so treating it as a refusal would suppress the reference join for every node on a shared
+  // import. See [catalogOwnsNode].
+  const ours = catalogOwnsNode(node, classes ?? new Set());
+  if (declared !== "" && ours) {
     // Terminal: a declared id that resolves to nothing must NOT fall through to the function name.
     // [matchesForPreviewId] returns empty for a *sanitised bundle-id collision* — a family where an
     // apparent exact hit can belong to the colliding sibling — and that emptiness is a refusal, not
@@ -121,7 +135,210 @@ function resolveServePreviewId(node, { byPreviewId, byFunction }) {
       return servePreviewId(matches[0].image?.path);
     }
   }
+  // Last, the design node itself. Both joins above are in the PRODUCING MODULE's namespace, so a
+  // repo publishing two catalogs off one shared page import resolves them for the module the import
+  // was written against and for neither sibling. The reference handle is in the design file's
+  // namespace, which both share — see [componentsByReference].
+  const referenced = componentForNodeReference(node, byReference ?? new Map());
+  if (referenced) {
+    const image = (referenced.images ?? []).find(
+      (candidate) => candidate?.path,
+    );
+    if (image) return servePreviewId(image.path);
+  }
   return null;
+}
+
+/**
+ * The `code` handle to publish for a node: this catalog's own, whenever it can say so.
+ *
+ * A node's incoming `code` is the REPO's claim — true of the repo, and true of exactly one of its
+ * modules. Republishing it verbatim into a sibling catalog states that the sibling implements a
+ * file it does not contain, which is how `remote-m3` came to list 75 components under
+ * `catalog/…/IconButtons.kt`. Three outcomes:
+ *
+ *  * the reference join found OUR component ⇒ restate the handle from it, so the row names the file
+ *    that actually draws the sticker beside it;
+ *  * the node is OURS ([catalogOwnsNode]) ⇒ keep the incoming handle, unchanged. The manifest was
+ *    written for this module, and an unresolved-but-ours claim is still true — which is the
+ *    coverage the surface exists to report;
+ *  * neither ⇒ null. The claim is demonstrably another module's, and publishing it would overstate
+ *    this catalog's coverage with work it could never do.
+ */
+export function codeForNode(node, { byReference, classes, moduleDir }) {
+  const incoming =
+    typeof node?.code === "string" && node.code !== ""
+      ? String(node.code)
+      : null;
+  // OURS first, and kept verbatim. The incoming handle is repo-relative and already correct for the
+  // module the import was written against, so a catalog that owns the node publishes exactly what
+  // it published before — no rewrite, no chance of moving a working source link.
+  if (incoming && catalogOwnsNode(node, classes ?? new Set())) return incoming;
+  // Not ours, but we reproduce the same design node: restate the handle from OUR component.
+  const referenced = componentForNodeReference(node, byReference ?? new Map());
+  if (referenced) {
+    const file =
+      typeof referenced.sourceFile === "string"
+        ? referenced.sourceFile.trim()
+        : "";
+    // `sourceFile` is MODULE-relative and the handle is REPO-relative, so the module's directory has
+    // to go back on — the same join the serve host makes to build a source link. Without a
+    // directory to prefix there is nothing honest to say, so the claim is dropped rather than
+    // published one namespace out.
+    const dir = moduleDir ? moduleDir(referenced.sourceModule) : "";
+    if (file !== "" && dir !== "") {
+      // OUR function, not the incoming one. Keeping the sibling's `#Member` beside our file names a
+      // function that does not exist in it — `CatalogPreviews.kt#FilledButton` when the preview is
+      // `FilledRemoteButton` — which is a worse link than no link, because it looks resolvable.
+      const fn = previewFunctionOf(referenced);
+      const path = `${dir}/${file}`;
+      return fn ? `${path}#${fn}` : path;
+    }
+  }
+  return null;
+}
+
+/**
+ * The `@Preview` function name behind a component, from its own published previews.
+ *
+ * A discovery id is `<package>.<File>Kt.<Function>` with an optional axis/variant suffix
+ * (`_VARIANT_disabled`, `_width_227dp_…`), so the function is the last dot-segment up to its first
+ * underscore. Null when the component publishes no usable id, which leaves the handle as a bare
+ * file path — still true, just less precise.
+ */
+export function previewFunctionOf(component) {
+  for (const image of component?.images ?? []) {
+    const previewId =
+      typeof image?.previewId === "string" ? image.previewId : "";
+    const member = previewId.slice(previewId.lastIndexOf(".") + 1);
+    const fn = member.split("_")[0];
+    if (previewId.includes(".") && fn !== "") return fn;
+  }
+  return null;
+}
+
+/**
+ * The repository directory a Gradle project path lives in — `:remote-catalog` → `remote-catalog`.
+ *
+ * Gradle's own default, and the same join the serve host makes to turn a component's module-relative
+ * `sourceFile` into a link. A `settings.gradle.kts` may remap a project's directory, and nothing in
+ * a published catalog records that — so this returns "" for anything it cannot derive plainly, and
+ * the caller drops the claim instead of publishing a path that resolves to nothing.
+ */
+export function moduleDirectory(modulePath, fallback) {
+  const raw =
+    typeof modulePath === "string" && modulePath.trim() !== ""
+      ? modulePath
+      : fallback;
+  const path = typeof raw === "string" ? raw.trim() : "";
+  if (path === "" || !path.startsWith(":")) return "";
+  const segments = path.slice(1).split(":").filter(Boolean);
+  return segments.length > 0 ? segments.join("/") : "";
+}
+
+/**
+ * This catalog's components indexed by the design node each one REPRODUCES (`reference`).
+ *
+ * The third join, and the only one that works across modules. The other two ask "which of my
+ * previews is this node?" through an id or a `@Preview` function name — both of which live in the
+ * producing module's namespace. A design-page import is a REPO-level artifact: one `pages.json`
+ * describes the whole design file, and a repo publishing two catalogs from it hands the same
+ * function names to both. The sibling's names resolve in neither.
+ *
+ * A `reference` handle does not have that problem. It names a node in the design file, which is the
+ * one namespace both sides already share — so "the component that reproduces this node" is
+ * answerable by any catalog whose components declare their references, without knowing anything
+ * about the other module.
+ *
+ * Measured on the catalogs this was written for: `remote-m3` publishes 51 components, 10 of which
+ * declare a reference, and all 10 land on a node of the kit sheet its previews reproduce. Before
+ * this, its pages resolved zero renders — the whole sheet was the sibling's function names.
+ *
+ * @returns Map of reference handle → the componentIds claiming it. A handle claimed by more than
+ *   one component stays in the map with all of them, so the caller can refuse it rather than guess.
+ */
+export function componentsByReference(catalog) {
+  const byReference = new Map();
+  for (const component of catalog?.components ?? []) {
+    const reference =
+      typeof component?.reference === "string"
+        ? component.reference.trim()
+        : "";
+    if (reference === "") continue;
+    const componentId =
+      typeof component?.componentId === "string"
+        ? component.componentId.trim()
+        : "";
+    if (componentId === "") continue;
+    const claims = byReference.get(reference) ?? [];
+    claims.push(component);
+    byReference.set(reference, claims);
+  }
+  return byReference;
+}
+
+/**
+ * The component this catalog publishes for the design node [node] draws, or null.
+ *
+ * Refuses an AMBIGUOUS claim, the same posture the id and function joins take: `Card` and
+ * `TitleCard` both reference one kit node in the catalog that motivated this, and putting one
+ * component's render inside the other's outline is worse than drawing no render at all.
+ */
+export function componentForNodeReference(node, byReference) {
+  const ref = typeof node?.ref === "string" ? node.ref.trim() : "";
+  if (ref === "") return null;
+  const claims = byReference.get(ref) ?? [];
+  return claims.length === 1 ? claims[0] : null;
+}
+
+/**
+ * The **declaring classes** this catalog publishes previews from — `…sections.ButtonsKt` — taken
+ * from its own images' discovery ids.
+ *
+ * The reliable way to ask "is this node's claim mine?". The obvious alternatives both fail:
+ * `imagesByPreviewFunction` is EMPTY for an annotation-derived catalog (it is built from spec
+ * entries, and `wear-m3-catalog` declares its inventory on annotations), and an exact previewId
+ * match drops a legitimate claim whose particular variant this catalog did not bake — measured, one
+ * of `wear-m3-catalog`'s 185.
+ *
+ * The class is the right granularity because it names the FILE the preview is declared in, which is
+ * exactly what a `code` handle claims. A catalog either publishes previews out of that file or it
+ * does not, and no ambiguity or bake-time choice can change the answer.
+ */
+export function declaringClasses(catalog) {
+  const classes = new Set();
+  for (const component of catalog?.components ?? []) {
+    for (const image of component?.images ?? []) {
+      const previewId =
+        typeof image?.previewId === "string" ? image.previewId : "";
+      const lastDot = previewId.lastIndexOf(".");
+      if (lastDot > 0) classes.add(previewId.slice(0, lastDot));
+    }
+  }
+  return classes;
+}
+
+/**
+ * Whether [node]'s claim can be this catalog's at all.
+ *
+ * Deliberately weaker than "does it resolve": a declared id that is ours but AMBIGUOUS, or a
+ * variant this catalog chose not to bake, is still our claim, and the resolver declines those on
+ * purpose — a refusal to guess which sticker, not a statement that the code is somebody else's.
+ * Only a preview declared in a file this catalog publishes nothing from says that.
+ *
+ * Measured on the shared import that motivated this: of 185 coded nodes, `wear-m3-catalog` owns 185
+ * and `remote-m3` owns 0. So this separates "the manifest was written for me" from "the manifest was
+ * written for my sibling" exactly, and is a no-op for every single-catalog repo.
+ */
+export function catalogOwnsNode(node, classes) {
+  const previewId = typeof node?.previewId === "string" ? node.previewId : "";
+  const lastDot = previewId.lastIndexOf(".");
+  if (lastDot <= 0) {
+    // No declared id to place. Nothing here can prove the claim foreign, so it is kept — the
+    // pre-existing behaviour for every manifest that names no preview ids at all.
+    return true;
+  }
+  return classes.has(previewId.slice(0, lastDot));
 }
 
 /**
@@ -176,6 +393,16 @@ export function planDesignPages({ manifest, spec, catalog }) {
 
   const byFunction = imagesByPreviewFunction(spec, catalog);
   const byPreviewId = imagesByPreviewId(catalog);
+  // The cross-module join. Empty for a catalog whose components declare no design references, which
+  // leaves both the resolver and the code handle exactly as they were.
+  const byReference = componentsByReference(catalog);
+  // Which files this catalog actually publishes previews from — the test for whether an incoming
+  // `code` claim can be ours at all.
+  const classes = declaringClasses(catalog);
+  // A component's own module when it records one, else the catalog's — repository-wide catalogs
+  // set `sourceModule` per component, single-module ones leave it to `source.module`.
+  const moduleDir = (sourceModule) =>
+    moduleDirectory(sourceModule, catalog?.source?.module);
 
   const images = [];
   const seen = new Set();
@@ -190,8 +417,14 @@ export function planDesignPages({ manifest, spec, catalog }) {
   }
   for (const page of manifest.pages) {
     const id = typeof page?.id === "string" ? page.id : "";
-    if (!SAFE_ID.test(id) || RESERVED_ID_SUFFIX.test(id) || DOT_SEGMENT.test(id)) {
-      warnings.push(`page ${JSON.stringify(page?.id ?? null)} has no route-safe id; skipped`);
+    if (
+      !SAFE_ID.test(id) ||
+      RESERVED_ID_SUFFIX.test(id) ||
+      DOT_SEGMENT.test(id)
+    ) {
+      warnings.push(
+        `page ${JSON.stringify(page?.id ?? null)} has no route-safe id; skipped`,
+      );
       continue;
     }
     if (seen.has(id)) {
@@ -204,7 +437,8 @@ export function planDesignPages({ manifest, spec, catalog }) {
       warnings.push(`page ${id} declares no usable frame size; skipped`);
       continue;
     }
-    const format = typeof page?.image?.format === "string" ? page.image.format : "svg";
+    const format =
+      typeof page?.image?.format === "string" ? page.image.format : "svg";
     if (format.toLowerCase() !== "svg") {
       // Refused rather than republished. The surface's whole capability is addressing nodes inside
       // the export; a raster is a picture, and a page the server can only stare at is worse than a
@@ -220,12 +454,34 @@ export function planDesignPages({ manifest, spec, catalog }) {
     seen.add(id);
 
     let unresolved = 0;
+    let foreign = 0;
     const nodes = [];
     for (const node of Array.isArray(page.nodes) ? page.nodes : []) {
       if (!isDrawableNode(node)) continue;
-      const link = LINK_METHODS.has(node?.link) ? node.link : "unlinked";
+      const declaredLink = LINK_METHODS.has(node?.link)
+        ? node.link
+        : "unlinked";
+      const code =
+        declaredLink === "unlinked"
+          ? null
+          : codeForNode(node, { byReference, classes, moduleDir });
+      // A claim this catalog cannot substantiate is not a link. Dropping the handle while keeping
+      // `link` would publish a linked node with nothing behind it — the contradiction
+      // `renderablePreviewId` already refuses to draw — so the two move together.
+      const link =
+        declaredLink !== "unlinked" && code === null
+          ? "unlinked"
+          : declaredLink;
+      if (declaredLink !== "unlinked" && link === "unlinked") foreign += 1;
       const previewId =
-        link === "unlinked" ? null : resolveServePreviewId(node, { byPreviewId, byFunction });
+        link === "unlinked"
+          ? null
+          : resolveServePreviewId(node, {
+              byPreviewId,
+              byFunction,
+              byReference,
+              classes,
+            });
       if (link !== "unlinked" && previewId === null) unresolved += 1;
       nodes.push({
         nodeId: String(node.nodeId),
@@ -235,7 +491,9 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // for the WHOLE manifest and hides every page. Same failure shape as an unsupported
         // `confidence`, and depth is only a nesting hint, so an out-of-range one becomes 0.
         depth:
-          Number.isInteger(node?.depth) && node.depth >= 0 && node.depth <= 2147483647
+          Number.isInteger(node?.depth) &&
+          node.depth >= 0 &&
+          node.depth <= 2147483647
             ? node.depth
             : 0,
         // The node's type in the design file, republished so the consumer can tell a container from
@@ -250,13 +508,15 @@ export function planDesignPages({ manifest, spec, catalog }) {
           : {}),
         ...(node?.ref ? { ref: String(node.ref) } : {}),
         link,
-        ...(node?.code ? { code: String(node.code) } : {}),
+        ...(code ? { code } : {}),
         ...(previewId ? { previewId } : {}),
         // Validated, not passed through. The consumer decodes this into a strict enum, so an
         // unrecognised value there is a parse failure for the WHOLE manifest — one bad string in
         // one node would hide every page the catalog publishes. Dropping the field costs only a
         // styling hint.
-        ...(CONFIDENCE_VALUES.has(node?.confidence) ? { confidence: node.confidence } : {}),
+        ...(CONFIDENCE_VALUES.has(node?.confidence)
+          ? { confidence: node.confidence }
+          : {}),
         // A grouping whose contents are listed below it — a COMPONENT_SET, whose children are the
         // variants. Nothing implements a set (a reference names one of its variants), so the
         // consumer draws it as structure and leaves it out of the coverage count. Dropping it here
@@ -282,6 +542,13 @@ export function planDesignPages({ manifest, spec, catalog }) {
         // `renderablePreviewId` refuses to draw.
         ...(link !== "unlinked" && isCellNode(node) ? { cell: true } : {}),
       });
+    }
+    if (foreign > 0) {
+      warnings.push(
+        `page ${id}: ${foreign} node(s) name code this catalog does not publish — a shared design ` +
+          `import describing a sibling module — so they publish as unlinked rather than as this ` +
+          `catalog's work`,
+      );
     }
     if (unresolved > 0) {
       warnings.push(

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -802,11 +802,36 @@ test("moduleDirectory derives a project's directory, and declines what it cannot
   // Falls back to the catalog's own module when a component records none.
   assert.equal(moduleDirectory(undefined, ":catalog"), "catalog");
   assert.equal(moduleDirectory("", ":catalog"), "catalog");
-  // A settings.gradle.kts may remap a project's directory and no published catalog records that, so
-  // anything not plainly derivable returns "" and the caller drops the claim.
-  assert.equal(moduleDirectory("catalog"), "");
+  // The ROOT project is a real answer, not a refusal: its sourceFile is already repo-relative, so
+  // the prefix is empty and the handle is published bare. Conflating this with "cannot derive"
+  // dropped every rewritable node of a root-project catalog.
   assert.equal(moduleDirectory(":"), "");
-  assert.equal(moduleDirectory(undefined, undefined), "");
+  // A settings.gradle.kts may remap a project's directory and no published catalog records that, so
+  // anything not plainly derivable returns null and the caller drops the claim.
+  assert.equal(moduleDirectory("catalog"), null);
+  assert.equal(moduleDirectory(undefined, undefined), null);
+});
+
+test("a root-project catalog publishes its bare, already-repo-relative sourceFile", () => {
+  const rootCatalog = {
+    source: { module: ":" },
+    components: [
+      {
+        ...parallelCatalog.components[0],
+        sourceModule: ":",
+        sourceFile: "app/src/main/kotlin/app/remote/RemotePreviews.kt",
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: rootCatalog,
+  });
+  assert.equal(
+    onlyNode(result).code,
+    "app/src/main/kotlin/app/remote/RemotePreviews.kt#FilledRemoteButton",
+  );
 });
 
 test("declaringClasses reads the files a catalog publishes previews from", () => {
@@ -862,4 +887,140 @@ test("previewFunctionOf strips the axis and variant suffixes discovery appends",
   );
   assert.equal(previewFunctionOf({ images: [] }), null);
   assert.equal(previewFunctionOf({}), null);
+});
+
+// ---- Review findings on the shared-import fix (#4680) ------------------------------------------
+
+test("an extra-renders catalog keeps its links instead of losing every one", () => {
+  // `--extra-renders` images deliberately carry no `previewId` (design-references.mjs), so the
+  // declaring-class set is EMPTY. That is ignorance, not evidence of foreignness — judging on it
+  // would unlink the whole page surface for such a catalog.
+  const extraRenders = {
+    source: { module: ":catalog" },
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+        images: [{ path: "images/button-filled/ideal__default.png" }],
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: extraRenders,
+  });
+  const node = onlyNode(result);
+  assert.equal(node.link, "manifest", "unable to judge ⇒ the claim is kept");
+  assert.equal(
+    node.code,
+    "catalog/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  );
+});
+
+test("a foreign node never resolves through a colliding local function name", () => {
+  // The function join is in the PRODUCING module's namespace. A generic `#Member` shared with an
+  // unrelated local preview would pair one component's code with another's render.
+  const collidingSpec = {
+    groups: [
+      {
+        components: [
+          { componentId: "Unrelated/Thing", preview: "FilledButton" },
+        ],
+      },
+    ],
+  };
+  const colliding = {
+    source: { module: ":remote-catalog" },
+    components: [
+      // Same @Preview function name as the owner's node, but a different component entirely, and
+      // it claims no reference.
+      {
+        componentId: "Unrelated/Thing",
+        sourceFile: "src/main/kotlin/app/remote/Unrelated.kt",
+        sourceModule: ":remote-catalog",
+        images: [
+          {
+            path: "images/unrelated-thing/ideal__default.png",
+            previewId: "app.remote.UnrelatedKt.FilledButton",
+          },
+        ],
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: collidingSpec,
+    catalog: colliding,
+  });
+  const node = onlyNode(result);
+  assert.equal(
+    node.link,
+    "unlinked",
+    "no reference claims this node, so nothing substantiates it",
+  );
+  assert.equal(
+    node.previewId,
+    undefined,
+    "and emphatically not the colliding component's render",
+  );
+});
+
+test("a rewritten node drops the owner's provenance rather than wearing it", () => {
+  // `confidence` grades a link we did not make; `cell` describes an override capture named in the
+  // SIBLING's id namespace. Neither is true of our component.
+  const owned = {
+    ...sharedImport,
+    pages: [
+      {
+        ...sharedImport.pages[0],
+        nodes: [
+          {
+            ...sharedImport.pages[0].nodes[0],
+            link: "code-connect",
+            confidence: "high",
+            previewId: "app.sections.ButtonsKt.FilledButton_VARIANT_off",
+          },
+        ],
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: owned,
+    spec: {},
+    catalog: parallelCatalog,
+  });
+  const node = onlyNode(result);
+  assert.equal(
+    node.link,
+    "manifest",
+    "our own reference tied this, not the owner's Code Connect",
+  );
+  assert.equal("confidence" in node, false);
+  assert.equal(
+    "cell" in node,
+    false,
+    "the override-variant claim was about the sibling's id",
+  );
+
+  // …and the owning catalog keeps all of it, because nothing was replaced.
+  const kept = onlyNode(
+    planDesignPages({ manifest: owned, spec: {}, catalog: ownerCatalog }),
+  );
+  assert.equal(kept.link, "code-connect");
+  assert.equal(kept.confidence, "high");
+  assert.equal(kept.cell, true);
+});
+
+test("previewFunctionOf keeps an underscore that belongs to the function name", () => {
+  // `Filled_Button_Light` truncated at the first underscore publishes `#Filled` — a handle naming
+  // no function at all. Only a recognised axis or variant suffix is stripped.
+  const fnFor = (previewId) => previewFunctionOf({ images: [{ previewId }] });
+  assert.equal(fnFor("app.PreviewsKt.Filled_Button_Light"), "Filled_Button");
+  assert.equal(fnFor("app.PreviewsKt.Filled_Button"), "Filled_Button");
+  assert.equal(fnFor("app.PreviewsKt.Sticker_width_227dp_dpi_320"), "Sticker");
+  assert.equal(fnFor("app.PreviewsKt.Sticker_VARIANT_disabled"), "Sticker");
+  // Unrecognised suffixes survive whole: too long still points at the right file, truncated points
+  // nowhere.
+  assert.equal(fnFor("app.PreviewsKt.Odd_Name_Here"), "Odd_Name_Here");
 });

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   PAGES_VERSION,
   catalogOwnsNode,
+  declaringClassOf,
   declaringClasses,
   moduleDirectory,
   pageImageName,
@@ -1023,4 +1024,38 @@ test("previewFunctionOf keeps an underscore that belongs to the function name", 
   // Unrecognised suffixes survive whole: too long still points at the right file, truncated points
   // nowhere.
   assert.equal(fnFor("app.PreviewsKt.Odd_Name_Here"), "Odd_Name_Here");
+});
+
+test("a dotted @Preview name does not split the declaring class", () => {
+  // `sanitizeForPath` deliberately keeps dots so an id stays lossless, so `@Preview(name = "Phone.v2")`
+  // ends `…FooKt.Render_Phone.v2`. Splitting at the last dot put two variants of ONE function in
+  // different "classes", and the unbaked one then read as foreign.
+  assert.equal(declaringClassOf("pkg.FooKt.Render_Phone.v2"), "pkg.FooKt");
+  assert.equal(declaringClassOf("pkg.FooKt.Render_Tablet.v3"), "pkg.FooKt");
+  assert.equal(
+    declaringClassOf("ee.app.sections.ButtonsKt.TextAction"),
+    "ee.app.sections.ButtonsKt",
+  );
+  assert.equal(declaringClassOf("nodots"), "");
+
+  // …so both variants place under one class, and neither is mistaken for a sibling's work.
+  const dotted = {
+    components: [
+      {
+        componentId: "Render",
+        images: [
+          {
+            path: "images/render/a.png",
+            previewId: "pkg.FooKt.Render_Phone.v2",
+          },
+        ],
+      },
+    ],
+  };
+  const classes = declaringClasses(dotted);
+  assert.deepEqual([...classes], ["pkg.FooKt"]);
+  assert.equal(
+    catalogOwnsNode({ previewId: "pkg.FooKt.Render_Tablet.v3" }, classes),
+    true,
+  );
 });

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -1,7 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { PAGES_VERSION, pageImageName, planDesignPages } from "./design-pages.mjs";
+import {
+  PAGES_VERSION,
+  catalogOwnsNode,
+  declaringClasses,
+  moduleDirectory,
+  pageImageName,
+  planDesignPages,
+  previewFunctionOf,
+} from "./design-pages.mjs";
 
 /** A catalog whose stickers carry the discovery preview ids a design-map entry would name. */
 const catalog = {
@@ -11,17 +19,24 @@ const catalog = {
       images: [
         {
           path: "images/top-app-bar-medium/ideal__default__light.png",
-          previewId: "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light",
+          previewId:
+            "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light",
         },
         {
           path: "images/top-app-bar-medium/ideal__default__dark.png",
-          previewId: "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Dark",
+          previewId:
+            "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Dark",
         },
       ],
     },
     {
       componentId: "List/Item",
-      images: [{ path: "images/list-item/ideal__default__light.png", previewId: "list_Light" }],
+      images: [
+        {
+          path: "images/list-item/ideal__default__light.png",
+          previewId: "list_Light",
+        },
+      ],
     },
   ],
 };
@@ -50,7 +65,12 @@ function page(nodes, overrides = {}) {
 }
 
 function manifest(pages) {
-  return { version: 2, source: "figma", fileKey: "ocdacdEsnHipMJD3egzxKb", pages };
+  return {
+    version: 2,
+    source: "figma",
+    fileKey: "ocdacdEsnHipMJD3egzxKb",
+    pages,
+  };
 }
 
 const appBar = {
@@ -60,7 +80,8 @@ const appBar = {
   ref: "figma:ocdacdEsnHipMJD3egzxKb/1:1",
   link: "manifest",
   code: "catalog/src/main/kotlin/ee/schimke/m3catalog/sections/TopAppBars.kt#MediumTopAppBarSticker",
-  previewId: "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light",
+  previewId:
+    "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light",
   confidence: "high",
 };
 
@@ -73,7 +94,11 @@ const statusBar = {
 };
 
 test("a node's discovery preview id is re-keyed to the catalog's serve preview id", () => {
-  const plan = planDesignPages({ manifest: manifest([page([appBar])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([appBar])]),
+    spec,
+    catalog,
+  });
   const node = plan.manifest.pages[0].nodes[0];
   // The whole point: the repo's id renders nothing on the server; this one renders the sticker.
   assert.equal(node.previewId, "top-app-bar-medium__ideal__default__light");
@@ -98,7 +123,11 @@ test("a node with no preview id falls back to the code handle's function name", 
 });
 
 test("an unlinked node is kept, without a preview id", () => {
-  const plan = planDesignPages({ manifest: manifest([page([appBar, statusBar])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([appBar, statusBar])]),
+    spec,
+    catalog,
+  });
   const nodes = plan.manifest.pages[0].nodes;
   assert.equal(nodes.length, 2);
   assert.equal(nodes[1].link, "unlinked");
@@ -107,14 +136,25 @@ test("an unlinked node is kept, without a preview id", () => {
 });
 
 test("a linked node the catalog publishes no sticker for keeps its mapping and warns", () => {
-  const orphan = { ...appBar, previewId: "nothing_Light", code: "ui/Ghost.kt#GhostSticker" };
-  const plan = planDesignPages({ manifest: manifest([page([orphan])]), spec, catalog });
+  const orphan = {
+    ...appBar,
+    previewId: "nothing_Light",
+    code: "ui/Ghost.kt#GhostSticker",
+  };
+  const plan = planDesignPages({
+    manifest: manifest([page([orphan])]),
+    spec,
+    catalog,
+  });
   const node = plan.manifest.pages[0].nodes[0];
   // Dropping it would understate the page's coverage, which is the number this surface reports.
   assert.equal(node.link, "manifest");
   assert.equal(node.code, "ui/Ghost.kt#GhostSticker");
   assert.equal(node.previewId, undefined);
-  assert.match(plan.warnings.join("\n"), /1 linked node\(s\) map to no published sticker/);
+  assert.match(
+    plan.warnings.join("\n"),
+    /1 linked node\(s\) map to no published sticker/,
+  );
 });
 
 test("a declared preview id that resolves to nothing does not fall back to the function name", () => {
@@ -127,18 +167,38 @@ test("a declared preview id that resolves to nothing does not fall back to the f
       {
         componentId: "TopAppBar/Medium",
         images: [
-          { path: "images/a/ideal__default__light.png", previewId: "Kt_Sticker_Small Round" },
-          { path: "images/b/ideal__default__light.png", previewId: "Kt_Sticker_Small_Round" },
-          { path: "images/c/ideal__default__light.png", previewId: "Kt_Sticker_Small_Round_1" },
+          {
+            path: "images/a/ideal__default__light.png",
+            previewId: "Kt_Sticker_Small Round",
+          },
+          {
+            path: "images/b/ideal__default__light.png",
+            previewId: "Kt_Sticker_Small_Round",
+          },
+          {
+            path: "images/c/ideal__default__light.png",
+            previewId: "Kt_Sticker_Small_Round_1",
+          },
         ],
       },
     ],
   };
   const collidingSpec = {
-    groups: [{ components: [{ componentId: "TopAppBar/Medium", preview: "MediumTopAppBarSticker" }] }],
+    groups: [
+      {
+        components: [
+          {
+            componentId: "TopAppBar/Medium",
+            preview: "MediumTopAppBarSticker",
+          },
+        ],
+      },
+    ],
   };
   const plan = planDesignPages({
-    manifest: manifest([page([{ ...appBar, previewId: "Kt_Sticker_Small_Round" }])]),
+    manifest: manifest([
+      page([{ ...appBar, previewId: "Kt_Sticker_Small_Round" }]),
+    ]),
     spec: collidingSpec,
     catalog: colliding,
   });
@@ -150,7 +210,10 @@ test("a page id ending in .svg is refused — the suffix is the export route", (
   // `/pages/shape.svg` reads as "the export of the page `shape`", so a page id'd `shape.svg` would
   // be unreachable behind it. The server refuses one too; refusing here keeps it off the branch.
   const plan = planDesignPages({
-    manifest: manifest([page([appBar], { id: "shape.svg" }), page([appBar], { id: "library" })]),
+    manifest: manifest([
+      page([appBar], { id: "shape.svg" }),
+      page([appBar], { id: "library" }),
+    ]),
     spec,
     catalog,
   });
@@ -163,7 +226,11 @@ test("a page id ending in .svg is refused — the suffix is the export route", (
 
 test("an unknown link method degrades to unlinked", () => {
   const odd = { ...appBar, link: "vibes" };
-  const plan = planDesignPages({ manifest: manifest([page([odd])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([odd])]),
+    spec,
+    catalog,
+  });
   assert.equal(plan.manifest.pages[0].nodes[0].link, "unlinked");
   assert.equal(plan.manifest.pages[0].nodes[0].previewId, undefined);
 });
@@ -175,12 +242,18 @@ test("a future manifest version publishes nothing rather than half of it", () =>
     catalog,
   });
   assert.equal(plan.manifest, null);
-  assert.match(plan.warnings.join("\n"), /version 99 is not one this catalog can publish/);
+  assert.match(
+    plan.warnings.join("\n"),
+    /version 99 is not one this catalog can publish/,
+  );
 });
 
 test("unroutable ids, duplicate ids and unusable frames are dropped; siblings survive", () => {
   const escaping = page([appBar], { id: "../escape" });
-  const noFrame = page([appBar], { id: "home", frame: { width: 0, height: 4497 } });
+  const noFrame = page([appBar], {
+    id: "home",
+    frame: { width: 0, height: 4497 },
+  });
   const first = page([appBar], { id: "library", name: "Library" });
   const duplicate = page([appBar], { id: "library", name: "Impostor" });
   const plan = planDesignPages({
@@ -201,7 +274,11 @@ test("a node with no node id is dropped — the id is the only handle there is",
   // There is no recorded rectangle in this contract: the SVG is the geometry, and a node is found
   // by its `data-node-id`. A node without one could never be outlined, hidden or swapped.
   const anonymous = { ...appBar, nodeId: "  " };
-  const plan = planDesignPages({ manifest: manifest([page([anonymous, statusBar])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([anonymous, statusBar])]),
+    spec,
+    catalog,
+  });
   assert.deepEqual(
     plan.manifest.pages[0].nodes.map((p) => p.name),
     ["Status bar"],
@@ -211,7 +288,10 @@ test("a node with no node id is dropped — the id is the only handle there is",
 test("a page exported as a raster is refused, not republished", () => {
   // The surface's whole capability is addressing nodes inside the export. A raster is a picture,
   // and a page the server can only stare at is worse than a page it never advertises.
-  const raster = page([appBar], { id: "home", image: { uri: "home.png", format: "png" } });
+  const raster = page([appBar], {
+    id: "home",
+    image: { uri: "home.png", format: "png" },
+  });
   const plan = planDesignPages({
     manifest: manifest([raster, page([appBar], { id: "library" })]),
     spec,
@@ -225,7 +305,11 @@ test("a page exported as a raster is refused, not republished", () => {
 });
 
 test("an annotation-led catalog with no spec still matches on the preview id", () => {
-  const plan = planDesignPages({ manifest: manifest([page([appBar])]), spec: {}, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([appBar])]),
+    spec: {},
+    catalog,
+  });
   assert.equal(
     plan.manifest.pages[0].nodes[0].previewId,
     "top-app-bar-medium__ideal__default__light",
@@ -236,7 +320,11 @@ test("a structurally malformed manifest is refused, not thrown out of", () => {
   // `{"pages":{}}` is valid JSON, so it survives the parse — and `for (const p of {})` would throw
   // "object is not iterable" straight into the workflow's `set -e`, taking the catalog publish
   // with it. Same for a nodes object.
-  const plan = planDesignPages({ manifest: { version: 2, pages: {} }, spec, catalog });
+  const plan = planDesignPages({
+    manifest: { version: 2, pages: {} },
+    spec,
+    catalog,
+  });
   assert.equal(plan.manifest, null);
   assert.match(plan.warnings.join("\n"), /no usable pages array/);
 
@@ -253,8 +341,18 @@ test("an ambiguous function-name fallback is declined rather than guessed", () =
   // bucket. Taking the first would overlay component A inside component B's rectangle.
   const ambiguous = {
     components: [
-      { componentId: "A", images: [{ path: "images/a/ideal__default__light.png", previewId: "a" }] },
-      { componentId: "B", images: [{ path: "images/b/ideal__default__light.png", previewId: "b" }] },
+      {
+        componentId: "A",
+        images: [
+          { path: "images/a/ideal__default__light.png", previewId: "a" },
+        ],
+      },
+      {
+        componentId: "B",
+        images: [
+          { path: "images/b/ideal__default__light.png", previewId: "b" },
+        ],
+      },
     ],
   };
   const sharedNameSpec = {
@@ -269,7 +367,9 @@ test("an ambiguous function-name fallback is declined rather than guessed", () =
   };
   const { previewId, ...noPreviewId } = appBar;
   const plan = planDesignPages({
-    manifest: manifest([page([{ ...noPreviewId, code: "ui/A.kt#DefaultPreview" }])]),
+    manifest: manifest([
+      page([{ ...noPreviewId, code: "ui/A.kt#DefaultPreview" }]),
+    ]),
     spec: sharedNameSpec,
     catalog: ambiguous,
   });
@@ -301,7 +401,11 @@ test("a container flag survives publishing", () => {
   // COMPONENT_SET comes back as a component nobody implemented and a fully-implemented page
   // reports missing work — the exact regression the consumer-side fix was for.
   const set = { ...appBar, nodeId: "1:8", name: "Shape Set", container: true };
-  const plan = planDesignPages({ manifest: manifest([page([set])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([set])]),
+    spec,
+    catalog,
+  });
   const node = plan.manifest.pages[0].nodes.find((n) => n.nodeId === "1:8");
   assert.equal(node.container, true);
 });
@@ -310,7 +414,11 @@ test("a truthy non-boolean container is dropped rather than republished", () => 
   // It decodes into a Kotlin Boolean; a string there fails the parse for the WHOLE manifest and
   // hides every page, which is a far worse outcome than counting one set as a gap.
   const set = { ...appBar, nodeId: "1:8", name: "Shape Set", container: "yes" };
-  const plan = planDesignPages({ manifest: manifest([page([set])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([set])]),
+    spec,
+    catalog,
+  });
   const node = plan.manifest.pages[0].nodes.find((n) => n.nodeId === "1:8");
   assert.equal(node.container, undefined);
 });
@@ -319,9 +427,18 @@ test("a node's inventory=false survives publishing; true is left implicit", () =
   // Same allowlist hazard as `container`: drop the field on the way to the delivery branch and the
   // kit's own base parts come back as 24 components nobody implemented. `true` is the consumer's
   // default, so emitting it would only make every manifest larger and every re-import noisier.
-  const base = { ...appBar, nodeId: "1:8", name: "Base / Loading Icon", inventory: false };
+  const base = {
+    ...appBar,
+    nodeId: "1:8",
+    name: "Base / Loading Icon",
+    inventory: false,
+  };
   const kept = { ...appBar, nodeId: "1:9", name: "Button", inventory: true };
-  const plan = planDesignPages({ manifest: manifest([page([base, kept])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([base, kept])]),
+    spec,
+    catalog,
+  });
   const nodes = plan.manifest.pages[0].nodes;
   assert.equal(nodes.find((n) => n.nodeId === "1:8").inventory, false);
   assert.equal(nodes.find((n) => n.nodeId === "1:9").inventory, undefined);
@@ -330,15 +447,28 @@ test("a node's inventory=false survives publishing; true is left implicit", () =
 test("a non-boolean inventory is dropped rather than republished", () => {
   // It decodes into a Kotlin Boolean. Same reasoning as `container`: one bad string there fails the
   // parse for the whole manifest and hides every page, which is worse than counting one base part.
-  const base = { ...appBar, nodeId: "1:8", name: "Base / Loading Icon", inventory: "no" };
-  const plan = planDesignPages({ manifest: manifest([page([base])]), spec, catalog });
+  const base = {
+    ...appBar,
+    nodeId: "1:8",
+    name: "Base / Loading Icon",
+    inventory: "no",
+  };
+  const plan = planDesignPages({
+    manifest: manifest([page([base])]),
+    spec,
+    catalog,
+  });
   assert.equal(plan.manifest.pages[0].nodes[0].inventory, undefined);
 });
 
 test("a page's inventory=false survives publishing; true is left implicit", () => {
   const icons = page([appBar], { id: "icons", inventory: false });
   const shapes = page([appBar], { id: "shapes", inventory: true });
-  const plan = planDesignPages({ manifest: manifest([icons, shapes]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([icons, shapes]),
+    spec,
+    catalog,
+  });
   const [published, other] = plan.manifest.pages;
   assert.equal(published.inventory, false);
   assert.equal(other.inventory, undefined);
@@ -350,7 +480,8 @@ test("a node drawn by an override cell says so; one drawn by its own preview doe
   const cell = {
     ...appBar,
     nodeId: "1:8",
-    previewId: "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light_VARIANT_off",
+    previewId:
+      "ee.schimke.m3catalog.sections.TopAppBarsKt_MediumTopAppBarSticker_Light_VARIANT_off",
   };
   const plan = planDesignPages({
     manifest: manifest([page([appBar, cell])]),
@@ -383,7 +514,11 @@ test("an unlinked node makes no cell claim, even carrying a stale variant previe
     link: "unlinked",
     previewId: "com.example.SwitchKt_SwitchOn_Light_VARIANT_off",
   };
-  const plan = planDesignPages({ manifest: manifest([page([stale])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([stale])]),
+    spec,
+    catalog,
+  });
   assert.equal(plan.manifest.pages[0].nodes[0].cell, undefined);
 });
 
@@ -391,7 +526,11 @@ test("an unsupported confidence is dropped, not republished", () => {
   // The consumer decodes this into a strict enum, so republishing an unknown value would fail the
   // parse for the WHOLE manifest — one bad string hiding every page the catalog publishes.
   const odd = { ...appBar, confidence: "certain" };
-  const plan = planDesignPages({ manifest: manifest([page([odd])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([odd])]),
+    spec,
+    catalog,
+  });
   const node = plan.manifest.pages[0].nodes[0];
   assert.equal(node.confidence, undefined);
   // The rest of the node survives — only the styling hint is lost.
@@ -404,14 +543,27 @@ test("a node's design-file type is republished, so containers are exact not infe
   // inside it, and infers from nesting depth only when no type is stated. Stripping the field here
   // meant every delivery branch took the inference, which an unlisted frame between two components
   // can fool.
-  const set = { ...statusBar, nodeId: "1:3", name: "Switch", type: "COMPONENT_SET" };
-  const plan = planDesignPages({ manifest: manifest([page([set, appBar])]), spec, catalog });
+  const set = {
+    ...statusBar,
+    nodeId: "1:3",
+    name: "Switch",
+    type: "COMPONENT_SET",
+  };
+  const plan = planDesignPages({
+    manifest: manifest([page([set, appBar])]),
+    spec,
+    catalog,
+  });
   const [container, component] = plan.manifest.pages[0].nodes;
   assert.equal(container.type, "COMPONENT_SET");
   assert.equal(component.type, undefined);
   // Not a type: an empty string would read as one on the consumer's side.
   const blank = { ...statusBar, nodeId: "1:4", type: "  " };
-  const other = planDesignPages({ manifest: manifest([page([blank])]), spec, catalog });
+  const other = planDesignPages({
+    manifest: manifest([page([blank])]),
+    spec,
+    catalog,
+  });
   assert.equal(other.manifest.pages[0].nodes[0].type, undefined);
 });
 
@@ -420,8 +572,294 @@ test("an out-of-range depth is normalised rather than republished", () => {
   // republishing it fails the parse for the whole manifest and hides every page. Depth is only a
   // nesting hint, so an out-of-range one becomes 0.
   const deep = { ...appBar, depth: 2147483648 };
-  const plan = planDesignPages({ manifest: manifest([page([deep])]), spec, catalog });
+  const plan = planDesignPages({
+    manifest: manifest([page([deep])]),
+    spec,
+    catalog,
+  });
   assert.equal(plan.manifest.pages[0].nodes[0].depth, 0);
   // The node itself survives — only the hint is normalised.
   assert.equal(plan.manifest.pages[0].nodes[0].link, "manifest");
+});
+
+// ---- A shared page import across two catalogs (wear-m3-catalog#98) -----------------------------
+//
+// `design/pages/pages.json` is a REPO-level artifact: one import describes the design file, and a
+// repo publishing two catalogs hands the same nodes to both. Everything below is about telling
+// "this node is mine" from "this node is my sibling's", which nothing used to ask.
+
+/** The sibling module's catalog — the one the shared import was written against. */
+const ownerCatalog = {
+  source: { module: ":catalog" },
+  components: [
+    {
+      componentId: "Button/Filled",
+      sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+      sourceModule: ":catalog",
+      images: [
+        {
+          path: "images/button-filled/ideal__default.png",
+          previewId: "app.sections.ButtonsKt.FilledButton",
+        },
+      ],
+    },
+  ],
+};
+
+/** The parallel catalog in the same repo: different module, reproducing the same kit node. */
+const parallelCatalog = {
+  source: { module: ":remote-catalog" },
+  components: [
+    {
+      componentId: "Button/Filled",
+      reference: "figma:FILE/35239:93092",
+      sourceFile: "src/main/kotlin/app/remote/RemotePreviews.kt",
+      sourceModule: ":remote-catalog",
+      images: [
+        {
+          path: "images/button-filled/ideal__default.png",
+          previewId:
+            "app.remote.RemotePreviewsKt.FilledRemoteButton_width_227dp",
+        },
+      ],
+    },
+  ],
+};
+
+const sharedImport = {
+  version: PAGES_VERSION,
+  pages: [
+    {
+      id: "buttons",
+      name: "Buttons",
+      nodeId: "1:1",
+      frame: { width: 100, height: 100 },
+      image: { uri: "buttons.svg", format: "svg" },
+      nodes: [
+        {
+          nodeId: "35239:93092",
+          name: "Style=Filled",
+          link: "manifest",
+          ref: "figma:FILE/35239:93092",
+          code: "catalog/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+          previewId: "app.sections.ButtonsKt.FilledButton",
+        },
+      ],
+    },
+  ],
+};
+
+const onlyNode = (result) => result.manifest.pages[0].nodes[0];
+
+test("the catalog the import was written for is completely unaffected", () => {
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: ownerCatalog,
+  });
+  const node = onlyNode(result);
+  // Verbatim: the incoming handle is repo-relative and already correct, so nothing is rewritten and
+  // no working source link can move.
+  assert.equal(
+    node.code,
+    "catalog/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  );
+  assert.equal(node.link, "manifest");
+  assert.equal(node.previewId, "button-filled__ideal__default");
+  assert.equal(
+    result.warnings.filter((w) => w.includes("does not publish")).length,
+    0,
+    "nothing is foreign to the module that owns the import",
+  );
+});
+
+test("the sibling catalog publishes ITS OWN component for the same design node", () => {
+  // The bug: remote-m3's pages listed 75 components under the wear catalog's files and scored
+  // nothing, because the id and function joins are both in the producing module's namespace.
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: parallelCatalog,
+  });
+  const node = onlyNode(result);
+  assert.equal(
+    node.code,
+    "remote-catalog/src/main/kotlin/app/remote/RemotePreviews.kt#FilledRemoteButton",
+    "our file AND our function — a sibling's #Member beside our file names nothing that exists",
+  );
+  assert.equal(
+    node.previewId,
+    "button-filled__ideal__default",
+    "and it has a render to score",
+  );
+});
+
+test("a node this catalog neither owns nor reproduces publishes as unlinked", () => {
+  const stranger = {
+    ...sharedImport,
+    pages: [
+      {
+        ...sharedImport.pages[0],
+        nodes: [
+          {
+            ...sharedImport.pages[0].nodes[0],
+            ref: "figma:FILE/nobody-references-this",
+          },
+        ],
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: stranger,
+    spec: {},
+    catalog: parallelCatalog,
+  });
+  const node = onlyNode(result);
+  assert.equal(
+    node.link,
+    "unlinked",
+    "the claim is demonstrably another module's",
+  );
+  assert.equal(
+    "code" in node,
+    false,
+    "so it is not republished as this catalog's work",
+  );
+  assert.equal(
+    result.warnings.some((w) => w.includes("does not publish")),
+    true,
+    "and the run says so, since a whole sheet of these is a misconfiguration",
+  );
+});
+
+test("an ambiguous reference is refused rather than guessed", () => {
+  // Two components claiming one kit node — `Card` and `TitleCard` in the catalog that motivated
+  // this. Putting one component's render inside the other's outline is worse than no render.
+  const ambiguous = {
+    ...parallelCatalog,
+    components: [
+      parallelCatalog.components[0],
+      { ...parallelCatalog.components[0], componentId: "Button/FilledAlt" },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: ambiguous,
+  });
+  const node = onlyNode(result);
+  assert.equal(node.link, "unlinked");
+  assert.equal(node.previewId, undefined);
+});
+
+test("a component with no sourceFile is dropped rather than published one namespace out", () => {
+  const noSource = {
+    ...parallelCatalog,
+    components: [{ ...parallelCatalog.components[0], sourceFile: undefined }],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: noSource,
+  });
+  assert.equal("code" in onlyNode(result), false);
+});
+
+test("a node with no declared previewId keeps its claim, as it always did", () => {
+  // Nothing can place it, so nothing can prove it foreign — the pre-existing behaviour for every
+  // manifest that names no preview ids at all.
+  const undeclared = {
+    ...sharedImport,
+    pages: [
+      {
+        ...sharedImport.pages[0],
+        nodes: [
+          {
+            ...sharedImport.pages[0].nodes[0],
+            previewId: undefined,
+            ref: undefined,
+          },
+        ],
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: undeclared,
+    spec: {},
+    catalog: parallelCatalog,
+  });
+  assert.equal(
+    onlyNode(result).code,
+    "catalog/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  );
+});
+
+// ---- The joins themselves ---------------------------------------------------------------------
+
+test("moduleDirectory derives a project's directory, and declines what it cannot", () => {
+  assert.equal(moduleDirectory(":remote-catalog"), "remote-catalog");
+  assert.equal(moduleDirectory(":a:b"), "a/b");
+  // Falls back to the catalog's own module when a component records none.
+  assert.equal(moduleDirectory(undefined, ":catalog"), "catalog");
+  assert.equal(moduleDirectory("", ":catalog"), "catalog");
+  // A settings.gradle.kts may remap a project's directory and no published catalog records that, so
+  // anything not plainly derivable returns "" and the caller drops the claim.
+  assert.equal(moduleDirectory("catalog"), "");
+  assert.equal(moduleDirectory(":"), "");
+  assert.equal(moduleDirectory(undefined, undefined), "");
+});
+
+test("declaringClasses reads the files a catalog publishes previews from", () => {
+  assert.deepEqual(
+    [...declaringClasses(parallelCatalog)],
+    ["app.remote.RemotePreviewsKt"],
+  );
+  assert.deepEqual([...declaringClasses({})], []);
+});
+
+test("catalogOwnsNode places a claim by its declaring file", () => {
+  const classes = declaringClasses(ownerCatalog);
+  assert.equal(
+    catalogOwnsNode(
+      { previewId: "app.sections.ButtonsKt.FilledButton" },
+      classes,
+    ),
+    true,
+  );
+  // A variant this catalog did not bake is still ours — the file is what the claim is about. One of
+  // wear-m3-catalog's 185 real nodes is exactly this case, and an exact-id test would drop it.
+  assert.equal(
+    catalogOwnsNode(
+      { previewId: "app.sections.ButtonsKt.NeverBaked_VARIANT_x" },
+      classes,
+    ),
+    true,
+  );
+  assert.equal(
+    catalogOwnsNode(
+      { previewId: "app.remote.RemotePreviewsKt.FilledRemoteButton" },
+      classes,
+    ),
+    false,
+  );
+  assert.equal(
+    catalogOwnsNode({}, classes),
+    true,
+    "nothing to place ⇒ nothing proves it foreign",
+  );
+});
+
+test("previewFunctionOf strips the axis and variant suffixes discovery appends", () => {
+  assert.equal(
+    previewFunctionOf(parallelCatalog.components[0]),
+    "FilledRemoteButton",
+  );
+  assert.equal(
+    previewFunctionOf({
+      images: [{ previewId: "a.b.CKt.Sticker_VARIANT_disabled" }],
+    }),
+    "Sticker",
+  );
+  assert.equal(previewFunctionOf({ images: [] }), null);
+  assert.equal(previewFunctionOf({}), null);
 });


### PR DESCRIPTION
Fixes yschimke/wear-m3-catalog#98 — `remote-m3`'s design pages showed the sibling catalog's components and scored nothing.

## One cause, both symptoms

A design-page import is a **repo-level** artifact: one `design/pages/pages.json` describes the design file, and a repo publishing two catalogs hands the same nodes to both. Both existing joins — declared preview id, and `@Preview` function name — live in the **producing module's** namespace, so they resolve for the module the import was written against and for neither sibling.

Measured on the published branches:

| | coded nodes | naming | with a render |
| --- | --- | --- | --- |
| `wear-m3-catalog` (owns the import) | 185 | `catalog/…` | 184 |
| `remote-m3` (before) | 185 | `catalog/…` ← sibling's files | **0** |

Zero renders is why every diff badge stayed a dash: `ServeWeb.renderable()` only emits a render for a preview id this catalog has, and `DesignPage.ts`'s `score()` skips any node without one. The server was right; the manifest was wrong.

## Three changes

**A third join, on the design node.** A component's `reference` handle names a node in the design file — the one namespace both catalogs already share — so "which of my components reproduces this node?" is answerable without knowing anything about the other module. Ambiguity is refused, like the two joins before it (`Card` and `TitleCard` both claim one kit node in the catalog that motivated this).

**A claim this catalog cannot substantiate is no longer republished as its work.** `declaringClasses` asks whether the catalog publishes previews from the *file* the node names. Deliberately weaker than "does it resolve": an ambiguous or unbaked-but-ours claim is still ours and is kept — one of `wear-m3-catalog`'s 185 real nodes is exactly that case, and an exact-id test would have dropped it. Only a file the catalog publishes nothing from is foreign.

**A restated handle names our file *and* our function.** My first cut kept the sibling's `#Member` beside our file and produced `CatalogPreviews.kt#FilledButton` where the preview is actually `FilledRemoteButton` — a link that looks resolvable and isn't. Caught by inspecting the output rather than the counts. The module directory goes back on too, since `sourceFile` is module-relative while the handle is repo-relative.

## Test plan

Run against the **real published artifacts** of both catalogs, not just fixtures.

**The owning catalog is byte-identical.** Planning `wear-m3-catalog`'s manifest before and after this change and diffing the JSON:

```
IDENTICAL — wear-m3-catalog's published pages manifest is unchanged
```

185 coded nodes, all still `catalog/…`, zero foreign warnings. An earlier iteration of this fix regressed it to 47 — `imagesByPreviewFunction` is empty for an annotation-derived catalog, which is what sent me to the declaring-class test — so this diff is the guard against exactly that.

**The parallel catalog now publishes its own work.** The `buttons` page that was reported:

```
buttons page: 325 nodes, 4 linked
  Style=Filled    → remote-catalog/…/CatalogPreviews.kt#FilledRemoteButton    render ✓
  Style=Outline   → remote-catalog/…/CatalogPreviews.kt#OutlinedRemoteButton  render ✓
  Style=Tonal     → …/ComponentVariantPreviews.kt#TonalRemoteButton           render ✓
  Alignment=Icon  → remote-catalog/…/CatalogPreviews.kt#CompactRemoteButton   render ✓
```

Every one is `remote-catalog`, and every one has a render, so the diff lane has something to score.

**Unit tests:** 10 new cases in `design-pages.test.mjs` (25 → 35, all passing) — the owner unaffected, the sibling resolving its own component, a node owned by neither publishing as unlinked with a warning, ambiguity refused, a component with no `sourceFile` dropped rather than published one namespace out, a node with no declared id keeping its claim, plus direct coverage of `moduleDirectory`, `declaringClasses`, `catalogOwnsNode` and `previewFunctionOf`.

**Full driver suite:** 1152 pass / 7 fail — the same 7 that fail on a clean tree at this base (`catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, the catalog-export-version test, `rc-compare-pixels`, `rc-font-axis-order`, `rc-size-modifier`). `prettier --check` clean.

The remaining 65 nodes that named the sibling's files now publish as unlinked with a warning naming the misconfiguration, which lowers `remote-m3`'s reported coverage to what it genuinely implements. That is the intended correction: the old number counted work the catalog could never do.

Non-visual change to a publish-time producer — no render surface moves, so nothing to embed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_