### PR TITLE
refactor(contracts): close three published-API hazards before the split

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImages.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImages.kt
@@ -270,13 +270,13 @@ class ServeHeroImages {
    * rounded or stale crop can't ask for pixels that aren't there.
    */
   private fun sourceRegion(renderW: Int, renderH: Int, crop: ContentCrop?): Region {
-    if (crop == null || crop.imgW <= 0) return Region(0, 0, renderW, renderH)
-    val scale = crop.imgW.toDouble() / renderW
+    if (crop == null || crop.render.w <= 0) return Region(0, 0, renderW, renderH)
+    val scale = crop.render.w.toDouble() / renderW
     if (scale <= 0.0) return Region(0, 0, renderW, renderH)
-    val x = (-crop.left / scale).roundToInt().coerceIn(0, renderW - 1)
-    val y = (-crop.top / scale).roundToInt().coerceIn(0, renderH - 1)
-    val w = (crop.boxW / scale).roundToInt().coerceIn(1, renderW - x)
-    val h = (crop.boxH / scale).roundToInt().coerceIn(1, renderH - y)
+    val x = (-crop.offset.left / scale).roundToInt().coerceIn(0, renderW - 1)
+    val y = (-crop.offset.top / scale).roundToInt().coerceIn(0, renderH - 1)
+    val w = (crop.window.w / scale).roundToInt().coerceIn(1, renderW - x)
+    val h = (crop.window.h / scale).roundToInt().coerceIn(1, renderH - y)
     return Region(x, y, w, h)
   }
 

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -5322,9 +5322,9 @@ ${captureControlsHtml().prependIndent("          ")}
     // stays auto (the img keeps the render's aspect); `left` %s resolve against the box width,
     // `top`
     // against its aspect-ratio height.
-    val w = cropPct(crop.imgW, crop.boxW)
-    val l = cropPct(crop.left, crop.boxW)
-    val t = cropPct(crop.top, crop.boxH)
+    val w = cropPct(crop.render.w, crop.window.w)
+    val l = cropPct(crop.offset.left, crop.window.w)
+    val t = cropPct(crop.offset.top, crop.window.h)
     val cropped =
       "<img$extraImgAttrs alt=\"$alt\" src=\"$src\" style=\"width:${w}%;left:${l}%;top:${t}%\">"
     // A gutter window does not hide its overflow: the pixels outside the box are the component's
@@ -5349,16 +5349,19 @@ ${captureControlsHtml().prependIndent("          ")}
     //
     // Derived rather than plumbed: the window's aspect ratio is `boxW/boxH` at every scale, so the
     // native height is `natBoxW * boxH / boxW`. That keeps `ContentCrop`'s published shape alone.
-    val natBoxH = if (crop.boxW > 0) (crop.natBoxW.toLong() * crop.boxH / crop.boxW).toInt() else 0
+    val natBoxH =
+      if (crop.window.w > 0) (crop.nativeWindowW.toLong() * crop.window.h / crop.window.w).toInt()
+      else 0
     val sizing =
-      if (crop.natBoxW > 0 && crop.natCapAxis > 0) {
-        "--cp-crop-w-per-cap:${cropRatio(crop.natBoxW, crop.natCapAxis)};" +
-          (if (natBoxH > 0) "--cp-crop-w-per-h:${cropRatio(crop.natBoxW, natBoxH)};" else "") +
-          "--cp-crop-max-w:${crop.natBoxW}px"
+      if (crop.nativeWindowW > 0 && crop.nativeCapAxis > 0) {
+        "--cp-crop-w-per-cap:${cropRatio(crop.nativeWindowW, crop.nativeCapAxis)};" +
+          (if (natBoxH > 0) "--cp-crop-w-per-h:${cropRatio(crop.nativeWindowW, natBoxH)};"
+          else "") +
+          "--cp-crop-max-w:${crop.nativeWindowW}px"
       } else {
-        "width:${crop.boxW}px"
+        "width:${crop.window.w}px"
       }
-    return "<span class=\"$cls\" style=\"$sizing;aspect-ratio:${crop.boxW}/${crop.boxH}\">$cropped</span>"
+    return "<span class=\"$cls\" style=\"$sizing;aspect-ratio:${crop.window.w}/${crop.window.h}\">$cropped</span>"
   }
 
   /**

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.CropOffset
+import ee.schimke.composeai.imagecrop.CropSize
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -582,17 +584,14 @@ class ServeBundleHostTest {
 
     assertEquals(
       ContentCrop(
-        boxW = 249,
-        boxH = 126,
-        imgW = 271,
-        imgH = 150,
-        left = -11,
-        top = -11,
+        window = CropSize(249, 126),
+        render = CropSize(271, 150),
+        offset = CropOffset(-11, -11),
         clip = false,
         // The native box and the capped axis (height, for a gutter crop) ride along, so the page
         // can re-derive the window's width for a narrower viewport's cap (#4544).
-        natBoxW = 249,
-        natCapAxis = 126,
+        nativeWindowW = 249,
+        nativeCapAxis = 126,
       ),
       crop,
     )
@@ -637,11 +636,11 @@ class ServeBundleHostTest {
 
     val crop = ServeBundleHost(dir, label = "b").contentCrop("sticker__ideal__rtl")
 
-    assertEquals(184, crop?.boxW) // 200 - 4 - 12, whichever way round
-    assertEquals(94, crop?.boxH)
+    assertEquals(184, crop?.window?.w) // 200 - 4 - 12, whichever way round
+    assertEquals(94, crop?.window?.h)
     // …but the render is offset by the RIGHT-hand 12, not by the declared `start`.
-    assertEquals(-12, crop?.left)
-    assertEquals(-1, crop?.top)
+    assertEquals(-12, crop?.offset?.left)
+    assertEquals(-1, crop?.offset?.top)
   }
 
   @Test
@@ -664,7 +663,7 @@ class ServeBundleHostTest {
 
     val host = ServeBundleHost(dir, label = "b", figmaDir = figma)
     val first = host.contentCrop("sticker__ideal__default")
-    assertEquals(192, first?.boxW)
+    assertEquals(192, first?.window?.w)
 
     // The vector lands: its box (not the gutter's) now decides, which could not happen if the
     // first answer had been cached.
@@ -674,8 +673,8 @@ class ServeBundleHostTest {
     // The vector's own box, NOT unioned with the render's drawn extent: on a guttered render that
     // extent includes the shadow the gutter reserved room for, and unioning it would grow the
     // window past the component and draw it smaller than its siblings. It bleeds instead.
-    assertEquals(40, second?.boxW)
-    assertEquals(20, second?.boxH)
+    assertEquals(40, second?.window?.w)
+    assertEquals(20, second?.window?.h)
     assertEquals(false, second?.clip)
   }
 }

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
@@ -4,6 +4,8 @@ import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.CropOffset
+import ee.schimke.composeai.imagecrop.CropSize
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
@@ -105,7 +107,12 @@ class ServeHeroImagesTest {
         g.fillRect(100, 150, 80, 40)
         g.dispose()
       }
-    val crop = ContentCrop(boxW = 80, boxH = 40, imgW = 400, imgH = 400, left = -100, top = -150)
+    val crop =
+      ContentCrop(
+        window = CropSize(80, 40),
+        render = CropSize(400, 400),
+        offset = CropOffset(-100, -150),
+      )
     val hero = ServeHeroImages().bake(source, crop)!!
     assertEquals(80, hero.cssWidth, "laid out at the component box, not the canvas")
     assertEquals(40, hero.cssHeight)
@@ -246,7 +253,11 @@ class ServeHeroImagesTest {
     // at a full, uncropped render the moment the visitor picks a declared theme — the page's clip
     // window has to keep framing both identically.
     val crop =
-      ContentCrop(boxW = 1000, boxH = 1000, imgW = 2000, imgH = 2000, left = -500, top = -500)
+      ContentCrop(
+        window = CropSize(1000, 1000),
+        render = CropSize(2000, 2000),
+        offset = CropOffset(-500, -500),
+      )
     val baked = decode(ServeHeroImages().bakeGridThumb(uiPng(2000, 2000), crop)!!.bytes)
     // The visible region — not the canvas — is what lands at the cap, so the cropped component is
     // as crisp as an uncropped one; the canvas around it rides along at the same scale.

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.CropOffset
+import ee.schimke.composeai.imagecrop.CropSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -21,14 +23,11 @@ class ServeWebGridThumbnailTest {
 
   private val crop =
     ContentCrop(
-      boxW = 120,
-      boxH = 48,
-      imgW = 454,
-      imgH = 454,
-      left = -167,
-      top = -203,
-      natBoxW = 120,
-      natCapAxis = 120,
+      window = CropSize(120, 48),
+      render = CropSize(454, 454),
+      offset = CropOffset(-167, -203),
+      nativeWindowW = 120,
+      nativeCapAxis = 120,
     )
 
   private fun page(

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.imagecrop.ContentCrop
+import ee.schimke.composeai.imagecrop.CropOffset
+import ee.schimke.composeai.imagecrop.CropSize
 import ee.schimke.composeai.imagecrop.computeGutterCrop
 import ee.schimke.composeai.imagecrop.computeThumbCrop
 import kotlin.test.Test
@@ -21,14 +23,11 @@ class ServeWebThumbCropTest {
     listOf(ServePreview(id = "filled-button__ideal__default__compact", label = "Filled"))
   private val crop =
     ContentCrop(
-      boxW = 120,
-      boxH = 48,
-      imgW = 454,
-      imgH = 454,
-      left = -167,
-      top = -203,
-      natBoxW = 120,
-      natCapAxis = 120,
+      window = CropSize(120, 48),
+      render = CropSize(454, 454),
+      offset = CropOffset(-167, -203),
+      nativeWindowW = 120,
+      nativeCapAxis = 120,
     )
 
   @Test
@@ -167,7 +166,11 @@ class ServeWebThumbCropTest {
   @Test
   fun `a crop with no native size keeps the fixed-px window`() {
     val handmade =
-      ContentCrop(boxW = 120, boxH = 48, imgW = 454, imgH = 454, left = -167, top = -203)
+      ContentCrop(
+        window = CropSize(120, 48),
+        render = CropSize(454, 454),
+        offset = CropOffset(-167, -203),
+      )
     val html =
       ServeWeb.landingPage(
         "wear-m3",

--- a/common/image-crop/api/common-image-crop.api
+++ b/common/image-crop/api/common-image-crop.api
@@ -16,29 +16,23 @@ public final class ee/schimke/composeai/imagecrop/ContentBox {
 }
 
 public final class ee/schimke/composeai/imagecrop/ContentCrop {
-	public fun <init> (IIIIIIZII)V
-	public synthetic fun <init> (IIIIIIZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun component3 ()I
-	public final fun component4 ()I
+	public fun <init> (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)V
+	public synthetic fun <init> (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/imagecrop/CropSize;
+	public final fun component2 ()Lee/schimke/composeai/imagecrop/CropSize;
+	public final fun component3 ()Lee/schimke/composeai/imagecrop/CropOffset;
+	public final fun component4 ()Z
 	public final fun component5 ()I
 	public final fun component6 ()I
-	public final fun component7 ()Z
-	public final fun component8 ()I
-	public final fun component9 ()I
-	public final fun copy (IIIIIIZII)Lee/schimke/composeai/imagecrop/ContentCrop;
-	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentCrop;IIIIIIZIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public final fun copy (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentCrop;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBoxH ()I
-	public final fun getBoxW ()I
 	public final fun getClip ()Z
-	public final fun getImgH ()I
-	public final fun getImgW ()I
-	public final fun getLeft ()I
-	public final fun getNatBoxW ()I
-	public final fun getNatCapAxis ()I
-	public final fun getTop ()I
+	public final fun getNativeCapAxis ()I
+	public final fun getNativeWindowW ()I
+	public final fun getOffset ()Lee/schimke/composeai/imagecrop/CropOffset;
+	public final fun getRender ()Lee/schimke/composeai/imagecrop/CropSize;
+	public final fun getWindow ()Lee/schimke/composeai/imagecrop/CropSize;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -54,5 +48,31 @@ public final class ee/schimke/composeai/imagecrop/ContentCropGeometryKt {
 	public static synthetic fun pngAlphaBounds$default ([BIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentBox;
 	public static final fun svgContentBox (Ljava/lang/String;)Lee/schimke/composeai/imagecrop/ContentBox;
 	public static final fun union (Lee/schimke/composeai/imagecrop/ContentBox;Lee/schimke/composeai/imagecrop/ContentBox;)Lee/schimke/composeai/imagecrop/ContentBox;
+}
+
+public final class ee/schimke/composeai/imagecrop/CropOffset {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/imagecrop/CropOffset;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/CropOffset;IIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/CropOffset;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLeft ()I
+	public final fun getTop ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/imagecrop/CropSize {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/imagecrop/CropSize;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/CropSize;IIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/CropSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getH ()I
+	public final fun getW ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
+++ b/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
@@ -22,16 +22,34 @@ import kotlin.math.roundToInt
  * [computeThumbCrop] returns `null` (no-op) for them — only the framed-in-a-canvas stickers get
  * cropped.
  */
+/** A width/height pair, in the crop's output pixels. */
+public data class CropSize(val w: Int, val h: Int)
+
+/**
+ * Where the render sits under the clip window, in the crop's output pixels.
+ *
+ * Normally NEGATIVE on both axes: the window's origin is the component's top-left, so the render
+ * has to be shifted up and left to bring that corner to it.
+ */
+public data class CropOffset(val left: Int, val top: Int)
+
+/**
+ * A clip window over a render, and the render's position under it.
+ *
+ * Grouped rather than flat, and that is the point: this carried six bare `Int`s in a row — window
+ * width and height, render width and height, and the two offsets — so any permutation of them
+ * compiled. It is a published contract that an extracted preview server will build catalog pages
+ * from, and a transposed pair there is a silently wrong crop rather than a build failure.
+ * [CropSize] and [CropOffset] make the transposition a type error; the two dimensions left inside
+ * each of them are in the conventional order and mean the same kind of thing.
+ */
 public data class ContentCrop(
-  /** Clip-window size (px) — the component box scaled to fit [CAP]. */
-  val boxW: Int,
-  val boxH: Int,
-  /** The full render `<img>` size (px) at the same scale; larger than the box, clipped by it. */
-  val imgW: Int,
-  val imgH: Int,
-  /** Negative offsets that shift the render so the component's top-left meets the clip origin. */
-  val left: Int,
-  val top: Int,
+  /** Clip-window size — the component box scaled to fit [CAP]. */
+  val window: CropSize,
+  /** The full render `<img>` size at the same scale; larger than the window, clipped by it. */
+  val render: CropSize,
+  /** The shift that brings the component's top-left to the window origin. */
+  val offset: CropOffset,
   /**
    * Whether what falls outside the window is hidden.
    *
@@ -44,17 +62,17 @@ public data class ContentCrop(
    */
   val clip: Boolean = true,
   /**
-   * The box width in NATIVE render pixels — the window's 1x ceiling, before [CAP] is applied. Zero
-   * when unknown (a hand-assembled crop), which makes the page fall back to a fixed-px window.
+   * The window width in NATIVE render pixels — its 1x ceiling, before [CAP] is applied. Zero when
+   * unknown (a hand-assembled crop), which makes the page fall back to a fixed-px window.
    */
-  val natBoxW: Int = 0,
+  val nativeWindowW: Int = 0,
   /**
    * The native length of the axis [CAP] bounds — the largest edge for a content crop, the height
-   * for a gutter crop. With [natBoxW] this is enough to re-derive the window's width for ANY cap,
-   * which is what lets the stylesheet shrink it at a narrow viewport (`width = natBoxW * min(1, cap
-   * / natCapAxis)`). Zero when unknown.
+   * for a gutter crop. With [nativeWindowW] this is enough to re-derive the window's width for ANY
+   * cap, which is what lets the stylesheet shrink it at a narrow viewport (`width = nativeWindowW *
+   * min(1, cap / nativeCapAxis)`). Zero when unknown.
    */
-  val natCapAxis: Int = 0,
+  val nativeCapAxis: Int = 0,
 )
 
 /** Largest edge (px) a cropped thumbnail is scaled to — mirrors the static gallery's `cap`. */
@@ -203,15 +221,13 @@ public fun computeGutterCrop(
   // live in CSS: constraining its height there squashes the box rather than scaling it.
   val scale = min(1.0, cap / boxH.toDouble())
   return ContentCrop(
-    boxW = max(1, (boxW * scale).roundToInt()),
-    boxH = max(1, (boxH * scale).roundToInt()),
-    imgW = (renderW * scale).roundToInt(),
-    imgH = (renderH * scale).roundToInt(),
-    left = (-left * scale).roundToInt(),
-    top = (-top * scale).roundToInt(),
+    window =
+      CropSize(w = max(1, (boxW * scale).roundToInt()), h = max(1, (boxH * scale).roundToInt())),
+    render = CropSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
+    offset = CropOffset(left = (-left * scale).roundToInt(), top = (-top * scale).roundToInt()),
     clip = false,
-    natBoxW = boxW,
-    natCapAxis = boxH,
+    nativeWindowW = boxW,
+    nativeCapAxis = boxH,
   )
 }
 
@@ -230,14 +246,12 @@ public fun computeThumbCrop(
   // Don't upscale past 1× — a tiny component shows at its native pixels, not blown up.
   val scale = min(1.0, cap / max(box.w, box.h).toDouble())
   return ContentCrop(
-    boxW = max(1, (box.w * scale).roundToInt()),
-    boxH = max(1, (box.h * scale).roundToInt()),
-    imgW = (renderW * scale).roundToInt(),
-    imgH = (renderH * scale).roundToInt(),
-    // `left`/`top` are the render's offset under the clip window: negative of the box origin.
-    left = (-box.x * scale).roundToInt(),
-    top = (-box.y * scale).roundToInt(),
-    natBoxW = box.w,
-    natCapAxis = max(box.w, box.h),
+    window =
+      CropSize(w = max(1, (box.w * scale).roundToInt()), h = max(1, (box.h * scale).roundToInt())),
+    render = CropSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
+    // The offset is the render's position under the clip window: negative of the box origin.
+    offset = CropOffset(left = (-box.x * scale).roundToInt(), top = (-box.y * scale).roundToInt()),
+    nativeWindowW = box.w,
+    nativeCapAxis = max(box.w, box.h),
   )
 }

--- a/common/image-crop/src/test/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometryTest.kt
+++ b/common/image-crop/src/test/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometryTest.kt
@@ -30,13 +30,13 @@ class ServeThumbCropTest {
     val crop = computeThumbCrop(svg("0 0 120 48", "translate(-167, -203)"), 454, 454)
     assertNotNull(crop)
     // maxEdge 120 < cap 240 → scale clamps to 1 (no upscaling).
-    assertEquals(120, crop.boxW)
-    assertEquals(48, crop.boxH)
-    assertEquals(454, crop.imgW)
-    assertEquals(454, crop.imgH)
+    assertEquals(120, crop.window.w)
+    assertEquals(48, crop.window.h)
+    assertEquals(454, crop.render.w)
+    assertEquals(454, crop.render.h)
     // Negative offsets shift the render so the component's top-left meets the clip origin.
-    assertEquals(-167, crop.left)
-    assertEquals(-203, crop.top)
+    assertEquals(-167, crop.offset.left)
+    assertEquals(-203, crop.offset.top)
   }
 
   @Test
@@ -53,24 +53,24 @@ class ServeThumbCropTest {
     val crop = computeThumbCrop(svg("0 0 300 100", "translate(-150, -250)"), 600, 600)
     assertNotNull(crop)
     // scale = 240 / max(300,100) = 0.8
-    assertEquals(240, crop.boxW) // 300 * 0.8
+    assertEquals(240, crop.window.w) // 300 * 0.8
     // The NATIVE box and the axis the cap acted on travel with the crop, so the page can re-derive
     // the window's width for a different cap (the narrow-viewport one) instead of freezing 240px.
-    assertEquals(300, crop.natBoxW)
-    assertEquals(300, crop.natCapAxis) // largest edge
-    assertEquals(80, crop.boxH) //  100 * 0.8
-    assertEquals(480, crop.imgW) // 600 * 0.8
-    assertEquals(480, crop.imgH)
-    assertEquals(-120, crop.left) // -150 * 0.8
-    assertEquals(-200, crop.top) // -250 * 0.8
+    assertEquals(300, crop.nativeWindowW)
+    assertEquals(300, crop.nativeCapAxis) // largest edge
+    assertEquals(80, crop.window.h) //  100 * 0.8
+    assertEquals(480, crop.render.w) // 600 * 0.8
+    assertEquals(480, crop.render.h)
+    assertEquals(-120, crop.offset.left) // -150 * 0.8
+    assertEquals(-200, crop.offset.top) // -250 * 0.8
   }
 
   @Test
   fun `a missing translate defaults the component box to the render origin`() {
     val crop = computeThumbCrop(svg("0 0 120 48", null), 454, 454)
     assertNotNull(crop)
-    assertEquals(0, crop.left)
-    assertEquals(0, crop.top)
+    assertEquals(0, crop.offset.left)
+    assertEquals(0, crop.offset.top)
   }
 
   @Test
@@ -126,10 +126,10 @@ class ServeThumbCropTest {
     val crop = computeThumbCrop(svg("0 0 166 136", "translate(-144, -159)"), 454, 454, alpha)
     assertNotNull(crop)
     // Box grew to the unioned 175×145 (< cap 240 → scale 1); origin is the unioned top-left.
-    assertEquals(175, crop.boxW)
-    assertEquals(145, crop.boxH)
-    assertEquals(-140, crop.left)
-    assertEquals(-155, crop.top)
+    assertEquals(175, crop.window.w)
+    assertEquals(145, crop.window.h)
+    assertEquals(-140, crop.offset.left)
+    assertEquals(-155, crop.offset.top)
   }
 
   @Test
@@ -138,10 +138,10 @@ class ServeThumbCropTest {
     val alpha = pngAlphaBounds(opaqueRectPng(x = 170, y = 210, w = 100, h = 40))
     val crop = computeThumbCrop(svg("0 0 120 48", "translate(-167, -203)"), 454, 454, alpha)
     assertNotNull(crop)
-    assertEquals(120, crop.boxW)
-    assertEquals(48, crop.boxH)
-    assertEquals(-167, crop.left)
-    assertEquals(-203, crop.top)
+    assertEquals(120, crop.window.w)
+    assertEquals(48, crop.window.h)
+    assertEquals(-167, crop.offset.left)
+    assertEquals(-203, crop.offset.top)
   }
 
   @Test
@@ -166,14 +166,14 @@ class ServeThumbCropTest {
     // (m3-catalog#179). Subtracting the gutter gives the sibling's box back, to the pixel.
     val crop = computeGutterCrop(11, 11, 11, 13, 271, 150)
     assertNotNull(crop)
-    assertEquals(249, crop.boxW)
-    assertEquals(126, crop.boxH)
-    assertEquals(271, crop.imgW)
-    assertEquals(150, crop.imgH)
-    assertEquals(-11, crop.left)
-    assertEquals(-11, crop.top)
-    assertEquals(249, crop.natBoxW)
-    assertEquals(126, crop.natCapAxis) // a gutter crop caps on HEIGHT, not the largest edge
+    assertEquals(249, crop.window.w)
+    assertEquals(126, crop.window.h)
+    assertEquals(271, crop.render.w)
+    assertEquals(150, crop.render.h)
+    assertEquals(-11, crop.offset.left)
+    assertEquals(-11, crop.offset.top)
+    assertEquals(249, crop.nativeWindowW)
+    assertEquals(126, crop.nativeCapAxis) // a gutter crop caps on HEIGHT, not the largest edge
     // The shadow lives in those 11px, so the window lines the box up without hiding what spills.
     assertFalse(crop.clip)
   }
@@ -188,8 +188,8 @@ class ServeThumbCropTest {
     val crop = computeGutterCrop(4, 4, 4, 4, 400, 400)
     assertNotNull(crop)
     // 392 tall is past the 240 cap, so the box comes back scaled — square in, square out.
-    assertEquals(240, crop.boxW)
-    assertEquals(240, crop.boxH)
+    assertEquals(240, crop.window.w)
+    assertEquals(240, crop.window.h)
   }
 
   @Test
@@ -200,12 +200,12 @@ class ServeThumbCropTest {
     // an aspect-ratio, and constraining its height there squashes it instead of scaling it.)
     val crop = computeGutterCrop(11, 11, 11, 11, 967, 1282)
     assertNotNull(crop)
-    assertEquals(180, crop.boxW)
-    assertEquals(240, crop.boxH)
-    assertEquals(184, crop.imgW)
-    assertEquals(244, crop.imgH)
-    assertEquals(-2, crop.left)
-    assertEquals(-2, crop.top)
+    assertEquals(180, crop.window.w)
+    assertEquals(240, crop.window.h)
+    assertEquals(184, crop.render.w)
+    assertEquals(244, crop.render.h)
+    assertEquals(-2, crop.offset.left)
+    assertEquals(-2, crop.offset.top)
   }
 
   @Test
@@ -215,8 +215,8 @@ class ServeThumbCropTest {
     // 3.6% smaller than the four beside it: the very mismatch this window removes.
     val crop = computeGutterCrop(11, 11, 11, 13, 271, 150)
     assertNotNull(crop)
-    assertEquals(249, crop.boxW)
-    assertEquals(126, crop.boxH)
+    assertEquals(249, crop.window.w)
+    assertEquals(126, crop.window.h)
   }
 
   @Test

--- a/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
+++ b/data/pseudolocale/connector/src/main/kotlin/ee/schimke/composeai/daemon/PseudolocaleResources.kt
@@ -89,15 +89,14 @@ internal class PseudolocaleResources(private val base: Resources, private val mo
     if (raw !is Spanned) return Pseudolocalizer.transform(raw.toString(), mode)
     val transformed = Pseudolocalizer.transformWithIndices(raw.toString(), mode)
     val sb = SpannableStringBuilder(transformed.text)
-    val map = transformed.indexMap
     val length = raw.length
     val outText = transformed.text
     for (span in raw.getSpans(0, length, Any::class.java)) {
       val srcStart = raw.getSpanStart(span).coerceIn(0, length)
       val srcEnd = raw.getSpanEnd(span).coerceIn(srcStart, length)
       val flags = raw.getSpanFlags(span)
-      var dstStart = map[srcStart]
-      var dstEnd = map[srcEnd]
+      var dstStart = transformed.indexAt(srcStart)
+      var dstEnd = transformed.indexAt(srcEnd)
       // SPAN_PARAGRAPH spans (BulletSpan, LeadingMarginSpan, …) must start at 0 or right after a
       // `\n`, and end at length or right after a `\n`. The transform prepends marker characters
       // (`[` in accent mode, RLO in bidi) which would shift a span starting at input 0 to output

--- a/data/pseudolocale/core/api/data-pseudolocale-core.api
+++ b/data/pseudolocale/core/api/data-pseudolocale-core.api
@@ -28,8 +28,8 @@ public final class ee/schimke/composeai/data/pseudolocale/Pseudolocalizer {
 }
 
 public final class ee/schimke/composeai/data/pseudolocale/Pseudolocalizer$TransformResult {
-	public fun <init> (Ljava/lang/String;[I)V
-	public final fun getIndexMap ()[I
+	public final fun getSize ()I
 	public final fun getText ()Ljava/lang/String;
+	public final fun indexAt (I)I
 }
 

--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
@@ -34,7 +34,24 @@ public object Pseudolocalizer {
    * before transformation and any preview using bold / annotation / URLSpan resources would render
    * unstyled — see `PseudolocaleResources` in `:data-pseudolocale-connector`.
    */
-  public class TransformResult(public val text: String, public val indexMap: IntArray)
+  public class TransformResult
+  internal constructor(public val text: String, private val indices: IntArray) {
+
+    /** Number of source indices mapped — one more than the input's length, so an end index maps. */
+    public val size: Int
+      get() = indices.size
+
+    /**
+     * Where source index [sourceIndex] landed in [text].
+     *
+     * A method rather than the `IntArray` itself: handing out the array published a mutable
+     * reference to this result's own state, so any caller could rewrite another caller's mapping.
+     * Returning a defensive copy from a getter would be worse — `result.indexMap[i]` in a loop
+     * would copy the whole array per iteration — so the array stays private and the lookup is the
+     * API.
+     */
+    public fun indexAt(sourceIndex: Int): Int = indices[sourceIndex]
+  }
 
   public fun accent(input: CharSequence): String = transform(input.toString(), Pseudolocale.ACCENT)
 

--- a/data/pseudolocale/core/src/test/kotlin/ee/schimke/composeai/data/pseudolocale/PseudolocalizerTest.kt
+++ b/data/pseudolocale/core/src/test/kotlin/ee/schimke/composeai/data/pseudolocale/PseudolocalizerTest.kt
@@ -57,34 +57,34 @@ class PseudolocalizerTest {
     val result = Pseudolocalizer.transformWithIndices("Hello", Pseudolocale.ACCENT)
     assertTrue("output starts with [: ${result.text}", result.text.startsWith("["))
     // Input 0 (`H`) should map to output position 1 (right after `[`).
-    assertEquals(1, result.indexMap[0])
+    assertEquals(1, result.indexAt(0))
     // Input 4 (`o`) should map to output position 5.
-    assertEquals(5, result.indexMap[4])
+    assertEquals(5, result.indexAt(4))
     // End-of-input (5) maps to position 6 — the slot right after `o`, before space + dots + `]`.
-    assertEquals(6, result.indexMap[5])
+    assertEquals(6, result.indexAt(5))
     // The character at the end-of-input slot should be the accented form of `o` — padding
     // intervenes between this slot and the closing `]`.
-    assertEquals('ö', result.text[result.indexMap[5] - 1])
+    assertEquals('ö', result.text[result.indexAt(5) - 1])
   }
 
   @Test
   fun `accent indexMap respects placeholder preservation`() {
     val result = Pseudolocalizer.transformWithIndices("a%1\$sb", Pseudolocale.ACCENT)
     // Input index 0 (`a`) → after `[`.
-    assertEquals(1, result.indexMap[0])
+    assertEquals(1, result.indexAt(0))
     // Input index 5 (`b`) sits after the 4-char `%1\$s` placeholder copied verbatim — output
     // position should be 1 (open bracket) + 1 (accented `a`) + 4 (placeholder) = 6.
-    assertEquals(6, result.indexMap[5])
+    assertEquals(6, result.indexAt(5))
   }
 
   @Test
   fun `bidi indexMap maps word chars to positions inside RLO PDF wrap`() {
     val result = Pseudolocalizer.transformWithIndices("hi", Pseudolocale.BIDI)
     // Output is RLO `h` `i` PDF — input 0 (`h`) → output 1, input 1 (`i`) → output 2.
-    assertEquals(1, result.indexMap[0])
-    assertEquals(2, result.indexMap[1])
+    assertEquals(1, result.indexAt(0))
+    assertEquals(2, result.indexAt(1))
     // End-of-input (2) → after PDF (4).
-    assertEquals(4, result.indexMap[2])
+    assertEquals(4, result.indexAt(2))
   }
 
   @Test
@@ -97,12 +97,12 @@ class PseudolocalizerTest {
     //   3 → 6 (`y`)
     //   4 → 7 (`o`)
     //   5 → 9 (after PDF)
-    assertEquals(1, result.indexMap[0])
-    assertEquals(2, result.indexMap[1])
-    assertEquals(4, result.indexMap[2])
-    assertEquals(6, result.indexMap[3])
-    assertEquals(7, result.indexMap[4])
-    assertEquals(9, result.indexMap[5])
+    assertEquals(1, result.indexAt(0))
+    assertEquals(2, result.indexAt(1))
+    assertEquals(4, result.indexAt(2))
+    assertEquals(6, result.indexAt(3))
+    assertEquals(7, result.indexAt(4))
+    assertEquals(9, result.indexAt(5))
   }
 
   @Test

--- a/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
+++ b/render-session/api/src/main/kotlin/ee/schimke/composeai/render/session/RenderSession.kt
@@ -36,6 +36,21 @@ import kotlinx.serialization.json.JsonObject
  * host the renderer — most commonly as a daemon subprocess driven over JSON-RPC, but a future
  * in-process embedded driver presents the same contract.
  *
+ * ## `Duration` and the mangled JVM names
+ *
+ * Every method here that takes a `timeout: Duration` compiles to a mangled JVM name —
+ * `renderNow-9VgGkz4`, `historyDiff-Wn2Vu4Y` — because `kotlin.time.Duration` is a value class. Two
+ * consequences worth knowing before changing a signature:
+ *
+ * - The methods are **not callable from Java**: `-` is not legal in a Java identifier. That is
+ *   accepted, not overlooked. This is a Kotlin-first library with no Java consumer, and the
+ *   alternative — `timeoutMillis: Long` across seventeen call sites — would make the API worse for
+ *   every real caller to serve a hypothetical one.
+ * - The suffix is a hash of the value-class parameters, so **swapping one value class for another
+ *   renames the method**. A binary-incompatible change of that kind shows up in the ABI dump as a
+ *   removed method plus an added one rather than as a changed signature; read it as the break it
+ *   is, not as a rename.
+ *
  * ## Lifecycle
  *
  * A session is born *initialized*: [RenderSessionFactory] performs the renderer-side `initialize`

--- a/render-session/subprocess/api/render-session-subprocess.api
+++ b/render-session/subprocess/api/render-session-subprocess.api
@@ -40,11 +40,9 @@ public final class ee/schimke/composeai/render/session/subprocess/SubprocessRend
 	public static final field INSTANCE Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;
 	public final fun descriptorFile (Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
 	public fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
-	public final fun getFileSystem ()Lokio/FileSystem;
 	public fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;)Lee/schimke/composeai/render/session/RenderSession;
 	public final fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
 	public final fun openBundleDaemon-w3P_Jxs (Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
 	public static synthetic fun openBundleDaemon-w3P_Jxs$default (Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;ILjava/lang/Object;)Lee/schimke/composeai/render/session/RenderSession;
-	public final fun setFileSystem (Lokio/FileSystem;)V
 }
 

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -29,7 +29,11 @@ import okio.Path.Companion.toPath
 public object SubprocessRenderSessions : RenderSessionFactory {
   override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
-  public var fileSystem: FileSystem = SystemFileSystem
+  // Private, not a published seam. This was a `public var` on a published singleton — a
+  // process-wide mutable global any consumer could swap — and nothing in the repository ever
+  // assigned it, here or in tests. A test hook nobody uses is not worth exporting from a contract
+  // module: the injectable seam that IS used is the `DaemonClientFactory` overload of `open`.
+  private val fileSystem: FileSystem = SystemFileSystem
 
   override fun open(config: RenderSessionConfig): RenderSession =
     open(config = config, factory = SubprocessDaemonClientFactory())


### PR DESCRIPTION
The four items from the API review. **Three fixed, one deliberately not** — reasoning below.

These are contracts an extracted preview server compiles against across a repo boundary. Fixing them after the split means coordinating two repositories; fixing them now costs one commit.

## `ContentCrop` took six bare `Int`s in a row

Window width and height, render width and height, and two offsets — so `ContentCrop(1,2,3,4,5,6,…)` compiled under any permutation, and a transposition is a silently wrong crop rather than a build failure.

Every call site today passes them by name, which is why nothing is broken. The hazard is the *next* caller, and after the split that caller is in another repository.

Grouped into `CropSize` and `CropOffset`, which makes a transposition a type error. `natBoxW` / `natCapAxis` are spelled out as `nativeWindowW` / `nativeCapAxis`.

```kotlin
ContentCrop(
  window = CropSize(249, 126),
  render = CropSize(271, 150),
  offset = CropOffset(-11, -11),
  clip = false,
  nativeWindowW = 249,
  nativeCapAxis = 126,
)
```

## `SubprocessRenderSessions.fileSystem` was a `public var` on a published singleton

A process-wide mutable global any consumer could swap. **Nothing in the repository ever assigned it** — not production, not tests. A test hook nobody uses is not worth exporting from a contract module; the injectable seam that *is* used is the `DaemonClientFactory` overload of `open`. Now private.

## `TransformResult.indexMap` handed out its own `IntArray`

So a caller could rewrite another caller's mapping. Returning a defensive copy from a getter would be **worse** — `result.indexMap[i]` in a loop would copy the whole array per iteration — so the array is private and `indexAt(sourceIndex)` is the API.

## Not changed: the `Duration` mangling

Every `RenderSession` method taking `timeout: Duration` compiles to a mangled JVM name (`renderNow-9VgGkz4`) and is uncallable from Java, since `-` is not a legal Java identifier.

I raised this one and I'm declining to "fix" it. The fix is `timeoutMillis: Long` across **seventeen** signatures — worse for every real caller, in a Kotlin-first library, to serve a Java consumer that does not exist (the three Java files in this repo are Robolectric stubs and a native loader; none touch `RenderSession`). Making the API worse to close a finding would be the wrong trade.

What was genuinely missing is that the trade-off was undocumented, and so was the sharper consequence: **the mangled suffix hashes the value-class parameters, so swapping one value class for another renames the method** — a binary break that shows up in the ABI dump as a removal plus an addition rather than a changed signature. Both are now stated on the interface. Say the word if you'd rather have the `Long` signatures.

## Test plan

- `:common-image-crop:check`, `:data-pseudolocale-core:check` (both include `checkKotlinAbi`), `:cli:serve:test`, `:cli:test`, `:render-session-api:check` — all green.
- Compiles clean: `:common-image-crop`, `:render-session-subprocess`, `:cli`, `:cli:serve` (main + test).
- `check-contract-registration.py` — 19 contracts. `check-serve-seam.py` OK. `check-preview-server-contracts.sh` — 19 contracts resolved, 0 leaks.
- `ktfmtCheckAll` clean. ABI dumps regenerated for the three changed modules.
- The `.left` / `.top` rewrites were done from the **compiler's** list of unresolved references, not by a name sweep — those names exist on other types, and a sweep on this codebase has produced compiling-but-wrong edits before (#4634).

**One pre-existing failure, not from this change:** `:render-session-subprocess:test → NonGradleContractTest` fails in my sandbox with `InvalidPathException: Malformed input or input contains unmappable characters` on a render filename containing an em-dash. I reproduced it identically on a pristine checkout of `origin/main` before concluding it was not mine — it is a non-UTF-8 filesystem encoding in this container, and CI runs UTF-8.

Non-visual: type shapes and a doc note. The crop *arithmetic* is untouched — same values, differently grouped — and the serve thumbnail/hero tests that assert on rendered crop geometry pass unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_