### PR TITLE
feat(design-artifacts): publish the parity verdict into the catalog bundle

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1601,6 +1601,31 @@ jobs:
             --source-repo "$SOURCE_REPOSITORY" \
             --ref "$SOURCE_REF_NAME"
 
+      # The verdict behind the server's Design parity panel (`parity/findings.json`) — the a11y,
+      # i18n, token and layout findings a design-parity run concluded about each comparison, with
+      # each one anchored to the region it is about.
+      #
+      # Like the activity feed above, this has to happen HERE. The run publishes its findings to
+      # its own `design-parity/<system>` branch keyed by the ids a RUN knows — the compose preview
+      # id and the design-map code handle — and the compare page routes on neither. It routes on
+      # the catalog's sticker id, which is minted by the reference step a few lines up. This is the
+      # one job holding both halves.
+      #
+      # Runs after the reference step for exactly that reason: the same `planDesignReferences`
+      # records that mint `references/index.json` are what scope a verdict to the board its page
+      # shows. Fail-soft like its neighbours — no parity branch, no design map, or a component with
+      # no published reference each drop with a warning rather than costing the catalog its render,
+      # so this is safe to run for every catalog unconditionally.
+      - name: Publish design-parity findings
+        if: ${{ inputs.publish || inputs.upload-out }}
+        run: |
+          set -euo pipefail
+          node compose-ai-tools/scripts/design-artifacts/emit-parity-findings.mjs \
+            --out "$GITHUB_WORKSPACE/out" \
+            --repo "$GITHUB_WORKSPACE" \
+            --spec "$INPUT_SPEC" \
+            --source-repo "$SOURCE_REPOSITORY"
+
       # Design pages: whole specimen sheets of the design file, cached as SVG, with the node id of
       # every component on them linked back to the catalog component that implements it. Feeds the
       # preview server's `/<system>/pages/` surface (`ServeDesignPages.kt`).
@@ -1873,7 +1898,12 @@ jobs:
           GITHUB_TOKEN_INLINE="$GH_TOKEN" \
           MSG="chore(design-artifacts): regenerate ${SYSTEM} catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
-          CARRY_FORWARD_PATHS='parity/issues.json history.json' \
+          # `parity/findings.json` carries forward for the same reason `parity/issues.json` does:
+          # both are produced from something a fork or a token-less run cannot reach — a
+          # credentialled issue query there, a sibling branch fetch here — so a republish that
+          # could not read it would otherwise blank the panel rather than leave the last good
+          # verdict standing.
+          CARRY_FORWARD_PATHS='parity/issues.json parity/findings.json history.json' \
           REVISION_PREVIEW_INDEX=1 \
           GIT_AUTHOR_NAME="$INPUT_COMMIT_USER_NAME" \
           GIT_AUTHOR_EMAIL="$INPUT_COMMIT_USER_EMAIL" \

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1963,6 +1963,18 @@ panels; clicking pins it, so the highlight survives the reader's eye moving from
 the frame, and two findings can be held up against each other. Nothing is lit at rest: a dozen
 findings' regions drawn at once over one frame answer "where is this one" for none of them.
 
+**Where the file comes from.** A design-parity run publishes its findings to its own
+`design-parity/<system>` branch, keyed by the ids a *run* knows — the fully-qualified compose
+preview id and the design-map code handle. The compare page routes on neither: it routes on the
+catalog's sticker id, minted at publish. So `emit-parity-findings.mjs` does the join in the
+publishing job, which is the only place holding both the run's output and the catalog it will be
+shown against — the same reason `parity/activity.json` is a publish step rather than a server
+feature. On the way through it fills in the two fields a run cannot know: the `referenceId`, from
+the same `planDesignReferences` records that mint `references/index.json`, so one board's token
+drift never prints under another board's panels; and the `reportUrl`, from the branch plus the
+`reportPath` the run's `run.json` records. A catalog with no parity branch publishes nothing and
+serves exactly as it did before the panel existed.
+
 A finding with no anchors keeps its sentence and is never offered as a control — no `tabindex`, no
 pointer affordance — because a promise of a highlight that cannot come is worse than plain text.
 Everything is fail-soft in the same way the reference and annotation manifests are: an unreadable

