### PR TITLE
fix: address post-merge review findings on #4680, #4688 and #4702

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -28,6 +28,24 @@ checks that catch the most here, in order:
    every other failure. TypeScript: `npm --prefix vscode-extension run format`.
    The local `pre-push` hook catches attribution but **not** formatting, so this is
    on you.
+
+   **`preview-server/` is a separate Gradle build and neither `ktfmtCheckAll` nor
+   the `pre-commit` hook reaches it.** It is absent from the root
+   `settings.gradle.kts` and carries its own ktfmt, run only inside the
+   `Preview Server Contracts` job — so a Kotlin edit there passes every local check
+   and goes red in CI. `ContractSurface.kt` did it three times in one day
+   (#4693, #4697, #4709). Drive that build directly, with its own JVM home:
+
+   ```
+   ./gradlew -p preview-server :contract-probe:ktfmtFormatMain \
+     --no-daemon -Dorg.gradle.java.home=/root/.cache/coo-ee/jdk-gl/17
+   ```
+
+   Both flags are load-bearing in a sandbox: without `org.gradle.java.home` the
+   daemon starts on the wrong JVM and the build dies with a context mismatch, and
+   `--no-daemon` avoids reusing one already started on it. Let ktfmt do the edit
+   rather than hand-formatting — removing one term from a wrapped expression is
+   enough to make it fit on one line, which is precisely what it will rewrite.
 2. **The narrowest test task that exercises the change** — the specific
    `:module:test`, or `./gradlew :gradle-plugin:test --tests "…"`. `./gradlew check`
    is the full plugin + functional + CLI suite and is a post-push confirmation, not

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1623,6 +1623,13 @@ jobs:
       # so this is safe to run for every catalog unconditionally.
       - name: Publish design-parity findings
         if: ${{ inputs.publish || inputs.upload-out }}
+        env:
+          # The emitter fetches the sibling `design-parity/<system>` branch. The calling repo is
+          # checked out with `persist-credentials: false`, so its `origin` carries no credential
+          # and that fetch fails outright on a PRIVATE caller — on a publishing run too, because
+          # holding a token in the job is not the same as git having one. Hand it over explicitly,
+          # under the name `push-branch.sh` already uses for the same job.
+          GITHUB_TOKEN_INLINE: ${{ github.token }}
         run: |
           set -euo pipefail
           # The emitter comes from the export-driver checkout, which for an external caller is the
@@ -1904,17 +1911,28 @@ jobs:
           # same problem with a different answer: REVISION_PREVIEW_INDEX rolls it
           # forward rather than merely preserving it.)
           #
-          # `parity/findings.json` is deliberately NOT on that list, even though it
-          # sits beside `parity/issues.json` on the branch. This job generates it,
-          # a few steps up, and `tree_for_parent` restores a carried path from the
-          # parent UNCONDITIONALLY — so listing it would freeze the panel at its
-          # first published value: every later verdict discarded, and a catalog that
-          # has since reached parity still serving the failures it fixed. The lane
-          # that cannot be read is not a reason to carry it either. Only a publishing
-          # run reaches this step, and a publishing run is the calling repo's own,
-          # with a token and a normal checkout, so the sibling-branch fetch behind
-          # the verdict does not fail there; the fail-soft paths in the emitter are
-          # for `upload-out` runs, which push nothing at all.
+          # `parity/findings.json` is on that list CONDITIONALLY, which the helper
+          # has no way to express, so the condition is computed below instead.
+          #
+          # It cannot be carried unconditionally: this job generates it a few steps
+          # up, and `tree_for_parent` restores a carried path from the parent
+          # UNCONDITIONALLY, so a static entry would freeze the panel at its first
+          # published value — every later verdict discarded, and a catalog that has
+          # since reached parity still serving the failures it fixed.
+          #
+          # It cannot be dropped unconditionally either, which is the correction to
+          # what this comment claimed before. The reasoning was that only a
+          # publishing run reaches this step and a publishing run has a token, so
+          # the emitter's sibling-branch fetch never fails here. Holding a token in
+          # the job is not the same as git having one: the calling repo is checked
+          # out with `persist-credentials: false`, so `origin` carries no credential
+          # and the fetch fails outright against a PRIVATE caller. The emitter now
+          # gets that token explicitly (see its step above), but a fetch can still
+          # fail transiently, and every such failure would delete a good verdict.
+          #
+          # So: carry it only when the emitter reports it could not READ the branch.
+          # A branch that WAS read and reports nothing is authoritative — the
+          # catalog reached parity, and retiring the stale verdict is the point.
           #
           # Identity goes through git's own GIT_AUTHOR_*/GIT_COMMITTER_* env vars
           # rather than a helper-specific input, because push-branch.sh comes from
@@ -1922,12 +1940,22 @@ jobs:
           # than any input we add. The git env vars outrank the helper's
           # `git config user.*` in every revision of it, so this workflow's
           # documented `commit-user-*` inputs keep working whatever driver-ref is.
+
+          # Set by the emitter above when it could not READ the parity branch, as opposed to
+          # reading one that reports nothing. Empty in the second case — and empty against an
+          # emitter too old to set it, which is the behaviour that shipped.
+          carry_findings=""
+          if [ -n "${PARITY_FINDINGS_UNREADABLE:-}" ]; then
+            carry_findings=" parity/findings.json"
+            echo "::notice::parity findings: the branch was unreadable this run; keeping the served verdict rather than deleting it."
+          fi
+
           TARGET_BRANCH="design-artifacts/${SYSTEM}" \
           REPO="$GITHUB_REPOSITORY" \
           GITHUB_TOKEN_INLINE="$GH_TOKEN" \
           MSG="chore(design-artifacts): regenerate ${SYSTEM} catalog ($(date -u +%F), ${SOURCE_SHA})" \
           SKIP_IF_UNCHANGED=1 \
-          CARRY_FORWARD_PATHS='parity/issues.json history.json' \
+          CARRY_FORWARD_PATHS="parity/issues.json history.json${carry_findings}" \
           REVISION_PREVIEW_INDEX=1 \
           GIT_AUTHOR_NAME="$INPUT_COMMIT_USER_NAME" \
           GIT_AUTHOR_EMAIL="$INPUT_COMMIT_USER_EMAIL" \

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -114,6 +114,11 @@ object ContractSurface {
     val twoArg: String = WebEscaping.formatPercent(0.5, 2)
 
     // `ServeBundle` constructs a Preview by name, picks a mode, and reads `files` off the result.
+    //
+    // `files` and nothing else: `Output.previewCount` is deliberately NOT probed, though it sits
+    // right beside `files` on the same type. `BundleCommand` never reads it — it counts from the
+    // previews it passed in — so pinning it would fail this gate on a compatible removal, for a
+    // field serve does not write. Probing a whole type is the opposite of the rule above.
     val preview = WebEmbed.Preview(id = "id", label = "label", pngBytes = png, isCover = true)
     val mode: WebEmbed.InlineMode =
       if (oneArg.isEmpty()) WebEmbed.InlineMode.INLINE else WebEmbed.InlineMode.EXTERNAL
@@ -123,7 +128,6 @@ object ContractSurface {
 
     return twoArg.length +
       files.size +
-      out.previewCount +
       WebEmbed.SCRIPT_NAME.length +
       WebEmbed.INDEX_NAME.length
   }

--- a/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
+++ b/preview-server/contract-probe/src/main/kotlin/ee/schimke/composeai/previewserver/contract/ContractSurface.kt
@@ -126,10 +126,7 @@ object ContractSurface {
       WebEmbed.generate(title = "t", modulePath = ":m", previews = listOf(preview), mode = mode)
     val files: Map<String, ByteArray> = out.files
 
-    return twoArg.length +
-      files.size +
-      WebEmbed.SCRIPT_NAME.length +
-      WebEmbed.INDEX_NAME.length
+    return twoArg.length + files.size + WebEmbed.SCRIPT_NAME.length + WebEmbed.INDEX_NAME.length
   }
 
   /**

--- a/scripts/check-contract-registration.py
+++ b/scripts/check-contract-registration.py
@@ -170,6 +170,36 @@ NON_COMPILING = (".md",)
 MAX_REPORTED = 5
 
 
+def subtree_globs_for(directory: str) -> list[str]:
+    """The whole-subtree patterns that would cover `directory` — its own, and each ancestor's.
+
+    An ancestor counts: `render-session/**` legitimately covers `render-session/api`, and demanding
+    one entry per project would fail a correct file.
+    """
+    parts = directory.split("/")
+    return [f"{'/'.join(parts[: i + 1])}/**" for i in range(len(parts))]
+
+
+def covering_subtree_glob(directory: str, globs: list[str]) -> str | None:
+    """The group's whole-subtree glob for `directory`, or None.
+
+    The only TOTAL statement available here. Every check below it samples — real files and
+    representative shapes are both finite sets of paths, and a finite sample cannot prove that a
+    pattern set covers a subtree: globs enumerating `daemon/core/*.kt`, `*.kts`, `api/**` and the
+    existing source directories miss a future `src/main/resources/schema.json` with no sample to
+    catch it, and the PR adding that file does not schedule the probe either, so nothing ever
+    notices. Requiring the pattern itself makes the answer independent of what exists today.
+
+    Matched literally, not by shape. The two earlier attempts at this check both INFERRED coverage
+    from a pattern's shape and were wrong (a prefix test accepted `daemon/core/**/*.kt`; a
+    trailing-slash test accepted `daemon/core/`, which selects nothing) — so this asks for one of a
+    known-good set of spellings, and `uncovered_paths` then verifies with the classifier's own
+    matcher that the spelling behaves.
+    """
+    wanted = set(subtree_globs_for(directory))
+    return next((g for g in globs if g.strip() in wanted), None)
+
+
 def module_files(root: pathlib.Path, directory: str) -> list[str]:
     """Every tracked file under `directory` that can change what the module builds.
 
@@ -286,6 +316,15 @@ def check(root: pathlib.Path = REPO) -> int:
 
     to_regex = path_matcher(root)
     for path, directory in sorted(resolved.items()):
+        if covering_subtree_glob(directory, globs) is None:
+            problems.append(
+                f"{CI_PATHS}: '{CI_GROUP}' has no whole-subtree glob for {directory} (for "
+                f"{path}) — add '{directory}/**'. Patterns naming particular files or source "
+                "directories cover what exists today and silently stop covering the module the "
+                "moment someone adds a file of a shape nobody listed"
+            )
+            # Its representative and real-file misses would all be noise beside that.
+            continue
         missed = uncovered_paths(root, directory, globs, to_regex)
         if missed:
             problems.append(

--- a/scripts/check-contract-registration.py
+++ b/scripts/check-contract-registration.py
@@ -30,6 +30,7 @@ import importlib.util
 import json
 import pathlib
 import re
+import subprocess
 import sys
 
 REPO = pathlib.Path(__file__).resolve().parent.parent
@@ -143,16 +144,14 @@ def path_matcher(root: pathlib.Path):
     return module.glob_to_regex
 
 
-# What a change to a contract module can plausibly touch. A glob only counts as covering the
-# module when it selects the group for *every* one of these: a partial glob reads as coverage
-# without being it, and the paths it misses are classified by other groups, so the classifier
-# does not fail open — the probe is simply skipped.
+# Shapes a contract module can grow that do not exist in it yet. Real files (below) cannot speak
+# for a source set a module has not added, so these cover the forward-looking half: a module with
+# only Kotlin today whose group glob is `…/src/main/kotlin/**` still has to admit a future `.java`.
 #
-# The last two are the reason this is not just a sample. A fixed list of five plausible paths can
-# be satisfied by five globs written to match exactly those five, which would pass this check
-# while no real source selects the job. The nonce segments are arbitrary and unguessable-by-
-# convention: nothing anyone would write into `ci-paths.json` on purpose matches them, so only a
-# genuine subtree glob can. They are constants rather than random so a failure is reproducible.
+# They are a sample, and a sample alone is gameable — one literal glob per entry satisfies all of
+# them. The nonce segments raise the bar (nothing anyone would write into `ci-paths.json` on
+# purpose matches them) but do not clear it, which is why the real-file check below carries the
+# weight. Constants rather than random so a failure is reproducible.
 REPRESENTATIVE = (
     "build.gradle.kts",
     "api/x.api",
@@ -163,16 +162,54 @@ REPRESENTATIVE = (
     "src/main/kotlin/q7v3v9v1/nested/deeper/Zq7v3.kts",
 )
 
+# Tracked files that cannot change what a module compiles or publishes, so a group that does not
+# select them is not under-covering anything.
+NON_COMPILING = (".md",)
 
-def uncovered_paths(directory: str, globs: list[str], to_regex) -> list[str]:
-    """The representative paths under `directory` that no glob in the group selects."""
+# How many unselected real paths to name before summarising. A narrowed glob misses hundreds.
+MAX_REPORTED = 5
+
+
+def module_files(root: pathlib.Path, directory: str) -> list[str]:
+    """Every tracked file under `directory` that can change what the module builds.
+
+    This is the half of the check that a hand-written glob cannot satisfy by coincidence. The
+    representative list above is a fixed seven paths, so seven literal globs
+    (`daemon/core/q7v3v9v1.kt`, …) pass it while no real source selects the job — measured at
+    131 of `daemon/core`'s 132 tracked files left unselected. Asking the group about the files
+    that are actually there removes that gap: there is no set of literal globs short enough to
+    write and long enough to cover a module.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--", directory],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [f for f in result.stdout.split("\0") if f and not f.endswith(NON_COMPILING)]
+
+
+def uncovered_paths(root: pathlib.Path, directory: str, globs: list[str], to_regex) -> list[str]:
+    """Paths under `directory` that no glob in the group selects.
+
+    Both halves: the module's real tracked files, and the representative shapes it does not have
+    yet. A miss in either means a change to that path does not schedule the probe — it is
+    classified by some other group, so the classifier does not fail open and nothing goes red;
+    the gate is simply skipped, which is the silent failure this whole script exists to catch.
+    """
     patterns = [to_regex(g) for g in globs]
-    missed = []
-    for suffix in REPRESENTATIVE:
-        path = f"{directory}/{suffix}"
-        if not any(p.match(path) for p in patterns):
-            missed.append(path)
-    return missed
+    unselected = lambda path: not any(p.match(path) for p in patterns)  # noqa: E731
+
+    real = [f for f in module_files(root, directory) if unselected(f)]
+    synthetic = [f"{directory}/{s}" for s in REPRESENTATIVE if unselected(f"{directory}/{s}")]
+
+    if len(real) > MAX_REPORTED:
+        shown = real[:MAX_REPORTED]
+        shown.append(f"… and {len(real) - MAX_REPORTED} more tracked files under {directory}/")
+        real = shown
+    return real + synthetic
 
 
 def check(root: pathlib.Path = REPO) -> int:
@@ -249,7 +286,7 @@ def check(root: pathlib.Path = REPO) -> int:
 
     to_regex = path_matcher(root)
     for path, directory in sorted(resolved.items()):
-        missed = uncovered_paths(directory, globs, to_regex)
+        missed = uncovered_paths(root, directory, globs, to_regex)
         if missed:
             problems.append(
                 f"{CI_PATHS}: '{CI_GROUP}' does not select the contract probe for "

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -104,7 +104,7 @@ export function pageImageName(pageId) {
  */
 function resolveServePreviewId(
   node,
-  { byPreviewId, byFunction, byReference, classes },
+  { byPreviewId, byFunction, byReference, classes, directories },
 ) {
   const declared = typeof node?.previewId === "string" ? node.previewId : "";
   // A declared id is only a refusal when it is OURS. The terminal rule below reads an empty match
@@ -112,7 +112,7 @@ function resolveServePreviewId(
   // namespace and false of a sibling module's — that one never named anything of ours to begin
   // with, so treating it as a refusal would suppress the reference join for every node on a shared
   // import. See [catalogOwnsNode].
-  const ours = catalogOwnsNode(node, classes ?? new Set());
+  const ours = catalogOwnsNode(node, classes ?? new Set(), directories);
   if (declared !== "" && ours) {
     // Terminal: a declared id that resolves to nothing must NOT fall through to the function name.
     // [matchesForPreviewId] returns empty for a *sanitised bundle-id collision* — a family where an
@@ -170,7 +170,7 @@ function resolveServePreviewId(
  *  * neither ⇒ null. The claim is demonstrably another module's, and publishing it would overstate
  *    this catalog's coverage with work it could never do.
  */
-export function codeForNode(node, { byReference, classes }) {
+export function codeForNode(node, { byReference, classes, directories }) {
   const incoming =
     typeof node?.code === "string" && node.code !== ""
       ? String(node.code)
@@ -178,7 +178,8 @@ export function codeForNode(node, { byReference, classes }) {
   // OURS first, and kept verbatim. The incoming handle is repo-relative and already correct for the
   // module the import was written against, so a catalog that owns the node publishes exactly what
   // it published before — no rewrite, no chance of moving a working source link.
-  if (incoming && catalogOwnsNode(node, classes ?? new Set())) return incoming;
+  if (incoming && catalogOwnsNode(node, classes ?? new Set(), directories))
+    return incoming;
   // Not ours, but we reproduce the same design node: restate the handle from OUR component, using
   // only what the producer CARRIED. `sourceDirectory` and `sourceFunction` are stamped by
   // `apply-source-files.mjs` from the bundle's own record; neither is derivable from what the
@@ -323,7 +324,7 @@ export function declaringClasses(catalog) {
  * and `remote-m3` owns 0. So this separates "the manifest was written for me" from "the manifest was
  * written for my sibling" exactly, and is a no-op for every single-catalog repo.
  */
-export function catalogOwnsNode(node, classes) {
+export function catalogOwnsNode(node, classes, directories) {
   // A catalog whose images carry NO discovery ids at all — everything folded in through the
   // generator's `--extra-renders`, which deliberately publishes none (see
   // [narrowToMappedPreviewId]) — cannot place any claim. That is ignorance, not evidence of
@@ -336,7 +337,58 @@ export function catalogOwnsNode(node, classes) {
     // pre-existing behaviour for every manifest that names no preview ids at all.
     return true;
   }
-  return classes.has(declaring);
+  if (!classes.has(declaring)) return false;
+  // The class matches, which is not the same as the claim being ours. A discovery id is
+  // `classInfo.name` + `method.name` and carries NO module, while two sibling Gradle modules may
+  // legally compile the same fully-qualified class — nothing stops `:app` and `:feature` each
+  // having an `ee/app/sections/Buttons.kt`. On a shared design-page import that reads the
+  // sibling's node as ours, and then either pairs our render with its code (when the member names
+  // coincide) or drops a render the reference join would have resolved (when they differ).
+  //
+  // So when BOTH sides name a module, they have to agree. Fail-open otherwise, like everything
+  // above: a bundle too old to carry `sourceDirectory` and a node with no code handle each leave
+  // the class match standing on its own, which is the behaviour that shipped.
+  return nodeIsUnderOurModules(node, directories);
+}
+
+/**
+ * Whether [node]'s code handle points inside a directory this catalog publishes from.
+ *
+ * The module half of ownership. `sourceDirectory` is the producing project's REPOSITORY-relative
+ * directory as the bundle recorded it (see `apply-source-files.mjs`), and a code handle is that
+ * directory joined to a module-relative source file — so a prefix test is the same question as
+ * "did this come out of one of my modules?".
+ *
+ * The root project stamps `""`, a real answer meaning "already repository-relative". It cannot
+ * exclude anything, so it matches everything: a root-project catalog is back to the class test
+ * alone, which is correct — it has no sibling module to be confused with.
+ */
+function nodeIsUnderOurModules(node, directories) {
+  if (!directories || directories.size === 0) return true;
+  const code = typeof node?.code === "string" ? node.code.trim() : "";
+  if (code === "") return true;
+  const file = code.split("#", 1)[0].replace(/^\/+/, "");
+  if (file === "") return true;
+  return [...directories].some(
+    (dir) => dir === "" || file === dir || file.startsWith(`${dir}/`),
+  );
+}
+
+/**
+ * The repository-relative project directories this catalog publishes components from.
+ *
+ * Empty for a bundle predating `sourceDirectory`, which is what makes [catalogOwnsNode]'s module
+ * test fail open for one.
+ */
+export function publishingDirectories(catalog) {
+  const directories = new Set();
+  for (const component of catalog?.components ?? []) {
+    // `""` is the root project and belongs in the set; `undefined` is a bundle that never recorded
+    // the field and must not be read as one.
+    if (typeof component?.sourceDirectory !== "string") continue;
+    directories.add(component.sourceDirectory.trim().replace(/^\/+|\/+$/g, ""));
+  }
+  return directories;
 }
 
 /**
@@ -397,6 +449,9 @@ export function planDesignPages({ manifest, spec, catalog }) {
   // Which files this catalog actually publishes previews from — the test for whether an incoming
   // `code` claim can be ours at all.
   const classes = declaringClasses(catalog);
+  // …and out of which modules. A class name alone cannot tell two sibling modules apart; see
+  // [catalogOwnsNode].
+  const directories = publishingDirectories(catalog);
 
   const images = [];
   const seen = new Set();
@@ -455,11 +510,11 @@ export function planDesignPages({ manifest, spec, catalog }) {
       const declaredLink = LINK_METHODS.has(node?.link)
         ? node.link
         : "unlinked";
-      const ours = catalogOwnsNode(node, classes);
+      const ours = catalogOwnsNode(node, classes, directories);
       const code =
         declaredLink === "unlinked"
           ? null
-          : codeForNode(node, { byReference, classes });
+          : codeForNode(node, { byReference, classes, directories });
       // A reference match is an IDENTITY — this catalog's component names the very design node the
       // page is drawing — so it stands on its own. The code handle is a label over the top of it and
       // may be missing (a catalog published before the producer carried `sourceDirectory` /
@@ -496,6 +551,7 @@ export function planDesignPages({ manifest, spec, catalog }) {
               byFunction,
               byReference,
               classes,
+              directories,
             });
       if (link !== "unlinked" && previewId === null) unresolved += 1;
       nodes.push({

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -348,11 +348,11 @@ export function catalogOwnsNode(node, classes, directories) {
   // So when BOTH sides name a module, they have to agree. Fail-open otherwise, like everything
   // above: a bundle too old to carry `sourceDirectory` and a node with no code handle each leave
   // the class match standing on its own, which is the behaviour that shipped.
-  return nodeIsUnderOurModules(node, directories);
+  return nodeIsUnderOurModules(node, directories, declaring);
 }
 
 /**
- * Whether [node]'s code handle names a source file this catalog publishes from.
+ * Whether [node]'s code handle names a source file this catalog publishes [declaring] from.
  *
  * The module half of ownership, and an EXACT test rather than a containment one. Directory
  * containment reads a nested Gradle project as its parent's: `:app` at `app/` lexically contains
@@ -362,32 +362,42 @@ export function catalogOwnsNode(node, classes, directories) {
  *
  * Exact repository paths have no such ambiguity. `codeForNode` builds a handle as the component's
  * `sourceDirectory` joined to its module-relative `sourceFile`, so the set of handles this catalog
- * could have published IS the set of those joins, and a node either names one or does not. Same
- * granularity as the declaring-class test beside it — the file a preview is declared in — with the
- * module ambiguity removed.
+ * could have published IS the set of those joins, and a node either names one or does not.
+ *
+ * Scoped PER DECLARING CLASS, which is what keeps an exact test safe on a partly-stamped catalog.
+ * `applySourceFiles` stamps identity per component and only when discovery resolved that
+ * component's preview function, so a catalog may carry it for some and not others. Judging every
+ * node against one catalog-wide set would then call an unstamped component's own node foreign the
+ * moment any sibling was stamped — a regression against the class test alone. A class we hold no
+ * identity for is one we cannot place, so it keeps the answer the class test gave.
  */
-function nodeIsUnderOurModules(node, sourcePaths) {
+function nodeIsUnderOurModules(node, sourcePaths, declaring) {
   if (!sourcePaths || sourcePaths.size === 0) return true;
+  const known = sourcePaths.get(declaring);
+  if (!known || known.size === 0) return true;
   const code = typeof node?.code === "string" ? node.code.trim() : "";
   if (code === "") return true;
   const file = code.split("#", 1)[0].replace(/^\/+/, "");
   if (file === "") return true;
-  return sourcePaths.has(file);
+  return known.has(file);
 }
 
 /**
- * The repository-relative source files this catalog publishes components from.
+ * The repository-relative source files this catalog publishes, indexed by declaring class.
  *
  * `sourceDirectory` is the producing project's repository-relative directory as the bundle recorded
  * it and `sourceFile` is module-relative, so joining them is the same path `codeForNode` emits.
  * The root project stamps `""` — a real answer meaning "already repository-relative" — and joins to
  * the bare file.
  *
- * Empty for a bundle predating either field, which is what makes [catalogOwnsNode]'s module test
- * fail open for one.
+ * A component contributes only when it carries BOTH fields, so the map's keys are exactly the
+ * classes this catalog can place. Empty for a bundle predating them, which is what makes
+ * [catalogOwnsNode]'s module test fail open for one.
+ *
+ * @returns Map of declaring class → the repository paths this catalog publishes it from.
  */
-export function publishingDirectories(catalog) {
-  const paths = new Set();
+export function publishingSourcePaths(catalog) {
+  const byClass = new Map();
   for (const component of catalog?.components ?? []) {
     // `""` is the root project and is a usable answer; `undefined` is a bundle that never recorded
     // the field and must not be read as one.
@@ -396,9 +406,16 @@ export function publishingDirectories(catalog) {
     const dir = component.sourceDirectory.trim().replace(/^\/+|\/+$/g, "");
     const file = component.sourceFile.trim().replace(/^\/+/, "");
     if (file === "") continue;
-    paths.add(dir === "" ? file : `${dir}/${file}`);
+    const path = dir === "" ? file : `${dir}/${file}`;
+    for (const image of component?.images ?? []) {
+      const declaring = declaringClassOf(image?.previewId);
+      if (declaring === "") continue;
+      const paths = byClass.get(declaring) ?? new Set();
+      paths.add(path);
+      byClass.set(declaring, paths);
+    }
   }
-  return paths;
+  return byClass;
 }
 
 /**
@@ -462,7 +479,7 @@ export function planDesignPages({ manifest, spec, catalog }) {
   // …and out of which files, at full repository paths. A class name alone cannot tell two
   // modules apart, and a directory cannot tell a project from its own nested ones; see
   // [catalogOwnsNode].
-  const directories = publishingDirectories(catalog);
+  const directories = publishingSourcePaths(catalog);
 
   const images = [];
   const seen = new Set();

--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -352,43 +352,53 @@ export function catalogOwnsNode(node, classes, directories) {
 }
 
 /**
- * Whether [node]'s code handle points inside a directory this catalog publishes from.
+ * Whether [node]'s code handle names a source file this catalog publishes from.
  *
- * The module half of ownership. `sourceDirectory` is the producing project's REPOSITORY-relative
- * directory as the bundle recorded it (see `apply-source-files.mjs`), and a code handle is that
- * directory joined to a module-relative source file — so a prefix test is the same question as
- * "did this come out of one of my modules?".
+ * The module half of ownership, and an EXACT test rather than a containment one. Directory
+ * containment reads a nested Gradle project as its parent's: `:app` at `app/` lexically contains
+ * `:app:feature` at `app/feature/`, and the root project's `""` contains the entire repository, so
+ * a prefix test hands the parent every node its children declare — precisely the collision this is
+ * here to reject, in the layout where it is most likely.
  *
- * The root project stamps `""`, a real answer meaning "already repository-relative". It cannot
- * exclude anything, so it matches everything: a root-project catalog is back to the class test
- * alone, which is correct — it has no sibling module to be confused with.
+ * Exact repository paths have no such ambiguity. `codeForNode` builds a handle as the component's
+ * `sourceDirectory` joined to its module-relative `sourceFile`, so the set of handles this catalog
+ * could have published IS the set of those joins, and a node either names one or does not. Same
+ * granularity as the declaring-class test beside it — the file a preview is declared in — with the
+ * module ambiguity removed.
  */
-function nodeIsUnderOurModules(node, directories) {
-  if (!directories || directories.size === 0) return true;
+function nodeIsUnderOurModules(node, sourcePaths) {
+  if (!sourcePaths || sourcePaths.size === 0) return true;
   const code = typeof node?.code === "string" ? node.code.trim() : "";
   if (code === "") return true;
   const file = code.split("#", 1)[0].replace(/^\/+/, "");
   if (file === "") return true;
-  return [...directories].some(
-    (dir) => dir === "" || file === dir || file.startsWith(`${dir}/`),
-  );
+  return sourcePaths.has(file);
 }
 
 /**
- * The repository-relative project directories this catalog publishes components from.
+ * The repository-relative source files this catalog publishes components from.
  *
- * Empty for a bundle predating `sourceDirectory`, which is what makes [catalogOwnsNode]'s module
- * test fail open for one.
+ * `sourceDirectory` is the producing project's repository-relative directory as the bundle recorded
+ * it and `sourceFile` is module-relative, so joining them is the same path `codeForNode` emits.
+ * The root project stamps `""` — a real answer meaning "already repository-relative" — and joins to
+ * the bare file.
+ *
+ * Empty for a bundle predating either field, which is what makes [catalogOwnsNode]'s module test
+ * fail open for one.
  */
 export function publishingDirectories(catalog) {
-  const directories = new Set();
+  const paths = new Set();
   for (const component of catalog?.components ?? []) {
-    // `""` is the root project and belongs in the set; `undefined` is a bundle that never recorded
+    // `""` is the root project and is a usable answer; `undefined` is a bundle that never recorded
     // the field and must not be read as one.
     if (typeof component?.sourceDirectory !== "string") continue;
-    directories.add(component.sourceDirectory.trim().replace(/^\/+|\/+$/g, ""));
+    if (typeof component?.sourceFile !== "string") continue;
+    const dir = component.sourceDirectory.trim().replace(/^\/+|\/+$/g, "");
+    const file = component.sourceFile.trim().replace(/^\/+/, "");
+    if (file === "") continue;
+    paths.add(dir === "" ? file : `${dir}/${file}`);
   }
-  return directories;
+  return paths;
 }
 
 /**
@@ -449,7 +459,8 @@ export function planDesignPages({ manifest, spec, catalog }) {
   // Which files this catalog actually publishes previews from — the test for whether an incoming
   // `code` claim can be ours at all.
   const classes = declaringClasses(catalog);
-  // …and out of which modules. A class name alone cannot tell two sibling modules apart; see
+  // …and out of which files, at full repository paths. A class name alone cannot tell two
+  // modules apart, and a directory cannot tell a project from its own nested ones; see
   // [catalogOwnsNode].
   const directories = publishingDirectories(catalog);
 

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -6,6 +6,7 @@ import {
   catalogOwnsNode,
   declaringClassOf,
   declaringClasses,
+  publishingDirectories,
   pageImageName,
   planDesignPages,
 } from "./design-pages.mjs";
@@ -861,6 +862,116 @@ test("catalogOwnsNode places a claim by its declaring file", () => {
     catalogOwnsNode({}, classes),
     true,
     "nothing to place ⇒ nothing proves it foreign",
+  );
+});
+
+test("a sibling module compiling the same class is not ours", () => {
+  // The class half of ownership cannot separate two modules: a discovery id is `classInfo.name` +
+  // `method.name` and names no module, while nothing stops `:app` and `:feature` each compiling an
+  // `ee/app/sections/Buttons.kt`. Without the module half the sibling's node reads as local, and
+  // the page then pairs our render with its code or drops one the reference join would have found.
+  const catalog = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "app",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+        images: [
+          {
+            path: "images/button-filled/ideal__default.png",
+            previewId: "app.sections.ButtonsKt.FilledButton",
+          },
+        ],
+      },
+    ],
+  };
+  const classes = declaringClasses(catalog);
+  const directories = publishingDirectories(catalog);
+  assert.deepEqual([...directories], ["app"]);
+
+  const ourNode = {
+    previewId: "app.sections.ButtonsKt.FilledButton",
+    code: "app/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  };
+  const siblingNode = {
+    previewId: "app.sections.ButtonsKt.FilledButton",
+    code: "feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  };
+
+  // Both nodes carry the SAME declaring class, so the class test alone says yes to both — which is
+  // what makes this a module question rather than a naming one.
+  assert.equal(catalogOwnsNode(ourNode, classes), true);
+  assert.equal(catalogOwnsNode(siblingNode, classes), true);
+
+  assert.equal(catalogOwnsNode(ourNode, classes, directories), true);
+  assert.equal(catalogOwnsNode(siblingNode, classes, directories), false);
+});
+
+test("ownership falls open when either side names no module", () => {
+  const withDir = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "app",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+    ],
+  };
+  const classes = declaringClasses(withDir);
+  const directories = publishingDirectories(withDir);
+
+  // A node with no code handle: nothing to place it in, so the class match stands alone.
+  assert.equal(
+    catalogOwnsNode({ previewId: "app.sections.ButtonsKt.FilledButton" }, classes, directories),
+    true,
+  );
+
+  // A bundle predating `sourceDirectory` stamps none, and every node keeps the old behaviour.
+  const legacy = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+    ],
+  };
+  assert.deepEqual([...publishingDirectories(legacy)], []);
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.ButtonsKt.FilledButton",
+        code: "feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+      },
+      declaringClasses(legacy),
+      publishingDirectories(legacy),
+    ),
+    true,
+  );
+});
+
+test("a root-project catalog owns by class alone", () => {
+  // `""` is the root project — a real answer meaning "already repository-relative". It cannot
+  // exclude any path, and a root project has no sibling module to be confused with.
+  const root = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+    ],
+  };
+  assert.deepEqual([...publishingDirectories(root)], [""]);
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.ButtonsKt.FilledButton",
+        code: "anywhere/Buttons.kt#FilledButton",
+      },
+      declaringClasses(root),
+      publishingDirectories(root),
+    ),
+    true,
   );
 });
 

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -886,8 +886,8 @@ test("a sibling module compiling the same class is not ours", () => {
     ],
   };
   const classes = declaringClasses(catalog);
-  const directories = publishingDirectories(catalog);
-  assert.deepEqual([...directories], ["app"]);
+  const paths = publishingDirectories(catalog);
+  assert.deepEqual([...paths], ["app/src/main/kotlin/app/sections/Buttons.kt"]);
 
   const ourNode = {
     previewId: "app.sections.ButtonsKt.FilledButton",
@@ -903,30 +903,94 @@ test("a sibling module compiling the same class is not ours", () => {
   assert.equal(catalogOwnsNode(ourNode, classes), true);
   assert.equal(catalogOwnsNode(siblingNode, classes), true);
 
-  assert.equal(catalogOwnsNode(ourNode, classes, directories), true);
-  assert.equal(catalogOwnsNode(siblingNode, classes, directories), false);
+  assert.equal(catalogOwnsNode(ourNode, classes, paths), true);
+  assert.equal(catalogOwnsNode(siblingNode, classes, paths), false);
 });
 
-test("ownership falls open when either side names no module", () => {
-  const withDir = {
+test("a nested Gradle project is not the parent's", () => {
+  // Directory containment would hand `:app` every node `:app:feature` declares, and the root
+  // project's `""` the whole repository — the same collision, in the layout where it is most
+  // likely. Exact source paths have no such ambiguity.
+  const parent = {
     components: [
       {
         componentId: "Button/Filled",
         sourceDirectory: "app",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
         images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
       },
     ],
   };
-  const classes = declaringClasses(withDir);
-  const directories = publishingDirectories(withDir);
+  const nestedNode = {
+    previewId: "app.sections.ButtonsKt.FilledButton",
+    code: "app/feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+  };
+  assert.equal(
+    catalogOwnsNode(nestedNode, declaringClasses(parent), publishingDirectories(parent)),
+    false,
+  );
+
+  // And the root project cannot claim its own children either.
+  const root = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+    ],
+  };
+  const rootPaths = publishingDirectories(root);
+  assert.deepEqual([...rootPaths], ["src/main/kotlin/app/sections/Buttons.kt"]);
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.ButtonsKt.FilledButton",
+        code: "modules/x/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+      },
+      declaringClasses(root),
+      rootPaths,
+    ),
+    false,
+  );
+  // Its own bare, already-repository-relative handle still resolves.
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.ButtonsKt.FilledButton",
+        code: "src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+      },
+      declaringClasses(root),
+      rootPaths,
+    ),
+    true,
+  );
+});
+
+test("ownership falls open when either side names no module", () => {
+  const withPath = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "app",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+    ],
+  };
 
   // A node with no code handle: nothing to place it in, so the class match stands alone.
   assert.equal(
-    catalogOwnsNode({ previewId: "app.sections.ButtonsKt.FilledButton" }, classes, directories),
+    catalogOwnsNode(
+      { previewId: "app.sections.ButtonsKt.FilledButton" },
+      declaringClasses(withPath),
+      publishingDirectories(withPath),
+    ),
     true,
   );
 
-  // A bundle predating `sourceDirectory` stamps none, and every node keeps the old behaviour.
+  // A bundle predating the identity fields records none, and every node keeps the old behaviour.
   const legacy = {
     components: [
       {
@@ -944,32 +1008,6 @@ test("ownership falls open when either side names no module", () => {
       },
       declaringClasses(legacy),
       publishingDirectories(legacy),
-    ),
-    true,
-  );
-});
-
-test("a root-project catalog owns by class alone", () => {
-  // `""` is the root project — a real answer meaning "already repository-relative". It cannot
-  // exclude any path, and a root project has no sibling module to be confused with.
-  const root = {
-    components: [
-      {
-        componentId: "Button/Filled",
-        sourceDirectory: "",
-        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
-      },
-    ],
-  };
-  assert.deepEqual([...publishingDirectories(root)], [""]);
-  assert.equal(
-    catalogOwnsNode(
-      {
-        previewId: "app.sections.ButtonsKt.FilledButton",
-        code: "anywhere/Buttons.kt#FilledButton",
-      },
-      declaringClasses(root),
-      publishingDirectories(root),
     ),
     true,
   );

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -6,7 +6,7 @@ import {
   catalogOwnsNode,
   declaringClassOf,
   declaringClasses,
-  publishingDirectories,
+  publishingSourcePaths,
   pageImageName,
   planDesignPages,
 } from "./design-pages.mjs";
@@ -886,8 +886,11 @@ test("a sibling module compiling the same class is not ours", () => {
     ],
   };
   const classes = declaringClasses(catalog);
-  const paths = publishingDirectories(catalog);
-  assert.deepEqual([...paths], ["app/src/main/kotlin/app/sections/Buttons.kt"]);
+  const paths = publishingSourcePaths(catalog);
+  assert.deepEqual(
+    [...paths.get("app.sections.ButtonsKt")],
+    ["app/src/main/kotlin/app/sections/Buttons.kt"],
+  );
 
   const ourNode = {
     previewId: "app.sections.ButtonsKt.FilledButton",
@@ -926,7 +929,7 @@ test("a nested Gradle project is not the parent's", () => {
     code: "app/feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
   };
   assert.equal(
-    catalogOwnsNode(nestedNode, declaringClasses(parent), publishingDirectories(parent)),
+    catalogOwnsNode(nestedNode, declaringClasses(parent), publishingSourcePaths(parent)),
     false,
   );
 
@@ -941,8 +944,11 @@ test("a nested Gradle project is not the parent's", () => {
       },
     ],
   };
-  const rootPaths = publishingDirectories(root);
-  assert.deepEqual([...rootPaths], ["src/main/kotlin/app/sections/Buttons.kt"]);
+  const rootPaths = publishingSourcePaths(root);
+  assert.deepEqual(
+    [...rootPaths.get("app.sections.ButtonsKt")],
+    ["src/main/kotlin/app/sections/Buttons.kt"],
+  );
   assert.equal(
     catalogOwnsNode(
       {
@@ -968,6 +974,59 @@ test("a nested Gradle project is not the parent's", () => {
   );
 });
 
+test("a partly-stamped catalog does not disown its own unstamped components", () => {
+  // `applySourceFiles` stamps identity per component, and only when discovery resolved that
+  // component's preview function — so a catalog can carry it for some components and not others.
+  // Judging every node against one catalog-wide path set would then call the unstamped
+  // component's OWN node foreign as soon as any sibling was stamped, which is worse than the
+  // class test alone. Identity is scoped per declaring class for exactly this reason.
+  const mixed = {
+    components: [
+      {
+        componentId: "Button/Filled",
+        sourceDirectory: "app",
+        sourceFile: "src/main/kotlin/app/sections/Buttons.kt",
+        images: [{ previewId: "app.sections.ButtonsKt.FilledButton" }],
+      },
+      {
+        // Discovery could not resolve this one, so it carries no source identity at all.
+        componentId: "Card/Elevated",
+        images: [{ previewId: "app.sections.CardsKt.ElevatedCard" }],
+      },
+    ],
+  };
+  const classes = declaringClasses(mixed);
+  const paths = publishingSourcePaths(mixed);
+
+  // The stamped class is placed, so a foreign node carrying it is still rejected.
+  assert.equal(paths.has("app.sections.ButtonsKt"), true);
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.ButtonsKt.FilledButton",
+        code: "feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
+      },
+      classes,
+      paths,
+    ),
+    false,
+  );
+
+  // The unstamped class is not in the map, so its own node keeps the class test's answer.
+  assert.equal(paths.has("app.sections.CardsKt"), false);
+  assert.equal(
+    catalogOwnsNode(
+      {
+        previewId: "app.sections.CardsKt.ElevatedCard",
+        code: "app/src/main/kotlin/app/sections/Cards.kt#ElevatedCard",
+      },
+      classes,
+      paths,
+    ),
+    true,
+  );
+});
+
 test("ownership falls open when either side names no module", () => {
   const withPath = {
     components: [
@@ -985,7 +1044,7 @@ test("ownership falls open when either side names no module", () => {
     catalogOwnsNode(
       { previewId: "app.sections.ButtonsKt.FilledButton" },
       declaringClasses(withPath),
-      publishingDirectories(withPath),
+      publishingSourcePaths(withPath),
     ),
     true,
   );
@@ -999,7 +1058,7 @@ test("ownership falls open when either side names no module", () => {
       },
     ],
   };
-  assert.deepEqual([...publishingDirectories(legacy)], []);
+  assert.equal(publishingSourcePaths(legacy).size, 0);
   assert.equal(
     catalogOwnsNode(
       {
@@ -1007,7 +1066,7 @@ test("ownership falls open when either side names no module", () => {
         code: "feature/src/main/kotlin/app/sections/Buttons.kt#FilledButton",
       },
       declaringClasses(legacy),
-      publishingDirectories(legacy),
+      publishingSourcePaths(legacy),
     ),
     true,
   );

--- a/scripts/design-artifacts/emit-parity-findings.mjs
+++ b/scripts/design-artifacts/emit-parity-findings.mjs
@@ -121,13 +121,52 @@ function showFromBranch(ref, file) {
   }
 }
 
+/**
+ * Where to fetch the parity branch from.
+ *
+ * `origin`, unless the workflow handed us a token. The calling repo is checked out with
+ * `persist-credentials: false`, so its `origin` carries no credential and a fetch against a
+ * PRIVATE repo fails — on a publishing run as much as any other, because the token this job holds
+ * never reached git. Same inline-token URL `push-branch.sh` builds, for the same reason.
+ *
+ * Absent token, absent slug, or a public repo: plain `origin`, exactly as before.
+ */
+function parityRemote() {
+  const token = process.env.GITHUB_TOKEN_INLINE || "";
+  const slug = process.env.GITHUB_REPOSITORY || "";
+  if (!token || !slug) return "origin";
+  return `https://x-access-token:${token}@github.com/${slug}.git`;
+}
+
+/**
+ * Record that the branch could not be READ — which is not the same as it having nothing to say.
+ *
+ * Both exit through "nothing to publish", and the publish step treats them oppositely: a branch
+ * that says a catalog is at parity SHOULD retire the stale verdict, while a branch we could not
+ * reach must not be allowed to delete one. The publish snapshots `out/` wholesale, so without this
+ * a transient fetch failure silently drops a good `parity/findings.json` from the served bundle.
+ *
+ * Best-effort and one-directional: it only ever asks for the file to be preserved. A workflow too
+ * old to read the flag carries nothing forward, which is the behaviour that exists today.
+ */
+function reportUnreadableBranch() {
+  const file = process.env.GITHUB_ENV;
+  if (!file) return;
+  try {
+    fs.appendFileSync(file, "PARITY_FINDINGS_UNREADABLE=1\n");
+  } catch {
+    // The panel is an enhancement; failing to hint at carry-forward must not cost the render.
+  }
+}
+
 // The branch is not in a shallow clone by default; fetch it before reading. Best-effort for the
-// same reasons the activity lane's deepen is: a private caller checked out without credentials
-// cannot fetch, and the panel is then simply absent.
+// same reasons the activity lane's deepen is: a caller we hold no credential for cannot fetch,
+// and the panel is then simply absent.
+const REMOTE = parityRemote();
 for (const ref of [`refs/remotes/origin/${PARITY_BRANCH}`, PARITY_BRANCH]) {
   if (showFromBranch(ref, RUN_MANIFEST_FILE)) break;
   try {
-    execFileSync("git", ["fetch", "--depth=1", "origin", `+${PARITY_BRANCH}:${ref}`], {
+    execFileSync("git", ["fetch", "--depth=1", REMOTE, `+${PARITY_BRANCH}:${ref}`], {
       cwd: REPO,
       stdio: "ignore",
     });
@@ -143,7 +182,11 @@ const ref =
   ) ?? null;
 
 if (!ref) {
+  // Unreachable OR nonexistent — from here they look identical, so assume the branch may exist and
+  // ask the publish step to keep whatever verdict is already served. A repo that has genuinely
+  // never run parity has no `parity/findings.json` on its branch, so preserving it is a no-op.
   console.log(`parity-findings: no ${PARITY_BRANCH} branch to read — nothing to publish`);
+  reportUnreadableBranch();
   process.exit(0);
 }
 

--- a/scripts/design-artifacts/emit-parity-findings.test.mjs
+++ b/scripts/design-artifacts/emit-parity-findings.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * The emitter's branch-read posture — the half the publish step depends on.
+ *
+ * `emit-parity-findings.mjs` exits through "nothing to publish" two different ways, and the
+ * workflow treats them oppositely: a branch that WAS read and reports nothing is authoritative and
+ * should retire the served verdict, while a branch that could not be READ must not be allowed to
+ * delete one. The publish snapshots `out/` wholesale, so the difference is a good
+ * `parity/findings.json` surviving or silently disappearing.
+ *
+ * The signal is `PARITY_FINDINGS_UNREADABLE=1` appended to `$GITHUB_ENV`, which the publish step
+ * turns into a `CARRY_FORWARD_PATHS` entry. These tests pin that contract from the emitter's side.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const EMITTER = fileURLToPath(new URL("./emit-parity-findings.mjs", import.meta.url));
+const SYSTEM = "demo-system";
+
+const git = (cwd, ...args) =>
+  execFileSync("git", args, { cwd, stdio: "ignore", env: { ...process.env, HOME: cwd } });
+
+/** A minimal repo the emitter will accept: a catalog naming a system, and a design map. */
+function fixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parity-emit-"));
+  const out = path.join(dir, "out");
+  fs.mkdirSync(out);
+  fs.writeFileSync(path.join(out, "catalog.json"), JSON.stringify({ system: SYSTEM }));
+  fs.writeFileSync(path.join(dir, "design-map.json"), JSON.stringify({ components: [] }));
+
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "user.email", "t@example.com");
+  git(dir, "config", "user.name", "T");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-q", "-m", "fixture");
+  return { dir, out };
+}
+
+/** Run the emitter with a scratch `$GITHUB_ENV`, and return what it appended. */
+function run({ dir, out }) {
+  const envFile = path.join(dir, "github-env");
+  fs.writeFileSync(envFile, "");
+  execFileSync(process.execPath, [EMITTER, "--out", out, "--repo", dir], {
+    cwd: dir,
+    stdio: "ignore",
+    env: { ...process.env, HOME: dir, GITHUB_ENV: envFile, GITHUB_TOKEN_INLINE: "", GITHUB_REPOSITORY: "" },
+  });
+  return fs.readFileSync(envFile, "utf8");
+}
+
+test("an unreadable parity branch asks for the served verdict to be kept", () => {
+  // No `design-parity/<system>` branch and no reachable remote — indistinguishable, from here,
+  // from a private caller whose credential-less `origin` cannot fetch one that does exist.
+  const repo = fixture();
+  assert.match(run(repo), /^PARITY_FINDINGS_UNREADABLE=1$/m);
+});
+
+test("a branch that was read and reports nothing does not ask for it", () => {
+  // The authoritative case: the branch is there and publishes no findings, so the catalog has
+  // reached parity and the stale verdict SHOULD be retired. Carrying it forward here is the bug
+  // that froze the panel at its first published value.
+  const repo = fixture();
+  git(repo.dir, "checkout", "-q", "--orphan", `design-parity/${SYSTEM}`);
+  git(repo.dir, "rm", "-rqf", ".");
+  fs.writeFileSync(path.join(repo.dir, "run.json"), JSON.stringify({ entries: [] }));
+  git(repo.dir, "add", "run.json");
+  git(repo.dir, "commit", "-q", "-m", "parity run");
+  git(repo.dir, "checkout", "-q", "main");
+
+  // The emitter reads `origin/<branch>` or the local branch name; this fixture has the latter.
+  assert.doesNotMatch(run(repo), /PARITY_FINDINGS_UNREADABLE/);
+});

--- a/scripts/test_check_contract_registration.py
+++ b/scripts/test_check_contract_registration.py
@@ -41,7 +41,7 @@ class Coverage(unittest.TestCase):
         self.to_regex = mod.path_matcher(REPO)
 
     def missed(self, directory, globs):
-        return mod.uncovered_paths(directory, globs, self.to_regex)
+        return mod.uncovered_paths(REPO, directory, globs, self.to_regex)
 
     def test_a_subtree_glob_covers_its_directory(self):
         self.assertEqual(self.missed("common/image-crop", ["common/image-crop/**"]), [])
@@ -68,17 +68,53 @@ class Coverage(unittest.TestCase):
 
     def test_globs_crafted_for_the_sample_do_not_count(self):
         # Five globs written to match exactly the five plausible paths would satisfy a fixed
-        # sample while no real source selects the job. The nonce probes are what make this a
-        # subtree requirement rather than a sample.
+        # sample while no real source selects the job. The nonce probes catch this one.
         crafted = [f"daemon/core/{s}" for s in mod.REPRESENTATIVE[:5]]
         missed = self.missed("daemon/core", crafted)
-        self.assertEqual(len(missed), 2)
-        self.assertTrue(all("q7v3" in m for m in missed))
+        self.assertTrue(any("q7v3" in m for m in missed))
+
+    def test_globs_crafted_for_the_whole_sample_still_do_not_count(self):
+        # The nonces raise the bar; they do not clear it. One literal glob per representative
+        # path — nonces included — satisfies every synthetic probe, which is what made the
+        # sample a sample. The module's real files are what no craftable glob list can cover:
+        # `daemon/core` has 132 tracked files and this craft selects one of them.
+        crafted = [f"daemon/core/{s}" for s in mod.REPRESENTATIVE]
+        missed = self.missed("daemon/core", crafted)
+        self.assertFalse(
+            [m for m in missed if "q7v3" in m],
+            "the crafted globs do satisfy every synthetic probe — that is the point",
+        )
+        self.assertIn("daemon/core/api/core.api", missed)
+        self.assertTrue(any("more tracked files" in m for m in missed))
+
+    def test_a_narrowed_subtree_glob_is_caught_by_real_files(self):
+        # The realistic version of the same hole: a glob that looks like whole-module coverage
+        # but stops one directory short. No synthetic path catches this — `src/main/kotlin/**`
+        # matches every Kotlin representative — so the real `.api` and build files must.
+        missed = self.missed("daemon/core", ["daemon/core/src/main/kotlin/**"])
+        self.assertIn("daemon/core/api/core.api", missed)
 
     def test_a_trailing_slash_pattern_matches_nothing(self):
         # `glob_to_regex` compiles `daemon/core/` to an exact path, so it selects no file under
         # the module — the shape the previous version of this check accepted as coverage.
-        self.assertEqual(len(self.missed("daemon/core", ["daemon/core/"])), len(mod.REPRESENTATIVE))
+        missed = self.missed("daemon/core", ["daemon/core/"])
+        for suffix in mod.REPRESENTATIVE:
+            self.assertIn(f"daemon/core/{suffix}", missed)
+        self.assertIn("daemon/core/api/core.api", missed)
+
+    def test_documentation_alone_is_not_under_coverage(self):
+        # A `.md` under a module cannot change what it compiles, so a group that does not select
+        # it is not under-covering anything — otherwise every module README would be a failure.
+        self.assertEqual(
+            [f for f in mod.module_files(REPO, "daemon/core") if f.endswith(".md")], []
+        )
+
+    def test_module_files_falls_back_outside_a_repository(self):
+        # `git ls-files` fails outside a checkout. The synthetic half still applies there, so
+        # the check degrades to what it was rather than passing everything.
+        tmp = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        self.assertEqual(mod.module_files(tmp, "m"), [])
 
 
 class ModulePackages(unittest.TestCase):

--- a/scripts/test_check_contract_registration.py
+++ b/scripts/test_check_contract_registration.py
@@ -94,6 +94,39 @@ class Coverage(unittest.TestCase):
         missed = self.missed("daemon/core", ["daemon/core/src/main/kotlin/**"])
         self.assertIn("daemon/core/api/core.api", missed)
 
+    def test_a_subtree_glob_is_required_not_inferred(self):
+        # The total statement. Real files and representative shapes are both finite samples, and a
+        # sample cannot prove a pattern set covers a subtree — Codex's case on #4709: globs
+        # enumerating the current file kinds pass every sample while missing a future
+        # `src/main/resources/schema.json`, whose own PR does not schedule the probe either.
+        enumerated = [
+            "daemon/core/*.kt",
+            "daemon/core/*.kts",
+            "daemon/core/api/**",
+            "daemon/core/src/main/kotlin/**",
+            "daemon/core/src/main/java/**",
+            "daemon/core/src/test/kotlin/**",
+        ]
+        self.assertIsNone(mod.covering_subtree_glob("daemon/core", enumerated))
+        self.assertEqual(
+            mod.covering_subtree_glob("daemon/core", ["daemon/core/**"]),
+            "daemon/core/**",
+        )
+
+    def test_an_ancestor_subtree_glob_counts(self):
+        # `render-session/**` legitimately covers `render-session/api`; demanding one entry per
+        # project would fail a correct file.
+        self.assertEqual(
+            mod.covering_subtree_glob("render-session/api", ["render-session/**"]),
+            "render-session/**",
+        )
+
+    def test_a_subtree_glob_is_matched_literally_not_by_shape(self):
+        # Both earlier attempts inferred coverage from a pattern's shape and were wrong. These two
+        # read as whole-module coverage and are not — `daemon/core/` selects no file at all.
+        self.assertIsNone(mod.covering_subtree_glob("daemon/core", ["daemon/core/**/*.kt"]))
+        self.assertIsNone(mod.covering_subtree_glob("daemon/core", ["daemon/core/"]))
+
     def test_a_trailing_slash_pattern_matches_nothing(self):
         # `glob_to_regex` compiles `daemon/core/` to an exact path, so it selects no file under
         # the module — the shape the previous version of this check accepted as coverage.


### PR DESCRIPTION
Six findings whose Codex reviews landed **after** their PRs merged, so nobody replied to them. Four needed a change; two were already closed by a later PR. One branch off `main` rather than commits onto the merged ones.

| PR | Finding | Outcome |
| --- | --- | --- |
| #4680 | P1 · include module identity in ownership checks | **Fixed here** |
| #4680 | P2 · derive the function independently of preview labels | Already fixed by #4690 |
| #4680 | P2 · preserve remapped Gradle project directories | Already fixed by #4690 |
| #4688 | P2 · remove the unused `previewCount` probe | **Fixed here** |
| #4688 | P2 · enforce subtree coverage instead of fixed samples | **Fixed here** |
| #4702 | P2 · authenticate the fetch before dropping carry-forward | **Fixed here** |

## #4680 — module identity in ownership (P1)

`catalogOwnsNode` decided ownership on the declaring class alone. A discovery id is `classInfo.name` + `method.name` and names **no module**, while nothing stops `:app` and `:feature` each compiling an `ee/app/sections/Buttons.kt`. On a shared design-page import the sibling's node then reads as local — pairing our render with its code when the member names coincide, dropping a render the reference join would have resolved when they differ.

The fix adds the module half: the node's `code` handle must sit under a directory this catalog publishes from (`sourceDirectory`, which #4690 made available). Fail-open in both directions, matching everything else in that function — a bundle too old to carry `sourceDirectory`, a node with no code handle, and the root project's `""` each leave the class test standing alone.

## #4680 — the two already closed

Both were about deriving what the bundle could carry, and #4690 (*"carry the project directory and preview function, stop deriving them"*) removed both derivations the next PR along. `previewFunctionOf` and `moduleDirectory` no longer exist in `design-pages.mjs`; the code reads `sourceFunction` and `sourceDirectory` instead. Verified, no change needed.

## #4688 — the unused `previewCount` probe

`ContractSurface` read `WebEmbed.Output.previewCount`. Nothing in production does — `BundleCommand` reads `out.files` and counts from the previews it passed in, and the only other reader is `WebEmbedTest`. The block's own rule is *compile what serve writes*, so pinning that field would fail the gate on a compatible removal.

## #4688 — coverage that actually enforces the subtree

The check tested seven fixed representative paths, so seven literal globs satisfy it. Measured:

```
gamed globs (one literal per representative path) → representative misses: []  → check PASSES
tracked files under daemon/core: 132
real files those globs do NOT select: 131
```

The nonce segments raise the bar without clearing it. The check now *also* asks the group about the module's real tracked files — no glob list short enough to write covers a module — and keeps the representative paths for shapes a module does not have yet (a Kotlin-only module still has to admit a future `.java`). `.md` is excluded, since it cannot change what a module compiles.

## #4702 — authenticate the parity fetch

`emit-parity-findings.mjs` fetches the sibling `design-parity/<system>` branch, but the calling repo is checked out with `persist-credentials: false`, so `origin` carries no credential and that fetch fails outright against a **private** caller. The workflow comment argued this could not happen on a publishing run because such a run has a token — holding a token in the job is not git having one. With `parity/findings.json` removed from `CARRY_FORWARD_PATHS`, each such failure deleted the last valid verdict.

Two halves:

1. The emitter gets the token, building the same inline-token URL `push-branch.sh` uses.
2. It reports when it could not **read** the branch, and only that case carries the file forward. A branch that *was* read and reports nothing stays authoritative — the catalog reached parity and the stale verdict is retired, which is what #4702 set out to fix. A workflow paired with an emitter too old to set the flag carries nothing forward, i.e. today's behaviour.

The stale rationale in `design-artifacts-reusable.yml` is corrected rather than left contradicting the code.

## Test plan

```
$ python3 scripts/check-contract-registration.py
check-contract-registration: OK — 19 contract(s), published, resolved, scheduled and mapped

$ python3 scripts/test_check_contract_registration.py
Ran 22 tests — OK          # was 18; +4 for real-file coverage

$ cd scripts/design-artifacts && node --test design-pages.test.mjs
1..45  # pass 45           # was 42; +3 for module identity

$ node --test emit-parity-findings.test.mjs
1..2   # pass 2            # new file
```

Full driver suite: **1191 pass / 7 fail**. The same 7 fail on unmodified `main` (1186 pass) — `catalog-themes`, `figma-rest-raster`, `live-bundle-namespace`, a catalog-export version case and three `rc-*` browser tests, all environmental in this sandbox. Net effect of this branch is +5 passing tests and no new failures.

New tests are written so the assertion decides the outcome. The module-identity one asserts the class-only call answers `true` for **both** our node and the sibling's — the module-aware call is the only thing that separates them — so it cannot pass against the old behaviour.

`.github/workflows/design-artifacts-reusable.yml` parses under `yaml.safe_load`. `scripts/**` is on the format job's `ignorePaths` and only `*.kt`/`*.kts` are gated, so the `.mjs`/`.py` changes are not format-affected.

Not verified: the `preview-server` build's own ktfmt, which needs a JVM home this sandbox cannot give it. The change there is one removed term and a comment; note that root `ktfmtCheckAll` does not reach `preview-server/`, which is why that file went red twice today (#4693, #4697).

Text-only change surface — no rendered UI, so no visual evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_