### PR TITLE
fix(ci): track the BTA types' published owner instead of hard-coding it

### DIFF
--- a/scripts/test_check_serve_seam.py
+++ b/scripts/test_check_serve_seam.py
@@ -348,10 +348,14 @@ class MappingOwnership(unittest.TestCase):
 
     Prefix matching alone accepted `ee.schimke.composeai.daemon.bta -> daemon-bta-host` purely
     because the package name resembled the module name. It does not: that package is declared by
-    BOTH `:daemon:core` and `:daemon:bta-host`, and the two types serve imports from it
-    (`BtaCompileSession`, `DiagnosticCollector`) are the `daemon-core` ones. The wrong mapping
-    invented a split blocker that does not exist, and prefix matching would have hidden a genuinely
-    new `daemon.*` package owned by a different module the same way.
+    TWO modules, and the two types serve imports from it (`BtaCompileSession`,
+    `DiagnosticCollector`) belong to the published one. The wrong mapping invented a split blocker
+    that does not exist, and prefix matching would have hidden a genuinely new `daemon.*` package
+    owned by a different module the same way.
+
+    The published owner was `:daemon:core` when this test was written and is `:daemon-bta` since
+    #4715, which split the in-process compile out. The pairing that matters is unchanged — these
+    types against the module that publishes them, never against unpublished `:daemon:bta-host`.
     """
 
     @classmethod
@@ -407,11 +411,20 @@ class MappingOwnership(unittest.TestCase):
                         mismatches.append(f"{fqn}: mapped to {want}, declared by {sorted(owners)}")
         self.assertEqual(mismatches, [], "\n".join(mismatches))
 
-    def test_the_bta_types_come_from_daemon_core(self):
-        """The specific error this test exists to prevent."""
+    def test_the_bta_types_come_from_the_published_module(self):
+        """The specific error this test exists to prevent.
+
+        Asserted against the allowlist's own mapping rather than a literal, so the next time the
+        published owner moves this fails only if the mapping and the sources disagree — which is
+        the bug — instead of failing merely because the module was renamed. #4715 moved the owner
+        from `daemon-core` to `daemon-bta` and this assertion, as a literal, went red on main.
+        """
+        mapping = mod.load_allowlist()["contractPackages"]
         for name in ("BtaCompileSession", "DiagnosticCollector"):
             fqn = f"ee.schimke.composeai.daemon.bta.{name}"
-            self.assertEqual(self.declared_by.get(fqn), {"daemon-core"}, fqn)
+            want = self.mapped_module(mod.package_of(fqn), mapping)
+            self.assertEqual(self.declared_by.get(fqn), {want}, fqn)
+            self.assertNotEqual(want, "daemon-bta-host", fqn)
 
     def test_there_is_no_unpublished_blocker_today(self):
         self.assertEqual(mod.load_allowlist()["unpublishedContracts"], {})


### PR DESCRIPTION
**`main` is red, and it is my fault.** #4715 moved `BtaCompileSession` and `DiagnosticCollector` from `:daemon:core` into the new `:daemon-bta`; `scripts/test_check_serve_seam.py` asserted `daemon-core` as a literal, so it went red the moment that PR landed. I wrote #4715 and did not update the test.

```
FAIL: test_the_bta_types_come_from_daemon_core (MappingOwnership)
AssertionError: Items in the first set but not the second: 'daemon-bta'
                Items in the second set but not the first: 'daemon-core'
                : ee.schimke.composeai.daemon.bta.BtaCompileSession
```

Reproduced on a pristine checkout of `origin/main` before fixing.

## The literal was the wrong way to say it

The invariant is **not** "these types live in `daemon-core`". It is that they belong to the module the mapping names, and specifically **not** to unpublished `:daemon:bta-host` — that package is declared by two modules, and an earlier mapping picked the wrong one, inventing a split blocker that did not exist (PR #4512 review).

A literal owner expresses that badly: it fails on a legitimate rename exactly as loudly as on the bug, which is what happened here. It now resolves through the allowlist's own `contractPackages` mapping, so it fails when the mapping and the sources **disagree** — the real defect — and stays quiet when the owner legitimately moves. The `bta-host` case it was written for is asserted explicitly rather than left implied by the literal.

## Verified the guard survived rather than got defanged

Re-introduced the original bug by mapping the package to `daemon-bta-host`:

| test | result |
| --- | --- |
| `test_the_bta_types_come_from_the_published_module` | FAIL |
| `test_each_imported_type_is_mapped_to_a_module_that_declares_it` | FAIL |
| `test_every_mapped_module_is_a_probe_contract_or_a_recorded_blocker` | FAIL |

Three independent failures on the exact mistake, so weakening the literal did not weaken the protection. 45 tests green with the mapping correct.

## How it reached main

Worth noting alongside #4717, which is open for a neighbouring problem. This test *is* scheduled for the paths #4715 touched, so unlike the three stale ABI dumps this was not a scheduling gap — the check ran. I did not verify #4715 was green before it merged, and I should have: my own test plan for that PR listed the suites I ran, and `scripts/test_check_serve_seam.py` was not among them even though the diff changed `serve-seam-allowlist.json`. Running the gates I *changed the inputs of*, rather than the ones I had in mind, is the same mistake in a different register as regenerating ABI dumps for the modules I was thinking about.

## Test plan

- `python3 scripts/test_check_serve_seam.py` — red on `origin/main`, 45 green here.
- Falsification above, run through the real allowlist.
- `check-serve-seam.py` OK; `check-contract-registration.py` OK.

Non-visual: a CI test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_