### PR TITLE
fix(design-artifacts): make the published parity verdict authoritative and safe to land

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1625,7 +1625,19 @@ jobs:
         if: ${{ inputs.publish || inputs.upload-out }}
         run: |
           set -euo pipefail
-          node compose-ai-tools/scripts/design-artifacts/emit-parity-findings.mjs \
+          # The emitter comes from the export-driver checkout, which for an external caller is the
+          # immutable release commit in .github/design-artifacts-driver-pin.txt — a revision that
+          # predates any file this workflow adds. Invoking it unconditionally would abort every
+          # external run with MODULE_NOT_FOUND the moment this lands, and go on doing it until the
+          # next release moves the pin. Same hazard push-history.sh guards against below, and the
+          # same answer: a catalog that cannot publish a verdict panel this run is not a failed
+          # render. compose-ai-tools' own runs execute the commit the run is on and never see this.
+          emitter=compose-ai-tools/scripts/design-artifacts/emit-parity-findings.mjs
+          if [ ! -f "$emitter" ]; then
+            echo "::notice::parity findings: the pinned export driver has no emit-parity-findings.mjs; skipping the verdict panel. It publishes once the driver pin advances."
+            exit 0
+          fi
+          node "$emitter" \
             --out "$GITHUB_WORKSPACE/out" \
             --repo "$GITHUB_WORKSPACE" \
             --spec "$INPUT_SPEC" \
@@ -1892,6 +1904,18 @@ jobs:
           # same problem with a different answer: REVISION_PREVIEW_INDEX rolls it
           # forward rather than merely preserving it.)
           #
+          # `parity/findings.json` is deliberately NOT on that list, even though it
+          # sits beside `parity/issues.json` on the branch. This job generates it,
+          # a few steps up, and `tree_for_parent` restores a carried path from the
+          # parent UNCONDITIONALLY — so listing it would freeze the panel at its
+          # first published value: every later verdict discarded, and a catalog that
+          # has since reached parity still serving the failures it fixed. The lane
+          # that cannot be read is not a reason to carry it either. Only a publishing
+          # run reaches this step, and a publishing run is the calling repo's own,
+          # with a token and a normal checkout, so the sibling-branch fetch behind
+          # the verdict does not fail there; the fail-soft paths in the emitter are
+          # for `upload-out` runs, which push nothing at all.
+          #
           # Identity goes through git's own GIT_AUTHOR_*/GIT_COMMITTER_* env vars
           # rather than a helper-specific input, because push-branch.sh comes from
           # the `driver-ref` checkout — which a caller may pin to a revision older
@@ -1903,12 +1927,7 @@ jobs:
           GITHUB_TOKEN_INLINE="$GH_TOKEN" \
           MSG="chore(design-artifacts): regenerate ${SYSTEM} catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
-          # `parity/findings.json` carries forward for the same reason `parity/issues.json` does:
-          # both are produced from something a fork or a token-less run cannot reach — a
-          # credentialled issue query there, a sibling branch fetch here — so a republish that
-          # could not read it would otherwise blank the panel rather than leave the last good
-          # verdict standing.
-          CARRY_FORWARD_PATHS='parity/issues.json parity/findings.json history.json' \
+          CARRY_FORWARD_PATHS='parity/issues.json history.json' \
           REVISION_PREVIEW_INDEX=1 \
           GIT_AUTHOR_NAME="$INPUT_COMMIT_USER_NAME" \
           GIT_AUTHOR_EMAIL="$INPUT_COMMIT_USER_EMAIL" \

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1978,7 +1978,10 @@ serves exactly as it did before the panel existed.
 A finding with no anchors keeps its sentence and is never offered as a control — no `tabindex`, no
 pointer affordance — because a promise of a highlight that cannot come is worse than plain text.
 Everything is fail-soft in the same way the reference and annotation manifests are: an unreadable
