### PR TITLE
fix(catalog): carry a second-tier cell's tier to every catalog that can list it

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -685,6 +685,7 @@ class ServeCatalogStore(
           size = record.size?.takeIf { it.isNotBlank() },
           componentId = record.componentId?.takeIf { it.isNotBlank() },
           fixedTheme = record.fixedTheme,
+          secondary = record.secondary,
           section = section,
           group = group,
           order = if (section != null || group != null) count + deferredIds.size - 1 else null,
@@ -2841,6 +2842,15 @@ class ServeCatalogStore(
      * theme with nothing to fall back to.
      */
     val fixedTheme: Boolean = false,
+    /**
+     * Discovery-time `@OverrideVariant(secondary = true)` — see [VariantMeta.secondary].
+     *
+     * Here for the same reason [fixedTheme] is. A second-tier cell CI declared live-only is
+     * described by this record and by nothing else, so without the field the flag had no route to
+     * the browse surface and the cell stayed listed in the variant tree — the flag going missing
+     * for precisely the deferred coverage it exists to thin out.
+     */
+    val secondary: Boolean = false,
   ) {
     /** The daemon preview to render this record through, or null when it has no live twin. */
     val daemonId: String?

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStoreTest.kt
@@ -3717,6 +3717,52 @@ class ServeCatalogStoreTest {
   }
 
   @Test
+  fun `a deferred record's second-tier flag reaches the browse surface`() {
+    // A second-tier cell CI declared live-only is described by its deferred record and by nothing
+    // else — it has no image for the components loop to carry the flag on. Without the field the
+    // flag had no route here at all, so exactly the cells `secondary` exists to thin out stayed
+    // listed in the component's variant tree, on the catalogs that defer the most of them.
+    val json =
+      """
+      {"schema":"design-parity-catalog/v1","system":"compose-m3",
+       "liveBundle":{"path":"bundle/","file":"compose-m3-bundle.png"},
+       "components":[{"componentId":"Progress/Segmented","section":"Components","group":"Progress",
+         "images":[
+           {"path":"images/progress-segmented/ideal__default.png","state":"default","previewId":"Segmented"}]}],
+       "deferred":[
+         {"componentId":"Progress/Segmented","section":"Components","group":"Progress","reason":"variant",
+          "path":"images/progress-segmented/ideal__segments-13.png","state":"segments-13",
+          "preview":"SegmentedProgress","previewId":"Segmented_VARIANT_segments-13",
+          "secondary":true},
+         {"componentId":"Progress/Segmented","section":"Components","group":"Progress","reason":"variant",
+          "path":"images/progress-segmented/ideal__disabled.png","state":"disabled",
+          "preview":"SegmentedProgress","previewId":"Segmented_VARIANT_disabled"}]}
+      """
+        .trimIndent()
+    var fronted: ServeHost? = null
+    val store =
+      ServeCatalogStore(
+        root = tempRoot(),
+        register = { n, h -> registered[n] = h },
+        trust = { trustedBranches },
+        fetch = deferredFetcher(json),
+        buildTrustedBundle = { _, _, _, _, bakedFallback, _ ->
+          fronted = bakedFallback()
+          true
+        },
+      )
+    assertTrue(store.load("compose-m3") is ServeCatalogStore.Result.Ok)
+
+    val host = fronted as ServeBundleHost
+    val tiered = host.previews.single { it.state == "segments-13" }
+    assertTrue(tiered.secondary, "the deferred record's tier survives into the variant metadata")
+    // It is listed differently, not served differently: everything else a deferred cell carries is
+    // untouched, and an ordinary deferred cell beside it is not silently promoted.
+    assertEquals("Components" to "Progress", tiered.section to tiered.group)
+    assertFalse(host.previews.single { it.state == "disabled" }.secondary)
+  }
+
+  @Test
   fun `a wholly deferred component's pairing reaches the server's parallel lookup`() {
     // The generator writes a wholly deferred component's `parallel` onto its DEFERRED record —
     // such a component short-circuits before it ever reaches `components[]`, so that is the only

--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -122,6 +122,12 @@ function variantIdentity(preview) {
     // lays its images out exactly like a bridged one's (m3-catalog#179).
     captureGutter: params.captureGutter ?? null,
     locale: typeof params.locale === "string" ? params.locale : null,
+    // Also not an identity field, and carried for exactly the reason the gutter is: a
+    // second-tier cell is a fact about the ANNOTATION that drew this image, and the declarations
+    // pass that also publishes it joins on `image.previewId` and runs only where a live lane or a
+    // buildable source exists. A baked-only catalog — which the public server serves read-only —
+    // therefore never saw the flag and listed every second-tier cell in full.
+    secondary: preview.overrides?.secondary === true,
   };
 }
 
@@ -577,6 +583,10 @@ export function stampPreviewDensities(manifest, spec, bundles) {
         image.density = density;
         stamped++;
       }
+      // The tier rides the same resolution, for the same reason the gutter does: this is the one
+      // pass that reaches every catalog, and it needs no `previewId` to know which annotation drew
+      // the pixels. See [variantIdentity] for what the declarations pass misses.
+      if (resolved?.secondary === true) image.secondary = true;
       // The gutter rides on the same resolution: pixels need the density this pass just picked, so
       // there is no second place that could disagree about which annotation rendered this image.
       const gutter = captureGutterPx(resolved?.captureGutter, {

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -1508,3 +1508,55 @@ test("separate LTR and RTL annotations resolve to their own preview, not the fir
     rtl: "pkg.CatalogKt.FilledButton_ar",
   });
 });
+
+test("a second-tier cell's tier is stamped in the same pass, so a baked-only catalog carries it", () => {
+  // `applyCatalogPreviewDeclarations` joins on `image.previewId`, which only the live bridge
+  // writes, and it runs only when a live lane or a buildable source exists. A baked-only catalog
+  // — which the public server explicitly serves — therefore never saw `secondary` at all and
+  // listed its second-tier cells in full, defeating the flag exactly where nothing can re-render.
+  // The annotation that drew the pixels is resolved here without a bridge or a previewId.
+  const spec = {
+    groups: [{ components: [{ componentId: "Progress/Segmented", preview: "SegmentedProgress" }] }],
+  };
+  const manifest = {
+    components: [
+      {
+        componentId: "Progress/Segmented",
+        images: [
+          { state: "default", path: "base.png" },
+          { state: "segments-13", path: "s13.png" },
+          { state: "disabled", path: "disabled.png" },
+        ],
+      },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "SegmentedProgress", functionName: "SegmentedProgress", params: { density: 2 } },
+      {
+        id: "SegmentedProgress_VARIANT_segments-13",
+        functionName: "SegmentedProgress",
+        params: { density: 2 },
+        overrides: { name: "segments-13", secondary: true },
+      },
+      {
+        id: "SegmentedProgress_VARIANT_disabled",
+        functionName: "SegmentedProgress",
+        params: { density: 2 },
+        overrides: { name: "disabled" },
+      },
+    ],
+  };
+
+  stampPreviewDensities(manifest, spec, [bundle]);
+
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.secondary),
+    [undefined, true, undefined],
+  );
+  // No previewId was needed, and none was invented.
+  assert.deepEqual(
+    manifest.components[0].images.map((i) => i.previewId),
+    [undefined, undefined, undefined],
+  );
+});

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -194,16 +194,30 @@ export function applyCatalogPreviewDeclarations(manifest, bundles) {
   // one: its only render is the live one, so without it the browse surface re-renders it under
   // every declared theme with no baked pixels to fall back to.
   //
-  // Only `fixedTheme` is stamped here. The knob declarations describe controls the viewer offers
-  // once a daemon is open, and a deferred record already resolves those through its live twin;
-  // `fixedTheme` is the one that has to be known BEFORE anything is opened, because it decides
-  // whether the card is asked to re-render at all.
+  // Only `fixedTheme` and `secondary` are stamped here. The knob declarations describe controls the
+  // viewer offers once a daemon is open, and a deferred record already resolves those through its
+  // live twin; these two have to be known BEFORE anything is opened, because they decide whether
+  // the card is asked to re-render at all and whether it is listed in the variant tree.
+  //
+  // `secondary` needs this as much as `fixedTheme` does. A second-tier cell that CI declared
+  // live-only — because its catalog variant or theme took deferred priority — reaches the browse
+  // surface through this loop and nowhere else, so leaving it out kept exactly those cells in the
+  // variant tree: the flag went missing for the coverage it was added to thin out.
   for (const record of manifest.deferred ?? []) {
     const previewId = record.previewId ?? (record.previewIds?.length === 1 ? record.previewIds[0] : null);
     if (!previewId) continue;
-    if (byId.get(previewId)?.fixedTheme !== true) continue;
-    record.fixedTheme = true;
-    stamped += 1;
+    const declarations = byId.get(previewId);
+    if (!declarations) continue;
+    let carried = false;
+    if (declarations.fixedTheme === true && record.fixedTheme !== true) {
+      record.fixedTheme = true;
+      carried = true;
+    }
+    if (declarations.secondary === true && record.secondary !== true) {
+      record.secondary = true;
+      carried = true;
+    }
+    if (carried) stamped += 1;
   }
   return stamped;
 }

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -373,3 +373,54 @@ test("an underscore-separated RTL locale still swaps the physical edges", () => 
     previewParams: { captureGutter: { left: 4, top: 4, right: 12, bottom: 5 } },
   });
 });
