### PR TITLE
ci: let Renovate see the xr-composite pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -187,5 +187,19 @@
       "matchCurrentValue": "/^9\\.7\\.0$/",
       "allowedVersions": "/^9\\.7\\.0$/"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "The `xr-composite` pin — the compositor's release version in compose-preview-xr. Invisible to the gradle manager: it is a bare `[versions]` entry with no library or plugin declaring `version.ref = \"xr-composite\"`, so there is no coordinate for Renovate to resolve. The CLI and the Gradle plugin both bake it in at build time and resolve the binary by it, so without this it is the one dependency here that could never be offered an update. Anchored to this single entry rather than written generically, because `extractVersionTemplate` below is specific to it: the catalog holds a bare `1.0.0` while the upstream tags are `v1.0.0`.",
+      "managerFilePatterns": [
+        "/^gradle/libs\\.versions\\.toml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\nxr-composite\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "semver"
+    }
   ]
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -170,6 +170,7 @@ xr-arcore-testing = "1.0.0-beta02"
 # line is the whole interface to it: bumping it is how a new compositor is taken.
 # `check_xr_composite_pin.py` fails a PR whose value does not name a real release
 # there with all three platform tarballs — a 404 downstream is a graceful skip.
+# renovate: datasource=github-releases depName=yschimke/compose-preview-xr
 xr-composite = "1.0.0"
 # `androidx.wear:wear` carries `androidx.wear.ambient.AmbientLifecycleObserver` —
 # the AOSP entry point both horologist's `AmbientAware` and direct subscribers


### PR DESCRIPTION
The same blind spot the Filament SDK pin had in compose-preview-xr ([#7 there](https://github.com/yschimke/compose-preview-xr/pull/7)), and the more consequential half.

`xr-composite` is a bare `[versions]` entry that **no library or plugin references with `version.ref`** — verified, zero users in the catalog — so the gradle manager has no coordinate to resolve and never sees it. That makes it the one dependency here that could not be offered an update, which matters more than usual now that it is the *entire* interface to the compositor: since #4799 nothing in this repository builds that binary, and this line is how a new one is taken.

## The `v` prefix is the load-bearing detail

The catalog holds a bare `1.0.0`; compose-preview-xr tags releases `v1.0.0`. Without `extractVersionTemplate` every proposed value would be written back with a `v` the provisioner does not expect — `XrCompositeProvision.assetUrl` builds `…/download/v$version/xr-composite-<platform>-$version.tar.gz`, so a `v`-prefixed pin yields `/vv1.1.0/…-v1.1.0.tar.gz`, a 404, and a **graceful skip**. The manager is deliberately anchored to this single entry rather than written generically, because that template is specific to it.

## Test plan

- `renovate-config-validator --strict` as **repo** config: `Config validated successfully`.
- Regex matches exactly once, with the right captures:
  ```
  {'datasource': 'github-releases', 'depName': 'yschimke/compose-preview-xr', 'currentValue': '1.0.0'}
  ```
- Simulated a bump to `1.1.0` (i.e. tag `v1.1.0` with the prefix stripped): writes back as `xr-composite = "1.1.0"` and the catalog still parses.
- `test_check_xr_composite_pin.py` — 27 pass; the live gate still reports `ok: yschimke/compose-preview-xr v1.0.0 exists with all 3 platform tarballs`.
- Both consumers still bake the value through the Gradle catalog accessor: `:cli:generateCliVersionResource` and `:gradle-plugin:generatePluginVersionResource` emit `xrCompositeVersion=1.0.0`.

## One gap worth naming, not fixed here

A Renovate PR bumping this pin gets **`XR Composite Pin`** as its PR-time proof — the release exists with all three tarballs. It does **not** get `Render XR composite (sample)`, which is `if: github.event_name != 'pull_request'`, so the actual binary↔plugin contract check (sample render + `:renderer-xr-client` integration test against the downloaded binary) only runs post-merge on `main` or nightly.

So a compositor release that broke the plugin contract would merge and be caught a few hours later rather than on the PR. Given how rare compositor releases are, and that the nightly does catch it, that seems an acceptable posture — but it is a real gap and the alternative is one line (let that job run when the pin changes, at ~6 min a go). Say the word and I'll add it, here or separately.

Renovate's own config has no automerge, so these PRs land manually either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_013kTrFWU2hdM6SmbRRssfVo)_