### PR TITLE
test(agents): make the indented-fence cases decide their own exit status

### DIFF
--- a/scripts/test-check-agent-entrypoints.sh
+++ b/scripts/test-check-agent-entrypoints.sh
@@ -131,10 +131,23 @@ d="$tmp/overindented-fence"; make_good "$d"
 printf '```\n    ```\n@AGENTS.md\n```\n' > "$d/CLAUDE.md"
 check "a four-space-indented fence marker does not close the block" 1 "$(run "$d")"
 
-# ...and three spaces still does, so the limit does not simply reject everything.
-d="$tmp/indented-fence-ok"; make_good "$d"
-printf '@AGENTS.md\n\n   ```\nfenced\n   ```\n' > "$d/CLAUDE.md"
-check "a three-space-indented fence still opens and closes" 0 "$(run "$d")"
+# ...and three spaces still open and close one. Both cases below are shaped so that
+# RECOGNISING the indented marker is what decides the exit status — an earlier
+# version put a live `@AGENTS.md` on line 1 and then checked for exit 0, which the
+# first line already guaranteed, so it would have passed with every trace of
+# optional-space handling deleted.
+#
+# Opener: the file's ONLY `@AGENTS.md` is inside a three-space-indented fence. Miss
+# the opener and the line is unfenced, reads as a live import, and the gate passes.
+d="$tmp/indented-opener"; make_good "$d"
+printf 'Put this at the top:\n\n   ```\n@AGENTS.md\n   ```\n' > "$d/CLAUDE.md"
+check "a three-space-indented fence opens, hiding the import inside it" 1 "$(run "$d")"
+
+# Closer: the import is AFTER a three-space-indented closing fence. Miss the closer
+# and the rest of the file stays fenced, the import is invisible, and the gate fails.
+d="$tmp/indented-closer"; make_good "$d"
+printf 'Example:\n\n   ```\nfenced\n   ```\n\n@AGENTS.md\n' > "$d/CLAUDE.md"
+check "a three-space-indented fence closes, so the import after it is live" 0 "$(run "$d")"
 
 d="$tmp/no-copilot"; make_good "$d"; rm "$d/.github/copilot-instructions.md"
 check "missing copilot-instructions.md is rejected" 1 "$(run "$d")"


### PR DESCRIPTION
Follow-up to #4675, which merged a few minutes after Codex posted this finding on it. Fresh branch off `main` rather than commits onto the merged one.

## The finding

The positive case I added in #4675 was vacuous:

```sh
printf '@AGENTS.md\n\n   ```\nfenced\n   ```\n' > "$d/CLAUDE.md"
check "a three-space-indented fence still opens and closes" 0 "$(run "$d")"
```

The fixture opens with a live `@AGENTS.md` on line 1, and the check only reads the script's overall exit status — which that first line already guarantees. Deleting every trace of optional-space handling from the matcher leaves this case, and the whole suite, green. It proved neither that a three-space opener is recognised nor that a three-space closer reopens the document.

## What replaces it

Two fixtures, each shaped so that recognising the indented marker is the only thing deciding the answer:

| fixture | must exit | what a missed marker does |
| --- | --- | --- |
| the file's **only** `@AGENTS.md` is inside a three-space-indented fence | `1` | opener missed → the line is unfenced, reads as a live import, gate passes |
| the import comes **after** a three-space-indented closing fence | `0` | closer missed → the rest stays fenced, the import is invisible, gate fails |

## Test plan

`scripts/test-check-agent-entrypoints.sh` — 22 passed, 0 failed.

Each case mutation-checked on its own, because a single mutation does not reach both:

- dropping the optional spaces (`^ ? ? ?(…)` → `^(…)`) fails **`a three-space-indented fence opens, hiding the import inside it`** — and leaves the closer case green, since with nothing fenced the trailing import is live either way
- requiring a closer at column 0 (`&& $0 ~ /^(\`|~)/`) fails **`a three-space-indented fence closes, so the import after it is live`**

Worth recording for the next person: the obvious mutation for the second one — requiring `RSTART == 1` — is a **no-op**, because `match($0, /^ ? ? ?(…)/)` is anchored, so `RSTART` is 1 whatever the indentation. It has to be tested against `$0`, not against the match position.

`scripts/check-agent-entrypoints.sh` is untouched; this is test-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_