### PR TITLE
fix(catalog): support released slot runtime

### DIFF
--- a/samples/design-catalog-m3-shared/build.gradle.kts
+++ b/samples/design-catalog-m3-shared/build.gradle.kts
@@ -35,6 +35,9 @@ plugins {
   id("org.jetbrains.kotlin.plugin.compose")
 }
 
+val useReleasedRuntimes =
+  providers.gradleProperty("composeaiUseReleasedRuntimes").orNull.toBoolean()
+
 kotlin {
   // JVM target so `commonMain` compiles against the Desktop flavor of
   // compose-runtime — that's what the desktop renderer / daemon
@@ -57,26 +60,37 @@ kotlin {
   }
 
   sourceSets {
-    commonMain.dependencies {
-      // String-typed `compose.*` accessors are deprecated in CMP 1.10 in favour
-      // of explicit coords, but the renamed coords aren't reliably published to
-      // every mirror yet — mirror the sibling CMP samples and accept the warning.
-      @Suppress("DEPRECATION") implementation(compose.runtime)
-      @Suppress("DEPRECATION") implementation(compose.foundation)
-      @Suppress("DEPRECATION") implementation(compose.material3)
-      @Suppress("DEPRECATION") implementation(compose.ui)
-      implementation(libs.graphics.shapes)
-      // Compose Multiplatform string resources: the catalog's component labels resolve from
-      // `commonMain/composeResources/values*/strings.xml`, so a `localeTag` override (or the
-      // `en-XA`/`ar-XB` pseudolocale) renders translated / pseudolocalised copy through the
-      // daemon's `LocaleList` provider. `api` so the desktop `@Preview` sticker sheet
-      // (`:samples:design-catalog-m3`) can reference the same generated `Res` for its
-      // scaffold-template strings without re-declaring its own resource set.
-      @Suppress("DEPRECATION") api(compose.components.resources)
-      // `PreviewSlot` / `LocalSlotMode` for the slotted-card component. `api` so the desktop
-      // sticker
-      // sheet (`:samples:design-catalog-m3`) can provide `LocalSlotMode` for its slot-mode sticker.
-      api(project(":slot-preview-runtime"))
+    commonMain {
+      // Slot constraints are new on HEAD and intentionally absent from the released runtime that
+      // published preview bundles compile against. Select the matching adapter at configuration
+      // time so the release guard keeps catching accidental direct use of unreleased APIs while
+      // normal builds still exercise the richer contract.
+      kotlin.srcDir(
+        if (useReleasedRuntimes) "src/releasedRuntimeMain/kotlin"
+        else "src/currentRuntimeMain/kotlin"
+      )
+      dependencies {
+        // String-typed `compose.*` accessors are deprecated in CMP 1.10 in favour
+        // of explicit coords, but the renamed coords aren't reliably published to
+        // every mirror yet — mirror the sibling CMP samples and accept the warning.
+        @Suppress("DEPRECATION") implementation(compose.runtime)
+        @Suppress("DEPRECATION") implementation(compose.foundation)
+        @Suppress("DEPRECATION") implementation(compose.material3)
+        @Suppress("DEPRECATION") implementation(compose.ui)
+        implementation(libs.graphics.shapes)
+        // Compose Multiplatform string resources: the catalog's component labels resolve from
+        // `commonMain/composeResources/values*/strings.xml`, so a `localeTag` override (or the
+        // `en-XA`/`ar-XB` pseudolocale) renders translated / pseudolocalised copy through the
+        // daemon's `LocaleList` provider. `api` so the desktop `@Preview` sticker sheet
+        // (`:samples:design-catalog-m3`) can reference the same generated `Res` for its
+        // scaffold-template strings without re-declaring its own resource set.
+        @Suppress("DEPRECATION") api(compose.components.resources)
+        // `PreviewSlot` / `LocalSlotMode` for the slotted-card component. `api` so the desktop
+        // sticker
+        // sheet (`:samples:design-catalog-m3`) can provide `LocalSlotMode` for its slot-mode
+        // sticker.
+        api(project(":slot-preview-runtime"))
+      }
     }
 
     // The named-override runtime (`previewOverride*`) is a plain JVM artifact with no wasm klib, so
@@ -123,7 +137,7 @@ compose.resources {
 // through the guard and only surface later as a linkage / render error, not a compile failure. Same
 // gate + release-please-managed version as the consumer (kept in lockstep by hand — a shared
 // convention over both modules is the DRY follow-up).
-if (providers.gradleProperty("composeaiUseReleasedRuntimes").orNull.toBoolean()) {
+if (useReleasedRuntimes) {
   val version =
     providers.gradleProperty("composeaiReleasedRuntimeVersion").orNull
       ?: error(

--- a/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
+++ b/samples/design-catalog-m3-shared/src/commonMain/kotlin/com/example/designcatalogm3/shared/CatalogComponents.kt
@@ -54,9 +54,6 @@ import com.example.designcatalogm3.shared.generated.resources.m3_body_overflow
 import com.example.designcatalogm3.shared.generated.resources.slot_headline
 import com.example.designcatalogm3.shared.generated.resources.slot_supporting
 import com.example.designcatalogm3.shared.generated.resources.textfield_label
-import ee.schimke.composeai.preview.slots.PreviewSlot
-import ee.schimke.composeai.preview.slots.PreviewSlotConstraints
-import ee.schimke.composeai.preview.slots.PreviewSlotSizing
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -165,39 +162,30 @@ fun CatalogComponent(id: String) {
     "card-slots" ->
       ElevatedCard {
         Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
-          PreviewSlot(
+          CatalogPreviewSlot(
             "leadingIcon",
             Modifier.size(40.dp),
-            constraints =
-              PreviewSlotConstraints(
-                horizontal = PreviewSlotSizing.Fixed,
-                vertical = PreviewSlotSizing.Fixed,
-              ),
+            horizontal = CatalogSlotSizing.Fixed,
+            vertical = CatalogSlotSizing.Fixed,
           ) {
             Box(
               Modifier.size(40.dp).background(catalogOverrideColor("iconColor", Color(0xFF6750A4)))
             )
           }
           Column(Modifier.padding(start = 12.dp)) {
-            PreviewSlot(
+            CatalogPreviewSlot(
               "headline",
               Modifier.width(140.dp),
-              constraints =
-                PreviewSlotConstraints(
-                  horizontal = PreviewSlotSizing.Fixed,
-                  vertical = PreviewSlotSizing.Hug,
-                ),
+              horizontal = CatalogSlotSizing.Fixed,
+              vertical = CatalogSlotSizing.Hug,
             ) {
               Text(catalogOverrideString("headline", stringResource(Res.string.slot_headline)))
             }
-            PreviewSlot(
+            CatalogPreviewSlot(
               "supporting",
               Modifier.width(140.dp),
-              constraints =
-                PreviewSlotConstraints(
-                  horizontal = PreviewSlotSizing.Fixed,
-                  vertical = PreviewSlotSizing.Hug,
-                ),
+              horizontal = CatalogSlotSizing.Fixed,
+              vertical = CatalogSlotSizing.Hug,
             ) {
               Text(catalogOverrideString("supporting", stringResource(Res.string.slot_supporting)))
             }

--- a/samples/design-catalog-m3-shared/src/currentRuntimeMain/kotlin/com/example/designcatalogm3/shared/CatalogPreviewSlot.kt
+++ b/samples/design-catalog-m3-shared/src/currentRuntimeMain/kotlin/com/example/designcatalogm3/shared/CatalogPreviewSlot.kt
@@ -1,0 +1,52 @@
+package com.example.designcatalogm3.shared
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.composeai.preview.slots.PreviewSlot
+import ee.schimke.composeai.preview.slots.PreviewSlotConstraints
+import ee.schimke.composeai.preview.slots.PreviewSlotSizing
+
+internal enum class CatalogSlotSizing {
+  Fixed,
+  Hug,
+}
+
+@Composable
+internal fun RowScope.CatalogPreviewSlot(
+  name: String,
+  modifier: Modifier,
+  horizontal: CatalogSlotSizing,
+  vertical: CatalogSlotSizing,
+  content: @Composable () -> Unit,
+) =
+  PreviewSlot(
+    name = name,
+    modifier = modifier,
+    constraints =
+      PreviewSlotConstraints(horizontal = horizontal.toRuntime(), vertical = vertical.toRuntime()),
+    content = content,
+  )
+
+@Composable
+internal fun ColumnScope.CatalogPreviewSlot(
+  name: String,
+  modifier: Modifier,
+  horizontal: CatalogSlotSizing,
+  vertical: CatalogSlotSizing,
+  content: @Composable () -> Unit,
+) =
+  PreviewSlot(
+    name = name,
+    modifier = modifier,
+    constraints =
+      PreviewSlotConstraints(horizontal = horizontal.toRuntime(), vertical = vertical.toRuntime()),
+    content = content,
+  )
+
+private fun CatalogSlotSizing.toRuntime(): PreviewSlotSizing =
+  when (this) {
+    CatalogSlotSizing.Fixed -> PreviewSlotSizing.Fixed
+    CatalogSlotSizing.Hug -> PreviewSlotSizing.Hug
+  }

--- a/samples/design-catalog-m3-shared/src/releasedRuntimeMain/kotlin/com/example/designcatalogm3/shared/CatalogPreviewSlot.kt
+++ b/samples/design-catalog-m3-shared/src/releasedRuntimeMain/kotlin/com/example/designcatalogm3/shared/CatalogPreviewSlot.kt
@@ -1,0 +1,32 @@
+package com.example.designcatalogm3.shared
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.composeai.preview.slots.PreviewSlot
+
+internal enum class CatalogSlotSizing {
+  Fixed,
+  Hug,
+}
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+internal fun RowScope.CatalogPreviewSlot(
+  name: String,
+  modifier: Modifier,
+  horizontal: CatalogSlotSizing,
+  vertical: CatalogSlotSizing,
+  content: @Composable () -> Unit,
+) = PreviewSlot(name = name, modifier = modifier, content = content)
+
+@Suppress("UNUSED_PARAMETER")
+@Composable
+internal fun ColumnScope.CatalogPreviewSlot(
+  name: String,
+  modifier: Modifier,
+  horizontal: CatalogSlotSizing,
+  vertical: CatalogSlotSizing,
+  content: @Composable () -> Unit,
+) = PreviewSlot(name = name, modifier = modifier, content = content)


### PR DESCRIPTION
## Summary
- select a current-runtime slot adapter for normal catalog builds
- select a compatibility adapter when published previews pin the released runtime
- preserve slot constraint metadata on HEAD without referencing unreleased APIs in the release lane

## Verification
- `./gradlew -PcomposeaiUseReleasedRuntimes=true :cli:installDist --no-daemon`
- `./gradlew -PcomposeaiUseReleasedRuntimes=true :samples:design-catalog-m3-shared:compileKotlinWasmJs :samples:design-catalog-m3-shared:compileKotlinDesktop --no-daemon`
- `./gradlew ktfmtCheckAll :samples:design-catalog-m3-shared:compileKotlinWasmJs --no-daemon`

Non-visual build compatibility fix; normal catalog rendering retains the constraint-aware adapter.