### PR TITLE
fix(serve): decode a query name before dropping the stale chrome pin

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -17,6 +17,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.decodeURLQueryComponent
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.ApplicationCallPipeline
 import io.ktor.server.application.createApplicationPlugin
@@ -4600,9 +4601,29 @@ class ServeHttpServer(
     val base = url.substringBefore('?')
     val kept =
       url.substringAfter('?', "").split('&').filter {
-        it.isNotEmpty() && it.substringBefore('=') != CHROME_PARAM
+        it.isNotEmpty() && queryParamName(it) != CHROME_PARAM
       }
     return "$base?" + (kept + "$CHROME_PARAM=$mode").joinToString("&")
+  }
+
+  /**
+   * The DECODED name of a raw `k=v` query pair.
+   *
+   * Ktor decodes a parameter name before it reaches [io.ktor.http.Parameters], so `?%63hrome=x` is
+   * `chrome` to every read in this file — including the [interfaceMode] check that decides this URL
+   * carries an unrecognised pin. Comparing the raw text instead kept that pair and appended a
+   * second `chrome=`, and a reader taking the FIRST value read the invalid one, ignored it and fell
+   * back to their own mode: the wrong-surface failure the pin exists to prevent, restored by the
+   * replacement meant to close it.
+   *
+   * `plusIsSpace` matches how Ktor reads a query component. A name that is not valid
+   * percent-encoding cannot be what Ktor decoded to `chrome`, so it keeps its raw text and is
+   * preserved rather than dropped — this only ever removes a pair the server itself reads as the
+   * chrome pin.
+   */
+  private fun queryParamName(pair: String): String {
+    val raw = pair.substringBefore('=')
+    return runCatching { raw.decodeURLQueryComponent(plusIsSpace = true) }.getOrDefault(raw)
   }
 
   private fun catalogBundleHost(host: ServeHost): ServeBundleHost? =

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeHttpRoutingTest.kt
@@ -1831,6 +1831,50 @@ class ServeHttpRoutingTest {
   }
 
   @Test
+  fun `a percent-encoded chrome pin is replaced, not doubled`() {
+    // Ktor decodes a parameter NAME before it reaches `queryParameters`, so `?%63hrome=invalid` is
+    // `chrome` to every read in the server — including the check that decides this URL carries an
+    // unrecognised pin. Comparing the raw text when dropping it kept the pair and appended a second
+    // `chrome=`, and a reader taking the first value read the invalid one, ignored it and fell back
+    // to their own mode: the wrong-surface failure the pin exists to prevent, restored by the
+    // replacement meant to close it.
+    val (_, page) = get("/compose-m3?%63hrome=invalid")
+    val report = page.substringAfter("id=\"cp-report\"", "").substringBefore("</form>")
+    assertTrue(report.isNotEmpty(), "the catalog report row is present: $page")
+    assertTrue(
+      report.contains("chrome%3Ddev") || report.contains("chrome=dev"),
+      "the resolved mode is pinned: $report",
+    )
+    // Neither spelling of the stale pin survives — the encoded pair is what used to.
+    assertTrue(
+      !report.contains("%2563hrome") && !report.contains("%63hrome"),
+      "the encoded pin is dropped rather than carried alongside the new one: $report",
+    )
+    assertTrue(
+      !report.contains("chrome%3Dinvalid") && !report.contains("chrome=invalid"),
+      "and its value does not reach the report by any spelling: $report",
+    )
+  }
+
+  @Test
+  fun `a query name that is not this pin survives the replacement`() {
+    // The drop is scoped to what the server itself reads as the chrome pin. An unrelated parameter
+    // — encoded or not, and including one whose name is not valid percent-encoding — is carried
+    // through untouched, so replacing the pin never costs a report its other context.
+    val (_, page) = get("/compose-m3?locale=en-US&%7Anote=keep&chrome=invalid")
+    val report = page.substringAfter("id=\"cp-report\"", "").substringBefore("</form>")
+    assertTrue(report.isNotEmpty(), "the catalog report row is present: $page")
+    assertTrue(
+      report.contains("locale%3Den-US") || report.contains("locale=en-US"),
+      "an ordinary parameter is kept: $report",
+    )
+    assertTrue(
+      report.contains("note%3Dkeep") || report.contains("note=keep"),
+      "so is an encoded one that is not the pin: $report",
+    )
+  }
+
+  @Test
   fun `viewer unfurl metadata uses the external origin and preserves render overrides`() {
     val request =
       Request.Builder()


### PR DESCRIPTION
The remaining review finding on #4733, which merged before it could be addressed. It is on code I wrote there.

## What happens

Ktor decodes a parameter **name** before it reaches `queryParameters`, so `?%63hrome=invalid` is `chrome` to every read in the server — including the `interfaceMode` check that decides this URL carries an unrecognised pin. The replacement branch then compared the **raw** text:

```kotlin
it.substringBefore('=') != CHROME_PARAM   // "%63hrome" != "chrome" → kept
```

…so the pair was kept and a second `chrome=<resolved>` appended.

That is the failure the replacement exists to close, arriving one encoding over. A reporter in Catalog mode files a link carrying two chrome values; a reader taking the first gets `invalid`, `interfaceMode` returns null, and the page falls back to the *reader's* own mode — the wrong surface, which is the whole thing the pin prevents.

| requested | before | after |
| --- | --- | --- |
| `?chrome=invalid` | `?chrome=dev` ✓ | `?chrome=dev` ✓ |
| `?%63hrome=invalid` | `?%63hrome=invalid&chrome=dev` ✗ | `?chrome=dev` ✓ |

## The fix

The drop matches on the decoded name, so it removes exactly the pairs the server itself reads as the pin. `plusIsSpace` matches how Ktor reads a query component. A name that is **not** valid percent-encoding cannot be what Ktor decoded to `chrome`, so it keeps its raw text and is preserved rather than dropped — the change only ever removes a pair the server would have read as the pin.

## Test plan

```
FAILED — a percent-encoded chrome pin is replaced, not doubled     (with the fix reverted)
```

plus a companion asserting the replacement costs a report none of its other context: an ordinary parameter, an encoded one that is not the pin, and one whose name is not decodable all survive.

- `./gradlew :cli:serve:test` — **BUILD SUCCESSFUL** (`ServeHttpRoutingTest`: 90 tests, 0 failures)
- `./gradlew :cli:serve:ktfmtFormatMain :cli:serve:ktfmtFormatTest` — clean, nothing to restage

Non-visual: this changes the query string of a report permalink, not any rendered surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_