### PR TITLE
test(rc-player-jvm): follow the AppCard clip geometry after the padding fix

### DIFF
--- a/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFigmaSvgExportTest.kt
+++ b/third_party/rc-embedded-player-jvm/src/test/kotlin/ee/schimke/composeai/rcembedded/jvm/RcJvmFigmaSvgExportTest.kt
@@ -195,15 +195,21 @@ class RcJvmFigmaSvgExportTest {
     assert(!svg.contains("href=\"figma-raster/")) {
       "AppCard production SVG contains a dangling raster layer"
     }
+    // The three numbers here have each moved once, for a reason worth keeping written down.
+    //
     // rx=52, not 104: the fixture's corner arrives from remote-core as `52` at DENSITY=2f (a 26dp
     // card corner with the density already folded in), and the player passes it through. This
     // asserted 104 while `RemoteRoundedClipShape` multiplied by density a second time — the
     // doubling that clipped the corners off `RemoteOutlinedCard`'s border
-    // (yschimke/wear-m3-catalog#89). 104 survives here for the same reason it survived there: on a
-    // 640x216 box a 104 radius is still under half the height, so nothing clamps it back.
+    // (yschimke/wear-m3-catalog#89).
+    //
+    // y=156 h=168, not y=132 h=216: the card's own padding was applied twice, so it was 48px
+    // taller and sat 24px higher. `PaddingModifier` now reads the source edges rather than the
+    // ones `updateVariables` re-scales (yschimke/wear-m3-catalog#90), and the card is the size its
+    // content asks for.
     assert(
       Regex(
-          "<clipPath[^>]*>\\s*<rect[^>]*x=\"0\"[^>]*y=\"132\"[^>]*width=\"640\"[^>]*height=\"216\"[^>]*rx=\"52\""
+          "<clipPath[^>]*>\\s*<rect[^>]*x=\"0\"[^>]*y=\"156\"[^>]*width=\"640\"[^>]*height=\"168\"[^>]*rx=\"52\""
         )
         .containsMatchIn(svg)
     ) {


### PR DESCRIPTION
**main is red.** #4727 merged with `Renderer Android Unit Tests` failing, and this is that failure. My miss: I ran `:third-party-rc-embedded-player:testDebugUnitTest` before pushing but not the `-jvm` sibling, which is the module that owns the fixture assertion. I made exactly this mistake once already on #4710 and did not carry the lesson forward.

## What moved

`RcJvmFigmaSvgExportTest` pins the AppCard fixture's clip rect. The card's own padding was being applied twice, so it was **48px taller and sat 24px higher** than its content asks for:

| | before | after |
| --- | --- | --- |
| `y` | 132 | **156** |
| `height` | 216 | **168** |
| `rx` | 52 | 52 (unchanged) |

`rx` staying put is the useful part: the corner radius was corrected by #4710 and the geometry by #4727, so the two fixes remain legible as separate facts in this baseline rather than collapsing into one number nobody can attribute. The comment records both.

This is a baseline that legitimately follows the fix — the rendered card really is a different size now, and correctly so.

## Test plan

- `:third-party-rc-embedded-player-jvm:test` — green (was the failing job).
- `:third-party-rc-embedded-player:testDebugUnitTest` — green.
- `./gradlew ktfmtCheckAll` — green.

Reproduced the failure on `origin/main` first, then confirmed the same suite passing with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx)_