### PR TITLE
fix(design-artifacts): keep cross-system row anchors unique, and reserve a wrapped heading

### DIFF
--- a/scripts/design-artifacts/render-cross-system-html.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.mjs
@@ -135,23 +135,49 @@ function rendersBothSides(pair, opts) {
 }
 
 /**
+ * One anchor per row, in row order, each unique on the page.
+ *
+ * `slug` is lossy on purpose — it collapses every run of non-alphanumerics to a
+ * single `-` — so two component ids that differ only in punctuation land on the
+ * same string: `Button/A+B` and `Button/A B` are both `button-a-b`. Deriving the
+ * anchor per row therefore emitted a duplicate `id`, and the second row became
+ * unaddressable: both self-links, and any bug report quoting either, resolve to
+ * the first. Unaddressable is the one thing this anchor exists to prevent.
+ *
+ * A colliding anchor takes a `-2`, `-3`, … suffix, and the suffix keeps counting
+ * past an id that genuinely slugs to the suffixed form. Stable across builds:
+ * `paired` is ordered, so the same input yields the same anchors and a link
+ * published today still lands tomorrow.
+ */
+function rowAnchors(pairs) {
+  const used = new Set();
+  return pairs.map((pair) => {
+    const base = `c-${slug(pair.local.componentId ?? "(unnamed)")}`;
+    let anchor = base;
+    for (let n = 2; used.has(anchor); n++) anchor = `${base}-${n}`;
+    used.add(anchor);
+    return anchor;
+  });
+}
+
+/**
  * One `<tr>` per pairing. Both renders are baked static thumbnails that link to
  * the live server; nothing is resolved at view time.
  *
- * The row is ANCHORED, `id="c-<slug>"`, and its component id is a self-link — the
- * same `c-<slug>` scheme `renderIndexHtml` already uses, so one convention covers
- * both pages. This is the page a cross-system bug report wants to point at: it is
+ * The row is ANCHORED and its component id is a self-link, on the `c-<slug>` scheme
+ * `renderIndexHtml` already uses so one convention covers both pages. The anchor is
+ * handed in rather than derived here, because uniqueness is a property of the whole
+ * table — see [rowAnchors]. This is the page a cross-system bug report wants to point at: it is
  * the only one carrying the kit reference and both renditions of a cell side by
  * side, which is the whole argument such a report makes. Without a per-row anchor
  * the best a report could do was link the page and name the row, so three
  * upstream issues in yschimke/wear-m3-catalog (#89, #90, #91) had to commit a
  * composed triptych image apiece instead.
  */
