### PR TITLE
fix(design-artifacts): let a stated absence earn the kit column, and fix the evidence fixture

### DIFF
--- a/docs/design/evidence/compared-variant-rows/README.md
+++ b/docs/design/evidence/compared-variant-rows/README.md
@@ -30,8 +30,9 @@ Three differences, one per finding:
 node docs/design/evidence/compared-variant-rows/fixture.mjs /tmp/after.html
 ```
 
-Renders through the working tree's `render-cross-system-html.mjs`; check out `origin/main`
-in a worktree and point the import at it for the before shot. Chromium screenshots the
+Renders through this checkout's own `render-cross-system-html.mjs` — the import is resolved from
+`import.meta.url`, so the path above is the only thing that has to be right. For the before shot,
+`git worktree add /tmp/base origin/main` and run the copy of this file that lands there. Chromium screenshots the
 `<table>` element at `deviceScaleFactor: 2`.
 
 The sibling ("Wear Compose Material 3") column shows broken images in both shots: it bakes

--- a/docs/design/evidence/compared-variant-rows/fixture.mjs
+++ b/docs/design/evidence/compared-variant-rows/fixture.mjs
@@ -1,5 +1,9 @@
 import { writeFileSync } from "node:fs";
-import { renderCrossSystemHtml } from "/home/user/compose-ai-tools/scripts/design-artifacts/render-cross-system-html.mjs";
+// Resolved from this file rather than an absolute path, so the documented reproduction works in
+// any checkout. Point it at a worktree's copy for the "before" shot.
+const { renderCrossSystemHtml } = await import(
+  new URL("../../../../scripts/design-artifacts/render-cross-system-html.mjs", import.meta.url)
+);
 
 /** A flat coloured PNG-ish swatch as an inline SVG data URI, labelled so the pick is visible. */
 const swatch = (label, fill, w, h) =>

--- a/scripts/design-artifacts/render-cross-system-html.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.mjs
@@ -195,6 +195,24 @@ function otherEmbed(pair, opts) {
  * design-map contributed it — worth showing, because a reader looking at a row where
  * only one implementation is mapped to the kit should be able to tell which.
  */
+/**
+ * The authored reason a row reaches no kit reference, or `""` when none was stated.
+ *
+ * A `noReference` is a finding, not a gap — "the kit exports no `Text=No` cell, so the honest
+ * reference is the sibling's own render" — and it is the one thing the kit column can publish for a
+ * row that has no picture to show.
+ */
+/**
+ * The `designRefById` a page shows the kit column from when nothing resolved but something was
+ * stated. Frozen-by-convention and never written to: `designEmbed` only reads it, and every lookup
+ * misses, which is the point — every cell falls to the stated-absence branch.
+ */
+const EMPTY_DESIGN_REFS = new Map();
+
+function statedAbsence(entry) {
+  return typeof entry?.noReference === "string" ? entry.noReference.trim() : "";
+}
+
 function designEmbed(pair, opts) {
   const ref = opts.designRefById?.get(pair.local.componentId);
   if (!ref?.url) {
@@ -204,7 +222,7 @@ function designEmbed(pair, opts) {
     // field exists to make. It reaches a variant row more often than a component one: the row a
     // variant flattens to never has a `designRefById` entry (the design map is keyed by component
     // id), so this branch is where a compared variant always lands.
-    const stated = typeof pair.local.noReference === "string" ? pair.local.noReference.trim() : "";
+    const stated = statedAbsence(pair.local);
     const missing = stated ? `no kit reference — ${esc(stated)}` : "no kit reference";
     const title = stated ? ` title="${esc(stated)}"` : "";
     return `<span class="pv-embed"><span class="pv-frame pv-frame--solid"><span class="pv-missing"${title}>${missing}</span></span></span>`;
@@ -341,7 +359,7 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
   const otherIndexUrl = `https://htmlpreview.github.io/?https://github.com/${otherRepo}/blob/${otherBranch}/index.html`;
   const previewBase = opts.previewBase ?? DEFAULT_PREVIEW_BASE;
   const otherHeroById = heroIndex(opts.otherManifest);
-  const designRefById = opts.designRefById?.size ? opts.designRefById : null;
+  const kitRefs = opts.designRefById?.size ? opts.designRefById : null;
   const designTitle = opts.designTitle ?? "Design kit";
 
   const { paired, onlyLocal, onlyOther } = crossSystemMatches(
@@ -349,6 +367,15 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
     opts.parallelById ?? {},
     opts.otherComponents ?? [],
   );