--- a/scripts/design-artifacts/emit-parity-findings.mjs
+++ b/scripts/design-artifacts/emit-parity-findings.mjs
@@ -1,0 +1,200 @@
+/**
+ * Write a published catalog's `parity/findings.json` — the verdict behind the preview server's
+ * **Design parity** panel on every focused comparison.
+ *
+ *     node emit-parity-findings.mjs --out <bundle dir> --repo <repo root> \
+ *       [--design-map design-map.json] [--spec catalog.spec.json] \
+ *       [--parity-branch design-parity/<system>] [--source-repo owner/name] [--strict]
+ *
+ * `--out` is the staged bundle the workflow is about to publish to `design-artifacts/<system>`;
+ * this adds one file and leaves the rest alone. Safe to run unconditionally: a repo whose parity
+ * run has never published a branch simply writes nothing, and its comparisons serve exactly as they
+ * did before the panel existed.
+ *
+ * ## Why this exists as a publish step
+ *
+ * The findings are produced by a design-parity run, which publishes them to its OWN branch
+ * (`design-parity/<system>`, beside the per-component reports) keyed by the ids a run knows: the
+ * fully-qualified compose preview id and the design-map code handle. The compare page routes on
+ * neither — it routes on the catalog's sticker id, which is minted here, at publish. So the join
+ * happens here, in the one job that holds both the run's output and the catalog it will be shown
+ * against. See `parity-findings.mjs` for the re-keying rules.
+ *
+ * The same shape as `emit-parity-activity.mjs` next door, and for the same reason: the serve host
+ * has no checkout and cannot read another branch.
+ *
+ * ## Failure posture
+ *
+ * Fail-soft, matching its neighbours and the server's own reader. No parity branch, an unreadable
+ * `findings.json`, a component with no published reference — each is a `::warning::` and the rest
+ * publishes, because a verdict panel is an enhancement and must never cost a catalog its render.
+ * `--strict` turns any skipped record into a non-zero exit for a repo that wants the panel gated.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { stripComments } from "./catalog-spec.mjs";
+import { planDesignReferences } from "./design-references.mjs";
+import {
+  FINDINGS_DIR,
+  FINDINGS_FILE,
+  RUN_FINDINGS_FILE,
+  RUN_MANIFEST_FILE,
+  buildServedFindings,
+} from "./parity-findings.mjs";
+
+function arg(name, def = undefined) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+const OUT = arg("out");
+const REPO = path.resolve(arg("repo", "."));
+const DESIGN_MAP = arg("design-map", "design-map.json");
+const SPEC = arg("spec", "catalog.spec.json");
+const SOURCE_REPO = arg("source-repo", process.env.GITHUB_REPOSITORY || "");
+const STRICT = process.argv.includes("--strict");
+
+if (!OUT) {
+  console.error("emit-parity-findings: --out <bundle dir> is required");
+  process.exit(2);
+}
+
+let skipped = 0;
+const warn = (message) => {
+  skipped += 1;
+  console.log(`::warning::parity-findings: ${message}`);
+};
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+
+const catalogPath = path.join(OUT, "catalog.json");
+if (!fs.existsSync(catalogPath)) {
+  console.error(`parity-findings: ${catalogPath} is missing — run after the catalog export`);
+  process.exit(2);
+}
+const catalog = readJson(catalogPath);
+
+const designMapPath = path.resolve(REPO, DESIGN_MAP);
+if (!fs.existsSync(designMapPath)) {
+  console.log("parity-findings: no design-map.json — nothing to publish");
+  process.exit(0);
+}
+const designMap = readJson(designMapPath);
+
+const specPath = path.resolve(REPO, SPEC);
+const spec = fs.existsSync(specPath)
+  ? JSON.parse(stripComments(fs.readFileSync(specPath, "utf8")))
+  : null;
+
+/**
+ * The branch the run published to. Defaults to `design-parity/<system>`, mirroring the
+ * `design-artifacts/<system>` branch this bundle is headed for — the two are per-system twins, so
+ * a catalog that renders several systems out of one repo keeps their verdicts apart.
+ */
+const system = catalog?.system ?? catalog?.meta?.system ?? "";
+const PARITY_BRANCH = arg("parity-branch", system ? `design-parity/${system}` : "");
+if (!PARITY_BRANCH) {
+  console.log("parity-findings: no parity branch to read — nothing to publish");
+  process.exit(0);
+}
+
+/**
+ * Read one file out of the parity branch without checking it out.
+ *
+ * `git show <ref>:<path>` against the fetched remote ref: the branch is a sibling of the one this
+ * job is standing on, and a checkout would cost the working tree the catalog was just built in.
+ * Every failure here is expected and normal — a repo that has never run parity, a fork with no
+ * access to fetch, a shallow clone — so it is a silent null and the caller warns once.
+ */
+function showFromBranch(ref, file) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${file}`], {
+      cwd: REPO,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+}
+
+// The branch is not in a shallow clone by default; fetch it before reading. Best-effort for the
+// same reasons the activity lane's deepen is: a private caller checked out without credentials
+// cannot fetch, and the panel is then simply absent.
+for (const ref of [`refs/remotes/origin/${PARITY_BRANCH}`, PARITY_BRANCH]) {
+  if (showFromBranch(ref, RUN_MANIFEST_FILE)) break;
+  try {
+    execFileSync("git", ["fetch", "--depth=1", "origin", `+${PARITY_BRANCH}:${ref}`], {
+      cwd: REPO,
+      stdio: "ignore",
+    });
+    break;
+  } catch {
+    // Try the next spelling, then give up below.
+  }
+}
+
+const ref =
+  [`refs/remotes/origin/${PARITY_BRANCH}`, PARITY_BRANCH].find((candidate) =>
+    showFromBranch(candidate, RUN_MANIFEST_FILE),
+  ) ?? null;
+
+if (!ref) {
+  console.log(`parity-findings: no ${PARITY_BRANCH} branch to read — nothing to publish`);
+  process.exit(0);
+}
+
+const parse = (name) => {
+  const raw = showFromBranch(ref, name);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    warn(`${PARITY_BRANCH}:${name} is not readable JSON (${error.message})`);
+    return null;
+  }
+};
+
+const runManifest = parse(RUN_MANIFEST_FILE);
+const runFindings = parse(RUN_FINDINGS_FILE);
+if (!runManifest || !runFindings) {
+  // A run that found nothing publishes no `findings.json` at all, which is the common and correct
+  // case for a catalog at parity — not a warning.
+  console.log(`parity-findings: ${PARITY_BRANCH} publishes no findings — nothing to publish`);
+  process.exit(0);
+}
+
+// The same planner that mints `references/index.json`, so a verdict is keyed to exactly the
+// reference ids the compare page will offer. Its warnings belong to the reference step, which has
+// already reported them; only the join's own drops are reported here.
+const { records } = planDesignReferences({ designMap, spec, catalog });
+
+const { document, warnings, mapped } = buildServedFindings({
+  runManifest,
+  runFindings,
+  references: records,
+  repoSlug: SOURCE_REPO,
+  branch: PARITY_BRANCH,
+});
+for (const message of warnings) warn(message);
+
+if (!document) {
+  console.log("parity-findings: no verdict reached a published comparison — nothing to publish");
+  process.exit(STRICT && skipped > 0 ? 1 : 0);
+}
+
+const dir = path.join(OUT, FINDINGS_DIR);
+fs.mkdirSync(dir, { recursive: true });
+fs.writeFileSync(path.join(dir, FINDINGS_FILE), `${JSON.stringify(document, null, 2)}\n`);
+console.log(
+  `parity-findings: published ${Object.keys(document.previews).length} comparison(s) ` +
+    `from ${mapped} mapping(s) on ${PARITY_BRANCH}`,
+);
+
+if (STRICT && skipped > 0) {
+  console.error(`parity-findings: --strict and ${skipped} record(s) were skipped`);
+  process.exit(1);
+}

--- a/scripts/design-artifacts/parity-findings.mjs
+++ b/scripts/design-artifacts/parity-findings.mjs
@@ -17,7 +17,9 @@
  *
  * - **`referenceId`**, from the same `planDesignReferences` records that mint `references/index.json`.
  *   This is what stops one board's token drift printing under another board's panels on a preview
- *   that carries several references.
+ *   that carries several references. The run's own `source` stamp is what makes that resolvable at
+ *   all where one code handle was diffed against several sources — it is consumed here and dropped,
+ *   because once a set names a reference id the source it came from is already implied.
  * - **`reportUrl`**, from the branch the run published to plus the `reportPath` its `run.json`
  *   already records. Deliberately the repository blob URL rather than a third-party HTML renderer:
  *   the link is a promise about where the report lives, not about how it will look.
@@ -97,8 +99,18 @@ export function buildServedFindings({
   for (const entry of runManifest?.entries ?? []) {
     const code = entry?.code;
     if (!code) continue;
-    const sets = runFindings?.previews?.[code];
-    if (!Array.isArray(sets) || sets.length === 0) continue;
+    const all = runFindings?.previews?.[code];
+    if (!Array.isArray(all) || all.length === 0) continue;
+
+    // One code handle can be diffed against SEVERAL sources, and those results share a code handle
+    // and a candidate preview id — the run tells them apart only by the `source` it stamps on each
+    // set. Matching on it is what stops the Figma verdict being published under the Stitch board
+    // as well. An entry with no source, or sets from a producer old enough not to stamp one, falls
+    // back to every set: one source is the overwhelmingly common shape, and there the filter has
+    // nothing to choose between.
+    const bySource = all.filter((set) => set?.source === entry.source);
+    const sets = bySource.length > 0 ? bySource : all.filter((set) => !set?.source);
+    if (sets.length === 0) continue;
 
     const targets = byCode.get(code) ?? [];
     if (targets.length === 0) {
@@ -110,7 +122,7 @@ export function buildServedFindings({
 
     const reportUrl = reportUrlFor({ repoSlug, branch, reportPath: entry.reportPath });
     for (const target of targets) {
-      const scoped = sets.map((set) => ({
+      const scoped = sets.map(({ source, ...set }) => ({
         ...set,
         referenceId: target.referenceId,
         ...(reportUrl ? { reportUrl } : {}),

--- a/scripts/design-artifacts/parity-findings.mjs
+++ b/scripts/design-artifacts/parity-findings.mjs
@@ -1,0 +1,128 @@
+/**
+ * Re-key a design-parity run's verdict onto the ids a preview server routes on.
+ *
+ * The run publishes `findings.json` on its own reporting branch
+ * (`design-parity/<system>`), in the same `compose-preview-parity-findings/v1` schema the server
+ * reads — but keyed by the two namespaces a RUN knows: the fully-qualified compose preview id
+ * (`a.b.C.fn`) and the design-map code handle (`ui/Button.kt#Primary`). The compare page routes on
+ * neither. It routes on the catalog's **sticker id** (`button-filled__ideal__default__light`),
+ * which is minted at publish time and therefore cannot be known by the run.
+ *
+ * `buildAnnotationManifest` learned this the expensive way — its comment records that keying on
+ * the preview id alone "produced a manifest the server silently ignored" — so the join is done
+ * here, where both namespaces are in hand.
+ *
+ * Two things the run left blank get filled in on the way through, both for the same reason: only a
+ * publisher knows them.
+ *
+ * - **`referenceId`**, from the same `planDesignReferences` records that mint `references/index.json`.
+ *   This is what stops one board's token drift printing under another board's panels on a preview
+ *   that carries several references.
+ * - **`reportUrl`**, from the branch the run published to plus the `reportPath` its `run.json`
+ *   already records. Deliberately the repository blob URL rather than a third-party HTML renderer:
+ *   the link is a promise about where the report lives, not about how it will look.
+ *
+ * Pure functions over already-parsed JSON — no I/O, no git, no network. The driver
+ * (`emit-parity-findings.mjs`) reads the branch and writes the file.
+ */
+
+/** The schema the preview server validates before reading a manifest. */
+export const FINDINGS_SCHEMA = "compose-preview-parity-findings/v1";
+
+/** Where the served document lands in the bundle. */
+export const FINDINGS_DIR = "parity";
+export const FINDINGS_FILE = "findings.json";
+
+/** What the run publishes on its own branch, beside `run.json`. */
+export const RUN_FINDINGS_FILE = "findings.json";
+export const RUN_MANIFEST_FILE = "run.json";
+
+/**
+ * Index the planned reference records by the design-map code handle the run reports against.
+ *
+ * A code handle can plan several records — a component rendered light and dark plans one per
+ * sticker, and a variant matrix plans a `secondary` per cell. Every one of them is a comparison
+ * page that should carry the verdict, so all are kept; the run's verdict is about the code, and
+ * each page shows that code against one board.
+ */
+export function referencesByCode(records) {
+  const byCode = new Map();
+  for (const record of records ?? []) {
+    const code = record?.source?.attributes?.code;
+    if (!code || !record?.previewId || !record?.id) continue;
+    if (!byCode.has(code)) byCode.set(code, []);
+    byCode.get(code).push({ previewId: record.previewId, referenceId: record.id });
+  }
+  return byCode;
+}
+
+/**
+ * `https://github.com/<owner>/<repo>/blob/<branch>/<path>`, or null when any part is missing.
+ *
+ * Only ever `https://`, because `ServeParityFindingStore` refuses anything else — a producer's
+ * string lands in an `href` on a page the reader trusts, so the scheme is checked on both sides.
+ */
+export function reportUrlFor({ repoSlug, branch, reportPath }) {
+  if (!repoSlug || !branch || !reportPath) return null;
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoSlug)) return null;
+  const path = String(reportPath).replace(/^\/+/, "");
+  if (!path || path.includes("..")) return null;
+  const encode = (segment) => segment.split("/").map(encodeURIComponent).join("/");
+  return `https://github.com/${repoSlug}/blob/${encode(branch)}/${encode(path)}`;
+}
+
+/**
+ * Build the served manifest from a run's published artifacts.
+ *
+ * Driven by `run.json`'s entries rather than by the findings map's keys, because the entry is the
+ * only place the two halves meet: it carries the `code` that indexes both the findings and the
+ * planned references, and the `reportPath` that becomes the outbound link. Walking the findings map
+ * instead would leave the code-handle and preview-id keys indistinguishable from one another.
+ *
+ * Every drop is reported rather than silently swallowed — a component whose verdict cannot reach a
+ * page is exactly the thing an operator would otherwise never learn.
+ */
+export function buildServedFindings({
+  runManifest,
+  runFindings,
+  references,
+  repoSlug,
+  branch,
+}) {
+  const byCode = referencesByCode(references);
+  const previews = {};
+  const warnings = [];
+  let mapped = 0;
+
+  for (const entry of runManifest?.entries ?? []) {
+    const code = entry?.code;
+    if (!code) continue;
+    const sets = runFindings?.previews?.[code];
+    if (!Array.isArray(sets) || sets.length === 0) continue;
+
+    const targets = byCode.get(code) ?? [];
+    if (targets.length === 0) {
+      // No planned reference means no comparison page: the verdict has nowhere to be shown, and
+      // publishing it under a key nothing routes to would be a manifest the server ignores.
+      warnings.push(`no published reference for ${code}; its verdict is not published`);
+      continue;
+    }
+
+    const reportUrl = reportUrlFor({ repoSlug, branch, reportPath: entry.reportPath });
+    for (const target of targets) {
+      const scoped = sets.map((set) => ({
+        ...set,
+        referenceId: target.referenceId,
+        ...(reportUrl ? { reportUrl } : {}),
+      }));
+      (previews[target.previewId] ??= []).push(...scoped);
+      mapped += 1;
+    }
+  }
+
+  return {
+    document: Object.keys(previews).length > 0 ? { schema: FINDINGS_SCHEMA, previews } : null,
+    warnings,
+    mapped,
+  };
+}

