### PR TITLE
fix(design-artifacts): carry the project directory and preview function, stop deriving them

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -348,6 +348,10 @@ env:
   INPUT_EMBED_DEPS: ${{ inputs.embed-deps }}
   INPUT_RENDER_TIMEOUT: ${{ inputs.render-timeout }}
   INPUT_SPEC: ${{ inputs.spec }}
+  # Where the rendered Gradle BUILD sits in the checkout. The plugin records each project's
+  # directory relative to its own `rootDir`, which for a separate-build monorepo is the sample's
+  # root — so the catalog step lifts those to repository-relative paths with this.
+  INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
   INPUT_LIVE_RERENDER_SOURCE: ${{ inputs.live-rerender-source }}
   INPUT_ALLOW_INCOMPLETE: ${{ inputs.allow-incomplete }}
   INPUT_PUBLISH_LIVE_BUNDLE: ${{ inputs.publish-live-bundle }}
@@ -1357,6 +1361,7 @@ jobs:
             "${fallback[@]}" \
             --out "$GITHUB_WORKSPACE/out" \
             --renderer "$(compose-preview --version | head -1)" \
+            --build-root "$INPUT_WORKING_DIRECTORY" \
             "${source_args[@]}" \
             "${live[@]}" \
             "${incomplete[@]}"

--- a/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
+++ b/bundle/format/src/main/kotlin/ee/schimke/composeai/bundle/PreviewBundleFormat.kt
@@ -354,6 +354,13 @@ public object BundleReader {
     val rawPreviewIds: List<String> = emptyList(),
     val classpath: List<ClasspathEntry>,
     val modulePath: String,
+    /**
+     * The producing project's directory relative to the repository root (`bundle/format` for
+     * `:bundle-format`). Empty for the root project and for any bundle packed before the field
+     * existed — [modulePath] is a LOGICAL name that `projectDir` may remap, so this cannot be
+     * derived from it.
+     */
+    val moduleDirectory: String = "",
     val producedBy: String,
     /** v3+: producing build system (`gradle`|`amper`|`bazel`). Defaults for v2 bundles. */
     val producer: String = "gradle",

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -202,6 +202,20 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Internal abstract val moduleProjectDir: DirectoryProperty
 
   /**
+   * The producing project's directory relative to the repository root — `bundle/format` for
+   * `:bundle-format`, empty for the root project.
+   *
+   * An `@Input` string rather than a path, because it is CARRIED CONTENT: it lands in the manifest
+   * as [BundleManifest.moduleDirectory] and a consumer joins it to a component's module-relative
+   * `sourceFile` to build a repository path. Distinct from [moduleProjectDir], which is an absolute
+   * resolution base and deliberately untracked.
+   *
+   * Recorded rather than derived downstream because [modulePath] is a LOGICAL name that
+   * `project(":x").projectDir = file("a/b")` may point anywhere; only Gradle knows which.
+   */
+  @get:Input @get:Optional abstract val moduleDirectory: Property<String>
+
+  /**
    * (v6 Android) The consumer module's **configured** build directory — where
    * [MergedResourceOwnership] looks for AGP's resource-merge blame files. Wired from
    * `project.layout.buildDirectory` rather than assumed to be `<moduleProjectDir>/build`, because a
@@ -528,6 +542,9 @@ abstract class BundlePreviewTask : DefaultTask() {
         coverPreviewId = coverId,
         classpath = classpathEntries,
         modulePath = modulePath.get(),
+        // Slash-separated regardless of the packing host, so a bundle packed on Windows reads the
+        // same as one packed on CI.
+        moduleDirectory = moduleDirectory.getOrElse("").replace('\\', '/'),
         producedBy = producedBy.get(),
         producer = PRODUCER_GRADLE,
         resolution = classpath.resolution,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -740,6 +740,11 @@ internal object ComposePreviewTasks {
       // (v6 Android) base dir for resolving test_config.properties' module-relative apk/manifest
       // paths. Harmless on desktop. See [BundlePreviewTask.moduleProjectDir].
       moduleProjectDir.set(project.layout.projectDirectory)
+      // The physical directory, resolved HERE because only Gradle knows it: `modulePath` above is a
+      // logical name and `projectDir` may put the project anywhere. Empty for the root project.
+      moduleDirectory.set(
+        project.projectDir.relativeToOrNull(project.rootDir)?.invariantSeparatorsPath.orEmpty()
+      )
       // Where AGP's resource-merge blame files actually land. Read from the layout rather than
       // assumed to be `<projectDir>/build` — a consumer that relocates `buildDirectory` would
       // otherwise silently lose the sibling-module retain-set. See

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewBundleFormat.kt
@@ -173,6 +173,19 @@ data class BundleManifest(
   val classpath: List<ClasspathEntry>,
   /** Source Gradle path that produced the bundle, e.g. `:samples:cmp`. */
   val modulePath: String,
+  /**
+   * The producing project's directory, RELATIVE TO THE REPOSITORY ROOT — `bundle/format` for
+   * `:bundle-format`. Empty for the root project, and empty on a bundle packed before the field
+   * existed.
+   *
+   * Recorded rather than derived because [modulePath] is a LOGICAL name and the two need not agree:
+   * `project(":bundle-format").projectDir = file("bundle/format")` is legal, common, and invisible
+   * to every consumer downstream. This repository remaps 100 projects that way and not one of them
+   * derives correctly from its Gradle path, so a consumer joining [modulePath] to a component's
+   * module-relative `sourceFile` builds a repository path that resolves nowhere. Only Gradle knows
+   * the answer, so Gradle is what writes it down.
+   */
+  val moduleDirectory: String = "",
   /** `BUNDLE_VERSION`-shaped identifier of the producer for diagnostics. */
   val producedBy: String,
   /**

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -3,8 +3,8 @@ package ee.schimke.composeai.previewserver.contract
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.WebEmbed
 import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
-import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.UiMode

--- a/scripts/design-artifacts/apply-source-files.mjs
+++ b/scripts/design-artifacts/apply-source-files.mjs
@@ -105,10 +105,13 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
  * behave exactly as they did.
  */
 function stampIdentity(component, source) {
+  // A string, INCLUDING the empty one. `""` is the root project — a real, usable answer meaning
+  // "already repository-relative" — while `undefined` is a bundle that never recorded the field.
+  // Requiring a non-empty value stamped nothing for a root-project catalog, so its handles were
+  // dropped as if the directory were unknown.
   if (
     component.sourceDirectory === undefined &&
-    typeof source?.directory === "string" &&
-    source.directory.length > 0
+    typeof source?.directory === "string"
   ) {
     component.sourceDirectory = source.directory;
   }

--- a/scripts/design-artifacts/apply-source-files.mjs
+++ b/scripts/design-artifacts/apply-source-files.mjs
@@ -64,6 +64,10 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
       ) {
         component.sourceModule = source.module;
       }
+      // The same identity fields, on the same condition: the exporter kept the path, so the module
+      // that produced it is still the one this join resolved.
+      if (source?.sourceFile === component.sourceFile)
+        stampIdentity(component, source);
       continue;
     }
     if (source?.sourceFile) {
@@ -76,8 +80,43 @@ export function applySourceFiles(manifest, spec, sourceByFn) {
       if (typeof source.bodyLine === "number" && source.bodyLine > 0) {
         component.bodyLine = source.bodyLine;
       }
+      stampIdentity(component, source);
       stamped += 1;
     }
   }
   return stamped;
+}
+
+/**
+ * The two identity fields a consumer needs to build a REPOSITORY path and a source anchor, neither
+ * of which is recoverable from what the catalog published before.
+ *
+ * * `sourceDirectory` — the producing project's directory relative to the repository root, as the
+ *   BUNDLE recorded it. `sourceModule` beside it is a LOGICAL Gradle path, and
+ *   `project(":x").projectDir = file("a/b")` may put the project anywhere: this repository remaps
+ *   100 projects and not one derives correctly from its path. Joined to the module-relative
+ *   `sourceFile`, this is what makes a repository path true rather than plausible.
+ * * `sourceFunction` — discovery's own `@Preview` function name. `buildVariantSuffix` appends an
+ *   arbitrary `@Preview(name = …)` / `group` through `sanitizeForPath`, which passes spaces and
+ *   dots through verbatim, so a preview id does not split back into function and label. Carrying
+ *   the name is the only way to state it.
+ *
+ * Written only when the producer supplied them, so an older bundle stamps neither and its consumers
+ * behave exactly as they did.
+ */
+function stampIdentity(component, source) {
+  if (
+    component.sourceDirectory === undefined &&
+    typeof source?.directory === "string" &&
+    source.directory.length > 0
+  ) {
+    component.sourceDirectory = source.directory;
+  }
+  if (
+    component.sourceFunction === undefined &&
+    typeof source?.functionName === "string" &&
+    source.functionName.length > 0
+  ) {
+    component.sourceFunction = source.functionName;
+  }
 }

--- a/scripts/design-artifacts/apply-source-files.test.mjs
+++ b/scripts/design-artifacts/apply-source-files.test.mjs
@@ -3,16 +3,36 @@ import assert from "node:assert/strict";
 
 import { applySourceFiles } from "./apply-source-files.mjs";
 
-const comp = (componentId, extra = {}) => ({ componentId, images: [], ...extra });
-const manifest = (components) => ({ schema: "design-parity-catalog/v1", system: "s", components });
+const comp = (componentId, extra = {}) => ({
+  componentId,
+  images: [],
+  ...extra,
+});
+const manifest = (components) => ({
+  schema: "design-parity-catalog/v1",
+  system: "s",
+  components,
+});
 const byFn = (entries) =>
