### PR TITLE
fix(ci): stop the parity bot reporting on runs it never measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,9 +637,15 @@ jobs:
       # Sticky comment, same shape as the serve-preview-diff one: find our marker, PATCH it if it
       # exists (no reviewer notification on a re-push), post it if it does not. Skipped for forks,
       # whose GITHUB_TOKEN cannot write — the log and the job summary still carry the report.
+      # `!cancelled()`, not `always()`. A fast-follow push cancels the in-flight run through this
+      # workflow's concurrency group, and under `always()` this step still fired on the corpse:
+      # the base-player build died mid-flight, `compare` never ran, and the PR got a "parity
+      # moved" comment describing a comparison that had not happened. `!cancelled()` keeps the
+      # step for real outcomes and drops it for superseded runs, whose successor posts the
+      # verdict a moment later anyway.
       - name: Comment the parity report on the PR
         if: >-
-          ${{ always() && steps.corpus.outputs.available == 'true'
+          ${{ !cancelled() && steps.corpus.outputs.available == 'true'
               && github.event_name == 'pull_request'
               && github.event.pull_request.head.repo.full_name == github.repository }}
         continue-on-error: true
@@ -651,11 +657,18 @@ jobs:
         run: |
           set -euo pipefail
           MARKER="<!-- rc-cmp-wasm-parity -->"
-          if [ "$OUTCOME" = "success" ]; then
-            HEADLINE="✅ No CMP/Wasm parity regression against the pull request base."
-          else
-            HEADLINE="⚠️ CMP/Wasm parity moved against the pull request base. This check does not block merging — read the rows below and decide."
-          fi
+          # Three outcomes, not two. `compare` is `skipped` when an earlier step in this job failed
+          # — the corpus fetch, either player build, either render — and in that case the parity
+          # verdict is unknown, not adverse. Saying "parity moved" there sends a reviewer hunting a
+          # regression that was never measured; the old two-branch form did exactly that.
+          case "$OUTCOME" in
+            success)
+              HEADLINE="✅ No CMP/Wasm parity regression against the pull request base." ;;
+            skipped)
+              HEADLINE="🚧 CMP/Wasm parity could not be measured — a step before the comparison failed, so this is not a verdict on the diff. See the job log." ;;
+            *)
+              HEADLINE="⚠️ CMP/Wasm parity moved against the pull request base. This check does not block merging — read the rows below and decide." ;;
+          esac
           {
             echo "$MARKER"
             echo "### Remote Compose CMP/Wasm parity"


### PR DESCRIPTION
The CMP/Wasm parity comment had two ways of claiming a regression that was never observed. Both surfaced on #4761.

## A cancelled run still commented

The step was gated on `always()`, which includes cancellation. A fast-follow push cancels the in-flight run via this workflow's concurrency group — so on #4761 the base-player build died mid-flight, `compare` never ran, and the PR got:

> ⚠️ CMP/Wasm parity moved against the pull request base.
> ```
> the comparison did not produce a report
> ```

…seven seconds after a push, describing a comparison that had not happened. Every superseded run does this.

`!cancelled()` keeps the step for real outcomes and drops it for superseded runs. The successor run posts the actual verdict a moment later, which is exactly what happened on #4761: the same comment was patched to `✅ 0 regression(s), 62 unchanged` once the fresh run completed.

## A skipped comparison read as an adverse one

The headline was a two-branch `if`: `success`, else *"parity moved"*. But `compare` is **`skipped`** whenever an earlier step in the job fails — the corpus fetch, either player build, either render — and then the verdict is *unknown*, not adverse.

The body already said so (`the comparison did not produce a report`); the headline directly above it contradicted that, and sends a reviewer hunting a regression nobody measured. It is now a three-way case:

| `steps.compare.outcome` | headline |
| --- | --- |
| `success` | ✅ No CMP/Wasm parity regression against the pull request base. |
| `skipped` | 🚧 CMP/Wasm parity could not be measured — a step before the comparison failed, so this is not a verdict on the diff. |
| anything else | ⚠️ CMP/Wasm parity moved against the pull request base. |

## Test plan

Non-visual change — no render evidence applies.

- Extracted the `case` statement and ran all four `steps.compare.outcome` values through it: `success` → ✅, `failure` → ⚠️, `skipped` → 🚧, `cancelled` → ⚠️ **but unreachable**, since the step gate now drops cancelled runs before the body executes.
- `ci.yml` parses as YAML.

The gate itself is best verified in production: the next superseded run should post nothing at all, where today it posts a ⚠️.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8Vytwmpg6kQJLdSJdKUd)_