-record costs the reader that row, never the comparison. And nothing is drawn on a **pinned**
+record costs the reader that row, never the comparison — and a run that publishes a schema the
+publishing driver does not know drops the panel outright rather than relabelling its records as
+v1, because the join rewrites what it republishes and an external caller runs a release-pinned
+driver that can be older than the producer. And nothing is drawn on a **pinned**
 revision, because a finding's anchors are bounds in today's render and its prose is a claim about
 today's code.
 

--- a/scripts/design-artifacts/emit-parity-findings.mjs
+++ b/scripts/design-artifacts/emit-parity-findings.mjs
@@ -163,8 +163,12 @@ const runFindings = parse(RUN_FINDINGS_FILE);
 if (!runManifest || !runFindings) {
   // A run that found nothing publishes no `findings.json` at all, which is the common and correct
   // case for a catalog at parity — not a warning.
+  //
+  // `skipped` separates that from the other way to arrive here: `parse` warned because the file IS
+  // there and is not readable JSON. Absent is normal and exits 0 even under `--strict`; unreadable
+  // is exactly what a caller who asked for the panel to be gated wants to hear about.
   console.log(`parity-findings: ${PARITY_BRANCH} publishes no findings — nothing to publish`);
-  process.exit(0);
+  process.exit(STRICT && skipped > 0 ? 1 : 0);
 }
 
 // The same planner that mints `references/index.json`, so a verdict is keyed to exactly the

