### PR TITLE
fix(design-map): report a folded variant's stated absence

### DIFF
--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -408,6 +408,19 @@ export function variantSeeds(preview) {
 }
 
 /** The name a variant render goes by, for a report and for the design-map `state` slot. */
+/**
+ * How a folded variant names itself in the reference diagnostics: `<parentId> [<variant>]`.
+ *
+ * Not the bare `componentId` — that is the PARENT's id for a VARIANT role, so reporting a variant's
+ * stated absence under it would read as a finding about a parent that may carry a perfectly good
+ * reference. Reuses [variantName] so the label matches what the variant is called everywhere else.
+ */
+export function variantAbsenceId(preview) {
+  const label = variantName(preview, variantSeeds(preview));
+  const parent = preview.catalog?.componentId ?? "(unnamed)";
+  return label ? `${parent} [${label}]` : parent;
+}
+
 function variantName(preview, seeds) {
   const catalog = preview.catalog;
   const cell = preview.overrides?.name;
@@ -532,8 +545,24 @@ export function projectDesignMap(previews, opts = {}) {
   const statedAbsentIds = new Map();
   for (const preview of previews) {
     const catalog = preview.catalog;
-    if (!catalog || catalog.role !== "COMPONENT" || catalog.reference) continue;
+    if (!catalog || catalog.reference) continue;
     if (isVariantCapture(preview)) continue;
+    // A `@CatalogVariant` can now state its own kit correspondence, so its absence is reported
+    // like a component's. Scanning components alone meant folding a render under a parent silently
+    // dropped its stated absence from this accounting — a catalog could lose an audit signal by
+    // restructuring, which is exactly what `statedAbsent` exists to prevent. `--strict` counts a
+    // variant's stated absence the same as a component's: someone looked, and wrote down what they
+    // found, wherever the render sits.
+    //
+    // Keyed by the variant's own label, not its parent's id (`componentId` is the PARENT for a
+    // VARIANT), or a folded variant's reason would be reported against a parent that may have a
+    // perfectly good reference of its own.
+    if (catalog.role === "VARIANT") {
+      if (!catalog.noReference) continue; // silence under a parent is the parent's business
+      statedAbsentIds.set(variantAbsenceId(preview), catalog.noReference);
+      continue;
+    }
+    if (catalog.role !== "COMPONENT") continue;
     const id = catalog.componentId;
     if (catalog.noReference) statedAbsentIds.set(id, catalog.noReference);
     else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -409,16 +409,24 @@ export function variantSeeds(preview) {
 
 /** The name a variant render goes by, for a report and for the design-map `state` slot. */
 /**
- * How a folded variant names itself in the reference diagnostics: `<parentId> [<variant>]`.
+ * How a folded variant names itself in the reference diagnostics: `<parentId> [<axis>=<value> …]`.
  *
  * Not the bare `componentId` — that is the PARENT's id for a VARIANT role, so reporting a variant's
  * stated absence under it would read as a finding about a parent that may carry a perfectly good
- * reference. Reuses [variantName] so the label matches what the variant is called everywhere else.
+ * reference.
+ *
+ * Not [variantName] either, though that is what the variant is called elsewhere: it narrows to the
+ * `state` alone whenever there is one, so two variants of a parent sharing a state and differing
+ * only in `props` produce the SAME name. These labels are map keys, so a collision silently drops
+ * one of the two stated absences — losing exactly the record this diagnostic exists to keep. The
+ * full seed vector is what distinguishes them, so the label is built from that.
  */
 export function variantAbsenceId(preview) {
-  const label = variantName(preview, variantSeeds(preview));
   const parent = preview.catalog?.componentId ?? "(unnamed)";
-  return label ? `${parent} [${label}]` : parent;
+  const axes = variantSeeds(preview)
+    .map((seed) => `${seed.key}=${seed.raw}`)
+    .join(" ");
+  return axes ? `${parent} [${axes}]` : parent;
 }
 
 function variantName(preview, seeds) {
@@ -543,6 +551,8 @@ export function projectDesignMap(previews, opts = {}) {
    */
   const unmappedIds = new Map();
   const statedAbsentIds = new Map();
+  /** Capture subjects whose absence is stated — a variant is named by subject, not by component. */
+  const referencelessSubjects = new Set();
   for (const preview of previews) {
     const catalog = preview.catalog;
     if (!catalog || catalog.reference) continue;
@@ -560,6 +570,12 @@ export function projectDesignMap(previews, opts = {}) {
     if (catalog.role === "VARIANT") {
       if (!catalog.noReference) continue; // silence under a parent is the parent's business
       statedAbsentIds.set(variantAbsenceId(preview), catalog.noReference);
+      // The ambiguity filter below matches on componentId, which for a VARIANT is the PARENT's --
+      // so a variant's own stated absence could not suppress its own ambiguous-mode record, and a
+      // parent carrying a good reference left it unsuppressed. `--strict --allow-stated-absence`
+      // then failed on precisely the case that flag exists to accept. A variant render has its own
+      // capture subject, so record that instead of trying to name it by component.
+      referencelessSubjects.add(captureIdentity(preview).subject);
       continue;
     }
     if (catalog.role !== "COMPONENT") continue;
@@ -643,7 +659,9 @@ export function projectDesignMap(previews, opts = {}) {
       // absence already reported above, and under --strict it would be a second, unfixable failure
       // for the same component.
       ambiguousMode: selection.ambiguous.filter(
-        (a) => !a.componentIds.length || a.componentIds.some((id) => !referencelessIds.has(id)),
+        (a) =>
+          !referencelessSubjects.has(a.subject) &&
+          (!a.componentIds.length || a.componentIds.some((id) => !referencelessIds.has(id))),
       ),
       variantRenders: declarations.reduce((n, d) => n + d.renders.length, 0),
       withSet: components.filter((c) => c.refSet).length,

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -550,9 +550,21 @@ export function projectDesignMap(previews, opts = {}) {
    * however many captures it publishes.
    */
   const unmappedIds = new Map();
+  /**
+   * Stated absences, keyed by a COLLISION-SAFE identity and carrying the display label separately.
+   *
+   * A component keys on its own id. A variant keys on its capture subject, which is per-composable
+   * and unique — never on its rendered label. The label is built by joining `key=value` pairs, and
+   * discovery splits an annotation prop at its FIRST `=` only, so a value may legally contain both
+   * a space and an `=`: `props = ["a=b c=d"]` is one prop, and renders identically to the two props
+   * `a=b` and `c=d`. Keying on that string would silently drop one of two distinct absences — the
+   * same data loss this diagnostic exists to prevent, one level subtler.
+   */
   const statedAbsentIds = new Map();
   /** Capture subjects whose absence is stated — a variant is named by subject, not by component. */
   const referencelessSubjects = new Set();
+  /** Component ids whose absence is stated, for the componentId-keyed ambiguity filter below. */
+  const statedAbsentComponentIds = new Set();
   for (const preview of previews) {
     const catalog = preview.catalog;
     if (!catalog || catalog.reference) continue;
@@ -564,39 +576,52 @@ export function projectDesignMap(previews, opts = {}) {
     // variant's stated absence the same as a component's: someone looked, and wrote down what they
     // found, wherever the render sits.
     //
-    // Keyed by the variant's own label, not its parent's id (`componentId` is the PARENT for a
-    // VARIANT), or a folded variant's reason would be reported against a parent that may have a
-    // perfectly good reference of its own.
+    // Reported under the variant's own label, not its parent's id (`componentId` is the PARENT for
+    // a VARIANT), or a folded variant's reason would be reported against a parent that may have a
+    // perfectly good reference of its own. The label is for reading; the KEY is the capture
+    // subject, which cannot collide — see the map's own note above.
     if (catalog.role === "VARIANT") {
       if (!catalog.noReference) continue; // silence under a parent is the parent's business
-      statedAbsentIds.set(variantAbsenceId(preview), catalog.noReference);
+      const subject = captureIdentity(preview).subject;
+      statedAbsentIds.set(subject, {
+        label: variantAbsenceId(preview),
+        reason: catalog.noReference,
+      });
       // The ambiguity filter below matches on componentId, which for a VARIANT is the PARENT's --
       // so a variant's own stated absence could not suppress its own ambiguous-mode record, and a
       // parent carrying a good reference left it unsuppressed. `--strict --allow-stated-absence`
       // then failed on precisely the case that flag exists to accept. A variant render has its own
       // capture subject, so record that instead of trying to name it by component.
-      referencelessSubjects.add(captureIdentity(preview).subject);
+      referencelessSubjects.add(subject);
       continue;
     }
     if (catalog.role !== "COMPONENT") continue;
     const id = catalog.componentId;
-    if (catalog.noReference) statedAbsentIds.set(id, catalog.noReference);
-    else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);
+    if (catalog.noReference) {
+      statedAbsentIds.set(id, { label: id, reason: catalog.noReference });
+      statedAbsentComponentIds.add(id);
+    } else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);
   }
   /** Components carrying neither a reference nor a stated reason for its absence. */
-  const unmapped = [...unmappedIds.keys()].filter((id) => !statedAbsentIds.has(id));
+  const unmapped = [...unmappedIds.keys()].filter((id) => !statedAbsentComponentIds.has(id));
   /**
    * Components whose reference is absent for a STATED reason. Reported apart from `unmapped`
    * because they are the opposite situation: someone looked, and what they found is that the kit
    * has nothing live to point at. Rolling the two together is what made a retired pattern read as
    * neglect.
    */
-  const statedAbsent = [...statedAbsentIds].map(([componentId, reason]) => ({
-    componentId,
+  const statedAbsent = [...statedAbsentIds.values()].map(({ label, reason }) => ({
+    componentId: label,
     reason,
   }));
-  /** Every component that reaches no reference, however its absence was spelled. */
-  const referencelessIds = new Set([...unmapped, ...statedAbsentIds.keys()]);
+  /**
+   * Every COMPONENT that reaches no reference, however its absence was spelled — the set the
+   * ambiguity filter tests `componentIds` against. A variant's key is a capture subject rather than
+   * a component id, so it is deliberately absent here and suppressed through
+   * [referencelessSubjects] instead; putting subjects in this set would only add entries no
+   * componentId can ever equal.
+   */
+  const referencelessIds = new Set([...unmapped, ...statedAbsentComponentIds]);
 
   for (const preview of previews) {
     const catalog = preview.catalog;

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -178,11 +178,64 @@ test("a folded variant's stated absence is reported under the variant, not its p
   ]);
   assert.deepEqual(diagnostics.statedAbsent, [
     {
-      componentId: "Button [icon-only]",
+      componentId: "Button [state=icon-only]",
       reason: "the kit exports no Text=No cell for this set",
     },
   ]);
   assert.deepEqual(diagnostics.unmapped, []);
+});
+
+test("two variants sharing a state but differing in props keep both absences", () => {
+  // The label is a Map key. `variantName` narrows to the state alone whenever there is one, so
+  // building the label from it collided these two and silently dropped one of the reasons --
+  // losing exactly the record this diagnostic exists to keep. The full seed vector distinguishes
+  // them.
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("ButtonDisabledIcon", "Button", {
+      state: "disabled",
+      props: [{ key: "content", value: "icon-only" }],
+      noReference: "no disabled icon-only cell",
+    }),
+    catalogVariant("ButtonDisabledText", "Button", {
+      state: "disabled",
+      props: [{ key: "content", value: "text-only" }],
+      noReference: "no disabled text-only cell",
+    }),
+  ]);
+  assert.equal(diagnostics.statedAbsent.length, 2);
+  assert.deepEqual(
+    diagnostics.statedAbsent.map((s) => s.reason).sort(),
+    ["no disabled icon-only cell", "no disabled text-only cell"],
+  );
+});
+
+test("a stated-absent variant's ambiguous modes are suppressed even when its parent has a reference", () => {
+  // The ambiguity filter matches on componentId, which for a VARIANT is the PARENT's -- so a
+  // variant's own stated absence could not suppress its own record, and a parent carrying a good
+  // reference left it standing. `--strict --allow-stated-absence` then failed on precisely the
+  // case that flag exists to accept. A variant render has its own capture subject.
+  const dark = {
+    ...catalogVariant("ButtonIconOnly", "Button", {
+      state: "icon-only",
+      noReference: "the kit exports no Text=No cell",
+    }),
+    id: "com.example.CatalogKt.ButtonIconOnly_Dark",
+  };
+  const coral = {
+    ...catalogVariant("ButtonIconOnly", "Button", {
+      state: "icon-only",
+      noReference: "the kit exports no Text=No cell",
+    }),
+    id: "com.example.CatalogKt.ButtonIconOnly_Coral",
+  };
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    dark,
+    coral,
+  ]);
+  assert.equal(diagnostics.statedAbsent.length, 1);
+  assert.deepEqual(diagnostics.ambiguousMode, []);
 });
 
 test("a variant that says nothing about the kit is not reported as unmapped", () => {

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -165,6 +165,37 @@ test("separates a stated absence from nobody having looked", () => {
   assert.deepEqual(diagnostics.unmapped, ["Forgotten"]);
 });
 
+test("a folded variant's stated absence is reported under the variant, not its parent", () => {
+  // Scanning components alone meant folding a render under a parent silently dropped its stated
+  // absence: a catalog could lose an audit signal by restructuring, which is what `statedAbsent`
+  // exists to prevent. The parent keeps its own reference and stays out of the report.
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("ButtonIconOnly", "Button", {
+      state: "icon-only",
+      noReference: "the kit exports no Text=No cell for this set",
+    }),
+  ]);
+  assert.deepEqual(diagnostics.statedAbsent, [
+    {
+      componentId: "Button [icon-only]",
+      reason: "the kit exports no Text=No cell for this set",
+    },
+  ]);
+  assert.deepEqual(diagnostics.unmapped, []);
+});
+
+test("a variant that says nothing about the kit is not reported as unmapped", () => {
+  // Silence under a parent is the parent's business: an ordinary state variant has never had a
+  // reference and reporting one per fold would drown the signal it is meant to carry.
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("ButtonPressed", "Button", { state: "pressed" }),
+  ]);
+  assert.deepEqual(diagnostics.statedAbsent, []);
+  assert.deepEqual(diagnostics.unmapped, []);
+});
+
 test("entries are sorted by code handle, so the file is diffable", () => {
   const { map } = projectDesignMap([
     component("Zebra", { reference: ref("1:2") }),

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -210,6 +210,32 @@ test("two variants sharing a state but differing in props keep both absences", (
   );
 });
 
+test("a prop value containing its own key=value text does not collide with two props", () => {
+  // Discovery splits an annotation prop at its FIRST `=` only, so `props = ["a=b c=d"]` is ONE
+  // prop whose value is `b c=d`. Joined for display it is indistinguishable from the two props
+  // `a=b` and `c=d`. The label is therefore not safe as a Map key -- these two variants must both
+  // survive, which they only do because the key is the capture subject.
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("OneProp", "Button", {
+      props: [{ key: "a", value: "b c=d" }],
+      noReference: "one prop whose value looks like two",
+    }),
+    catalogVariant("TwoProps", "Button", {
+      props: [
+        { key: "a", value: "b" },
+        { key: "c", value: "d" },
+      ],
+      noReference: "genuinely two props",
+    }),
+  ]);
+  assert.equal(diagnostics.statedAbsent.length, 2);
+  assert.deepEqual(
+    diagnostics.statedAbsent.map((s) => s.reason).sort(),
+    ["genuinely two props", "one prop whose value looks like two"],
+  );
+});
+
 test("a stated-absent variant's ambiguous modes are suppressed even when its parent has a reference", () => {
   // The ambiguity filter matches on componentId, which for a VARIANT is the PARENT's -- so a
   // variant's own stated absence could not suppress its own record, and a parent carrying a good


### PR DESCRIPTION
Follow-up to #4719, and credit where it's due: Codex found this on that PR, after it had merged — then found two real defects in the fix itself, both now addressed in `12c013c`.

#4719 let a `@CatalogVariant` declare its own `reference` / `noReference`. `projectDesignMap`'s reference diagnostics scan `catalog.role === "COMPONENT"` only, so those declarations reached nothing.

## Why it matters

It makes restructuring lossy in the one direction the diagnostic exists to catch.

Converting a top-level component into a variant of its neighbour says nothing about the design kit — it is a statement about *structure*. But today it silently removes that component's "someone looked, and the kit has nothing to point at" record from the `--strict` accounting. A catalog would lose an audit signal by tidying its own inventory, which is precisely what `statedAbsent` exists to prevent.

wear-m3-catalog has 17 such candidates queued for exactly that conversion, **16 of them carrying exactly that prose** — `"Varies \`Button/Filled\`, whose kit set the Wear sibling maps…"`. Converting them today would drop all 16.

## What it does

Includes VARIANT-role previews in the absence scan, reported under the variant's own label rather than its `componentId` — which is the **parent's** id for a VARIANT role. A folded variant's reason attributed to a parent that carries a perfectly good reference reads as a finding about the parent:

```
Button [state=icon-only] — the kit exports no Text=No cell for this set
```

The label is built from the variant's **full seed vector**, not from `variantName`. `variantName` narrows to the `state` alone whenever there is one — correct for a display name, wrong for a map key: two variants of a parent sharing a state and differing only in `props` collided, and one reason was silently dropped. Losing a stated absence is exactly what this diagnostic exists to prevent, so its key cannot be built on a name designed to be lossy.

**A variant that says nothing about the kit stays unreported.** Silence under a parent is the parent's business — an ordinary `state` variant has never had a reference of its own, and one `unmapped` entry per fold would drown the signal the report carries.

## Ambiguous modes

`selection.ambiguous` records carry `componentIds`, which for a VARIANT capture is the parent's id — so a decorated variant label never matches, and a parent holding a good reference is not referenceless either. Nothing suppressed the record, and `--strict --allow-stated-absence` failed on a stated absence: the one case that flag exists to accept.

A variant render has its own **capture subject**, which is already what `selectCaptures` groups modes by, so the absence loop records that too:

```js
ambiguousMode: selection.ambiguous.filter(
  (a) =>
    !referencelessSubjects.has(a.subject) &&
    (!a.componentIds.length || a.componentIds.some((id) => !referencelessIds.has(id))),
),
```

The `componentIds` arm is unchanged, so a parent's own ambiguity still reports.

## Scope

`statedAbsent` feeds the `--strict` gate and the emitted diagnostics; it is **not** part of the published `design-map.json` component entries, so no downstream committed artifact changes shape. `--strict` now counts a variant's stated absence the same as a component's, which is the intended reading: someone looked and wrote down what they found, wherever the render sits.

## What this does not do

A variant's own **`reference`** still does not become a design-map entry. That is a larger question than this fix — the map's model is that the parent holds the reference and variants are cells within it, so a variant-level reference has no slot to go in and inventing one deserves its own change. 1 of the 17 candidates has a `reference`; 16 have `noReference`, which is the half that would actually be lost.

## Test plan

`design-map` package suite — **63 pass**, 4 new:

- a folded variant's stated absence reported under its own label, with the parent staying out of the report;
- a say-nothing variant reported as neither `statedAbsent` nor `unmapped`;
- two variants of one parent sharing a `state` and differing in `props`, both reasons surviving;
- a stated-absent variant publishing Dark + Coral with no Light, under a parent that *does* carry a reference — `ambiguousMode` comes back empty and the absence survives.

The existing "separates a stated absence from nobody having looked" case is unchanged, so component behaviour is pinned as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx