### PR TITLE
fix(parity): publish reference-side bounds in the rescaled raster's space

### DIFF
--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -1666,6 +1666,19 @@ branch and rewrites it to a server-owned path. IDs and paths are contained, dupl
 discarded, and an optional SHA-256 is verified before the reference is advertised. A reference names
 one preview id — the mapping is never inferred.
 
+**A rescaled reference records what was done to it.** The publish step normalises every reference
+onto the sticker's canvas: a Figma node is exported at the renderer's density and centred, a raster
+within rounding distance is resampled, and genuinely different proportions are fitted and
+letterboxed. Reference-side *geometry* — an adapter's annotation boxes, a parity finding's anchor —
+is measured in the space the design tool captured, which is the space **before** that normalisation,
+so where the raster moved the two describe different pictures and a redline sits off the element it
+names. So a reference whose pixels this export moved carries a `raster.transform`
+(`{ "scaleX", "scaleY", "offsetX", "offsetY" }`) mapping a captured pixel onto the published one,
+and the steps that write the annotation and findings manifests carry their boxes through it. A
+reference published exactly as it arrived carries no `transform` at all: absent *is* the identity,
+and its manifests are byte-for-byte what they were before the field existed. `serve` ignores the
+field — by the time it reads a manifest, everything is already in one space.
+
 **The two sides are scored on their content box, not their canvas.** A reference and a preview are
 framed differently by construction: the preview carries whatever its `@Preview` scaffold added
 (`showBackground`'s opaque sheet, a `padding()` inset, a fixed-height container the content does not
@@ -1993,6 +2006,15 @@ the same `planDesignReferences` records that mint `references/index.json`, so on
 drift never prints under another board's panels; and the `reportUrl`, from the branch plus the
 `reportPath` the run's `run.json` records. A catalog with no parity branch publishes nothing and
 serves exactly as it did before the panel existed.
+
+It also *corrects* one thing on the way through. A reference-side anchor is a box in the space the
+design tool's adapter captured, and the reference step a few lines up in the same job may have
+resampled, reduced or letterboxed that raster onto the sticker's canvas — so the anchor and the
+picture it points into describe different pixel spaces. That is worst on exactly the `layout`
+findings that anchor on **both** panels so an offset can be seen rather than read. The transform the
+reference step recorded in `references/index.json` is read back here and applied to every
+`side: "reference"` anchor. Candidate-side anchors are never touched: they were measured in the
+render's own pixels, which is the frame the server serves.
 
 A finding with no anchors keeps its sentence and is never offered as a control — no `tabindex`, no
 pointer affordance — because a promise of a highlight that cannot come is worse than plain text.

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -623,6 +623,11 @@ export function referenceManifest(records) {
  *
  * A reference the export did not move carries no `transform` and is simply absent, which is what
  * lets a consumer treat "no entry" as the identity rather than as missing information.
+ *
+ * Each entry carries the published raster's own dimensions as its `canvas`, so a consumer can clip
+ * what it moves. That is not decoration: a placement that crops an empty margin sits at a negative
+ * offset, and the server discards a box with a negative origin rather than drawing it outside the
+ * panel — so an unclipped box does not merely sit wrong, it disappears.
  */
 export function referenceTransforms(manifest) {
   const transforms = new Map();
@@ -632,7 +637,12 @@ export function referenceTransforms(manifest) {
     const { scaleX, scaleY } = transform;
     if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY)) continue;
     if (!(scaleX > 0) || !(scaleY > 0)) continue;
-    if (reference.id) transforms.set(reference.id, transform);
+    if (!reference.id) continue;
+    const { width, height } = reference.raster;
+    transforms.set(reference.id, {
+      ...transform,
+      ...(width > 0 && height > 0 ? { canvas: { width, height } } : {}),
+    });
   }
   return transforms;
 }

--- a/scripts/design-artifacts/design-references.mjs
+++ b/scripts/design-artifacts/design-references.mjs
@@ -614,3 +614,25 @@ export function referenceManifest(records) {
       .map(({ origin, rastered, ...reference }) => reference),
   };
 }
+
+/**
+ * The publish transform each reference in a served manifest was rasterised through, keyed by
+ * reference id — the map a later publish step needs to carry reference-side geometry (a finding's
+ * anchor, an adapter's annotation layer) out of the space the design tool captured it in and onto
+ * the raster actually published (#4696).
+ *
+ * A reference the export did not move carries no `transform` and is simply absent, which is what
+ * lets a consumer treat "no entry" as the identity rather than as missing information.
+ */
+export function referenceTransforms(manifest) {
+  const transforms = new Map();
+  for (const reference of manifest?.references ?? []) {
+    const transform = reference?.raster?.transform;
+    if (!transform || typeof transform !== "object") continue;
+    const { scaleX, scaleY } = transform;
+    if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY)) continue;
+    if (!(scaleX > 0) || !(scaleY > 0)) continue;
+    if (reference.id) transforms.set(reference.id, transform);
+  }
+  return transforms;
+}

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -11,6 +11,7 @@ import {
   planDesignReferences,
   referenceId,
   referenceManifest,
+  referenceTransforms,
   servePreviewId,
 } from "./design-references.mjs";
 