+
+  // Whether the kit column has anything to say — which is NOT the same question as whether any
+  // reference resolved. A catalog whose components all declare `noReference` passes an empty map,
+  // and gating the column on the map alone dropped the column, and with it every authored reason:
+  // the rationale showed up only when some unrelated component happened to contribute a reference.
+  // A stated absence is exactly the finding this column exists to publish, so it earns the column
+  // on its own.
+  const statedAbsences = paired.filter((p) => statedAbsence(p.local)).length;
+  const designRefById = kitRefs ?? (statedAbsences ? EMPTY_DESIGN_REFS : null);
 
   const rowOpts = {
     otherSystem,
@@ -361,8 +388,8 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
   const anchors = rowAnchors(paired);
   const body = paired.map((p, i) => pairRow(p, rowOpts, anchors[i])).join("\n");
   const pairedReal = paired.filter((p) => rendersBothSides(p, rowOpts)).length;
-  const designed = designRefById
-    ? paired.filter((p) => designRefById.get(p.local.componentId)?.url).length
+  const designed = kitRefs
+    ? paired.filter((p) => kitRefs.get(p.local.componentId)?.url).length
     : 0;
 
   const onlyLocalList = onlyLocal.length
@@ -385,12 +412,16 @@ export function renderCrossSystemHtml(catalog, opts = {}) {
     // this one did not — which only became a hazard with the cross-repo form, where `otherTitle`
     // can come straight out of a FETCHED sibling `catalog.json` rather than a spec in this
     // checkout. The arrow span is ours and stays raw; the titles are data.
-    designRefById
+    kitRefs
       ? `${esc(title)} <span class="arrow">↔</span> ${esc(otherTitle)}, both against ${esc(designTitle)}`
       : `${esc(title)} <span class="arrow">↔</span> ${esc(otherTitle)}`,
     `${paired.length} paired`,
     `${pairedReal} rendered both sides`,
-    ...(designRefById ? [`${designed} against a kit reference`] : []),
+    // Counted off `kitRefs`, not the column: a column carried by stated absences alone would
+    // otherwise announce "0 against a kit reference", which reads as a failure rather than as the
+    // audited absence it is.
+    ...(kitRefs ? [`${designed} against a kit reference`] : []),
+    ...(statedAbsences ? [`${statedAbsences} with a stated absence`] : []),
   ];
 
   return `<!doctype html>

--- a/scripts/design-artifacts/render-cross-system-html.test.mjs
+++ b/scripts/design-artifacts/render-cross-system-html.test.mjs
@@ -532,3 +532,31 @@ test("a variant's stated reason is escaped, never injected as markup", () => {
   assert.doesNotMatch(html, /<img src=x/);
   assert.match(html, /&lt;img src=x/);
 });
+
+test("a catalog with only stated absences still gets the kit column", () => {
+  // The driver passes an empty `designRefById` when nothing resolved, which used to normalise to
+  // null and drop the column entirely — so the authored reasons showed up only when some unrelated
+  // component happened to contribute a reference, as every other test here does.
+  const absencesOnly = {
+    ...catalog,
+    components: [
+      { ...catalog.components[0], noReference: "the kit retired this button" },
+      catalog.components[1],
+    ],
+  };
+  const html = renderCrossSystemHtml(absencesOnly, { ...opts, designRefById: new Map() });
+
+  assert.match(html, /<th scope="col">Design kit<\/th>/);
+  assert.match(html, /no kit reference — the kit retired this button/);
+  // Counted honestly: no reference resolved, so the page does not claim a three-way comparison.
+  assert.match(html, /1 with a stated absence/);
+  assert.doesNotMatch(html, /against a kit reference/);
+  assert.doesNotMatch(html, /both against Design kit/);
+});
+
+test("no references and no stated absences leaves the kit column off", () => {
+  const html = renderCrossSystemHtml(catalog, { ...opts, designRefById: new Map() });
+  assert.doesNotMatch(html, /Design kit/);
+  assert.doesNotMatch(html, /col-d/);
+  assert.doesNotMatch(html, /with a stated absence/);
+});


### PR DESCRIPTION
Two review findings on #4740, which merged before either could be addressed. Both are on code I wrote there.

### The rationale was invisible on the catalogs that need it most

#4740 taught `designEmbed` to publish a variant's authored `noReference` instead of the generic cell — but the column it renders into is gated on `designRefById?.size`. A catalog whose components all declare `noReference` passes an **empty** map, that normalises to `null`, and the whole design column is dropped. Every authored reason went with it.

So the new branch fired only when some *unrelated* component happened to contribute a reference — which is exactly what the regression test and the evidence fixture both did. A catalog that has nothing but stated absences, which is the case the field is for, showed none of them.

A stated absence is the finding the kit column exists to publish, so it now earns the column on its own. The counts stay honest about the difference between the two reasons a column can be there:

| | resolved refs | absences only |
| --- | --- | --- |
| kit column | shown | **shown** (was: dropped) |
| `…, both against Design kit` | yes | no — there is no third party to compare against |
| `N against a kit reference` | yes | omitted (would have read `0`, i.e. as failure rather than as audited absence) |
| `N with a stated absence` | when any | **yes** |

### The evidence fixture only ran in the checkout it was captured in

`docs/design/evidence/compared-variant-rows/fixture.mjs` imported the renderer through an absolute `/home/user/compose-ai-tools/…` path, so the reproduction its README documents failed anywhere else. Resolved from `import.meta.url` now, and the before-shot recipe rewritten to run the worktree's own copy rather than to hand-edit the import.

## Test plan

```
not ok — a catalog with only stated absences still gets the kit column      (with the fix reverted)
```

plus a companion asserting a catalog with **neither** references nor absences still gets no column — the behaviour this must not change.

- `render-cross-system-html`: 29 pass, 0 fail
- whole `scripts/design-artifacts` suite: 1250 pass / 7 fail, the same seven environment failures `origin/main` shows unmodified
- `node docs/design/evidence/compared-variant-rows/fixture.mjs /tmp/repro.html` run end to end from a relative cwd

Non-visual in the diff itself; the surface it restores is the one #4740 captured, and that evidence is unchanged and still accurate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_