### PR TITLE
fix(remotecompose): declare the density behavior the capture actually writes

### DIFF
--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -132,20 +132,45 @@ fun RemoteOverridablePreview(
   val context = LocalContext.current
 
   val displayMetrics = context.resources.displayMetrics
-  // Capture in `Dp` density behavior, not the 3-arg default (`Legacy`). Legacy serialises the
-  // dp-typed size modifiers (`size(dp)`, `heightIn(dp)` / `buttonSizeModifier`) inconsistently, so
-  // a
-  // player can't reproduce the generation-density render — Material3 button/card fills and the
-  // circular-progress indicator come out ~1/density too small. `Dp` keeps those dimensions in dp so
-  // a player can scale them by the generation density. That density is written into the header
-  // below (the alpha writer records DOC_WIDTH/HEIGHT in px and the density *behavior*, but not the
-  // density value itself), which the rc-player consumes to scale the dp modifiers back to px.
+  // Capture in `Legacy` density behavior, which is the only value that describes what
+  // `remote-creation-compose` actually writes.
+  //
+  // The header is a single global flag, but the document it describes is MIXED, and the creation
+  // library's choice does not follow the flag — a document captured under `Dp` and one captured
+  // under `Pixels` are byte-identical. What it writes is fixed:
+  //
+  //   padding / spacedBy gaps / border width / clip radii   PIXELS (`RemoteDp.toPx()` at capture)
+  //   heightIn / widthIn                                    DP     (relies on core to scale)
+  //   height / width                                        EXACT_DP, self-describing
+  //
+  // And remote-core's `updateVariables` applies a DIFFERENT predicate per op:
+  //
+  //   PaddingModifierOperation          scales when behavior == DP
+  //   DimensionInModifierOperation      scales when behavior != PIXELS
+  //   RoundedClipRectModifierOperation  never scales
+  //
+  // So no single flag is right for every op, and only `Legacy` is right for every op *as the
+  // library writes them*: padding is left alone (it is already px) and `heightIn` is scaled (it is
+  // dp). `Dp` — what this used to declare — asserts that padding is dp, so core multiplied
+  // already-scaled pixels a second time. That is one bug, and it surfaced three times: the
+  // outlined card's border (wear-m3-catalog#89, via this player's matching assumption in
+  // `ClipModifier`), the compact button's height (#90), and `RemoteButtonGroup`'s 4dp gap rendering
+  // at 8dp.
+  //
+  // The comment this replaces rejected `Legacy` because "Material3 button/card fills and the
+  // circular-progress indicator come out ~1/density too small". That does not reproduce: measured
+  // across the 57-sticker `remote-catalog` sheet, `Legacy` renders 56 byte-identical to `Dp` and
+  // fixes the 57th. The original symptom was a player-side bug, not a serialisation one.
+  //
+  // `DOC_DENSITY_AT_GENERATION` is still stamped below: the alpha writer records DOC_WIDTH/HEIGHT
+  // in px and the behavior but not the density value, and the player needs it to resolve the
+  // dp-typed dimensions.
   val displayInfo =
     RemoteCreationDisplayInfo(
       displayMetrics.widthPixels,
       displayMetrics.heightPixels,
       displayMetrics.densityDpi,
-      densityBehavior = RemoteDensityBehavior.Dp,
+      densityBehavior = RemoteDensityBehavior.Legacy,
     )
   // Same capture pattern as upstream `RemotePreview` — `runBlocking` inside `remember` so the
   // document materialises once per (profile, content) pair without re-capturing across


### PR DESCRIPTION
Follows the contract instead of compensating for it, which is what Codex was pushing for on #4727.

**This is a workaround, not the fix.** The defect is upstream — the creation library ignores the header that core reads. Filed as #4735, which carries the full analysis and the proposed AndroidX change. This PR is what makes renders correct until that lands.

## What the capture actually writes

The header is a single global flag. The document it describes is **mixed**, and the creation library's output does not follow the flag at all — a capture under `Dp` and one under `Pixels` are **byte-identical** (verified by dumping both).

| written by `remote-creation-compose` | unit |
| --- | --- |
| padding, `spacedBy` gaps, border width, clip radii | **px** — `RemoteDp.toPx()` folds density at capture |
| `heightIn` / `widthIn` | **dp** — relies on core to scale |
| `height` / `width` | `EXACT_DP`, self-describing |

## What remote-core does with it

Core applies a **different predicate per op** — this is the part that makes a single flag unable to be right:

| op | scales by density when |
| --- | --- |
| `PaddingModifierOperation` (`updateVariables`) | behavior `== DP` |
| `RoundedClipRectModifierOperation` (`paint`) | behavior `== DP` |
| `DimensionInModifierOperation` — `heightIn`/`widthIn` (`updateVariables`) | behavior `!= PIXELS` |
| `DimensionModifierOperation` — `height`/`width` | never — branches on its own `EXACT` / `EXACT_DP` type |

Cross those two tables and only one flag works:

| header | padding | clip radii | `heightIn` | `spacedBy` |
| --- | --- | --- | --- | --- |
| `Dp` (what we declared) | ✗ doubled | ✗ doubled | ✓ | ✗ doubled |
| `Pixels` | ✓ | ✓ | ✗ halved — filled button renders 30dp | ✓ |
| **`Legacy`** | ✓ | ✓ | ✓ | ✓ |

`Dp` asserted that padding is dp, so core multiplied already-scaled pixels a second time. **One bug, surfaced three times:** the outlined card's border ([wear-m3-catalog#89](https://github.com/yschimke/wear-m3-catalog/issues/89)), the compact button's height ([#90](https://github.com/yschimke/wear-m3-catalog/issues/90)), and `RemoteButtonGroup`'s gap.

## The comment this replaces was wrong

It rejected `Legacy` because *"Material3 button/card fills and the circular-progress indicator come out ~1/density too small"*. That does not reproduce. Measured across the whole 57-sticker `remote-catalog` sheet, `Legacy` renders **56 byte-identical to `Dp`** and fixes the 57th. Filled buttons are 52dp, the three circular-progress stickers render at full canvas, nothing comes back empty.

The original symptom was a player-side bug, not a serialisation one — the same confusion this whole thread has been untangling.

## The 57th

`ButtonGroupRemote`'s interior gap:

| | gap |
| --- | --- |
| `Dp` (today) | 8dp |
| `Legacy` | **4dp** |

`RemoteButtonGroupDefaults.Spacing` is `4.rdp` — confirmed in the bytecode (`iconst_4`). So this is a third render corrected, not a regression.

## Relationship to the two merged player fixes

- **#4710 (clip radius)** — still necessary and unaffected here. Correction to what this PR originally said: `RoundedClipRectModifierOperation` *does* carry a density predicate, in `paint()` rather than `updateVariables`, so the vendored player's multiply was mirroring core's own. Removing it is right for the px payload the library actually writes, and under `Legacy` player and core agree again. If #4735 is fixed such that the library emits dp radii, that multiply has to come back — the two are coupled, and #4735 records it.
- **#4727 (raw padding read)** — becomes a **no-op** under `Legacy`, since core no longer writes a scaled `mLeftValue`, so the source and resolved fields are equal. Harmless, and I have left it: it keeps the player correct for a document captured by an older connector, which every already-published `.rc` sidecar is. Worth simplifying once those age out, not now.

## Test plan

- `:data-remotecompose-connector:test` — green.
- `./gradlew ktfmtCheckAll` — green.
- End-to-end: published the connector to mavenLocal at `1.45.0-SNAPSHOT` and re-rendered wear-m3-catalog's `remote-catalog` under all three behaviors with the current player. `Dp` vs `Legacy`: 56/57 identical, `ButtonGroupRemote` corrected. `Pixels` verified as the wrong answer (filled button 30dp) rather than assumed.
- Document contents dumped under `Dp` and `Pixels` to establish the creation library ignores the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQFfhPw2qioPWGv8S2VSDx)_