--- a/scripts/design-artifacts/parity-findings.test.mjs
+++ b/scripts/design-artifacts/parity-findings.test.mjs
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  FINDINGS_SCHEMA,
+  buildServedFindings,
+  referencesByCode,
+  reportUrlFor,
+} from "./parity-findings.mjs";
+
+/** Planned reference records, in the shape `planDesignReferences` returns. */
+const records = [
+  {
+    id: "button-filled__ideal__default__light-0",
+    previewId: "button-filled__ideal__default__light",
+    source: { attributes: { code: "ui/Button.kt#Filled" } },
+  },
+  {
+    id: "button-filled__ideal__default__dark-0",
+    previewId: "button-filled__ideal__default__dark",
+    source: { attributes: { code: "ui/Button.kt#Filled" } },
+  },
+  {
+    id: "card__ideal__default__light-0",
+    previewId: "card__ideal__default__light",
+    source: { attributes: { code: "ui/Card.kt#Elevated" } },
+  },
+];
+
+const set = (message) => ({
+  status: "fail",
+  findings: [{ kind: "token", severity: "error", message }],
+});
+
+/** What a run publishes: keyed by BOTH the compose preview id and the code handle. */
+const runFindings = {
+  schema: FINDINGS_SCHEMA,
+  previews: {
+    "ui/Button.kt#Filled": [set("padding drifted")],
+    "ui.ButtonKt.Filled": [set("padding drifted")],
+  },
+};
+
+const runManifest = {
+  formatVersion: 1,
+  entries: [
+    { code: "ui/Button.kt#Filled", status: "fail", reportPath: "ui-Button-kt-Filled/report.html" },
+  ],
+};
+
+const build = (over = {}) =>
+  buildServedFindings({
+    runManifest,
+    runFindings,
+    references: records,
+    repoSlug: "yschimke/m3-catalog",
+    branch: "design-parity/m3-catalog",
+    ...over,
+  });
+
+test("referencesByCode keeps every page a code handle plans", () => {
+  const byCode = referencesByCode(records);
+  assert.equal(byCode.get("ui/Button.kt#Filled").length, 2);
+  assert.equal(byCode.get("ui/Card.kt#Elevated").length, 1);
+});
+
+test("a verdict is re-keyed onto the sticker ids the compare page routes on", () => {
+  const { document } = build();
+  // NOT the run's own keys: neither the code handle nor the compose preview id is what
+  // `ServeParityFindingStore` is asked for.
+  assert.deepEqual(Object.keys(document.previews).sort(), [
+    "button-filled__ideal__default__dark",
+    "button-filled__ideal__default__light",
+  ]);
+  assert.equal(document.schema, FINDINGS_SCHEMA);
+});
+
+test("each page's set is scoped to the reference that page shows", () => {
+  const { document } = build();
+  assert.equal(
+    document.previews["button-filled__ideal__default__light"][0].referenceId,
+    "button-filled__ideal__default__light-0",
+  );
+  assert.equal(
+    document.previews["button-filled__ideal__default__dark"][0].referenceId,
+    "button-filled__ideal__default__dark-0",
+  );
+});
+
+test("the report link points at the branch the run published to", () => {
+  const { document } = build();
+  assert.equal(
+    document.previews["button-filled__ideal__default__light"][0].reportUrl,
+    // The branch's own slash stays a path separator — that is the form GitHub serves a
+    // slash-named branch under, and encoding it would 404.
+    "https://github.com/yschimke/m3-catalog/blob/design-parity/m3-catalog/" +
+      "ui-Button-kt-Filled/report.html",
+  );
+});
+
+test("a component with no published reference is reported, not published", () => {
+  // Its verdict has nowhere to be shown: no reference means no comparison page.
+  const { document, warnings } = build({
+    runManifest: {
+      entries: [{ code: "ui/Ghost.kt#Ghost", reportPath: "x/report.html" }],
+    },
+    runFindings: { previews: { "ui/Ghost.kt#Ghost": [set("drifted")] } },
+  });
+  assert.equal(document, null);
+  assert.match(warnings[0], /no published reference for ui\/Ghost\.kt#Ghost/);
+});
+
+test("a run with no findings for an entry publishes nothing for it", () => {
+  const { document } = build({ runFindings: { previews: {} } });
+  assert.equal(document, null);
+});
+
+test("reportUrlFor refuses anything the server would refuse", () => {
+  assert.equal(reportUrlFor({ repoSlug: "", branch: "b", reportPath: "r" }), null);
+  assert.equal(reportUrlFor({ repoSlug: "a/b", branch: "b", reportPath: "" }), null);
+  // A traversal in a producer-authored path never becomes a link.
+  assert.equal(reportUrlFor({ repoSlug: "a/b", branch: "b", reportPath: "../x" }), null);
+  assert.equal(reportUrlFor({ repoSlug: "a b/c", branch: "b", reportPath: "r" }), null);
+  assert.ok(reportUrlFor({ repoSlug: "a/b", branch: "m", reportPath: "r" }).startsWith("https://"));
+});
+
+test("a missing report path costs the link, not the verdict", () => {
+  const { document } = build({
+    runManifest: { entries: [{ code: "ui/Button.kt#Filled", status: "fail" }] },
+  });
+  const scoped = document.previews["button-filled__ideal__default__light"][0];
+  assert.equal(scoped.reportUrl, undefined);
+  assert.equal(scoped.findings[0].message, "padding drifted");
+});

--- a/scripts/design-artifacts/parity-findings.test.mjs
+++ b/scripts/design-artifacts/parity-findings.test.mjs
@@ -98,6 +98,57 @@ test("the report link points at the branch the run published to", () => {
   );
 });
 