--- a/scripts/design-artifacts/parity-findings.mjs
+++ b/scripts/design-artifacts/parity-findings.mjs
@@ -74,6 +74,21 @@ export function reportUrlFor({ repoSlug, branch, reportPath }) {
 }
 
 /**
+ * The sets a run published under one key, as a list.
+ *
+ * An own-property read for the same reason `previews` is prototype-free below: `previews.toString`
+ * on a plain object from `JSON.parse` is inherited, not absent, and would sail past a bare
+ * truthiness check.
+ */
+function findingsFor(runFindings, code) {
+  const map = runFindings?.previews;
+  if (!map || typeof map !== "object") return [];
+  if (!Object.prototype.hasOwnProperty.call(map, code)) return [];
+  const sets = map[code];
+  return Array.isArray(sets) ? sets : [];
+}
+
+/**
  * Build the served manifest from a run's published artifacts.
  *
  * Driven by `run.json`'s entries rather than by the findings map's keys, because the entry is the
@@ -83,6 +98,14 @@ export function reportUrlFor({ repoSlug, branch, reportPath }) {
  *
  * Every drop is reported rather than silently swallowed — a component whose verdict cannot reach a
  * page is exactly the thing an operator would otherwise never learn.
+ *
+ * The producer's own `schema` is checked before any of it is read. This driver rewrites a run's
+ * records and republishes them under `FINDINGS_SCHEMA` — a claim that the sets mean what a v1
+ * reader believes they mean. A producer that has moved to a v2 with different set semantics would
+ * otherwise have those records relabelled as trusted v1 data by whatever driver revision an
+ * external caller happens to be pinned to. Dropping the panel is the honest answer: it is an
+ * enhancement, and a wrong verdict is worse than an absent one. An UNSTAMPED document is accepted,
+ * because the first producer to ship this file predates the field.
  */
 export function buildServedFindings({
   runManifest,
@@ -92,15 +115,42 @@ export function buildServedFindings({
   branch,
 }) {
   const byCode = referencesByCode(references);
-  const previews = {};
+  // No prototype, because both key spaces here are producer- and catalog-controlled strings: a
+  // component legitimately named `constructor` or `toString` would otherwise resolve to the
+  // inherited member rather than a missing entry, and `??= []` would never fire.
+  const previews = Object.create(null);
   const warnings = [];
   let mapped = 0;
 
-  for (const entry of runManifest?.entries ?? []) {
+  const schema = runFindings?.schema;
+  if (schema != null && schema !== FINDINGS_SCHEMA) {
+    return {
+      document: null,
+      warnings: [
+        `the run publishes ${JSON.stringify(String(schema))}, not ${FINDINGS_SCHEMA}; ` +
+          `its verdict is not published`,
+      ],
+      mapped: 0,
+    };
+  }
+
+  // A structurally malformed `run.json` is a dropped panel, never a failed publish: the emitter
+  // runs under `set -e`, so letting `for...of` throw on a non-array would cost the catalog its
+  // render over an optional enhancement.
+  const entries = runManifest?.entries;
+  if (entries != null && !Array.isArray(entries)) {
+    return {
+      document: null,
+      warnings: [`the run's entries are not a list; its verdict is not published`],
+      mapped: 0,
+    };
+  }
+
+  for (const entry of entries ?? []) {
     const code = entry?.code;
     if (!code) continue;
-    const all = runFindings?.previews?.[code];
-    if (!Array.isArray(all) || all.length === 0) continue;
+    const all = findingsFor(runFindings, code);
+    if (all.length === 0) continue;
 
     // One code handle can be diffed against SEVERAL sources, and those results share a code handle
     // and a candidate preview id — the run tells them apart only by the `source` it stamps on each

--- a/scripts/design-artifacts/parity-findings.test.mjs
+++ b/scripts/design-artifacts/parity-findings.test.mjs
@@ -183,3 +183,58 @@ test("a missing report path costs the link, not the verdict", () => {
   assert.equal(scoped.reportUrl, undefined);
   assert.equal(scoped.findings[0].message, "padding drifted");
 });
+
+test("a run publishing a schema this driver does not know is dropped, not relabelled", () => {
+  // The join REWRITES a run's records and republishes them under FINDINGS_SCHEMA. An external
+  // caller runs a release-pinned driver, so a producer that has moved on would otherwise have a
+  // v2's set semantics restamped as trusted v1 by a driver too old to know the difference.
+  const { document, warnings } = build({
+    runFindings: { ...runFindings, schema: "compose-preview-parity-findings/v2" },
+  });
+  assert.equal(document, null);
+  assert.match(warnings[0], /v2.*not compose-preview-parity-findings\/v1/);
+});
+
+test("a run that stamps no schema at all still publishes", () => {
+  // The first producer to ship this file predates the field; absent is not a mismatch.
+  const { previews } = build({ runFindings: { previews: runFindings.previews } }).document;
+  const set0 = previews["button-filled__ideal__default__light"][0];
+  assert.equal(set0.findings[0].message, "padding drifted");
+});
+
+test("a structurally malformed run.json drops the panel rather than throwing", () => {
+  // The emitter runs under `set -e`: a `for...of` over a non-array would cost the catalog its
+  // render over an optional enhancement.
+  const { document, warnings } = build({
+    runManifest: { entries: { code: "ui/Button.kt#Filled" } },
+  });
+  assert.equal(document, null);
+  assert.match(warnings[0], /entries are not a list/);
+});
+
+test("a code handle named after an inherited member is a lookup miss, not a crash", () => {
+  // `previews.constructor` on a plain JSON object resolves to Object's constructor, and
+  // `(previews[id] ??= []).push(...)` would then throw on a perfectly valid catalog route id.
+  const proto = [
+    {
+      id: "constructor-0",
+      previewId: "constructor",
+      source: { attributes: { code: "toString" } },
+    },
+  ];
+  const { document } = build({
+    references: proto,
+    runManifest: { entries: [{ code: "toString", reportPath: "toString/report.html" }] },
+    runFindings: { previews: { toString: [set("drifted")] } },
+  });
+  assert.deepEqual(Object.keys(document.previews), ["constructor"]);
+  assert.equal(document.previews.constructor[0].findings[0].message, "drifted");
+});
+
+test("a code handle that only INHERITS from the run's map publishes nothing", () => {
+  const { document } = build({
+    runManifest: { entries: [{ code: "hasOwnProperty", reportPath: "x/report.html" }] },
+    runFindings: { previews: {} },
+  });
+  assert.equal(document, null);
+});


### PR DESCRIPTION
Follow-up to #4699, which auto-merged with six defects still open on it. Three of them would have broken publishing outright.

## The two that break `design-artifacts` publishing

**The comment terminated the assignment chain.** The block introducing `CARRY_FORWARD_PATHS` sat between `SKIP_IF_UNCHANGED=1 \` and the next assignment. A `\`-continued logical line does not survive a `#` comment, so `TARGET_BRANCH`, `REPO`, `GITHUB_TOKEN_INLINE` and `MSG` stayed ordinary shell variables instead of being passed to `push-branch.sh` — and every publish through this workflow would have died at the helper's `TARGET_BRANCH required` check. The prose moved above the block, which is uninterrupted again. I swept every other `run:` block in the file for the same shape; there are none.

**`parity/findings.json` should never have been carried forward.** `push-branch.sh`'s `tree_for_parent` restores a listed path from the parent *unconditionally* — including when the staged bundle holds a newly emitted version:

```sh
if git cat-file -e "${parent}:${path}" 2>/dev/null; then
  git restore --source="$parent" --staged -- "$path"
```

So after the first publication the panel would have frozen at its first value: every later verdict discarded, and a catalog that has since reached parity still serving the failures it fixed. The list is for files the branch owns and `out/` does not generate — `parity/issues.json` is on it because `parity-issues-reusable.yml` owns it, `history.json` because a second commit publishes it. This job *generates* `findings.json`, so that reasoning does not transfer, and the emitter is now authoritative.

My original rationale was that a run which could not read the parity branch would blank the panel rather than leave the last good verdict standing. That case does not arise on this path: only a publishing run reaches the step, and a publishing run is the calling repo's own — with a token and a normal checkout — so the sibling-branch fetch succeeds. The emitter's fail-soft paths are for `upload-out` runs, which push nothing at all. The reference and activity lanes next door already accept exactly this trade.

## The one that breaks external callers

An external caller's `driver` job checks out the release commit in `design-artifacts-driver-pin.txt` — `v1.43.1` as of #4698, which predates `emit-parity-findings.mjs`. The unconditional `node …/emit-parity-findings.mjs` would have failed every external `@main` run with `MODULE_NOT_FOUND` until a later release moved the pin. Guarded exactly the way `push-history.sh` already is, one step below: a `::notice::` and `exit 0`, because a catalog that cannot publish a verdict panel this run is not a failed render.

## Three in the re-keying

- **An unknown producer schema is dropped, not relabelled.** The join rewrites a run's records and republishes them under `compose-preview-parity-findings/v1`. A producer that moves to a v2 with different set semantics would otherwise have those records restamped as trusted v1 by whatever driver revision an external caller is pinned to. An *unstamped* document is still accepted — the first producer to ship this file predates the field.
- **A non-array `entries` warns instead of throwing.** The emitter runs under `set -e`, so `for…of` over a malformed optional artifact would have cost the catalog its render.
- **A code handle named for an inherited member is a lookup miss.** `previews.constructor` on a `JSON.parse` object resolves to `Object`'s constructor, so `(previews[id] ??= []).push(…)` would throw on a valid catalog route id. The output map is `Object.create(null)` and the producer's map is read with `hasOwnProperty`.

Plus `--strict`, which could not gate an unreadable `run.json`: the early return now exits nonzero when a parse warned, while a genuinely absent file — a catalog at parity, the common case — still exits 0.

## Test plan

- `node --test scripts/design-artifacts/parity-findings.test.mjs` — 15 passing, 5 new: an unknown schema dropped with its warning, an unstamped one still published, a non-array `entries` warning rather than throwing, and both halves of the prototype hazard (`toString` as a code handle publishing under a `constructor` preview id; a handle that only *inherits* from the run's map publishing nothing).
- Workflow YAML re-validated, and a scan of every `run:` block for a comment inside a `\` continuation: none.
- Full driver suite from `scripts/design-artifacts`: 1182 pass, 7 fail — all in files this PR does not touch (`catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, `rc-compare-pixels`, `rc-font-axis-order`, `rc-size-modifier`, one `catalog-export` version case) and failing the same way on `main` in this sandbox.

Text-only: no rendered surface changes. The panel this feeds is unchanged from the evidence in #4676.

---
_Generated by [Claude Code](https://claude.ai/code/session_0182LfFspu62Vogm1ezszybP)_