### PR TITLE
fix: address post-merge review findings on #4713

### DIFF
--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHostTest.kt
@@ -3,7 +3,8 @@ package ee.schimke.composeai.cli.serve
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.imagecrop.CropOffset
-import ee.schimke.composeai.imagecrop.CropSize
+import ee.schimke.composeai.imagecrop.RenderSize
+import ee.schimke.composeai.imagecrop.WindowSize
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -584,8 +585,8 @@ class ServeBundleHostTest {
 
     assertEquals(
       ContentCrop(
-        window = CropSize(249, 126),
-        render = CropSize(271, 150),
+        window = WindowSize(249, 126),
+        render = RenderSize(271, 150),
         offset = CropOffset(-11, -11),
         clip = false,
         // The native box and the capped axis (height, for a gutter crop) ride along, so the page

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHeroImagesTest.kt
@@ -5,7 +5,8 @@ import ee.schimke.composeai.daemon.protocol.StreamCodec
 import ee.schimke.composeai.daemon.protocol.StreamFrameParams
 import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.imagecrop.CropOffset
-import ee.schimke.composeai.imagecrop.CropSize
+import ee.schimke.composeai.imagecrop.RenderSize
+import ee.schimke.composeai.imagecrop.WindowSize
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
@@ -109,8 +110,8 @@ class ServeHeroImagesTest {
       }
     val crop =
       ContentCrop(
-        window = CropSize(80, 40),
-        render = CropSize(400, 400),
+        window = WindowSize(80, 40),
+        render = RenderSize(400, 400),
         offset = CropOffset(-100, -150),
       )
     val hero = ServeHeroImages().bake(source, crop)!!
@@ -254,8 +255,8 @@ class ServeHeroImagesTest {
     // window has to keep framing both identically.
     val crop =
       ContentCrop(
-        window = CropSize(1000, 1000),
-        render = CropSize(2000, 2000),
+        window = WindowSize(1000, 1000),
+        render = RenderSize(2000, 2000),
         offset = CropOffset(-500, -500),
       )
     val baked = decode(ServeHeroImages().bakeGridThumb(uiPng(2000, 2000), crop)!!.bytes)

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebGridThumbnailTest.kt
@@ -2,7 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.imagecrop.CropOffset
-import ee.schimke.composeai.imagecrop.CropSize
+import ee.schimke.composeai.imagecrop.RenderSize
+import ee.schimke.composeai.imagecrop.WindowSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -23,8 +24,8 @@ class ServeWebGridThumbnailTest {
 
   private val crop =
     ContentCrop(
-      window = CropSize(120, 48),
-      render = CropSize(454, 454),
+      window = WindowSize(120, 48),
+      render = RenderSize(454, 454),
       offset = CropOffset(-167, -203),
       nativeWindowW = 120,
       nativeCapAxis = 120,

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebThumbCropTest.kt
@@ -2,7 +2,8 @@ package ee.schimke.composeai.cli.serve
 
 import ee.schimke.composeai.imagecrop.ContentCrop
 import ee.schimke.composeai.imagecrop.CropOffset
-import ee.schimke.composeai.imagecrop.CropSize
+import ee.schimke.composeai.imagecrop.RenderSize
+import ee.schimke.composeai.imagecrop.WindowSize
 import ee.schimke.composeai.imagecrop.computeGutterCrop
 import ee.schimke.composeai.imagecrop.computeThumbCrop
 import kotlin.test.Test
@@ -23,8 +24,8 @@ class ServeWebThumbCropTest {
     listOf(ServePreview(id = "filled-button__ideal__default__compact", label = "Filled"))
   private val crop =
     ContentCrop(
-      window = CropSize(120, 48),
-      render = CropSize(454, 454),
+      window = WindowSize(120, 48),
+      render = RenderSize(454, 454),
       offset = CropOffset(-167, -203),
       nativeWindowW = 120,
       nativeCapAxis = 120,
@@ -167,8 +168,8 @@ class ServeWebThumbCropTest {
   fun `a crop with no native size keeps the fixed-px window`() {
     val handmade =
       ContentCrop(
-        window = CropSize(120, 48),
-        render = CropSize(454, 454),
+        window = WindowSize(120, 48),
+        render = RenderSize(454, 454),
         offset = CropOffset(-167, -203),
       )
     val html =

--- a/common/image-crop/api/common-image-crop.api
+++ b/common/image-crop/api/common-image-crop.api
@@ -16,23 +16,23 @@ public final class ee/schimke/composeai/imagecrop/ContentBox {
 }
 
 public final class ee/schimke/composeai/imagecrop/ContentCrop {
-	public fun <init> (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)V
-	public synthetic fun <init> (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lee/schimke/composeai/imagecrop/CropSize;
-	public final fun component2 ()Lee/schimke/composeai/imagecrop/CropSize;
+	public fun <init> (Lee/schimke/composeai/imagecrop/WindowSize;Lee/schimke/composeai/imagecrop/RenderSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)V
+	public synthetic fun <init> (Lee/schimke/composeai/imagecrop/WindowSize;Lee/schimke/composeai/imagecrop/RenderSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lee/schimke/composeai/imagecrop/WindowSize;
+	public final fun component2 ()Lee/schimke/composeai/imagecrop/RenderSize;
 	public final fun component3 ()Lee/schimke/composeai/imagecrop/CropOffset;
 	public final fun component4 ()Z
 	public final fun component5 ()I
 	public final fun component6 ()I
-	public final fun copy (Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)Lee/schimke/composeai/imagecrop/ContentCrop;
-	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentCrop;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public final fun copy (Lee/schimke/composeai/imagecrop/WindowSize;Lee/schimke/composeai/imagecrop/RenderSize;Lee/schimke/composeai/imagecrop/CropOffset;ZII)Lee/schimke/composeai/imagecrop/ContentCrop;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/ContentCrop;Lee/schimke/composeai/imagecrop/WindowSize;Lee/schimke/composeai/imagecrop/RenderSize;Lee/schimke/composeai/imagecrop/CropOffset;ZIIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/ContentCrop;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClip ()Z
 	public final fun getNativeCapAxis ()I
 	public final fun getNativeWindowW ()I
 	public final fun getOffset ()Lee/schimke/composeai/imagecrop/CropOffset;
-	public final fun getRender ()Lee/schimke/composeai/imagecrop/CropSize;
-	public final fun getWindow ()Lee/schimke/composeai/imagecrop/CropSize;
+	public final fun getRender ()Lee/schimke/composeai/imagecrop/RenderSize;
+	public final fun getWindow ()Lee/schimke/composeai/imagecrop/WindowSize;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -63,12 +63,25 @@ public final class ee/schimke/composeai/imagecrop/CropOffset {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class ee/schimke/composeai/imagecrop/CropSize {
+public final class ee/schimke/composeai/imagecrop/RenderSize {
 	public fun <init> (II)V
 	public final fun component1 ()I
 	public final fun component2 ()I
-	public final fun copy (II)Lee/schimke/composeai/imagecrop/CropSize;
-	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/CropSize;IIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/CropSize;
+	public final fun copy (II)Lee/schimke/composeai/imagecrop/RenderSize;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/RenderSize;IIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/RenderSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getH ()I
+	public final fun getW ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class ee/schimke/composeai/imagecrop/WindowSize {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lee/schimke/composeai/imagecrop/WindowSize;
+	public static synthetic fun copy$default (Lee/schimke/composeai/imagecrop/WindowSize;IIILjava/lang/Object;)Lee/schimke/composeai/imagecrop/WindowSize;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getH ()I
 	public final fun getW ()I

--- a/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
+++ b/common/image-crop/src/main/kotlin/ee/schimke/composeai/imagecrop/ContentCropGeometry.kt
@@ -22,8 +22,19 @@ import kotlin.math.roundToInt
  * [computeThumbCrop] returns `null` (no-op) for them — only the framed-in-a-canvas stickers get
  * cropped.
  */
-/** A width/height pair, in the crop's output pixels. */
-public data class CropSize(val w: Int, val h: Int)
+/**
+ * The clip window's size, in the crop's output pixels.
+ *
+ * A type of its own rather than a shared width/height pair, because the window and the render are
+ * the one transposable remainder: grouping the six loose `Int`s into three pairs made `w`/`h` and
+ * size/offset mix-ups impossible, but left `window` and `render` the SAME type — so a positional
+ * `ContentCrop(render, window, …)` still compiled, in the exact shape this contract is meant to
+ * rule out. Distinct types make that a compile error too.
+ */
+public data class WindowSize(val w: Int, val h: Int)
+
+/** The full render's size at the window's scale, in the crop's output pixels. See [WindowSize]. */
+public data class RenderSize(val w: Int, val h: Int)
 
 /**
  * Where the render sits under the clip window, in the crop's output pixels.
@@ -36,18 +47,19 @@ public data class CropOffset(val left: Int, val top: Int)
 /**
  * A clip window over a render, and the render's position under it.
  *
- * Grouped rather than flat, and that is the point: this carried six bare `Int`s in a row — window
+ * Typed rather than flat, and that is the point: this carried six bare `Int`s in a row — window
  * width and height, render width and height, and the two offsets — so any permutation of them
  * compiled. It is a published contract that an extracted preview server will build catalog pages
  * from, and a transposed pair there is a silently wrong crop rather than a build failure.
- * [CropSize] and [CropOffset] make the transposition a type error; the two dimensions left inside
- * each of them are in the conventional order and mean the same kind of thing.
+ * [WindowSize], [RenderSize] and [CropOffset] make every transposition between the three a type
+ * error; the two dimensions left inside each of them are in the conventional order and mean the
+ * same kind of thing.
  */
 public data class ContentCrop(
   /** Clip-window size — the component box scaled to fit [CAP]. */
-  val window: CropSize,
+  val window: WindowSize,
   /** The full render `<img>` size at the same scale; larger than the window, clipped by it. */
-  val render: CropSize,
+  val render: RenderSize,
   /** The shift that brings the component's top-left to the window origin. */
   val offset: CropOffset,
   /**
@@ -222,8 +234,8 @@ public fun computeGutterCrop(
   val scale = min(1.0, cap / boxH.toDouble())
   return ContentCrop(
     window =
-      CropSize(w = max(1, (boxW * scale).roundToInt()), h = max(1, (boxH * scale).roundToInt())),
-    render = CropSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
+      WindowSize(w = max(1, (boxW * scale).roundToInt()), h = max(1, (boxH * scale).roundToInt())),
+    render = RenderSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
     offset = CropOffset(left = (-left * scale).roundToInt(), top = (-top * scale).roundToInt()),
     clip = false,
     nativeWindowW = boxW,
@@ -247,8 +259,11 @@ public fun computeThumbCrop(
   val scale = min(1.0, cap / max(box.w, box.h).toDouble())
   return ContentCrop(
     window =
-      CropSize(w = max(1, (box.w * scale).roundToInt()), h = max(1, (box.h * scale).roundToInt())),
-    render = CropSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
+      WindowSize(
+        w = max(1, (box.w * scale).roundToInt()),
+        h = max(1, (box.h * scale).roundToInt()),
+      ),
+    render = RenderSize(w = (renderW * scale).roundToInt(), h = (renderH * scale).roundToInt()),
     // The offset is the render's position under the clip window: negative of the box origin.
     offset = CropOffset(left = (-box.x * scale).roundToInt(), top = (-box.y * scale).roundToInt()),
     nativeWindowW = box.w,

--- a/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
+++ b/data/pseudolocale/core/src/main/kotlin/ee/schimke/composeai/data/pseudolocale/Pseudolocalizer.kt
@@ -23,13 +23,13 @@ public object Pseudolocalizer {
    * Pseudolocalised text plus the input-to-output index map needed to remap span ranges over the
    * original [input] onto the transformed [text].
    *
-   * `indexMap[i]` is the output position corresponding to input position `i`, with size
+   * [indexAt] gives the output position corresponding to an input position, and [size] is
    * `input.length + 1` so a span's `endExclusive` index can be looked up unambiguously
-   * (`indexMap[input.length]` is the position immediately after the last input character — before
+   * (`indexAt(input.length)` is the position immediately after the last input character — before
    * any trailing accent padding / closing bracket).
    *
    * Callers consume this when the input came from a `Spanned`/`SpannedString`: walk the original
-   * spans, look up start/end through `indexMap`, and re-attach to a `SpannableStringBuilder` built
+   * spans, look up start/end through [indexAt], and re-attach to a `SpannableStringBuilder` built
    * from [text]. Without that, calling `toString()` on the styled `CharSequence` strips the spans
    * before transformation and any preview using bold / annotation / URLSpan resources would render
    * unstyled — see `PseudolocaleResources` in `:data-pseudolocale-connector`.

--- a/render-session/subprocess/api/render-session-subprocess.api
+++ b/render-session/subprocess/api/render-session-subprocess.api
@@ -41,7 +41,8 @@ public final class ee/schimke/composeai/render/session/subprocess/SubprocessRend
 	public final fun descriptorFile (Ljava/io/File;Ljava/lang/String;)Ljava/io/File;
 	public fun getBackendKind ()Lee/schimke/composeai/render/session/RenderSessionBackend;
 	public fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;)Lee/schimke/composeai/render/session/RenderSession;
-	public final fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
+	public final fun open (Lee/schimke/composeai/render/session/RenderSessionConfig;Lee/schimke/composeai/daemon/client/DaemonClientFactory;Lokio/FileSystem;)Lee/schimke/composeai/render/session/RenderSession;
+	public static synthetic fun open$default (Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;Lee/schimke/composeai/render/session/RenderSessionConfig;Lee/schimke/composeai/daemon/client/DaemonClientFactory;Lokio/FileSystem;ILjava/lang/Object;)Lee/schimke/composeai/render/session/RenderSession;
 	public final fun openBundleDaemon-w3P_Jxs (Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;)Lee/schimke/composeai/render/session/RenderSession;
 	public static synthetic fun openBundleDaemon-w3P_Jxs$default (Lee/schimke/composeai/render/session/subprocess/SubprocessRenderSessions;Ljava/util/List;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/lang/String;JLjava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Lee/schimke/composeai/daemon/client/DaemonClientFactory;ILjava/lang/Object;)Lee/schimke/composeai/render/session/RenderSession;
 }

--- a/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
+++ b/render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt
@@ -29,22 +29,33 @@ import okio.Path.Companion.toPath
 public object SubprocessRenderSessions : RenderSessionFactory {
   override val backendKind: RenderSessionBackend = RenderSessionBackend.Subprocess
 
-  // Private, not a published seam. This was a `public var` on a published singleton — a
-  // process-wide mutable global any consumer could swap — and nothing in the repository ever
-  // assigned it, here or in tests. A test hook nobody uses is not worth exporting from a contract
-  // module: the injectable seam that IS used is the `DaemonClientFactory` overload of `open`.
-  private val fileSystem: FileSystem = SystemFileSystem
-
   override fun open(config: RenderSessionConfig): RenderSession =
     open(config = config, factory = SubprocessDaemonClientFactory())
 
   /**
-   * Open a session, injecting a custom [DaemonClientFactory]. Test scaffolding pairs an in-memory
-   * factory with a fake daemon; production callers stick with the default factory in [open].
+   * Open a session, injecting a custom [DaemonClientFactory] and, optionally, the [FileSystem] the
+   * launch descriptor is read through. Test scaffolding pairs an in-memory factory with a fake
+   * daemon; production callers stick with the defaults.
+   *
+   * A defaulted PARAMETER rather than a property on this object. The `public var` this replaced was
+   * a process-wide mutable global any consumer could swap, and it deserved to go — but a private
+   * `val` left no seam at all, and `:common-io`'s rule for a stateless `object` that touches files
+   * is a defaulted `fileSystem` parameter (see `docs/AGENT_GUIDE.md` → Important constraints).
+   * Per-call injection has none of a global's problems: production behaviour is unchanged, and a
+   * test can hand in a `FakeFileSystem` without affecting any other caller.
    */
-  public fun open(config: RenderSessionConfig, factory: DaemonClientFactory): RenderSession {
+  public fun open(
+    config: RenderSessionConfig,
+    factory: DaemonClientFactory,
+    fileSystem: FileSystem = SystemFileSystem,
+  ): RenderSession {
     val descriptorFile = config.descriptorPath
-    if (!descriptorFile.isFile) {
+    val descriptorPath = descriptorFile.path.toPath()
+    // Through the injected filesystem, not `File.isFile`: an existence check that always reads the
+    // real disk would reject every path a `FakeFileSystem` holds, making the parameter above a seam
+    // in name only. `isRegularFile` keeps `isFile`'s exact meaning — a directory is still not a
+    // descriptor.
+    if (fileSystem.metadataOrNull(descriptorPath)?.isRegularFile != true) {
       throw RenderSessionException(
         "Daemon launch descriptor not found at ${descriptorFile.path}. " +
           "Run `:<modulePath>:composePreviewDaemonStart` to materialise it."
@@ -52,7 +63,7 @@ public object SubprocessRenderSessions : RenderSessionFactory {
     }
     val descriptor =
       try {
-        DaemonLaunchDescriptor.parse(fileSystem.read(descriptorFile.path.toPath()) { readUtf8() })
+        DaemonLaunchDescriptor.parse(fileSystem.read(descriptorPath) { readUtf8() })
       } catch (e: Exception) {
         throw RenderSessionException(
           "Daemon launch descriptor at ${descriptorFile.path} is unreadable: " +


### PR DESCRIPTION
#4713 merged at 14:27; its review landed at 14:34. All three findings verified against `main` and fixed here.

## Window and render were the one transposition still allowed

The refactor's own KDoc states the goal: six loose `Int`s became three pairs so "a transposed pair there is a silently wrong crop rather than a build failure". But `window` and `render` were **both** `CropSize`, so a positional `ContentCrop(render, window, …)` still compiled — the exact shape the type was introduced to reject.

`CropSize` becomes `WindowSize` and `RenderSize`. A **replacement, not an addition**: `CropSize` had no other user in the repository, so this removes a type rather than adding two. Read sites are untouched — every use is `.window.w` / `.render.h`, never the whole value — so only the two producers and the six test constructions name the types at all.

## The filesystem seam

`SubprocessRenderSessions` bound the descriptor read to `SystemFileSystem` via a private `val`. The `public var` that replaced deserved to go — it was a process-wide mutable global any consumer could swap — but a private `val` leaves no seam, and `docs/AGENT_GUIDE.md` → Important constraints is specific about the shape for this case:

> stateless functions / `object`s take a defaulted `fileSystem: FileSystem = SystemFileSystem` parameter

A defaulted *parameter* has none of a global's problems: per-call, production default unchanged, and a test can inject `FakeFileSystem` without affecting other callers.

The existence check moves from `File.isFile` onto the same filesystem, using `metadataOrNull(…)?.isRegularFile` to keep `isFile`'s exact meaning. Without that the parameter would be a seam in name only — a check that always reads real disk rejects every path a `FakeFileSystem` holds, so injection could never get as far as the read.

## The stale KDoc

`TransformResult`'s class doc still told callers to use `indexMap[i]` and to look ranges up "through `indexMap`" after the array property became `indexAt()`. Three references corrected. The mention inside `indexAt`'s own doc stays deliberately — it is explaining why the array is *not* the API.

## Test plan

```
./gradlew :common-image-crop:test :render-session-subprocess:compileKotlin        # BUILD SUCCESSFUL
./gradlew :cli:serve:test --tests '*ServeWebThumbCropTest*' \
  --tests '*ServeWebGridThumbnailTest*' --tests '*ServeHeroImagesTest*' \
  --tests '*ServeBundleHostTest*'                                                 # BUILD SUCCESSFUL
./gradlew :common-image-crop:checkKotlinAbi :render-session-subprocess:checkKotlinAbi
                                                                                  # BUILD SUCCESSFUL
```

Both ABI dumps changed and are updated. Worth noting how: I first hand-edited them, and `checkKotlinAbi` — the gate #4717 added an hour ago — rejected `common-image-crop` over a trailing newline. The committed dumps are the tool's own output, not my transcription.

The transposition fix has no runtime test because there is nothing left to test at runtime: `ContentCrop(render, window, …)` is now a type error, and the compiler is the assertion. The existing crop tests all exercise the new types.

ktfmt run on every touched module. Non-visual change, so no render evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_