+test("a code handle diffed against two sources keeps its verdicts apart", () => {
+  // The run stamps `source` on each set precisely because these share a code handle and a
+  // candidate preview id; matching on it is what stops the Figma verdict being published under
+  // the Stitch board as well.
+  const { document } = build({
+    runManifest: {
+      entries: [
+        {
+          code: "ui/Button.kt#Filled",
+          source: "figma",
+          reportPath: "ui-Button-kt-Filled/report.html",
+        },
+        {
+          code: "ui/Button.kt#Filled",
+          source: "stitch",
+          reportPath: "ui-Button-kt-Filled-stitch/report.html",
+        },
+      ],
+    },
+    runFindings: {
+      previews: {
+        "ui/Button.kt#Filled": [
+          { ...set("figma says padding"), source: "figma" },
+          { ...set("stitch says radius"), source: "stitch" },
+        ],
+      },
+    },
+  });
+  const sets = document.previews["button-filled__ideal__default__light"];
+  // Two entries × one reference each, and each carries only its own source's finding.
+  assert.deepEqual(
+    sets.map((s) => s.findings[0].message),
+    ["figma says padding", "stitch says radius"],
+  );
+  // The stamp is consumed, not republished: a set naming a reference id already implies its source.
+  assert.equal(sets[0].source, undefined);
+  assert.match(sets[1].reportUrl, /ui-Button-kt-Filled-stitch/);
+});
+
+test("a producer that stamps no source still publishes", () => {
+  // One source is the overwhelmingly common shape, and there the filter has nothing to choose
+  // between — an unstamped set must not be dropped for failing to name what it was measured against.
+  const { document } = build({
+    runManifest: { entries: [{ code: "ui/Button.kt#Filled", source: "figma" }] },
+  });
+  assert.equal(
+    document.previews["button-filled__ideal__default__light"][0].findings[0].message,
+    "padding drifted",
+  );
+});
+
 test("a component with no published reference is reported, not published", () => {
   // Its verdict has nowhere to be shown: no reference means no comparison page.
   const { document, warnings } = build({


### PR DESCRIPTION
Closes #4694.

The preview server has read `parity/findings.json` since #4664 — `ServeCatalogStore` stages it, `ServeParityFindingStore` validates it, the compare page renders it and lights a finding's regions on hover. **Nothing wrote it.** The panel has been dark on every published catalog since the day it shipped: correct, and untriggered.

## Why the join belongs here

A design-parity run publishes its findings to its own `design-parity/<system>` branch, keyed by the ids a *run* knows — the fully-qualified compose preview id and the design-map code handle. The compare page routes on neither: it routes on the catalog's **sticker id**, minted by the reference step a few lines above this one in the same job. `buildAnnotationManifest` learned this the expensive way; its comment records that keying on the preview id alone "produced a manifest the server silently ignored".

So the join happens in the one job holding both halves — the same reason `parity/activity.json` is a publish step rather than a server feature.

## What it fills in

`parity-findings.mjs` is the re-keying (pure, no I/O); `emit-parity-findings.mjs` reads the branch with `git show` — no checkout, since the working tree is the one the catalog was just built in — and writes the file. Two fields a run cannot know are added on the way through:

- **`referenceId`**, from the same `planDesignReferences` records that mint `references/index.json`. This is what stops one board's token drift printing under another board's panels on a preview carrying several references.
- **`reportUrl`**, from the branch plus the `reportPath` the run's `run.json` already records. Deliberately the repository blob URL and never a third-party HTML renderer: the link is a promise about where the report lives, not about how it will look. `https://` only, because `ServeParityFindingStore` refuses anything else.

The manifest is driven by `run.json`'s **entries** rather than the findings map's keys, because the entry is the only place the two halves meet — it carries the `code` that indexes both the findings and the planned references, plus the `reportPath`. Walking the map instead would leave the code-handle and preview-id keys indistinguishable from each other.

## Failure posture

Fail-soft like its neighbours. No parity branch, no design map, an unreadable file, or a component with no published reference each drop with a `::warning::` rather than costing the catalog its render, so the step runs unconditionally for every catalog. `--strict` gates it for a repo that wants the panel enforced.

It joins `CARRY_FORWARD_PATHS` for the same reason `parity/issues.json` is there: both are produced from something a fork or a token-less run cannot reach — a credentialled issue query there, a sibling-branch fetch here — so a republish that could not read it leaves the last good verdict standing instead of blanking the panel.

## Test plan

- `node --test parity-findings.test.mjs parity-activity.test.mjs design-references.test.mjs` — 69 passing, 8 new. The new cases cover the re-keying onto sticker ids (asserting the run's own keys are *not* what lands), per-page reference scoping, the report link's exact shape (including that a slash-named branch keeps its slash, which is the form GitHub serves), a component with no published reference being reported rather than published, a missing report path costing the link and not the verdict, and `reportUrlFor` refusing an empty slug, an empty path, a traversal and a malformed slug.
- The new tests are picked up automatically by the **Design Artifacts Driver Tests** job (`npm test` is a bare `node --test`).
- Workflow YAML validated; both env vars the new step uses (`INPUT_SPEC`, `SOURCE_REPOSITORY`) are job-level and already in scope.

Producer half: yschimke/design-parity#420 — the run that writes the branch file this reads.

## Sequencing

This is inert until design-parity#420 ships and a catalog's parity run republishes its branch: with no `findings.json` on the branch, the step logs "publishes no findings" and writes nothing. Safe to merge in either order.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182LfFspu62Vogm1ezszybP)_