### PR TITLE
refactor(render-session): narrow the api dependency to :daemon-protocol

### DIFF
--- a/render-session/api/build.gradle.kts
+++ b/render-session/api/build.gradle.kts
@@ -26,7 +26,18 @@ dependencies {
   // Protocol message types (`RenderTier`, `PreviewOverrides`, `FileKind`, etc.) are re-exposed
   // through this module's API. Consumers see them as `ee.schimke.composeai.daemon.protocol.*`
   // and the `RenderSession` contract references them directly — no duplicate DTOs in this jar.
-  api(project(":daemon:core"))
+  //
+  // `:daemon-protocol`, NOT `:daemon:core`. Every one of the 24 types this module's public
+  // surface names is declared in the protocol module; none comes from the daemon implementation.
+  // Depending on `:daemon:core` therefore put 653 public declarations — the JSON-RPC server, the
+  // encoders, the sandbox lifecycle, the history archive — on the compile ABI of a contract that
+  // needs none of them, which is what kept this module out of the extracted contracts repository
+  // (compose-ai-tools#4732: "publishing it from there would publish the daemon from there").
+  //
+  // Package is not module: these types all live in the `…daemon.protocol` package, but that alone
+  // proved nothing — `docs/design/PREVIEW_SERVER_SPLIT.md` records the same assumption being wrong
+  // elsewhere. Each declaration site was checked before this narrowed.
+  api(project(":daemon-protocol"))
 
   testImplementation(libs.junit)
 }


### PR DESCRIPTION
One of the four follow-ups left open by #4732 after the split. This is the one that unblocks `render-session-api` for the contracts repository.

## The problem

`:render-session-api` declared `api(project(":daemon:core"))` — putting the daemon **implementation** on the compile ABI of a contract that needs none of it. The JSON-RPC server, the APNG/GIF/ffmpeg encoders, the sandbox lifecycle, incremental discovery, the history archive: 653 public declarations.

**Nothing in the module used any of them.** All 24 types its public surface names are declared in `:daemon-protocol`:

`ChangeType`, `DataFetchResult`, `DataSubscribeResult`, `ExtensionsDisableResult`, `ExtensionsEnableResult`, `ExtensionsListResult`, `FileKind`, `HistoryDiffMode`, `HistoryDiffResult`, `HistoryListParams`, `HistoryListResult`, `HistoryReadResultDto`, `InitializeResult`, `InteractiveInputKind`, `PreviewOverrides`, `RecordingEncodeResult`, `RecordingFormat`, `RecordingScriptEvent`, `RecordingStartResult`, `RecordingStopResult`, `RenderNowResult`, `RenderTier`, `StreamCodec`, `StreamStartResult`.

Checked per declaration site, not inferred from the package. They all sit in `…daemon.protocol`, but that proves nothing on its own — `docs/design/PREVIEW_SERVER_SPLIT.md` records exactly this assumption being wrong elsewhere: *"the check keys a crossing on the package an import names, not on the module that declares it."* Grepping the declaration sites in `daemon/protocol/src/main` vs `daemon/core/src/main` gives 24 in the former, **0** in the latter.

## Why it matters beyond tidiness

This dependency is why the module was left out of [`yschimke/compose-preview-contracts`](https://github.com/yschimke/compose-preview-contracts). #4732's narrow cut excluded it because publishing it from there would have published the daemon from there. With the floor narrowed, that objection is gone — moving it is a separate change, and a decision for later, but it is no longer blocked.

The module's own comment claimed the dependency existed so consumers would see protocol types directly rather than through duplicate DTOs. They still do — now from the module that actually declares them.

## The one consumer-visible consequence

`checkKotlinAbi` is **unchanged**: the module's own declarations did not move, so this is a dependency-scope change, not an API change.

What *does* change is the published POM. `ee.schimke.composeai:render-session-api` stops pulling `daemon-core` transitively, so an external consumer who was getting the daemon implementation that way now has to name it. That is deliberate — the transitive reach is the defect being removed — but it is worth a release note.

## Test plan

Non-visual change — no render evidence applies. The risk here is a dependent that silently relied on the transitive reach, so the checks target that specifically:

| check | result |
| --- | --- |
| `:render-session-api:check` (incl. `checkKotlinAbi`) | pass, ABI dump unchanged |
| `:render-session-subprocess:compileKotlin` | pass |
| `:render-cli:compileKotlin` | pass |
| `:render-session-embedded-desktop:compileKotlin` | pass |
| `:cli:compileKotlin` | pass |
| `:cli:serve:compileKotlin` | pass |
| `:mcp:compileKotlin` | pass |
| `check-contract-registration.py` | OK — 20 contracts |
| `check-serve-seam.py` | OK — 27 crossings, all allowlisted |
| `scripts/check-preview-server-contracts.sh` | pass — 20 contracts published, 0 leaks |
| `ktfmtCheckAll` | pass |

All six in-repo dependents compiling against the narrowed floor is the evidence that none was leaning on the transitive dependency. `daemon-core` remains a contract in its own right in the probe's list, so the contract graph is otherwise untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8Vytwmpg6kQJLdSJdKUd)_