@@ -1029,4 +1030,52 @@ test("planDesignReferences refuses every id in an ambiguous bundle collision fam
   assert.deepEqual(exactAuthoredSuffix.records, []);
   assert.equal(exactAuthoredSuffix.warnings.length, 1);
   assert.match(exactAuthoredSuffix.warnings[0], /collision family cannot be reversed/);
+});
+
+// ---- referenceTransforms ----------------------------------------------------------------------
+//
+// The reference step records what it did to a raster's pixels so a LATER step can carry
+// reference-side geometry — a finding's anchor — into the same space (#4696).
+
+test("referenceTransforms indexes the transforms a published manifest carries", () => {
+  const manifest = {
+    schema: REFERENCES_SCHEMA,
+    references: [
+      {
+        id: "button__ideal__light-0",
+        raster: {
+          path: "references/button__ideal__light-0.png",
+          transform: { scaleX: 0.5, scaleY: 0.5, offsetX: 0, offsetY: 100 },
+        },
+      },
+      // Published exactly as it arrived: no transform, and so no entry — absent IS the identity.
+      { id: "card__ideal__light-0", raster: { path: "references/card__ideal__light-0.png" } },
+    ],
+  };
+  const transforms = referenceTransforms(manifest);
+  assert.deepEqual(transforms.get("button__ideal__light-0"), {
+    scaleX: 0.5,
+    scaleY: 0.5,
+    offsetX: 0,
+    offsetY: 100,
+  });
+  assert.equal(transforms.has("card__ideal__light-0"), false);
+});
+
+test("referenceTransforms drops a factor that would move a box to nonsense", () => {
+  // A wrong anchor is worse than an unmoved one: the reader has no way to tell it is wrong.
+  const manifest = {
+    references: [
+      { id: "a", raster: { transform: { scaleX: 0, scaleY: 1 } } },
+      { id: "b", raster: { transform: { scaleX: -2, scaleY: -2 } } },
+      { id: "c", raster: { transform: { scaleX: "2", scaleY: 2 } } },
+      { id: "d", raster: { transform: "2x" } },
+    ],
+  };
+  assert.equal(referenceTransforms(manifest).size, 0);
+});
+
+test("referenceTransforms is empty for a manifest that is not there", () => {
+  assert.equal(referenceTransforms(undefined).size, 0);
+  assert.equal(referenceTransforms({}).size, 0);
 });

--- a/scripts/design-artifacts/design-references.test.mjs
+++ b/scripts/design-artifacts/design-references.test.mjs
@@ -1062,6 +1062,27 @@ test("referenceTransforms indexes the transforms a published manifest carries", 
   assert.equal(transforms.has("card__ideal__light-0"), false);
 });
 