+
+test("stamps secondary onto a deferred (live-only) second-tier cell", () => {
+  // A second-tier cell CI declared live-only — its catalog variant or theme took deferred priority
+  // — reaches the browse surface through the deferred loop and nowhere else. Stamping only
+  // `fixedTheme` there left exactly those cells listed in the variant tree: the flag went missing
+  // for the coverage it exists to thin out.
+  const manifest = {
+    components: [],
+    deferred: [
+      { previewId: "Segmented_VARIANT_segments-13", componentId: "Progress/Segmented" },
+      { previewId: "Segmented_VARIANT_disabled", componentId: "Progress/Segmented" },
+      { previewIds: ["Solo_VARIANT_wide"], componentId: "Solo" },
+    ],
+  };
+  const bundle = {
+    previews: [
+      { id: "Segmented_VARIANT_segments-13", captures: [], overrides: { name: "s13", secondary: true } },
+      { id: "Segmented_VARIANT_disabled", captures: [], overrides: { name: "disabled" } },
+      { id: "Solo_VARIANT_wide", captures: [], overrides: { name: "wide", secondary: true } },
+    ],
+    entries: {},
+  };
+
+  applyCatalogPreviewDeclarations(manifest, [bundle]);
+
+  assert.equal(manifest.deferred[0].secondary, true);
+  assert.equal(manifest.deferred[1].secondary, undefined, "an ordinary deferred cell is untouched");
+  assert.equal(manifest.deferred[2].secondary, true, "a single-entry previewIds resolves");
+});
+
+test("a deferred record carrying both flags is counted once", () => {
+  const manifest = {
+    components: [],
+    deferred: [{ previewId: "themecatalog__Brand", componentId: "Theme/Brand" }],
+  };
+  const bundle = {
+    previews: [
+      {
+        id: "themecatalog__Brand",
+        captures: [],
+        fixedTheme: true,
+        overrides: { name: "brand", secondary: true },
+      },
+    ],
+    entries: {},
+  };
+
+  assert.equal(applyCatalogPreviewDeclarations(manifest, [bundle]), 1);
+  assert.equal(manifest.deferred[0].fixedTheme, true);
+  assert.equal(manifest.deferred[0].secondary, true);
+});