-function pairRow(pair, opts) {
+function pairRow(pair, opts, anchor) {
   const { local, parallelId, other } = pair;
   const id = local.componentId ?? "(unnamed)";
   const group = local.group ?? "Components";
-  const anchor = `c-${slug(id)}`;
   const design = opts.designRefById ? `<td class="col-d">${designEmbed(pair, opts)}</td>` : "";
   return `<tr class="crow" id="${esc(anchor)}">
   <th scope="row" class="rowhead"><a class="cid anchor" href="#${esc(anchor)}">${esc(id)}</a><span class="grp">${esc(group)}</span></th>
@@ -236,7 +262,8 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
     previewBase,
     designRefById,
   };
-  const body = paired.map((p) => pairRow(p, rowOpts)).join("\n");
+  const anchors = rowAnchors(paired);
+  const body = paired.map((p, i) => pairRow(p, rowOpts, anchors[i])).join("\n");
   const pairedReal = paired.filter((p) => rendersBothSides(p, rowOpts)).length;
   const designed = designRefById
     ? paired.filter((p) => designRefById.get(p.local.componentId)?.url).length
@@ -289,14 +316,30 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
   header.top code { background:var(--panel); padding:1px 6px; border-radius:5px; }
   main { padding:8px clamp(16px,4vw,40px) 64px; }
   table { border-collapse:collapse; width:100%; }
+  /* line-height is pinned, not inherited: the row offset below is arithmetic on these
+     exact numbers, and a heading whose height nobody can compute is a header rows hide
+     under. */
   thead th { position:sticky; top:0; background:var(--bg); text-align:left; font-size:12px; color:var(--muted);
-    padding:10px 12px; border-bottom:1px solid var(--line); z-index:1; }
+    line-height:1.35; padding:10px 12px; border-bottom:1px solid var(--line); z-index:1; }
   tbody tr.crow { border-bottom:1px solid var(--line); }
   th.rowhead { text-align:left; font-weight:600; padding:12px; vertical-align:middle; width:22%; }
   th.rowhead .cid { display:block; word-break:break-word; }
   /* scroll-margin-top because thead th is sticky: without it a row jumped to from
-     its #c-slug anchor lands underneath the header and reads as the wrong row. */
-  tr.crow { scroll-margin-top:44px; }
+     its #c-slug anchor lands underneath the header and reads as the wrong row.
+
+     Derived, not guessed. It used to be a flat 44px — the height of a ONE-LINE
+     heading — and a heading wraps: the design-reference column's "M3 Wear OS Apps
+     Design Kit" does it at a narrow viewport, and the row then lands back under the
+     header, which is the failure this margin exists to prevent. So the reserve is
+     three heading lines, spelled as the arithmetic that produces it:
+     3 lines x 1.35 x 12px, + 10px padding top and bottom, + the 1px border.
+
+     Overshooting is free and undershooting is not — too much margin leaves a little
+     empty space above the row, too little hides the row — so this reserves more than
+     any current heading needs, on purpose. The page carries no script -- the
+     "fully static" test pins that -- so measuring the header at view time is not on
+     the table; keep these numbers in step with thead th above if either moves. */
+  tr.crow { scroll-margin-top:calc(3 * 1.35 * 12px + 21px); }
   a.anchor { color:inherit; text-decoration:none; }
   a.anchor:hover, a.anchor:focus-visible { text-decoration:underline; }
   a.anchor::after { content:" #"; color:var(--muted); opacity:0; }

--- a/scripts/design-artifacts/render-cross-system-html.test.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.test.mjs
@@ -301,6 +301,50 @@ test("every paired row is anchored, and its component id links to itself", () =>
   assert.match(html, /tr\.crow \{ scroll-margin-top:/);
 });
 
+test("the row offset reserves a wrapped heading, derived from the header's own metrics", () => {
+  // A flat 44px is the height of a ONE-LINE heading, and headings wrap — the
+  // design-reference column's "M3 Wear OS Apps Design Kit" does it at a narrow
+  // viewport, putting the row back under the header the offset exists to clear. The
+  // page carries no script (see the fully-static test), so the reserve is arithmetic
+  // on the header's own type metrics rather than a measurement; both halves are
+  // pinned here so neither can move without the other.
+  const html = renderCrossSystemHtml(catalog, opts);
+
+  assert.match(html, /thead th \{[^}]*line-height:1\.35;/);
+  assert.match(html, /tr\.crow \{ scroll-margin-top:calc\(3 \* 1\.35 \* 12px \+ 21px\); \}/);
+  // 3 heading lines + 10px padding top and bottom + the 1px border ≈ 70px, against
+  // the 44px one line needs. Overshooting leaves a little space above the row;
+  // undershooting hides it — so this deliberately reserves more than any current
+  // heading uses.
+  assert.doesNotMatch(html, /scroll-margin-top:44px/);
+});
+
+test("two component ids that slug the same still get their own anchor", () => {
+  // `slug` collapses every run of non-alphanumerics to one `-`, so `Button/A+B` and
+  // `Button/A B` are both `button-a-b`. Deriving the anchor per row emitted a
+  // duplicate id and made the second row unaddressable: its self-link, and any bug
+  // report quoting it, resolved to the first — the one thing a per-row anchor exists
+  // to prevent.
+  const colliding = {
+    system: "remote-m3",
+    components: [
+      { componentId: "Button/A+B", group: "Buttons", images: [] },
+      { componentId: "Button/A B", group: "Buttons", images: [] },
+    ],
+  };
+  const html = renderCrossSystemHtml(colliding, {
+    ...opts,
+    parallelById: { "Button/A+B": "Button/Filled", "Button/A B": "Button/Icon" },
+  });
+
+  assert.match(html, /<tr class="crow" id="c-button-a-b">/);
+  assert.match(html, /<tr class="crow" id="c-button-a-b-2">/);
+  // ...and each row's self-link points at its OWN row, not at the first one.
+  assert.match(html, /href="#c-button-a-b">Button\/A\+B</);
+  assert.match(html, /href="#c-button-a-b-2">Button\/A B</);
+  assert.equal(html.match(/id="c-button-a-b"/g).length, 1);
+});
+
 test("an anchor cannot be smuggled out of a component id", () => {
   // componentId reaches the id attribute AND an href. `slug` collapses everything
   // non-alphanumeric, so the danger is a quote surviving into either — assert on


### PR DESCRIPTION
The two substantive findings left on #4644. (The third was the agent-commit-identity P1 — `git log --format=fuller` shows Yuri Schimke as author and committer on that branch and on this one, and `Reject agent attribution` runs on every PR as the authority.)

## Two component ids can slug the same

`slug` collapses every run of non-alphanumerics to a single `-`, so `Button/A+B` and `Button/A B` both become `button-a-b`. `pairRow` derived its anchor from the id alone, so both rows emitted `id="c-button-a-b"` — and the second became unaddressable: its own self-link, and any bug report quoting it, resolves to the first row. Being addressable is the entire reason the anchor was added (three upstream issues had to commit a composed triptych image apiece before it existed).

Anchors are now assigned across the whole table in `rowAnchors`, and a colliding one takes a `-2`, `-3`, … suffix — which keeps counting past an id that genuinely slugs to the suffixed form, so the disambiguator cannot collide either. `paired` is ordered, so the same input yields the same anchors and a link published today still lands tomorrow.

## The offset was the height of a one-line heading

`tr.crow { scroll-margin-top: 44px }` is exactly one heading line. Headings wrap — the design-reference column's "M3 Wear OS Apps Design Kit" does it at a narrow viewport — and the row then lands back under the sticky header, which is the failure the margin was added to prevent, just at a width nobody measured.

Of the reviewer's two options, measuring the header at view time is not available: this page carries **no script at all**, and that is a pinned invariant (`the page is fully static — no view-time fetch/resolver`). So it takes the other one and reserves the space, derived rather than guessed:

```css
thead th { … line-height:1.35; padding:10px 12px; … }
tr.crow  { scroll-margin-top:calc(3 * 1.35 * 12px + 21px); }   /* ≈ 70px */
```

Three heading lines, plus 10px padding top and bottom, plus the 1px border. `line-height` is now pinned on `thead th` rather than inherited, because the offset is arithmetic on these exact numbers and a heading whose height nobody can compute is a header rows hide under.

Overshooting is free and undershooting is not — too much margin leaves a little empty space above the row, too little hides the row — so this deliberately reserves more than any current heading needs.

## Test plan

`node --test scripts/design-artifacts/render-cross-system-html.test.mjs` — 18 pass, 0 fail (16 before). Two new cases, both confirmed non-vacuous by running them against `main`'s module, where both fail:

- `two component ids that slug the same still get their own anchor` — asserts the `-2` suffix, that each self-link points at its *own* row, and that `id="c-button-a-b"` appears exactly once
- `the row offset reserves a wrapped heading, derived from the header's own metrics` — pins the `line-height` and the `calc()` together, so neither can move without the other, and asserts the flat `44px` is gone

Dependent suites green: `tag-index` (23), `render-index-html` (10), `cross-system-compare` (14). The fully-static test still passes — no script was added.

Visually this changes only where a row lands after an anchor jump and which row a duplicate anchor addresses; both are behaviours of the fragment target rather than of any rendered component, so there is nothing a before/after render would show. The measurements are in the test instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_