### PR TITLE
ci: leave the rc-player ABI dumps to the macOS job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,19 @@ jobs:
             # `gradle/libs.versions.toml` resolves to. Without it, an ABI-changing edit that also
             # trips a global path skips the gate entirely — which is how the gate ends up existing
             # without running, the exact failure this was added to stop.
+            #
+            # The four `rc-player-*` modules are excluded because the macOS job below already owns
+            # them: their dumps are klib dumps covering the iOS targets, and that is the repo's one
+            # macOS job. Excluded rather than merely duplicated — this branch runs on
+            # `ubuntu-latest`, and while the checks do pass on Linux (verified with
+            # `--rerun-tasks`), that was in a container with the Kotlin/Native toolchain already
+            # warm, which a fresh runner is not. Their coverage is not weakened: the macOS job runs
+            # exactly these four unconditionally.
             ./gradlew test checkKotlinAbi --continue \
+              -x :rc-player-trace:checkKotlinAbi \
+              -x :rc-player-protocol:checkKotlinAbi \
+              -x :rc-player-runtime:checkKotlinAbi \
+              -x :rc-player-compose:checkKotlinAbi \
               -x :samples:android:test \
               -x :samples:android-alpha:test \
               -x :samples:android-library:test \


### PR DESCRIPTION
Follow-up to #4717, which merged while I was addressing its review. The finding was correct; the fix missed the merge by about two minutes.

## The finding

#4717 added an unqualified `checkKotlinAbi` to the `full` branch. Unqualified means Gradle matches it in **all 24** projects that have one — and four of those are `rc-player-*`, whose dumps are klib dumps covering iOS targets. `ci.yml` already documents that they belong in the repo's one macOS job for exactly that reason, and the `full` branch runs on `ubuntu-latest`.

## What I could and could not confirm

The premise is right — the four are in the aggregate, verified from `checkKotlinAbi --dry-run`:

```
:rc-player-compose:checkKotlinAbi
:rc-player-protocol:checkKotlinAbi
:rc-player-runtime:checkKotlinAbi
:rc-player-trace:checkKotlinAbi
```

The conclusion I could **not** confirm. Forced with `--rerun-tasks`, all four *pass* on Linux here — `BUILD SUCCESSFUL`, exit 0. But "here" is a container whose Kotlin/Native toolchain is already warm from earlier builds, which a fresh GitHub runner is not, so a green run in this sandbox is not evidence about CI. Reporting that rather than either asserting the reviewer was wrong or pretending I reproduced a failure I didn't.

Excluded rather than left to find out. **No coverage is lost** — the macOS job runs exactly these four unconditionally — and duplicating them on Linux buys only a second opinion on the targets that platform can see. `-x` matches how this same command already excludes the sample test tasks.

## Verified with the exclusions in place

| case | result |
| --- | --- |
| line deleted from `common/io`'s dump | exit **1** |
| clean tree | exit **0** |
| `rc-player` ABI tasks in the run | **0** |

So the gate still catches what it was added for, and the four really are excluded rather than silently still running.

83 `.github/ci` tests green; `ci.yml` parses.

## One process note

#4717 merged at 15:19:52Z and my push landed after, which re-created the merged branch — the second time today (the first was #4682). Both times the cause was the same: I ran the attribution scan and pushed without re-reading the PR's `state`/`merged` first, which is the repo's stated rule and the one guard that actually catches this. Nothing is lost — this commit is that work, on a fresh branch from `main` — but `agent/abi-check-scheduling` now carries one commit past its merge and wants deleting, and force-push is blocked for me.

Non-visual: a CI workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQJKxzuDLpRUepa8RYeaU5)_