### PR TITLE
fix(serve): close the four ways a cache generation could still be ignored

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCacheGeneration.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCacheGeneration.kt
@@ -58,6 +58,9 @@ object ServeCacheGeneration {
    */
   fun normalize(raw: String?): String? = ServeCatalogRevision.normalize(raw)
 
+  /** The generation as it appears in a refusal message — the same short form a pin banner shows. */
+  fun short(commit: String): String = ServeCatalogRevision.short(commit)
+
   /**
    * Append [PARAM] to an already-built asset [link], or return it untouched.
    *

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3734,11 +3734,24 @@ class ServeHttpServer(
    * generation (a refresh restages them), so it caches like the baked PNGs do.
    */
   private suspend fun RoutingContext.handleRcCompareAsset(sessionInPath: Boolean) {
-    if (rejectBadToken()) return
+    if (rejectBadToken() || rejectMalformedGeneration()) return
     val sessionId = selectedSessionId(sessionInPath)
     val name = "${call.parameters["lane"].orEmpty()}/${call.parameters["name"].orEmpty()}"
     withLeasedSession(sessionId, onMissing = { call.respond(HttpStatusCode.NotFound) }) { renderHost
       ->
+      // The catalog restages these on refresh and keeps only the current staging, so a wall from an
+      // earlier publish has no answer here — and today's raster under that publish's printed
+      // mismatch percentage is a confident number about two pictures that were never compared.
+      // Refusing lets the page reload instead ([ServeCacheGeneration]).
+      val stale = staleGeneration(renderHost)
+      if (stale != null) {
+        call.respondText(
+          "this catalog has restaged its player comparison since " +
+            "'${ServeCacheGeneration.PARAM}=${ServeCacheGeneration.short(stale)}' — reload the page",
+          status = HttpStatusCode.Conflict,
+        )
+        return@withLeasedSession
+      }
       val bytes = renderHost.rcCompareImage(name)
       if (bytes == null) {
         call.respond(HttpStatusCode.NotFound)
@@ -3844,15 +3857,18 @@ class ServeHttpServer(
       // measured in CI over the baked render.
       //
       // This used to be necessary but NOT sufficient, and the gap was caching: an override-free
-      // baked `/render/<id>.png` was served on a lifetime of its own while this index rode in the
-      // page, so a client could pair previous-generation pixels with a freshly-fetched index. That
-      // mattered because a tag selection persists the index's bounds as the acceptance baseline —
-      // bounds from another frame surviving into a record that later reports an unchanged element
-      // as moved.
+      // baked `/render/<id>.png` was served on a lifetime of its own while this index was fetched
+      // separately, so a client could pair one generation's pixels with another generation's
+      // bounds. That matters because a tag selection persists the index's bounds as the acceptance
+      // baseline — bounds from another frame surviving into a record that later reports an
+      // unchanged element as moved.
       //
-      // Closed by [ServeCacheGeneration] (issue #4695): this page's frame URLs name the publish the
-      // page was assembled from, so the frame beside this index is that publish's frame or the
-      // request fails. The condition below is now sufficient as well as necessary.
+      // Closed by [ServeCacheGeneration] (issue #4695), and it took BOTH halves. The frame URL and
+      // this page's `/tags/<id>` URL are scoped to the same publish, the frame lane answers for
+      // that publish out of the delivery branch, and the tag lane — which can only ever describe
+      // today's render — refuses a generation the catalog has moved on from rather than answering
+      // with bounds measured on a different frame. So the pair on screen is one publish or the
+      // picker fails closed. The condition below is now sufficient as well as necessary.
       val frameIsReplayedBaked =
         !pinned && overrideParams.isEmpty() && !renderHost.canApplyOverrides
       val tagIndex = renderHost.tagIndexForPreview(preview.id)
@@ -6514,15 +6530,37 @@ class ServeHttpServer(
    * [ServeHost.tagIndexForPreview] to their baked host — so an override-bearing or pinned frame is
    * a different render than the one these bounds were measured on. Tag-derived selection therefore
    * has to be gated on the frame being the baked one ([ServeWeb.ReferenceComparison.tagSelection],
-   * decided by the page that knows which frame it is showing), and the element gates in batch 05
-   * need a shared render generation before they can read this at all. Recording bounds from another
-   * frame into an acceptance is worse than having no element gate: it reports an element that never
-   * moved as moved, with a plausible explanation attached.
+   * decided by the page that knows which frame it is showing). Recording bounds from another frame
+   * into an acceptance is worse than having no element gate: it reports an element that never moved
+   * as moved, with a plausible explanation attached.
+   *
+   * That gate is now paired with a **generation** one ([ServeCacheGeneration]): a caller may name
+   * the publish it is asking about, and this route refuses one the catalog has moved on from rather
+   * than answering with today's bounds. It cannot answer for an older publish — the index is read
+   * from the catalog on disk and the branch publishes no per-revision copy — so refusing is the
+   * whole of what it can honestly do, and it is enough: the pair is one publish or there is no
+   * pair.
    */
   private suspend fun RoutingContext.handleTagIndex(sessionInPath: Boolean) {
-    if (rejectBadToken()) return
+    if (rejectBadToken() || rejectMalformedGeneration()) return
     val requested = call.parameters["name"].orEmpty()
     withLeasedSession(selectedSessionId(sessionInPath)) { renderHost ->
+      // A comparison page scopes this URL to the publish it was assembled from, and this index is
+      // measured over that publish's baked render. Once the catalog has moved on there is no
+      // answer for the frame the caller is looking at — only today's bounds — and handing those
+      // back is worse than handing back nothing: a selection made from them is persisted as an
+      // acceptance baseline and later reports an element that never moved as moved. Refusing lets
+      // the picker fail closed and the page reload ([ServeCacheGeneration]).
+      val stale = staleGeneration(renderHost)
+      if (stale != null) {
+        call.respondText(
+          "this catalog has moved on from " +
+            "'${ServeCacheGeneration.PARAM}=${ServeCacheGeneration.short(stale)}'; the published " +
+            "tag index describes the current render, not that one — reload the page",
+          status = HttpStatusCode.Conflict,
+        )
+        return@withLeasedSession
+      }
       // Verbatim wins over the alias, so a preview whose id really ends in `.json` keeps its own
       // index instead of being answered with another preview's.
       val previewId =
@@ -7279,6 +7317,11 @@ class ServeHttpServer(
       // report point at is the frame this page drew ([ServeCacheGeneration]). Not scoped under an
       // override: the URL then names a render made to order, which is `no-store` and belongs to no
       // publish.
+      //
+      // `requestQuerySuffix()` is the page's RAW query, so this URL also inherits whatever page
+      // state the visitor's link carried. That is deliberate for an override — the card should show
+      // what they are looking at — and harmless for the rest, because the raster lane reads none of
+      // it and its own generation test is scoped to the parameters that actually change pixels.
       val imageQuerySuffix =
         if (revisions.pinned != null) pinnedRenderQuerySuffix()
         else if (requestCarriesOverrides()) requestQuerySuffix()
@@ -7663,6 +7706,14 @@ class ServeHttpServer(
       // normal way. Those params ride on the same URL by design (the grid appends `themeProvider=`
       // to the card's `src` when the visitor picks a theme), so this check is what keeps a themed
       // render from being answered with an unthemed thumbnail.
+      //
+      // A **stale generation** leaves the lane for the same reason a pin does, and it has to be
+      // asked here rather than inside [plainThumbRequest]: the thumbnail is downscaled from the
+      // catalog on disk, so it is by definition this generation's, and the fast path sits ahead of
+      // the routing that would otherwise fetch the named publish's bytes. Answering would be the
+      // worst shape available — a 200, `immutable`, from a generation the URL says it is not
+      // (#4714 review). A `gen=` naming the generation on disk is no obstacle at all and stays on
+      // the fast path, which is what keeps a scoped card cheap.
       val thumbHash = call.request.queryParameters[ServeHeroImages.THUMB_PARAM]
       if (
         thumbHash != null &&
@@ -7671,7 +7722,8 @@ class ServeHttpServer(
           !wantA11y &&
           !wantAnnotations &&
           !wantRcDoc &&
-          plainThumbRequest()
+          plainThumbRequest() &&
+          staleGeneration(renderHost) == null
       ) {
         val thumb =
           heroImages.gridThumbFor(
@@ -7685,10 +7737,12 @@ class ServeHttpServer(
         }
       }
       // A product can be selected by *query* rather than by suffix: `?scroll=long` is a full-page
-      // capture, `?rcPlayer=cmp-jvm` is a different player's raster, and any override
-      // (`fontScale`, `device`, `knob.…`) asks for pixels rendered to order. None of those is a
-      // published byte. Hoisted ahead of the two revision lanes below because both need the answer
-      // — and reach opposite conclusions from it.
+      // capture, `?rcPlayer=cmp-jvm` is a different player's raster, `mode=` presents the SVG
+      // export, and any override (`fontScale`, `device`, `knob.…`) asks for pixels rendered to
+      // order. None of those is a published byte, so a **pin** naming one of them is a URL claiming
+      // two contradictory things and is refused below. The generation lane asks a narrower version
+      // of the same question ([madeToOrder]) and reaches the opposite conclusion; both are stated
+      // where they are decided rather than shared, because they are not the same rule.
       val onDemand =
         requestCarriesOverrides() ||
           call.request.queryParameters["scroll"] != null ||
@@ -7716,19 +7770,44 @@ class ServeHttpServer(
       // generation on disk falls through, which is the ordinary browse: it changes nothing but the
       // response's cache lifetime, decided further down.
       //
-      // Where a pin **refuses** a request that also asks for a produced product, a generation steps
-      // aside for one — the raster is the only thing it reconciles. The difference is who wrote the
-      // parameter and what it claims. A pin is a person asking for a past publish, so a URL asking
-      // for both that and a live render is a contradiction worth naming. A generation is the
-      // server's own note about which page drew this frame, and every produced product — an
-      // override, a scroll capture, `.svg`, `.slots`, `.a11y`, `.annotations`, `.rc` — is served
-      // `no-store` and reflects no published bytes at all, so there is no pair for a cache to hold
-      // wrongly and nothing for the note to reconcile. Refusing there would break the one
-      // interaction this coupling must not cost: turning a knob on a page a refresh overtook.
-      val wantsProducedProduct =
-        onDemand || wantSvg || wantSlots || wantA11y || wantAnnotations || wantRcDoc
-      val pinnedCommit =
-        requestedPin ?: if (wantsProducedProduct) null else staleGeneration(renderHost)
+      // Exactly one thing makes a stale generation step aside: a render **made to order**. An
+      // override, a scroll capture, a player selection, an exploded projection — the visitor asked
+      // for pixels that reflect no published bytes at all, the response is `no-store`, and there is
+      // no pair for a cache to hold wrongly. Refusing there would break the one interaction this
+      // coupling must not cost: turning a knob on a page a refresh overtook.
+      //
+      // Deliberately NARROWER than the pin's [onDemand] in one place, and the difference is
+      // load-bearing: `mode=` selects a presentation of the SVG export and does nothing whatever on
+      // the raster lane, while it is ordinary page state that a viewer's shared link carries and
+      // that the frame URL inherits. Reading it as "made to order" here would opt the commonest
+      // shared link straight back out of the coupling, with a 200 and no sign of it.
+      val madeToOrder =
+        requestCarriesOverrides() ||
+          call.request.queryParameters["scroll"] != null ||
+          call.request.queryParameters["rcPlayer"] != null ||
+          (wantSvg && call.request.queryParameters["mode"] != null) ||
+          ServeExplodedSvg.PARAMS.any { call.request.queryParameters[it] != null }
+      val staleGeneration = if (madeToOrder) null else staleGeneration(renderHost)
+      // A stale generation on a **non-raster product** refuses, exactly as a pin does. These are
+      // the products whose whole purpose is to *describe* the frame — a semantics tree, an a11y
+      // pass, the typography and layout annotations the redline draws and an element selection
+      // records as an acceptance baseline — and the server can only describe today's. Answering
+      // would hand a page from one publish a measurement of another's, which is the corruption this
+      // parameter exists to prevent, arriving through the one door it left open: stepping aside
+      // here was silently the same bug pointing the other way (#4714 review).
+      if (
+        staleGeneration != null &&
+          (wantSvg || wantSlots || wantA11y || wantAnnotations || wantRcDoc)
+      ) {
+        call.respondText(
+          "only the baked render is published per generation; this catalog has moved on from " +
+            "'${ServeCacheGeneration.PARAM}=${ServeCacheGeneration.short(staleGeneration)}', so " +
+            "there is no answer for that frame — reload the page",
+          status = HttpStatusCode.Conflict,
+        )
+        return@withLeasedSession
+      }
+      val pinnedCommit = requestedPin ?: staleGeneration
       if (pinnedCommit != null) {
         // The non-raster products are made on demand by the daemon — an SVG export, a slot tree,
         // an a11y or annotation pass, a captured Remote Compose document. The branch publishes

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -9643,7 +9643,16 @@ ${captureControlsHtml().prependIndent("          ")}
         """
           .trimIndent()
     val rcLanes = rcCompare?.let {
-      rcLanesSection(it, previews, previewIdsByCard, token, linkSessionId, basePath, isPublic)
+      rcLanesSection(
+        it,
+        previews,
+        previewIdsByCard,
+        token,
+        linkSessionId,
+        basePath,
+        isPublic,
+        generation,
+      )
     }
     // The wall's page-scoped catalog report, in a provenance row of its own — see
     // [pageReportRowHtml] for why it borrows the viewer's row rather than styling a new one.
@@ -9737,12 +9746,19 @@ ${captureControlsHtml().prependIndent("          ")}
     linkSessionId: String?,
     basePath: String,
     isPublic: Boolean,
+    /** The wall's cache generation, scoping the staged rasters. See [ServeCacheGeneration]. */
+    generation: String?,
   ): String? {
     if (manifest.lanes.isEmpty() || manifest.rows.isEmpty()) return null
     val q = querySuffix(linkQuery(token, linkSessionId, basePath, isPublic))
+    // These rasters are published per catalog generation and restaged by a refresh, and the
+    // mismatch percentages beside them are baked into this HTML. Scoping them is what stops a
+    // cached wall showing one publish's scores against the next publish's player images (#4714
+    // review) — the same claim the primary render/reference pair makes, about a different pair.
+    val assetQ = ServeCacheGeneration.scope(q, generation)
     val previewsById = previews.associateBy { it.id }
     fun asset(name: String): String =
-      if (name.isEmpty()) "" else "$basePath/${ServeRcCompare.DIRECTORY}/$name$q"
+      if (name.isEmpty()) "" else "$basePath/${ServeRcCompare.DIRECTORY}/$name$assetQ"
 
     // Worst-match first on the worst-scoring player, so a preview only one player gets wrong still
     // sorts to the top; rows nothing scored sink, then alphabetical. Mirrors the published page.
@@ -10165,11 +10181,16 @@ ${if (annotationsSelectable) "          data-cp-selectable=\"1\"\n" else ""}    
     // The element selector. A dragged region needs nothing from the server — it is read off the
     // displayed pixels — so the control is offered on every focused comparison; the tag picker only
     // appears where the index describes the frame being shown. See [tagIndexUrl].
+    // Generation-scoped like the frame it describes. The index is measured over the baked render,
+    // and clicking one of its entries persists its bounds as an acceptance baseline — so an index
+    // fetched from a publish other than the one on screen is precisely the record corruption this
+    // page's coupling exists to prevent. Scoping it means the lane can refuse a stale one instead
+    // of answering with today's bounds (#4714 review).
     val tagIndexUrl =
       if (!tagIndexAvailable) null
       else
         "$basePath/tags/${WebEscaping.urlEncodeSegment(preview.id)}" +
-          querySuffix(linkQuery(token, linkSessionId, basePath, isPublic))
+          assetQuery(querySuffix(linkQuery(token, linkSessionId, basePath, isPublic)), revisions)
     val tagAttr = tagIndexUrl?.let { " data-cp-tags=\"${WebEscaping.htmlEscape(it)}\"" }.orEmpty()
     val tagNote =
       tagSelectionNote
@@ -12158,8 +12179,15 @@ ${scriptTag("known-differences.js")}
     @Suppress("NAME_SHADOWING") val historyRepo = historyRepo?.takeUnless { componentBrowser }
     @Suppress("NAME_SHADOWING")
     val historyInlineJson = historyInlineJson?.takeUnless { componentBrowser }
+    // Catalog mode hides the revision *control* — a component browser embedded in someone else's
+    // docs has no business offering a publish history. It must not drop the page's **generation**
+    // with it: that is not a control, it is which publish this HTML was assembled from, and losing
+    // it leaves the browser-built stage URL unscoped while the server-built Open Graph and
+    // issue-report URLs beside it still name the generation (#4714 review). Same page, two
+    // publishes.
     @Suppress("NAME_SHADOWING")
-    val revisions = if (componentBrowser) CatalogRevisions.NONE else revisions
+    val revisions =
+      if (componentBrowser) CatalogRevisions(generation = revisions.generation) else revisions
     @Suppress("NAME_SHADOWING")
     val parityIssues = if (componentBrowser) emptyList() else parityIssues
     @Suppress("NAME_SHADOWING")

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCacheGenerationTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCacheGenerationTest.kt
@@ -56,6 +56,22 @@ class ServeCacheGenerationTest {
     """
       .trimIndent()
 
+  /**
+   * A published tag index for the preview on the fixture's comparison page.
+   *
+   * Present so the tag picker is actually offered: the coupling between this index and the frame is
+   * the whole subject of the P1 the review raised, and a fixture that publishes none would let the
+   * assertions about it pass without testing anything.
+   */
+  private val tagsJson =
+    """
+    {"schema":"compose-preview-tags/v1","previews":{
+      "$previewId":{
+        "glyph":{"count":1,"bounds":{"x":0,"y":0,"width":2,"height":2},"space":"render-pixels"}
+      }}}
+    """
+      .trimIndent()
+
   private val previewIndexJson =
     """
     {"schema":"compose-preview-revision-index/v1","current":["$previewId"],"revisions":[
@@ -92,6 +108,8 @@ class ServeCacheGenerationTest {
       "${byBranch}preview-index.json" -> previewIndexJson.encodeToByteArray()
       "${tip}references/index.json",
       "${byBranch}references/index.json" -> referencesJson.encodeToByteArray()
+      "${tip}tags/index.json",
+      "${byBranch}tags/index.json" -> tagsJson.encodeToByteArray()
       "${tip}references/button.png",
       "${byBranch}references/button.png" -> currentReference
       "${tip}images/button-filled/ideal__default__dark.png",
@@ -154,6 +172,20 @@ class ServeCacheGenerationTest {
     val ogImage =
       Regex("<meta property=\"og:image\" content=\"([^\"]+)\"").find(page)?.groupValues?.get(1)
     assertTrue(ogImage?.contains("gen=$newCommit") == true, page)
+  }
+
+  @Test
+  fun `Catalog mode hides the revision control without dropping the generation`() {
+    val port = start().port
+
+    val page = text("http://127.0.0.1:$port/$system/p/$previewId?chrome=catalog")
+
+    // The embedded component browser has no business offering a publish history — but the
+    // generation is not a control, it is which publish this HTML is. Dropping it left the
+    // browser-built stage URL unscoped while the server-built card and report URLs beside it still
+    // named the publish: one page, two generations.
+    assertFalse(page.contains("cp-revisions"), page)
+    assertTrue(page.contains("data-generation=\"$newCommit\""), page)
   }
 
   @Test
@@ -244,6 +276,75 @@ class ServeCacheGenerationTest {
     assertNotEquals(
       400,
       get("http://127.0.0.1:$port/$system/render/$previewId.annotations?gen=$oldCommit").first,
+    )
+  }
+
+  @Test
+  fun `a lane that can only describe today refuses a stale generation rather than answering`() {
+    val port = start().port
+
+    // Every product that *describes* the frame — the published tag index, and the semantics,
+    // typography and a11y passes the redline and the element picker read — is measured against the
+    // catalog on disk. There is no older copy to serve, so answering would hand a page from one
+    // publish a measurement of another's: the record corruption the coupling exists to prevent,
+    // arriving through the one door "step aside" left open.
+    assertEquals(
+      409,
+      get("http://127.0.0.1:$port/$system/tags/$previewId?gen=$oldCommit").first,
+    )
+    for (suffix in listOf(".annotations", ".a11y", ".slots", ".svg", ".rc")) {
+      assertEquals(
+        409,
+        get("http://127.0.0.1:$port/$system/render/$previewId$suffix?gen=$oldCommit").first,
+        suffix,
+      )
+    }
+    // The current generation is the ordinary browse and answers as it always did.
+    assertEquals(200, get("http://127.0.0.1:$port/$system/tags/$previewId?gen=$newCommit").first)
+    assertEquals(200, get("http://127.0.0.1:$port/$system/tags/$previewId").first)
+  }
+
+  @Test
+  fun `the comparison scopes the tag index to the same publish as the frame`() {
+    val port = start().port
+
+    val page = text("http://127.0.0.1:$port/$system/compare/$previewId")
+
+    // Clicking a tag entry persists its bounds as an acceptance baseline, so the index and the
+    // pixels have to be one publish. Scoping the URL is what lets the lane refuse a stale one.
+    assertTrue(page.contains("data-cp-tags="), page)
+    assertTrue(page.contains("/tags/$previewId?gen=$newCommit"), page)
+  }
+
+  @Test
+  fun `a prebaked thumbnail never answers for a generation it is not`() {
+    val port = start().port
+
+    // The thumbnail is downscaled from the catalog on disk, so it is this generation's by
+    // definition — and its fast path sits ahead of the routing that would fetch the named
+    // publish's bytes. A 200 marked `immutable` from the wrong generation is the worst shape
+    // available, so a stale `gen=` has to leave the lane before it is reached.
+    val hash =
+      Regex("[?&]${ServeHeroImages.THUMB_PARAM}=([A-Za-z0-9_-]+)")
+        .find(text("http://127.0.0.1:$port/$system/"))
+        ?.groupValues
+        ?.get(1)
+    assertTrue(hash != null, "the fixture published no grid thumbnail to test the fast path with")
+    val stale =
+      get(
+        "http://127.0.0.1:$port/$system/render/$previewId.png" +
+          "?${ServeHeroImages.THUMB_PARAM}=$hash&gen=$oldCommit"
+      )
+    assertEquals(200, stale.first)
+    assertContentEquals(historicalRender, stale.second)
+    // …and the current generation stays on the fast path, which is what keeps a scoped card cheap.
+    assertEquals(
+      200,
+      get(
+          "http://127.0.0.1:$port/$system/render/$previewId.png" +
+            "?${ServeHeroImages.THUMB_PARAM}=$hash&gen=$newCommit"
+        )
+        .first,
     )
   }
 

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -544,12 +544,33 @@ the server made to itself, invisible to the reader, withholding nothing — and 
 permalink that is not one. A pinned page writes the pin and no generation: the pin already fixes which
 publish every frame comes from, and a second sha beside it is only something to disagree with.
 
-Where a pin **refuses** a URL that also asks for a product made to order (`?at=…&fontScale=1.5`, or
-`.svg` / `.slots` / `.a11y` / `.annotations` / `.rc`), a generation **steps aside** for one. Those
-responses are `no-store` and reflect no published bytes at all, so there is no pair for a cache to
-hold wrongly and nothing to reconcile — and refusing would cost the one interaction this coupling must
-not: turning a knob on a page that a refresh overtook. A `gen=` that is not a sha is a `400`, for the
-same reason `?at=main` is.
+Exactly one thing makes a stale generation **step aside**: a render made to order. An override, a
+scroll capture, a player selection, an exploded projection — the visitor asked for pixels that reflect
+no published bytes, the response is `no-store`, and there is nothing for a cache to pair wrongly.
+Refusing there would cost the one interaction this coupling must not: turning a knob on a page a
+refresh overtook.
+
+Everything else either answers for the generation named or **refuses with a `409`**, and the second
+half matters as much as the first. The products that *describe* a frame — the published tag index at
+`/tags/<id>`, and the `.annotations`, `.a11y` and `.slots` passes the redline and the element picker
+read — are measured against the catalog on disk, and the branch publishes no per-revision copy of
+them. Answering a stale generation with today's bounds would hand a page from one publish a
+measurement of another's, which is the record corruption the coupling exists to prevent, arriving
+through the door "step aside" would leave open: a tag selection persists those bounds as an
+acceptance baseline. So the picker fails closed and the page reloads. The catalog's staged
+`/rc-compare/` player rasters follow the same rule for the same reason — their mismatch percentages
+are baked into the cached wall.
+
+Two smaller places the parameter has to be honoured rather than merely accepted. The prebaked
+`?thumb=<hash>` fast path is downscaled from the catalog on disk, so it is *this* generation's by
+definition and sits ahead of the routing that would fetch another's; a stale `gen=` leaves the lane
+rather than being answered `200` and `immutable` from a generation the URL says it is not. And the
+render lane's reading of "made to order" is deliberately narrower than the pin's in one place: `mode=`
+presents the SVG export and does nothing whatever on the raster lane, while it is ordinary page state
+that a shared viewer link carries and the frame URL inherits — reading it as produced-on-demand there
+would opt the commonest shared link straight back out of the coupling.
+
+A `gen=` that is not a sha is a `400`, for the same reason `?at=main` is.
 
 Sessions with no delivery branch — an uploaded bundle, a local project, a daemon-backed module —
 write no generation. They have no published-per-generation bytes to reconcile and no branch to read an


### PR DESCRIPTION
Follow-up to #4714, which merged before its review findings could land on it. Same subject: a catalog page and the frames it draws are one publish ([`ServeCacheGeneration`](https://github.com/yschimke/compose-ai-tools/blob/main/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCacheGeneration.kt), issue #4695).

Four lanes accepted `gen=` and then answered as though they had not. Each is the same shape, and the last one is the one that matters.

## The describing products answered for the wrong frame

`gen=` made a stale generation **step aside** for anything not a plain raster. That was right for a render made to order — an override reflects no published bytes, is `no-store`, and there is nothing for a cache to pair wrongly. It was wrong for the products whose whole job is to *describe* the frame: `/tags/<id>` was not scoped at all, and `.annotations` / `.a11y` / `.slots` stepped aside and returned today's measurements.

That is the original corruption inverted rather than closed. Before, the HTML and the index were fresh and the pixels were stale; after #4714, the pixels follow the page and the bounds do not. Either way a tag selection persists bounds from a frame that is not on screen, and the acceptance record later reports an element that never moved as moved.

These have no older copy to serve — the index is read from the catalog on disk and the branch publishes no per-revision copy — so the honest answer is to refuse. The tag URL is now generation-scoped and every describing product answers `409` for a generation the catalog has moved on from, so the picker fails closed and the page reloads. The catalog's staged `/rc-compare/` player rasters follow the same rule for the same reason: their mismatch percentages are baked into the cached wall, so today's raster under an older publish's printed number is a confident claim about two pictures that were never compared.

The `frameIsReplayedBaked` comment claimed sufficiency on the strength of the frame half alone. It now says what actually makes the pair one publish — and that it took both halves.

## …and three smaller ways out

- **The prebaked `?thumb=` fast path** sits ahead of the stale-generation routing and is downscaled from the catalog on disk, so `?thumb=<current-hash>&gen=<older-sha>` returned today's pixels under a `200` marked `immutable` — the worst available shape. It now leaves the lane when the generation is stale, and stays on it when the generation is current, so a scoped card stays cheap.
- **Catalog mode** replaced the page's revisions with `CatalogRevisions.NONE` to hide the revision control, dropping the generation with it. The generation is not a control — it is which publish the HTML is — so the browser-built stage URL went unscoped while the server-built card and report URLs beside it still named the publish. It now hides the control and keeps the generation.
- **`mode=` was read as produced-on-demand.** It presents the SVG export and does nothing whatever on the raster lane, while it is ordinary page state a shared viewer link carries and the frame URL inherits — so the commonest shared link opted itself straight back out of the coupling, with a `200` and no sign of it. The generation now asks a narrower question than the pin does, stated where it is decided rather than shared, because they are not the same rule.

## Test plan

New cases in `ServeCacheGenerationTest`, on a fixture extended to publish a real `tags/index.json` so the tag assertions are not vacuous:

- `/tags/<id>?gen=<older>` and `.annotations` / `.a11y` / `.slots` / `.svg` / `.rc` at an older generation are `409`; the current generation and an unscoped request still answer `200`.
- The comparison page emits `data-cp-tags` pointing at `/tags/<id>?gen=<current>`.
- `?thumb=<hash>&gen=<older>` returns the *older* publish's render (proving it left the fast path), while `?thumb=<hash>&gen=<current>` still answers `200` from it.
- `?chrome=catalog` renders no revision control and still carries `data-generation`.

`./gradlew :cli:serve:test ktfmtCheckAll` — green.

Non-visual: query strings, status codes and `Cache-Control` headers only. No renderer or pixel change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C7yW8gVFW5qkYubwEewA7E)_