### PR TITLE
ci: name the multiplatform test tasks on the full-suite path too

### DIFF
--- a/.github/actions/apply/scope-project-graph.init.gradle
+++ b/.github/actions/apply/scope-project-graph.init.gradle
@@ -61,7 +61,12 @@ if (outPath != null) {
         // `wasmJsBrowserTest`, `iosSimulatorArm64Test` and Android's variant tasks, each of
         // which needs a toolchain this job does not have — turning a coverage fix into a
         // platform-provisioning problem. The browser and iOS lanes are tracked separately.
-        jvmTestTasks: ['test', 'jvmTest'].findAll { p.tasks.findByName(it) != null },
+        // `desktopTest` is in the list because a KMP JVM target can be NAMED: a module declaring
+        // `jvm("desktop")` gets `desktopTest` and no `jvmTest`. `:samples:cmp-shared` and
+        // `:samples:design-catalog-m3-shared` are both that shape, and the latter is reachable
+        // from `:slot-preview-runtime` through the reverse closure — so it was being selected
+        // and then handed no task at all.
+        jvmTestTasks: ['test', 'jvmTest', 'desktopTest'].findAll { p.tasks.findByName(it) != null },
         // `checkKotlinAbi` exists only where a module opted into `abiValidation()`. The
         // affected-tests resolver needs to know per project, because naming a task that a
         // project does not have fails the whole Gradle invocation rather than that one task.

--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -104,6 +104,19 @@ class AffectedGradleTestsTest(unittest.TestCase):
             ":core:test",
         )
 
+    def test_a_named_jvm_target_runs_its_test_task(self):
+        # A KMP JVM target can be NAMED: `jvm("desktop")` produces `desktopTest` and no
+        # `jvmTest`. `:samples:design-catalog-m3-shared` is that shape and is reachable from
+        # `:slot-preview-runtime` through the reverse closure, so it was being selected and then
+        # handed no task at all.
+        projects = [dict(p) for p in self.projects]
+        named = next(p for p in projects if p["path"] == ":kmp")
+        named["jvmTestTasks"] = ["desktopTest"]
+        self.assertEqual(
+            mod.resolve(["kmp/src/Main.kt"], self.config, projects, self.root),
+            ":kmp:desktopTest",
+        )
+
     def test_docs_only_skips(self):
         self.assertEqual(mod.resolve(["docs/x.md"], self.config, self.projects, self.root), "none")
 
@@ -122,6 +135,18 @@ class ModuleUnitTestsGateTest(unittest.TestCase):
     job can be enabled with nothing to run. Without the gate below it invoked `gradlew none` and
     failed the PR. Asserted as text so the test needs no YAML parser.
     """
+
+    def test_the_full_branch_names_the_multiplatform_test_tasks(self):
+        """`full` is not the scoped path, and it was missing the same tasks.
+
+        Every non-PR event (push to main, the nightly cron) and every global-path PR takes the
+        `full` branch, which invokes unqualified task names. `test` alone matches only projects
+        that HAVE a `test` task — which a KMP module does not — so six modules' JVM suites were
+        absent from a run that calls itself full. Naming them here is the same mechanism
+        `checkKotlinAbi` already relies on.
+        """
+        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        self.assertIn("./gradlew test jvmTest desktopTest checkKotlinAbi --continue", ci)
 
     def test_ci_gates_module_unit_tests_on_a_non_none_task_list(self):
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,17 @@ jobs:
             # `--rerun-tasks`), that was in a container with the Kotlin/Native toolchain already
             # warm, which a fresh runner is not. Their coverage is not weakened: the macOS job runs
             # exactly these four unconditionally.
-            ./gradlew test checkKotlinAbi --continue \
+            # `jvmTest` and `desktopTest` alongside `test`, for the same reason and by the same
+            # mechanism as `checkKotlinAbi`: unqualified, so Gradle runs each in every project
+            # that HAS it and does not match the rest.
+            #
+            # `test` alone was a single-platform assumption. A Kotlin Multiplatform module names
+            # its JVM tests `jvmTest` — or `desktopTest`, when the target is declared
+            # `jvm("desktop")` — and registers no `test` task, so six modules' JVM suites were
+            # absent from a run that calls itself full. This is the branch every non-PR event
+            # takes (push to main, the nightly cron) and the one a global-path PR resolves to,
+            # so it is where the gap mattered most and was least visible.
+            ./gradlew test jvmTest desktopTest checkKotlinAbi --continue \
               -x :rc-player-trace:checkKotlinAbi \
               -x :rc-player-protocol:checkKotlinAbi \
               -x :rc-player-runtime:checkKotlinAbi \


### PR DESCRIPTION
Two review findings on #4826, **both correct and both mine** — the same single-platform assumption that PR fixed, left in two places it did not reach.

## 1. The `full` branch never ran them

[Thread](https://github.com/yschimke/compose-ai-tools/pull/4826#discussion_r3887523147)

The full branch invokes `./gradlew test checkKotlinAbi`, and unqualified `test` matches only projects that *have* a `test` task — which a KMP module does not.

So the six modules #4826 wired into the scoped path were still absent from **every push to main, every nightly cron, every global-path PR and every fail-open resolution**. The runs that call themselves full, and the ones nobody re-reads. I fixed the path that runs on PRs and left the one that runs on `main`, which is the wrong half to get right.

`jvmTest` and `desktopTest` are now named alongside `test`, by the same mechanism the existing comment already justifies for `checkKotlinAbi`.

## 2. A named JVM target has neither task

[Thread](https://github.com/yschimke/compose-ai-tools/pull/4826#discussion_r3887523152)

`jvm("desktop")` produces `desktopTest` and no `jvmTest`, so the allowlist reported nothing for `:samples:cmp-shared` and `:samples:design-catalog-m3-shared`. The second is reachable from `:slot-preview-runtime` through the reverse closure — **selected by the resolver, then handed no task at all.**

I saw `desktopTest` while building #4826 and excluded it as browser-adjacent. It is an ordinary headless JVM task, and that was simply wrong.

## Test plan

Verified before wiring, since this switches on suites that have never run:

```
./gradlew :preview-annotations:jvmTest :rc-player-compose:jvmTest \
          :rc-player-protocol:jvmTest :rc-player-runtime:jvmTest \
          :rc-player-trace:jvmTest :slot-preview-runtime:jvmTest \
          :samples:cmp-shared:desktopTest \
          :samples:design-catalog-m3-shared:desktopTest --continue
→ all pass
```

`:preview-annotations` is a **seventh module #4826 missed entirely** — it has no wasm target, so it never showed up in the search that found the others.

The full branch's exact invocation, exclusions included, was `--dry-run` to prove Gradle accepts the added names and schedules them rather than failing the whole invocation on an unmatched one:

```
:preview-annotations:jvmTest SKIPPED
:rc-player-compose:jvmTest SKIPPED
…
```

End to end against the real graph, a `:slot-preview-runtime` change now resolves:

```
:samples:cmp-shared:desktopTest :samples:design-catalog-m3-shared:desktopTest :slot-preview-runtime:jvmTest
```

**One honest gap in the guards:** the full-branch assertion fails against the unfixed `ci.yml`, but the resolver's `desktopTest` test does *not* discriminate — that gap lives in the Gradle init script, which the Python tests cannot reach. The graph evidence above is what covers it; the test only pins the resolver's half.

15 resolver tests pass, plus the other six `.github/ci` suites and all five apply-action suites.

## Visual evidence

Not applicable — CI task resolution, no rendered surface.
