### PR TITLE
ci: retry the ktfmt check once, for a plugin flake that blocks merges

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -49,5 +49,36 @@ jobs:
       - uses: ./.github/actions/buildfetch-cache
         with:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      # Retried once, and only because the failure mode being retried is provably not a
+      # formatting violation.
+      #
+      # `com.ncorti.ktfmt.gradle` fails intermittently on its own scratch files:
+      #
+      #   Execution failed for task ':rc-player-trace:ktfmtCheckScripts'
+      #   > Could not read path '…/rc-player/trace/build/tmp/ktfmtCheckKmpWasmJsMain/<uuid>/<uuid>.txt'
+      #
+      # Note the mismatch — `ktfmtCheckScripts` naming `ktfmtCheckKmpWasmJsMain`'s directory.
+      # Each task writes results under `getTemporaryDir()/<random uuid>` (its OWN directory),
+      # so one task cannot legitimately name another's. What it actually shows is Gradle
+      # attributing an un-awaited worker failure to whichever task reached the barrier first,
+      # which is why both the reported task and the reported path move between runs.
+      #
+      # It is not this repository's to fix: the plugin is on 0.27.0, already the newest
+      # published version, and nothing in the build config chooses those paths.
+      #
+      # Retrying is sound here for one specific reason: an actual unformatted file is
+      # deterministic and fails both attempts, so this rescues the flake WITHOUT weakening the
+      # gate. Observed on 2026-08-29 across three unrelated branches in one hour (#11009,
+      # #11024, #11033), each cleared by a re-run of the identical commit — a merge blocker
+      # for everyone, resolved only by someone noticing and pressing the button.
+      #
+      # If this ever starts needing more than one retry, that is a different failure and the
+      # retry should come out rather than grow.
       - name: Run ktfmt check
-        run: ./gradlew ktfmtCheckAll
+        # Spelled with `if` for legibility, not necessity: under the default `bash -e` shell,
+        # `cmd && exit 0` also reaches the retry, because `-e` is exempt for every element of an
+        # AND-list but the last. Verified both spellings rather than trusting the folklore.
+        run: |
+          if ./gradlew ktfmtCheckAll; then exit 0; fi
+          echo "::warning::ktfmt check failed; retrying once (see the comment in format.yml)."
+          ./gradlew ktfmtCheckAll


### PR DESCRIPTION
The second half of "fix ci workflows" (#4824). The first is #4826.

## The flake

`com.ncorti.ktfmt.gradle` fails intermittently on its own scratch files:

```
Execution failed for task ':rc-player-trace:ktfmtCheckScripts'
> Could not read path
  '…/rc-player/trace/build/tmp/ktfmtCheckKmpWasmJsMain/<uuid>/<uuid>.txt'
```

Note the mismatch — `ktfmtCheckScripts` naming **`ktfmtCheckKmpWasmJsMain`'s** directory. Disassembling the plugin (`javap` on `KtfmtBaseTask`) shows each task writing under its *own* `getTemporaryDir()/<random uuid>`, so one task cannot legitimately name another's. What the message actually shows is Gradle attributing an **un-awaited worker failure** to whichever task reached the barrier first — which is why both the reported task and the reported path move between runs.

It is not this repository's to fix: the plugin is on **0.27.0, already the newest published version**, and nothing in the build config chooses those paths.

## Why it's worth a workflow change

Observed on 2026-08-29 across three unrelated branches within one hour — `format.yml` runs **#11009**, **#11024**, **#11033** — each cleared by re-running the identical commit.

Runs **#11009 and #11030 are the same commit on the same branch, failing then passing.** That is the nondeterminism demonstrated rather than assumed. Until someone notices and presses the button, it is a merge blocker on an unrelated PR — #11033 was mine, and I had to diagnose and re-run it by hand.

## Why retrying is not weakening the gate

One specific reason, and only that one: **an actual unformatted file is deterministic and fails both attempts.** The retry rescues the flake and nothing else.

Verified rather than reasoned about, with a stub that fails once then passes, and a second that always fails:

| case | outcome |
| --- | --- |
| flaky (fail, then pass) | retry reached → **exit 0** |
| always fails (a real violation) | retry reached → **exit 1** |

The second row is the one that matters.

## A correction worth flagging

My first draft justified `if …; then exit 0; fi` over `cmd && exit 0` by claiming the default `bash -e` shell would exit before reaching the retry. **That is wrong** — `-e` is exempt for every element of an AND-list but the last, and both spellings reach the retry. I tested both instead of trusting it, and the comment in the file now says so. A workflow file is a bad place for confident folklore.

`if` is kept purely for legibility.

## If this ever needs more than one retry

That is a different failure, and the retry should come out rather than grow. Worth reporting upstream to ktfmt-gradle either way — the worker-barrier attribution makes it look like a formatting failure when it is not, which is most of why it costs time.

## Visual evidence

Not applicable — CI workflow logic, no rendered surface.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJAAraKvACDV4VxXCFZcrS)_