### PR TITLE
perf(design-artifacts): read reference structure from the parity cache

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -199,6 +199,27 @@ on:
         required: false
         type: boolean
         default: true
+      reference-cache-branch:
+        description: >
+          Branch holding the design-parity reference cache (`design-parity/reference`, maintained by
+          design-parity-import-reusable.yml). When set, the reference lane reads each node's
+          STRUCTURE from it instead of asking `/v1/files/:key/nodes`, which is the same JSON that
+          endpoint returns — the import wrote it from exactly that response.
+
+          Worth setting because this lane runs on every push while the kit moves rarely, and the
+          Figma limiter is per TOKEN: it is shared with the parity runs, the import, and the sibling
+          catalog. This lane was the last one still spending it unguarded.
+
+          PIXELS ARE UNAFFECTED. The cache also holds a resolution-free `image.svg`, but the exports
+          here are PNG at a per-record density and the `match` score baked into the manifest is
+          computed from those pixels — rasterising the SVG locally would move every score. So images
+          keep coming from Figma's own renderer, and this input only removes the structure calls.
+
+          A miss is not an error: the node falls through to the API exactly as it did before, so an
+          absent or partial cache costs requests, never coverage.
+        required: false
+        type: string
+        default: ''
       reference-backdrop:
         description: >
           Publish each design reference on the ground its sticker was drawn on, as a hex colour
@@ -1512,6 +1533,33 @@ jobs:
       #
       # Fail-soft on purpose: an unrenderable reference is dropped with a warning
       # rather than costing the catalog its render.
+      # The design-parity reference cache, if the caller maintains one. Cloned
+      # rather than fetched through the API for the same reason the parity
+      # workflow does it: the branch IS the cache, so `git` is the transport and
+      # no Figma credential is involved.
+      #
+      # Best-effort by design. A branch that does not exist (never bootstrapped,
+      # or pruned) leaves the dir unset and the lane fetches structure live, as
+      # it always has. That is the opposite of the parity run, where the cache is
+      # authoritative and a miss is a reported gap — here it is only ever a
+      # question of how many requests this run makes.
+      - name: Fetch the design reference cache
+        id: refcache
+        if: ${{ (inputs.publish || inputs.upload-out) && inputs.reference-cache-branch != '' }}
+        env:
+          BRANCH: ${{ inputs.reference-cache-branch }}
+          CACHE_DIR: ${{ runner.temp }}/design-reference-cache
+        run: |
+          set -euo pipefail
+          repo="https://x-access-token:${{ github.token }}@github.com/${GITHUB_REPOSITORY}.git"
+          if git clone -q --depth 1 --branch "$BRANCH" "$repo" "$CACHE_DIR" 2>/dev/null; then
+            rm -rf "$CACHE_DIR/.git"
+            echo "dir=${CACHE_DIR}" >> "$GITHUB_OUTPUT"
+            echo "Reference cache from ${BRANCH}: $(du -sh "$CACHE_DIR" | cut -f1)."
+          else
+            echo "::notice title=No reference cache::'${BRANCH}' does not exist yet, so node structure will be fetched live. Run the design-parity import workflow to build it."
+          fi
+
       - name: Publish design references
         if: ${{ inputs.publish || inputs.upload-out }}
         env:
@@ -1522,6 +1570,7 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.figma_token }}
           FIGMA_CONTENTS_ONLY: ${{ inputs.figma-contents-only }}
           REFERENCE_BACKDROP: ${{ inputs.reference-backdrop }}
+          REFERENCE_CACHE: ${{ steps.refcache.outputs.dir }}
         run: |
           set -euo pipefail
           if [ ! -f "design-map.json" ]; then
@@ -1553,6 +1602,18 @@ jobs:
           # catalog would have published with no input at all — stale against the caller's intent,
           # never wrong — and a reference lane must not cost a catalog its render.
           emitter=compose-ai-tools/scripts/design-artifacts/emit-design-references.mjs