+test("referenceTransforms carries the published canvas so a consumer can clip", () => {
+  // A placement that cropped an empty margin sits at a negative offset, and the server discards a
+  // box with a negative origin — so an unclipped box does not sit wrong, it disappears.
+  const [entry] = referenceTransforms({
+    references: [
+      {
+        id: "a",
+        raster: { width: 219, height: 84, transform: { scaleX: 1, scaleY: 1, offsetY: -21 } },
+      },
+    ],
+  }).values();
+  assert.deepEqual(entry.canvas, { width: 219, height: 84 });
+});
+
+test("referenceTransforms omits a canvas the manifest does not state", () => {
+  const [entry] = referenceTransforms({
+    references: [{ id: "a", raster: { transform: { scaleX: 2, scaleY: 2 } } }],
+  }).values();
+  assert.equal("canvas" in entry, false);
+});
+
 test("referenceTransforms drops a factor that would move a box to nonsense", () => {
   // A wrong anchor is worse than an unmoved one: the reader has no way to tell it is wrong.
   const manifest = {

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -608,7 +608,10 @@ for (const record of records) {
   const transform = publishTransform(captured.width, captured.height, placement);
   if (transform) {
     record.raster.transform = transform;
-    referenceTransforms.set(record.id, transform);
+    // The canvas travels alongside rather than inside the published field: `raster.width`/`height`
+    // already state it, and a box is clipped to it because `placeRgba` crops an empty margin by
+    // placing the source at a negative offset — see `clipToCanvas`.
+    referenceTransforms.set(record.id, { ...transform, canvas: target });
   }
 }
 
@@ -738,7 +741,7 @@ function writeReferenceAnnotations() {
   for (const [referenceId, transform] of referenceTransforms) {
     const layer = existing.references?.[referenceId];
     if (!Array.isArray(layer) || layer.length === 0) continue;
-    existing.references[referenceId] = transformAnnotations(layer, transform);
+    existing.references[referenceId] = transformAnnotations(layer, transform, transform.canvas);
     rebased++;
   }
   if (rebased > 0) {

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -74,7 +74,7 @@ import { alphaBounds, fitRgba, isRoundingDelta, placeRgba, resampleRgba } from "
 import { applyBackdrop, parseBackdrop, stageOf } from "./reference-backdrop.mjs";
 import { scaleFinding, scaleMessage, scaleVerdict } from "./reference-scale.mjs";
 import { layoutFromNode } from "@design-parity/adapter-figma";
-import { scaleTree } from "./reference-layout.mjs";
+import { publishTransform, scaleTree, transformAnnotations } from "./reference-layout.mjs";
 import { withReferenceAnnotations } from "@design-parity/catalog-export";
 import { FigmaRestRasterizer, parseFigmaRef } from "./figma-rest-raster.mjs";
 import { openScorer } from "./design-reference-score.mjs";
@@ -419,6 +419,14 @@ let stagedScaleChecks = 0;
 const backdropTally = { disc: 0, frame: 0, skipped: 0 };
 /** Reference id -> a `{ layout }` shim; `referenceAnnotations` reads only that field. */
 const annotatedReferences = {};
+/**
+ * Reference id -> the transform this export applied to that reference's pixels.
+ *
+ * Only the rescaled ones appear. It is what carries geometry captured in the source raster's space
+ * — an adapter's annotation layer, and the reference-side anchors `emit-parity-findings.mjs` reads
+ * back out of `references/index.json` — onto the raster actually published (#4696).
+ */
+const referenceTransforms = new Map();
 if (FIGMA_TOKEN) {
   for (const contentsOnly of [true, false]) {
     const requests = records
@@ -453,6 +461,11 @@ for (const record of records) {
         density: referenceDensity(record),
       })
     : undefined;
+
+  // The raster as it arrived, before anything here moves it. Reference-side geometry captured by
+  // the design tool's adapter is measured in THESE pixels, so it is the space every published
+  // annotation box and finding anchor has to be carried out of.
+  const captured = { width: raster.width, height: raster.height };
 
   // Where the artwork ends up inside the published raster. Full-bleed unless it is placed/fitted.
   let placement = { width: target.width, height: target.height, x: 0, y: 0 };
@@ -587,6 +600,16 @@ for (const record of records) {
     ? scaleTree(capturedLayout, placement.width, placement.x, placement.y)
     : undefined;
   if (scaled) annotatedReferences[record.id] = { layout: scaled };
+
+  // What this export did to the pixels, published so the manifests that describe them can agree
+  // with them. Absent when nothing moved — a reference the placement left alone publishes exactly
+  // the record it publishes today, which is the whole of what a consumer reading no `transform`
+  // is entitled to assume.
+  const transform = publishTransform(captured.width, captured.height, placement);
+  if (transform) {
+    record.raster.transform = transform;
+    referenceTransforms.set(record.id, transform);
+  }
 }
 
 // The gate m3-catalog#180 asked for: 107 of that catalog's 536 references drew their component at
@@ -681,12 +704,23 @@ await scoreReferences();
  * and merges rather than overwriting — dropping the other half would trade one annotated column for
  * the other instead of getting both.
  *
+ * A reference layer already in that file was captured by somebody else — a repo whose own parity job
+ * wrote it with `withReferenceAnnotations` before this step ran — and its boxes are in the SOURCE
+ * raster's pixels. Where this export rescaled or letterboxed that raster the two describe different
+ * pictures, and a redline sits off the element it names (#4696). Each such layer is carried through
+ * the transform this run applied before the layers captured here are merged over it; the layers
+ * captured here are already in the published space, because [scaleTree] put them there.
+ *
+ * That rebase assumes what the workflow guarantees: this step runs ONCE against a freshly staged
+ * bundle. Run twice over the same `--out` and the layer it wrote the first time is read back as a
+ * captured one and moved again — while the raster, re-placed from its source each run, stays put.
+ *
  * Fail-soft like everything else here: an unreadable existing manifest is replaced rather than
  * fatal, and no captured geometry simply leaves the file alone. A reference lane is an enhancement
  * and must never cost a catalog its render.
  */
 function writeReferenceAnnotations() {
-  if (Object.keys(annotatedReferences).length === 0) return;
+  if (Object.keys(annotatedReferences).length === 0 && referenceTransforms.size === 0) return;
   const dir = path.join(OUT, "annotations");
   const file = path.join(dir, "index.json");
   let existing = { schema: "compose-preview-annotations/v1", previews: {}, references: {} };
@@ -699,6 +733,21 @@ function writeReferenceAnnotations() {
       warn(`annotations/index.json is unreadable (${error.message}); replacing it`);
     }
   }
+  // Rebase what was already there, then let this run's own layers land on top of it.
+  let rebased = 0;
+  for (const [referenceId, transform] of referenceTransforms) {
+    const layer = existing.references?.[referenceId];
+    if (!Array.isArray(layer) || layer.length === 0) continue;
+    existing.references[referenceId] = transformAnnotations(layer, transform);
+    rebased++;
+  }
+  if (rebased > 0) {
+    console.log(
+      `design-references: moved ${rebased} pre-existing reference annotation layer(s) into the ` +
+        `published raster's pixel space`,
+    );
+  }
+
   const merged = withReferenceAnnotations(existing, annotatedReferences);
   const count = Object.keys(merged.references).length;
   if (count === 0) return;

--- a/scripts/design-artifacts/emit-parity-findings.mjs
+++ b/scripts/design-artifacts/emit-parity-findings.mjs
@@ -23,6 +23,11 @@
  * The same shape as `emit-parity-activity.mjs` next door, and for the same reason: the serve host
  * has no checkout and cannot read another branch.
  *
+ * It also runs after `emit-design-references.mjs`, and now depends on that ordering for a second
+ * reason: a finding's reference-side anchor is measured in the space the design tool captured, and
+ * the reference step publishes the raster onto the sticker's canvas. The transform it recorded in
+ * `references/index.json` is read here and applied to those anchors (#4696).
+ *
  * ## Failure posture
  *
  * Fail-soft, matching its neighbours and the server's own reader. No parity branch, an unreadable
@@ -35,7 +40,11 @@ import path from "node:path";
 import { execFileSync } from "node:child_process";
 
 import { stripComments } from "./catalog-spec.mjs";
-import { planDesignReferences } from "./design-references.mjs";
+import {
+  REFERENCES_DIR,
+  planDesignReferences,
+  referenceTransforms,
+} from "./design-references.mjs";
 import {
   FINDINGS_DIR,
   FINDINGS_FILE,
@@ -176,10 +185,37 @@ if (!runManifest || !runFindings) {
 // already reported them; only the join's own drops are reported here.
 const { records } = planDesignReferences({ designMap, spec, catalog });
 
+/**
+ * What the reference step did to each reference's pixels, read back out of the manifest it just
+ * wrote a few steps up in the same job.
+ *
+ * A run's reference-side anchors are boxes in the space the design tool's adapter captured; a
+ * reference this export resampled, reduced or letterboxed is published in a different one, and the
+ * highlight then sits off the element the finding names (#4696). Read rather than recomputed
+ * because only the step that moved the pixels knows how far it moved them — the plan above says
+ * what a reference SHOULD be, not what the raster turned out to need.
+ *
+ * Absent or unreadable ⇒ an empty map, which is the identity: the same anchors this published
+ * before the transform existed, never a guessed one.
+ */
+let transforms = new Map();
+const referenceIndex = path.join(OUT, REFERENCES_DIR, "index.json");
+if (fs.existsSync(referenceIndex)) {
+  try {
+    transforms = referenceTransforms(readJson(referenceIndex));
+  } catch (error) {
+    warn(
+      `${REFERENCES_DIR}/index.json is not readable (${error.message}); anchors are published ` +
+        `in the space the run captured them in`,
+    );
+  }
+}
+
 const { document, warnings, mapped } = buildServedFindings({
   runManifest,
   runFindings,
   references: records,
+  referenceTransforms: transforms,
   repoSlug: SOURCE_REPO,
   branch: PARITY_BRANCH,
 });

--- a/scripts/design-artifacts/parity-findings.mjs
+++ b/scripts/design-artifacts/parity-findings.mjs
@@ -24,9 +24,21 @@
  *   already records. Deliberately the repository blob URL rather than a third-party HTML renderer:
  *   the link is a promise about where the report lives, not about how it will look.
  *
+ * A third thing is CORRECTED on the way through. A finding's reference-side anchor is a box in the
+ * coordinate space the design tool's adapter captured, and `emit-design-references.mjs` publishes
+ * that reference onto the sticker's canvas — resampling, reducing or letterboxing it on the way.
+ * Where it did, the anchor and the raster describe different pictures and the highlight sits off the
+ * element the finding names, which is worst on exactly the `layout` findings that anchor on both
+ * panels so an offset can be SEEN (#4696). The reference step records what it did, per reference, in
+ * `references/index.json`; those transforms are applied here, at the point a set is scoped to the
+ * reference it is about. Candidate-side anchors are already in the render's own pixels — the frame
+ * the server serves — and are never touched.
+ *
  * Pure functions over already-parsed JSON — no I/O, no git, no network. The driver
  * (`emit-parity-findings.mjs`) reads the branch and writes the file.
  */
+
+import { transformBounds } from "./reference-layout.mjs";
 
 /** The schema the preview server validates before reading a manifest. */
 export const FINDINGS_SCHEMA = "compose-preview-parity-findings/v1";
@@ -107,10 +119,37 @@ function findingsFor(runFindings, code) {
  * enhancement, and a wrong verdict is worse than an absent one. An UNSTAMPED document is accepted,
  * because the first producer to ship this file predates the field.
  */
+/**
+ * One finding with its REFERENCE-side anchors moved into the published raster's pixel space.
+ *
+ * Returned as it stands when the export did not move that reference's pixels, so a catalog whose
+ * references all published at their captured size emits byte-identical findings. An anchor on the
+ * `actual` panel is left alone in every case: it was measured in the render's own pixels, which is
+ * the frame the server serves.
+ */
+function rebaseAnchors(finding, transform) {
+  if (!transform || !Array.isArray(finding?.anchors)) return finding;
+  return {
+    ...finding,
+    anchors: finding.anchors.map((anchor) =>
+      anchor?.side === "reference" && anchor.bounds
+        ? { ...anchor, bounds: transformBounds(anchor.bounds, transform) }
+        : anchor,
+    ),
+  };
+}
+
+/** One set, with every finding's reference-side anchor moved onto the reference as published. */
+function rebaseSet(set, transform) {
+  if (!transform || !Array.isArray(set?.findings)) return set;
+  return { ...set, findings: set.findings.map((finding) => rebaseAnchors(finding, transform)) };
+}
+
 export function buildServedFindings({
   runManifest,
   runFindings,
   references,
+  referenceTransforms,
   repoSlug,
   branch,
 }) {
@@ -172,8 +211,10 @@ export function buildServedFindings({
 
     const reportUrl = reportUrlFor({ repoSlug, branch, reportPath: entry.reportPath });
     for (const target of targets) {
+      // The reference is only known HERE, and so is the transform its raster was published through.
+      const transform = referenceTransforms?.get(target.referenceId);
       const scoped = sets.map(({ source, ...set }) => ({
-        ...set,
+        ...rebaseSet(set, transform),
         referenceId: target.referenceId,
         ...(reportUrl ? { reportUrl } : {}),
       }));

--- a/scripts/design-artifacts/parity-findings.mjs
+++ b/scripts/design-artifacts/parity-findings.mjs
@@ -126,17 +126,23 @@ function findingsFor(runFindings, code) {
  * references all published at their captured size emits byte-identical findings. An anchor on the
  * `actual` panel is left alone in every case: it was measured in the render's own pixels, which is
  * the frame the server serves.
+ *
+ * An anchor the placement cropped away entirely is DROPPED rather than published pointing at
+ * nothing, and a finding left with none loses the field: `ServeParityFindingStore` offers a finding
+ * with no anchors as prose and never as a control, which is the honest answer for a region this
+ * reference does not show. The candidate-side anchor of the same finding survives, so a `layout`
+ * finding keeps the half that can still be pointed at.
  */
 function rebaseAnchors(finding, transform) {
   if (!transform || !Array.isArray(finding?.anchors)) return finding;
-  return {
-    ...finding,
-    anchors: finding.anchors.map((anchor) =>
-      anchor?.side === "reference" && anchor.bounds
-        ? { ...anchor, bounds: transformBounds(anchor.bounds, transform) }
-        : anchor,
-    ),
-  };
+  const anchors = finding.anchors.flatMap((anchor) => {
+    if (anchor?.side !== "reference" || !anchor.bounds) return [anchor];
+    const bounds = transformBounds(anchor.bounds, transform, transform.canvas);
+    return bounds ? [{ ...anchor, bounds }] : [];
+  });
+  if (anchors.length > 0) return { ...finding, anchors };
+  const { anchors: dropped, ...rest } = finding;
+  return rest;
 }
 
 /** One set, with every finding's reference-side anchor moved onto the reference as published. */

--- a/scripts/design-artifacts/parity-findings.test.mjs
+++ b/scripts/design-artifacts/parity-findings.test.mjs
@@ -326,3 +326,69 @@ test("a finding with no honest anchor is not given one", () => {
   const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
   assert.equal(finding.anchors, undefined);
 });
+
+test("drops a reference anchor the placement cropped away, keeping the candidate's", () => {
+  // A cropped-away anchor points at a region this reference does not publish; the server discards a
+  // negative-origin box anyway, so publishing one costs the finding its highlight silently.
+  const { document } = build({
+    runFindings: anchoredRun,
+    referenceTransforms: new Map([
+      [
+        "button-filled__ideal__default__light-0",
+        { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -80, canvas: { width: 300, height: 210 } },
+      ],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  assert.equal(finding.anchors.length, 1);
+  assert.equal(finding.anchors[0].side, "actual");
+});
+
+test("a finding whose every anchor was cropped away carries no anchors at all", () => {
+  // Not an empty list: the server offers an unanchored finding as prose and never as a control.
+  const referenceOnly = {
+    schema: FINDINGS_SCHEMA,
+    previews: {
+      "ui/Button.kt#Filled": [
+        {
+          status: "fail",
+          findings: [
+            {
+              kind: "layout",
+              severity: "error",
+              message: "padding drifted",
+              anchors: [{ side: "reference", bounds: { x: 0, y: 0, width: 100, height: 40 } }],
+            },
+          ],
+        },
+      ],
+    },
+  };
+  const { document } = build({
+    runFindings: referenceOnly,
+    referenceTransforms: new Map([
+      [
+        "button-filled__ideal__default__light-0",
+        { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -80, canvas: { width: 300, height: 210 } },
+      ],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  assert.equal("anchors" in finding, false);
+});
+
+test("clips a reference anchor that only partly survived the crop", () => {
+  const { document } = build({
+    runFindings: anchoredRun,
+    referenceTransforms: new Map([
+      [
+        "button-filled__ideal__default__light-0",
+        { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -30, canvas: { width: 300, height: 210 } },
+      ],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  // Captured at y 20, height 40; the crop takes the 30 rows above the artwork, so the box loses
+  // its top 10 and the remaining 30 sit flush against the top of the published canvas.
+  assert.deepEqual(finding.anchors[0].bounds, { x: 10, y: 0, width: 100, height: 30 });
+});

--- a/scripts/design-artifacts/parity-findings.test.mjs
+++ b/scripts/design-artifacts/parity-findings.test.mjs
@@ -238,3 +238,91 @@ test("a code handle that only INHERITS from the run's map publishes nothing", ()
   });
   assert.equal(document, null);
 });
+
+// ---- Reference-side anchors -------------------------------------------------------------------
+//
+// A run's anchors are boxes in the space the design tool's adapter captured; the reference step
+// publishes that raster onto the sticker's canvas and records what it did. Applying it here is what
+// keeps a `layout` finding's two highlights over the same element on both panels (#4696).
+
+/** A layout finding anchored on BOTH panels, which is the case the offset is most misleading in. */
+const anchored = {
+  status: "fail",
+  findings: [
+    {
+      kind: "layout",
+      severity: "error",
+      message: "padding is 24 where the design asserts 16",
+      anchors: [
+        { side: "reference", bounds: { x: 10, y: 20, width: 100, height: 40 }, label: "Send" },
+        { side: "actual", bounds: { x: 12, y: 24, width: 96, height: 48 }, label: "Send" },
+      ],
+    },
+  ],
+};
+
+const anchoredRun = {
+  schema: FINDINGS_SCHEMA,
+  previews: { "ui/Button.kt#Filled": [anchored] },
+};
+
+test("moves a reference-side anchor onto the reference as it was published", () => {
+  const { document } = build({
+    runFindings: anchoredRun,
+    referenceTransforms: new Map([
+      ["button-filled__ideal__default__light-0", { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 30 }],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  assert.deepEqual(finding.anchors[0], {
+    side: "reference",
+    bounds: { x: 20, y: 70, width: 200, height: 80 },
+    label: "Send",
+  });
+});
+
+test("leaves the candidate-side anchor alone — it is already in the render's pixels", () => {
+  const { document } = build({
+    runFindings: anchoredRun,
+    referenceTransforms: new Map([
+      ["button-filled__ideal__default__light-0", { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 30 }],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  assert.deepEqual(finding.anchors[1], anchored.findings[0].anchors[1]);
+});
+
+test("only the reference the transform names is moved", () => {
+  // One code handle plans a record per sticker, and light and dark can be published through
+  // different transforms — a set scoped to one must not inherit the other's.
+  const { document } = build({
+    runFindings: anchoredRun,
+    referenceTransforms: new Map([
+      ["button-filled__ideal__default__light-0", { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 30 }],
+    ]),
+  });
+  const dark = document.previews["button-filled__ideal__default__dark"][0].findings[0];
+  assert.deepEqual(dark.anchors, anchored.findings[0].anchors);
+});
+
+test("publishes exactly what it publishes today when no reference was rescaled", () => {
+  // The acceptance the fix is held to: a reference the export did not move carries no transform,
+  // and its verdict has to come out byte-identical.
+  const before = build({ runFindings: anchoredRun }).document;
+  const after = build({ runFindings: anchoredRun, referenceTransforms: new Map() }).document;
+  assert.deepEqual(after, before);
+  assert.deepEqual(
+    before.previews["button-filled__ideal__default__light"][0].findings[0].anchors,
+    anchored.findings[0].anchors,
+  );
+});
+
+test("a finding with no honest anchor is not given one", () => {
+  const { document } = build({
+    referenceTransforms: new Map([
+      ["button-filled__ideal__default__light-0", { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 30 }],
+    ]),
+  });
+  const [finding] = document.previews["button-filled__ideal__default__light"][0].findings;
+  assert.equal(finding.anchors, undefined);
+});

--- a/scripts/design-artifacts/reference-layout.mjs
+++ b/scripts/design-artifacts/reference-layout.mjs
@@ -1,11 +1,19 @@
 /**
- * Rescale a captured design-reference layout tree into the published raster's pixel space.
+ * Map design-reference geometry into the published raster's pixel space.
  *
  * `layoutFromNode` (@design-parity/adapter-figma) returns root-relative dp measured off the Figma
  * frame. The raster those annotations are drawn over is fitted to the catalog sticker's dimensions
  * — see png-resample.mjs — so a frame authored at a different size would put every annotation box
  * in the wrong place. Applying the same transform the raster went through keeps each annotation on
  * top of the thing it describes.
+ *
+ * [scaleTree] does that for the one tree this pipeline captures itself, whose numbers are in the
+ * DESIGN frame's units. Geometry captured by somebody else — a reference-side annotation layer an
+ * adapter already wrote into `annotations/index.json`, a parity finding's reference-side anchor — is
+ * measured in the source raster's own pixels instead, and only the publish step knows what it did to
+ * those pixels. [publishTransform] states that as a factor and an offset, and [transformBounds] /
+ * [transformAnnotations] carry a box through it, so both halves of a comparison end up describing
+ * the same picture (compose-ai-tools#4696).
  *
  * Split out of emit-design-references.mjs so it can be tested: that script self-executes on import.
  */
@@ -43,4 +51,64 @@ export function scaleTree(tree, targetWidth, offsetX = 0, offsetY = 0) {
     children: (node.children ?? []).map(visit),
   });
   return { ...tree, root: visit(tree.root) };
+}
+
+/**
+ * The transform the publish step applied to a reference raster, as `{ scaleX, scaleY, offsetX,
+ * offsetY }` mapping a source-raster pixel onto the published one — or null when the raster was
+ * published exactly as it arrived.
+ *
+ * `placement` is where the source landed inside the published canvas: `png-resample.mjs` returns it
+ * from [fitRgba] and [placeRgba], and a raster that was merely resampled to close a rounding gap
+ * "landed" at the target's full size with no offset. Null for the identity so a caller can carry it
+ * only where it means something — a reference nothing moved must publish exactly the manifests it
+ * publishes today.
+ *
+ * Scales are trimmed to six decimals: a factor is a ratio of two pixel counts and its tail is
+ * float noise, which would otherwise be written into every manifest that carries one.
+ */
+export function publishTransform(sourceWidth, sourceHeight, placement) {
+  if (!(sourceWidth > 0) || !(sourceHeight > 0) || !placement) return null;
+  const { width, height, x = 0, y = 0 } = placement;
+  if (!(width > 0) || !(height > 0)) return null;
+  const scaleX = Number((width / sourceWidth).toFixed(6));
+  const scaleY = Number((height / sourceHeight).toFixed(6));
+  if (scaleX === 1 && scaleY === 1 && x === 0 && y === 0) return null;
+  return { scaleX, scaleY, offsetX: x, offsetY: y };
+}
+
+/**
+ * Move one box from the source raster's pixel space into the published raster's.
+ *
+ * Returned unchanged — the same object — when there is no transform, so a consumer can call this
+ * unconditionally and a reference that was not rescaled keeps the very bytes it has today.
+ *
+ * Width and height are floored at 1: a box small enough to round to nothing under a reduction is
+ * still a box somebody drew, and a zero-area rectangle is invisible rather than honest.
+ */
+export function transformBounds(bounds, transform) {
+  if (!transform || !bounds) return bounds;
+  const { scaleX, scaleY, offsetX = 0, offsetY = 0 } = transform;
+  return {
+    ...bounds,
+    x: Math.round(bounds.x * scaleX) + offsetX,
+    y: Math.round(bounds.y * scaleY) + offsetY,
+    width: Math.max(1, Math.round(bounds.width * scaleX)),
+    height: Math.max(1, Math.round(bounds.height * scaleY)),
+  };
+}
+
+/**
+ * Move a reference's annotation layer into the published raster's pixel space.
+ *
+ * The list is returned as it stands when nothing moved, and an annotation carrying no `bounds` is
+ * passed through rather than given one.
+ */
+export function transformAnnotations(annotations, transform) {
+  if (!transform || !Array.isArray(annotations)) return annotations;
+  return annotations.map((annotation) =>
+    annotation?.bounds
+      ? { ...annotation, bounds: transformBounds(annotation.bounds, transform) }
+      : annotation,
+  );
 }

--- a/scripts/design-artifacts/reference-layout.mjs
+++ b/scripts/design-artifacts/reference-layout.mjs
@@ -78,37 +78,65 @@ export function publishTransform(sourceWidth, sourceHeight, placement) {
 }
 
 /**
- * Move one box from the source raster's pixel space into the published raster's.
+ * A box intersected with the canvas it is drawn on, or null when it lies entirely outside it.
  *
- * Returned unchanged — the same object — when there is no transform, so a consumer can call this
- * unconditionally and a reference that was not rescaled keeps the very bytes it has today.
- *
- * Width and height are floored at 1: a box small enough to round to nothing under a reduction is
- * still a box somebody drew, and a zero-area rectangle is invisible rather than honest.
+ * Load-bearing rather than tidy: `placeRgba` crops an empty margin by placing the source at a
+ * NEGATIVE offset — the m3-catalog touch-target case puts a 218x126 export at `y: -21` — so a box
+ * spanning that margin transforms to a negative origin. Both `ServeAnnotationStore` and
+ * `ServeParityFindingStore` discard a box with a negative origin, so the annotation would vanish
+ * instead of moving. A partially cropped box is honestly the part of it that survived the crop;
+ * one whose every pixel was cropped away has nothing left to point at and is dropped.
  */
-export function transformBounds(bounds, transform) {
-  if (!transform || !bounds) return bounds;
-  const { scaleX, scaleY, offsetX = 0, offsetY = 0 } = transform;
-  return {
-    ...bounds,
-    x: Math.round(bounds.x * scaleX) + offsetX,
-    y: Math.round(bounds.y * scaleY) + offsetY,
-    width: Math.max(1, Math.round(bounds.width * scaleX)),
-    height: Math.max(1, Math.round(bounds.height * scaleY)),
-  };
+function clipToCanvas(box, canvas) {
+  if (!canvas || !(canvas.width > 0) || !(canvas.height > 0)) return box;
+  const x = Math.max(0, box.x);
+  const y = Math.max(0, box.y);
+  const right = Math.min(canvas.width, box.x + box.width);
+  const bottom = Math.min(canvas.height, box.y + box.height);
+  if (right <= x || bottom <= y) return null;
+  return { ...box, x, y, width: right - x, height: bottom - y };
 }
 
 /**
- * Move a reference's annotation layer into the published raster's pixel space.
+ * Move one box from the source raster's pixel space into the published raster's, clipped to
+ * `canvas` (the published raster's dimensions) when one is given.
+ *
+ * Returned unchanged — the same object — when there is no transform, so a consumer can call this
+ * unconditionally and a reference that was not rescaled keeps the very bytes it has today. Only a
+ * box this actually moved is clipped, for the same reason. Null when the move puts every pixel of
+ * it outside the canvas; see [clipToCanvas].
+ *
+ * Width and height are floored at 1 before the clip: a box small enough to round to nothing under a
+ * reduction is still a box somebody drew, and a zero-area rectangle is invisible rather than honest.
+ */
+export function transformBounds(bounds, transform, canvas = undefined) {
+  if (!transform || !bounds) return bounds;
+  const { scaleX, scaleY, offsetX = 0, offsetY = 0 } = transform;
+  return clipToCanvas(
+    {
+      ...bounds,
+      x: Math.round(bounds.x * scaleX) + offsetX,
+      y: Math.round(bounds.y * scaleY) + offsetY,
+      width: Math.max(1, Math.round(bounds.width * scaleX)),
+      height: Math.max(1, Math.round(bounds.height * scaleY)),
+    },
+    canvas,
+  );
+}
+
+/**
+ * Move a reference's annotation layer into the published raster's pixel space, clipped to `canvas`.
  *
  * The list is returned as it stands when nothing moved, and an annotation carrying no `bounds` is
- * passed through rather than given one.
+ * passed through rather than given one. An annotation whose box the crop removed entirely is
+ * dropped: it describes a region of the design that this reference does not publish, and a label
+ * with nowhere to sit is worse than a missing one.
  */
-export function transformAnnotations(annotations, transform) {
+export function transformAnnotations(annotations, transform, canvas = undefined) {
   if (!transform || !Array.isArray(annotations)) return annotations;
-  return annotations.map((annotation) =>
-    annotation?.bounds
-      ? { ...annotation, bounds: transformBounds(annotation.bounds, transform) }
-      : annotation,
-  );
+  return annotations.flatMap((annotation) => {
+    if (!annotation?.bounds) return [annotation];
+    const bounds = transformBounds(annotation.bounds, transform, canvas);
+    return bounds ? [{ ...annotation, bounds }] : [];
+  });
 }

--- a/scripts/design-artifacts/reference-layout.test.mjs
+++ b/scripts/design-artifacts/reference-layout.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { scaleTree } from "./reference-layout.mjs";
+import {
+  publishTransform,
+  scaleTree,
+  transformAnnotations,
+  transformBounds,
+} from "./reference-layout.mjs";
 
 const tree = {
   root: {
@@ -69,4 +74,92 @@ test("offsets every box by where the artwork sits in a letterboxed raster", () =
 
 test("no offset is the default, so a full-bleed reference is unaffected", () => {
   assert.deepEqual(scaleTree(tree, 400).root.bounds, scaleTree(tree, 400, 0, 0).root.bounds);
+});
+
+// ---- publishTransform / transformBounds / transformAnnotations ----------------------------------
+//
+// The half of this module that carries geometry captured by SOMEBODY ELSE — an adapter's annotation
+// layer, a finding's anchor — out of the source raster's pixels and onto the raster published
+// (#4696). `scaleTree` above works from the design frame's own units; these work from the raster's.
+
+test("no transform for a reference published exactly as it arrived", () => {
+  // Identity is null, not a unit transform: the manifests of a reference nothing moved must stay
+  // byte-identical to what they are today, and that is easiest to guarantee by not writing a field.
+  assert.equal(publishTransform(400, 800, { width: 400, height: 800, x: 0, y: 0 }), null);
+});
+
+test("states the factor a rounding resample applied", () => {
+  // 402x800 stretched onto the sticker's 400x800: both axes move, neither by the same amount.
+  assert.deepEqual(publishTransform(402, 800, { width: 400, height: 800, x: 0, y: 0 }), {
+    scaleX: 0.995025,
+    scaleY: 1,
+    offsetX: 0,
+    offsetY: 0,
+  });
+});
+
+test("states the factor and the offset a letterboxed fit applied", () => {
+  assert.deepEqual(publishTransform(200, 200, { width: 400, height: 400, x: 0, y: 200 }), {
+    scaleX: 2,
+    scaleY: 2,
+    offsetX: 0,
+    offsetY: 200,
+  });
+});
+
+test("a centred placement is a transform even when nothing was rescaled", () => {
+  // `placeRgba` centres a density-matched export without enlarging it. The scale is 1 and the
+  // artwork still moved, so a box that ignored the offset would sit off it by the whole margin.
+  assert.deepEqual(publishTransform(100, 40, { width: 100, height: 40, x: 150, y: 180 }), {
+    scaleX: 1,
+    scaleY: 1,
+    offsetX: 150,
+    offsetY: 180,
+  });
+});
+
+test("no transform for dimensions that describe nothing", () => {
+  assert.equal(publishTransform(0, 800, { width: 400, height: 800 }), null);
+  assert.equal(publishTransform(400, 800, undefined), null);
+  assert.equal(publishTransform(400, 800, { width: 0, height: 800 }), null);
+});
+
+test("moves a box by the transform the raster went through", () => {
+  const transform = { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 200 };
+  assert.deepEqual(transformBounds({ x: 10, y: 20, width: 30, height: 40 }, transform), {
+    x: 20,
+    y: 240,
+    width: 60,
+    height: 80,
+  });
+});
+
+test("returns the very box it was given when nothing moved", () => {
+  // Identity is pass-through by reference, so an unrescaled reference cannot even be re-rounded.
+  const bounds = { x: 10, y: 20, width: 30, height: 40 };
+  assert.equal(transformBounds(bounds, null), bounds);
+});
+
+test("keeps a box drawable when a reduction would round it away", () => {
+  // A 1px hairline under a 0.3x reduction rounds to zero, and a zero-area rectangle is invisible
+  // rather than honest — the reader loses the annotation and is told nothing.
+  const thin = transformBounds({ x: 4, y: 4, width: 1, height: 1 }, { scaleX: 0.3, scaleY: 0.3 });
+  assert.deepEqual(thin, { x: 1, y: 1, width: 1, height: 1 });
+});
+
+test("moves every annotation's box and leaves the rest of it alone", () => {
+  const layer = [
+    { kind: "layout", label: "pad 16dp", bounds: { x: 0, y: 0, width: 100, height: 50 } },
+    { kind: "typography", label: "bodyLarge 16sp", detail: { unit: "sp" } },
+  ];
+  const moved = transformAnnotations(layer, { scaleX: 2, scaleY: 2, offsetX: 0, offsetY: 10 });
+  assert.deepEqual(moved[0].bounds, { x: 0, y: 10, width: 200, height: 100 });
+  assert.equal(moved[0].label, "pad 16dp");
+  // No bounds, nothing to move — and nothing invented either.
+  assert.deepEqual(moved[1], layer[1]);
+});
+
+test("passes an annotation layer straight through when nothing moved", () => {
+  const layer = [{ kind: "layout", bounds: { x: 0, y: 0, width: 10, height: 10 } }];
+  assert.equal(transformAnnotations(layer, null), layer);
 });

--- a/scripts/design-artifacts/reference-layout.test.mjs
+++ b/scripts/design-artifacts/reference-layout.test.mjs
@@ -163,3 +163,58 @@ test("passes an annotation layer straight through when nothing moved", () => {
   const layer = [{ kind: "layout", bounds: { x: 0, y: 0, width: 10, height: 10 } }];
   assert.equal(transformAnnotations(layer, null), layer);
 });
+
+test("clips a box the placement cropped rather than letting it be discarded", () => {
+  // `placeRgba` crops an empty margin by placing the source at a NEGATIVE offset — the m3-catalog
+  // touch-target case is `{ width: 218, height: 126, x: 0, y: -21 }`. A box spanning that margin
+  // transforms to a negative origin, and both `ServeAnnotationStore` and `ServeParityFindingStore`
+  // discard a box with one, so the annotation would vanish instead of moving.
+  const transform = { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -21 };
+  const canvas = { width: 219, height: 84 };
+  assert.deepEqual(transformBounds({ x: 0, y: 0, width: 218, height: 126 }, transform, canvas), {
+    x: 0,
+    y: 0,
+    width: 218,
+    height: 84,
+  });
+});
+
+test("drops a box the placement cropped away entirely", () => {
+  // Nothing of it is published, so there is nowhere honest to draw it.
+  const transform = { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -21 };
+  const gone = transformBounds({ x: 0, y: 0, width: 218, height: 20 }, transform, {
+    width: 219,
+    height: 84,
+  });
+  assert.equal(gone, null);
+});
+
+test("clips a box that runs off the far edge too", () => {
+  const clipped = transformBounds({ x: 90, y: 0, width: 40, height: 10 }, { scaleX: 2, scaleY: 2 }, {
+    width: 200,
+    height: 100,
+  });
+  assert.deepEqual(clipped, { x: 180, y: 0, width: 20, height: 20 });
+});
+
+test("clips nothing without a canvas to clip to", () => {
+  // The canvas is optional, and absent it the box is moved and left alone rather than guessed at.
+  assert.deepEqual(
+    transformBounds({ x: 0, y: 0, width: 10, height: 10 }, { scaleX: 1, scaleY: 1, offsetY: -21 }),
+    { x: 0, y: -21, width: 10, height: 10 },
+  );
+});
+
+test("drops an annotation whose box the crop removed, and keeps the rest", () => {
+  const layer = [
+    { kind: "layout", label: "in the margin", bounds: { x: 0, y: 0, width: 218, height: 20 } },
+    { kind: "layout", label: "on the button", bounds: { x: 0, y: 21, width: 218, height: 84 } },
+  ];
+  const moved = transformAnnotations(layer, { scaleX: 1, scaleY: 1, offsetX: 0, offsetY: -21 }, {
+    width: 219,
+    height: 84,
+  });
+  assert.equal(moved.length, 1);
+  assert.equal(moved[0].label, "on the button");
+  assert.deepEqual(moved[0].bounds, { x: 0, y: 0, width: 218, height: 84 });
+});


### PR DESCRIPTION
Fixes #4696.

## The gap

`emit-design-references.mjs` normalises every reference onto the catalog sticker's canvas — a density-matched export is centred and reduced only if its content overflows, a raster within rounding distance is resampled, and genuinely different proportions are fitted and letterboxed. Reference-**side** geometry — an adapter's annotation boxes, a parity finding's anchor — is measured in the space the design tool captured, which is the space *before* that normalisation. Where the raster moved, the two describe different pixel spaces and a redline or a finding's highlight sits slightly off the element it names. That is worst on exactly the `layout` findings that anchor on **both** panels so an offset can be seen rather than read.

Option (1) from the issue: the publish step applies its own transform, because only it knows what it did.

## The change

- **`reference-layout.mjs`** gains the second half of its job. `publishTransform(sourceWidth, sourceHeight, placement)` states what the placement did as `{ scaleX, scaleY, offsetX, offsetY }` — or `null` for the identity — and `transformBounds` / `transformAnnotations` carry a box through it, **clipped to the published canvas**. That clip is load-bearing: `placeRgba` crops an empty margin by placing the source at a *negative* offset (the m3-catalog touch-target case is `y: -21`), and both `ServeAnnotationStore` and `ServeParityFindingStore` discard a box with a negative origin — so an unclipped box would not sit wrong, it would disappear. A partially cropped box keeps the part that survived; one cropped away entirely is dropped. `scaleTree` is untouched: it maps the tree this pipeline captures itself, whose numbers are in the design frame's units, and it already applied the placement.
- **`emit-design-references.mjs`** records the transform per reference. It publishes it as `raster.transform` in `references/index.json`, and rebases any reference annotation layer already in `annotations/index.json` — one a repo's own parity job wrote with `withReferenceAnnotations` before this step ran — into the published space. Layers captured here are already in it.
- **`emit-parity-findings.mjs` / `parity-findings.mjs`** read those transforms back out of the manifest the reference step just wrote (the two steps already run in that order, in the same job) and apply them to every `side: "reference"` anchor at the point a set is scoped to the reference it is about — the only place the reference id is known. An anchor cropped away is dropped, and a finding left with none loses the field rather than carrying an empty list, since an unanchored finding is offered as prose and never as a control. Candidate-side anchors are never touched: they are in the render's own pixels, which is the frame the server serves.
- **`docs/public-preview-server.md`** documents the field and the correction.

A reference the export did not move carries no `transform` at all — absent *is* the identity — so its manifests come out byte-for-byte what they are today. `serve` ignores the field (`ignoreUnknownKeys`); by the time it reads a manifest everything is in one space.

## Test plan

- `npm test` in `scripts/design-artifacts`: 1277 pass, 0 fail. 37 new cases across `reference-layout.test.mjs` (the transform, the box and layer walks, the canvas clip and the wholly-cropped drop), `design-references.test.mjs` (`referenceTransforms` indexes a manifest with its canvas, and drops a factor that would move a box to nonsense) and `parity-findings.test.mjs` (a reference anchor moves, is clipped, or is dropped; the candidate anchor never is; only the reference the transform names is moved; and a run with no rescaled reference publishes an identical document).
- End-to-end against a staged bundle, not committed. A 150×105 mock published onto a 300×210 sticker emits `"transform": { "scaleX": 2, "scaleY": 2, "offsetX": 0, "offsetY": 0 }` and moves a pre-existing annotation box from `{30, 21, 90, 63}` to `{60, 42, 180, 126}`. On the cropping geometry — a 218×126 export with an 84-row button onto a 219×84 sticker, placed at `offsetY: -21` — the frame box goes from `y: -21` (discarded by the server) to `{0, 0, 218, 84}`, the margin-only box is dropped, and the button box lands on the artwork. Re-run with a 300×210 mock, the manifest carries no `transform` and `annotations/index.json` is byte-identical.

Not UI-affecting in the render sense: no `@Preview`, catalog, overlay or theme changes. What moves is the coordinate a redline is drawn at, and the evidence for that is the box arithmetic above rather than a render — the surfaces that draw these manifests are the preview server's own compare page, which this PR does not touch.