-  new Map(entries.map(([fn, sf, bodyLine]) => [fn, { sourceFile: sf, bodyLine }]));
+  new Map(
+    entries.map(([fn, sf, bodyLine]) => [fn, { sourceFile: sf, bodyLine }]),
+  );
 
 test("stamps each component's sourceFile from its spec function's discovery path", () => {
   const spec = {
     groups: [
-      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
-      { name: "Cards", components: [{ componentId: "Cards/Elevated", preview: "ElevatedCardPreview" }] },
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+      {
+        name: "Cards",
+        components: [
+          { componentId: "Cards/Elevated", preview: "ElevatedCardPreview" },
+        ],
+      },
     ],
   };
   const m = manifest([comp("Buttons/Filled"), comp("Cards/Elevated")]);
@@ -24,13 +44,26 @@ test("stamps each component's sourceFile from its spec function's discovery path
   const stamped = applySourceFiles(m, spec, sources);
 
   assert.equal(stamped, 2);
-  assert.equal(m.components[0].sourceFile, "src/main/kotlin/com/example/Buttons.kt");
-  assert.equal(m.components[1].sourceFile, "src/main/kotlin/com/example/Cards.kt");
+  assert.equal(
+    m.components[0].sourceFile,
+    "src/main/kotlin/com/example/Buttons.kt",
+  );
+  assert.equal(
+    m.components[1].sourceFile,
+    "src/main/kotlin/com/example/Cards.kt",
+  );
 });
 
 test("leaves a component untouched when its function carried no recorded path", () => {
   const spec = {
-    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+    ],
   };
   const m = manifest([comp("Buttons/Filled")]);
   // Discovery recorded the function but with no sourceFile (undefined).
@@ -44,10 +77,21 @@ test("leaves a component untouched when its function carried no recorded path", 
 
 test("never clobbers a sourceFile already on the component", () => {
   const spec = {
-    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+    ],
   };
-  const m = manifest([comp("Buttons/Filled", { sourceFile: "already/There.kt" })]);
-  const sources = byFn([["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"]]);
+  const m = manifest([
+    comp("Buttons/Filled", { sourceFile: "already/There.kt" }),
+  ]);
+  const sources = byFn([
+    ["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"],
+  ]);
 
   const stamped = applySourceFiles(m, spec, sources);
 
@@ -57,9 +101,16 @@ test("never clobbers a sourceFile already on the component", () => {
 
 test("adds a matching module to a sourceFile already preserved by the exporter", () => {
   const spec = {
-    groups: [{ name: "TV", components: [{ componentId: "tv/Main", preview: "MainPreview" }] }],
+    groups: [
+      {
+        name: "TV",
+        components: [{ componentId: "tv/Main", preview: "MainPreview" }],
+      },
+    ],
   };
-  const m = manifest([comp("tv/Main", { sourceFile: "src/main/kotlin/Main.kt" })]);
+  const m = manifest([
+    comp("tv/Main", { sourceFile: "src/main/kotlin/Main.kt" }),
+  ]);
   const sources = new Map([
     ["MainPreview", { sourceFile: "src/main/kotlin/Main.kt", module: ":tv" }],
   ]);
@@ -70,48 +121,97 @@ test("adds a matching module to a sourceFile already preserved by the exporter",
 
 test("leaves manifest components absent from the spec untouched", () => {
   const spec = {
-    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+    ],
   };
   const m = manifest([comp("Buttons/Filled"), comp("Orphan/NotInSpec")]);
-  const sources = byFn([["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"]]);
+  const sources = byFn([
+    ["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"],
+  ]);
 
   applySourceFiles(m, spec, sources);
 
-  assert.equal(m.components[0].sourceFile, "src/main/kotlin/com/example/Buttons.kt");
+  assert.equal(
+    m.components[0].sourceFile,
+    "src/main/kotlin/com/example/Buttons.kt",
+  );
   assert.equal("sourceFile" in m.components[1], false);
 });
 
 test("is idempotent — a second pass stamps nothing", () => {
   const spec = {
-    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+    ],
   };
   const m = manifest([comp("Buttons/Filled")]);
-  const sources = byFn([["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"]]);
+  const sources = byFn([
+    ["FilledButtonPreview", "src/main/kotlin/com/example/Buttons.kt"],
+  ]);
 
   assert.equal(applySourceFiles(m, spec, sources), 1);
   assert.equal(applySourceFiles(m, spec, sources), 0);
-  assert.equal(m.components[0].sourceFile, "src/main/kotlin/com/example/Buttons.kt");
+  assert.equal(
+    m.components[0].sourceFile,
+    "src/main/kotlin/com/example/Buttons.kt",
+  );
 });
 
 test("is a no-op with an empty / missing lookup and tolerates empty inputs", () => {
   const spec = {
-    groups: [{ name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] }],
+    groups: [
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
+    ],
   };
-  assert.equal(applySourceFiles(manifest([comp("Buttons/Filled")]), spec, new Map()), 0);
-  assert.equal(applySourceFiles(manifest([comp("Buttons/Filled")]), spec, undefined), 0);
-  assert.equal(applySourceFiles({ components: [] }, {}, byFn([["X", "a.kt"]])), 0);
+  assert.equal(
+    applySourceFiles(manifest([comp("Buttons/Filled")]), spec, new Map()),
+    0,
+  );
+  assert.equal(
+    applySourceFiles(manifest([comp("Buttons/Filled")]), spec, undefined),
+    0,
+  );
+  assert.equal(
+    applySourceFiles({ components: [] }, {}, byFn([["X", "a.kt"]])),
+    0,
+  );
   assert.equal(applySourceFiles({}, { groups: [] }, byFn([["X", "a.kt"]])), 0);
 });
 
 test("stamps bodyLine alongside sourceFile so the playground can open one declaration", () => {
   const spec = {
     groups: [
-      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
     ],
   };
   const m = manifest([comp("Buttons/Filled")]);
 
-  applySourceFiles(m, spec, byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", 81]]));
+  applySourceFiles(
+    m,
+    spec,
+    byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", 81]]),
+  );
 
   assert.equal(m.components[0].sourceFile, "src/main/kotlin/Buttons.kt");
   assert.equal(m.components[0].bodyLine, 81);
@@ -119,11 +219,19 @@ test("stamps bodyLine alongside sourceFile so the playground can open one declar
 
 test("stamps the owning Gradle module alongside a repository-wide source path", () => {
   const spec = {
-    groups: [{ name: "TV", components: [{ componentId: "tv/Main", preview: "MainPreview" }] }],
+    groups: [
+      {
+        name: "TV",
+        components: [{ componentId: "tv/Main", preview: "MainPreview" }],
+      },
+    ],
   };
   const m = manifest([comp("tv/Main")]);
   const sources = new Map([
-    ["MainPreview", { sourceFile: "src/main/kotlin/Main.kt", bodyLine: 9, module: ":tv" }],
+    [
+      "MainPreview",
+      { sourceFile: "src/main/kotlin/Main.kt", bodyLine: 9, module: ":tv" },
+    ],
   ]);
 
   applySourceFiles(m, spec, sources);
@@ -137,12 +245,21 @@ test("omits bodyLine when discovery recorded none, rather than writing a bogus z
   // so a 0 or null here would be a line number that points at nothing.
   const spec = {
     groups: [
-      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
     ],
   };
   const m = manifest([comp("Buttons/Filled")]);
 
-  applySourceFiles(m, spec, byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", undefined]]));
+  applySourceFiles(
+    m,
+    spec,
+    byFn([["FilledButtonPreview", "src/main/kotlin/Buttons.kt", undefined]]),
+  );
 
   assert.equal(m.components[0].sourceFile, "src/main/kotlin/Buttons.kt");
   assert.equal("bodyLine" in m.components[0], false);
@@ -151,7 +268,12 @@ test("omits bodyLine when discovery recorded none, rather than writing a bogus z
 test("never stamps a bodyLine without a sourceFile to resolve it against", () => {
   const spec = {
     groups: [
-      { name: "Buttons", components: [{ componentId: "Buttons/Filled", preview: "FilledButtonPreview" }] },
+      {
+        name: "Buttons",
+        components: [
+          { componentId: "Buttons/Filled", preview: "FilledButtonPreview" },
+        ],
+      },
     ],
   };
   const m = manifest([comp("Buttons/Filled")]);
@@ -160,4 +282,44 @@ test("never stamps a bodyLine without a sourceFile to resolve it against", () =>
 
   assert.equal(m.components[0].sourceFile, undefined);
   assert.equal("bodyLine" in m.components[0], false);
+});
+
+test("stamps the root project's empty directory rather than treating it as absent", () => {
+  // `""` is the ROOT project — already repository-relative — while `undefined` is a bundle packed
+  // before the field existed. Requiring a non-empty value stamped nothing for the root case.
+  const manifest = { components: [{ componentId: "A", images: [] }] };
+  const spec = {
+    groups: [{ components: [{ componentId: "A", preview: "Sticker" }] }],
+  };
+  applySourceFiles(
+    manifest,
+    spec,
+    new Map([
+      [
+        "Sticker",
+        {
+          sourceFile: "app/Preview.kt",
+          module: ":",
+          directory: "",
+          functionName: "Sticker",
+        },
+      ],
+    ]),
+  );
+  assert.equal(manifest.components[0].sourceDirectory, "");
+  assert.equal(manifest.components[0].sourceFunction, "Sticker");
+});
+
+test("stamps nothing for a bundle that never recorded a directory", () => {
+  const manifest = { components: [{ componentId: "A", images: [] }] };
+  const spec = {
+    groups: [{ components: [{ componentId: "A", preview: "Sticker" }] }],
+  };
+  applySourceFiles(
+    manifest,
+    spec,
+    new Map([["Sticker", { sourceFile: "app/Preview.kt", module: ":app" }]]),
+  );
+  assert.equal("sourceDirectory" in manifest.components[0], false);
+  assert.equal("sourceFunction" in manifest.components[0], false);
 });

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -170,7 +170,7 @@ function resolveServePreviewId(
  *  * neither ⇒ null. The claim is demonstrably another module's, and publishing it would overstate
  *    this catalog's coverage with work it could never do.
  */
-export function codeForNode(node, { byReference, classes, moduleDir }) {
+export function codeForNode(node, { byReference, classes }) {
   const incoming =
     typeof node?.code === "string" && node.code !== ""
       ? String(node.code)
@@ -179,95 +179,33 @@ export function codeForNode(node, { byReference, classes, moduleDir }) {
   // module the import was written against, so a catalog that owns the node publishes exactly what
   // it published before — no rewrite, no chance of moving a working source link.
   if (incoming && catalogOwnsNode(node, classes ?? new Set())) return incoming;
-  // Not ours, but we reproduce the same design node: restate the handle from OUR component.
+  // Not ours, but we reproduce the same design node: restate the handle from OUR component, using
+  // only what the producer CARRIED. `sourceDirectory` and `sourceFunction` are stamped by
+  // `apply-source-files.mjs` from the bundle's own record; neither is derivable from what the
+  // catalog published before, and both were previously guessed — the directory from the logical
+  // Gradle path (wrong for all 100 remapped projects in this repository) and the function by
+  // splitting a preview id that an arbitrary `@Preview(name = …)` makes unsplittable.
+  //
+  // Absent ⇒ no handle. That costs the row its source text on a catalog published before the fields
+  // existed; it does NOT cost the render, which [resolveServePreviewId] establishes from the design
+  // node itself.
   const referenced = componentForNodeReference(node, byReference ?? new Map());
-  if (referenced) {
-    const file =
-      typeof referenced.sourceFile === "string"
-        ? referenced.sourceFile.trim()
-        : "";
-    // `sourceFile` is MODULE-relative and the handle is REPO-relative, so the module's directory has
-    // to go back on — the same join the serve host makes to build a source link. Without a
-    // directory to prefix there is nothing honest to say, so the claim is dropped rather than
-    // published one namespace out.
-    const dir = moduleDir ? moduleDir(referenced.sourceModule) : null;
-    if (file !== "" && dir !== null) {
-      // OUR function, not the incoming one. Keeping the sibling's `#Member` beside our file names a
-      // function that does not exist in it — `CatalogPreviews.kt#FilledButton` when the preview is
-      // `FilledRemoteButton` — which is a worse link than no link, because it looks resolvable.
-      const fn = previewFunctionOf(referenced);
-      // The root project prefixes nothing — its files are already repository-relative.
-      const path = dir === "" ? file : `${dir}/${file}`;
-      return fn ? `${path}#${fn}` : path;
-    }
-  }
-  return null;
-}
-
-/**
- * The `@Preview` function name behind a component, from its own published previews.
- *
- * A discovery id is `<package>.<File>Kt.<Function>` with an optional axis/variant suffix
- * (`_VARIANT_disabled`, `_width_227dp_…`), so the function is the last dot-segment up to its first
- * underscore. Null when the component publishes no usable id, which leaves the handle as a bare
- * file path — still true, just less precise.
- */
-export function previewFunctionOf(component) {
-  for (const image of component?.images ?? []) {
-    const previewId =
-      typeof image?.previewId === "string" ? image.previewId : "";
-    if (!previewId.includes(".")) continue;
-    const member = previewId.slice(previewId.lastIndexOf(".") + 1);
-    const fn = stripPreviewSuffixes(member);
-    if (fn !== "") return fn;
-  }
-  return null;
-}
-
-/**
- * The `@Preview` axes and variant markers discovery appends to a member name.
- *
- * Anchored to the axis VOCABULARY rather than to the first underscore, because a Kotlin function
- * name may contain one: `Filled_Button_Light` truncated at the first `_` publishes `#Filled`, a
- * handle that names no function at all. Only a recognised suffix is removed, so an unrecognised
- * name survives whole — which is the safe direction, since a too-long name still points at the
- * right file while a truncated one points nowhere.
- */
-const PREVIEW_SUFFIX = new RegExp(
-  [
-    "_VARIANT_.*$",
-    "_(?:width|height|dpi|density|fontScale|locale|uiMode|device|apiLevel|group|showBackground|backgroundColor|wallpaper)_.*$",
-    "_(?:Light|Dark)$",
-  ].join("|"),
-);
-
-function stripPreviewSuffixes(member) {
-  return member.replace(PREVIEW_SUFFIX, "");
-}
-
-/**
- * The repository directory a Gradle project path lives in — `:remote-catalog` → `remote-catalog`.
- *
- * Gradle's own default, and the same join the serve host makes to turn a component's module-relative
- * `sourceFile` into a link. A `settings.gradle.kts` may remap a project's directory, and nothing in
- * a published catalog records that — so this returns `null` for anything it cannot derive plainly,
- * and the caller drops the claim instead of publishing a path that resolves to nothing.
- *
- * `":"` — the root project — returns `""`, which is a real answer and not a refusal: such a
- * catalog's `sourceFile` is already repository-relative and needs no prefix.
- */
-export function moduleDirectory(modulePath, fallback) {
-  const raw =
-    typeof modulePath === "string" && modulePath.trim() !== ""
-      ? modulePath
-      : fallback;
-  const path = typeof raw === "string" ? raw.trim() : "";
-  if (path === "" || !path.startsWith(":")) return null;
-  const segments = path.slice(1).split(":").filter(Boolean);
-  // `":"` is the ROOT project, and its answer is the empty prefix — a root-project catalog's
-  // `sourceFile` is already repository-relative. Distinct from `null`, which means the path could
-  // not be derived at all; conflating the two dropped every rewritable node of a root catalog.
-  return segments.join("/");
+  if (!referenced) return null;
+  const file =
+    typeof referenced.sourceFile === "string"
+      ? referenced.sourceFile.trim()
+      : "";
+  const dir =
+    typeof referenced.sourceDirectory === "string"
+      ? referenced.sourceDirectory.trim().replace(/^\/+|\/+$/g, "")
+      : null;
+  if (file === "" || dir === null) return null;
+  const path = dir === "" ? file : `${dir}/${file}`;
+  const fn =
+    typeof referenced.sourceFunction === "string"
+      ? referenced.sourceFunction.trim()
+      : "";
+  return fn !== "" ? `${path}#${fn}` : path;
 }
 
 /**
@@ -459,10 +397,6 @@ export function planDesignPages({ manifest, spec, catalog }) {
   // Which files this catalog actually publishes previews from — the test for whether an incoming
   // `code` claim can be ours at all.
   const classes = declaringClasses(catalog);
-  // A component's own module when it records one, else the catalog's — repository-wide catalogs
-  // set `sourceModule` per component, single-module ones leave it to `source.module`.
-  const moduleDir = (sourceModule) =>
-    moduleDirectory(sourceModule, catalog?.source?.module);
 
   const images = [];
   const seen = new Set();
@@ -525,18 +459,28 @@ export function planDesignPages({ manifest, spec, catalog }) {
       const code =
         declaredLink === "unlinked"
           ? null
-          : codeForNode(node, { byReference, classes, moduleDir });
+          : codeForNode(node, { byReference, classes });
+      // A reference match is an IDENTITY — this catalog's component names the very design node the
+      // page is drawing — so it stands on its own. The code handle is a label over the top of it and
+      // may be missing (a catalog published before the producer carried `sourceDirectory` /
+      // `sourceFunction`); losing the label must not cost the render, which is the whole point of
+      // the surface.
+      const referencedHere =
+        componentForNodeReference(node, byReference) !== null;
       // Whether the reference join REPLACED this node's mapping rather than inheriting it. None of
       // the owner's provenance survives that swap: its `confidence` grades a link we did not make,
       // and its `cell` says the id it declared is an override capture — a claim about a preview id
       // in the sibling's namespace, not about ours. Republishing either would label our component
       // with the other catalog's bookkeeping.
-      const rewritten = declaredLink !== "unlinked" && !ours && code !== null;
+      const rewritten =
+        declaredLink !== "unlinked" &&
+        !ours &&
+        (code !== null || referencedHere);
       // A claim this catalog cannot substantiate is not a link. Dropping the handle while keeping
       // `link` would publish a linked node with nothing behind it — the contradiction
       // `renderablePreviewId` already refuses to draw — so the two move together.
       const link =
-        declaredLink !== "unlinked" && code === null
+        declaredLink !== "unlinked" && code === null && !referencedHere
           ? "unlinked"
           : rewritten
             ? // Our own catalog metadata tied this node to a component — the `reference` handle on

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -1109,3 +1109,24 @@ test("a catalog published before the fields existed keeps its render, losing onl
     "but nothing is claimed about the source",
   );
 });
+
+test("the root project's empty directory is a usable answer, not a missing one", () => {
+  // The producer records `""` for a root-project catalog and the stamp must carry it: treating it
+  // as absent dropped every handle such a catalog could publish.
+  const root = {
+    components: [
+      {
+        ...parallelCatalog.components[0],
+        sourceDirectory: "",
+        sourceFile: "app/src/main/kotlin/app/Preview.kt",
+        sourceFunction: "Sticker",
+      },
+    ],
+  };
+  assert.equal(
+    onlyNode(
+      planDesignPages({ manifest: sharedImport, spec: {}, catalog: root }),
+    ).code,
+    "app/src/main/kotlin/app/Preview.kt#Sticker",
+  );
+});

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -6,10 +6,8 @@ import {
   catalogOwnsNode,
   declaringClassOf,
   declaringClasses,
-  moduleDirectory,
   pageImageName,
   planDesignPages,
-  previewFunctionOf,
 } from "./design-pages.mjs";
 
 /** A catalog whose stickers carry the discovery preview ids a design-map entry would name. */
@@ -616,6 +614,11 @@ const parallelCatalog = {
       reference: "figma:FILE/35239:93092",
       sourceFile: "src/main/kotlin/app/remote/RemotePreviews.kt",
       sourceModule: ":remote-catalog",
+      // Carried by the producer, not derived here: the directory because `projectDir` may remap a
+      // logical path anywhere, the function because an arbitrary `@Preview(name = …)` makes a
+      // preview id unsplittable.
+      sourceDirectory: "remote-catalog",
+      sourceFunction: "FilledRemoteButton",
       images: [
         {
           path: "images/button-filled/ideal__default.png",
@@ -797,29 +800,15 @@ test("a node with no declared previewId keeps its claim, as it always did", () =
 
 // ---- The joins themselves ---------------------------------------------------------------------
 
-test("moduleDirectory derives a project's directory, and declines what it cannot", () => {
-  assert.equal(moduleDirectory(":remote-catalog"), "remote-catalog");
-  assert.equal(moduleDirectory(":a:b"), "a/b");
-  // Falls back to the catalog's own module when a component records none.
-  assert.equal(moduleDirectory(undefined, ":catalog"), "catalog");
-  assert.equal(moduleDirectory("", ":catalog"), "catalog");
-  // The ROOT project is a real answer, not a refusal: its sourceFile is already repo-relative, so
-  // the prefix is empty and the handle is published bare. Conflating this with "cannot derive"
-  // dropped every rewritable node of a root-project catalog.
-  assert.equal(moduleDirectory(":"), "");
-  // A settings.gradle.kts may remap a project's directory and no published catalog records that, so
-  // anything not plainly derivable returns null and the caller drops the claim.
-  assert.equal(moduleDirectory("catalog"), null);
-  assert.equal(moduleDirectory(undefined, undefined), null);
-});
-
 test("a root-project catalog publishes its bare, already-repo-relative sourceFile", () => {
+  // The root project's carried directory is the empty string — a real answer, not a missing one.
   const rootCatalog = {
     source: { module: ":" },
     components: [
       {
         ...parallelCatalog.components[0],
         sourceModule: ":",
+        sourceDirectory: "",
         sourceFile: "app/src/main/kotlin/app/remote/RemotePreviews.kt",
       },
     ],
@@ -873,21 +862,6 @@ test("catalogOwnsNode places a claim by its declaring file", () => {
     true,
     "nothing to place ⇒ nothing proves it foreign",
   );
-});
-
-test("previewFunctionOf strips the axis and variant suffixes discovery appends", () => {
-  assert.equal(
-    previewFunctionOf(parallelCatalog.components[0]),
-    "FilledRemoteButton",
-  );
-  assert.equal(
-    previewFunctionOf({
-      images: [{ previewId: "a.b.CKt.Sticker_VARIANT_disabled" }],
-    }),
-    "Sticker",
-  );
-  assert.equal(previewFunctionOf({ images: [] }), null);
-  assert.equal(previewFunctionOf({}), null);
 });
 
 // ---- Review findings on the shared-import fix (#4680) ------------------------------------------
@@ -1013,19 +987,6 @@ test("a rewritten node drops the owner's provenance rather than wearing it", () 
   assert.equal(kept.cell, true);
 });
 
-test("previewFunctionOf keeps an underscore that belongs to the function name", () => {
-  // `Filled_Button_Light` truncated at the first underscore publishes `#Filled` — a handle naming
-  // no function at all. Only a recognised axis or variant suffix is stripped.
-  const fnFor = (previewId) => previewFunctionOf({ images: [{ previewId }] });
-  assert.equal(fnFor("app.PreviewsKt.Filled_Button_Light"), "Filled_Button");
-  assert.equal(fnFor("app.PreviewsKt.Filled_Button"), "Filled_Button");
-  assert.equal(fnFor("app.PreviewsKt.Sticker_width_227dp_dpi_320"), "Sticker");
-  assert.equal(fnFor("app.PreviewsKt.Sticker_VARIANT_disabled"), "Sticker");
-  // Unrecognised suffixes survive whole: too long still points at the right file, truncated points
-  // nowhere.
-  assert.equal(fnFor("app.PreviewsKt.Odd_Name_Here"), "Odd_Name_Here");
-});
-
 test("a dotted @Preview name does not split the declaring class", () => {
   // `sanitizeForPath` deliberately keeps dots so an id stays lossless, so `@Preview(name = "Phone.v2")`
   // ends `…FooKt.Render_Phone.v2`. Splitting at the last dot put two variants of ONE function in
@@ -1057,5 +1018,94 @@ test("a dotted @Preview name does not split the declaring class", () => {
   assert.equal(
     catalogOwnsNode({ previewId: "pkg.FooKt.Render_Tablet.v3" }, classes),
     true,
+  );
+});
+
+// ---- The producer carries what cannot be derived (wear-m3-catalog#98 follow-up) ----------------
+
+test("a remapped project directory is published as recorded, not as derived", () => {
+  // `project(":bundle-format").projectDir = file("bundle/format")`. This repository remaps 100
+  // projects and NOT ONE derives correctly from its Gradle path, so the directory is carried.
+  const remapped = {
+    source: { module: ":bundle-format" },
+    components: [
+      {
+        ...parallelCatalog.components[0],
+        sourceModule: ":bundle-format",
+        sourceDirectory: "bundle/format",
+        sourceFile: "src/main/kotlin/app/Preview.kt",
+        sourceFunction: "Sticker",
+      },
+    ],
+  };
+  const result = planDesignPages({
+    manifest: sharedImport,
+    spec: {},
+    catalog: remapped,
+  });
+  assert.equal(
+    onlyNode(result).code,
+    "bundle/format/src/main/kotlin/app/Preview.kt#Sticker",
+  );
+});
+
+test("a carried function name survives what no id parse could recover", () => {
+  // `@Preview(name = "Large Round")` and `name = "Phone.v2"` reach the id through `sanitizeForPath`,
+  // which passes spaces and dots verbatim — the id does not split back into function and label.
+  for (const fn of ["Filled_Button", "Render", "A_B_C"]) {
+    const catalog = {
+      components: [
+        {
+          ...parallelCatalog.components[0],
+          sourceFunction: fn,
+          images: [
+            {
+              path: "images/button-filled/ideal__default.png",
+              previewId: `app.remote.RemotePreviewsKt.${fn}_Large Round`,
+            },
+          ],
+        },
+      ],
+    };
+    assert.equal(
+      onlyNode(planDesignPages({ manifest: sharedImport, spec: {}, catalog }))
+        .code,
+      `remote-catalog/src/main/kotlin/app/remote/RemotePreviews.kt#${fn}`,
+    );
+  }
+});
+
+test("a catalog published before the fields existed keeps its render, losing only the label", () => {
+  // The migration case, and the reason the render does not hang off the code handle: a reference
+  // match is an identity, so the sticker stands even when nothing can be said about its source.
+  const older = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        reference: "figma:FILE/35239:93092",
+        sourceFile: "src/main/kotlin/app/remote/RemotePreviews.kt",
+        sourceModule: ":remote-catalog",
+        images: [
+          {
+            path: "images/button-filled/ideal__default.png",
+            previewId: "app.remote.RemotePreviewsKt.FilledRemoteButton",
+          },
+        ],
+      },
+    ],
+  };
+  const node = onlyNode(
+    planDesignPages({ manifest: sharedImport, spec: {}, catalog: older }),
+  );
+  assert.equal(node.link, "manifest", "the pairing is still established");
+  assert.equal(
+    node.previewId,
+    "button-filled__ideal__default",
+    "and still scores",
+  );
+  assert.equal(
+    "code" in node,
+    false,
+    "but nothing is claimed about the source",
   );
 });

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -45,10 +45,17 @@ import {
 import { buildCatalog, writeCatalog } from "@design-parity/catalog-export";
 
 import { foldVariants, variantLabel } from "./catalog-variants.mjs";
-import { foldMotion, motionArtifactsFor, motionPreviewFor } from "./catalog-motion.mjs";
+import {
+  foldMotion,
+  motionArtifactsFor,
+  motionPreviewFor,
+} from "./catalog-motion.mjs";
 import { publishMotionArtifacts } from "./catalog-motion-publish.mjs";
 import { checkMotionCarried } from "./motion-carried.mjs";
-import { unclaimedMotionPreviews, unclaimedMotionWarning } from "./unclaimed-motion.mjs";
+import {
+  unclaimedMotionPreviews,
+  unclaimedMotionWarning,
+} from "./unclaimed-motion.mjs";
 import {
   DEFERRED,
   deferralPlan,
@@ -112,13 +119,26 @@ import {
 // CI warnings and fatal diagnostics should be visible as workflow annotations,
 // not buried among catalog-generation milestones. Keep local output unchanged.
 if (process.env.GITHUB_ACTIONS === "true") {
-  const annotate = (level, title, sink) => (...parts) => {
-    const escape = (value) =>
-      String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
-    sink(`::${level} title=${escape(title)}::${escape(parts.join(" "))}`);
-  };
-  console.warn = annotate("warning", "Design artifact warning", console.warn.bind(console));
-  console.error = annotate("error", "Design artifact failure", console.error.bind(console));
+  const annotate =
+    (level, title, sink) =>
+    (...parts) => {
+      const escape = (value) =>
+        String(value)
+          .replaceAll("%", "%25")
+          .replaceAll("\r", "%0D")
+          .replaceAll("\n", "%0A");
+      sink(`::${level} title=${escape(title)}::${escape(parts.join(" "))}`);
+    };
+  console.warn = annotate(
+    "warning",
+    "Design artifact warning",
+    console.warn.bind(console),
+  );
+  console.error = annotate(
+    "error",
+    "Design artifact failure",
+    console.error.bind(console),
+  );
 }
 import { exportsNoSticker } from "./capture-mode.mjs";
 import {
@@ -155,6 +175,7 @@ import {
 } from "./completeness-exemptions.mjs";
 import {
   additionalBundleLiveConflict,
+  bundleModuleDirectory,
   bundleModulePath,
   claimedComponentIds,
   claimedPreviewFunctions,
@@ -273,9 +294,14 @@ async function loadCandidates(path, breakpoints) {
   // rather than by whether a hand-typed name coincides with the kit's naming. Props win over state
   // for such a cell (stamping both would double-count one render), so the axis pass runs first and
   // the state pass skips any image it claimed.
-  const axisProps = applyVariantAxisProps(candidates, overridesByPreviewId(candidateBundle));
+  const axisProps = applyVariantAxisProps(
+    candidates,
+    overridesByPreviewId(candidateBundle),
+  );
   if (axisProps.stamped > 0) {
-    console.log(`[${basename(path)}] stamped @PreviewAxis props on ${axisProps.stamped} image(s)`);
+    console.log(
+      `[${basename(path)}] stamped @PreviewAxis props on ${axisProps.stamped} image(s)`,
+    );
   }
   for (const candidate of candidates) {
     const state = variantStateFromId(candidate.previewId ?? candidate.id);
@@ -309,7 +335,10 @@ async function loadCandidates(path, breakpoints) {
   // class, where it is indistinguishable from the sibling expansion that DID match — the collapse
   // that otherwise surfaces much later as an overwritten sticker or a duplicate-axis failure. Say so
   // here, while the fix (one more `breakpoints` entry) is still obvious.
-  const undeclaredDevices = undeclaredBreakpointDevices(candidateBundle.previews, breakpoints);
+  const undeclaredDevices = undeclaredBreakpointDevices(
+    candidateBundle.previews,
+    breakpoints,
+  );
   if (undeclaredDevices.length > 0) {
     console.warn(
       `[${basename(path)}] ${undeclaredDevices.length} @Preview device id(s) match no declared ` +
@@ -365,13 +394,33 @@ function sourceByFunction(bundle) {
   const out = new Map();
   const prefer = (id) => /(_|\b)light$/i.test(id);
   const module = bundleModulePath(bundle);
+  // The physical directory the bundle recorded, carried beside the logical path. A consumer that
+  // needs a REPOSITORY path — the design-page surface joining this to `sourceFile` — cannot derive
+  // it from `module`, so the producer hands it over instead of leaving it to be guessed.
+  const directory = bundleModuleDirectory(bundle);
   for (const preview of bundle.previews ?? []) {
     const fn = preview.functionName ?? preview.id;
     if (out.has(fn) && !prefer(preview.id)) continue;
+    // `fn` is discovery's OWN function name, kept as a field rather than left to be re-parsed out
+    // of a preview id: `buildVariantSuffix` appends an arbitrary `@Preview(name = …)` through
+    // `sanitizeForPath`, which passes spaces and dots verbatim, so the id is not losslessly
+    // splittable back into function and label.
     if (preview.sourceFile)
-      out.set(fn, { sourceFile: preview.sourceFile, bodyLine: preview.bodyLine, module });
+      out.set(fn, {
+        sourceFile: preview.sourceFile,
+        bodyLine: preview.bodyLine,
+        module,
+        directory,
+        functionName: fn,
+      });
     else if (!out.has(fn))
-      out.set(fn, { sourceFile: undefined, bodyLine: undefined, module });
+      out.set(fn, {
+        sourceFile: undefined,
+        bodyLine: undefined,
+        module,
+        directory,
+        functionName: fn,
+      });
   }
   return out;
 }
@@ -547,7 +596,9 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
             componentId: specComponent.componentId,
             group: group.name,
             ...(group.section !== undefined ? { section: group.section } : {}),
-            ...(specComponent.caption !== undefined ? { caption: specComponent.caption } : {}),
+            ...(specComponent.caption !== undefined
+              ? { caption: specComponent.caption }
+              : {}),
             preview: specComponent.preview,
             reason: "entry",
           });
@@ -561,7 +612,9 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
           if (exportsNoSticker(variant)) {
             // Same label shape `foldVariants` uses for the required path, from the same helper, so a
             // reader can't tell from the report which lane the entry took.
-            noSticker.push(`${specComponent.componentId} [${variantLabel(variant)}]`);
+            noSticker.push(
+              `${specComponent.componentId} [${variantLabel(variant)}]`,
+            );
             continue;
           }
           deferred.push({
@@ -579,7 +632,8 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       }
       // Fold only the REQUIRED variants; each deferred one is recorded live-only instead of being
       // looked up (and then reported missing) below.
-      const { component, deferredVariants } = splitDeferredVariants(specComponent);
+      const { component, deferredVariants } =
+        splitDeferredVariants(specComponent);
       for (const variant of deferredVariants) {
         deferred.push({
           componentId: component.componentId,
@@ -605,7 +659,10 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       // `@Preview` function and still be separate cards with their own ids and captions — the
       // alternative being to split the function in the module (see catalog-select.mjs).
       const select = selectOf(component);
-      const { images: selected, missing: unselected } = selectComponentImages(component, candidate);
+      const { images: selected, missing: unselected } = selectComponentImages(
+        component,
+        candidate,
+      );
       if (unselected) {
         missing.push(unselected);
         continue;
@@ -628,7 +685,10 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       // dropped from the baked set (so no PNG is written and the Figma/static kit stays lean) and
       // recorded live-only. Only stickers that NAME a theme are eligible, so every component keeps
       // its untagged primary render.
-      const { baked, deferred: deferredImages } = splitDeferredImages(ideal, spec);
+      const { baked, deferred: deferredImages } = splitDeferredImages(
+        ideal,
+        spec,
+      );
       for (const image of deferredImages) {
         deferred.push({
           componentId: component.componentId,
@@ -658,7 +718,9 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       const seenAxes = new Set(
         [...deferredImages, ...baked]
           .filter((image) => image.theme)
-          .map((image) => deferralAxisKey(image.theme, image.state, image.props, image.size)),
+          .map((image) =>
+            deferralAxisKey(image.theme, image.state, image.props, image.size),
+          ),
       );
       // A `select`ed entry covers ONE breakpoint of its function, so its deferred-mode record has to
       // name that size — otherwise the sibling entry selecting the other breakpoint dedupes against
@@ -674,10 +736,17 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
       ];
       for (const source of modeSources) {
         if (!source.preview) continue;
-        for (const previewId of opts.previewIdsByFunction?.get(source.preview) ?? []) {
+        for (const previewId of opts.previewIdsByFunction?.get(
+          source.preview,
+        ) ?? []) {
           const mode = modeOfPreviewId(previewId, spec.modes);
           if (!mode || modePriority(spec, mode) !== DEFERRED) continue;
-          const key = deferralAxisKey(mode, source.state, source.props, source.size);
+          const key = deferralAxisKey(
+            mode,
+            source.state,
+            source.props,
+            source.size,
+          );
           if (seenAxes.has(key)) continue;
           seenAxes.add(key);
           deferred.push({
@@ -774,7 +843,14 @@ function catalogFromCandidates(candidates, spec, opts = {}) {
   // is silently dropped here unless it is threaded through by hand. Missing it published a catalog
   // with no `themes[]` while the run logged that it was publishing them.
   const catalog = buildCatalog(meta, sources, opts.themeTokens, opts.themes);
-  return { catalog, missing, noSticker, withoutSemantics, deferred, motionByComponentId };
+  return {
+    catalog,
+    missing,
+    noSticker,
+    withoutSemantics,
+    deferred,
+    motionByComponentId,
+  };
 }
 // --- end vendored join --------------------------------------------------------
 
@@ -979,9 +1055,16 @@ const allBundles = [bundle, extraBundle, ...additionalBundles].filter(Boolean);
 // `candidates` above — so its `@CatalogComponent` must reach the inventory as well,
 // or the component would render but never enter `spec.groups`. Primary previews come
 // first, so a component present in both dedupes to the primary's annotation.
-const inventoryPreviews = allBundles.flatMap((renderBundle) => renderBundle.previews ?? []);
-const { groups: annotationGroups, orphanVariants, withoutBreakpoints } =
-  inventoryFromPreviews(inventoryPreviews, { breakpoints: catalogBreakpoints(spec) });
+const inventoryPreviews = allBundles.flatMap(
+  (renderBundle) => renderBundle.previews ?? [],
+);
+const {
+  groups: annotationGroups,
+  orphanVariants,
+  withoutBreakpoints,
+} = inventoryFromPreviews(inventoryPreviews, {
+  breakpoints: catalogBreakpoints(spec),
+});
 if (withoutBreakpoints.length > 0) {
   // `perBreakpoint` asked for a card per breakpoint but no render resolved to one — an undeclared
   // device, or a catalog with no `breakpoints` table at all. The component is kept WHOLE rather
@@ -1007,7 +1090,10 @@ if (annotationGroups.length > 0) {
     0,
   );
   spec.groups = mergeCatalogGroups(annotationGroups, spec.groups ?? []);
-  const mergedCount = spec.groups.reduce((n, g) => n + (g.components?.length ?? 0), 0);
+  const mergedCount = spec.groups.reduce(
+    (n, g) => n + (g.components?.length ?? 0),
+    0,
+  );
   console.log(
     `[${spec.system}] merged annotation inventory: ${annotationGroups.reduce((n, g) => n + g.components.length, 0)} ` +
       `annotated component(s) + ${specComponentCount} spec component(s) → ${mergedCount} total`,
@@ -1026,7 +1112,10 @@ if (values["generate-fallbacks"]) {
   );
   if (fallbackGroups.length > 0) {
     spec.groups = [...(spec.groups ?? []), ...fallbackGroups];
-    const count = fallbackGroups.reduce((n, group) => n + group.components.length, 0);
+    const count = fallbackGroups.reduce(
+      (n, group) => n + group.components.length,
+      0,
+    );
     console.log(
       `[${spec.system}] generated ${count} fallback component(s) across ` +
         `${fallbackGroups.length} module/preview group(s)`,
@@ -1058,7 +1147,9 @@ spec.groups = applyGroupOrder(spec.groups, spec.groupOrder);
 
 const renderFailures = renderFailuresFromBundles(allBundles, spec);
 if (renderFailures.length > 0) {
-  const signatures = new Set(renderFailures.map((f) => `${f.errorClass}\u0000${f.message}`));
+  const signatures = new Set(
+    renderFailures.map((f) => `${f.errorClass}\u0000${f.message}`),
+  );
   console.warn(
     `[${spec.system}] ${renderFailures.length} failed render(s), ${signatures.size} distinct ` +
       `error signature(s) — recorded in catalog.json`,
@@ -1147,7 +1238,11 @@ function designParityVersion() {
 // which a `--allow-render-trusted` box builds). Refuse here rather than publish a thinner catalog
 // than the spec describes. Mirrored (leniently, since it can't know the publish flags) by
 // `validateSpec`'s `liveBundle` option in the build-free pre-flight.
-if (specDefersAnything(spec) && !values["publish-live-bundle"] && !values["source-module"]) {
+if (
+  specDefersAnything(spec) &&
+  !values["publish-live-bundle"] &&
+  !values["source-module"]
+) {
   console.error(
     `[${spec.system}] this spec defers coverage (\`priority: "deferred"\` / \`modePriority\`) but ` +
       `neither --publish-live-bundle nor --source-module was passed — the deferred entries would ` +
@@ -1168,24 +1263,30 @@ if (specDefersAnything(spec)) {
   );
 }
 
-const { catalog, missing, noSticker, withoutSemantics, deferred, motionByComponentId } =
-  catalogFromCandidates(candidates, spec, {
-    ...(values.renderer ? { renderer: values.renderer } : {}),
-    ...(designParityVersion() ? { designParity: designParityVersion() } : {}),
-    ...(themeTokens ? { themeTokens } : {}),
-    ...(declaredThemes.length > 0 ? { themes: declaredThemes } : {}),
-    // Every daemon preview id per function, from the bundles' FULL preview lists — including the
-    // deferred palettes whose render was skipped (#2966), which is how their live-only coverage still
-    // gets declared even though no image of them exists to fold.
-    previewIdsByFunction: daemonPreviewIdsByFunction(allBundles),
-    // The same fan-outs with their render parameters. A separately named motion function may
-    // declare annotations in a different order, so theme inheritance joins by axis identity rather
-    // than zipping the two id arrays.
-    previewCellsByFunction: daemonPreviewCellsByFunction(allBundles),
-    // Motion artifacts are read from every catalog module. Keep the legacy extra-render supplement
-    // out: it fills in stills the primary could not produce and does not own motion captures.
-    motionBundle: [bundle, ...additionalBundles],
-  });
+const {
+  catalog,
+  missing,
+  noSticker,
+  withoutSemantics,
+  deferred,
+  motionByComponentId,
+} = catalogFromCandidates(candidates, spec, {
+  ...(values.renderer ? { renderer: values.renderer } : {}),
+  ...(designParityVersion() ? { designParity: designParityVersion() } : {}),
+  ...(themeTokens ? { themeTokens } : {}),
+  ...(declaredThemes.length > 0 ? { themes: declaredThemes } : {}),
+  // Every daemon preview id per function, from the bundles' FULL preview lists — including the
+  // deferred palettes whose render was skipped (#2966), which is how their live-only coverage still
+  // gets declared even though no image of them exists to fold.
+  previewIdsByFunction: daemonPreviewIdsByFunction(allBundles),
+  // The same fan-outs with their render parameters. A separately named motion function may
+  // declare annotations in a different order, so theme inheritance joins by axis identity rather
+  // than zipping the two id arrays.
+  previewCellsByFunction: daemonPreviewCellsByFunction(allBundles),
+  // Motion artifacts are read from every catalog module. Keep the legacy extra-render supplement
+  // out: it fills in stills the primary could not produce and does not own motion captures.
+  motionBundle: [bundle, ...additionalBundles],
+});
 
 // Completeness gate: `bundle pack --with-semantics` is best-effort and exits 0
 // even when the daemon never started or captured zero semantics. For a scheduled
@@ -1477,8 +1578,15 @@ if (values["publish-live-bundle"]) {
     const dest = join(outPath, path, file);
     await mkdir(dirname(dest), { recursive: true });
     await cp(record.renderPath, dest);
-    liveBundles.push({ path, file, module, previewIdPrefix: moduleIdentityPrefix(module) });
-    console.log(`[${spec.system}] carried module live bundle ${module} → ${path}${file}`);
+    liveBundles.push({
+      path,
+      file,
+      module,
+      previewIdPrefix: moduleIdentityPrefix(module),
+    });
+    console.log(
+      `[${spec.system}] carried module live bundle ${module} → ${path}${file}`,
+    );
   }
 }
 
@@ -1501,7 +1609,8 @@ if (values["publish-live-bundle"]) {
   // preview to its source on GitHub. No-op when discovery recorded no paths.
   const sourcesByFunction = new Map();
   for (const renderBundle of allBundles) {
-    for (const [fn, source] of sourceByFunction(renderBundle)) sourcesByFunction.set(fn, source);
+    for (const [fn, source] of sourceByFunction(renderBundle))
+      sourcesByFunction.set(fn, source);
   }
   const stampedSources = applySourceFiles(manifest, spec, sourcesByFunction);
   if (stampedSources > 0) {
@@ -1603,10 +1712,14 @@ if (values["publish-live-bundle"]) {
           : {}),
         ...(ids.length > 0 ? { previewIds: ids } : {}),
         // Never clobber a record that already carries one, matching `applyParallels`.
-        ...(parallel !== undefined && record.parallel === undefined ? { parallel } : {}),
+        ...(parallel !== undefined && record.parallel === undefined
+          ? { parallel }
+          : {}),
       };
     });
-    const addressable = manifest.deferred.filter((r) => r.path && r.previewId).length;
+    const addressable = manifest.deferred.filter(
+      (r) => r.path && r.previewId,
+    ).length;
     console.log(
       `[${spec.system}] ${addressable}/${manifest.deferred.length} deferred record(s) carry a ` +
         `route + daemon preview id (the live-only lane a trusted serve host registers them under)`,
@@ -1632,12 +1745,7 @@ if (values["publish-live-bundle"]) {
     // Both bundles: an `--extra-renders`-only component's previews live solely in the
     // supplement, so passing just the primary left every one of its images with no
     // `previewId` — no live lane for it, and no per-variant figma-svg.
-    bridgeLivePreviewIds(
-      manifest,
-      spec,
-      allBundles,
-      overriddenFunctions,
-    );
+    bridgeLivePreviewIds(manifest, spec, allBundles, overriddenFunctions);
     // The shared live daemon opens only the primary bundle. An extra-only image renders through a
     // per-preview supplement bundle that stays closed until first render, so the browse surface
     // cannot discover its authored knobs / focus / gesture controls from the daemon. Record those
@@ -1755,7 +1863,8 @@ if (values["publish-live-bundle"]) {
 // PNG-only. Extra wins on a name clash, matching the candidate fold above.
 const layoutByFn = new Map();
 for (const renderBundle of allBundles) {
-  for (const [fn, value] of layoutByFunction(renderBundle)) layoutByFn.set(fn, value);
+  for (const [fn, value] of layoutByFunction(renderBundle))
+    layoutByFn.set(fn, value);
 }
 const fnByComponentId = new Map(
   spec.groups.flatMap((g) =>
@@ -2058,7 +2167,11 @@ if (compare) {
     // below and skips the compare page with a warning, which is the loud outcome that error wants.
     const otherSpecPath = compare.spec
       ? resolve(dirname(specPath), compare.spec)
-      : join(dirname(dirname(specPath)), `design-catalog-${compare.system}`, "catalog.spec.json");
+      : join(
+          dirname(dirname(specPath)),
+          `design-catalog-${compare.system}`,
+          "catalog.spec.json",
+        );
     const otherSpec = compare.spec
       ? JSON.parse(await readFile(otherSpecPath, "utf8"))
       : await readJsonBestEffort(otherSpecPath);
@@ -2081,7 +2194,9 @@ if (compare) {
     // pixels stay current — only a brand-new sibling component waits a run.
     const otherRepo = compare.repo ?? repo;
     const otherBranchBase = `https://raw.githubusercontent.com/${otherRepo}/design-artifacts/${compare.system}/`;
-    const otherManifest = await fetchJsonBestEffort(`${otherBranchBase}catalog.json`);
+    const otherManifest = await fetchJsonBestEffort(
+      `${otherBranchBase}catalog.json`,
+    );
     if (otherManifest) {
       console.log(
         `[${spec.system}] resolved ${otherManifest.components?.length ?? 0} sibling render(s) ` +
@@ -2159,7 +2274,9 @@ if (compare) {
         if (image?.path) publishedPreviewIds.add(servePreviewId(image.path));
     const designRefById = new Map();
     if (compare.design !== false) {
-      const sibling = await fetchJsonBestEffort(`${otherBranchBase}references/index.json`);
+      const sibling = await fetchJsonBestEffort(
+        `${otherBranchBase}references/index.json`,
+      );
       const local = await fetchJsonBestEffort(
         `https://raw.githubusercontent.com/${repo}/design-artifacts/${spec.system}/references/index.json`,
       );
@@ -2201,7 +2318,10 @@ if (compare) {
         // `meta` object rather than nesting it — so the fetched fallback reads `.title`. The `.meta`
         // arm is for a reader handed the nested in-memory shape; both are cheap and only one is
         // ever populated.
-        otherTitle: otherSpec?.title ?? otherManifest?.title ?? otherManifest?.meta?.title,
+        otherTitle:
+          otherSpec?.title ??
+          otherManifest?.title ??
+          otherManifest?.meta?.title,
         repo,
         otherRepo,
         designRefById,
@@ -2212,7 +2332,11 @@ if (compare) {
     );
     crossSystem = {
       system: compare.system,
-      title: otherSpec?.title ?? otherManifest?.title ?? otherManifest?.meta?.title ?? compare.system,
+      title:
+        otherSpec?.title ??
+        otherManifest?.title ??
+        otherManifest?.meta?.title ??
+        compare.system,
     };
     console.log(`[${spec.system}] matches → ${matchesPath}`);
   } catch (err) {
@@ -2296,7 +2420,9 @@ if (figmaVariantGapCount) {
 // manifest carries the flattened `images[]` with the `previewId` the stamp pass bridged on — see
 // its declaration above. Against `catalog.components` this check iterates nothing and reports
 // nothing, whatever the export actually emitted, which is the one way a checker can fail worst.
-const variantRenderMismatches = mismatchedVariantRenders(indexManifest.components);
+const variantRenderMismatches = mismatchedVariantRenders(
+  indexManifest.components,
+);
 if (variantRenderMismatches.length) {
   const shown = describeMismatchedRenders(variantRenderMismatches).slice(0, 8);
   const more =

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -400,6 +400,10 @@ function sourceByFunction(bundle) {
   const directory = bundleModuleDirectory(bundle);
   for (const preview of bundle.previews ?? []) {
     const fn = preview.functionName ?? preview.id;
+    // What the SOURCE declares, which is not always the join key: `namespaceModuleRecords` rewrites
+    // a colliding `functionName` to `:module::Foo` so two modules can share a catalog, and that key
+    // is not a Kotlin identifier. `declaredFunctionName` survives the rewrite for exactly this.
+    const declared = preview.declaredFunctionName ?? fn;
     if (out.has(fn) && !prefer(preview.id)) continue;
     // `fn` is discovery's OWN function name, kept as a field rather than left to be re-parsed out
     // of a preview id: `buildVariantSuffix` appends an arbitrary `@Preview(name = …)` through
@@ -411,7 +415,7 @@ function sourceByFunction(bundle) {
         bodyLine: preview.bodyLine,
         module,
         directory,
-        functionName: fn,
+        functionName: declared,
       });
     else if (!out.has(fn))
       out.set(fn, {
@@ -419,7 +423,7 @@ function sourceByFunction(bundle) {
         bodyLine: undefined,
         module,
         directory,
-        functionName: fn,
+        functionName: declared,
       });
   }
   return out;
@@ -860,6 +864,13 @@ const { values } = parseArgs({
     renders: { type: "string" },
     out: { type: "string" },
     renderer: { type: "string" },
+    // The repo-relative directory of the Gradle BUILD the renders came from, for a monorepo whose
+    // samples are separate builds (compose-samples: `JetNews/`, `Jetcaster/`, each with its own
+    // `gradlew`). The plugin records a project's directory relative to ITS OWN `rootDir`, which in
+    // that layout is the sample's root and not the checkout — so `:app` records `app` while the
+    // repository path is `JetNews/app`. Only the caller knows the difference, so the caller says.
+    // Empty (the default, and every single-build repository) changes nothing.
+    "build-root": { type: "string" },
     // Base URL of the live preview server the catalog deep-links into (the
     // `livePreview` fields + README "Customise live" links). Falls back to
     // $PREVIEW_SERVER_BASE, then the public default.
@@ -1608,9 +1619,23 @@ if (values["publish-live-bundle"]) {
   // buildCatalog) from the bundle's discovery previews, so the preview server can link a
   // preview to its source on GitHub. No-op when discovery recorded no paths.
   const sourcesByFunction = new Map();
+  // Lift each project's build-root-relative directory to a REPOSITORY-relative one. The producer
+  // records what it can know (a directory under its own build root); this is the one place that
+  // knows where that build sits in the checkout.
+  const buildRoot = (values["build-root"] ?? "")
+    .trim()
+    .replace(/^\/+|\/+$/g, "");
+  const inRepo = (directory) => {
+    if (typeof directory !== "string") return undefined;
+    if (buildRoot === "") return directory;
+    return directory === "" ? buildRoot : `${buildRoot}/${directory}`;
+  };
   for (const renderBundle of allBundles) {
     for (const [fn, source] of sourceByFunction(renderBundle))
-      sourcesByFunction.set(fn, source);
+      sourcesByFunction.set(fn, {
+        ...source,
+        directory: inRepo(source.directory),
+      });
   }
   const stampedSources = applySourceFiles(manifest, spec, sourcesByFunction);
   if (stampedSources > 0) {

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -23,7 +23,11 @@ export function bundleModulePath(bundle, fallback = ":unknown") {
  */
 export function bundleModuleDirectory(bundle) {
   const dir = bundle?.manifest?.moduleDirectory;
-  return typeof dir === "string" ? dir : "";
+  // `undefined` and `""` are DIFFERENT answers and a consumer must be able to tell them apart:
+  // `""` is the ROOT project, whose files are already repository-relative, while `undefined` is a
+  // bundle packed before the field existed and therefore an unknown directory. Collapsing the two
+  // made a root-project catalog look unknown and dropped every handle it could have published.
+  return typeof dir === "string" ? dir : undefined;
 }
 
 /** The candidate/spec join key. */
@@ -116,6 +120,11 @@ function namespaceAdditionalRecord(record, module, keyByFunction) {
       id: newId,
       functionName:
         keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+      // The name the SOURCE actually declares, kept beside the namespaced join key. Namespacing
+      // rewrites `functionName` to `:module::Foo` when two modules share a name, which is a catalog
+      // key and not a Kotlin identifier — a consumer that publishes it as a source anchor emits
+      // `File.kt#:feature::Foo`, which names nothing. The key joins; this states.
+      declaredFunctionName: previewFunction(preview),
       ...(Array.isArray(preview.captures)
         ? {
             captures: preview.captures.map((capture) =>

--- a/scripts/design-artifacts/multi-module-catalog.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.mjs
@@ -13,6 +13,19 @@ export function bundleModulePath(bundle, fallback = ":unknown") {
   return bundle?.manifest?.modulePath ?? bundle?.manifest?.module ?? fallback;
 }
 
+/**
+ * The producing project's directory relative to the repository root, as the BUNDLE recorded it.
+ *
+ * Never derived from [bundleModulePath]: a Gradle path is a logical name and `projectDir` may map
+ * it anywhere — this repository remaps 100 projects and not one derives correctly (`:bundle-format`
+ * lives at `bundle/format`). Empty for the root project, and empty for a bundle packed before the
+ * plugin recorded it, which a consumer must treat as "unknown" rather than as the root.
+ */
+export function bundleModuleDirectory(bundle) {
+  const dir = bundle?.manifest?.moduleDirectory;
+  return typeof dir === "string" ? dir : "";
+}
+
 /** The candidate/spec join key. */
 function candidateFunction(candidate) {
   return candidate?.functionName ?? candidate?.componentId;
@@ -43,7 +56,8 @@ function rewriteArtifactPath(path, oldId, newId) {
   const leaf = path.slice(slash + 1);
   if (!leaf.startsWith(oldId)) return path;
   const suffix = leaf.slice(oldId.length);
-  if (suffix !== "" && !suffix.startsWith(".") && !suffix.startsWith("_")) return path;
+  if (suffix !== "" && !suffix.startsWith(".") && !suffix.startsWith("_"))
+    return path;
   return `${path.slice(0, slash + 1)}${newId}${suffix}`;
 }
 
@@ -67,10 +81,15 @@ function rewriteJsonEntry(entries, name, transform) {
 function namespaceAdditionalRecord(record, module, keyByFunction) {
   const prefix = moduleIdentityPrefix(module);
   const manifest = record.bundle?.manifest ?? {};
-  const entryIds = manifest.previewIds ?? (record.bundle?.previews ?? []).map((p) => p.id);
+  const entryIds =
+    manifest.previewIds ?? (record.bundle?.previews ?? []).map((p) => p.id);
   const rawIds = manifest.rawPreviewIds ?? entryIds;
-  const entryIdMap = new Map(entryIds.map((id) => [id, modulePreviewId(module, id)]));
-  const rawIdMap = new Map(rawIds.map((id) => [id, modulePreviewId(module, id)]));
+  const entryIdMap = new Map(
+    entryIds.map((id) => [id, modulePreviewId(module, id)]),
+  );
+  const rawIdMap = new Map(
+    rawIds.map((id) => [id, modulePreviewId(module, id)]),
+  );
   const anyIdMap = new Map([...entryIdMap, ...rawIdMap]);
   const rewriteId = (id) => anyIdMap.get(id) ?? id;
   const artifactPathMap = new Map();
@@ -95,47 +114,62 @@ function namespaceAdditionalRecord(record, module, keyByFunction) {
     return {
       ...preview,
       id: newId,
-      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+      functionName:
+        keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
       ...(Array.isArray(preview.captures)
-        ? { captures: preview.captures.map((capture) => rewriteCapture(capture, oldId, newId)) }
+        ? {
+            captures: preview.captures.map((capture) =>
+              rewriteCapture(capture, oldId, newId),
+            ),
+          }
         : {}),
     };
   });
   const candidates = (record.candidates ?? []).map((candidate) => ({
     ...candidate,
     functionName:
-      keyByFunction.get(candidateFunction(candidate)) ?? candidateFunction(candidate),
+      keyByFunction.get(candidateFunction(candidate)) ??
+      candidateFunction(candidate),
     module,
-    ...(candidate.previewId ? { previewId: rewriteId(candidate.previewId) } : {}),
+    ...(candidate.previewId
+      ? { previewId: rewriteId(candidate.previewId) }
+      : {}),
     ...(Array.isArray(candidate.images)
       ? {
           images: candidate.images.map((image) => ({
             ...image,
-            ...(image.previewId ? { previewId: rewriteId(image.previewId) } : {}),
+            ...(image.previewId
+              ? { previewId: rewriteId(image.previewId) }
+              : {}),
           })),
         }
       : {}),
   }));
 
   const entries = {};
-  const orderedEntryIds = [...entryIdMap.keys()].sort((a, b) => b.length - a.length);
+  const orderedEntryIds = [...entryIdMap.keys()].sort(
+    (a, b) => b.length - a.length,
+  );
   for (const [path, bytes] of Object.entries(record.bundle?.entries ?? {})) {
     let rewritten = artifactPathMap.get(path) ?? path;
     if (path.startsWith("previews/")) {
       const rest = path.slice("previews/".length);
       const oldId = orderedEntryIds.find(
-        (id) => rest === id || rest.startsWith(`${id}.`) || rest.startsWith(`${id}_`),
+        (id) =>
+          rest === id || rest.startsWith(`${id}.`) || rest.startsWith(`${id}_`),
       );
-      if (oldId) rewritten = `previews/${entryIdMap.get(oldId)}${rest.slice(oldId.length)}`;
+      if (oldId)
+        rewritten = `previews/${entryIdMap.get(oldId)}${rest.slice(oldId.length)}`;
     }
     entries[rewritten] = bytes;
   }
   rewriteJsonEntry(entries, "previews.json", (value) => {
-    const list = Array.isArray(value) ? value : value.previews ?? [];
+    const list = Array.isArray(value) ? value : (value.previews ?? []);
     const rewritten = list.map((preview) => ({
       ...preview,
       id: rewriteId(preview.id),
-      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+      functionName:
+        keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
     }));
     return Array.isArray(value) ? rewritten : { ...value, previews: rewritten };
   });
@@ -145,7 +179,11 @@ function namespaceAdditionalRecord(record, module, keyByFunction) {
       ? { previewIds: value.previewIds.map((id) => entryIdMap.get(id) ?? id) }
       : {}),
     ...(Array.isArray(value.rawPreviewIds)
-      ? { rawPreviewIds: value.rawPreviewIds.map((id) => rawIdMap.get(id) ?? id) }
+      ? {
+          rawPreviewIds: value.rawPreviewIds.map(
+            (id) => rawIdMap.get(id) ?? id,
+          ),
+        }
       : {}),
   }));
 
@@ -160,10 +198,18 @@ function namespaceAdditionalRecord(record, module, keyByFunction) {
       manifest: {
         ...manifest,
         ...(Array.isArray(manifest.previewIds)
-          ? { previewIds: manifest.previewIds.map((id) => entryIdMap.get(id) ?? id) }
+          ? {
+              previewIds: manifest.previewIds.map(
+                (id) => entryIdMap.get(id) ?? id,
+              ),
+            }
           : {}),
         ...(Array.isArray(manifest.rawPreviewIds)
-          ? { rawPreviewIds: manifest.rawPreviewIds.map((id) => rawIdMap.get(id) ?? id) }
+          ? {
+              rawPreviewIds: manifest.rawPreviewIds.map(
+                (id) => rawIdMap.get(id) ?? id,
+              ),
+            }
           : {}),
       },
     },
@@ -207,15 +253,18 @@ export function namespaceModuleRecords(primary, additional = []) {
         if (!owner) claimed.set(fn, module);
       }
     }
-    if (record !== ordered[0]) return namespaceAdditionalRecord(record, module, keyByFunction);
+    if (record !== ordered[0])
+      return namespaceAdditionalRecord(record, module, keyByFunction);
     const previews = (record.bundle?.previews ?? []).map((preview) => ({
       ...preview,
-      functionName: keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
+      functionName:
+        keyByFunction.get(previewFunction(preview)) ?? previewFunction(preview),
     }));
     const candidates = (record.candidates ?? []).map((candidate) => ({
       ...candidate,
       functionName:
-        keyByFunction.get(candidateFunction(candidate)) ?? candidateFunction(candidate),
+        keyByFunction.get(candidateFunction(candidate)) ??
+        candidateFunction(candidate),
       module,
     }));
     return {
@@ -230,13 +279,15 @@ export function namespaceModuleRecords(primary, additional = []) {
 /** Preview functions already represented by the effective authored/annotation inventory. */
 export function claimedPreviewFunctions(groups) {
   return new Set(
-    (groups ?? []).flatMap((group) =>
-      (group.components ?? []).flatMap((component) => [
-        component.preview,
-        component.motionPreview,
-        ...(component.variants ?? []).map((variant) => variant.preview),
-      ]),
-    ).filter(Boolean),
+    (groups ?? [])
+      .flatMap((group) =>
+        (group.components ?? []).flatMap((component) => [
+          component.preview,
+          component.motionPreview,
+          ...(component.variants ?? []).map((variant) => variant.preview),
+        ]),
+      )
+      .filter(Boolean),
   );
 }
 
@@ -244,7 +295,9 @@ export function claimedPreviewFunctions(groups) {
 export function claimedComponentIds(groups) {
   return new Set(
     (groups ?? []).flatMap((group) =>
-      (group.components ?? []).map((component) => component.componentId).filter(Boolean),
+      (group.components ?? [])
+        .map((component) => component.componentId)
+        .filter(Boolean),
     ),
   );
 }
@@ -261,7 +314,9 @@ export function combinedBundleMap(bundles, mapBundle) {
 /** Additional bundles cannot share a single buildable source module. Live publication is supported. */
 export function additionalBundleLiveConflict(values) {
   if (!(values?.["additional-renders"]?.length > 0)) return null;
-  const conflicts = [values["source-module"] && "--source-module"].filter(Boolean);
+  const conflicts = [values["source-module"] && "--source-module"].filter(
+    Boolean,
+  );
   return conflicts.length > 0 ? conflicts : null;
 }
 
@@ -294,7 +349,13 @@ export function generatedFallbackGroups(
     const seen = new Set();
     for (const candidate of record.candidates ?? []) {
       const fn = candidateFunction(candidate);
-      if (!fn || claimed.has(fn) || seen.has(fn) || !(candidate.images?.length > 0)) continue;
+      if (
+        !fn ||
+        claimed.has(fn) ||
+        seen.has(fn) ||
+        !(candidate.images?.length > 0)
+      )
+        continue;
       seen.add(fn);
       const preview = previewByFunction.get(fn);
       const name = preview?.params?.group?.trim() || "Previews";

--- a/scripts/design-artifacts/multi-module-catalog.test.mjs
+++ b/scripts/design-artifacts/multi-module-catalog.test.mjs
@@ -23,11 +23,17 @@ const record = (module, functions) => ({
     previews: functions.map((fn) => ({
       id: `${module}.${fn}`,
       functionName: fn,
-      params: { group: fn === "Grouped" ? "Controls" : null, name: `${fn} caption` },
+      params: {
+        group: fn === "Grouped" ? "Controls" : null,
+        name: `${fn} caption`,
+      },
     })),
     entries: { [`${module}.entry`]: module },
   },
-  candidates: functions.map((fn) => ({ componentId: fn, images: [{ path: `${fn}.png` }] })),
+  candidates: functions.map((fn) => ({
+    componentId: fn,
+    images: [{ path: `${fn}.png` }],
+  })),
 });
 
 test("additional modules are sorted and duplicate functions are deterministically namespaced", () => {
@@ -38,9 +44,18 @@ test("additional modules are sorted and duplicate functions are deterministicall
   assert.equal(primary.module, ":catalog");
   assert.equal(a.module, ":a");
   assert.equal(z.module, ":z");
-  assert.deepEqual(primary.candidates.map((it) => it.functionName), ["Shared", "CatalogOnly"]);
-  assert.deepEqual(a.candidates.map((it) => it.functionName), [":a::Shared", "AOnly"]);
-  assert.deepEqual(z.candidates.map((it) => it.functionName), [":z::Shared"]);
+  assert.deepEqual(
+    primary.candidates.map((it) => it.functionName),
+    ["Shared", "CatalogOnly"],
+  );
+  assert.deepEqual(
+    a.candidates.map((it) => it.functionName),
+    [":a::Shared", "AOnly"],
+  );
+  assert.deepEqual(
+    z.candidates.map((it) => it.functionName),
+    [":z::Shared"],
+  );
 });
 
 test("additional modules namespace equal preview ids and every keyed sidecar", () => {
@@ -66,7 +81,13 @@ test("additional modules namespace equal preview ids and every keyed sidecar", (
         "previews/ScreenPreview-deadbeef.gif": bytes(`motion:${module}`),
         "previews.json": bytes(
           JSON.stringify({
-            previews: [{ id: "pkg.ScreenPreview", functionName: "ScreenPreview", targets: [] }],
+            previews: [
+              {
+                id: "pkg.ScreenPreview",
+                functionName: "ScreenPreview",
+                targets: [],
+              },
+            ],
           }),
         ),
       },
@@ -80,41 +101,51 @@ test("additional modules namespace equal preview ids and every keyed sidecar", (
     ],
   });
 
-  const [primary, additional] = namespaceModuleRecords(collisionRecord(":app"), [
-    collisionRecord(":feature"),
-  ]);
+  const [primary, additional] = namespaceModuleRecords(
+    collisionRecord(":app"),
+    [collisionRecord(":feature")],
+  );
   const additionalId = additional.bundle.previews[0].id;
   assert.equal(primary.bundle.previews[0].id, "pkg.ScreenPreview");
   assert.notEqual(additionalId, "pkg.ScreenPreview");
   assert.equal(additional.candidates[0].previewId, additionalId);
   assert.equal(additional.candidates[0].images[0].previewId, additionalId);
-  const additionalMotion = additional.bundle.previews[0].captures[0].renderOutput;
+  const additionalMotion =
+    additional.bundle.previews[0].captures[0].renderOutput;
   assert.notEqual(additionalMotion, "previews/ScreenPreview-deadbeef.gif");
   assert.ok(additional.bundle.entries[additionalMotion]);
   assert.ok(additional.bundle.entries[`previews/${additionalId}.png`]);
-  assert.ok(additional.bundle.entries[`previews/${additionalId}.semantics.json`]);
-  assert.ok(additional.bundle.entries[`previews/${additionalId}.figma-raster/node.png`]);
+  assert.ok(
+    additional.bundle.entries[`previews/${additionalId}.semantics.json`],
+  );
+  assert.ok(
+    additional.bundle.entries[`previews/${additionalId}.figma-raster/node.png`],
+  );
   assert.deepEqual(
-    Object.keys(combinedBundleEntries([primary.bundle, additional.bundle])).filter((path) =>
-      path.endsWith(".semantics.json"),
-    ),
+    Object.keys(
+      combinedBundleEntries([primary.bundle, additional.bundle]),
+    ).filter((path) => path.endsWith(".semantics.json")),
     [
       "previews/pkg.ScreenPreview.semantics.json",
       `previews/${additionalId}.semantics.json`,
     ],
   );
-  const raw = JSON.parse(new TextDecoder().decode(additional.bundle.entries["previews.json"]));
+  const raw = JSON.parse(
+    new TextDecoder().decode(additional.bundle.entries["previews.json"]),
+  );
   assert.equal(raw.previews[0].id, additionalId);
   assert.equal(raw.previews[0].functionName, ":feature::ScreenPreview");
 });
 
 test("fallback inventory groups by Gradle module and preview group and skips curated previews", () => {
-  const records = namespaceModuleRecords(
-    record(":catalog", ["Curated"]),
-    [record(":feature", ["Grouped", "Plain"])],
-  );
+  const records = namespaceModuleRecords(record(":catalog", ["Curated"]), [
+    record(":feature", ["Grouped", "Plain"]),
+  ]);
   const claimed = claimedPreviewFunctions([
-    { name: "Authored", components: [{ componentId: "curated", preview: "Curated" }] },
+    {
+      name: "Authored",
+      components: [{ componentId: "curated", preview: "Curated" }],
+    },
   ]);
   assert.deepEqual(generatedFallbackGroups(records, claimed), [
     {
@@ -132,7 +163,11 @@ test("fallback inventory groups by Gradle module and preview group and skips cur
       name: "Previews",
       section: ":feature",
       components: [
-        { componentId: "feature/Plain", preview: "Plain", caption: "Plain caption" },
+        {
+          componentId: "feature/Plain",
+          preview: "Plain",
+          caption: "Plain caption",
+        },
       ],
     },
   ]);
@@ -201,6 +236,43 @@ test("additional renders allow live bundles but reject a single source module", 
     }),
     null,
   );
-  assert.equal(additionalBundleLiveConflict({ "additional-renders": ["feature.png"] }), null);
-  assert.equal(additionalBundleLiveConflict({ "publish-live-bundle": true }), null);
+  assert.equal(
+    additionalBundleLiveConflict({ "additional-renders": ["feature.png"] }),
+    null,
+  );
+  assert.equal(
+    additionalBundleLiveConflict({ "publish-live-bundle": true }),
+    null,
+  );
+});
+
+test("namespacing keeps the declared function name beside the join key", () => {
+  // A colliding name becomes `:module::Foo` so two modules can share a catalog. That key is not a
+  // Kotlin identifier, so publishing it as a source anchor emits `File.kt#:feature::Foo`, which
+  // names nothing — the declared name rides along for anything that has to state it.
+  const record = (module, fn) => ({
+    bundle: {
+      manifest: {
+        modulePath: module,
+        previewIds: [`${fn}_p`],
+        rawPreviewIds: [`${fn}_p`],
+      },
+      previews: [{ id: `${fn}_p`, functionName: fn }],
+    },
+    candidates: [],
+  });
+  const [, additional] = namespaceModuleRecords(record(":app", "Foo"), [
+    record(":feature", "Foo"),
+  ]);
+  const preview = additional.bundle.previews[0];
+  assert.equal(
+    preview.functionName,
+    ":feature::Foo",
+    "the join key is namespaced",
+  );
+  assert.equal(
+    preview.declaredFunctionName,
+    "Foo",
+    "the source still declares Foo",
+  );
 });


### PR DESCRIPTION
Follow-up to #4680, addressing the third review round that arrived after it merged. Both defects are the same mistake: the design-page rewrite **reconstructed** two facts from strings that do not encode them.

## What was wrong

**The repository directory was derived from the logical Gradle path.** `project(":bundle-format").projectDir = file("bundle/format")` is legal and common. Measured on this repository:

```
projectDir remaps: 100
  derived == actual : 0
  derived != actual : 100
     :bundle-format       derived=bundle-format       actual=bundle/format
     :preview-data-api    derived=preview-data-api    actual=api/preview-data-api
     :common-io           derived=common-io           actual=common/io
```

Not occasionally wrong — wrong every single time a remap exists.

**The `@Preview` function was split out of a discovery id.** `buildVariantSuffix` appends an arbitrary `name` / `group` through `sanitizeForPath`, which passes spaces and dots verbatim *precisely so the id stays lossless* — the comment there says so. It therefore does not split back:

| id | derived | actual |
| --- | --- | --- |
| `…FooKt.Render_Phone.v2` | `#v2` | `#Render` |
| `…FooKt.Render_Large Round` | `#Render_Large Round` | `#Render` |

## The fix: record it at the producer

Neither fact is recoverable downstream, so nothing downstream should be guessing at it.

- **Gradle writes the physical directory** into the bundle manifest (`BundleManifest.moduleDirectory`) — only Gradle knows where `projectDir` put the project. The CLI's mirror gains the same field, defaulted, so older bundles read unchanged.
- `sourceByFunction` carries it alongside discovery's own `functionName`, and `apply-source-files.mjs` stamps both onto the component as `sourceDirectory` / `sourceFunction`.
- `codeForNode` states the handle from carried fields **only**, and publishes nothing when they are absent. A path that resolves nowhere is worse than no path, because a reader cannot tell the difference.

## The render no longer hangs off the handle

This is what makes the migration safe, and it is worth calling out because it changes the shape of the earlier fix. A `reference` match is an **identity** — our component names the very design node the page is drawing — so it stands whether or not anything can be said about its source.

So a catalog published *before* these fields exist keeps every sticker and every score, and gains the source label when it next republishes. Without this, the #98 fix would have regressed for the whole migration window.

## Test plan

**Real published artifacts, both catalogs:**

- `wear-m3-catalog`'s planned manifest is **byte-identical to main** (the same before/after JSON diff that guarded #4680).
- `remote-m3` still resolves all four of its own components on the reported `buttons` page, each with a render — now with `code=undefined` until its next publish, which is the intended trade.

**Unit tests:** 41 passing in `design-pages.test.mjs`. Three new cases pin the contract — a remapped `bundle/format` published as recorded, a carried function name (`Filled_Button`, `A_B_C`) surviving where no id parse could recover it, and the migration case keeping `link` + `previewId` while claiming no `code`. The tests that pinned the two removed derivations are gone with them.

**Kotlin:** `:gradle-plugin:compileKotlin` and `:bundle-format:compileKotlin` clean; `:bundle-format:test` green; ktfmt clean on all four touched files.

**Full driver suite:** 1167 pass / 7 fail — the same 7 that fail on a clean tree at this base. `prettier --check` clean.

Also removes `moduleDirectory()` and `previewFunctionOf()` from `design-pages.mjs`: they existed only to perform the two derivations this replaces.

Non-visual change to a publish-time producer plus the manifest schema — nothing to embed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_