### PR TITLE
fix(design-map): read a variant's own kit correspondence, and its marker exactly

### DIFF
--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -68,9 +68,37 @@ const LIGHT_MODE = "Light";
 /** The tag discovery puts in the id of an `@OverrideVariant` reseed: `…_VARIANT_<name>`. */
 const VARIANT_TAG = "_VARIANT_";
 
+/**
+ * The head of a capture's id with the `_VARIANT_<name>` reseed suffix removed, and whether there
+ * was one — `{ head, reseed }`.
+ *
+ * `_VARIANT_` is a legal substring of a Kotlin function name, so a plain `includes()` read the BASE
+ * capture of a composable called `Icon_VARIANT_Only` as a generated reseed. Every `continue` guarded
+ * by that test then dropped the composable outright, including its explicit `noReference` — a
+ * record whose whole purpose is to survive into the diagnostics.
+ *
+ * Discovery appends the tag to the id it has already built (`base.id + "_VARIANT_<name>"`), so the
+ * marker of an actual reseed is the LAST one and the function's own name is still in front of it.
+ * Splitting there and requiring the `.<functionName>` marker to survive in the head distinguishes
+ * the two: `…FooKt.Icon_VARIANT_Only_Light` splits to `…FooKt.Icon`, which no longer contains
+ * `.Icon_VARIANT_Only`, so it is a base capture; a real reseed of `Icon`,
+ * `…FooKt.Icon_Light_VARIANT_pressed`, splits to `…FooKt.Icon_Light`, which still contains `.Icon`.
+ *
+ * A capture that names no function cannot be told apart this way, so it keeps the old reading.
+ */
+function splitVariantTag(preview) {
+  const id = String(preview.id ?? "");
+  const at = id.lastIndexOf(VARIANT_TAG);
+  if (at < 0) return { head: id, reseed: false };
+  const head = id.slice(0, at);
+  const marker = preview.functionName ? `.${preview.functionName}` : null;
+  if (marker && !head.includes(marker)) return { head: id, reseed: false };
+  return { head, reseed: true };
+}
+
 /** Whether a capture is an `@OverrideVariant` reseed rather than a base capture. */
 function isVariantCapture(preview) {
-  return String(preview.id ?? "").includes(VARIANT_TAG);
+  return splitVariantTag(preview).reseed;
 }
 
 /**
@@ -80,13 +108,14 @@ function isVariantCapture(preview) {
  * is the `@Preview` name a multipreview gives the capture — `Light` / `Dark` for a themed pair, and
  * EMPTY for an unnamed single capture. Splitting on the function name rather than pattern-matching
  * the tail is what lets a dark-first catalog be recognised at all: its ids carry no mode segment to
- * match against.
+ * match against. The reseed suffix comes off first, via [splitVariantTag] rather than a bare
+ * substring split, so a function whose own name contains `_VARIANT_` keeps its whole identity.
  *
  * A capture whose id does not contain its own function name is left as its own subject with an
  * empty mode — it cannot be grouped with anything, so it selects itself.
  */
 export function captureIdentity(preview) {
-  const head = String(preview.id ?? "").split(VARIANT_TAG)[0];
+  const { head } = splitVariantTag(preview);
   const marker = preview.functionName ? `.${preview.functionName}` : null;
   const at = marker ? head.lastIndexOf(marker) : -1;
   if (at < 0) return { subject: head, mode: "" };
@@ -519,8 +548,28 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
     const seeds = variantSeeds(preview);
     if (!seeds.length) continue;
 
+    // A `@CatalogVariant` may state its OWN kit correspondence, and either spelling changes what a
+    // resolver should do with this render. Without reading them here a variant's declaration is
+    // emitted under the parent's `reference` regardless — which is precisely the mispairing the two
+    // fields were added to prevent.
+    //
+    // `noReference` says the kit exports no cell this render could honestly pair with. Handing it
+    // to the resolver anyway scores it against the PARENT's picture, so it is dropped: the absence
+    // is already reported once, as a stated absence, and a render that says "there is nothing to
+    // compare me to" must not then be compared.
+    if (isCatalogVariant && catalog.noReference) continue;
+
     const list = byComponent.get(catalog.componentId) ?? [];
-    list.push({ previewId: preview.id, name: variantName(preview, seeds), seeds });
+    list.push({
+      previewId: preview.id,
+      name: variantName(preview, seeds),
+      seeds,
+      // `reference` names the variant's own kit cell. Carried onto the render so a resolver pairs
+      // that handle instead of deriving one from the parent's by seed. Additive to the sidecar's
+      // shape — a resolver that does not read it sees exactly what it saw before, which is why the
+      // schema string does not move.
+      ...(isCatalogVariant && catalog.reference ? { reference: catalog.reference } : {}),
+    });
     byComponent.set(catalog.componentId, list);
   }
   return byComponent;
