### PR TITLE
ci: run multiplatform modules' jvmTest, which the resolver never named

### DIFF
--- a/.github/actions/apply/scope-project-graph.init.gradle
+++ b/.github/actions/apply/scope-project-graph.init.gradle
@@ -48,6 +48,20 @@ if (outPath != null) {
         dir: p.projectDir.absolutePath,
         hasPreviewPlugin: hasPlugin,
         hasTestTask: p.tasks.findByName('test') != null,
+        // Which of the headless JVM test tasks this project actually has.
+        //
+        // `test` alone is a single-platform assumption. A Kotlin Multiplatform module names its
+        // JVM tests `jvmTest` and registers NO `test` task, so every one of them reported
+        // "has no tests" and the resolver emitted nothing — `:rc-player-compose` (25 test
+        // files), `:rc-player-runtime` (12), `:rc-player-protocol`, `:rc-player-trace` and
+        // `:slot-preview-runtime` had never run in CI, while `Module Unit Tests` skipped and
+        // the path config made them look covered (#4819).
+        //
+        // Deliberately an allowlist, not `withType(AbstractTestTask)`. That would also sweep in
+        // `wasmJsBrowserTest`, `iosSimulatorArm64Test` and Android's variant tasks, each of
+        // which needs a toolchain this job does not have — turning a coverage fix into a
+        // platform-provisioning problem. The browser and iOS lanes are tracked separately.
+        jvmTestTasks: ['test', 'jvmTest'].findAll { p.tasks.findByName(it) != null },
         // `checkKotlinAbi` exists only where a module opted into `abiValidation()`. The
         // affected-tests resolver needs to know per project, because naming a task that a
         // project does not have fails the whole Gradle invocation rather than that one task.

--- a/.github/ci/affected-gradle-tests.py
+++ b/.github/ci/affected-gradle-tests.py
@@ -4,7 +4,17 @@
 Prints `full`, `none`, or a space-separated task list. Any ambiguity fails
 open to `full`; non-PR callers should bypass this script and run the full suite.
 
-Emits `:<project>:test` and, where the project has one, `:<project>:checkKotlinAbi`.
+Emits each project's headless JVM test tasks (`test` and/or `jvmTest`) and, where the
+project has one, `:<project>:checkKotlinAbi`. A task is named only where the project
+actually has it: naming one it does not have fails the entire invocation.
+
+Naming only `test` was a single-platform assumption. A Kotlin Multiplatform module calls
+its JVM tests `jvmTest` and registers no `test` task, so the graph reported "no tests"
+and this resolver emitted nothing for it. `:rc-player-compose` (25 test files),
+`:rc-player-runtime` (12), `:rc-player-protocol`, `:rc-player-trace` and
+`:slot-preview-runtime` had therefore never run in CI — `Module Unit Tests` skipped on a
+PR touching only them, while their paths sat in `ci-paths.json` making them look covered
+(#4819).
 
 The ABI half is not decoration. Every module with a published surface wires
 `checkKotlinAbi` into `check` and says in a comment that a gate is only worth having
@@ -80,8 +90,17 @@ def resolve(files: list[str], config: dict, projects: list[dict], workspace: Pat
     def task(path: str, name: str) -> str:
         return f"{path}:{name}" if path != ":" else f":{name}"
 
+    # `jvmTestTasks` is the current shape; `hasTestTask` is read as a fallback so a graph
+    # produced before that field existed still resolves `test` rather than silently
+    # resolving nothing — this script fails open everywhere else for the same reason.
+    def test_tasks(project: dict) -> list[str]:
+        names = project.get("jvmTestTasks")
+        if names is None:
+            names = ["test"] if project.get("hasTestTask") else []
+        return [task(project["path"], name) for name in names]
+
     tasks = sorted(
-        [task(p["path"], "test") for p in selected if p.get("hasTestTask")]
+        [t for p in selected for t in test_tasks(p)]
         + [task(p["path"], "checkKotlinAbi") for p in selected if p.get("hasAbiCheck")]
     )
     return " ".join(tasks) if tasks else "none"

--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -19,17 +19,26 @@ class AffectedGradleTestsTest(unittest.TestCase):
         self.root = Path(self.temp.name)
         (self.root / "core").mkdir()
         (self.root / "app").mkdir()
+        (self.root / "kmp").mkdir()
         self.projects = [
-            {"path": ":", "dir": str(self.root), "dependencies": [], "hasTestTask": False},
+            {"path": ":", "dir": str(self.root), "dependencies": [], "jvmTestTasks": []},
             {
                 "path": ":core",
                 "dir": str(self.root / "core"),
                 "dependencies": [],
-                "hasTestTask": True,
+                "jvmTestTasks": ["test"],
                 # A published module: `abiValidation()` gives it `checkKotlinAbi`.
                 "hasAbiCheck": True,
             },
-            {"path": ":app", "dir": str(self.root / "app"), "dependencies": [":core"], "hasTestTask": True},
+            {"path": ":app", "dir": str(self.root / "app"), "dependencies": [":core"], "jvmTestTasks": ["test"]},
+            # A Kotlin Multiplatform module: its JVM tests are `jvmTest` and it registers no
+            # `test` task at all, which is exactly the shape that read as "no tests".
+            {
+                "path": ":kmp",
+                "dir": str(self.root / "kmp"),
+                "dependencies": [],
+                "jvmTestTasks": ["jvmTest"],
+            },
         ]
         self.config = {"ignorePaths": ["docs/**"], "globalPaths": ["gradle/**"]}
 
@@ -55,6 +64,45 @@ class AffectedGradleTestsTest(unittest.TestCase):
     def test_a_project_without_abi_validation_is_never_given_the_task(self):
         tasks = mod.resolve(["app/src/App.kt"], self.config, self.projects, self.root).split()
         self.assertEqual(tasks, [":app:test"])
+
+    def test_a_multiplatform_module_runs_its_jvmTest(self):
+        # The regression this exists for: a KMP module names its JVM tests `jvmTest` and has no
+        # `test` task, so the graph said "no tests", this resolver emitted nothing, and
+        # `Module Unit Tests` skipped — while the module's path in `ci-paths.json` made it look
+        # covered. `:rc-player-compose` had 25 test files that had never run (#4819).
+        self.assertEqual(
+            mod.resolve(["kmp/src/Main.kt"], self.config, self.projects, self.root),
+            ":kmp:jvmTest",
+        )
+
+    def test_a_module_is_never_given_a_test_task_it_lacks(self):
+        # Same trap as `checkKotlinAbi`: naming a task a project does not have fails the entire
+        # Gradle invocation, not just that task.
+        tasks = mod.resolve(["app/src/App.kt"], self.config, self.projects, self.root).split()
+        self.assertEqual(tasks, [":app:test"])
+        self.assertNotIn(":app:jvmTest", tasks)
+
+    def test_a_module_with_both_runs_both(self):
+        # A module carrying a JVM target beside a plain `test` gets both; neither substitutes
+        # for the other, and running one would silently skip the other's suite.
+        projects = [dict(p) for p in self.projects]
+        both = next(p for p in projects if p["path"] == ":kmp")
+        both["jvmTestTasks"] = ["test", "jvmTest"]
+        self.assertEqual(
+            mod.resolve(["kmp/src/Main.kt"], self.config, projects, self.root),
+            ":kmp:jvmTest :kmp:test",
+        )
+
+    def test_a_graph_without_the_field_still_resolves_test(self):
+        # Fail-open, like every other unknown in this script: a graph produced before
+        # `jvmTestTasks` existed must not silently resolve to no tests at all.
+        legacy = [
+            {"path": ":core", "dir": str(self.root / "core"), "dependencies": [], "hasTestTask": True}
+        ]
+        self.assertEqual(
+            mod.resolve(["core/src/Core.kt"], self.config, legacy, self.root),
+            ":core:test",
+        )
 
     def test_docs_only_skips(self):
         self.assertEqual(mod.resolve(["docs/x.md"], self.config, self.projects, self.root), "none")


### PR DESCRIPTION
Acting on "fix ci workflows" (#4824). I went looking for the `:cli:serve-wasm` gap and found a much larger one behind it.

## The gap

The affected-module resolver emits `:<project>:test`. That is a single-platform assumption: **a Kotlin Multiplatform module names its JVM tests `jvmTest` and registers no `test` task at all**, so the project graph reported `hasTestTask: false`, the resolver emitted nothing, and `Module Unit Tests` skipped.

Five modules have never run a test in CI:

| Module | Test files |
| --- | --- |
| `:rc-player-compose` | 25 |
| `:rc-player-runtime` | 12 |
| `:rc-player-protocol` | 2 |
| `:rc-player-trace` | 1 |
| `:slot-preview-runtime` | — |

Their paths *are* in `ci-paths.json`, so the gate turns the job **on** and the scope resolver then empties it. That is why this reads as covered from the config alone and is observable only as a skipped job — which is exactly how it survived.

## The change

The graph now reports which of `test` / `jvmTest` a project actually has, and the resolver names each.

Deliberately an allowlist rather than `withType(AbstractTestTask)`. That would also sweep in `wasmJsBrowserTest`, `iosSimulatorArm64Test` and Android's variant tasks — each needing a toolchain this job does not have, turning a coverage fix into a platform-provisioning problem.

## Test plan

Switching on 40 never-run test files is precisely where a coverage fix turns into a red `main`, so this is verified rather than assumed:

```
./gradlew :rc-player-compose:jvmTest :rc-player-protocol:jvmTest \
          :rc-player-runtime:jvmTest :rc-player-trace:jvmTest \
          :slot-preview-runtime:jvmTest --continue
→ all pass
```

End to end against the real project graph, a change under `rc-player/compose/` now resolves:

```
:rc-player-compose:checkKotlinAbi :rc-player-compose:jvmTest :rc-player-profile:test
```

The new resolver case returns `none` against the unfixed resolver. 13 resolver tests pass, plus the other six `.github/ci` suites and all five apply-action suites.

The resolver still reads `hasTestTask` when `jvmTestTasks` is absent, so a graph produced before this field resolves `test` rather than silently resolving nothing — the fail-open contract the rest of the script follows.

## Not fixed here

**`:cli:serve-wasm` — the module that prompted this — still resolves to `none`.** Its only test task is `wasmJsBrowserTest`; the Kotlin/Wasm runner provisions a browser toolchain through yarn, which is a different problem from naming a task and needs verifying on a real runner before it gates anyone's PR. #4819 tracks it, and this PR does not close it.

So: the tests I added in #4824 still do not execute. This fixes the larger, verifiable half.

## Visual evidence

Not applicable — CI task resolution, no rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJAAraKvACDV4VxXCFZcrS)_