### PR TITLE
fix(plugin): order composePreviewBundle after every render task it reads

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -762,6 +762,25 @@ internal object ComposePreviewTasks {
       // implicit-dependency validation error. `mustRunAfter` supplies it WITHOUT pulling render in
       // when only bundle is requested — render still doesn't run unless the caller asks for it.
       mustRunAfter("composePreviewRender")
+      // …and the same for the OTHER two dirs `renderFiles` declares. `composePreviewRenderSvg` and
+      // `composePreviewRenderLottie` write `svg-renders/` and `lottie-renders/`, which are wired as
+      // inputs a few lines below, so they need the ordering for exactly the reason the render task
+      // above does — and only the render task above had it. Asking for both halves in one
+      // invocation therefore failed the build outright:
+      //
+      //   $ ./gradlew :catalog:composePreviewRenderAll :catalog:composePreviewBundle
+      //   Declare an explicit dependency on ':catalog:composePreviewRenderLottie'
+      //   from ':catalog:composePreviewBundle' using Task#mustRunAfter.
+      //
+      // which is what `composePreviewRenderAll` aggregates, so the documented pack flow only
+      // survived by being two separate Gradle invocations.
+      //
+      // By type rather than by name: these two are registered on the Android path only, so naming
+      // them as strings would throw on a desktop module, and a `matching {}` predicate would
+      // realize every task to test it. A typed collection stays lazy and is empty where they do not
+      // exist. It also catches the desktop `composePreviewRender`, which is harmless — it is
+      // already named above, and an ordering declared twice is still one edge.
+      mustRunAfter(project.tasks.withType(RenderPreviewsTask::class.java))
       dependsOn(discoverTaskName)
       // Pack the module's PROCESSED resources into `classes/app.jar` ([moduleResourcesDir] points
       // at

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleRenderOrderingTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/BundleRenderOrderingTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the ordering `composePreviewBundle` declares against the render tasks whose output it reads.
+ *
+ * `renderFiles` declares three directories as inputs — `renders/`, `svg-renders/` and
+ * `lottie-renders/` — written by three different tasks. Only the first had an ordering, so asking
+ * for the whole render family and the bundle in ONE Gradle invocation failed the build outright:
+ * ```
+ * $ ./gradlew :catalog:composePreviewRenderAll :catalog:composePreviewBundle
+ * Declare an explicit dependency on ':catalog:composePreviewRenderLottie'
+ * from ':catalog:composePreviewBundle' using Task#mustRunAfter.
+ * ```
+ *
+ * `composePreviewRenderAll` aggregates all three, so the documented "render then pack" flow only
+ * worked as two separate invocations — and a consumer that split it that way had no way to know the
+ * bundle would happily pack whatever renders were left on disk from an earlier run.
+ *
+ * Ordering, not dependency: bundling WITHOUT a render is a supported flow (stub cover), which is
+ * why `registerBundleTask` has never used `dependsOn` here. These assertions are as much about that
+ * choice as about the edges — a `dependsOn` would pass the first test and break the third.
+ */
+class BundleRenderOrderingTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private fun projectWithBundle(): org.gradle.api.Project {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    // `registerBundleTask` declares `dependsOn(discoverTaskName)`, so the discover task has to
+    // exist before `taskDependencies` can be resolved at all.
+    project.tasks.register("composePreviewDiscover")
+    // The two asset passes are registered on the Android path in the real plugin; register them
+    // directly here so the ordering can be asserted without standing up AGP.
+    project.tasks.register("composePreviewRender", RenderPreviewsTask::class.java)
+    project.tasks.register("composePreviewRenderSvg", RenderPreviewsTask::class.java)
+    project.tasks.register("composePreviewRenderLottie", RenderPreviewsTask::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    return project
+  }
+
+  private fun orderingNames(project: org.gradle.api.Project): Set<String> {
+    val bundle = project.tasks.getByName("composePreviewBundle")
+    return bundle.mustRunAfter.getDependencies(bundle).map { it.name }.toSet()
+  }
+
+  @Test
+  fun `bundle runs after every render task whose output it declares as an input`() {
+    assertThat(orderingNames(projectWithBundle()))
+      .containsAtLeast(
+        "composePreviewRender",
+        "composePreviewRenderSvg",
+        "composePreviewRenderLottie",
+      )
+  }
+
+  @Test
+  fun `the ordering is empty where the asset passes are not registered`() {
+    // Desktop modules have no SVG/Lottie tasks. Naming them as strings would throw there, which is
+    // why the ordering is declared by type.
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.tasks.register("composePreviewDiscover")
+    project.tasks.register("composePreviewRender", RenderPreviewsTask::class.java)
+    ComposePreviewTasks.registerBundleTask(
+      project = project,
+      extension = extension,
+      previewOutputDir = project.layout.buildDirectory.dir("compose-previews"),
+      sourceClassDirs = project.files("build/classes/kotlin/main"),
+      resolveDependencyConfigName = { "runtimeClasspath" },
+      discoverTaskName = "composePreviewDiscover",
+    )
+    assertThat(orderingNames(project)).containsExactly("composePreviewRender")
+  }
+
+  @Test
+  fun `bundle does not depend on any render task, so packing without one still works`() {
+    val project = projectWithBundle()
+    val bundle = project.tasks.getByName("composePreviewBundle")
+    val dependsOn = bundle.taskDependencies.getDependencies(bundle).map { it.name }
+    assertThat(dependsOn).doesNotContain("composePreviewRender")
+    assertThat(dependsOn).doesNotContain("composePreviewRenderSvg")
+    assertThat(dependsOn).doesNotContain("composePreviewRenderLottie")
+  }
+}


### PR DESCRIPTION
Closes #4782.

`renderFiles` declares **three** directories as inputs — `renders/`, `svg-renders/` and `lottie-renders/` — written by three different tasks. Only the first had an ordering, so asking for the render family and the bundle in **one** Gradle invocation failed the build outright:

```
$ ./gradlew :catalog:composePreviewRenderAll :catalog:composePreviewBundle
FAILURE: Build failed with an exception.
  Declare an explicit dependency on ':catalog:composePreviewRenderLottie'
  from ':catalog:composePreviewBundle' using Task#mustRunAfter.
```

`composePreviewRenderAll` aggregates all three, so the documented render-then-pack flow only survived as two separate invocations — and a consumer that split it that way had no signal that the bundle would happily pack whatever renders were left on disk from an earlier run. `wear-m3-catalog`'s parity script did exactly that and served **05:12 pixels for a 09:23 edit**, reading as "my change did nothing".

## Ordering, not dependency

I filed #4782 suggesting `dependsOn` as the better answer. **That was wrong**, and the KDoc on `registerBundleTask` says why:

> The bundle task does NOT depend on `composePreviewRender` — bundling without pre-rendering is the common case for the CLI's "pack and share" flow.

Forcing a render would break a supported path. The real defect is narrower: the ordering already existed for `composePreviewRender` (with a comment explaining this exact validation error) and simply never covered the two sibling tasks whose output was added to `renderFiles` alongside it. `mustRunAfter` is what Gradle's own error recommends, and what the line above already used.

## Declared by type

```kotlin
mustRunAfter(project.tasks.withType(RenderPreviewsTask::class.java))
```

`composePreviewRenderSvg` and `composePreviewRenderLottie` are registered on the **Android path only**, so naming them as strings would throw `UnknownTaskException` on a desktop module. A `matching { }` predicate would realize every task to test it, costing configuration avoidance. A typed collection stays lazy and is simply empty where they do not exist.

It also catches the desktop `composePreviewRender`, which is harmless — already named on the line above, and an ordering declared twice is still one edge.

## Test plan

New `BundleRenderOrderingTest`, three cases:

- the bundle is ordered after all three render tasks
- a desktop project (no SVG/Lottie tasks registered) gets only the one, proving the by-type declaration degrades correctly
- **`dependsOn` stays absent** on all three, so a future change that reaches for it fails here rather than quietly forcing a render on the pack-and-share path

Against the unfixed code, exactly one fails and the other two pass:

```
BundleRenderOrderingTest > bundle runs after every render task whose output it declares as an input FAILED
3 tests completed, 1 failed
```

With the fix: `BUILD SUCCESSFUL`.

Also `./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest` — clean.

## Consumer note

`wear-m3-catalog#155` works around this by splitting into two Gradle invocations and moving its staleness guard onto `renders/` rather than the bundle. That workaround stays correct after this lands; the ordering just means a single invocation is now an option again.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqjheSt3Nwbsp55TGhnU1u)_