### PR TITLE
fix(design-map): namespace absence keys and name seedless variants

### DIFF
--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -426,7 +426,13 @@ export function variantAbsenceId(preview) {
   const axes = variantSeeds(preview)
     .map((seed) => `${seed.key}=${seed.raw}`)
     .join(" ");
-  return axes ? `${parent} [${axes}]` : parent;
+  // `state` and `props` are both optional, so a variant CAN declare `noReference` and name no axis
+  // at all. Falling back to the bare parent id then publishes "Button — <reason>" for a parent that
+  // may hold a perfectly good reference: it reads as a finding about the parent, and says nothing
+  // about which variant the reason belongs to. The function name is what distinguishes such a
+  // variant, so it stands in for the axes it did not give.
+  const label = axes || preview.functionName || captureIdentity(preview).subject;
+  return label ? `${parent} [${label}]` : parent;
 }
 
 function variantName(preview, seeds) {
@@ -553,8 +559,10 @@ export function projectDesignMap(previews, opts = {}) {
   /**
    * Stated absences, keyed by a COLLISION-SAFE identity and carrying the display label separately.
    *
-   * A component keys on its own id. A variant keys on its capture subject, which is per-composable
-   * and unique — never on its rendered label. The label is built by joining `key=value` pairs, and
+   * A component keys on its own id and a variant on its capture subject, each behind its own
+   * prefix. Both are free-form strings from different namespaces — a `@CatalogComponent(id = …)`
+   * may legally be spelled like a capture subject — so sharing one map without tagging the domain
+   * is the same collision one namespace over. Never keyed on the rendered label. The label is built by joining `key=value` pairs, and
    * discovery splits an annotation prop at its FIRST `=` only, so a value may legally contain both
    * a space and an `=`: `props = ["a=b c=d"]` is one prop, and renders identically to the two props
    * `a=b` and `c=d`. Keying on that string would silently drop one of two distinct absences — the
@@ -583,7 +591,7 @@ export function projectDesignMap(previews, opts = {}) {
     if (catalog.role === "VARIANT") {
       if (!catalog.noReference) continue; // silence under a parent is the parent's business
       const subject = captureIdentity(preview).subject;
-      statedAbsentIds.set(subject, {
+      statedAbsentIds.set(`subject:${subject}`, {
         label: variantAbsenceId(preview),
         reason: catalog.noReference,
       });
@@ -598,7 +606,7 @@ export function projectDesignMap(previews, opts = {}) {
     if (catalog.role !== "COMPONENT") continue;
     const id = catalog.componentId;
     if (catalog.noReference) {
-      statedAbsentIds.set(id, { label: id, reason: catalog.noReference });
+      statedAbsentIds.set(`component:${id}`, { label: id, reason: catalog.noReference });
       statedAbsentComponentIds.add(id);
     } else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);
   }

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -236,6 +236,41 @@ test("a prop value containing its own key=value text does not collide with two p
   );
 });
 
+test("a seedless variant names itself, not its parent", () => {
+  // `state` and `props` are both optional, so a variant can declare `noReference` and name no axis.
+  // Falling back to the bare parent id published "Button - <reason>" for a parent that holds a
+  // perfectly good reference: a finding about the wrong thing, with no clue which variant meant it.
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("SpecialButton", "Button", { noReference: "the kit never drew this one" }),
+  ]);
+  assert.deepEqual(diagnostics.statedAbsent, [
+    { componentId: "Button [SpecialButton]", reason: "the kit never drew this one" },
+  ]);
+  // The parent keeps its reference and stays out of both buckets.
+  assert.deepEqual(diagnostics.unmapped, []);
+});
+
+test("a component id spelled like a capture subject does not collide with a variant", () => {
+  // Component ids are free-form, so one may legally be spelled like a capture subject. Sharing a
+  // map between the two namespaces without tagging the domain is the same collision one namespace
+  // over -- either reason overwriting the other, or an unexplained component skipping `unmapped`.
+  const subjectShaped = "com.example.CatalogKt.IconOnly";
+  const { diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    component(subjectShaped, { noReference: "component that is named like a subject" }),
+    catalogVariant("IconOnly", "Button", {
+      state: "icon-only",
+      noReference: "variant whose subject is that name",
+    }),
+  ]);
+  assert.equal(diagnostics.statedAbsent.length, 2);
+  assert.deepEqual(
+    diagnostics.statedAbsent.map((s) => s.reason).sort(),
+    ["component that is named like a subject", "variant whose subject is that name"],
+  );
+});
+
 test("a stated-absent variant's ambiguous modes are suppressed even when its parent has a reference", () => {
   // The ambiguity filter matches on componentId, which for a VARIANT is the PARENT's -- so a
   // variant's own stated absence could not suppress its own record, and a parent carrying a good


### PR DESCRIPTION
Follow-up to #4722, which merged before these two landed. Both found by Codex on that PR, both reachable from legal declarations, both the same family as the collisions fixed there.

## Component ids and capture subjects are different namespaces

`statedAbsentIds` keys a component on its own id and a variant on its capture subject. Both are free-form strings, and a `@CatalogComponent(id = "com.example.CatalogKt.IconOnly")` may legally be spelled like a subject. Sharing one map between two namespaces without tagging the domain is the same collision one namespace over: depending on manifest order, either one reason overwrites the other, or an unexplained component skips `unmapped` and `--strict` passes when it should fail.

Keys now carry a `component:` / `subject:` prefix.

## A seedless variant must name itself

`state` and `props` are both optional, so a variant can declare `noReference` and name no axis at all — and the projection already anticipates that elsewhere (`if (!seeds.length) continue` in the capture loop). The label then fell back to the bare parent id:

```
Button — the kit never drew this one
```

for a parent that may hold a perfectly good reference. It reads as a finding about the parent, and says nothing about which variant meant it. Such a variant is distinguished by its function name, so that stands in for the axes it did not give: `Button [SpecialButton]`.

## One finding I did not act on

Codex also flagged that `isVariantCapture` matches the `_VARIANT_` marker as a bare substring, so a function named `Icon_VARIANT_Only` is misclassified as a generated `@OverrideVariant` reseed and skipped.

That is real, but **pre-existing and unchanged by #4722** — `if (isVariantCapture(preview)) continue;` sits in the same position it did before, and a component with such a name was already dropped from `unmapped` / `statedAbsent`. Fixing it means parsing the id structurally rather than by substring, which also governs the `@OverrideVariant` path and deserves its own change and its own evidence. Flagging it here rather than widening this one.

## Test plan

`design-map` package suite — **66 pass**, 2 new:

- a seedless variant reported as `Button [SpecialButton]`, with the parent keeping its reference and staying out of both buckets;
- a component id spelled like a capture subject alongside a variant whose subject is that name — both reasons surviving.

The four cases added in #4722 are unchanged and still pass, so nothing there regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx)_