### PR TITLE
fix(serve-wasm): read a colour override's argb, not a value it never has

### DIFF
--- a/cli/serve-wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/Main.kt
+++ b/cli/serve-wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/Main.kt
@@ -233,23 +233,37 @@ class BrowserPreviewClient(private val config: ClientConfig) {
   private fun JsonObject.int(key: String): Int? =
     this[key]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
 
-  private fun JsonObject.overrideSeeds(): Map<String, String> =
-    this["overrides"]
-      ?.jsonArray
-      .orEmpty()
-      .mapNotNull { value ->
-        val declaration = value as? JsonObject ?: return@mapNotNull null
-        val key = declaration.string("key")?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
-        val index = declaration.int("index")
-        val encoded =
-          ((declaration["current"] ?: declaration["default"]) as? JsonObject)
-            ?.get("value")
-            ?.jsonPrimitive
-            ?.contentOrNull ?: return@mapNotNull null
-        (if (index == null) key else "$key[$index]") to encoded
-      }
-      .toMap()
+  private fun JsonObject.overrideSeeds(): Map<String, String> = overrideSeedsOf(this)
 }
+
+/**
+ * The knob seeds a published preview's override declarations carry.
+ *
+ * A declaration's value is not always spelled `value`. `PreviewOverrideValue` serialises each case
+ * under its own property name, and the colour case carries `argb` — so reading only `value` dropped
+ * every colour override on the floor and rendered the composable's author default instead of the
+ * catalog's current colour, silently and only for colours.
+ *
+ * Top-level and `internal` so the parsing can be tested without a browser: it is the half of this
+ * client that has rules, and the half where a missing case looks like a working render.
+ */
+internal fun overrideSeedsOf(root: JsonObject): Map<String, String> =
+  root["overrides"]
+    ?.jsonArray
+    .orEmpty()
+    .mapNotNull { value ->
+      val declaration = value as? JsonObject ?: return@mapNotNull null
+      val key =
+        (declaration["key"]?.jsonPrimitive?.contentOrNull)?.takeIf { it.isNotBlank() }
+          ?: return@mapNotNull null
+      val index = declaration["index"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+      val declared = (declaration["current"] ?: declaration["default"]) as? JsonObject
+      val encoded =
+        (declared?.get("value") ?: declared?.get("argb"))?.jsonPrimitive?.contentOrNull
+          ?: return@mapNotNull null
+      (if (index == null) key else "$key[$index]") to encoded
+    }
+    .toMap()
 
 internal fun parseQuery(search: String): Map<String, String> {
   val raw = search.removePrefix("?")

--- a/cli/serve-wasm/src/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/OverrideSeedsTest.kt
+++ b/cli/serve-wasm/src/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/OverrideSeedsTest.kt
@@ -1,0 +1,71 @@
+package ee.schimke.composeai.servewasm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Reading a published preview's override declarations.
+ *
+ * The failure this guards is quiet by construction: a dropped seed does not error, it renders the
+ * composable's author default. The preview still looks like a preview — just not like the catalog.
+ */
+class OverrideSeedsTest {
+  private fun parse(json: String): Map<String, String> =
+    overrideSeedsOf(Json.parseToJsonElement(json) as JsonObject)
+
+  @Test
+  fun `reads a colour declaration, which spells its value argb`() {
+    // `PreviewOverrideValue` serialises each case under its own property name. Every other kind
+    // uses `value`; colour uses `argb`. Reading only the first dropped every colour override.
+    assertEquals(
+      mapOf("iconColor" to "#FF7DE2FF"),
+      parse(
+        """{"overrides":[{"key":"iconColor","current":{"kind":"color","argb":"#FF7DE2FF"}}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `still reads the kinds that spell it value`() {
+    assertEquals(
+      mapOf("enabled" to "true", "count" to "3"),
+      parse(
+        """{"overrides":[
+             {"key":"enabled","current":{"kind":"bool","value":true}},
+             {"key":"count","default":{"kind":"int","value":3}}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `prefers the current value over the declared default`() {
+    assertEquals(
+      mapOf("iconColor" to "#FF001122"),
+      parse(
+        """{"overrides":[{"key":"iconColor",
+             "default":{"kind":"color","argb":"#FFAABBCC"},
+             "current":{"kind":"color","argb":"#FF001122"}}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `keys an indexed declaration by its position`() {
+    assertEquals(
+      mapOf("rowColor[1]" to "#FF7DE2FF"),
+      parse(
+        """{"overrides":[{"key":"rowColor","index":1,"current":{"kind":"color","argb":"#FF7DE2FF"}}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `skips a declaration with no value of either spelling`() {
+    assertEquals(
+      emptyMap(),
+      parse("""{"overrides":[{"key":"mystery","current":{"kind":"future"}}]}"""),
+    )
+  }
+}


### PR DESCRIPTION
An unaddressed P2 from the review on #4803 ([thread](https://github.com/yschimke/compose-ai-tools/pull/4803#discussion_r3886770923)). Triaged in #4821.

## The problem

`PreviewOverrideValue` serialises each case under its own property name. Every kind except colour spells its payload `value`; colour spells it `argb`:

```json
{"kind":"color","argb":"#FF7DE2FF"}     // ServeBundleStoreTest fixes this shape
{"kind":"bool","value":true}            // every other kind
```

`Main.kt` read `value` alone, so every colour declaration was dropped from `knobSeeds` and the native preview rendered the composable's **author default** instead of the catalog's current colour.

Quiet by construction: nothing errors, and a preview still appears — it is simply the wrong colour. On a tool whose whole job is parity, that is the failure that matters most and the one least likely to be spotted.

## The change

The parse now reads `value` and falls back to `argb`.

`overrideSeeds` becomes the top-level `internal overrideSeedsOf` so the parsing can be tested without a browser — it is the half of this client that has rules, and the half where a missing case looks like a working render.

## ⚠️ Verification status — corrected

**The five tests in this PR do not execute anywhere.** My first version of this description said "CI is the first place these run". That was wrong, and the correction matters more than the original claim.

Locally, `:cli:serve-wasm:wasmJsTest` cannot run in the sandbox — the Kotlin/Wasm test runner provisions Node tooling through yarn and the fetch fails behind the proxy:

```
Execution failed for task ':kotlinWasmToolingSetup'
> Process 'Setup of tooling dependencies' returns 1
```

**And CI does not run them either.** `:cli:serve-wasm` has no `test` task — only `wasmJsTest` — so the affected-module resolver finds nothing to invoke, `tasks` resolves to `none`, and the `Module Unit Tests` job skips. That is observable on this PR's own check runs: `Module Unit Tests — skipped`, on a PR whose only changes are in that module. `grep -rn "wasmJsTest\|serve-wasm" .github/workflows/` returns nothing.

What I *can* evidence:

- `:cli:serve-wasm:compileKotlinWasmJs` — clean
- `:cli:serve-wasm:compileTestKotlinWasmJs` — clean (so the tests are at least valid Kotlin against the real API)
- `:cli:serve-wasm:ktfmtCheck` — clean

So the fix rests on reading, and the tests are provision for when the module is wired up. By construction the colour case returns an empty map without the fix — but I have not watched it fail, and nothing else will until `wasmJsTest` runs somewhere.

I have not wired `wasmJsTest` into CI in this PR: I cannot validate that the Wasm test runner comes up on a CI runner (it does not here), and speculatively adding a job that might go red for everyone is not a change to make blind. Filed as a concrete root cause on #4819 instead.

## Not fixed here

The other findings on that review — [fonts not loaded natively](https://github.com/yschimke/compose-ai-tools/pull/4803#discussion_r3886770917), [harness-dependent variants rendered without their harness](https://github.com/yschimke/compose-ai-tools/pull/4803#discussion_r3886770920), and [version-gating against the catalog artifact](https://github.com/yschimke/compose-ai-tools/pull/4803#discussion_r3886770919) — are all larger than a parse fix and point at one decision: whether the native lane should fall back to the server-backed snapshot for anything it cannot faithfully reproduce. Left on #4821 for that call.

## Visual evidence

This changes which colour a native preview renders — a real visual effect I cannot capture, since the surface has no automated preview coverage at all (#4819). The rendered result needs either that coverage or a human opening the composer against a colour-seeded catalog.
