### PR TITLE
ci: compile what serve writes, and stop the coverage sample being gameable

### DIFF
--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -83,27 +83,49 @@ object ContractSurface {
   /**
    * The two web surfaces #4666 extracted.
    *
-   * Bound as typed function references rather than as the objects themselves, and that distinction
-   * is the finding this block exists to answer. `val webEscaping: WebEscaping = WebEscaping` proves
-   * only that a public object of that name exists in the published jar; every member could be
-   * renamed, hidden or re-signed underneath it and this file would still compile. A `::member`
-   * reference with an explicit function type pins the name *and* the signature, so a parameter
-   * added or a return type changed fails here — which is the regression the probe is for.
+   * Written as expressions serve actually evaluates, not as types it mentions, and each widening of
+   * this block came from a reviewer finding the previous form too weak — worth recording, because
+   * the same mistake is available to the next person adding a contract here:
    *
-   * These are exactly the members serve calls, drawn from its real import set.
+   * - `val webEscaping: WebEscaping = WebEscaping` proves only that a public object of that name
+   *   exists. Every member under it could be renamed and this still compiles.
+   * - A typed `::member` reference fixes that for the name and the signature — but a *call* has a
+   *   shape a reference does not. `formatPercent(x)` relies on the second parameter having a
+   *   default; a `(Double, Int) -> String` reference survives that default being removed, while
+   *   serve's one-argument call sites do not.
+   * - Naming `Preview`, `InlineMode` and `Output` in a function type checks that the types exist.
+   *   It does not check that `Preview`'s constructor still takes those parameters, that `INLINE`
+   *   and `EXTERNAL` are still spelled that way, or that `Output.files` is still there.
+   *
+   * So the rule for this block: compile what serve writes. `serveWebCalls` is never invoked — the
+   * compiler checking it is the entire point.
    */
   val htmlEscape: (String) -> String = WebEscaping::htmlEscape
   val jsString: (String) -> String = WebEscaping::jsString
   val urlEncodeSegment: (String) -> String = WebEscaping::urlEncodeSegment
-  val formatPercent: (Double, Int) -> String = WebEscaping::formatPercent
   val pngDimensions: (ByteArray) -> Pair<Int, Int> = WebEscaping::pngDimensions
 
-  val webEmbedGenerate:
-    (String, String, List<WebEmbed.Preview>, WebEmbed.InlineMode) -> WebEmbed.Output =
-    WebEmbed::generate
+  @Suppress("unused")
+  private fun serveWebCalls(png: ByteArray): Int {
+    // `ServeWeb` calls formatPercent both ways; the one-argument form is the one a removed
+    // default would break.
+    val oneArg: String = WebEscaping.formatPercent(0.5)
+    val twoArg: String = WebEscaping.formatPercent(0.5, 2)
 
-  val webEmbedScriptName: String = WebEmbed.SCRIPT_NAME
-  val webEmbedIndexName: String = WebEmbed.INDEX_NAME
+    // `ServeBundle` constructs a Preview by name, picks a mode, and reads `files` off the result.
+    val preview = WebEmbed.Preview(id = "id", label = "label", pngBytes = png, isCover = true)
+    val mode: WebEmbed.InlineMode =
+      if (oneArg.isEmpty()) WebEmbed.InlineMode.INLINE else WebEmbed.InlineMode.EXTERNAL
+    val out: WebEmbed.Output =
+      WebEmbed.generate(title = "t", modulePath = ":m", previews = listOf(preview), mode = mode)
+    val files: Map<String, ByteArray> = out.files
+
+    return twoArg.length +
+      files.size +
+      out.previewCount +
+      WebEmbed.SCRIPT_NAME.length +
+      WebEmbed.INDEX_NAME.length
+  }
 
   /** File IO. The server funnels reads/writes through `:common-io` like every other module. */
   val fileSystem: FileSystem = SystemFileSystem

--- a/scripts/check-contract-registration.py
+++ b/scripts/check-contract-registration.py
@@ -147,12 +147,20 @@ def path_matcher(root: pathlib.Path):
 # module when it selects the group for *every* one of these: a partial glob reads as coverage
 # without being it, and the paths it misses are classified by other groups, so the classifier
 # does not fail open — the probe is simply skipped.
+#
+# The last two are the reason this is not just a sample. A fixed list of five plausible paths can
+# be satisfied by five globs written to match exactly those five, which would pass this check
+# while no real source selects the job. The nonce segments are arbitrary and unguessable-by-
+# convention: nothing anyone would write into `ci-paths.json` on purpose matches them, so only a
+# genuine subtree glob can. They are constants rather than random so a failure is reproducible.
 REPRESENTATIVE = (
     "build.gradle.kts",
     "api/x.api",
     "src/main/kotlin/ee/schimke/composeai/X.kt",
     "src/main/java/ee/schimke/composeai/X.java",
     "src/test/kotlin/ee/schimke/composeai/XTest.kt",
+    "q7v3v9v1.kt",
+    "src/main/kotlin/q7v3v9v1/nested/deeper/Zq7v3.kts",
 )
 
 

--- a/scripts/test_check_contract_registration.py
+++ b/scripts/test_check_contract_registration.py
@@ -66,6 +66,15 @@ class Coverage(unittest.TestCase):
         self.assertIn("daemon/core/build.gradle.kts", missed)
         self.assertIn("daemon/core/src/main/java/ee/schimke/composeai/X.java", missed)
 
+    def test_globs_crafted_for_the_sample_do_not_count(self):
+        # Five globs written to match exactly the five plausible paths would satisfy a fixed
+        # sample while no real source selects the job. The nonce probes are what make this a
+        # subtree requirement rather than a sample.
+        crafted = [f"daemon/core/{s}" for s in mod.REPRESENTATIVE[:5]]
+        missed = self.missed("daemon/core", crafted)
+        self.assertEqual(len(missed), 2)
+        self.assertTrue(all("q7v3" in m for m in missed))
+
     def test_a_trailing_slash_pattern_matches_nothing(self):
         # `glob_to_regex` compiles `daemon/core/` to an exact path, so it selects no file under
         # the module — the shape the previous version of this check accepted as coverage.


### PR DESCRIPTION
Follow-up to #4682, which merged while I was addressing its review. Three findings, all correct, all in the same direction: **a check that samples is not a check that enforces.**

## The probe checked types, not call shapes

`::formatPercent` typed as `(Double, Int) -> String` survives the second parameter's default being removed — while `ServeWeb`'s one-argument calls do not. And naming `Preview`, `InlineMode` and `Output` in a function type says nothing about `Preview`'s constructor parameters, the spelling of `INLINE`/`EXTERNAL`, or `Output.files`, all of which `ServeBundle` writes out.

The block now compiles the expressions serve actually evaluates, in a private function that is never invoked — the compiler checking it is the point.

## The coverage check could be satisfied by globs written for its own sample

Five `ci-paths.json` entries matching exactly the five representative paths would pass while no real source selects the job. Two nonce paths fix that: nothing anyone would write into that file on purpose matches them, so only a genuine subtree glob can. Constants rather than random values, so a failure reproduces.

## My first falsification was wrong, and worth saying so

I mutated an enum constant, which broke `WebEmbed`'s own `when` — so the probe failed on the *module*, not on the surface. A red for the wrong reason is as useless as a green for the wrong reason, and I nearly recorded it as proof.

Redone with mutations that keep the mutated module compiling, so every error lands in `ContractSurface.kt`:

| mutation | error |
| --- | --- |
| remove `formatPercent`'s default | `No value passed for parameter 'decimals'` |
| rename `Output.files` | `Unresolved reference 'files'` |
| rename `Preview.label` | `No parameter with name 'label' found` |
| five globs crafted for the sample | names the two nonce paths as unselected |

Baseline run confirmed green before each.

## Test plan

- 18 tests green, including the crafted-globs case.
- All four mutations above run through `check-preview-server-contracts.sh` end to end; baseline exit 0, each mutation exit 1 with the error in `ContractSurface.kt`.
- `check-contract-registration.py` OK — 18 contracts. `check-serve-seam.py` OK.
- `ktfmtCheckAll` clean, and `:contract-probe:ktfmtCheckMain` under `-p preview-server` — the probe is in the `preview-server` composite build, so running its formatter from the root selects nothing and reports success. That bit me here; noted in the commit.

Non-visual: a CI script and a probe surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_