### PR DESCRIPTION
Both post-merge review findings on #4734. `@OverrideVariant(secondary = true)` reached `catalog.json` on exactly one path, and missed the two where a cell most needs it.

### A deferred (live-only) cell had no route for the flag

A deferred record carries no image, so the components loop never sees it. The deferred loop stamped only `fixedTheme`, and `ServeCatalogStore.DeferredRecord` had no `secondary` field for it to land in even if it had.

A second-tier cell CI declared live-only — because its catalog variant or theme took deferred priority — is described by that record and by nothing else, so the flag simply never reached the browse surface and the cell stayed listed in the component's variant tree. Missing for precisely the coverage it exists to thin out.

Both flags are now carried through the deferred loop, and `DeferredRecord` gained `secondary` alongside `fixedTheme`, wired into the `VariantMeta` the loop builds. A record carrying both still counts as one stamp.

### A baked-only catalog never ran the pass at all

`applyCatalogPreviewDeclarations` identifies an image through `image.previewId`, which only `bridgeLivePreviewIds` writes, and `generate-design-catalog.mjs` calls it solely inside the `liveBundle || source-module` block. The public server explicitly serves read-only baked catalogs, and those listed every second-tier cell in full — on exactly the catalogs with no daemon that could re-render anything.

The tier now rides `stampPreviewDensities`, which runs unconditionally and already resolves the annotation that drew each image, with no bridge and no preview id. That is the same seam and the same argument `captureGutter` already uses one field over in `variantIdentity`:

> Not an identity field — carried so `stampPreviewDensities` can publish the capture gutter in the same pass, on every catalog. The declarations pass that also publishes it runs only where a live lane is bridged…

The live path is untouched and still stamps the flag; the two agree because they now read the same annotation.

## Test plan

Four regression tests, each confirmed to fail with **its own** fix reverted:

```
catalog-preview-declarations  not ok — stamps secondary onto a deferred (live-only) second-tier cell
catalog-preview-declarations  not ok — a deferred record carrying both flags is counted once
bridge-live-preview-ids       not ok — a second-tier cell's tier is stamped in the same pass, so a
                                       baked-only catalog carries it
ServeCatalogStoreTest         FAILED  — a deferred record's second-tier flag reaches the browse surface
```

The JS test also asserts no `previewId` was invented along the way; the Kotlin one asserts an ordinary deferred cell beside it is not silently promoted.

- `./gradlew :cli:serve:test` — **BUILD SUCCESSFUL** (`ServeCatalogStoreTest`: 97 tests, 0 failures)
- `./gradlew :cli:serve:ktfmtFormatMain :cli:serve:ktfmtFormatTest` — clean, nothing to restage
- `scripts/design-artifacts` suite: 1244 pass / 7 fail, the same seven environment failures `origin/main` shows unmodified

Non-visual: this changes which cells a browse surface lists, and the listing itself is `cli/serve-web`'s, unchanged here. The flag's own rendering was covered by #4734.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_