### PR TITLE
fix(ci): restore ktfmt import order in ContractSurface.kt

### DIFF
--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -3,8 +3,8 @@ package ee.schimke.composeai.previewserver.contract
 import ee.schimke.composeai.bundle.BundleReader
 import ee.schimke.composeai.bundle.WebEmbed
 import ee.schimke.composeai.bundle.coordinates.CoordinateResolver
-import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.UiMode


### PR DESCRIPTION
## main is red

`Preview Server Contracts` fails on `origin/main`:

```
Execution failed for task ':contract-probe:ktfmtCheckMain'
> [ktfmt] Found 1 files that are not properly formatted:
  src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
```

Reproduced on a clean checkout of the current tip, so it fails every PR whose merge commit inherits it — I hit it on #4690, whose diff does not go near this file.

## One import out of order

#4677 moved `DaemonLaunchDescriptor` to `daemon-protocol`, and the rewritten import kept its old position instead of sorting into its new package's place:

```diff
-import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.DaemonLaunchDescriptor
```

Worth noting why it slipped through: `preview-server/` is **its own Gradle build**, so the repository-wide `ktfmtCheckAll` that gates ordinary PRs never sees this file. The only check that does is `Preview Server Contracts`, which is path-gated — and #4677's diff qualified for it while the formatting slip landed anyway.

## Test plan

- `./gradlew -p preview-server :contract-probe:ktfmtCheckMain` — was the failure above on `origin/main`, now passes.
- `ktfmt --google-style --dry-run --set-exit-if-changed` clean on the file.
- Formatting only; no behaviour change and no contract change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxFXsm1Wq4hGfvBBWmaPKT)_