### PR TITLE
fix(design-artifacts): only trust cached structure at the file's current revision

### DIFF
--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -218,10 +218,20 @@ export class FigmaRestRasterizer {
     // to make an unchanged kit cost a single request.
     if (this.cacheDir) {
       for (const [fileKey, ids] of [...missingByFile]) {
-        if (!(await this.cacheIsCurrent(fileKey))) continue;
-        for (const nodeId of [...ids]) {
+        // Read from disk BEFORE paying for the revision check. A file listed in
+        // `index.json` whose requested nodes are not actually cached — a partial
+        // import, a node added to the map since — would otherwise cost a
+        // `?depth=1` request that cannot enable a single hit, turning a
+        // one-request miss into two. Worse under a 429: `fetchWithRetry` would
+        // spend its whole backoff budget on a question whose answer is moot.
+        const hits = new Map();
+        for (const nodeId of ids) {
           const cached = this.nodeFromCache({ fileKey, nodeId });
-          if (!cached) continue;
+          if (cached) hits.set(nodeId, cached);
+        }
+        if (hits.size === 0) continue;
+        if (!(await this.cacheIsCurrent(fileKey))) continue;
+        for (const [nodeId, cached] of hits) {
           this.nodes.set(`${fileKey}/${nodeId}`, cached);
           ids.delete(nodeId);
         }

--- a/scripts/design-artifacts/figma-rest-raster.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.mjs
@@ -68,6 +68,8 @@ export class FigmaRestRasterizer {
   }) {
     this.token = token;
     this.cacheDir = cacheDir;
+    this.cacheIndex = undefined;
+    this.cacheCurrent = new Map();
     this.fetchImpl = fetchImpl;
     this.sleep = sleep;
     this.batchSize = batchSize;
@@ -110,6 +112,52 @@ export class FigmaRestRasterizer {
    * Node ids contain a colon (`1:42`); the cache spells directories with a dash
    * (`1-42`), the same way Figma's own URLs do.
    */
+  /** The file `version` the cache was imported at, or null. */
+  cacheVersion(fileKey) {
+    if (!this.cacheDir) return null;
+    if (this.cacheIndex === undefined) {
+      try {
+        this.cacheIndex = JSON.parse(
+          fs.readFileSync(path.join(this.cacheDir, "index.json"), "utf8"),
+        );
+      } catch {
+        this.cacheIndex = null;
+      }
+    }
+    return this.cacheIndex?.files?.[fileKey]?.version ?? null;
+  }
+
+  /**
+   * Whether the cache still describes the revision the images endpoint will
+   * render. Memoized per file: one request, however many nodes it covers.
+   *
+   * Anything unclear is a NO — no index, no version for the file, a request that
+   * failed. The cache is an optimisation here, so the safe answer when freshness
+   * cannot be established is to fetch structure live, exactly as before.
+   */
+  async cacheIsCurrent(fileKey) {
+    if (!this.cacheDir) return false;
+    const known = this.cacheCurrent.get(fileKey);
+    if (known !== undefined) return known;
+    let current = false;
+    const cached = this.cacheVersion(fileKey);
+    if (cached) {
+      try {
+        const response = await this.fetchWithRetry(
+          `https://api.figma.com/v1/files/${encodeURIComponent(fileKey)}?depth=1`,
+          { headers: this.headers() },
+          "figma file version",
+        );
+        const json = await response.json();
+        current = Boolean(json?.version) && String(json.version) === String(cached);
+      } catch {
+        current = false;
+      }
+    }
+    this.cacheCurrent.set(fileKey, current);
+    return current;
+  }
+
   nodeFromCache({ fileKey, nodeId }) {
     if (!this.cacheDir) return null;
     const file = path.join(this.cacheDir, fileKey, nodeId.replace(/:/g, "-"), "node.json");
@@ -153,14 +201,32 @@ export class FigmaRestRasterizer {
     for (const { parsed } of parsedRequests) {
       const key = this.nodeKey(parsed);
       if (this.nodes.has(key)) continue;
-      const cached = this.nodeFromCache(parsed);
-      if (cached) {
-        this.nodes.set(key, cached);
-        continue;
-      }
       const ids = missingByFile.get(parsed.fileKey) ?? new Set();
       ids.add(parsed.nodeId);
       missingByFile.set(parsed.fileKey, ids);
+    }
+
+    // Serve what the cache can — but only for a file whose revision it still
+    // describes. Structure and pixels have to come from the SAME revision: the
+    // images request below is unversioned and always renders the file as it is
+    // now, while the cache holds whatever the last import saw. Mixing them
+    // publishes annotations and finding anchors measured against one raster on
+    // top of a different one, which is worse than either being stale.
+    //
+    // The check is one request per FILE (`?depth=1` for its `version`), against
+    // ~one per 50 nodes it saves — the same version gate the import itself uses
+    // to make an unchanged kit cost a single request.
+    if (this.cacheDir) {
+      for (const [fileKey, ids] of [...missingByFile]) {
+        if (!(await this.cacheIsCurrent(fileKey))) continue;
+        for (const nodeId of [...ids]) {
+          const cached = this.nodeFromCache({ fileKey, nodeId });
+          if (!cached) continue;
+          this.nodes.set(`${fileKey}/${nodeId}`, cached);
+          ids.delete(nodeId);
+        }
+        if (ids.size === 0) missingByFile.delete(fileKey);
+      }
     }
 
     for (const [fileKey, ids] of missingByFile) {

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -174,8 +174,12 @@ test("retries a rate-limited batch once and respects Retry-After", async () => {
 });
 
 /** A design-parity reference cache holding structure for the given node ids. */
-function referenceCache(fileKey, nodeIds) {
+function referenceCache(fileKey, nodeIds, version = "v1") {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "reference-cache-"));
+  fs.writeFileSync(
+    path.join(dir, "index.json"),
+    JSON.stringify({ formatVersion: 1, files: { [fileKey]: { version } } }),
+  );
   for (const nodeId of nodeIds) {
     const entry = path.join(dir, fileKey, nodeId.replace(/:/g, "-"));
     fs.mkdirSync(entry, { recursive: true });
@@ -187,48 +191,93 @@ function referenceCache(fileKey, nodeIds) {
   return dir;
 }
 
-test("reads node structure from a reference cache instead of the nodes endpoint", async () => {
-  const calls = [];
-  const fetchImpl = async (url) => {
+/** A Figma whose file sits at `version`, recording every URL it is asked for. */
+function fakeFigma(calls, { version = "v1", nodeId = "1:1" } = {}) {
+  return async (url) => {
     calls.push(url);
-    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
+    if (url.includes("?depth=1")) return json({ version });
+    if (url.includes("/nodes?")) {
+      return json({ nodes: { [nodeId]: { document: { absoluteBoundingBox: { width: 10 } } } } });
+    }
+    if (url.includes("/images/")) return json({ images: { [nodeId]: `https://cdn.test/${nodeId}` } });
     return new Response(onePixelPng(), { status: 200 });
   };
+}
+
+const TARGET = { width: 20, height: 20, density: 2.625 };
+
+test("reads node structure from a reference cache at the file's current revision", async () => {
+  const calls = [];
   const rasterizer = new FigmaRestRasterizer({
     token: "token",
-    fetchImpl,
-    cacheDir: referenceCache("file", ["1:1"]),
+    fetchImpl: fakeFigma(calls),
+    cacheDir: referenceCache("file", ["1:1"], "v1"),
   });
-  const target = { width: 20, height: 20, density: 2.625 };
 
-  const raster = await rasterizer.rasterize("figma:file/1:1", target);
+  const raster = await rasterizer.rasterize("figma:file/1:1", TARGET);
 
-  // The structure came off disk, so the rate-limited nodes endpoint is never asked.
+  // Structure came off disk, so the nodes endpoint is never asked — at the cost
+  // of ONE `?depth=1` request for the revision, however many nodes it covers.
   assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 0);
-  // Pixels still come from Figma's own renderer: the published `match` score is
+  assert.equal(calls.filter((url) => url.includes("?depth=1")).length, 1);
+  // Pixels still come from Figma's renderer: the published `match` score is
   // computed from them, so they are deliberately NOT taken from the cache's SVG.
   assert.equal(calls.filter((url) => url.includes("/images/")).length, 1);
   assert.deepEqual(raster.document, { absoluteBoundingBox: { width: 10 } });
 });
 
-test("falls through to the nodes endpoint when the cache misses", async () => {
+test("ignores a cache imported at a different revision than the images endpoint serves", async () => {
   const calls = [];
-  const fetchImpl = async (url) => {
-    calls.push(url);
-    if (url.includes("/nodes?")) {
-      return json({ nodes: { "2:2": { document: { absoluteBoundingBox: { width: 10 } } } } });
-    }
-    if (url.includes("/images/")) return json({ images: { "2:2": "https://cdn.test/2:2" } });
-    return new Response(onePixelPng(), { status: 200 });
-  };
   const rasterizer = new FigmaRestRasterizer({
     token: "token",
-    fetchImpl,
-    // Holds a different node, so `2:2` is a miss.
-    cacheDir: referenceCache("file", ["1:1"]),
+    // The kit moved since the import: cache says v1, the file is now v2.
+    fetchImpl: fakeFigma(calls, { version: "v2" }),
+    cacheDir: referenceCache("file", ["1:1"], "v1"),
   });
 
-  await rasterizer.rasterize("figma:file/2:2", { width: 20, height: 20, density: 2.625 });
+  await rasterizer.rasterize("figma:file/1:1", TARGET);
+
+  // Structure MUST come from the same revision the unversioned images request
+  // renders. Serving stale `document` under current pixels would publish spec
+  // annotations and finding anchors measured against a different raster.
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
+});
+
+test("checks the revision once per file, not once per node", async () => {
+  const calls = [];
+  const dir = referenceCache("file", ["1:1", "1:2", "1:3"], "v1");
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl: async (url) => {
+      calls.push(url);
+      if (url.includes("?depth=1")) return json({ version: "v1" });
+      if (url.includes("/images/")) {
+        const ids = new URL(url).searchParams.get("ids").split(",");
+        return json({ images: Object.fromEntries(ids.map((id) => [id, `https://cdn.test/${id}`])) });
+      }
+      return new Response(onePixelPng(), { status: 200 });
+    },
+    cacheDir: dir,
+  });
+  const refs = ["1:1", "1:2", "1:3"].map((id) => `figma:file/${id}`);
+
+  await rasterizer.prepare(refs.map((ref) => ({ ref, target: TARGET })));
+  await Promise.all(refs.map((ref) => rasterizer.rasterize(ref, TARGET)));
+
+  assert.equal(calls.filter((url) => url.includes("?depth=1")).length, 1);
+  assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 0);
+});
+
+test("falls through to the nodes endpoint when the cache misses", async () => {
+  const calls = [];
+  const rasterizer = new FigmaRestRasterizer({
+    token: "token",
+    fetchImpl: fakeFigma(calls, { nodeId: "2:2" }),
+    // Holds a different node, so `2:2` is a miss.
+    cacheDir: referenceCache("file", ["1:1"], "v1"),
+  });
+
+  await rasterizer.rasterize("figma:file/2:2", TARGET);
 
   // A miss is not fatal here — unlike the parity run, where the cache is
   // authoritative. It just costs the request it would have cost anyway.
@@ -237,21 +286,15 @@ test("falls through to the nodes endpoint when the cache misses", async () => {
 
 test("ignores a cacheDir that does not exist", async () => {
   const calls = [];
-  const fetchImpl = async (url) => {
-    calls.push(url);
-    if (url.includes("/nodes?")) {
-      return json({ nodes: { "1:1": { document: { absoluteBoundingBox: { width: 10 } } } } });
-    }
-    if (url.includes("/images/")) return json({ images: { "1:1": "https://cdn.test/1:1" } });
-    return new Response(onePixelPng(), { status: 200 });
-  };
   const rasterizer = new FigmaRestRasterizer({
     token: "token",
-    fetchImpl,
+    fetchImpl: fakeFigma(calls),
     cacheDir: "/nope/not/a/cache",
   });
 
-  await rasterizer.rasterize("figma:file/1:1", { width: 20, height: 20, density: 2.625 });
+  await rasterizer.rasterize("figma:file/1:1", TARGET);
 
+  // No index, so no revision to trust: never even asks for the file version.
+  assert.equal(calls.filter((url) => url.includes("?depth=1")).length, 0);
   assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
 });

--- a/scripts/design-artifacts/figma-rest-raster.test.mjs
+++ b/scripts/design-artifacts/figma-rest-raster.test.mjs
@@ -282,6 +282,9 @@ test("falls through to the nodes endpoint when the cache misses", async () => {
   // A miss is not fatal here — unlike the parity run, where the cache is
   // authoritative. It just costs the request it would have cost anyway.
   assert.equal(calls.filter((url) => url.includes("/nodes?")).length, 1);
+  // And ONLY that request: the revision check is skipped when nothing on disk
+  // could satisfy the batch, so a miss stays one request rather than two.
+  assert.equal(calls.filter((url) => url.includes("?depth=1")).length, 0);
 });
 
 test("ignores a cacheDir that does not exist", async () => {


### PR DESCRIPTION
Follow-up to #4754, which merged at its **first** commit. The review finding on it was fixed in a second commit that landed a minute too late to be squashed in, so `main` currently carries the cache **without** its correctness gate. This is that commit, re-applied.

## What is on main right now

`nodeFromCache` is present; `cacheIsCurrent` is not. The cache hit is unconditional.

**Latent, not active:** the capability is opt-in via `reference-cache-branch` and no caller sets it, so `cacheDir` is empty and the cache is never consulted today. But it must not be adopted in that state.

## The bug

The cache hit was unconditional, and the images request below it is **unversioned** — it always renders the file as it is *now*, while the cache holds whatever the last import saw. Any kit edit since that import makes this lane publish current pixels underneath structure from an older revision.

That is not cosmetic staleness. `emit-design-references.mjs` does:

```js
const capturedLayout = raster.document
  ? layoutFromNode(raster.document, { styles: raster.styles, … })
```

…so specification annotations and finding anchors would be **measured against one raster and drawn on another**, with nothing in the output saying so. Stale structure under fresh pixels is worse than either alone.

Credit to the Codex review on #4754 for catching it.

## The fix

Gate the cache on the file revision: compare the version the cache recorded in its `index.json` against `GET /v1/files/:key?depth=1`, and use the cache only when they agree. Memoized per file — **one** request however many nodes it covers, against the ~one-per-50-nodes it saves, and the same version gate the import itself uses to make an unchanged kit cost a single request.

Anything unclear is a no: no index, no version for the file, or a failed request all fall through to `/nodes` exactly as before the cache existed.

**Why not the other option.** The reviewer offered pinning the image export to the cached revision instead. That would publish *historical* pixels as the current reference, which is the wrong answer for a lane whose job is showing what the kit looks like today. Verifying freshness keeps pixels current and drops the cache when it cannot be trusted.

## Test plan

- `node --test *.test.mjs` in `scripts/design-artifacts` — **1301 passed, 0 failed**, 29 self-skipped (browser tests).
- Three tests fail without the gate, verified by forcing `cacheIsCurrent` to return `true` and watching them fail:
  - cache at the current revision → structure from disk, **zero** `/nodes`, one `?depth=1`
  - **cache at `v1` while the file serves `v2` → falls back to `/nodes`** (the regression this fixes)
  - revision checked **once per file**, not per node
- `agent-attribution-scan.sh --range origin/main..HEAD` passes.
- No published pixel changes: images still come from Figma's renderer, unchanged by #4754 and by this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyTcAAsHW98Z5ChjYwT5xP)_