### PR TITLE
fix(bundle-format): record the Manifest's new field in the ABI dump

### DIFF
--- a/bundle/format/api/bundle-format.api
+++ b/bundle/format/api/bundle-format.api
@@ -401,16 +401,17 @@ public final class ee/schimke/composeai/bundle/BundleReader$ExternalResource$Com
 
 public final class ee/schimke/composeai/bundle/BundleReader$Manifest {
 	public static final field Companion Lee/schimke/composeai/bundle/BundleReader$Manifest$Companion;
-	public fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/util/List;
-	public final fun component12 ()Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
-	public final fun component13 ()Ljava/util/List;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
 	public final fun component14 ()Ljava/util/List;
 	public final fun component15 ()Ljava/util/List;
 	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/String;
@@ -419,8 +420,8 @@ public final class ee/schimke/composeai/bundle/BundleReader$Manifest {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
-	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$Manifest;ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public final fun copy (ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
+	public static synthetic fun copy$default (Lee/schimke/composeai/bundle/BundleReader$Manifest;ILjava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lee/schimke/composeai/bundle/BundleReader$AndroidResources;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/bundle/BundleReader$Manifest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAndroidResources ()Lee/schimke/composeai/bundle/BundleReader$AndroidResources;
 	public final fun getBackend ()Ljava/lang/String;
@@ -430,6 +431,7 @@ public final class ee/schimke/composeai/bundle/BundleReader$Manifest {
 	public final fun getExternalClasspath ()Ljava/util/List;
 	public final fun getExternalResources ()Ljava/util/List;
 	public final fun getIntermediateRepresentations ()Ljava/util/List;
+	public final fun getModuleDirectory ()Ljava/lang/String;
 	public final fun getModulePath ()Ljava/lang/String;
 	public final fun getPreviewIds ()Ljava/util/List;
 	public final fun getProducedBy ()Ljava/lang/String;


### PR DESCRIPTION
`main` is red on `:bundle-format:checkKotlinAbi`.

#4690 added a field to `BundleReader.Manifest` without regenerating the dump, so the recorded constructor and `componentN` accessors are one parameter behind the source. The check fails on `main` and on every branch that merges it.

Nine lines from `:bundle-format:updateLegacyAbi`, not written by hand. Confirmed against `origin/main`'s own recorded dump before attributing it; `checkKotlinAbi` exits 0 on this branch.

## Third one today, which is the part worth reading

| PR | module | introduced by |
| --- | --- | --- |
| #4673 | `bundle-format` | #4662 |
| #4685 | `data-render-core` | #4602 |
| this | `bundle-format` | #4690 |

Three in a single session is not three mistakes. **`checkKotlinAbi` is not being scheduled for the changes that move it** — a module's `check` should be selected by a change to its own sources, and if it were, none of these could have merged. I found this one only because a stale dump on an unrelated branch made me run `updateLegacyAbi` over every module, which is a poor way to discover it.

I have not touched the scheduling here — this PR is just the red build. But it is the same "a gate that exists without running" shape as the `ci-paths.json` omissions #4663, #4682 and #4688 were about, and it is worth fixing at the scheduling layer rather than one dump at a time. Happy to take that on if you want it.

## Test plan

- `:bundle-format:checkKotlinAbi` — red on `origin/main`, `BUILD SUCCESSFUL` here.

Non-visual: a generated ABI dump. No rendered output changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_