+          # Same shape, same reason: an EXTERNAL caller runs the release-pinned
+          # driver, so a freshly merged flag reaches it only when the next
+          # release moves design-artifacts-driver-pin.txt. Silence here would
+          # look exactly like a cache that is working.
+          if [ -n "${REFERENCE_CACHE:-}" ] && ! grep -q 'reference-cache' "$emitter"; then
+            echo "::warning title=Driver too old for reference-cache::This run's export driver \
+          predates the --reference-cache flag, so the cache was ignored and node structure was \
+          fetched live. References published are unchanged — this costs requests, not coverage. \
+          External callers run the driver pinned in \
+          compose-ai-tools/.github/design-artifacts-driver-pin.txt; it reaches them when the next \
+          release moves that pin."
+          fi
           if [ -n "$REFERENCE_BACKDROP" ] && ! grep -q 'reference-backdrop' "$emitter"; then
             echo "::warning title=Driver too old for reference-backdrop::This run's export driver \
           predates the --reference-backdrop flag, so '$REFERENCE_BACKDROP' was ignored and the \
@@ -1567,7 +1628,8 @@ jobs:
             --repo "$GITHUB_WORKSPACE" \
             --spec "$INPUT_SPEC" \
             --figma-contents-only "$FIGMA_CONTENTS_ONLY" \
-            --reference-backdrop "$REFERENCE_BACKDROP"
+            --reference-backdrop "$REFERENCE_BACKDROP" \
+            --reference-cache "${REFERENCE_CACHE:-}"
 
       # The design-parity dashboard's feed (`parity/activity.json`) — recent
       # commits, recent Figma versions/comments, and the mapping gaps behind

--- a/scripts/design-artifacts/emit-design-references.mjs
+++ b/scripts/design-artifacts/emit-design-references.mjs
@@ -5,7 +5,7 @@
  *     node emit-design-references.mjs --out <bundle dir> --repo <repo root> \
  *       [--design-map design-map.json] [--spec catalog.spec.json] \
  *       [--reference-images <dir>] [--reference-backdrop '#000000'] \
- *       [--chromium <path>] [--strict]
+ *       [--reference-cache <dir>] [--chromium <path>] [--strict]
  *
  * `--out` is the staged bundle the workflow is about to force-push to `design-artifacts/<system>`;
  * this adds `references/index.json` plus one normalised PNG per reference and leaves the rest of it
@@ -89,6 +89,17 @@ const REPO = path.resolve(arg("repo", "."));
 const DESIGN_MAP = arg("design-map", "design-map.json");
 const SPEC = arg("spec", "catalog.spec.json");
 const REFERENCE_IMAGES = arg("reference-images");
+/**
+ * A design-parity reference cache checkout (`design-parity/reference`). Node
+ * STRUCTURE is read from it instead of `/v1/files/:key/nodes`; a miss just costs
+ * the request it would have cost anyway.
+ *
+ * Only the structure. The cache also holds a resolution-free `image.svg`, but
+ * the pixels here feed the `match` score baked into the manifest at publish, so
+ * swapping Figma's renderer for a local SVG raster would move every score in it.
+ * That is a decision, not a caching detail, so it is not taken here.
+ */
+const REFERENCE_CACHE = arg("reference-cache", process.env.DESIGN_REFERENCES_CACHE || "");
 const EXEC = arg("chromium", process.env.DESIGN_REFERENCES_CHROMIUM || undefined);
 const STRICT = process.argv.includes("--strict");
 const FIGMA_CONTENTS_ONLY = arg("figma-contents-only", "true") !== "false";
