### PR TITLE
ci: decide contract-probe coverage with the CI classifier's own matcher

### DIFF
--- a/common/web-escaping/src/test/kotlin/ee/schimke/composeai/web/WebEscapingTest.kt
+++ b/common/web-escaping/src/test/kotlin/ee/schimke/composeai/web/WebEscapingTest.kt
@@ -1,6 +1,5 @@
-package ee.schimke.composeai.cli.serve
+package ee.schimke.composeai.web
 
-import ee.schimke.composeai.web.WebEscaping
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.previewserver.contract
 
 import ee.schimke.composeai.bundle.BundleReader
+import ee.schimke.composeai.bundle.WebEmbed
 import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
 import ee.schimke.composeai.daemon.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
@@ -18,6 +19,7 @@ import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.render.session.RenderSessionFactory
 import ee.schimke.composeai.render.session.subprocess.SubprocessRenderSessions
+import ee.schimke.composeai.web.WebEscaping
 import kotlin.reflect.KClass
 import okio.FileSystem
 
@@ -77,6 +79,17 @@ object ContractSurface {
    * consumers, not a privileged caller.
    */
   val renderSessions: RenderSessionFactory = SubprocessRenderSessions
+
+  /**
+   * The two web surfaces #4666 extracted. Naming the module in `contracts` proves an artifact with
+   * that coordinate resolves; it does not prove the type inside it is still there, still public,
+   * and still shaped the way serve calls it. These two references are what make that a checked
+   * claim — if `WebEscaping.attr` is renamed or `WebEmbed` moves again, this file stops compiling
+   * against the published jars, which is the whole point of the probe.
+   */
+  val webEscaping: WebEscaping = WebEscaping
+
+  val webEmbed: WebEmbed = WebEmbed
 
   /** File IO. The server funnels reads/writes through `:common-io` like every other module. */
   val fileSystem: FileSystem = SystemFileSystem

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -81,15 +81,29 @@ object ContractSurface {
   val renderSessions: RenderSessionFactory = SubprocessRenderSessions
 
   /**
-   * The two web surfaces #4666 extracted. Naming the module in `contracts` proves an artifact with
-   * that coordinate resolves; it does not prove the type inside it is still there, still public,
-   * and still shaped the way serve calls it. These two references are what make that a checked
-   * claim — if `WebEscaping.attr` is renamed or `WebEmbed` moves again, this file stops compiling
-   * against the published jars, which is the whole point of the probe.
+   * The two web surfaces #4666 extracted.
+   *
+   * Bound as typed function references rather than as the objects themselves, and that distinction
+   * is the finding this block exists to answer. `val webEscaping: WebEscaping = WebEscaping` proves
+   * only that a public object of that name exists in the published jar; every member could be
+   * renamed, hidden or re-signed underneath it and this file would still compile. A `::member`
+   * reference with an explicit function type pins the name *and* the signature, so a parameter
+   * added or a return type changed fails here — which is the regression the probe is for.
+   *
+   * These are exactly the members serve calls, drawn from its real import set.
    */
-  val webEscaping: WebEscaping = WebEscaping
+  val htmlEscape: (String) -> String = WebEscaping::htmlEscape
+  val jsString: (String) -> String = WebEscaping::jsString
+  val urlEncodeSegment: (String) -> String = WebEscaping::urlEncodeSegment
+  val formatPercent: (Double, Int) -> String = WebEscaping::formatPercent
+  val pngDimensions: (ByteArray) -> Pair<Int, Int> = WebEscaping::pngDimensions
 
-  val webEmbed: WebEmbed = WebEmbed
+  val webEmbedGenerate:
+    (String, String, List<WebEmbed.Preview>, WebEmbed.InlineMode) -> WebEmbed.Output =
+    WebEmbed::generate
+
+  val webEmbedScriptName: String = WebEmbed.SCRIPT_NAME
+  val webEmbedIndexName: String = WebEmbed.INDEX_NAME
 
   /** File IO. The server funnels reads/writes through `:common-io` like every other module. */
   val fileSystem: FileSystem = SystemFileSystem

--- a/scripts/check-contract-registration.py
+++ b/scripts/check-contract-registration.py
@@ -26,6 +26,7 @@ it a build failure instead of a thing to remember.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import pathlib
 import re
@@ -38,6 +39,7 @@ SHELL = "scripts/check-preview-server-contracts.sh"
 CI_PATHS = ".github/ci/ci-paths.json"
 SETTINGS = "settings.gradle.kts"
 ALLOWLIST = "scripts/serve-seam-allowlist.json"
+PATH_SCOPE = ".github/ci/path-scope.py"
 CI_GROUP = "preview_server_contracts"
 
 
@@ -126,26 +128,43 @@ def mapping_for(package: str, mapping: dict[str, str]) -> tuple[str | None, str 
     return key, mapping[key]
 
 
-def covered(directory: str, globs: list[str]) -> bool:
-    """True when some glob in the CI group schedules the probe for `directory`.
+def path_matcher(root: pathlib.Path):
+    """`glob_to_regex` from the CI path classifier itself.
 
-    A prefix test rather than an equality test on purpose: `render-session/**` legitimately
-    covers both `render-session/api` and `render-session/subprocess`, and demanding an exact
-    entry per project would fail a correct file.
-
-    But only a glob that takes the *whole* subtree counts. `daemon/core/**/*.kt` has the same
-    directory prefix and does not schedule the job for a change to that module's build file or
-    to a Java source under it — and those paths are classified by other groups, so the
-    classifier does not fail open and the probe is simply skipped. A partial glob is worse than
-    a missing one: it reads as coverage.
+    Reimplementing the matching was the bug: a prefix test accepted `daemon/core/**/*.kt` and a
+    trailing-slash test accepted `daemon/core/`, neither of which selects the group for a change
+    to that module's build file — `daemon/core/` in fact matches nothing at all. The only
+    trustworthy answer to "does this glob schedule the job for this path" comes from the code
+    that decides it.
     """
-    for glob in globs:
-        if glob != "**" and not glob.endswith("/**") and not glob.endswith("/"):
-            continue  # not whole-subtree coverage; see above
-        prefix = glob.split("*", 1)[0].rstrip("/")
-        if prefix and (directory == prefix or directory.startswith(prefix + "/")):
-            return True
-    return False
+    spec = importlib.util.spec_from_file_location("path_scope", root / PATH_SCOPE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.glob_to_regex
+
+
+# What a change to a contract module can plausibly touch. A glob only counts as covering the
+# module when it selects the group for *every* one of these: a partial glob reads as coverage
+# without being it, and the paths it misses are classified by other groups, so the classifier
+# does not fail open — the probe is simply skipped.
+REPRESENTATIVE = (
+    "build.gradle.kts",
+    "api/x.api",
+    "src/main/kotlin/ee/schimke/composeai/X.kt",
+    "src/main/java/ee/schimke/composeai/X.java",
+    "src/test/kotlin/ee/schimke/composeai/XTest.kt",
+)
+
+
+def uncovered_paths(directory: str, globs: list[str], to_regex) -> list[str]:
+    """The representative paths under `directory` that no glob in the group selects."""
+    patterns = [to_regex(g) for g in globs]
+    missed = []
+    for suffix in REPRESENTATIVE:
+        path = f"{directory}/{suffix}"
+        if not any(p.match(path) for p in patterns):
+            missed.append(path)
+    return missed
 
 
 def check(root: pathlib.Path = REPO) -> int:
@@ -220,12 +239,14 @@ def check(root: pathlib.Path = REPO) -> int:
                     f"add an explicit '{package}': '{artifact}' entry"
                 )
 
+    to_regex = path_matcher(root)
     for path, directory in sorted(resolved.items()):
-        if not covered(directory, globs):
+        missed = uncovered_paths(directory, globs, to_regex)
+        if missed:
             problems.append(
-                f"{CI_PATHS}: '{CI_GROUP}' does not cover {directory}/ (for {path}), so the "
-                "contract probe is not scheduled for changes to it — the gate would exist "
-                "without running"
+                f"{CI_PATHS}: '{CI_GROUP}' does not select the contract probe for "
+                f"{', '.join(missed)} (for {path}) — the gate would exist without running for "
+                "those changes"
             )
 
     if problems:

--- a/scripts/test_check_contract_registration.py
+++ b/scripts/test_check_contract_registration.py
@@ -28,33 +28,48 @@ mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 
 
-class Covered(unittest.TestCase):
-    def test_exact_glob_covers_its_directory(self):
-        self.assertTrue(mod.covered("common/image-crop", ["common/image-crop/**"]))
+class Coverage(unittest.TestCase):
+    """Coverage is decided by the CI classifier's own matcher, not by a pattern-shape guess.
 
-    def test_broader_glob_covers_a_nested_project(self):
-        # `render-session/**` legitimately covers api/ and subprocess/; demanding one entry
-        # per project would fail a correct file.
-        self.assertTrue(mod.covered("render-session/api", ["render-session/**"]))
-        self.assertTrue(mod.covered("render-session/subprocess", ["render-session/**"]))
+    Both earlier attempts were wrong in the same direction — they accepted a glob that reads as
+    whole-module coverage and is not. A prefix test accepted `daemon/core/**/*.kt`; the
+    trailing-slash allowance that replaced it accepted `daemon/core/`, which `glob_to_regex`
+    compiles to a pattern matching no file at all.
+    """
+
+    def setUp(self):
+        self.to_regex = mod.path_matcher(REPO)
+
+    def missed(self, directory, globs):
+        return mod.uncovered_paths(directory, globs, self.to_regex)
+
+    def test_a_subtree_glob_covers_its_directory(self):
+        self.assertEqual(self.missed("common/image-crop", ["common/image-crop/**"]), [])
+
+    def test_a_broader_glob_covers_a_nested_project(self):
+        # `render-session/**` legitimately covers api/ and subprocess/; demanding one entry per
+        # project would fail a correct file.
+        self.assertEqual(self.missed("render-session/api", ["render-session/**"]), [])
+        self.assertEqual(self.missed("render-session/subprocess", ["render-session/**"]), [])
 
     def test_a_sibling_prefix_does_not_count(self):
-        # `common/io` must not be satisfied by `common/image-crop/**`.
-        self.assertFalse(mod.covered("common/io", ["common/image-crop/**"]))
+        self.assertNotEqual(self.missed("common/io", ["common/image-crop/**"]), [])
 
     def test_a_partial_name_does_not_count(self):
-        # `bundle/format2` is not covered by `bundle/format/**`.
-        self.assertFalse(mod.covered("bundle/format2", ["bundle/format/**"]))
-
-    def test_a_selective_glob_is_not_whole_module_coverage(self):
-        # Same directory prefix, but a change to the module's build file or a Java source under
-        # it would not select the group — and other groups classify those paths, so the
-        # classifier does not fail open. A partial glob reads as coverage without being it.
-        self.assertFalse(mod.covered("daemon/core", ["daemon/core/**/*.kt"]))
-        self.assertTrue(mod.covered("daemon/core", ["daemon/core/**"]))
+        self.assertNotEqual(self.missed("bundle/format2", ["bundle/format/**"]), [])
 
     def test_no_globs_covers_nothing(self):
-        self.assertFalse(mod.covered("common/io", []))
+        self.assertNotEqual(self.missed("common/io", []), [])
+
+    def test_a_kotlin_only_glob_misses_the_build_file(self):
+        missed = self.missed("daemon/core", ["daemon/core/**/*.kt"])
+        self.assertIn("daemon/core/build.gradle.kts", missed)
+        self.assertIn("daemon/core/src/main/java/ee/schimke/composeai/X.java", missed)
+
+    def test_a_trailing_slash_pattern_matches_nothing(self):
+        # `glob_to_regex` compiles `daemon/core/` to an exact path, so it selects no file under
+        # the module — the shape the previous version of this check accepted as coverage.
+        self.assertEqual(len(self.missed("daemon/core", ["daemon/core/"])), len(mod.REPRESENTATIVE))
 
 
 class ModulePackages(unittest.TestCase):
@@ -87,6 +102,7 @@ class Omissions(unittest.TestCase):
             mod.CI_PATHS,
             mod.SETTINGS,
             mod.ALLOWLIST,
+            mod.PATH_SCOPE,
         ):
             dst = self.root / rel
             dst.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Three review findings that merged unaddressed on #4666 and #4674. All three were correct. Each is falsified here before being fixed.

## The coverage test was wrong twice, in the same direction

#4663's prefix test accepted `daemon/core/**/*.kt`. The trailing-slash allowance I added in #4674 *to fix that* accepted `daemon/core/` — which `glob_to_regex` compiles to an exact directory path matching **no file at all**:

```
'daemon/core/'        -> build.gradle.kts=False  src/main/kotlin/X.kt=False
'daemon/core/**'      -> build.gradle.kts=True   src/main/kotlin/X.kt=True
'daemon/core/**/*.kt' -> build.gradle.kts=False  src/main/kotlin/X.kt=True
```

Guessing at pattern shapes was the bug both times, so this stops guessing. It loads `glob_to_regex` from `.github/ci/path-scope.py` — the code that actually decides scheduling — and asks whether the group selects each of a build file, an ABI dump, a Kotlin source, a Java source and a test. A glob counts only when it selects all five, and the failure names exactly what it misses:

```
'preview_server_contracts' does not select the contract probe for
daemon/core/build.gradle.kts, daemon/core/api/x.api,
daemon/core/src/main/java/ee/schimke/composeai/X.java (for :daemon:core)
— the gate would exist without running for those changes
```

## `:common-web-escaping:check` tested nothing

#4666 extracted the module and left `WebEscapingTest` in `cli/serve/src/test` with a new import, so the module reported success over **zero tests** — and that coverage would have been lost from the publisher side on extraction. Moved into the module: `tests="3"` where it was 0.

## The probe resolved the web contracts without compiling against them

Naming `common-web-escaping` in `contracts` proves an artifact with that coordinate resolves. It says nothing about the type inside still being there, still public, and still shaped the way serve calls it. `ContractSurface` now references `WebEscaping` and `WebEmbed` alongside `ContentCrop` and `BundleReader`.

Verified it is load-bearing rather than decorative by breaking one on purpose:

```
FALSIFY_EXIT=1
e: ContractSurface.kt:90:56 Unresolved reference 'attrNoSuchMember'.
```

## Test plan

- 17 tests green. The coverage cases now run against the real matcher, including one asserting that a trailing-slash pattern misses **every** representative path.
- Falsified both partial-glob shapes on the real tree before fixing; both are caught after.
- `scripts/check-preview-server-contracts.sh` — *"18 contracts resolved, 0 known leak(s)"*, plus the deliberate-break run above.
- `:common-web-escaping:check` and `:cli:serve:test` green.
- `check-contract-registration.py` OK — 18 contracts. `check-serve-seam.py` OK at `main.serveInternalsUsedByCli=12`, `test=15`.
- `ktfmtCheckAll` clean.

Non-visual: CI scripts, a test move, and a probe reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_