@@ -608,7 +657,14 @@ export function projectDesignMap(previews, opts = {}) {
     if (catalog.noReference) {
       statedAbsentIds.set(`component:${id}`, { label: id, reason: catalog.noReference });
       statedAbsentComponentIds.add(id);
-    } else if (!statedAbsentIds.has(id)) unmappedIds.set(id, true);
+      // Unconditional: [unmapped] below filters this set through [statedAbsentComponentIds], which
+      // is the only correct place for it — a component's stated absence may be read from a LATER
+      // capture than the one that first reports it unmapped, and a guard here can only see what has
+      // been read so far. The guard that used to stand here tested a bare `id` against a map now
+      // keyed `component:<id>` / `subject:<id>`, so for an ordinary id it never matched, and for a
+      // component legally named `component:X` it matched the wrong entry and dropped it from
+      // `unmapped` — letting `--strict` pass over a component with no reference and no reason.
+    } else unmappedIds.set(id, true);
   }
   /** Components carrying neither a reference nor a stated reason for its absence. */
   const unmapped = [...unmappedIds.keys()].filter((id) => !statedAbsentComponentIds.has(id));

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -920,3 +920,86 @@ test("an override cell rides the base breakpoint, and is not repeated at every s
     ["240dp", "month"],
   );
 });
+
+test("a component named like a namespaced absence key still reports as unmapped", () => {
+  // `statedAbsentIds` is keyed `component:<id>` / `subject:<id>`, and a `@CatalogComponent(id = …)`
+  // may legally be spelled the same way. Testing the bare id against that map read the FIRST
+  // component's entry as the SECOND's, and dropped the second from `unmapped` — `--strict` then
+  // passed over a component with no reference and no stated reason.
+  const { diagnostics } = projectDesignMap([
+    component("Icon", { componentId: "X", noReference: "retired in the kit" }),
+    component("Chip", { componentId: "component:X" }),
+  ]);
+  assert.deepEqual(diagnostics.unmapped, ["component:X"]);
+  assert.deepEqual(
+    diagnostics.statedAbsent,
+    [{ componentId: "X", reason: "retired in the kit" }],
+  );
+});
+
+test("a function whose own name contains _VARIANT_ is a base capture, not a reseed", () => {
+  // `Icon_VARIANT_Only` is a legal Kotlin name, so its base id carries the marker discovery uses
+  // for a generated reseed. Read as a reseed, the component was skipped everywhere the marker
+  // gates — losing its explicit `noReference`, the one record that diagnostic exists to keep.
+  const marked = {
+    id: "com.example.CatalogKt.Icon_VARIANT_Only_Light",
+    functionName: "Icon_VARIANT_Only",
+    sourceFile: "Catalog.kt",
+    catalog: {
+      role: "COMPONENT",
+      componentId: "Icon_VARIANT_Only",
+      noReference: "the kit draws no icon-only cell",
+    },
+  };
+  const { diagnostics } = projectDesignMap([marked]);
+  assert.deepEqual(diagnostics.statedAbsent, [
+    { componentId: "Icon_VARIANT_Only", reason: "the kit draws no icon-only cell" },
+  ]);
+  // And its reseeds are still reseeds: the marker discovery appended is the LAST one.
+  const { variants } = projectDesignMap([
+    { ...marked, catalog: { ...marked.catalog, noReference: undefined, reference: ref("1:2") } },
+    {
+      id: "com.example.CatalogKt.Icon_VARIANT_Only_Light_VARIANT_pressed",
+      functionName: "Icon_VARIANT_Only",
+      sourceFile: "Catalog.kt",
+      catalog: { role: "COMPONENT", componentId: "Icon_VARIANT_Only" },
+      overrides: { name: "pressed", seeds: [{ key: "state", raw: "pressed" }] },
+    },
+  ]);
+  assert.deepEqual(
+    variants.components[0].renders.map((r) => r.name),
+    ["pressed"],
+  );
+});
+
+test("a variant that states its absence is not handed to the parent's resolver", () => {
+  // The declaration resolves against the PARENT's reference, so emitting a render whose annotation
+  // says the kit exports no cell for it scores it against the parent's picture — the mispairing
+  // `noReference` exists to prevent. Reported once, as a stated absence, and never paired.
+  const { variants, diagnostics } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("ButtonTextless", "Button", {
+      state: "textless",
+      noReference: "the kit exports no Text=No cell",
+    }),
+  ]);
+  assert.deepEqual(variants.components, []);
+  assert.deepEqual(diagnostics.statedAbsent, [
+    { componentId: "Button [state=textless]", reason: "the kit exports no Text=No cell" },
+  ]);
+});
+
+test("a variant's own reference rides its render into the sidecar", () => {
+  const { variants } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    catalogVariant("ButtonCompact", "Button", { state: "compact", reference: ref("9:9") }),
+    catalogVariant("ButtonLoud", "Button", { state: "loud" }),
+  ]);
+  assert.deepEqual(
+    variants.components[0].renders.map((r) => [r.name, r.reference]),
+    [
+      ["compact", ref("9:9")],
+      ["loud", undefined],
+    ],
+  );
+});


