### PR TITLE
fix(design-artifacts): let a folded state fall through to the cell's props

### DIFF
--- a/scripts/design-artifacts/bridge-live-preview-ids.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.mjs
@@ -450,16 +450,29 @@ function keyedCandidates(candidates, record) {
   const named = typeof state === "string" && state !== "" && state !== "default" ? state : null;
   if (named) {
     const byName = candidates.filter((c) => c.overrideName === named);
-    return byName.length > 0 ? byName : null;
+    if (byName.length > 0) return byName;
+    // Deliberately NOT a return: a `state` is not always an override on THIS function. A
+    // `@CatalogVariant` render folds under its parent carrying the fold's own axis as the state
+    // (`wave`), and may hold a `@PreviewAxis` matrix of its own on top — so a record legitimately
+    // carries both, and only the props name the cell. Returning here read the fold's name, found no
+    // reseed called `wave`, and routed the record to the base without ever trying them.
   }
   const wanted = record?.props;
   if (wanted && typeof wanted === "object") {
-    // Every axis the reseed declares must be the one this record asks for. A subset match, not an
+    // Every axis the reseed declares must be one this record asks for. A subset match, not an
     // equality: the record may also carry a `fontScale` or a spec-authored prop from another axis.
+    //
+    // The key must be PRESENT, not merely stringify equal. `@PreviewAxis` permits the literal
+    // string value `"undefined"`, and `String(wanted[k])` renders a missing key as exactly that —
+    // so a record naming an unrelated axis matched such a reseed and rendered its cell instead of
+    // the base.
     const byProps = candidates.filter(
       (c) =>
         c.overrideProps &&
-        Object.entries(c.overrideProps).every(([k, v]) => String(wanted[k]) === String(v)),
+        Object.entries(c.overrideProps).every(
+          ([k, v]) =>
+            Object.prototype.hasOwnProperty.call(wanted, k) && String(wanted[k]) === String(v),
+        ),
     );
     if (byProps.length > 0) return byProps;
   }

--- a/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
+++ b/scripts/design-artifacts/bridge-live-preview-ids.test.mjs
@@ -1758,3 +1758,71 @@ test("a keyed variant deferral selects its cell instead of expanding over every 
     );
   }
 });
+
+test("a folded state that names no reseed still lets the record's props name the cell", () => {
+  // A `state` is not always an override on THIS function. A `@CatalogVariant` render folds under
+  // its parent carrying the fold's own axis as the state (`wave`), and may hold a `@PreviewAxis`
+  // matrix of its own on top — so the record legitimately carries both, and only the props name the
+  // cell. Returning on an empty name match read the fold's name, found no reseed called `wave`, and
+  // routed the record to the base without ever trying them.
+  const spec = { groups: [{ components: [{ componentId: "P/Circular", preview: "Wave" }] }] };
+  const preview = (id, night, overrides) => ({
+    id,
+    functionName: "Wave",
+    params: { uiMode: night ? "UI_MODE_NIGHT_YES" : "UI_MODE_NIGHT_NO" },
+    ...(overrides ? { overrides } : {}),
+  });
+  const cell = [{ key: "progress", value: "full" }];
+  const bundle = {
+    previews: [
+      preview("Wave_Light", false),
+      preview("Wave_Dark", true),
+      preview("Wave_Light_VARIANT_full", false, { name: "full", props: cell }),
+      preview("Wave_Dark_VARIANT_full", true, { name: "full", props: cell }),
+    ],
+  };
+  const route = (record) =>
+    expandDeferredRecords(
+      [{ componentId: "P/Circular", preview: "Wave", reason: "mode", ...record }],
+      spec,
+      [bundle],
+    ).map((r) => r.previewId);
+
+  assert.deepEqual(route({ theme: "light", state: "wave", props: { progress: "full" } }), [
+    "Wave_Light_VARIANT_full",
+  ]);
+  // The fold's state alone still names no cell on this function, so the base is right.
+  assert.deepEqual(route({ theme: "light", state: "wave" }), ["Wave_Light"]);
+});
+
+test("a props match requires the record to name the axis, not merely to stringify equal", () => {
+  // `@PreviewAxis` permits the literal string value "undefined", and `String(wanted[k])` renders a
+  // MISSING key as exactly that — so a record naming an unrelated axis matched such a reseed and
+  // rendered its cell instead of the base.
+  const spec = { groups: [{ components: [{ componentId: "B", preview: "Wave" }] }] };
+  const preview = (id, overrides) => ({
+    id,
+    functionName: "Wave",
+    params: { uiMode: "UI_MODE_NIGHT_NO" },
+    ...(overrides ? { overrides } : {}),
+  });
+  const bundle = {
+    previews: [
+      preview("Wave_Light"),
+      preview("Wave_Light_VARIANT_odd", {
+        name: "odd",
+        props: [{ key: "size", value: "undefined" }],
+      }),
+    ],
+  };
+  const route = (props) =>
+    expandDeferredRecords(
+      [{ componentId: "B", preview: "Wave", reason: "mode", theme: "light", props }],
+      spec,
+      [bundle],
+    ).map((r) => r.previewId);
+
+  assert.deepEqual(route({ content: "icon" }), ["Wave_Light"]);
+  // …and the record that really does name that axis still selects the reseed.
+  assert.deepEqual(route({ size: "undefined" }), ["Wave_Light_VARIANT_odd"]);
+});


