### PR TITLE
feat(xr): make the render service handshake load-bearing

### DIFF
--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderServer.kt
@@ -67,9 +67,17 @@ public fun interface XrRenderServerFactory {
 public class XrRenderServer
 private constructor(
   private val client: XrServerClient,
-  /** The server's advertised `capabilities` from `initialize`. */
-  public override val capabilities: JsonObject,
+  /**
+   * The verified `initialize` result — protocol version, scene version and capabilities. Unlike the
+   * raw [capabilities] object this is checked at handshake time, so holding one means the server is
+   * a version this client can actually speak.
+   */
+  public val handshake: XrServerHandshake,
 ) : XrRenderServerHandle {
+
+  /** The server's advertised `capabilities` from `initialize`. */
+  public override val capabilities: JsonObject
+    get() = handshake.capabilities
 
   public override fun render(
     sessionId: String,
@@ -92,8 +100,10 @@ private constructor(
   public companion object {
     /**
      * Spawn `xr-composite --serve` from [binary] (+ [materials]) and complete `initialize`. Throws
-     * [XrServerException] if the handshake fails. [width]/[height] are the process-level defaults
-     * for sessions that don't pass their own.
+     * [XrServerException] if the handshake fails — including when the server speaks a protocol
+     * version this client does not, which the daemon surfaces as an `xr/start` error rather than as
+     * a composite that never appears. [width]/[height] are the process-level defaults for sessions
+     * that don't pass their own.
      */
     public fun start(
       binary: File,
@@ -102,14 +112,14 @@ private constructor(
       height: Int = 800,
     ): XrRenderServer {
       val client = XrServerClient.spawn(binary, materials, width, height)
-      val caps =
+      val handshake =
         try {
           client.initialize()
         } catch (e: Throwable) {
           client.close()
           throw e
         }
-      return XrRenderServer(client, caps)
+      return XrRenderServer(client, handshake)
     }
 
     /**

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderService.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrRenderService.kt
@@ -31,6 +31,19 @@ public object XrRenderService {
    */
   public const val XR_RENDER_SERVICE_VERSION: Int = 1
 
+  /**
+   * Oldest service version a current client still speaks.
+   *
+   * The compatibility window exists because the pin makes version skew the NORMAL case, not an
+   * error: the compositor is provisioned at a version that deliberately lags, so the server is
+   * routinely older than the client. Requiring equality would make bumping this contract a flag day
+   * — every render broken until a new compositor is built, published and pinned. So a client
+   * accepts a server in [min-supported-version, version] and refuses one NEWER than itself, whose
+   * semantics it cannot know. Individual additions are gated by `capabilities` instead, which is
+   * what they are for.
+   */
+  public const val MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION: Int = 1
+
   /** Value of `initialize`'s `serverInfo.name`. */
   public const val SERVER_NAME: String = "xr-composite"
 

--- a/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
+++ b/renderers/xr-client/src/main/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClient.kt
@@ -15,8 +15,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.int
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
@@ -35,6 +38,73 @@ public data class StreamFrame(
 /** Thrown on transport / protocol failure talking to the native render server. */
 public class XrServerException(message: String, cause: Throwable? = null) :
   RuntimeException(message, cause)
+
+/**
+ * What `initialize` told us about the server we are attached to.
+ *
+ * The handshake used to be plumbed and then ignored — `capabilities` was carried as an untyped
+ * `JsonObject` that nothing read. That was survivable while client and server were built from the
+ * same commit; it is not, now that the compositor is provisioned at a pinned version that
+ * deliberately lags (see the `xr-composite` pin). Version skew is the normal case here, so the
+ * handshake has to be load-bearing: a mismatch must surface as a NAMED error, not as a composite
+ * that silently never appears.
+ */
+public data class XrServerHandshake(
+  /** `serverInfo.name` — `xr-composite` for the real server. Reported in errors, not enforced. */
+  val serverName: String?,
+  /** `serverInfo.version` — the RPC surface the server speaks. */
+  val serviceVersion: Int,
+  /** `capabilities.spatialSceneVersion` — the scene format it parses, or null if unreported. */
+  val spatialSceneVersion: Int?,
+  /** The raw `capabilities` object, for callers that want to inspect beyond the typed fields. */
+  val capabilities: JsonObject,
+) {
+  /** Whether the server advertised [name] as a boolean-true capability. */
+  public fun has(name: String): Boolean = capabilities[name]?.jsonPrimitive?.booleanOrNull == true
+
+  public companion object {
+    /**
+     * Parse and VERIFY an `initialize` result. Pure, so the compatibility rules are unit-testable
+     * without spawning a process.
+     *
+     * Accepts a server in `[MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION, XR_RENDER_SERVICE_VERSION]`
+     * and refuses one newer than this client, whose semantics we cannot know. Refusing a *newer*
+     * server rather than an older one is deliberate: the pin means the server normally lags, so
+     * requiring equality would make every service bump a flag day.
+     */
+    public fun parse(result: JsonObject): XrServerHandshake {
+      val capabilities =
+        result[XrRenderService.Result.CAPABILITIES]?.jsonObject
+          ?: throw XrServerException("initialize: no capabilities in result ($result)")
+      val serverInfo = result[XrRenderService.Result.SERVER_INFO]?.jsonObject
+      val name = serverInfo?.get("name")?.jsonPrimitive?.contentOrNull
+      val version =
+        serverInfo?.get("version")?.jsonPrimitive?.intOrNull
+          ?: throw XrServerException(
+            "initialize: no serverInfo.version — not an ${XrRenderService.SERVER_NAME} render " +
+              "server, or one too old to report its protocol version (result: $result)"
+          )
+      if (
+        version > XrRenderService.XR_RENDER_SERVICE_VERSION ||
+          version < XrRenderService.MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION
+      ) {
+        throw XrServerException(
+          "XR render service version mismatch: ${name ?: "server"} speaks v$version, this client " +
+            "speaks v${XrRenderService.XR_RENDER_SERVICE_VERSION} and supports back to " +
+            "v${XrRenderService.MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION}. Update the " +
+            "`xr-composite` pin to a release built from a compatible commit."
+        )
+      }
+      return XrServerHandshake(
+        serverName = name,
+        serviceVersion = version,
+        spatialSceneVersion =
+          capabilities[XrRenderService.Capability.SPATIAL_SCENE_VERSION]?.jsonPrimitive?.intOrNull,
+        capabilities = capabilities,
+      )
+    }
+  }
+}
 
 /**
  * JVM client for the native `xr-composite --serve` render server (see
@@ -66,17 +136,44 @@ internal constructor(
   // One frame queue per sessionId — the reader routes `streamFrame` notifications here by
   // sessionId.
   private val frames = ConcurrentHashMap<String, LinkedBlockingQueue<StreamFrame>>()
+  // The verified `initialize` result, retained so render/updatePanels can gate on what the server
+  // actually advertised. Null until initialize() runs.
+  @Volatile private var handshake: XrServerHandshake? = null
+  // Sessions this client has rendered into and not yet stopped — the basis of the `multiSession`
+  // gate. A single-session server silently reuses one scene for a second id, so opening one
+  // without the capability corrupts both sessions rather than failing.
+  private val openSessions = ConcurrentHashMap.newKeySet<String>()
   private val reader =
     Thread({ runReader(input) }, "xr-server-client-reader").apply {
       isDaemon = true
       start()
     }
 
-  /** Drives `initialize`; returns the server's `capabilities` object. */
-  public fun initialize(timeout: Duration = 60.seconds): JsonObject {
+  /**
+   * Drives `initialize` and VERIFIES the result, throwing [XrServerException] on a protocol version
+   * this client cannot speak. The handshake is retained so later calls can gate on the capabilities
+   * the server actually advertised rather than assuming them.
+   */
+  public fun initialize(timeout: Duration = 60.seconds): XrServerHandshake {
     val result = request(XrRenderService.Method.INITIALIZE, buildJsonObject {}, timeout)
-    return result[XrRenderService.Result.CAPABILITIES]?.jsonObject
-      ?: throw XrServerException("initialize: no capabilities in result ($result)")
+    val parsed = XrServerHandshake.parse(result)
+    handshake = parsed
+    return parsed
+  }
+
+  /**
+   * Fail unless the server advertised [capability]. An absent capability means the server predates
+   * the feature; calling anyway produces a confusing mid-stream error instead of a named one.
+   */
+  private fun requireCapability(capability: String, what: String) {
+    val caps =
+      handshake ?: throw XrServerException("$what before initialize: the handshake has not run yet")
+    if (!caps.has(capability)) {
+      throw XrServerException(
+        "$what: server ${caps.serverName ?: "(unknown)"} v${caps.serviceVersion} does not " +
+          "advertise the `$capability` capability"
+      )
+    }
   }
 
   /**
@@ -93,6 +190,14 @@ internal constructor(
     height: Int? = null,
     timeout: Duration = 60.seconds,
   ): StreamFrame {
+    requireCapability(XrRenderService.Capability.RENDER, "render")
+    checkSceneVersion(scene)
+    if (!openSessions.contains(sessionId) && openSessions.isNotEmpty()) {
+      requireCapability(
+        XrRenderService.Capability.MULTI_SESSION,
+        "render into a second session ($sessionId, alongside ${openSessions.joinToString()})",
+      )
+    }
     val params = buildJsonObject {
       put(XrRenderService.Param.SESSION_ID, sessionId)
       put(XrRenderService.Param.SCENE, scene)
@@ -102,6 +207,7 @@ internal constructor(
       height?.let { put(XrRenderService.Param.HEIGHT, it) }
     }
     request(XrRenderService.Method.RENDER, params, timeout)
+    openSessions.add(sessionId)
     return awaitFrame(sessionId, timeout)
   }
 
@@ -115,6 +221,7 @@ internal constructor(
     panels: JsonArray,
     timeout: Duration = 60.seconds,
   ): StreamFrame {
+    requireCapability(XrRenderService.Capability.UPDATE_PANELS, "updatePanels")
     val params = buildJsonObject {
       put(XrRenderService.Param.SESSION_ID, sessionId)
       put(XrRenderService.Param.PANELS, panels)
@@ -133,6 +240,7 @@ internal constructor(
       }
     )
     frames.remove(sessionId)
+    openSessions.remove(sessionId)
   }
 
   /** Whether the spawned child is still alive (always true for the stream-backed test client). */
@@ -167,6 +275,27 @@ internal constructor(
       process?.destroyForcibly()
     }
     reader.join(2_000)
+  }
+
+  /**
+   * Fail when the scene we are about to send declares a `version` the server said it cannot parse.
+   *
+   * Checks the actual payload against the server's advertised `spatialSceneVersion` rather than a
+   * compile-time constant, which is both stricter and keeps this module free of a dependency on the
+   * SpatialScene DTOs — its whole dependency list is kotlinx-serialization-json. Silent when either
+   * side does not report a version: an unreported version is not evidence of a mismatch.
+   */
+  private fun checkSceneVersion(scene: JsonElement) {
+    val serverVersion = handshake?.spatialSceneVersion ?: return
+    val sceneVersion = (scene as? JsonObject)?.get("version")?.jsonPrimitive?.intOrNull ?: return
+    if (sceneVersion != serverVersion) {
+      throw XrServerException(
+        "SpatialScene version mismatch: this scene is v$sceneVersion but the render server parses " +
+          "v$serverVersion. The compositor is pinned separately from this repository " +
+          "(`xr-composite` in gradle/libs.versions.toml); bump that pin to a release built " +
+          "against scene v$sceneVersion."
+      )
+    }
   }
 
   // ---- internals ----

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerClientTest.kt
@@ -8,6 +8,7 @@ import java.io.PipedOutputStream
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -38,7 +39,17 @@ class XrServerClientTest {
   /**
    * A scripted fake server: reads each request and replies, pushing a streamFrame before the ack.
    */
-  private fun startFakeServer(serverIn: InputStream, serverOut: OutputStream) {
+  private fun startFakeServer(
+    serverIn: InputStream,
+    serverOut: OutputStream,
+    capabilities: JsonObject = buildJsonObject {
+      put("render", true)
+      put("updatePanels", true)
+      put("streamFrame", true)
+      put("multiSession", true)
+      put("spatialSceneVersion", 1)
+    },
+  ) {
     serverThread =
       Thread {
         var seq = 0L
@@ -54,14 +65,17 @@ class XrServerClientTest {
                 result(
                   id!!,
                   buildJsonObject {
+                    // Mirrors what the native server actually sends. This fake omitted
+                    // `serverInfo` entirely until the handshake became load-bearing — an
+                    // unfaithful fake nothing could detect, because nothing read the result.
                     put(
-                      "capabilities",
+                      "serverInfo",
                       buildJsonObject {
-                        put("render", true)
-                        put("updatePanels", true)
-                        put("streamFrame", true)
+                        put("name", XrRenderService.SERVER_NAME)
+                        put("version", XrRenderService.XR_RENDER_SERVICE_VERSION)
                       },
                     )
+                    put("capabilities", capabilities)
                   },
                 ),
               )
@@ -105,8 +119,11 @@ class XrServerClientTest {
 
     val client = XrServerClient(clientToServer, clientIn, process = null)
 
-    val caps = client.initialize()
-    assertEquals(true, caps["render"]?.jsonPrimitive?.content?.toBoolean())
+    val handshake = client.initialize()
+    assertEquals(XrRenderService.SERVER_NAME, handshake.serverName)
+    assertEquals(XrRenderService.XR_RENDER_SERVICE_VERSION, handshake.serviceVersion)
+    assertEquals(1, handshake.spatialSceneVersion)
+    assertEquals(true, handshake.has(XrRenderService.Capability.RENDER))
 
     val scene = buildJsonObject {
       put("version", 1)
@@ -233,5 +250,115 @@ class XrServerClientTest {
       }
       buf.write(b)
     }
+  }
+
+  /** Wire a client to a fake server advertising [capabilities]. */
+  private fun connect(capabilities: JsonObject? = null): XrServerClient {
+    val clientToServer = PipedOutputStream()
+    val serverIn = PipedInputStream(clientToServer, 1 shl 16)
+    val serverToClient = PipedOutputStream()
+    val clientIn = PipedInputStream(serverToClient, 1 shl 16)
+    if (capabilities == null) startFakeServer(serverIn, serverToClient)
+    else startFakeServer(serverIn, serverToClient, capabilities)
+    return XrServerClient(clientToServer, clientIn, process = null)
+  }
+
+  private fun scene(version: Int = 1) = buildJsonObject {
+    put("version", version)
+    put("units", "dp")
+    put("camera", buildJsonObject { put("kind", "orbit") })
+    put("panels", buildJsonArray {})
+  }
+
+  @Test
+  fun `a second session is refused when the server does not advertise multiSession`() {
+    // A single-session server silently reuses one scene for a second id, so the two sessions
+    // corrupt each other's frames rather than failing. Refuse before sending.
+    val client =
+      connect(
+        buildJsonObject {
+          put("render", true)
+          put("updatePanels", true)
+          put("streamFrame", true)
+          put("multiSession", false)
+          put("spatialSceneVersion", 1)
+        }
+      )
+    client.initialize()
+    client.render("s1", scene(), sceneDir = ".")
+    val e = assertFailsWith<XrServerException> { client.render("s2", scene(), sceneDir = ".") }
+    assertTrue(e.message!!.contains("multiSession"), e.message)
+  }
+
+  @Test
+  fun `reusing the same session needs no multiSession capability`() {
+    val client =
+      connect(
+        buildJsonObject {
+          put("render", true)
+          put("updatePanels", true)
+          put("streamFrame", true)
+          put("multiSession", false)
+          put("spatialSceneVersion", 1)
+        }
+      )
+    client.initialize()
+    client.render("s1", scene(), sceneDir = ".")
+    // Re-rendering the SAME session is single-session behaviour and must stay allowed.
+    assertEquals(2L, client.render("s1", scene(), sceneDir = ".").seq)
+  }
+
+  @Test
+  fun `a stopped session no longer counts against the multiSession gate`() {
+    val client =
+      connect(
+        buildJsonObject {
+          put("render", true)
+          put("updatePanels", true)
+          put("streamFrame", true)
+          put("multiSession", false)
+          put("spatialSceneVersion", 1)
+        }
+      )
+    client.initialize()
+    client.render("s1", scene(), sceneDir = ".")
+    client.stop("s1")
+    // One session at a time is exactly what a single-session server supports.
+    assertEquals(2L, client.render("s2", scene(), sceneDir = ".").seq)
+  }
+
+  @Test
+  fun `a scene whose version the server cannot parse is refused before sending`() {
+    val client = connect()
+    client.initialize()
+    val e =
+      assertFailsWith<XrServerException> { client.render("s1", scene(version = 2), sceneDir = ".") }
+    assertTrue(e.message!!.contains("SpatialScene version mismatch"), e.message)
+    assertTrue(e.message!!.contains("xr-composite"), e.message)
+  }
+
+  @Test
+  fun `updatePanels is refused when the server does not advertise it`() {
+    val client =
+      connect(
+        buildJsonObject {
+          put("render", true)
+          put("updatePanels", false)
+          put("streamFrame", true)
+          put("multiSession", true)
+          put("spatialSceneVersion", 1)
+        }
+      )
+    client.initialize()
+    client.render("s1", scene(), sceneDir = ".")
+    val e = assertFailsWith<XrServerException> { client.updatePanels("s1", buildJsonArray {}) }
+    assertTrue(e.message!!.contains("updatePanels"), e.message)
+  }
+
+  @Test
+  fun `calling render before initialize is a named error`() {
+    val client = connect()
+    val e = assertFailsWith<XrServerException> { client.render("s1", scene(), sceneDir = ".") }
+    assertTrue(e.message!!.contains("before initialize"), e.message)
   }
 }

--- a/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerHandshakeTest.kt
+++ b/renderers/xr-client/src/test/kotlin/ee/schimke/composeai/renderer/xr/client/XrServerHandshakeTest.kt
@@ -1,0 +1,164 @@
+package ee.schimke.composeai.renderer.xr.client
+
+import kotlin.test.assertFailsWith
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The compatibility rules the `initialize` handshake enforces.
+ *
+ * These matter because the compositor is provisioned at a pinned version that deliberately lags
+ * this repository, so a client and server built from different commits is the NORMAL case. Before
+ * the handshake was verified, a mismatch produced no error at all — the composite simply never
+ * appeared, because every provisioning and render failure downstream is a graceful skip.
+ *
+ * [XrServerHandshake.parse] is pure, so every rule is testable without spawning a process.
+ */
+class XrServerHandshakeTest {
+
+  private fun result(
+    version: Int? = XrRenderService.XR_RENDER_SERVICE_VERSION,
+    name: String? = XrRenderService.SERVER_NAME,
+    capabilities: JsonObject = buildJsonObject { put("render", true) },
+    includeServerInfo: Boolean = true,
+  ) = buildJsonObject {
+    if (includeServerInfo) {
+      put(
+        "serverInfo",
+        buildJsonObject {
+          if (name != null) put("name", name)
+          if (version != null) put("version", version)
+        },
+      )
+    }
+    put("capabilities", capabilities)
+  }
+
+  @Test
+  fun `a current server parses`() {
+    val h = XrServerHandshake.parse(result())
+    assertEquals(XrRenderService.SERVER_NAME, h.serverName)
+    assertEquals(XrRenderService.XR_RENDER_SERVICE_VERSION, h.serviceVersion)
+    assertTrue(h.has(XrRenderService.Capability.RENDER))
+  }
+
+  @Test
+  fun `a server newer than this client is refused`() {
+    // We cannot know a future version's semantics, so this direction is the hard failure.
+    val e =
+      assertFailsWith<XrServerException> {
+        XrServerHandshake.parse(result(version = XrRenderService.XR_RENDER_SERVICE_VERSION + 1))
+      }
+    assertTrue(e.message!!, e.message!!.contains("version mismatch"))
+    assertTrue(e.message!!, e.message!!.contains("xr-composite"))
+  }
+
+  @Test
+  fun `a server below the supported floor is refused`() {
+    val e =
+      assertFailsWith<XrServerException> {
+        XrServerHandshake.parse(
+          result(version = XrRenderService.MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION - 1)
+        )
+      }
+    assertTrue(e.message!!, e.message!!.contains("version mismatch"))
+  }
+
+  @Test
+  fun `an older but still supported server is accepted`() {
+    // The pin makes the server normally OLDER than the client. Requiring equality would turn every
+    // service bump into a flag day, so anything inside the window must pass.
+    val oldest = XrRenderService.MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION
+    assertEquals(oldest, XrServerHandshake.parse(result(version = oldest)).serviceVersion)
+  }
+
+  @Test
+  fun `a result without serverInfo version is refused`() {
+    val e = assertFailsWith<XrServerException> { XrServerHandshake.parse(result(version = null)) }
+    assertTrue(e.message!!, e.message!!.contains("serverInfo.version"))
+  }
+
+  @Test
+  fun `a result with no serverInfo at all is refused`() {
+    assertFailsWith<XrServerException> {
+      XrServerHandshake.parse(result(includeServerInfo = false))
+    }
+  }
+
+  @Test
+  fun `a result without capabilities is refused`() {
+    val e =
+      assertFailsWith<XrServerException> {
+        XrServerHandshake.parse(buildJsonObject { put("x", 1) })
+      }
+    assertTrue(e.message!!, e.message!!.contains("capabilities"))
+  }
+
+  @Test
+  fun `an unreported scene version is null rather than an error`() {
+    // Absence is not evidence of a mismatch; the render-time check stays silent on it.
+    assertNull(XrServerHandshake.parse(result()).spatialSceneVersion)
+  }
+
+  @Test
+  fun `the real server's handshake is one this client accepts`() {
+    // Captured verbatim from `xr-composite --serve` built at this commit. The generated mirror
+    // already keeps the two vocabularies in step; this pins the actual production PAYLOAD, so a
+    // server that stopped reporting its version or dropped a capability fails here rather than in
+    // a render nobody is watching.
+    val real =
+      Json.parseToJsonElement(
+          """
+          {
+            "capabilities": {
+              "dataProducts": ["xr/composite"],
+              "multiSession": true,
+              "render": true,
+              "spatialSceneVersion": 1,
+              "streamFrame": true,
+              "updatePanels": true
+            },
+            "serverInfo": { "name": "xr-composite", "version": 1 }
+          }
+          """
+        )
+        .jsonObject
+    val h = XrServerHandshake.parse(real)
+    assertEquals(XrRenderService.SERVER_NAME, h.serverName)
+    assertEquals(XrRenderService.XR_RENDER_SERVICE_VERSION, h.serviceVersion)
+    assertEquals(1, h.spatialSceneVersion)
+    assertTrue(h.has(XrRenderService.Capability.RENDER))
+    assertTrue(h.has(XrRenderService.Capability.UPDATE_PANELS))
+    assertTrue(h.has(XrRenderService.Capability.STREAM_FRAME))
+    assertTrue(h.has(XrRenderService.Capability.MULTI_SESSION))
+  }
+
+  @Test
+  fun `capability lookup is false for absent and non-boolean values`() {
+    val h =
+      XrServerHandshake.parse(
+        result(
+          capabilities =
+            buildJsonObject {
+              put("render", true)
+              put("multiSession", false)
+              put("spatialSceneVersion", 1)
+            }
+        )
+      )
+    assertTrue(h.has(XrRenderService.Capability.RENDER))
+    assertFalse(h.has(XrRenderService.Capability.MULTI_SESSION))
+    assertFalse("absent capability must not read as advertised", h.has("updatePanels"))
+    // A non-boolean value is not an advertisement of support.
+    assertFalse(h.has(XrRenderService.Capability.SPATIAL_SCENE_VERSION))
+    assertEquals(1, h.spatialSceneVersion)
+  }
+}

--- a/renderers/xr-composite/src/xr_render_service.hpp
+++ b/renderers/xr-composite/src/xr_render_service.hpp
@@ -35,6 +35,19 @@ namespace xrcomposite::xr_render_service {
 constexpr int XR_RENDER_SERVICE_VERSION = 1;
 
 /**
+ * Oldest service version a current client still speaks.
+ *
+ * The compatibility window exists because the pin makes version skew the NORMAL case, not
+ * an error: the compositor is provisioned at a version that deliberately lags, so the
+ * server is routinely older than the client. Requiring equality would make bumping this
+ * contract a flag day — every render broken until a new compositor is built, published and
+ * pinned. So a client accepts a server in [min-supported-version, version] and refuses one
+ * NEWER than itself, whose semantics it cannot know. Individual additions are gated by
+ * `capabilities` instead, which is what they are for.
+ */
+constexpr int kMinSupportedXrRenderServiceVersion = 1;
+
+/**
  * Value of `initialize`'s `serverInfo.name`.
  */
 constexpr const char* kServerName = "xr-composite";

--- a/renderers/xr-composite/test/xr_render_service.py
+++ b/renderers/xr-composite/test/xr_render_service.py
@@ -28,6 +28,17 @@ graceful skip.
 # vice versa.
 XR_RENDER_SERVICE_VERSION = 1
 
+# Oldest service version a current client still speaks.
+#
+# The compatibility window exists because the pin makes version skew the NORMAL case, not
+# an error: the compositor is provisioned at a version that deliberately lags, so the
+# server is routinely older than the client. Requiring equality would make bumping this
+# contract a flag day — every render broken until a new compositor is built, published and
+# pinned. So a client accepts a server in [min-supported-version, version] and refuses one
+# NEWER than itself, whose semantics it cannot know. Individual additions are gated by
+# `capabilities` instead, which is what they are for.
+MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION = 1
+
 # Value of `initialize`'s `serverInfo.name`.
 SERVER_NAME = "xr-composite"
 

--- a/schema/xr-render-service.schema.json
+++ b/schema/xr-render-service.schema.json
@@ -13,6 +13,8 @@
   "x-service": {
     "version": 1,
     "version-description": "Version of THIS RPC surface, reported as `initialize`'s `serverInfo.version`.\n\nBumped when a method, parameter, result field or error code changes meaning — not when the\nSpatialScene format changes, which carries its own `SPATIAL_SCENE_VERSION`. A client compares\nthe two independently: it can speak service v1 against a server whose scene format moved, and\nvice versa.",
+    "min-supported-version": 1,
+    "min-supported-version-description": "Oldest service version a current client still speaks.\n\nThe compatibility window exists because the pin makes version skew the NORMAL case, not\nan error: the compositor is provisioned at a version that deliberately lags, so the\nserver is routinely older than the client. Requiring equality would make bumping this\ncontract a flag day — every render broken until a new compositor is built, published and\npinned. So a client accepts a server in [min-supported-version, version] and refuses one\nNEWER than itself, whose semantics it cannot know. Individual additions are gated by\n`capabilities` instead, which is what they are for.",
     "server-name": "xr-composite",
     "default-session-id": "default",
     "default-session-id-description": "Session id the server falls back to when a call carries neither `sessionId` nor\n`frameStreamId` and `initialize` registered no default. Part of the contract: a\nsingle-session client that never names a session still has its frames tagged with this,\nso a client demultiplexing by session id must use the same literal.",

--- a/scripts/codegen/gen-xr-render-service.mjs
+++ b/scripts/codegen/gen-xr-render-service.mjs
@@ -153,6 +153,9 @@ function emitKotlin() {
   out.push(...ktDoc(svc["version-description"], "  "));
   out.push(`  public const val ${VERSION_CONST}: Int = ${svc.version}`);
   out.push("");
+  out.push(...ktDoc(svc["min-supported-version-description"], "  "));
+  out.push(`  public const val MIN_SUPPORTED_${VERSION_CONST}: Int = ${svc["min-supported-version"]}`);
+  out.push("");
   out.push(...ktDoc(`Value of \`initialize\`'s \`serverInfo.name\`.`, "  "));
   out.push(`  public const val SERVER_NAME: String = "${svc["server-name"]}"`);
   out.push("");
@@ -244,6 +247,10 @@ function emitCpp() {
   out.push(...cppDoc(svc["version-description"]));
   out.push(`constexpr int ${VERSION_CONST} = ${svc.version};`);
   out.push("");
+  out.push(...cppDoc(svc["min-supported-version-description"]));
+  out.push(`constexpr int kMinSupported${VERSION_CONST
+    .split("_").map((w) => w.charAt(0) + w.slice(1).toLowerCase()).join("")} = ${svc["min-supported-version"]};`);
+  out.push("");
   out.push(...cppDoc("Value of `initialize`'s `serverInfo.name`."));
   out.push(`constexpr const char* kServerName = "${svc["server-name"]}";`);
   out.push("");
@@ -328,6 +335,9 @@ function emitPython() {
   out.push("");
   out.push(...pyDoc(svc["version-description"]));
   out.push(`${VERSION_CONST} = ${svc.version}`);
+  out.push("");
+  out.push(...pyDoc(svc["min-supported-version-description"]));
+  out.push(`MIN_SUPPORTED_${VERSION_CONST} = ${svc["min-supported-version"]}`);
   out.push("");
   out.push('# Value of `initialize`\'s `serverInfo.name`.');
   out.push(`SERVER_NAME = "${svc["server-name"]}"`);


### PR DESCRIPTION
Items 2 and 3 of #4774, following #4777 which single-sourced the vocabulary.

`XR-Release: none - client-side only; the only change under renderers/xr-composite is the regenerated mirror, and the binary's behaviour is unchanged`

## The problem

`initialize` has always returned a version and a capability set. **Nothing read either.** `XrRenderServer` carried them as `public val capabilities: JsonObject` that no code anywhere consulted — not the version, not `spatialSceneVersion`, not `multiSession`. The negotiation was plumbed and then ignored.

So a client and server that disagreed produced **no error at all**. Every failure downstream — provisioning, render, composite — is a graceful skip, so the symptom was a composite that silently never appeared. That was survivable while both sides were built from the same commit. It stopped being survivable at #4773, which pinned the compositor at a version that deliberately lags: **skew is now the normal case, not the exception.**

## The version rule is a window, not equality

The obvious check — server version must equal client version — would be wrong here, and worth spelling out because it is the one design decision in this PR.

The pin means the server is normally **older** than the client. Requiring equality would make every future service bump a flag day: the moment the constant moved, every render would break until a new compositor was built, published, and pinned. So:

- a client accepts a server in `[MIN_SUPPORTED_XR_RENDER_SERVICE_VERSION, XR_RENDER_SERVICE_VERSION]`
- and refuses one **newer** than itself, whose semantics it cannot know

Individual additions are gated by `capabilities`, which is what they are for. `min-supported-version` lives in the schema alongside `version`, so the compatibility window is contract rather than convention, and it generates into all three mirrors.

## What now fails, and how

| condition | before | after |
| --- | --- | --- |
| server speaks a version this client doesn't | silent skip | named `XrServerException` naming both versions and the pin to bump |
| result has no `serverInfo.version` | silent skip | named error |
| second concurrent session, no `multiSession` | both sessions silently share one scene | refused before sending |
| scene version the server can't parse | render fails mid-stream, skipped | refused before sending, naming both versions |
| `updatePanels` without the capability | confusing mid-stream error | named error |
| any call before `initialize` | NPE-ish | named error |

The daemon already wraps `xr/start` in a `try/catch`, so a mismatch surfaces as a JSON-RPC error rather than a crash — which is the point: a bug someone must see, rather than a picture that quietly never renders.

The scene check compares the **actual payload's** `version` against the server's advertised `spatialSceneVersion`, not a compile-time constant. That is both stricter and keeps `:renderer-xr-client` free of a dependency on the SpatialScene DTOs — its entire dependency list is still `kotlinx-serialization-json`.

## A fake that had drifted

`XrServerClientTest`'s fake server **never sent `serverInfo` at all**. It had diverged from the real protocol and nothing could detect it, precisely because nothing read the result. Corrected here to mirror what the native server actually sends.

## Test plan

- **Captured the real server's `initialize` reply** from a freshly built `xr-composite --serve` under Xvfb/llvmpipe, and pinned it verbatim as a test asserting this client accepts it — so a server that stops reporting its version or drops a capability fails in CI rather than in a render nobody is watching:
  ```
  {"capabilities":{"dataProducts":["xr/composite"],"multiSession":true,"render":true,
    "spatialSceneVersion":1,"streamFrame":true,"updatePanels":true},
   "serverInfo":{"name":"xr-composite","version":1}}
  ```
- **Rebuilt the native binary and re-ran the serve smoke**: `OK: 4 streamFrames across sessions {'fs1','b','a'}; per-frame update changed image`.
- `:renderer-xr-client:test` — **32 tests, all green** (9 handshake, 7 client incl. 6 new gate tests, 11 session manager, 5 binary resolution). Covers both directions of the version window, the missing-`serverInfo` cases, same-session reuse still working without `multiSession`, and a stopped session freeing the gate.
- Both codegen `--check`s and `ktfmtCheckMain`/`CheckTest` green.

Text-only change in behaviour; no rendered surface moves.

## Note on one thing I did not do

`serverInfo.name` is reported in error messages but not enforced — a fork or rename shouldn't be a hard failure, and the version check already covers the case that matters.

---
_Generated by [Claude Code](https://claude.ai/code/session_013kTrFWU2hdM6SmbRRssfVo)_