### PR TITLE
fix(serve): stop a plain module offering a catalog report, and pin the mode

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4524,19 +4524,36 @@ class ServeHttpServer(
    * A preview's own defect keeps the better route it already has wherever one exists: the viewer
    * and the focused comparison file against that exact preview.
    */
+  /**
+   * The page-scoped catalog report for this surface, or null when there is no catalog to file
+   * against.
+   *
+   * Nullable deliberately, and every caller's parameter already says so — *"Null (a plain module,
+   * or any caller that has nothing to file against) omits it entirely"*. The handlers passed it
+   * unconditionally, so a `compose-preview serve` on a PLAIN MODULE offered to file a bug about
+   * "this catalog": there is no catalog, `catalogBundleHost` is null, and
+   * [ServeIssueReport.repoFor] fell back to compose-ai-tools — the tool's own tracker named as the
+   * repo declaring a catalog the visitor does not have.
+   *
+   * The gate is whether a catalog EXISTS, not whether it names a repo. A catalog that declares
+   * neither source nor provenance still has something to report about, and the fallback is the
+   * right last resort for it — "better than nothing, and usually the same project". Gating on the
+   * repo instead would silently drop the tracker from every such catalog, which
+   * `ServeDesignPageRoutingTest` and `ServeHttpRoutingTest` both assert it must not.
+   */
   private fun RoutingContext.pageScopedReportIssue(
     renderHost: ServeHost,
     sessionId: String,
     subject: String,
-  ): ServeWeb.ReportIssue {
-    val bundleHost = catalogBundleHost(renderHost)
+  ): ServeWeb.ReportIssue? {
+    val bundleHost = catalogBundleHost(renderHost) ?: return null
     val context =
       ServeIssueReport.Context(
-        repo = ServeIssueReport.repoFor(bundleHost?.catalogSource, bundleHost?.provenance),
+        repo = ServeIssueReport.repoFor(bundleHost.catalogSource, bundleHost.provenance),
         system = sessionId,
-        catalog = bundleHost?.provenance?.let { "${it.repo}@${it.branch}" },
-        toolVersion = bundleHost?.provenance?.toolVersion,
-        pageUrl = ServeIssueReport.withoutToken(externalPageUrl()),
+        catalog = bundleHost.provenance?.let { "${it.repo}@${it.branch}" },
+        toolVersion = bundleHost.provenance?.toolVersion,
+        pageUrl = ServeIssueReport.withoutToken(pageUrlPinningChrome()),
         publicRender = isPublic,
       )
     return ServeWeb.ReportIssue(
@@ -4547,6 +4564,27 @@ class ServeHttpServer(
       login = githubAuth?.currentLogin(call),
       subject = subject,
     )
+  }
+
+  /**
+   * This page's URL with the presentation mode the request RESOLVED pinned onto it.
+   *
+   * A report link is read by someone who does not have the reporter's cookie. The mode is
+   * deliberately a property of the visitor rather than of each URL — the previous scheme appended
+   * `?chrome=` to every same-origin href and was removed because it "put a parameter nobody chose
+   * into every URL a visitor copied" — but `?chrome=` was kept for exactly this: *"a link may pin
+   * the presentation it was written for"*. Without it a Catalog-mode report opens the Dev landing
+   * for a triager whose own cookie says Dev, which is a different surface from the one reported.
+   *
+   * Both modes are pinned, not just Catalog: a Dev-mode report read by a Catalog-mode triager is
+   * the same failure mirrored. A URL that already carries `?chrome=` is left alone — it pinned
+   * itself, and that pin is what the request resolved anyway.
+   */
+  private fun RoutingContext.pageUrlPinningChrome(): String {
+    val url = externalPageUrl()
+    if (call.request.queryParameters[CHROME_PARAM] != null) return url
+    val mode = if (componentBrowserMode()) "catalog" else "dev"
+    return url + (if ('?' in url) "&" else "?") + "$CHROME_PARAM=$mode"
   }
 
   private fun catalogBundleHost(host: ServeHost): ServeBundleHost? =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1729,6 +1729,56 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a plain module's landing offers no catalog tracker`() {
+    // `burst` is a plain `ServeHost`, not a `ServeBundleHost`, so `catalogBundleHost` is null and
+    // there is no catalog to file anything against. The page-scoped report was built
+    // unconditionally, and `repoFor` falls back to compose-ai-tools when a session names neither
+    // source nor provenance — so this module's visitor was offered a form naming the TOOL's own
+    // tracker as the repo that declares "this catalog", for a catalog that does not exist. Every
+    // caller's parameter documents the opposite: "Null (a plain module, or any caller that has
+    // nothing to file against) omits it entirely."
+    //
+    // `/burst` rather than `/`: this server registers several sessions, so `/` is the FRONT DOOR
+    // and carries no catalog report either way — an assertion there passes whatever the handler
+    // does, which is how the first version of this test managed to hold against the bug.
+    //
+    // Only the catalog half is asserted absent. The floating launcher's SERVER half legitimately
+    // points at this repository — a preview server bug is ours — and is not what this removes.
+    val (code, landing) = get("/burst")
+    assertEquals(200, code, "the plain module's landing is served: $landing")
+    assertTrue(
+      !landing.contains("id=\"cp-report\""),
+      "a plain module's landing carries no catalog report row: $landing",
+    )
+    assertTrue(
+      !landing.contains("data-cp-subject=\"this catalog\""),
+      "and nothing claims a catalog it does not have: $landing",
+    )
+  }
+
+  @Test
+  fun `a page-scoped report pins the presentation mode it was filed from`() {
+    // The report link is read by a triager who does not have the reporter's cookie. Mode is
+    // deliberately a property of the visitor rather than of each URL, but `?chrome=` was kept
+    // precisely as a permalink — "a link may pin the presentation it was written for". Without it a
+    // Catalog-mode report opens the Dev surface for a Dev-mode triager, which is not the page that
+    // was reported.
+    val (_, dev) = get("/compose-m3")
+    assertTrue(dev.contains("chrome%3Ddev") || dev.contains("chrome=dev"), "Dev pins dev: $dev")
+
+    val (_, catalog) = get("/compose-m3?chrome=catalog")
+    assertTrue(
+      catalog.contains("chrome%3Dcatalog") || catalog.contains("chrome=catalog"),
+      "Catalog mode pins catalog: $catalog",
+    )
+    // A URL that already pinned itself is left alone rather than pinned twice.
+    assertTrue(
+      !catalog.contains("chrome%3Dcatalog%26chrome") && !catalog.contains("chrome=catalog&chrome"),
+      "the pin is not appended to a URL that already carries one: $catalog",
+    )
+  }
+
+  @Test
   fun `viewer unfurl metadata uses the external origin and preserves render overrides`() {
     val request =
       Request.Builder()

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebFixtureTest.kt
@@ -2554,6 +2554,11 @@ class ServeWebFixtureTest {
         trust = "branch:yschimke/compose-ai-tools@design-artifacts/compose-m3",
         isPublic = true,
         version = version,
+        // `handleMotionIndex` passes a page-scoped report, so a fixture without one captures a page
+        // shape production never serves — the committed HTML had no `#cp-report` at all, and the
+        // Playwright motion snapshots were diffing a row short. Same subject the handler uses.
+        reportIssue =
+          fixturePageReportIssue("https://preview.coo.ee/compose-m3/motion", "this motion browser"),
       )
 
     val designPageIndex =

--- a/preview-server/preview-harness/fixtures/pages/serve-motion-index.html
+++ b/preview-server/preview-harness/fixtures/pages/serve-motion-index.html
@@ -60,6 +60,48 @@
         by component and set side by side — so a transition that is shaped differently from its
         neighbours is visible without opening each component in turn.
         5 recordings across 4 components.</p>
+          <div class="cp-preview-links cp-page-links">
+      <details class="cp-report" id="cp-report" data-cp-repo="yschimke/compose-ai-tools" data-cp-subject="this motion browser"><summary class="cp-report-link" title="Something wrong with this motion browser — files against yschimke/compose-ai-tools as @yschimke"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> report a catalog issue</summary>
+        <div class="cp-report-panel"><form class="cp-report-form" method="get" target="_blank" rel="noopener" action="https://github.com/yschimke/compose-ai-tools/issues/new"><label class="cp-report-summary">Summary<input class="cp-report-summary-input" type="text" name="title" required autocomplete="off" placeholder="Briefly describe what is wrong"></label><input type="hidden" name="body" id="cp-report-body" value="### What&#39;s wrong
+
+&lt;!-- What did you expect to see, and what did you get? --&gt;
+
+
+### Screenshot
+
+&lt;!-- Paste it here. The &quot;Report a problem&quot; launcher on the page has a capture control that copies the whole view, a region, or one element to your clipboard, so Ctrl-V / Cmd-V lands it in this issue. --&gt;
+
+
+### Which page
+
+| | |
+| --- | --- |
+| Design system | `compose-m3` |
+| Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
+| Rendered by | compose-ai-tools 0.16.54 |
+
+[Open this page](https://preview.coo.ee/compose-m3/motion)
+" data-report-template="### What&#39;s wrong
+
+&lt;!-- What did you expect to see, and what did you get? --&gt;
+
+
+### Screenshot
+
+&lt;!-- Paste it here. The &quot;Report a problem&quot; launcher on the page has a capture control that copies the whole view, a region, or one element to your clipboard, so Ctrl-V / Cmd-V lands it in this issue. --&gt;
+
+
+### Which page
+
+| | |
+| --- | --- |
+| Design system | `compose-m3` |
+| Catalog | `yschimke/compose-ai-tools@design-artifacts/compose-m3` |
+| Rendered by | compose-ai-tools 0.16.54 |
+
+[Open this page](https://preview.coo.ee/compose-m3/motion)
+"><button type="submit" class="cp-report-submit"><svg class="cp-gh" viewBox="0 0 16 16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> Open a prefilled issue</button><span class="cp-report-note">Files against <code>yschimke/compose-ai-tools</code> as @yschimke — the project whose code declares this motion browser, <em>not</em> the preview server. The rest of the report — what you were looking at, which build, the links — is filled in for you on GitHub.</span></form></div></details>
+          </div>
         <div class="cp-motion-toolbar">
           <button type="button" id="cp-motion-all" class="cp-action-chip cp-motion-all"
             aria-pressed="false" aria-controls="cp-motion-index">Play all</button>


### PR DESCRIPTION
#4706 merged at 13:40; its review landed at 13:45. All three findings verified and fixed.

## A plain module was offered a catalog report against this repo

`compose-preview serve` on a plain module has no catalog, but the landing built its page-scoped report unconditionally. `catalogBundleHost` is null, `repoFor` falls back to `yschimke/compose-ai-tools`, and the visitor got a form offering to file a bug about **"this catalog"** against the tool's own tracker — the wrong repo, for a thing that does not exist.

Every caller's parameter already documented the opposite:

> Null (a plain module, or any caller that has nothing to file against) omits it entirely.

**The gate is whether a catalog exists, not whether it names a repo.** My first attempt gated on source/provenance, per the finding's wording, and it broke `ServeDesignPageRoutingTest` and `ServeHttpRoutingTest` — both assert the tracker *is* offered for catalogs that declare neither. They're right: such a catalog still has something to report about, and the fallback is the correct last resort there ("better than nothing, and usually the same project"). The bug is the plain module.

Fixed in the shared helper, so all five page-scoped callers get it, not just the landing.

## The report link lost the presentation mode

Mode lives in the `cp_chrome` cookie, so a report's "Open this page" link opened whatever surface the *triager's* cookie says — not the one reported. Mode is deliberately a property of the visitor rather than of each URL, but `?chrome=` was kept for exactly this case:

> `?chrome=` survives as a **permalink**: a link may pin the presentation it was written for.

Both modes are pinned, not only Catalog — a Dev-mode report read by a Catalog-mode triager is the same failure mirrored. A URL that already carries `?chrome=` is left alone.

## The motion golden was a row short

`ServeWebFixtureTest` built `motionIndexPage` without `reportIssue`, so the committed `serve-motion-index.html` had no `#cp-report` and the Playwright snapshots were diffing a page shape production never serves. Regenerated with `UPDATE_SERVE_WEB_FIXTURES=true`; **that fixture is the only one that moved** (the sync check reported `1 stale, 0 missing of 75`), so this rebaselines exactly the one capture.

## Test plan

```
./gradlew :cli:serve:test          # BUILD SUCCESSFUL — full serve suite
./gradlew :cli:serve:ktfmtFormatMain :cli:serve:ktfmtFormatTest
```

Two new tests, both checked for vacuity by reverting the fix and confirming they fail:

- `a plain module's landing offers no catalog tracker` — **the first version of this test was vacuous and I caught it that way.** It used `/`, which on this server is the front door, not a landing; it carries no catalog report whatever the handler does, so it passed against the bug. Retargeted at `/burst`, a real plain `ServeHost`. It now fails without the fix.
- `a page-scoped report pins the presentation mode it was filed from` — fails without the fix, since the URL previously carried no `chrome=` at all.

The motion capture will show as changed on the diff bot. That change is the fix: the row was missing from the golden, not added to the page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_