### PR TITLE
feat(serve): let a variant cell declare itself second-tier

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -90,6 +90,37 @@ package ee.schimke.composeai.preview
  * Resolution walks the whole meta-annotation closure, so an annotation class that is itself tagged
  * with another one contributes both sets.
  *
+ * ## When a matrix is bigger than a menu
+ *
+ * [secondary] drops a cell out of the component's variant TREE while changing nothing else about
+ * it: it renders, it bakes, it keeps its `_VARIANT_<name>` URL, and it pairs with its design-kit
+ * node exactly as a primary cell does. What it loses is a row in the navigation — the tree and the
+ * viewer's subtree list the primary cells only, and a secondary one is reached by its link (from a
+ * kit page, a design-map pairing, a search result, or the sheet's own "browse all").
+ *
+ * The tiering is not new: theme, breakpoint, font scale and locale have always been secondary, on
+ * the ground that they are a different *rendering* of the same thing rather than a different thing
+ * to look at, and listing them multiplies every row by a matrix nobody navigates by. What is new is
+ * that a state cell can say the same about itself. A catalog that draws a kit set exhaustively
+ * needs it: `wear-m3-catalog`'s segmented progress indicator is 90 cells — 14 segment counts by two
+ * stroke widths by four progress values by disabled — every one of them a real kit node worth
+ * comparing, and none of them something a reader browses to by name.
+ *
+ * ```
+ * @OverrideVariant(
+ *   name = "segments-13-small-stroke-overflow",
+ *   ints = ["segmentCount=13"],
+ *   strings = ["stroke=small"],
+ *   floats = ["progress=1.4"],
+ *   kitProps = ["Segments=13", "Stroke Width=Small", "Progress=Overflow"],
+ *   secondary = true,
+ * )
+ * ```
+ *
+ * Reach for it when the cells exist for a comparison rather than for a reader, and leave it alone
+ * for the handful a reviewer actually looks for (`disabled`, `pressed`, `icon`). It is not a way to
+ * hide a render that does not work: an unwanted cell should not be authored at all.
+ *
  * ## Design-kit correspondence
  *
  * [kitAxis] names the design-kit variant property that the seeded knob represents when its name is
