### PR TITLE
fix(serve): mark catalogs explicitly, and replace an unrecognised chrome pin

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -42,6 +42,24 @@ class ServeBundleHost(
    */
   val trust: BundleVerifier.Verdict = BundleVerifier.Verdict.Unverified("not checked"),
   /**
+   * Whether this host serves a **design-system catalog** rather than a plain bundle.
+   *
+   * The type cannot answer this. `ServeBundleHost` backs three different things — a catalog
+   * published by [ServeCatalogStore], a `--bundles` directory ([ServeRunner]), and an uploaded
+   * portable bundle ([ServeBundleStore]) — and only the first has a `catalog.json` behind it. The
+   * other two are plain bundles that happen to share the implementation, so an `is ServeBundleHost`
+   * test reads them as catalogs too.
+   *
+   * Set true only where a catalog is actually being built. Callers that speak *about a catalog* —
+   * the page-scoped issue report says "this catalog" — need this rather than the type, or a plain
+   * uploaded bundle is offered a report naming a catalog it does not have (#4728 review).
+   *
+   * Not inferred from [title] / [provenance] / [catalogSource]: those are all individually optional
+   * on a real catalog, so absence proves nothing and a catalog declaring none of them would be
+   * misread as plain.
+   */
+  val isCatalog: Boolean = false,
+  /**
    * Human display title for a design-system catalog (e.g. "Compose Material 3"), taken from
    * `catalog.json`'s `title`. Null for a plain uploaded bundle (no such metadata). Surfaced on the
    * public server's home index so each system card reads as a name, not a bare id.

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -896,6 +896,9 @@ class ServeCatalogStore(
           dir,
           safe,
           verdict,
+          // The one construction site with a `catalog.json` behind it. See
+          // [ServeBundleHost.isCatalog].
+          isCatalog = true,
           title = catalog.title?.takeIf { it.isNotBlank() },
           subtitle =
             catalog.library.filter { it.isNotBlank() }.take(2).joinToString(" · ").ifBlank { null },

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4540,13 +4540,19 @@ class ServeHttpServer(
    * right last resort for it — "better than nothing, and usually the same project". Gating on the
    * repo instead would silently drop the tracker from every such catalog, which
    * `ServeDesignPageRoutingTest` and `ServeHttpRoutingTest` both assert it must not.
+   *
+   * [ServeBundleHost.isCatalog] rather than the host type, because `ServeBundleHost` also backs a
+   * `--bundles` directory and an uploaded portable bundle. Those are plain bundles with no
+   * `catalog.json`, and the type alone read them as catalogs — so an upload was offered a report
+   * about "this catalog" against the fallback repo, the same defect as the plain module one door
+   * along (#4728 review).
    */
   private fun RoutingContext.pageScopedReportIssue(
     renderHost: ServeHost,
     sessionId: String,
     subject: String,
   ): ServeWeb.ReportIssue? {
-    val bundleHost = catalogBundleHost(renderHost) ?: return null
+    val bundleHost = catalogBundleHost(renderHost)?.takeIf { it.isCatalog } ?: return null
     val context =
       ServeIssueReport.Context(
         repo = ServeIssueReport.repoFor(bundleHost.catalogSource, bundleHost.provenance),
@@ -4582,9 +4588,21 @@ class ServeHttpServer(
    */
   private fun RoutingContext.pageUrlPinningChrome(): String {
     val url = externalPageUrl()
-    if (call.request.queryParameters[CHROME_PARAM] != null) return url
+    // A RECOGNISED pin is left alone: `componentBrowserMode` honours it, so the URL already names
+    // the mode the page was served in. An UNRECOGNISED one is not — `interfaceMode` returns null
+    // for anything but `catalog`/`dev`, and the request falls back to the cookie or the server
+    // default. Carrying that value into the report would pin a mode the page was never in, which
+    // is the wrong-surface failure this exists to prevent arriving through the one value nobody
+    // validated. So it is REPLACED rather than kept or appended to — a second `chrome=` would
+    // leave the reader's own parser to break the tie.
+    if (interfaceMode(call.request.queryParameters[CHROME_PARAM]) != null) return url
     val mode = if (componentBrowserMode()) "catalog" else "dev"
-    return url + (if ('?' in url) "&" else "?") + "$CHROME_PARAM=$mode"
+    val base = url.substringBefore('?')
+    val kept =
+      url.substringAfter('?', "").split('&').filter {
+        it.isNotEmpty() && it.substringBefore('=') != CHROME_PARAM
+      }
+    return "$base?" + (kept + "$CHROME_PARAM=$mode").joinToString("&")
   }
 
   private fun catalogBundleHost(host: ServeHost): ServeBundleHost? =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeDesignPageRoutingTest.kt
@@ -57,7 +57,9 @@ class ServeDesignPageRoutingTest {
       File(dir, "${ServeDesignPageStore.DIRECTORY}/shape.svg").writeText(svg)
       File(dir, "${ServeDesignPageStore.DIRECTORY}/icons.svg").writeText(svg)
     }
-    return ServeBundleHost(dir, label = label)
+    // A catalog: these fixtures serve design pages and assert the catalog tracker. Plain bundles
+    // (`--bundles`, uploads) construct without this and are correctly excluded.
+    return ServeBundleHost(dir, label = label, isCatalog = true)
   }
 
   private val manifest =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -257,6 +257,12 @@ class ServeHttpRoutingTest {
     parityFeed: Boolean = false,
     stagesRcCompare: Boolean = false,
     tagIndex: Boolean = false,
+    /**
+     * False builds the shape `--bundles` and an upload produce: the same host type with no
+     * `catalog.json` behind it. Defaults true because every other fixture here stands in for a
+     * published catalog.
+     */
+    isCatalog: Boolean = true,
   ): ServeBundleHost {
     val dir = Files.createTempDirectory("routing-$label").toFile().also { it.deleteOnExit() }
     File(dir, "index.html").writeText("<html></html>")
@@ -402,6 +408,7 @@ class ServeHttpRoutingTest {
     return ServeBundleHost(
       dir,
       label = label,
+      isCatalog = isCatalog,
       title = title,
       degradations = degradations,
       stagesRcCompare = stagesRcCompare,
@@ -436,7 +443,7 @@ class ServeHttpRoutingTest {
         """
           .trimIndent()
       )
-    return ServeBundleHost(dir, label = label, figmaDir = figma)
+    return ServeBundleHost(dir, label = label, figmaDir = figma, isCatalog = true)
   }
 
   private val registry = ServeSessionRegistry(open = { null })
@@ -476,6 +483,14 @@ class ServeHttpRoutingTest {
     registry.register(
       "staging-rc",
       host = bundle("staging-rc", rcDoc = rcDocBytes, stagesRcCompare = true),
+      pinned = true,
+    )
+    // A PLAIN BUNDLE — the shape `--bundles` and an upload produce: the same `ServeBundleHost`
+    // type with no `catalog.json` behind it. Kept off `catalogSessions` like `baked-only` so the
+    // home-index test is unaffected.
+    registry.register(
+      "plain-bundle",
+      host = bundle("plain-bundle", isCatalog = false),
       pinned = true,
     )
     registry.register("burst", host = burstHost, pinned = true)
@@ -1757,6 +1772,25 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a plain bundle is not a catalog and offers no catalog tracker`() {
+    // `ServeBundleHost` backs three different things: a catalog published by `ServeCatalogStore`, a
+    // `--bundles` directory, and an uploaded portable bundle. Only the first has a `catalog.json`.
+    // Testing the host TYPE read all three as catalogs, so an upload was offered a report about
+    // "this catalog" against the fallback compose-ai-tools repo — the same defect as the plain
+    // module one door along, arriving through a host that IS a `ServeBundleHost`.
+    val (code, landing) = get("/plain-bundle")
+    assertEquals(200, code, "the plain bundle's landing is served: $landing")
+    assertTrue(
+      !landing.contains("id=\"cp-report\""),
+      "a plain bundle carries no catalog report row: $landing",
+    )
+    assertTrue(
+      !landing.contains("data-cp-subject=\"this catalog\""),
+      "and claims no catalog it does not have: $landing",
+    )
+  }
+
+  @Test
   fun `a page-scoped report pins the presentation mode it was filed from`() {
     // The report link is read by a triager who does not have the reporter's cookie. Mode is
     // deliberately a property of the visitor rather than of each URL, but `?chrome=` was kept
@@ -1775,6 +1809,24 @@ class ServeHttpRoutingTest {
     assertTrue(
       !catalog.contains("chrome%3Dcatalog%26chrome") && !catalog.contains("chrome=catalog&chrome"),
       "the pin is not appended to a URL that already carries one: $catalog",
+    )
+
+    // An UNRECOGNISED pin is replaced, not kept: `interfaceMode` accepts only `catalog`/`dev`, so
+    // the request fell back to the cookie or the server default and the raw value names a mode the
+    // page was never served in. Keeping it pins the wrong surface through the one value nobody
+    // validated; appending would leave two `chrome=` for the reader's parser to break.
+    val (_, bogus) = get("/compose-m3?chrome=invalid")
+    // Scoped to the report form: the raw query legitimately survives elsewhere on the page (the
+    // canonical `og:url` is the URL as requested). What must not carry it is the report.
+    val report = bogus.substringAfter("id=\"cp-report\"", "").substringBefore("</form>")
+    assertTrue(report.isNotEmpty(), "the catalog report row is present: $bogus")
+    assertTrue(
+      report.contains("chrome%3Ddev") || report.contains("chrome=dev"),
+      "an unrecognised pin is replaced with the resolved mode: $report",
+    )
+    assertTrue(
+      !report.contains("chrome%3Dinvalid") && !report.contains("chrome=invalid"),
+      "and the unrecognised value does not survive into the report: $report",
     )
   }
 


### PR DESCRIPTION
Both findings from the review on #4728, which merged before either could be addressed. Both are on code I wrote there.

## A plain bundle is not a catalog

`ServeBundleHost` backs three different things — a catalog published by `ServeCatalogStore`, a `--bundles` directory (`ServeRunner`), and an uploaded portable bundle (`ServeBundleStore`) — and only the first has a `catalog.json` behind it. #4728 gated the page-scoped report on `catalogBundleHost(...) != null`, i.e. on the host **type**, which reads all three as catalogs.

So an uploaded bundle was still offered a report about "this catalog" against the fallback `yschimke/compose-ai-tools` — the same defect the plain-module gate closed, arriving through a host that genuinely *is* a `ServeBundleHost`.

Fixed with an explicit `isCatalog` marker, set at the one construction site that has a `catalog.json`. Deliberately **not** inferred from `title` / `provenance` / `catalogSource`: each is individually optional on a real catalog, so absence proves nothing and a catalog declaring none of them would be misread as plain. (I tried that shape on #4728 and two tests correctly rejected it.)

## An unrecognised chrome pin was preserved

`pageUrlPinningChrome` left any URL alone that already carried `?chrome=`. But `interfaceMode` accepts only `catalog`/`dev` — anything else is ignored and the request falls back to the cookie or the server default. `?chrome=invalid` therefore put a pin in the report naming a mode the page was **never served in**: the wrong-surface failure the pin exists to prevent, arriving through the one value nobody validated.

Only a *recognised* pin is now left alone. An unrecognised one is **replaced** rather than kept — and replaced rather than appended, so no reader has to break a tie between two `chrome=` values.

## Test plan

```
./gradlew :cli:serve:test    # BUILD SUCCESSFUL — full serve suite
./gradlew :cli:serve:ktfmtFormatMain :cli:serve:ktfmtFormatTest
```

Two new assertions, plus a new `plain-bundle` session built from the existing fixture helper with the marker off — the same builder every catalog fixture uses, which is what makes it a fair stand-in for an upload.

The three fixtures that stand in for published catalogs now declare `isCatalog = true`. They were constructing bare hosts and asserting catalog behaviour, so this makes them honest about what they model rather than papering over the gap.

One correction I had to make while writing the chrome test: my first assertion checked the whole page body for the absence of `chrome=invalid`, and failed — the raw query legitimately survives in the canonical `og:url`, which is the URL as requested. The assertion is now scoped to the report form, which is the only place the stale pin would actually mislead anyone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_