### PR DESCRIPTION
Three post-merge review findings, all in `design-map/design-map.mjs`, all landed after their PRs auto-merged.

### #4719 (P1) — a `@CatalogVariant`'s own kit correspondence never reached the projection

`@CatalogVariant(reference = …)` and `noReference` were plumbed through discovery and the inventory, but `projectDesignMap` never read them. `variantRendersByComponent` emitted **every** variant render as a declaration under the parent's `reference`, so:

- a variant stating *"the kit exports no `Text=No` cell"* was still handed to the resolver, to be scored against its parent's picture — the exact mispairing `noReference` was added to prevent;
- a variant naming its own cell had that handle silently dropped.

Both now hold. A stated absence stops the render being paired at all (it is already reported once, as a stated absence), and a variant's own `reference` rides its render into the sidecar. The field is additive, so a resolver that does not read it sees exactly what it saw before — which is why `compose-preview-design-map-variants/v1` does not move.

### #4722 (P2) — the reseed marker was matched as a substring

`_VARIANT_` is legal inside a Kotlin function name, so the **base** capture of a composable called `Icon_VARIANT_Only` read as a generated `@OverrideVariant` reseed. Every `continue` that marker gates then dropped the composable outright — including its explicit `noReference`, the one record that diagnostic exists to keep.

Discovery appends the tag as a suffix to the id it has already built, so a real reseed's marker is the **last** one and the function's own name is still in front of it. Splitting there and requiring `.<functionName>` to survive in the head separates the two:

| id | head | reading |
| --- | --- | --- |
| `…FooKt.Icon_VARIANT_Only_Light` | `…FooKt.Icon` — no `.Icon_VARIANT_Only` | base capture |
| `…FooKt.Icon_Light_VARIANT_pressed` | `…FooKt.Icon_Light` — has `.Icon` | reseed |

`captureIdentity` takes the same head, which also restores the mode segment such a capture used to lose (it split at the first marker and left `mode` empty).

### #4725 (P2) — the unmapped check used the un-namespaced key

`statedAbsentIds` became `component:<id>` / `subject:<id>` in #4725, but the unmapped guard still tested a bare `id`. For an ordinary id it therefore never matched; for a component legally named `component:X` it matched the *wrong* entry and dropped it from `unmapped`, letting `--strict` pass over a component with no reference and no stated reason.

The guard was vestigial either way — `unmapped` already filters through `statedAbsentComponentIds` after the loop, which is the only correct place for it, since a component's stated absence may be read from a later capture than the one that first reports it unmapped. Removed rather than re-namespaced.

## Test plan

Four regression tests, each confirmed to fail with **its own** fix reverted and no other:

```
not ok — a component named like a namespaced absence key still reports as unmapped
not ok — a function whose own name contains _VARIANT_ is a base capture, not a reseed
not ok — a variant that states its absence is not handed to the parent's resolver
not ok — a variant's own reference rides its render into the sidecar
```

`node --test design-map/*.test.mjs` → 70 pass, 0 fail (66 before).

Non-visual: this module is a pure projection with no rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_