### PR TITLE
fix(render-session): publish Okio on the consumer compile classpath

### DIFF
--- a/render-session/subprocess/build.gradle.kts
+++ b/render-session/subprocess/build.gradle.kts
@@ -18,7 +18,13 @@ plugins {
 
 dependencies {
   api(project(":render-session-api"))
-  implementation(project(":common-io"))
+
+  // `api`, not `implementation`: `SubprocessRenderSessions.open` takes a defaulted
+  // `fileSystem: okio.FileSystem`, so Okio is part of this module's PUBLIC signature. `:common-io`
+  // exposes it with `api(libs.okio)` for exactly this reason, but an `implementation` edge keeps it
+  // off the consumer's COMPILE classpath — Gradle publishes it as a runtime dependency — so an
+  // external caller could not name the parameter without depending on Okio itself.
+  api(project(":common-io"))
 
   // JSON-RPC client + subprocess spawn infrastructure. Public surface here is the `RenderSession`
   // contract; the client types stay internal to this module.


### PR DESCRIPTION
Follow-up to #4724, which merged before I could address this review. The finding is correct and the regression is mine.

## What was wrong

#4724 restored the filesystem injection seam by adding a defaulted `fileSystem: okio.FileSystem` to `SubprocessRenderSessions.open`. That puts Okio in this module's **public signature** — but `render-session/subprocess/build.gradle.kts` still declared `:common-io` as `implementation`, so Gradle published it as a runtime-only dependency.

The result: an external consumer could not name the parameter without adding Okio themselves. The seam that PR existed to restore was unusable from outside this build.

`:common-io` already exposes Okio deliberately — `api(libs.okio)`, with a comment saying the point is to "put `SystemFileSystem` / `okio.Path` on their compile classpath". The edge into it just had to carry that through.

## Verification

On the generated POM rather than by reading the keyword:

```
# before
<artifactId>common-io</artifactId>  <scope>runtime</scope>

# after
<artifactId>common-io</artifactId>  <scope>compile</scope>
```

`./gradlew :render-session-subprocess:compileKotlin` — clean. Formatter run on the build script.

## Worth noting

That file already carried a comment about this exact class of mistake — `implementation(project(":mcp"))` once made consuming the render-session library drag an MCP server onto the classpath, recorded as "the last leak the preview-server contract probe recorded". This is the mirror error: a dependency that needed to be `api` and wasn't, rather than one that leaked when it shouldn't have.

Nothing catches it automatically. The ABI dump records the signature but not which classpath resolves it, and the contract probe compiles inside this build where the `implementation` edge is still visible. A consumer-classpath check would have to build against the published POM.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_