### PR TITLE
fix(data-render-core): record PreviewFilter's id-exclude-file surface in the ABI dump

### DIFF
--- a/data/render/core/api/data-render-core.api
+++ b/data/render/core/api/data-render-core.api
@@ -310,6 +310,7 @@ public final class ee/schimke/composeai/data/render/PreviewDeviceSpec {
 
 public final class ee/schimke/composeai/data/render/PreviewFilter {
 	public static final field ANCHOR Ljava/lang/String;
+	public static final field ID_EXCLUDE_FILE_PROPERTY Ljava/lang/String;
 	public static final field ID_EXCLUDE_PROPERTY Ljava/lang/String;
 	public static final field ID_FILTER_PROPERTY Ljava/lang/String;
 	public static final field INSTANCE Lee/schimke/composeai/data/render/PreviewFilter;
@@ -318,6 +319,8 @@ public final class ee/schimke/composeai/data/render/PreviewFilter {
 	public final fun excludeById (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Z)Ljava/util/List;
 	public static synthetic fun excludeById$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun fqName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun idExcludesFrom (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
+	public static synthetic fun idExcludesFrom$default (Lee/schimke/composeai/data/render/PreviewFilter;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/util/List;
 	public final fun keptRowIndices (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public final fun matches (Ljava/util/Collection;Ljava/lang/String;Ljava/lang/String;)Z
 	public final fun matchesId (Ljava/util/Collection;Ljava/lang/String;)Z


### PR DESCRIPTION
`main` is red on `:data-render-core:checkKotlinAbi`.

#4602 added `PreviewFilter.ID_EXCLUDE_FILE_PROPERTY` and `idExcludesFrom` without regenerating the dump. Neither appears in the recorded `.api`, so the check fails on `main` and on every branch that merges it.

```
+	public static final field ID_EXCLUDE_FILE_PROPERTY Ljava/lang/String;
+	public final fun idExcludesFrom (…)Ljava/util/List;
+	public static synthetic fun idExcludesFrom$default (…)Ljava/util/List;
```

Three lines from `:data-render-core:updateLegacyAbi`, not written by hand. Confirmed against `origin/main`'s recorded dump before attributing it.

## This is the second one today

#4673 was the same failure in `bundle-format`, from #4662. I found this one only because a stale dump on my own branch made me run `updateLegacyAbi` over **every** module instead of the ones I expected to drift — which is a bad way to find it.

Two in an hour looks less like two mistakes than like `checkKotlinAbi` not being scheduled for the changes that move it. A module's `check` should be selected by a change to its own sources; if it were, neither of these could have merged. I have not touched that here — this PR is just the red build — but it is worth a look at which `check` tasks a source change actually selects, and it is the same "a gate that exists without running" shape as the `ci-paths.json` omissions #4663 and #4682 are about.

## Test plan

- `:data-render-core:checkKotlinAbi` — red on `origin/main`, `BUILD SUCCESSFUL` here.

Non-visual: a generated ABI dump. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_