### PR TITLE
ci: report which split-out consumers a PR's contract changes reach

### DIFF
--- a/.github/ci/consumer-contract-notice.py
+++ b/.github/ci/consumer-contract-notice.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Report which split-out consumers a PR's contract changes will reach.
+
+`compose-ai-tools` used to contain every consumer of its own contracts, so a
+protocol change and the code reading it moved in one commit and CI checked both.
+After the split (#4732) two consumers live elsewhere:
+
+  * yschimke/compose-preview-vscode    — the VS Code extension
+  * yschimke/compose-preview-contracts — the published wire contracts
+
+Both pin a *released* version of this repository and vendor copies of what they
+need. Their own gates catch drift — but only against the release they pin, which
+means a contract change here is invisible to them until somebody bumps that pin.
+That is the gap #4732 records as "a `daemon-protocol` bump has to fail the
+consumer's CI, not just the producer's".
+
+**This is informational, never blocking, and that is deliberate.** A consumer
+cannot adopt a change that has not been released yet, so failing this PR would
+deadlock: the PR waits for the consumer, the consumer waits for the release, the
+release waits for the PR. What is actually missing is not a veto but *visibility*
+— the obligation exists the moment the change lands, and nothing surfaced it.
+The consumer-side half of the gate (a canary that tests against this repo's
+`main` rather than its pin) is what turns drift red over there.
+
+Usage:
+    consumer-contract-notice.py <changed-path>...
+    git diff --name-only BASE HEAD | consumer-contract-notice.py -
+
+Prints a Markdown report to stdout, or the sentinel `NO_CONTRACT_SURFACES` when
+the change touches none. Always exits 0.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import sys
+
+SENTINEL = "NO_CONTRACT_SURFACES"
+
+EXT = "yschimke/compose-preview-vscode"
+CONTRACTS = "yschimke/compose-preview-contracts"
+
+# Each entry: the surface, the paths that constitute it, and per consumer what
+# that consumer has to do once this change is released. Keep the follow-ups
+# concrete — a notice that only says "something changed" gets ignored.
+SURFACES: list[dict] = [
+    {
+        "name": "Daemon protocol fixtures",
+        "patterns": ["docs/daemon/protocol-fixtures/*"],
+        "why": (
+            "The cross-language wire goldens. Both consumers vendor a copy and parse it "
+            "in their own suites; that shared parse is the drift check."
+        ),
+        "consumers": {
+            EXT: (
+                "vendors these at `protocol-fixtures/`. Its `Protocol Fixtures` workflow "
+                "diffs that copy against the release its `plugin-version.json` pins, so it "
+                "goes red on the pin bump unless the same commit runs "
+                "`scripts/sync-protocol-fixtures.sh`."
+            ),
+            CONTRACTS: (
+                "vendors these at `docs/daemon/protocol-fixtures/`, where `MessagesTest` and "
+                "`daemonFraming` round-trip them. Re-sync when adopting the release."
+            ),
+        },
+    },
+    {
+        "name": "Wire protocol types",
+        "patterns": ["daemon/protocol/src/main/**"],
+        "why": (
+            "The `@Serializable` request/response/notification shapes. NOTE: "
+            f"{CONTRACTS} currently holds its own copy of this module rather than consuming "
+            "one — until the cutover, the two can genuinely diverge, and only this notice "
+            "says so."
+        ),
+        "consumers": {
+            CONTRACTS: (
+                "publishes `ee.schimke.composeai:daemon-protocol` from its own copy of this "
+                "module. Port the change there, or the published contract stops describing "
+                "what this repository's daemon actually speaks."
+            ),
+            EXT: (
+                "hand-maintains the TypeScript counterpart in `src/daemon/daemonProtocol.ts`. "
+                "A field added here needs adding there; `checkDaemonLaunchSchema` covers only "
+                "the launch descriptor, not the whole protocol."
+            ),
+        },
+    },
+    {
+        "name": "Device catalog",
+        "patterns": [
+            "daemon/devices/src/main/**",
+            "gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/DeviceDimensions.kt",
+        ],
+        "why": (
+            "`DeviceDimensions` — the device table and the `spec:` grammar — is duplicated "
+            "between the plugin and the daemon, and has drifted before (`parent=`, a "
+            "symmetric `orientation=`)."
+        ),
+        "consumers": {
+            CONTRACTS: (
+                "publishes `daemon-devices` and runs `DeviceDimensionsCatalogDriftTest` against "
+                "a checkout of this repository. Its CI compares the two copies on every run, so "
+                "a one-sided change here turns it red."
+            ),
+        },
+    },
+    {
+        "name": "Daemon launch descriptor",
+        "patterns": [
+            "gradle-plugin/daemon-launch-builder/src/main/**",
+            "daemon/protocol/src/main/kotlin/ee/schimke/composeai/daemon/protocol/DaemonLaunchDescriptor.kt",
+        ],
+        "why": (
+            "Three copies of the schema, and the TypeScript one is the only reader that "
+            "*gates* on the version."
+        ),
+        "consumers": {
+            EXT: (
+                "carries that reader. `checkDaemonLaunchSchema` here already checks it when a "
+                "checkout is present (CI sets `COMPOSE_PREVIEW_VSCODE_ROOT`), so a mismatch "
+                "should have failed this PR — if it did not, the checkout step is the thing to "
+                "look at."
+            ),
+        },
+    },
+    {
+        "name": "Spatial scene schema",
+        "patterns": ["schema/spatial-scene.schema.json"],
+        "why": "The Kotlin, C++ and TypeScript mirrors are generated from this one file.",
+        "consumers": {
+            EXT: (
+                "holds the TypeScript mirror at `src/webview/shared/spatialScene.ts`, and "
+                "**no gate covers it** — `--check` here compares only the Kotlin and C++ "
+                "mirrors, because this repository cannot write into that one. Regenerate it "
+                "there with `gen-spatial-scene.mjs --emit-typescript`."
+            ),
+        },
+    },
+    {
+        "name": "Agent-grant vocabulary",
+        "patterns": ["api/agent-grant-protocol/src/main/**"],
+        "why": "Both ends of `--agent-grants` speak it: the server mints, the client asks.",
+        "consumers": {
+            CONTRACTS: "publishes `agent-grant-protocol` from its own copy; port the change.",
+        },
+    },
+    {
+        "name": "Build Tools API result shapes",
+        "patterns": ["daemon/bta/src/main/**"],
+        "why": "`CompileErrorDetail` and `SourceChangeSet` cross the wire.",
+        "consumers": {
+            CONTRACTS: "publishes `daemon-bta` from its own copy; port the change.",
+        },
+    },
+]
+
+
+def matches(path: str, pattern: str) -> bool:
+    """Glob match where `**` spans directories, as in a workflow `paths:` filter."""
+    if pattern.endswith("/**"):
+        return path.startswith(pattern[:-2])
+    return fnmatch.fnmatch(path, pattern)
+
+
+def affected(paths: list[str]) -> list[tuple[dict, list[str]]]:
+    """`(surface, sorted matching paths)` for every surface the change touches."""
+    out = []
+    for surface in SURFACES:
+        hits = sorted({p for p in paths for pat in surface["patterns"] if matches(p, pat)})
+        if hits:
+            out.append((surface, hits))
+    return out
+
+
+def report(hits: list[tuple[dict, list[str]]]) -> str:
+    lines = [
+        "<!-- consumer-contract-notice -->",
+        "## Contract surfaces this PR reaches",
+        "",
+        "This change touches contracts that consumers outside this repository depend on. "
+        "**Nothing here blocks the merge** — a consumer cannot adopt a change that has not "
+        "shipped yet, so gating on them would deadlock. It is here so the follow-up is "
+        "visible now rather than discovered on a pin bump months later.",
+        "",
+    ]
+    for surface, paths in hits:
+        lines.append(f"### {surface['name']}")
+        lines.append("")
+        lines.append(surface["why"])
+        lines.append("")
+        for path in paths[:10]:
+            lines.append(f"- `{path}`")
+        if len(paths) > 10:
+            lines.append(f"- …and {len(paths) - 10} more")
+        lines.append("")
+        for repo, todo in surface["consumers"].items():
+            lines.append(f"**[{repo}](https://github.com/{repo})** {todo}")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    if args == ["-"]:
+        paths = [ln.strip() for ln in sys.stdin if ln.strip()]
+    else:
+        paths = [a for a in args if a.strip()]
+
+    hits = affected(paths)
+    if not hits:
+        print(SENTINEL)
+        return 0
+    sys.stdout.write(report(hits))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/ci/test_consumer_contract_notice.py
+++ b/.github/ci/test_consumer_contract_notice.py
@@ -1,0 +1,102 @@
+"""Tests for consumer-contract-notice.py.
+
+Two kinds. The first are ordinary: matching, reporting, the sentinel. The second
+matter more — they assert the surface map still describes THIS repository. A
+notice that names a path which no longer exists is worse than no notice: it reads
+as authoritative and is silently covering nothing.
+
+    python3 .github/ci/test_consumer_contract_notice.py
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "consumer_contract_notice", HERE / "consumer-contract-notice.py"
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+class Matching(unittest.TestCase):
+    def test_double_star_spans_directories(self):
+        self.assertTrue(mod.matches("daemon/protocol/src/main/kotlin/a/b/C.kt", "daemon/protocol/src/main/**"))
+
+    def test_double_star_does_not_leak_to_siblings(self):
+        self.assertFalse(mod.matches("daemon/protocol/src/test/X.kt", "daemon/protocol/src/main/**"))
+
+    def test_exact_file_pattern(self):
+        self.assertTrue(mod.matches("schema/spatial-scene.schema.json", "schema/spatial-scene.schema.json"))
+        self.assertFalse(mod.matches("schema/other.schema.json", "schema/spatial-scene.schema.json"))
+
+    def test_single_star_is_one_segment(self):
+        self.assertTrue(mod.matches("docs/daemon/protocol-fixtures/a.json", "docs/daemon/protocol-fixtures/*"))
+
+
+class Reporting(unittest.TestCase):
+    def test_unrelated_change_reports_the_sentinel(self):
+        self.assertEqual(mod.affected(["README.md", "cli/src/Main.kt"]), [])
+
+    def test_fixture_change_names_both_consumers(self):
+        hits = mod.affected(["docs/daemon/protocol-fixtures/client-initialize.json"])
+        self.assertEqual(len(hits), 1)
+        body = mod.report(hits)
+        self.assertIn("compose-preview-vscode", body)
+        self.assertIn("compose-preview-contracts", body)
+
+    def test_report_carries_the_sticky_marker_first(self):
+        body = mod.report(mod.affected(["schema/spatial-scene.schema.json"]))
+        self.assertTrue(body.startswith("<!-- consumer-contract-notice -->"))
+
+    def test_report_says_it_does_not_block(self):
+        # The whole design rests on this; if the wording is lost, a reader will
+        # reasonably assume the notice is a gate and wait for it to go green.
+        body = mod.report(mod.affected(["schema/spatial-scene.schema.json"]))
+        self.assertIn("blocks the merge", body)
+
+    def test_one_change_can_hit_several_surfaces(self):
+        hits = mod.affected([
+            "docs/daemon/protocol-fixtures/client-initialize.json",
+            "schema/spatial-scene.schema.json",
+        ])
+        self.assertEqual(len(hits), 2)
+
+    def test_long_path_lists_are_truncated(self):
+        many = [f"docs/daemon/protocol-fixtures/f{i}.json" for i in range(25)]
+        body = mod.report(mod.affected(many))
+        self.assertIn("…and 15 more", body)
+
+
+class SurfaceMapIsCurrent(unittest.TestCase):
+    """Every path in the map must still exist, or the notice covers nothing."""
+
+    def test_every_pattern_resolves_to_something_in_the_tree(self):
+        missing = []
+        for surface in mod.SURFACES:
+            for pattern in surface["patterns"]:
+                if pattern.endswith("/**"):
+                    ok = (REPO / pattern[:-3]).is_dir()
+                elif pattern.endswith("/*"):
+                    ok = (REPO / pattern[:-2]).is_dir()
+                else:
+                    ok = (REPO / pattern).exists()
+                if not ok:
+                    missing.append(f"{surface['name']}: {pattern}")
+        self.assertEqual(missing, [], f"surface map names paths that no longer exist: {missing}")
+
+    def test_every_surface_names_at_least_one_consumer(self):
+        for surface in mod.SURFACES:
+            self.assertTrue(surface["consumers"], f"{surface['name']} names no consumer")
+
+    def test_consumer_repos_are_the_known_two(self):
+        known = {mod.EXT, mod.CONTRACTS}
+        for surface in mod.SURFACES:
+            self.assertLessEqual(set(surface["consumers"]), known, surface["name"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1443,6 +1443,8 @@ jobs:
       # pairs with.
       - name: Run figma-reference tests
         run: node --test .github/actions/lib/figma-reference/index.test.mjs
+      - name: Run consumer contract notice tests
+        run: python3 .github/ci/test_consumer_contract_notice.py -v
       # The export-driver pin decides which revision of this repo other people's CI
       # executes, and it is rewritten unattended after each release. Both failure
       # modes are quiet: sites drifting apart means two jobs in one run render with
@@ -1495,6 +1497,59 @@ jobs:
   # vscjava.vscode-gradle stub so our extensionDependency check passes, and
   # run the extension against a fixture workspace. xvfb is needed because
   # VS Code expects a display even in headless mode.
+  consumer-contract-notice:
+    name: Consumer Contract Notice
+    # Informational only — see the script's docstring for why this must not gate. It is a
+    # separate job rather than a step on an existing one so its permissions stay minimal and
+    # a failure to comment can never be mistaken for a contract problem.
+    if: ${{ github.event_name == 'pull_request' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Detect contract surfaces and comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # Fail open: a diff we cannot compute must not look like "no contracts touched".
+          git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+          if ! changed=$(git diff --name-only "$BASE_SHA" "$MERGE_SHA" 2>/dev/null); then
+            echo "::warning::could not diff against the base; skipping the consumer contract notice."
+            exit 0
+          fi
+
+          body=$(printf '%s\n' "$changed" | python3 .github/ci/consumer-contract-notice.py -)
+          MARKER="<!-- consumer-contract-notice -->"
+          COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+
+          if [ "$body" = "NO_CONTRACT_SURFACES" ]; then
+            # Nothing to say. Patch an existing notice to reflect that rather than leaving a
+            # stale one describing surfaces a later push removed from the diff; never post a
+            # fresh "nothing to report" comment.
+            if [ -n "$COMMENT_ID" ]; then
+              gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X PATCH \
+                -f body="${MARKER}"$'\n'"## Contract surfaces this PR reaches"$'\n\n'"None as of $(git rev-parse --short "$MERGE_SHA"). An earlier revision of this PR touched one; it no longer does."
+            fi
+            echo "no contract surfaces touched"
+            exit 0
+          fi
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$body"
+          else
+            gh pr comment "$PR_NUMBER" --body "$body"
+          fi
+
   serve-web-bundle:
     name: Serve Web Components
     if: ${{ !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}


### PR DESCRIPTION
The producer half of the cross-repo drift gate #4732 left open.

## The gap

Before the split, this repository contained every consumer of its own contracts — a protocol change and the code reading it moved in one commit, and CI checked both. Two consumers live elsewhere now, and both pin a **released** version. Their gates are real, but they fire only against the release they pin, so a contract change here is invisible to them until somebody bumps that pin.

That's the gap the issue records as *"a `daemon-protocol` bump has to fail the consumer's CI, not just the producer's."*

## What this does

`consumer-contract-notice.py` maps seven contract surfaces to the consumers that depend on them, and says what each will have to do:

| surface | consumers |
| --- | --- |
| Daemon protocol fixtures | both |
| Wire protocol types | both |
| Device catalog | contracts |
| Daemon launch descriptor | extension |
| Spatial scene schema | extension |
| Agent-grant vocabulary | contracts |
| BTA result shapes | contracts |

A PR touching any of them gets one sticky comment naming the surface and the concrete follow-up per repository — not "something changed", but *"bump the pin and run `scripts/sync-protocol-fixtures.sh` in the same commit"*.

## Informational, never blocking — deliberately

A consumer cannot adopt a change that has not been released. Gating on them deadlocks: the PR waits for the consumer, the consumer waits for the release, the release waits for the PR.

What was missing was never a veto — it was **visibility**. The obligation exists the moment the change lands, and nothing surfaced it. A test asserts the "does not block the merge" wording survives, because a reader who mistakes this for a gate will sit waiting for it to go green.

## Two things it made visible that weren't written down anywhere

- **compose-preview-contracts holds its own *copy*** of `daemon/protocol`, `daemon/devices`, `daemon/bta` and `agent-grant-protocol` rather than consuming them. Until the cutover those can genuinely diverge — and nothing said so.
- **The extension's TypeScript spatial-scene mirror has no gate on either side.** `gen-spatial-scene.mjs --check` covers only the Kotlin and C++ mirrors, because this repository cannot write into that one. The notice is currently the only thing that will tell anyone.

## Test plan

Non-visual change — no render evidence applies.

**13 tests.** Beyond the ordinary matching and reporting cases, three of them guard the map itself:

- every pattern resolves to a path that still exists in this tree
- every surface names at least one consumer
- no surface names a repository outside the known two

A notice citing a path that has moved is worse than no notice — it reads as authoritative while covering nothing.

| check | result |
| --- | --- |
| `test_consumer_contract_notice.py` | 13 passed |
| full `.github/ci` suite | 94 passed |
| sentinel on an unrelated diff (`README.md`) | `NO_CONTRACT_SURFACES` |
| two-surface report (fixture + schema change) | both surfaces, both consumers named |
| `ci.yml` | parses; job present |

The job body's fail-open behaviour matches the other diff-based jobs here: if the base diff cannot be computed it warns and exits rather than reporting "no contracts touched".

## What this does not do

The consumer-side complement — something that turns *their* CI red when this repo's contracts move ahead of their pin. A naive "diff against upstream `main`" canary would be permanently red, since the pin legitimately lags; the useful signal is narrower (*a newer release exists whose contracts differ from ours*) and depends on the versioning decision #4732 also leaves open. Separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Th8Vytwmpg6kQJLdSJdKUd)_