@@ -201,6 +232,15 @@ annotation class OverrideVariant(
    * discovery warning and the cell keeps `kitProps`.
    */
   val kitProps: Array<String> = [],
+  /**
+   * Whether this cell is **second-tier**: rendered, addressable and paired with its kit node as
+   * usual, but left out of the component's variant tree and the viewer's subtree.
+   *
+   * For a matrix that exists to be compared rather than to be browsed — see **When a matrix is
+   * bigger than a menu** above. Defaults to false, which is every cell written before the field
+   * existed.
+   */
+  val secondary: Boolean = false,
 )
 
 /** Harness-driven state for an addressable [OverrideVariant]. */

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -540,6 +540,7 @@ class ServeBundleHost(
           supportsFocus = meta?.supportsFocus == true,
           supportsGestures = meta?.supportsGestures == true,
           fixedTheme = meta?.fixedTheme == true,
+          secondary = meta?.secondary == true,
           // `state` comes only from a `catalog.json`-backed bundle's `variants.json`
           // (`meta.state`).
           // A plain module bundle has no manifest, so an `@OverrideVariant` synthetic preview

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -625,7 +625,8 @@ class ServeCatalogStore(
             image.remoteComposeKnobs.isNotEmpty() ||
             image.supportsFocus ||
             image.supportsGestures ||
-            image.fixedTheme
+            image.fixedTheme ||
+            image.secondary
         ) {
           variants[id] =
             VariantMeta(
@@ -639,6 +640,7 @@ class ServeCatalogStore(
               supportsFocus = image.supportsFocus,
               supportsGestures = image.supportsGestures,
               fixedTheme = image.fixedTheme,
+              secondary = image.secondary,
               motion = motion,
               section = planned.section,
               group = planned.group,
@@ -3020,6 +3022,13 @@ class ServeCatalogStore(
      */
     val fixedTheme: Boolean = false,
     /**
+     * Whether this render is a **second-tier** variant cell — `@OverrideVariant(secondary = true)`,
+     * lifted onto the image by the publisher. It renders, it is addressable and it pairs with its
+     * design-kit node like any other cell; what it is kept out of is the browse surface's variant
+     * tree. See [VariantMeta.secondary].
+     */
+    val secondary: Boolean = false,
+    /**
      * This render's `@Preview` ground and device frame, lifted from the bundle's `previews.json` at
      * export time. See [PreviewParamsMeta] for why a published catalog cannot recover them
      * otherwise.
@@ -3156,6 +3165,17 @@ class ServeCatalogStore(
     val supportsGestures: Boolean = false,
     /** Discovery-time `@FixedTheme` — see [Image.fixedTheme]. */
     val fixedTheme: Boolean = false,
+    /**
+     * Whether this render is a **second-tier** variant cell: listed nowhere in the component's
+     * variant tree, but rendered, addressable by its own URL and paired with its design-kit node
+     * like any other cell. From `@OverrideVariant(secondary = true)`, through the publisher's
+     * per-preview declarations.
+     *
+     * It exists for the catalog that draws a kit set exhaustively: a 90-cell component is 90 real
+     * comparisons and one unusable menu, and the axes that were already second-tier (theme,
+     * breakpoint, font scale, locale) are second-tier for exactly this reason.
+     */
+    val secondary: Boolean = false,
     /**
      * Animated captures this preview can offer instead of its still. Empty for the overwhelming
      * majority of previews; a viewer shows the still exactly as before and surfaces these only as

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRenderHost.kt
@@ -148,6 +148,18 @@ data class ServePreview(
    */
   val fixedTheme: Boolean = false,
   /**
+   * Whether this render is a **second-tier** variant cell: it renders, it keeps its own URL and its
+   * design-kit pairing, but it is not listed in the component's variant tree or in the viewer's
+   * subtree. From `@OverrideVariant(secondary = true)` by way of `previews/variants.json`.
+   *
+   * The tree has always had two tiers — `state` and `props` in it, theme / breakpoint / font scale
+   * / locale out of it, because those are a different rendering of one thing rather than a
+   * different thing to look at. This lets a state cell say the same about itself, which is what a
+   * catalog that draws a kit set exhaustively needs: 90 cells of one progress indicator are 90 real
+   * comparisons and one menu nobody can read.
+   */
+  val secondary: Boolean = false,
+  /**
    * The baked component **state** this preview render represents — `"unchecked"`, `"pressed"`,
    * `"disabled"`, `"unselected"`, … — or `null`/`"default"` for the default render (and for plain
    * bundles / app screens that carry no state). Carried from the catalog's `previews/variants.json`

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeWeb.kt
@@ -3056,10 +3056,17 @@ ${captureControlsHtml().prependIndent("          ")}
     // property of the whole set (see [variantLabel]), so nothing can be named until both passes
     // have run.
     val rows = LinkedHashMap<String, Pair<ServePreview, String>>()
+    // A second-tier cell is never a ROW here — that is what the tier means — but the render on
+    // screen is always its own subtree's subject, so it is exempt from its own filter. Arriving on
+    // one by its link (from a kit page, say) must show a page that says where it is, not a tree of
+    // everything except it. `componentSubtreeHtml` re-adds it if these passes do not, so this only
+    // decides whether it is labelled by its axis or by its name.
+    fun listed(p: ServePreview) = !p.secondary || p.id == current.id
     // This render's own state axis, holding its props fixed.
     val stateKey = switcherStateKey(current)
     val byState = LinkedHashMap<String, ServePreview>()
     for (p in all) {
+      if (!listed(p)) continue
       if (switcherStateKey(p) != stateKey || themeLane(p, darkFirst) != lane) continue
       byState.putIfAbsent(p.state ?: "default", p)
     }
@@ -3068,6 +3075,7 @@ ${captureControlsHtml().prependIndent("          ")}
     val curState = current.state ?: "default"
     val byProps = LinkedHashMap<String, ServePreview>()
     for (p in all) {
+      if (!listed(p)) continue
       if (switcherPropsKey(p) != propsKey || themeLane(p, darkFirst) != lane) continue
       if ((p.state ?: "default") != curState) continue
       byProps.putIfAbsent(propsSignature(p.props), p)
@@ -3078,6 +3086,7 @@ ${captureControlsHtml().prependIndent("          ")}
     val bySize = LinkedHashMap<String, ServePreview>()
     for (p in all) {
       if (p.size == null) continue
+      if (!listed(p)) continue
       if (switcherSizeKey(p) != sizeKey || themeLane(p, darkFirst) != lane) continue
       bySize.putIfAbsent(p.size, p)
     }
@@ -3172,6 +3181,13 @@ ${captureControlsHtml().prependIndent("          ")}
    * theme because the card already swaps it in place, the rest because they multiply every row by a
    * matrix nobody navigates by.
    *
+   * A state cell can now declare itself secondary too ([ServePreview.secondary], from
+   * `@OverrideVariant(secondary = true)`), and it is dropped here on the same ground: an
+   * exhaustively drawn kit set is a matrix nobody navigates by either. Only the LISTING changes —
+   * such a render is still served, still addressed by its own URL, and still paired with its kit
+   * node — so a link from a kit page or a design-map pairing lands on it, and its own subtree still
+   * offers the primary rows to get back by.
+   *
    * The viewer's own subtree ([componentSubtreeHtml]) is built from this same function, so the two
    * cannot offer different sets: one definition of what a component's renders are, drawn twice.
    */
@@ -3197,6 +3213,7 @@ ${captureControlsHtml().prependIndent("          ")}
     val stateKey = switcherStateKey(default)
     val seenStates = LinkedHashMap<String, ServePreview>()
     for (p in all) {
+      if (p.secondary) continue
       if (switcherStateKey(p) != stateKey) continue
       if (themeLane(p, darkFirst) != lane) continue
       if (!hasNonDefaultProps(p) && isNonDefaultState(p)) {
@@ -3208,6 +3225,7 @@ ${captureControlsHtml().prependIndent("          ")}
     val propsKey = switcherPropsKey(default)
     val seenProps = LinkedHashMap<String, ServePreview>()
     for (p in all) {
+      if (p.secondary) continue
       if (switcherPropsKey(p) != propsKey) continue
       if (themeLane(p, darkFirst) != lane) continue
       if ((p.state ?: "default") != defaultState) continue

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -2178,6 +2178,40 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a second-tier image reaches the browse surface as one`() {
+    // Like `fixedTheme`, this has to ride a variants-manifest entry of its own: an exhaustive
+    // matrix cell declares no knobs and detects no features, and if the flag did not carry it the
+    // browse surface would list all ninety of them in the component's tree.
+    val declared =
+      """
+      {"schema":"design-parity-catalog/v1","system":"meshcore","components":[
+        {"componentId":"Progress","images":[{
+          "path":"images/progress/ideal__segments-13.png",
+          "previewId":"progress__ideal__segments-13",
+          "state":"segments-13",
+          "secondary":true
+        }]}]}
+      """
+        .trimIndent()
+    val fetch: (String) -> ByteArray? = { url ->
+      when {
+        url.endsWith("/${ServeCatalogStore.CATALOG_FILE}") -> declared.toByteArray()
+        url.endsWith(".png") -> png()
+        else -> null
+      }
+    }
+
+    assertTrue(
+      store(TrustStore.EMPTY, fetch = fetch).load("meshcore") is ServeCatalogStore.Result.Ok
+    )
+
+    val preview = registered.getValue("meshcore").previews.single()
+    assertTrue(preview.secondary)
+    // The cell keeps everything else a cell has — it is listed differently, not served differently.
+    assertEquals("segments-13", preview.state)
+  }
+
+  @Test
   fun `catalog props preserve arbitrary JSON values through the variants manifest`() {
     val flexibleProps =
       """

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeWebTest.kt
@@ -163,6 +163,61 @@ class ServeWebTest {
       ),
     )
 
+  // An exhaustively drawn kit set: two cells a reader browses by, and one of the eighty-eight that
+  // exist to be compared against a kit node rather than navigated to.
+  private val exhaustive =
+    listOf(
+      ServePreview("progress__ideal__default", "Progress", state = "default"),
+      ServePreview("progress__ideal__disabled", "Progress", state = "disabled"),
+      ServePreview(
+        "progress__ideal__segments-13-small-stroke",
+        "Progress",
+        state = "segments-13-small-stroke",
+        secondary = true,
+      ),
+    )
+
+  @Test
+  fun `a second-tier cell stays out of the component subtree`() {
+    val html =
+      ServeWeb.viewerPage(
+        exhaustive[0],
+        token = "t",
+        basePath = "/wear-m3-catalog",
+        siblings = exhaustive,
+      )
+    val nav = html.substringAfter("class=\"cp-tree cp-axes-tree\"").substringBefore("</nav>")
+
+    assertTrue(nav.contains("/p/progress__ideal__disabled"), "a primary cell is still listed")
+    assertFalse(
+      nav.contains("segments-13-small-stroke"),
+      "the exhaustive cell is not a row a reader has to scroll past",
+    )
+  }
+
+  @Test
+  fun `a second-tier cell reached by its own link still says where it is`() {
+    // The whole point of the tier is that the render stays addressable — a kit page links straight
+    // to it — so the page it lands on has to be a page, tree and all, not a dead end.
+    val html =
+      ServeWeb.viewerPage(
+        exhaustive[2],
+        token = "t",
+        basePath = "/wear-m3-catalog",
+        siblings = exhaustive,
+      )
+    val nav = html.substringAfter("class=\"cp-tree cp-axes-tree\"").substringBefore("</nav>")
+
+    assertTrue(
+      nav.contains("progress__ideal__segments-13-small-stroke"),
+      "the render on screen is a row of its own tree",
+    )
+    assertTrue(
+      nav.contains("/p/progress__ideal__disabled"),
+      "and the primary cells are still the way back",
+    )
+  }
+
   @Test
   fun `the state switcher reaches untagged siblings from the primary-lane default`() {
     val current = mixedTagging[0] // default, light

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -339,6 +339,43 @@ The dark lane is unchanged, and an untagged render now links back to the primary
 well as forward to its siblings — the relation is symmetric because both sides resolve to a lane
 string rather than one of them being `null`.
 
+## The second tier: a cell that is compared but not listed
+
+The tree has always had two tiers. `state` and `props` are **primary** — a different thing to look
+at — and go in it; theme, breakpoint, font scale and locale are **secondary** — a different
+rendering of one thing — and stay out, because listing them multiplies every row by a matrix nobody
+navigates by.
+
+`@OverrideVariant(secondary = true)` lets a state cell say the same about itself:
+
+```kotlin
+@OverrideVariant(
+  name = "segments-13-small-stroke-overflow",
+  ints = ["segmentCount=13"],
+  strings = ["stroke=small"],
+  floats = ["progress=1.4"],
+  kitProps = ["Segments=13", "Stroke Width=Small", "Progress=Overflow"],
+  secondary = true,
+)
+```
+
+Only the **listing** changes. The cell renders, it bakes, it keeps its own `/p/<id>`, and it pairs
+with its design-kit node exactly as before — so a link from an imported kit page, a design-map
+pairing or a search result lands on it, and the page it lands on is a whole page: the viewer's
+subtree always carries the render on screen as a row, with the primary cells under it as the way
+back.
+
+It exists for the catalog that draws a kit set exhaustively. `wear-m3-catalog`'s segmented progress
+indicator is 90 cells — 14 segment counts by two stroke widths by four progress values by disabled —
+every one of them a kit node worth comparing and none of them something a reader browses to by name
+([wear-m3-catalog#101](https://github.com/yschimke/wear-m3-catalog/issues/101)). Without the flag a
+catalog buys a readable menu by not drawing the cells, which trades away the comparison to shorten
+a list.
+
+The flag travels annotation → discovery (`previews.json`) → the publisher's per-preview
+declarations → `previews/variants.json` → `ServePreview.secondary`, and `primaryVariantRows` is the
+one place that reads it. Nothing about rendering, addressing or parity consults it.
+
 ## Value sets: a knob that says what it may be
 
 A `previewOverride*` knob publishes its current value, and until it also publishes its **value set**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1179,6 +1179,15 @@ data class OverrideVariantSpec(
    * happen to alias to. See the annotation for why the two are kept apart.
    */
   val kitProps: List<CatalogVariantProp> = emptyList(),
+  /**
+   * Whether this cell is **second-tier** — `@OverrideVariant.secondary`.
+   *
+   * Carried through the manifest so a browse surface can list the cells a reader navigates by and
+   * leave an exhaustive matrix out of the menu, without changing what is rendered, what it is
+   * addressed by, or what it is compared against. False for every cell that declares nothing, which
+   * is every cell authored before the field existed.
+   */
+  val secondary: Boolean = false,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2445,6 +2445,10 @@ object PreviewDiscovery {
             "keeping kitProps and ignoring the singular pair. Declare one or the other."
         )
       }
+      // `runCatching` for the same reason `kitProps` above needs it: a consumer compiled against an
+      // older preview-annotations has no `secondary` parameter, and `getValue` throws for one that
+      // is absent rather than answering its default.
+      val secondary = (runCatching { pv.getValue("secondary") }.getOrNull() as? Boolean) ?: false
       val spec =
         OverrideVariantSpec(
           name = name,
@@ -2454,6 +2458,7 @@ object PreviewDiscovery {
           kitAxis = kitAxis.takeIf { kitProps.isEmpty() },
           kitValue = kitValue.takeIf { kitProps.isEmpty() },
           kitProps = kitProps,
+          secondary = secondary,
         )
       val existing = specs.putIfAbsent(name, spec)
       // Only a *conflicting* duplicate is worth a warning. The same annotation reached twice — once

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -192,6 +192,58 @@ class PreviewDataTest {
   }
 
   @Test
+  fun `a second-tier cell says so through the preview manifest`() {
+    // The cell is otherwise ordinary: it seeds knobs, it names a kit assignment, it renders. What
+    // `secondary` carries is how prominently a browse surface should LIST it — an exhaustive kit
+    // matrix is a comparison per cell and a menu nobody can read.
+    val preview =
+      PreviewInfo(
+        id = "test.SegmentedProgress_VARIANT_segments-13-small-stroke",
+        functionName = "SegmentedProgress",
+        className = "test.ProgressKt",
+        overrides =
+          OverrideVariantSpec(
+            name = "segments-13-small-stroke",
+            seeds =
+              listOf(
+                OverrideSeed(key = "segmentCount", kind = OverrideSeedKind.INT, raw = "13"),
+                OverrideSeed(key = "stroke", kind = OverrideSeedKind.STRING, raw = "small"),
+              ),
+            secondary = true,
+          ),
+      )
+    val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews.single().overrides?.secondary).isTrue()
+    // And the seeds are untouched by it: the tier decides the listing, never the render.
+    assertThat(decoded.previews.single().overrides?.seeds?.map { it.key })
+      .containsExactly("segmentCount", "stroke")
+  }
+
+  @Test
+  fun `a cell that declares no tier is primary`() {
+    val preview =
+      PreviewInfo(
+        id = "test.Switch_VARIANT_off",
+        functionName = "SwitchOn",
+        className = "test.SwitchKt",
+        overrides =
+          OverrideVariantSpec(
+            name = "off",
+            seeds =
+              listOf(OverrideSeed(key = "checked", kind = OverrideSeedKind.BOOLEAN, raw = "false")),
+          ),
+      )
+    val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews.single().overrides?.secondary).isFalse()
+  }
+
+  @Test
   fun `a cell that declares no kit assignment carries an empty one`() {
     val preview =
       PreviewInfo(

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
@@ -121,6 +121,33 @@ class PreviewDiscoveryProjectJarTest {
   }
 
   @Test
+  fun `an override variant's tier is read off the annotation`() {
+    // The read matters more than the field: discovery has to answer `false` for a catalog compiled
+    // against an annotations jar that predates the parameter (ClassGraph throws for one that is
+    // absent rather than handing back its default), and `true` for one that declares it.
+    val jar = File(tempDir.root, "secondary-variant-classes.jar")
+    writeSecondaryVariantClassJar(jar)
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = emptyList(),
+          dependencyJars = emptyList(),
+          sourceFiles = emptyList(),
+          moduleName = ":catalog",
+          variantName = "debug",
+          projectDirectory = tempDir.root,
+          failOnEmpty = true,
+          projectClassJars = listOf(jar),
+        )
+      ) as PreviewDiscovery.Outcome.Success
+
+    val variants = outcome.manifest.previews.mapNotNull { it.overrides }.associateBy { it.name }
+    assertThat(variants.getValue("segments-13").secondary).isTrue()
+    assertThat(variants.getValue("disabled").secondary).isFalse()
+  }
+
+  @Test
   fun `a CatalogVariant's design kit correspondence is discovered`() {
     // The other half of the same idea: a folded component names the kit's spelling for the axis
     // its one prop turns, so `type=range` can stay the Compose word while the join uses the kit's
@@ -205,6 +232,58 @@ class PreviewDiscoveryProjectJarTest {
       visit("kitValue", "Full-screen (range)")
       visitArray("props").apply {
         visit(null, "type=range")
+        visitEnd()
+      }
+      visitEnd()
+    }
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+
+    JarOutputStream(jar.outputStream()).use { jos ->
+      jos.putNextEntry(JarEntry("$internalName.class"))
+      jos.write(cw.toByteArray())
+      jos.closeEntry()
+    }
+  }
+
+  /** Writes two `@OverrideVariant`s, one of them declaring itself second-tier. */
+  private fun writeSecondaryVariantClassJar(jar: File) {
+    val internalName = "test/SecondaryVariantPreviewKt"
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv =
+      cw.visitMethod(
+        Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC,
+        "SegmentedProgress",
+        "()V",
+        null,
+        null,
+      )
+    mv.visitAnnotation("Landroidx/compose/ui/tooling/preview/Preview;", false).visitEnd()
+    mv.visitAnnotation("Lee/schimke/composeai/preview/OverrideVariant;", false).apply {
+      visit("name", "segments-13")
+      visit("secondary", true)
+      visitArray("ints").apply {
+        visit(null, "segmentCount=13")
+        visitEnd()
+      }
+      visitEnd()
+    }
+    // The one a reader browses by: same shape, no tier declared, so it stays primary.
+    mv.visitAnnotation("Lee/schimke/composeai/preview/OverrideVariant;", false).apply {
+      visit("name", "disabled")
+      visitArray("booleans").apply {
+        visit(null, "enabled=false")
         visitEnd()
       }
       visitEnd()

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -139,6 +139,12 @@ export function declarationsByPreviewId(bundles) {
       // this card under a theme override, and it has to know that from catalog.json alone —
       // deciding it lazily would mean the specimen re-themes until its daemon happens to be opened.
       const fixedTheme = preview.fixedTheme === true;
+      // `@OverrideVariant(secondary = true)`: a cell that is rendered and compared but kept out of
+      // the browse surface's variant tree. It rides here rather than on the image's `state`,
+      // because it says nothing about WHICH cell this is — only about how prominently to list it —
+      // and because the browse surface has to know it from catalog.json alone, before any daemon is
+      // opened, exactly as `fixedTheme` does.
+      const secondary = preview.overrides?.secondary === true;
       // What ground this render sits on and what device frame it was captured in. These live ONLY
       // in the bundle's root `previews.json`, which a published catalog does not stage — it carries
       // per-preview metadata on `previews/variants.json` instead. Without lifting them here, every
@@ -153,6 +159,7 @@ export function declarationsByPreviewId(bundles) {
         supportsFocus ||
         supportsGestures ||
         fixedTheme ||
+        secondary ||
         previewParams
       ) {
         out.set(preview.id, {
@@ -161,6 +168,7 @@ export function declarationsByPreviewId(bundles) {
           ...(supportsFocus ? { supportsFocus: true } : {}),
           ...(supportsGestures ? { supportsGestures: true } : {}),
           ...(fixedTheme ? { fixedTheme: true } : {}),
+          ...(secondary ? { secondary: true } : {}),
           ...(previewParams ? { previewParams } : {}),
         });
       }

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -36,6 +36,24 @@ test("reads authored declarations and detected features from a preview bundle", 
   });
 });
 
+test("carries a second-tier cell's tier onto its image", () => {
+  // `secondary` says how prominently to LIST the cell, so the browse surface has to know it from
+  // catalog.json — before any daemon is opened, exactly as `fixedTheme` does.
+  const bundle = {
+    previews: [
+      {
+        id: "SegmentedProgress_VARIANT_segments-13",
+        overrides: { name: "segments-13", secondary: true },
+      },
+      { id: "SegmentedProgress_VARIANT_disabled", overrides: { name: "disabled" } },
+    ],
+  };
+
+  const byId = declarationsByPreviewId(bundle);
+  assert.deepEqual(byId.get("SegmentedProgress_VARIANT_segments-13"), { secondary: true });
+  assert.equal(byId.has("SegmentedProgress_VARIANT_disabled"), false);
+});
+
 test("stamps supplement-only image declarations by bridged daemon id", () => {
   const manifest = {
     components: [


### PR DESCRIPTION
Closes #4726.

`ServeWeb` has always sorted a component's renders into two tiers — `state` and `props` in the tree, theme / breakpoint / font scale / locale out of it, "because they multiply every row by a matrix nobody navigates by". There was no way for a **state** cell to say the same about itself, so a catalog that draws a kit set exhaustively floods its own navigation.

`@OverrideVariant(secondary = true)` is that missing half:

```kotlin
@OverrideVariant(
  name = "segments-13-small-stroke-overflow",
  ints = ["segmentCount=13"],
  strings = ["stroke=small"],
  floats = ["progress=1.4"],
  kitProps = ["Segments=13", "Stroke Width=Small", "Progress=Overflow"],
  secondary = true,
)
```

**Only the listing changes.** The cell renders, bakes, keeps its own `/p/<id>` and pairs with its design-kit node exactly as before — which is what makes it navigable from the outside: a link from an imported kit page, a design-map pairing or a search result lands on it, and the page it lands on is a whole page, because the viewer's subtree always carries the render on screen as a row with the primary cells under it as the way back.

## The route

| Hop | What carries it |
| --- | --- |
| annotation | `OverrideVariant.secondary` |
| discovery | `OverrideVariantSpec.secondary` → `previews.json` |
| publisher | `declarationsByPreviewId` → `catalog.json` image, beside `fixedTheme` |
| catalog store | `Image.secondary` → `VariantMeta` → `previews/variants.json` |
| serve | `ServePreview.secondary`, read by `primaryVariantRows` and `componentRenderRows` |

Two details worth a reviewer's eye:

* **Discovery reads it through `runCatching`**, like `kitProps`: a consumer compiled against an older `preview-annotations` has no such parameter, and ClassGraph's `getValue` throws for an absent one rather than answering its default. A jar-level test covers both answers.
* **The render on screen is exempt from its own filter** (`componentRenderRows`' `listed()`). Arriving on a secondary cell by its link must not show a tree of everything except the thing you are looking at.

Nothing about rendering, addressing, folding or parity consults the flag — the grid still shows one card per component, and a secondary cell still folds onto it.

## Why now

`wear-m3-catalog` finished drawing its kit exhaustively today ([#101](https://github.com/yschimke/wear-m3-catalog/issues/101)): 228 → 548 of the kit's 888 cells, which puts **90 cells on one `SegmentedCircularProgressIndicator`** — 14 segment counts by two stroke widths by four progress values by disabled. Every one is a real kit node worth comparing; none is something a reader browses to by name. Without this flag the only way to keep that menu readable is to not draw the cells, which trades a comparison away to shorten a list.

## Scope, and what deliberately isn't here

* **`@CatalogVariant` and `@PreviewAxis` don't have the field yet.** Their cells reach `image.state` by a different route (the spec's `variants` list, and the axis product), so each is its own hop. Worth adding when a catalog needs it; nothing here blocks it.
* **The static catalog site is unchanged.** Its expanded card lists every folded state too, and a "browse all" disclosure there is a layout decision rather than a plumbing one.
* **No consumer change.** `wear-m3-catalog` pins a released plugin, so it adopts this after the next release.

## Test plan

* `./gradlew :cli:serve:test` — full suite green, including two new `ServeWebTest` cases: a second-tier cell is absent from a component's subtree, and reaching one by its own link still renders a tree that says where it is.
* `./gradlew -p gradle-plugin :preview-discovery:test` — green, with a new bytecode-level test that discovery reads the annotation (`true` when declared, `false` when the parameter is absent) and a manifest round-trip.
* `node --test scripts/design-artifacts/catalog-preview-declarations.test.mjs` — 17/17, including the publisher hop.
* `ktfmtCheck` on every module touched. (`:preview-discovery:ktfmtCheckMain` fails on `main` too, on three files this PR does not touch — I left them alone rather than dragging an unrelated reformat in.)

Text-only change to the served HTML: what it removes from a page is rows, and the new tests assert exactly that, so there is no before/after picture worth embedding.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HrdvZk4A4T7XdP69pH89F)_