@@ -261,7 +272,11 @@ function referenceContentsOnly(record) {
 function figmaRasterizerFor(contentsOnly) {
   let rasterizer = figmaRasterizers.get(contentsOnly);
   if (!rasterizer) {
-    rasterizer = new FigmaRestRasterizer({ token: FIGMA_TOKEN, contentsOnly });
+    rasterizer = new FigmaRestRasterizer({
+      token: FIGMA_TOKEN,
+      contentsOnly,
+      ...(REFERENCE_CACHE ? { cacheDir: REFERENCE_CACHE } : {}),
+    });
     figmaRasterizers.set(contentsOnly, rasterizer);
   }
   return rasterizer;

--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { PNG } from "pngjs";
 
 /** `figma:<fileKey>/<nodeId>` -> `{ fileKey, nodeId }`, or null. */
@@ -48,8 +51,23 @@ export class FigmaRestRasterizer {
     batchSize = 50,
     maxAttempts = 5,
     contentsOnly = true,
+    /**
+     * A design-parity reference cache checkout (the `design-parity/reference`
+     * branch). When set, node STRUCTURE is read from `<fileKey>/<nodeId>/node.json`
+     * instead of `/v1/files/:key/nodes`, which is the same JSON that endpoint
+     * returns — the import wrote it from exactly that response.
+     *
+     * Images are deliberately NOT read from it. The cache holds a
+     * resolution-free `image.svg`, but this rasterizer needs a PNG at a density
+     * derived per record, and the published `match` score is computed from these
+     * very pixels. Rasterising the SVG locally would move every score in the
+     * manifest, so pixels stay on Figma's own renderer until that is a decision
+     * somebody makes deliberately.
+     */
+    cacheDir = "",
   }) {
     this.token = token;
+    this.cacheDir = cacheDir;
     this.fetchImpl = fetchImpl;
     this.sleep = sleep;
     this.batchSize = batchSize;
@@ -78,6 +96,28 @@ export class FigmaRestRasterizer {
 
   nodeKey({ fileKey, nodeId }) {
     return `${fileKey}/${nodeId}`;
+  }
+
+  /**
+   * The cached structure for a node, or null for a miss.
+   *
+   * A miss is not an error and never fatal: the node simply falls through to the
+   * API below, exactly as it did before a cache existed. That keeps a partial or
+   * absent cache a matter of how many requests this run makes, never of what it
+   * can publish — the opposite of the parity run, where the cache is
+   * authoritative and a miss is reported.
+   *
+   * Node ids contain a colon (`1:42`); the cache spells directories with a dash
+   * (`1-42`), the same way Figma's own URLs do.
+   */
+  nodeFromCache({ fileKey, nodeId }) {
+    if (!this.cacheDir) return null;
+    const file = path.join(this.cacheDir, fileKey, nodeId.replace(/:/g, "-"), "node.json");
+    try {
+      return JSON.parse(fs.readFileSync(file, "utf8"));
+    } catch {
+      return null;
+    }
   }
 
   scaleFor(parsed, target) {
@@ -113,6 +153,11 @@ export class FigmaRestRasterizer {
     for (const { parsed } of parsedRequests) {
       const key = this.nodeKey(parsed);
       if (this.nodes.has(key)) continue;
+      const cached = this.nodeFromCache(parsed);
+      if (cached) {
+        this.nodes.set(key, cached);
+        continue;
+      }
       const ids = missingByFile.get(parsed.fileKey) ?? new Set();
       ids.add(parsed.nodeId);
       missingByFile.set(parsed.fileKey, ids);

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { PNG } from "pngjs";
 
 import {
@@ -168,4 +171,87 @@ test("retries a rate-limited batch once and respects Retry-After", async () => {
   assert.equal(nodeAttempts, 2);
   assert.deepEqual(sleeps, [0]);
   assert.equal(raster.width, 1);
+});
+
+/** A design-parity reference cache holding structure for the given node ids. */
+function referenceCache(fileKey, nodeIds) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "reference-cache-"));
+  for (const nodeId of nodeIds) {
+    const entry = path.join(dir, fileKey, nodeId.replace(/:/g, "-"));
+    fs.mkdirSync(entry, { recursive: true });
+    fs.writeFileSync(
+      path.join(entry, "node.json"),
+      JSON.stringify({ document: { absoluteBoundingBox: { width: 10 } }, styles: {} }),
+    );
+  }
+  return dir;
+}
+
+test("reads node structure from a reference cache instead of the nodes endpoint", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    return new Response(onePixelPng(), { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl,
+    cacheDir: referenceCache("file", ["1:1"]),
+  });
+  const target = { width: 20, height: 20, density: 2.625 };
+
+  const raster = await rasterizer.rasterize("figma:file/1:1", target);
+
+  // The structure came off disk, so the rate-limited nodes endpoint is never asked.
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 0);
+  // Pixels still come from Figma's own renderer: the published `match` score is
+  // computed from them, so they are deliberately NOT taken from the cache's SVG.
+  assert.equal(calls.filter((url) => url.includes("/images/")).length, 1);
+  assert.deepEqual(raster.document, { absoluteBoundingBox: { width: 10 } });
+});
+
+test("falls through to the nodes endpoint when the cache misses", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/nodes?")) {
+      return json({ nodes: { "2:2": { document: { absoluteBoundingBox: { width: 10 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { "2:2": "https://cdn.test/2:2" } });
+    return new Response(onePixelPng(), { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl,
+    // Holds a different node, so `2:2` is a miss.
+    cacheDir: referenceCache("file", ["1:1"]),
+  });
+
+  await rasterizer.rasterize("figma:file/2:2", { width: 20, height: 20, density: 2.625 });
+
+  // A miss is not fatal here — unlike the parity run, where the cache is
+  // authoritative. It just costs the request it would have cost anyway.
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
+});
+
+test("ignores a cacheDir that does not exist", async () => {
+  const calls = [];
+  const fetchImpl = async (url) => {
+    calls.push(url);
+    if (url.includes("/nodes?")) {
+      return json({ nodes: { "1:1": { document: { absoluteBoundingBox: { width: 10 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    return new Response(onePixelPng(), { status: 200 });
+  };
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl,
+    cacheDir: "/nope/not/a/cache",
+  });
+
+  await rasterizer.rasterize("figma:file/1:1", { width: 20, height: 20, density: 2.625 });
+
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
 });


### PR DESCRIPTION
## The last unguarded lane

The reference lane runs on **every push** to a catalog path, in both catalogs, and re-reads the same Figma nodes each time — while the kit it reads moves rarely. It was the only consumer of the token still doing that: parity runs read a committed cache and make zero calls, and the import is version-gated.

That matters because the limiter is **per token**, shared across every repo and workflow holding the same PAT. It is the concrete reason wear-m3-catalog's cache bootstrap took four passes on 2026-08-28 rather than one — the import kept losing quota to `Design Artifacts` runs it had no idea it was competing with:

| Import pass | Nodes | Competing for the token |
| --- | --- | --- |
| #1 | 4 | two parity runs live-fetching |
| #2 | 115 | two `Design Artifacts` runs |
| #3 | ~320 | those cleared mid-run |
| #4 | ~145 → `complete=true` | quieter |

## The change

`reference-cache-branch`. When set, the lane clones the design-parity reference cache and reads each node's structure from `<fileKey>/<nodeId>/node.json` instead of calling `/v1/files/:key/nodes` — the same JSON that endpoint returns, since the import wrote it from exactly that response.

## Structure only — and this is the important part

The cache also holds a resolution-free `image.svg`, and rasterising it locally would remove the image calls too. **I deliberately did not do that**, because of what it would quietly break:

- exports here are **PNG at a per-record density** (`scaleFor` derives it from the renderer density), and
- `scoreReferences()` bakes a `match` score into the published manifest, computed from *those very pixels*.

Swapping Figma's renderer for a local SVG raster would therefore **move every published match score in both catalogs** — in a system whose entire job is measuring visual divergence. That is a decision about what a reference *is*, not a caching detail, and it shouldn't ride in on a performance PR. Pixels stay on Figma's renderer.

So this removes the structure calls (~12 per run for a 581-node map) and leaves the image calls alone. A smaller win than the headline number suggests, and honest about which half is safe.

## Failure behaviour

A miss is **not** an error here — unlike the parity run, where the cache is authoritative and a miss is a reported gap. The node falls through to the API exactly as before, so an absent, partial or pruned cache costs requests, never coverage. Three tests pin that.

A driver predating the flag **warns** rather than silently looking like a working cache, matching the existing `reference-backdrop` guard. That matters because external callers run the release-pinned driver, so the flag only reaches them when the next release moves `design-artifacts-driver-pin.txt`.

## Test plan

- `node --test *.test.mjs` in `scripts/design-artifacts` — **1278 passed, 0 failed**, 29 self-skipped (browser tests, no browser here).
- Three new tests: structure served from cache with **zero** `/nodes` calls (and the image call still made, pinning the pixels-stay-remote decision); cache miss falls through; non-existent `cacheDir` ignored.
- Both workflow files parse under `yaml.safe_load`.
- `agent-attribution-scan.sh --range origin/main..HEAD` passes.
- No renderer or comparison change, and no published pixel changes, so no visual evidence applies — that is the point of the structure/image split above.

## Not wired up yet

This adds the capability; no caller sets it. wear-m3-catalog and m3-catalog both have a populated `design-parity/reference`, so both can adopt it in a follow-up. Note the saving only lands for external callers once a release moves the driver pin — until then the new warning says so out loud.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyTcAAsHW98Z5ChjYwT5xP)_