### PR TITLE
fix(serve): honour a catalog's declared dark surface in the viewer's Theme control

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -11836,7 +11836,9 @@ ${scriptTag("known-differences.js")}
     siblings: List<ServePreview> = emptyList(),
     /**
      * The catalog's declared stage surface (`catalog.json`'s `display.surface`) — decides whether
-     * an unthemed preview's stage backs on dark. Null ⇒ the system-name dark-first heuristic.
+     * an unthemed preview's stage backs on dark, and with it whether the page offers a day/night
+     * choice at all (a declared-dark catalog does not). Null ⇒ the system-name dark-first
+     * heuristic.
      */
     declaredSurface: String? = null,
     /**
@@ -12095,16 +12097,24 @@ ${scriptTag("known-differences.js")}
     val label = WebEscaping.htmlEscape(displayName)
     val idText = WebEscaping.htmlEscape(preview.id)
     val modes = preview.modes.joinToString(",") { it.wire }
-    // Wear OS is an always-dark surface. Do not expose the generic day/night override: besides
-    // being meaningless for Wear, an old light choice within the Wear catalog must not turn into a
-    // confetti-wear live render.
-    val wearAlwaysDark = SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" })
-    val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
-    val irReplayAttr = if (irReplay) " data-ir-replay=\"1\"" else ""
-    val replayThemesAttr = if (replayThemes) " data-replay-themes=\"1\"" else ""
     // The baked fallback shown before any override is chosen. The unified Theme selector displays
     // this choice without sending a redundant uiMode override on first load.
     val viewerDarkFirst = isDarkFirstSystem(basePath, sessionId, declaredSurface)
+    // A dark-first surface has no day mode. Do not expose the generic day/night override: besides
+    // being meaningless there, an old light choice within the Wear catalog must not turn into a
+    // confetti-wear live render.
+    //
+    // Resolved through [isDarkFirstSystem] — the catalog's DECLARED `display.surface` first, the
+    // Wear/watch id heuristic only as the fallback — rather than the heuristic alone, which is the
+    // same signal the stage under the pixels already uses ([viewerDarkFirst]). Splitting them let
+    // a dark-only catalog whose id doesn't read as Wear (`remote-m3`: `modes: ["dark"]`,
+    // `display.surface: "dark"`, every document carrying explicit dark-first Material colours) draw
+    // its stickers on the dark stage while still offering a Light chip that nothing behind it can
+    // honour — wear-m3-catalog#99.
+    val wearAlwaysDark = viewerDarkFirst
+    val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
+    val irReplayAttr = if (irReplay) " data-ir-replay=\"1\"" else ""
+    val replayThemesAttr = if (replayThemes) " data-replay-themes=\"1\"" else ""
     val viewerTheme = previewTheme(preview, viewerDarkFirst)
     // The Wasm tier is opt-in via a toggle (like "Live (stream)"), so the always-works PNG snapshot
     // stays the default. Both the iframe and the toggle are omitted entirely when no Wasm app backs

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -12104,14 +12104,22 @@ ${scriptTag("known-differences.js")}
     // being meaningless there, an old light choice within the Wear catalog must not turn into a
     // confetti-wear live render.
     //
-    // Resolved through [isDarkFirstSystem] — the catalog's DECLARED `display.surface` first, the
-    // Wear/watch id heuristic only as the fallback — rather than the heuristic alone, which is the
-    // same signal the stage under the pixels already uses ([viewerDarkFirst]). Splitting them let
-    // a dark-only catalog whose id doesn't read as Wear (`remote-m3`: `modes: ["dark"]`,
-    // `display.surface: "dark"`, every document carrying explicit dark-first Material colours) draw
-    // its stickers on the dark stage while still offering a Light chip that nothing behind it can
-    // honour — wear-m3-catalog#99.
-    val wearAlwaysDark = viewerDarkFirst
+    // The DECLARED `display.surface` now counts too, not just the Wear/watch id heuristic. Reading
+    // the heuristic alone let a dark-only catalog whose id doesn't read as Wear (`remote-m3`:
+    // `modes: ["dark"]`, `display.surface: "dark"`, every document carrying explicit dark-first
+    // Material colours) draw its stickers on the dark stage — which goes through the
+    // declaration-first [isDarkFirstSystem] — while still offering a Light chip that nothing behind
+    // it could honour (wear-m3-catalog#99).
+    //
+    // It is `||`, not the resolved [viewerDarkFirst] alone, and that asymmetry is deliberate: a
+    // declaration can add an always-dark catalog, never take one away. [normalizeOverrideParams]
+    // drops `uiMode` for a Wear id **unconditionally**, on every render and socket lane, so a Wear
+    // catalog declaring `display.surface: "light"` would otherwise get an enabled Light choice that
+    // moves the control and the URL while the server returns the same pixels. The control and the
+    // request normalization have to agree about what has no day mode; until the normalization can
+    // read a declaration (it is handed a system id and nothing else), the id keeps its veto.
+    val wearAlwaysDark =
+      viewerDarkFirst || SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" })
     val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
     val irReplayAttr = if (irReplay) " data-ir-replay=\"1\"" else ""
     val replayThemesAttr = if (replayThemes) " data-replay-themes=\"1\"" else ""

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -12118,8 +12118,18 @@ ${scriptTag("known-differences.js")}
     // moves the control and the URL while the server returns the same pixels. The control and the
     // request normalization have to agree about what has no day mode; until the normalization can
     // read a declaration (it is handed a system id and nothing else), the id keeps its veto.
+    //
+    // And the declaration's half is narrowed by what the catalog actually PUBLISHES, because
+    // `display.surface` is a stage colour in the spec schema and not a statement about modes: a
+    // catalog can perfectly well bake a light/dark pair and ask for a dark stage under both. Only a
+    // declared-dark catalog with **no light render anywhere in the session** is dark-only, which is
+    // `remote-m3` (every capture is one transparent dark-first document, and there is no `__light`
+    // twin to swap to). One that bakes a light variant keeps its pair, and keeps `previewTheme`'s
+    // label honest about the pixels on screen.
+    val hasLightRender = (siblings + preview).any { previewTheme(it, darkFirst = false) == "light" }
     val wearAlwaysDark =
-      viewerDarkFirst || SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" })
+      SystemDisplay.isDarkFirst(basePath.trim('/').ifBlank { sessionId ?: "" }) ||
+        (viewerDarkFirst && !hasLightRender)
     val alwaysDarkAttr = if (wearAlwaysDark) " data-always-dark=\"1\"" else ""
     val irReplayAttr = if (irReplay) " data-ir-replay=\"1\"" else ""
     val replayThemesAttr = if (replayThemes) " data-replay-themes=\"1\"" else ""

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -107,6 +107,40 @@ class ServePageThemeTest {
     assertTrue(unstated.contains("data-theme-choice=\"light\""), unstated)
   }
 
+  /**
+   * A declaration can ADD an always-dark catalog; it cannot take one away from a Wear id.
+   *
+   * `SystemDisplay.normalizeOverrideParams` drops `uiMode` for a Wear/watch id unconditionally, on
+   * every render and socket lane, and it is handed a system id with no declaration to read. So a
+   * Wear catalog declaring `display.surface: "light"` must not sprout an enabled Light choice: it
+   * would move the control and the URL while the server returned the same pixels.
+   */
+  @Test
+  fun `a Wear id keeps its veto over a declared light surface`() {
+    val wearLight =
+      ServeWeb.viewerPage(
+        ServePreview("button__ideal__default__light", "Button", theme = "light"),
+        token = "t",
+        basePath = "/confetti-wear",
+        sessionId = "confetti-wear",
+        declaredSurface = "light",
+      )
+
+    assertTrue(wearLight.contains("data-always-dark=\"1\""), wearLight)
+    assertFalse(
+      wearLight.contains("data-theme-choice=\"light\""),
+      "the render lane drops uiMode for a Wear id, so the control must not offer Light: $wearLight",
+    )
+    assertTrue(
+      ServeWeb.SystemDisplay.normalizeOverrideParams(
+          "confetti-wear",
+          mapOf("uiMode" to "light"),
+        )
+        .isEmpty(),
+      "the premise of the assertion above",
+    )
+  }
+
   @Test
   fun `the resolved scheme is pinned before first paint, not after the page loads`() {
     // Deferring this to the shell bundle would paint the page in the wrong mode and correct it a

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -66,6 +66,47 @@ class ServePageThemeTest {
     assertTrue(themes.first { it.name == "Coral" }.mode == "dark")
   }
 
+  /**
+   * A catalog that DECLARES a dark stage offers no Light chip, whatever its id reads like —
+   * yschimke/wear-m3-catalog#99.
+   *
+   * The viewer used to decide this from the system id alone (`SystemDisplay.isDarkFirst`) while the
+   * stage under the pixels went through the declaration-first `resolveDarkFirst`. `remote-m3` —
+   * dark-only Remote Compose documents, `display.surface: "dark"`, an id with no `wear`/`watch`
+   * token in it — landed between the two: dark stage, and a Light chip on top of it that no lane
+   * behind the page could honour, because every document carries explicit dark-first colours.
+   */
+  @Test
+  fun `a catalog declaring a dark surface offers no day-night choice`() {
+    val darkOnly =
+      ServeWeb.viewerPage(
+        ServePreview("appcard__ideal__default__compact", "AppCard"),
+        token = "t",
+        basePath = "/remote-m3",
+        sessionId = "remote-m3",
+        declaredSurface = "dark",
+      )
+
+    assertTrue(darkOnly.contains("data-always-dark=\"1\""), darkOnly)
+    assertFalse(
+      darkOnly.contains("data-theme-choice=\"light\""),
+      "a declared-dark catalog must not offer a Light chip: $darkOnly",
+    )
+
+    // …and a catalog that declares nothing, on an id that reads like neither a watch nor a dark
+    // surface, keeps the pair it always had.
+    val unstated =
+      ServeWeb.viewerPage(
+        ServePreview("button__ideal__default__light", "Button", theme = "light"),
+        token = "t",
+        basePath = "/compose-m3",
+        sessionId = "compose-m3",
+      )
+
+    assertFalse(unstated.contains("data-always-dark=\"1\""), unstated)
+    assertTrue(unstated.contains("data-theme-choice=\"light\""), unstated)
+  }
+
   @Test
   fun `the resolved scheme is pinned before first paint, not after the page loads`() {
     // Deferring this to the shell bundle would paint the page in the wrong mode and correct it a

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePageThemeTest.kt
@@ -108,6 +108,31 @@ class ServePageThemeTest {
   }
 
   /**
+   * A dark STAGE is not a dark-only catalog.
+   *
+   * `display.surface` is a stage colour in the spec schema, declared independently of what a
+   * catalog bakes: a non-Wear catalog can perfectly well publish a light/dark pair and ask for a
+   * dark ground under both. Suppressing its Light chip would leave `previewTheme` labelling the
+   * light render on screen as Dark, with no way back to it. Only a declared-dark catalog with no
+   * light render anywhere in the session is dark-only.
+   */
+  @Test
+  fun `a declared dark stage keeps the pair when the catalog bakes a light render`() {
+    val html =
+      ServeWeb.viewerPage(
+        previews[1],
+        token = "t",
+        basePath = "/compose-m3",
+        sessionId = "compose-m3",
+        siblings = previews,
+        declaredSurface = "dark",
+      )
+
+    assertFalse(html.contains("data-always-dark=\"1\""), html)
+    assertTrue(html.contains("data-theme-choice=\"light\""), html)
+  }
+
+  /**
    * A declaration can ADD an always-dark catalog; it cannot take one away from a Wear id.
    *
    * `SystemDisplay.normalizeOverrideParams` drops `uiMode` for a Wear/watch id unconditionally, on


### PR DESCRIPTION
Closes half of yschimke/wear-m3-catalog#99 — the half that lives here. (The other half, the `remote-m3` sheet declaring the same themes as its sibling, is yschimke/wear-m3-catalog#100.)

## The split

`ServeWeb.viewerPage` decided whether to offer the day/night choice from the **system id alone** (`SystemDisplay.isDarkFirst` — the Wear/watch token heuristic), while the stage under the pixels went through the **declaration-first** `resolveDarkFirst` (`display.surface`, heuristic only as fallback). A catalog that declares a dark surface on an id that reads as neither watch nor dark fell between the two: dark stage, Light chip on top of it.

`remote-m3` is exactly that catalog. Its spec declares `modes: ["dark"]` and `display.surface: "dark"`, every sticker is a Remote Compose document carrying explicit dark-first Material colours, and no lane behind the page can answer a Light pick — the viewer offered one anyway.

## The gate

```kotlin
val hasLightRender = (siblings + preview).any { previewTheme(it, darkFirst = false) == "light" }
val wearAlwaysDark =
  SystemDisplay.isDarkFirst(system) || (viewerDarkFirst && !hasLightRender)
```

Three deliberate parts, two of them added in review (thanks Codex — both findings were real):

1. **A Wear id keeps its veto.** `normalizeOverrideParams` strips `uiMode` for a Wear/watch id *unconditionally*, on every render and socket lane, and is handed a system id with no declaration to read. Reading the resolved value alone would have given a Wear catalog declaring `display.surface: "light"` an enabled Light choice that moves the control and the URL while the server returns identical pixels. A declaration can **add** an always-dark catalog; it cannot take one away from a Wear id, until the normalization can read a declaration too.
2. **A dark stage is not a dark-only catalog.** `display.surface` is a stage colour in the spec schema, declared independently of what a catalog bakes — a non-Wear catalog can publish a light/dark pair under a dark ground. So the declaration's half also requires that no preview in the session resolves light, or the light render on screen would be labelled Dark with no way back to it.
3. **`darkFirst = false` in that probe** is what keeps it honest: only an *explicit* light render counts (`preview.theme`, a night-off `uiMode`, a declared white backdrop, a `__light` id token), never an untagged preview falling through to a stage default.

`remote-m3` qualifies through (2): one transparent dark-first document per capture, no `__light` twin to swap to. A catalog that declares nothing is unchanged.

Nothing else moves: `data-always-dark` already gated the Theme chips, the `uiMode` select and the override control; only the input to it changed.

## Test plan

Three cases in `ServePageThemeTest`, one per part of the gate:

- `a catalog declaring a dark surface offers no day-night choice` — a `/remote-m3` page with `declaredSurface = "dark"` carries `data-always-dark="1"` and no `data-theme-choice="light"`; a `/compose-m3` page that declares nothing keeps both.
- `a Wear id keeps its veto over a declared light surface` — no Light chip on `/confetti-wear` declaring `"light"`, **and** an assertion that `normalizeOverrideParams` really does strip `uiMode` for that id, so the first half can't quietly stop meaning anything.
- `a declared dark stage keeps the pair when the catalog bakes a light render` — a dark-declared `/compose-m3` with a `__light` sibling keeps its pair.

`./gradlew :cli:serve:test` green on each push (full module suite, not just the touched classes); `ktfmtFormatMain` / `ktfmtFormatTest` clean.

Server-rendered HTML only, no pixel surface, so there is no before/after render to embed; the assertions above are what a reader would otherwise be shown as screenshots of the Theme menu.