### PR TITLE
fix(serve): restore revision menu images

### DIFF
--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeBundleHost.kt
@@ -882,9 +882,11 @@ class ServeBundleHost(
   fun pinnedCatalogIsAuthoritative(commit: String): Boolean =
     pinnedManifest?.forCommit(commit)?.catalogRead == true
 
-  /** Null means this branch or revision predates the generation-time index, so menus fail open. */
+  /** Null means this branch predates the generation-time index, so menus fail open. */
   fun revisionContainsPreview(commit: String, previewId: String): Boolean? =
-    ServeCatalogRevision.normalize(commit)?.let { revisionPreviewIds?.get(it)?.contains(previewId) }
+    revisionPreviewIds?.let { index ->
+      ServeCatalogRevision.normalize(commit)?.let { index[it]?.contains(previewId) ?: false }
+    }
 
   /**
    * The delivery-branch publishes in which [previewId]'s render actually changed, or null when the

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeCatalogStore.kt
@@ -434,7 +434,7 @@ class ServeCatalogStore(
     // have no index and deliberately fail open; the pinned catalog remains authoritative on click.
     val revisionPreviewIds = runCatching {
       ServeRevisionPreviewIndex.parse(fetchCatalogAsset(base + ServeRevisionPreviewIndex.FILE_NAME))
-        ?.previewsByCommit()
+        ?.previewsByCommit(deliveryCommit.orEmpty())
     }
       .getOrNull()
 

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -3494,7 +3494,9 @@ class ServeHttpServer(
    * preview existed. Offering those as this preview's versions only manufactures links to honest
    * 404s. The publisher rolls a compact preview index forward with every catalog generation, so
    * this is an in-memory lookup rather than one historical `catalog.json` fetch per row. A missing
-   * index or entry fails open, keeping older publishers backward-compatible.
+   * index fails open, keeping older publishers backward-compatible. Once a valid index exists, an
+   * unindexed commit is not a catalog generation (for example a parity-issue refresh on the same
+   * delivery branch), so it is omitted rather than offered as another copy of the same image.
    */
   private fun availableRevisions(
     host: ServeBundleHost,

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndex.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndex.kt
@@ -13,13 +13,15 @@ data class ServeRevisionPreviewIndex(
   @Serializable data class Entry(val commit: String = "", val previews: List<String> = emptyList())
 
   /** Null means this branch predates the index, so callers must fail open. */
-  fun previewsByCommit(): Map<String, Set<String>>? {
+  fun previewsByCommit(currentCommit: String): Map<String, Set<String>>? {
     if (schema != SCHEMA) return null
-    return revisions
-      .mapNotNull { entry ->
-        ServeCatalogRevision.normalize(entry.commit)?.let { it to entry.previews.toSet() }
+    val tip = ServeCatalogRevision.normalize(currentCommit) ?: return null
+    return buildMap {
+      put(tip, current.toSet())
+      revisions.forEach { entry ->
+        ServeCatalogRevision.normalize(entry.commit)?.let { put(it, entry.previews.toSet()) }
       }
-      .toMap()
+    }
   }
 
   companion object {

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServePinnedRevisionTest.kt
@@ -677,6 +677,38 @@ class ServePinnedRevisionTest {
   }
 
   @Test
+  fun `metadata-only branch commits are not image revisions`() {
+    val metadataCommit = "3333333333333333333333333333333333333333"
+    val oldEntry = "<entry>\n        <id>tag:github.com,2008:Grit::Commit/$oldCommit"
+    val metadataEntry =
+      """
+      <entry>
+        <id>tag:github.com,2008:Grit::Commit/$metadataCommit</id>
+        <updated>2026-08-07T10:00:00Z</updated>
+        <content type="html">refresh parity issue index</content>
+      </entry>
+      """
+        .trimIndent()
+    val feedWithMetadata = feed.replace(oldEntry, "$metadataEntry\n      $oldEntry")
+    val port = startServer { url ->
+      when (url) {
+        ServeCatalogRevision.commitsFeedUrl(repo, branch) -> feedWithMetadata.encodeToByteArray()
+        renderFeedUrl ->
+          "<feed><entry><id>tag:github.com,2008:Grit::Commit/$oldCommit</id></entry></feed>"
+            .encodeToByteArray()
+        else -> fetch(url)
+      }
+    }
+      .port
+
+    val page = text("http://127.0.0.1:$port/$system/p/$previewId")
+    val runs = text("http://127.0.0.1:$port/$system/api/render-runs/$previewId")
+
+    assertFalse(page.contains(metadataCommit), page)
+    assertTrue(runs.contains("\"revisions\":2"), runs)
+  }
+
+  @Test
   fun `a run the window cuts off says so instead of claiming a count`() {
     // The only publish that touched this render predates both rows in the window, so the run's
     // length is a floor. Reporting it as an exact two would be a claim the branch never supported.

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndexTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeRevisionPreviewIndexTest.kt
@@ -18,7 +18,10 @@ class ServeRevisionPreviewIndexTest {
           .encodeToByteArray()
       )
 
-    assertEquals(mapOf("1111111" to setOf("old", "shared")), index?.previewsByCommit())
+    assertEquals(
+      mapOf("2222222" to setOf("today"), "1111111" to setOf("old", "shared")),
+      index?.previewsByCommit("2222222"),
+    )
   }
 
   @Test
@@ -27,7 +30,17 @@ class ServeRevisionPreviewIndexTest {
     assertNull(ServeRevisionPreviewIndex.parse("nope".encodeToByteArray()))
     assertNull(
       ServeRevisionPreviewIndex.parse("""{"schema":"future","revisions":[]}""".encodeToByteArray())
-        ?.previewsByCommit()
+        ?.previewsByCommit("2222222")
     )
+  }
+
+  @Test
+  fun `invalid current commit fails open instead of dropping every revision`() {
+    val index =
+      ServeRevisionPreviewIndex.parse(
+        """{"schema":"compose-preview-revision-index/v1","current":["today"]}""".encodeToByteArray()
+      )
+
+    assertNull(index?.previewsByCommit("not-a-sha"))
   }
 }

--- a/docs/public-preview-server.md
+++ b/docs/public-preview-server.md
@@ -454,9 +454,11 @@ line:
 
 The rows are preview-specific even though the commit feed is catalog-wide. Each generated delivery
 branch carries a rolling `preview-index.json`; the server uses it to omit revisions that did not
-publish the preview on the page. Branches produced before this index existed fail open and retain
-their rows, while a direct link to a genuinely absent preview still returns a contextual `404` with
-a route back to the current preview.
+publish the preview on the page. A valid index also distinguishes catalog generations from
+metadata-only commits (such as parity-issue refreshes) made on the same delivery branch, so those
+commits do not appear as duplicate image revisions. Branches produced before this index existed
+fail open and retain their rows, while a direct link to a genuinely absent preview still returns a
+contextual `404` with a route back to the current preview.
 
 ![The viewer's folded Revisions disclosure](images/serve-revision-viewer.png)
 


### PR DESCRIPTION
## Summary

- treat indexed catalog generations as the revision-menu source of truth
- map the index current inventory to the delivery-branch tip and omit interleaved metadata-only commits
- keep legacy catalogs without a revision index fail-open and document the behavior

Closes #4791

## Verification

- `./gradlew :cli:serve:test --tests 'ee.schimke.composeai.cli.serve.ServeRevisionPreviewIndexTest' --tests 'ee.schimke.composeai.cli.serve.ServePinnedRevisionTest' :cli:serve:ktfmtCheckMain :cli:serve:ktfmtCheckTest --no-daemon`

## Visual evidence

Before — the reported menu fell back to plain date/SHA rows because `/api/render-runs` returned 404:

![Revision menu without images](https://github.com/user-attachments/assets/7822d572-ea33-4a05-bdcb-2a4d59527980)

After — committed revision-menu render proxy showing the restored thumbnails and distinct-render summary; the focused server regression test covers the metadata-only commit that caused the live 404:

![Revision menu with render thumbnails](https://raw.githubusercontent.com/yschimke/compose-ai-tools/27c7f15b4070501717b111022e2686aed8784d9c/docs/design/evidence/revision-render-runs/after-render-runs.png)
