### PR TITLE
docs(flake-triage): split the two preview harnesses into their own commands

### DIFF
--- a/.claude/skills/flake-triage/SKILL.md
+++ b/.claude/skills/flake-triage/SKILL.md
@@ -30,14 +30,34 @@ compares a file against itself and always "passes".
 
 **A harness capture has the same oracle, and it is cheaper.** The captures the
 `vscode-preview-diff` bot compares are Playwright shots of committed static
-fixtures, so N runs cost seconds and need no JVM:
+fixtures, so N runs cost seconds and need no JVM. **Two harnesses write into that
+one baseline set**, and they do not share an invocation — find which one owns your
+capture (`git grep "<fixture>" -- '*/preview-harness/*'`) and use its own:
 
 ```
-cd preview-server/preview-harness      # or vscode-extension/preview-harness
+# preview-server/preview-harness — the `serve` web surfaces (serve-*, viewer-*).
+cd preview-server/preview-harness
 HARNESS_CHROMIUM=/path/to/chromium HARNESS_THEME=light \
   npx playwright test -c playwright.config.mjs pages-snapshot.spec.mjs -g "<fixture>"
 md5sum out/<capture>.light.png
 ```
+
+```
+# vscode-extension/preview-harness — the VS Code panel's own fixtures.
+# Run from `vscode-extension/`, not from inside the harness directory, and build
+# the webview bundle first: the fixtures load it, so a stale one moves pixels for
+# reasons no commit explains.
+cd vscode-extension
+node esbuild.webview.mjs
+HARNESS_CHROMIUM=/path/to/chromium HARNESS_FIXTURE=<fixture> HARNESS_THEME=light \
+  npx playwright test -c preview-harness/playwright.config.mjs snapshot.spec.mjs
+md5sum preview-harness/out/<capture>.light.png
+```
+
+The spec filenames differ (`pages-snapshot.spec.mjs` vs `snapshot.spec.mjs`), so
+the two commands are not interchangeable. `HARNESS_THEME` narrows to one theme in
+both; `HARNESS_FIXTURE` is the extension harness's own selector and is cleaner
+than `-g` there.
 
 There is no `--rerun` equivalent to remember: each invocation rewrites `out/`.
 


### PR DESCRIPTION
Follow-up to #4701, whose review landed after it merged. The finding is right and it is mine — so this is a fresh branch off `main` rather than commits onto the merged one.

## What was wrong

#4701 added a repeat-render oracle for harness captures as a single command block with `# or vscode-extension/preview-harness` as a comment on the `cd`. That second branch cannot work. Run it as written and Playwright finds nothing:

```
$ cd vscode-extension/preview-harness
$ npx playwright test -c playwright.config.mjs pages-snapshot.spec.mjs -g "grid-default"
Error: No tests found.
```

The extension harness's spec is `snapshot.spec.mjs`; `pages-snapshot.spec.mjs` lives only in `preview-server/preview-harness`. Codex named that one. Checking it turned up two more in the same three lines:

- **Wrong working directory.** Its config is `preview-harness/playwright.config.mjs` and the npm script runs from `vscode-extension/`, not from inside the harness.
- **A missing build step.** `harness:snapshot` is `node esbuild.webview.mjs && playwright test …`. The fixtures load the webview bundle, so skipping it renders against a stale one — pixels moving for reasons no commit explains, which is precisely the failure mode this skill exists to diagnose.

The single-command shape is what hid all three: one `cd` with an `or` in a comment implies the rest of the block transfers, and none of it does.

## The fix

Two blocks, one per harness, plus a line saying they are not interchangeable and a `git grep` to find which one owns a given capture. The extension block uses `HARNESS_FIXTURE`, its own selector, rather than a `-g` title regex.

## Test plan

Both blocks run as written.

`preview-server/preview-harness` — already the basis of #4701's eight-run oracle.

`vscode-extension` — the newly documented one:

```
$ cd vscode-extension
$ node esbuild.webview.mjs
⚡ Done in 419ms
$ HARNESS_CHROMIUM=/opt/pw-browsers/chromium HARNESS_FIXTURE=grid-default HARNESS_THEME=light \
    npx playwright test -c preview-harness/playwright.config.mjs snapshot.spec.mjs
[1/1] preview-harness/snapshot.spec.mjs:24:9 › snapshot · grid-default · light
  1 passed (2.0s)
$ ls preview-harness/out/
grid-default.light.png
```

`HARNESS_THEME` narrows to one theme in both harnesses (`_fixtures.mjs:29`), and `HARNESS_CHROMIUM` is honoured by both configs.

- `scripts/check-agent-entrypoints.sh` — green (a skill file carries no invariant anchor).

Docs only; no runtime surface, so no visual evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_