### PR DESCRIPTION
Two post-merge review findings on #4747, both in the candidate matcher it added. Reproduced against `origin/main` before changing anything.

### A `state` is not always an override on the function that renders it

A `@CatalogVariant` render folds under its parent carrying the **fold's** own axis as the state (`wave`), and may hold a `@PreviewAxis` matrix of its own on top. So a deferred record legitimately carries both the fold's state and the cell's props, and only the props name the cell. Returning as soon as the name matched nothing read `wave`, found no reseed by that name on this function, and routed the record to the base:

```
{theme: light, state: wave, props: {progress: full}} -> Wave_Light          ← before
                                                     -> Wave_Light_VARIANT_full  ← after
```

An empty name match now falls through to the props lookup instead of returning. The fold's state *alone* still names no cell here, so a record carrying only it keeps the base — pinned by the test.

### The props comparison matched on a value it was never given

`String(wanted[k])` renders a **missing** key as the string `"undefined"`, and `@PreviewAxis` permits that as a literal axis value. So a record naming an unrelated axis selected such a reseed and rendered its cell:

```
{props: {content: icon}} -> Wave_Light_VARIANT_odd   (odd declares size="undefined")
                         -> Wave_Light                                        ← after
```

The key must now be present on the record, not merely stringify equal to the reseed's value. A record that really does name that axis still selects the reseed — also pinned.

## Test plan

Two regression tests, each confirmed to fail with **its own** fix reverted:

```
not ok — a folded state that names no reseed still lets the record's props name the cell
not ok — a props match requires the record to name the axis, not merely to stringify equal
```

Each also asserts the case that must **not** change, since both fixes widen a match and the risk is over-matching rather than under-matching.

- `bridge-live-preview-ids`: 47 pass, 0 fail
- whole `scripts/design-artifacts` suite: 1262 pass / 7 fail, the same seven environment failures `origin/main` shows unmodified

Non-visual: it changes which annotation a live-only card renders through.

## A note on this file

This is the third follow-up round on `keyedCandidates`, and the function has now needed four corrections since it was introduced two PRs ago. Each finding has been real and each fix smaller than the last, but the shape is a chain of narrowing branches with fall-through rules, and the bugs have all been *which branch wins and when* rather than the individual predicates. If a fourth round appears, restructuring it into one ordered resolution over an explicit candidate identity is probably worth more than another patch — flagging rather than doing it here, since that is a design call and this PR is meant to close two concrete bugs on merged code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJVTdPE3RwJ1gLMbLpThZP)_