### PR TITLE
fix(ci): restore contract-probe import order, which is red on main

### DIFF
--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -3,8 +3,8 @@ package ee.schimke.composeai.previewserver.contract
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.WebEmbed
 import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
-import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.UiMode


### PR DESCRIPTION
`Preview Server Contracts` is failing on `main`. `:contract-probe:ktfmtCheckMain` rejects `ContractSurface.kt`:

```
[ktfmt] Invalid formatting for: …/preview-server/contract-probe/src/main/kotlin/…/ContractSurface.kt
> [ktfmt] Found 1 files that are not properly formatted
```

One line: `ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor` sits above `ee.schimke.composeai.daemon.devices.DeviceDimensions`. The import moved package in #4677 (`refactor(daemon): move DaemonLaunchDescriptor to daemon-protocol`) and the alphabetical reorder that move implies was never applied.

## Why nothing caught it

The root `./gradlew ktfmtCheckAll` **cannot** see this file. `preview-server/` is a separate Gradle build, deliberately absent from the root `settings.gradle.kts` — so its only format gate is the one inside the `Preview Server Contracts` job, and that job runs on a path filter (`preview_server_contracts` in `ci-paths.json`) which did not fire for the PR that broke it.

I hit this on #4689, whose diff does not touch `preview-server/` at all.

## Test plan

```
cd preview-server && ../gradlew :contract-probe:ktfmtCheckMain
```

Fails on `main`, passes here. Verified the working tree was byte-identical to `main` before formatting, so this is exactly ktfmt's own output and nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_