### PR TITLE
fix: drop the cross-repo Dockerfile mirror check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,6 +918,18 @@ jobs:
           persist-credentials: false
           path: .compose-preview-vscode
           fetch-depth: 1
+      # Same reason, third copy: the prebuilt host image moved to yschimke/compose-preview-server,
+      # and its Dockerfile pins the `android-all-instrumented` coordinate that Kotlin here also
+      # spells. The checker SKIPS that mirror without a checkout — right for a contributor, wrong
+      # here. Unpinned like the extension above and unlike the contracts pin below: nothing in this
+      # build resolves the server as an artifact (the dependency runs the other way), so there is
+      # no version for it to agree with — only "do the two default branches still spell it alike".
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: yschimke/compose-preview-server
+          persist-credentials: false
+          path: .compose-preview-server
+          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
@@ -958,6 +970,9 @@ jobs:
           # And whose JVM reader lives in the contracts repo. Same failure mode: without this it
           # silently checks one reader instead of two.
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
+          # And whose mirrored `android-all-instrumented` coordinate lives in the server repo's
+          # image Dockerfile. Same failure mode again: without this the mirror is not checked.
+          COMPOSE_PREVIEW_SERVER_ROOT: ${{ github.workspace }}/.compose-preview-server
         run: ./gradlew :cli:build :bundle-viewer:build
 
   # End-to-end gate for the XR composite still: fetch the PINNED compositor release, then run the
@@ -1277,6 +1292,18 @@ jobs:
           persist-credentials: false
           path: .compose-preview-vscode
           fetch-depth: 1
+      # Same reason, third copy: the prebuilt host image moved to yschimke/compose-preview-server,
+      # and its Dockerfile pins the `android-all-instrumented` coordinate that Kotlin here also
+      # spells. The checker SKIPS that mirror without a checkout — right for a contributor, wrong
+      # here. Unpinned like the extension above and unlike the contracts pin below: nothing in this
+      # build resolves the server as an artifact (the dependency runs the other way), so there is
+      # no version for it to agree with — only "do the two default branches still spell it alike".
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: yschimke/compose-preview-server
+          persist-credentials: false
+          path: .compose-preview-server
+          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
@@ -1340,14 +1367,15 @@ jobs:
         env:
           COMPOSE_PREVIEW_VSCODE_ROOT: ${{ github.workspace }}/.compose-preview-vscode
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
+          COMPOSE_PREVIEW_SERVER_ROOT: ${{ github.workspace }}/.compose-preview-server
         run: |
           set -euo pipefail
           out=$(python3 scripts/test_check_daemon_launch_schema.py -v 2>&1) || { echo "$out"; exit 1; }
           echo "$out"
-          # A skipped cross-repo test reports the same green as a passing one. Two readers live
-          # outside this repository now, so either checkout failing to resolve has to be loud.
+          # A skipped cross-repo test reports the same green as a passing one. Three copies live
+          # outside this repository now, so any checkout failing to resolve has to be loud.
           if grep -q "skipped" <<<"$out"; then
-            echo "::error::cross-repo schema tests SKIPPED — COMPOSE_PREVIEW_VSCODE_ROOT or COMPOSE_PREVIEW_CONTRACTS_ROOT did not resolve"
+            echo "::error::cross-repo schema tests SKIPPED — one of COMPOSE_PREVIEW_VSCODE_ROOT, COMPOSE_PREVIEW_CONTRACTS_ROOT or COMPOSE_PREVIEW_SERVER_ROOT did not resolve"
             exit 1
           fi
       # The AdaptiveJetStream XR cell renders the sample's Subspaces with OUR compose-testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -918,18 +918,6 @@ jobs:
           persist-credentials: false
           path: .compose-preview-vscode
           fetch-depth: 1
-      # Same reason, third copy: the prebuilt host image moved to yschimke/compose-preview-server,
-      # and its Dockerfile pins the `android-all-instrumented` coordinate that Kotlin here also
-      # spells. The checker SKIPS that mirror without a checkout — right for a contributor, wrong
-      # here. Unpinned like the extension above and unlike the contracts pin below: nothing in this
-      # build resolves the server as an artifact (the dependency runs the other way), so there is
-      # no version for it to agree with — only "do the two default branches still spell it alike".
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: yschimke/compose-preview-server
-          persist-credentials: false
-          path: .compose-preview-server
-          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
@@ -970,9 +958,6 @@ jobs:
           # And whose JVM reader lives in the contracts repo. Same failure mode: without this it
           # silently checks one reader instead of two.
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
-          # And whose mirrored `android-all-instrumented` coordinate lives in the server repo's
-          # image Dockerfile. Same failure mode again: without this the mirror is not checked.
-          COMPOSE_PREVIEW_SERVER_ROOT: ${{ github.workspace }}/.compose-preview-server
         run: ./gradlew :cli:build :bundle-viewer:build
 
   # End-to-end gate for the XR composite still: fetch the PINNED compositor release, then run the
@@ -1292,18 +1277,6 @@ jobs:
           persist-credentials: false
           path: .compose-preview-vscode
           fetch-depth: 1
-      # Same reason, third copy: the prebuilt host image moved to yschimke/compose-preview-server,
-      # and its Dockerfile pins the `android-all-instrumented` coordinate that Kotlin here also
-      # spells. The checker SKIPS that mirror without a checkout — right for a contributor, wrong
-      # here. Unpinned like the extension above and unlike the contracts pin below: nothing in this
-      # build resolves the server as an artifact (the dependency runs the other way), so there is
-      # no version for it to agree with — only "do the two default branches still spell it alike".
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: yschimke/compose-preview-server
-          persist-credentials: false
-          path: .compose-preview-server
-          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
@@ -1367,15 +1340,14 @@ jobs:
         env:
           COMPOSE_PREVIEW_VSCODE_ROOT: ${{ github.workspace }}/.compose-preview-vscode
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
-          COMPOSE_PREVIEW_SERVER_ROOT: ${{ github.workspace }}/.compose-preview-server
         run: |
           set -euo pipefail
           out=$(python3 scripts/test_check_daemon_launch_schema.py -v 2>&1) || { echo "$out"; exit 1; }
           echo "$out"
-          # A skipped cross-repo test reports the same green as a passing one. Three copies live
-          # outside this repository now, so any checkout failing to resolve has to be loud.
+          # A skipped cross-repo test reports the same green as a passing one. Two readers live
+          # outside this repository now, so either checkout failing to resolve has to be loud.
           if grep -q "skipped" <<<"$out"; then
-            echo "::error::cross-repo schema tests SKIPPED — one of COMPOSE_PREVIEW_VSCODE_ROOT, COMPOSE_PREVIEW_CONTRACTS_ROOT or COMPOSE_PREVIEW_SERVER_ROOT did not resolve"
+            echo "::error::cross-repo schema tests SKIPPED — COMPOSE_PREVIEW_VSCODE_ROOT or COMPOSE_PREVIEW_CONTRACTS_ROOT did not resolve"
             exit 1
           fi
       # The AdaptiveJetStream XR cell renders the sample's Subspaces with OUR compose-testing

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -761,31 +761,6 @@ tasks.register<CheckDaemonLaunchSchema>("checkDaemonLaunchSchema") {
       )
     }
   )
-  // Not only Kotlin/TypeScript: the mirrored-constant rule reads the production image, where the
-  // sandbox-count key is a literal in `JAVA_TOOL_OPTIONS`. Without this the same up-to-date hole
-  // the source tree had would reopen for exactly the file that rule was added to cover.
-  //
-  // That image left this repository with the preview server, so it is resolved from a checkout
-  // like the two readers below — `COMPOSE_PREVIEW_SERVER_ROOT`, else a sibling
-  // `../compose-preview-server` — and simply not declared when there is none, which is the same
-  // SKIP the checker itself applies. Eagerly to a String for the configuration-cache reason given
-  // below.
-  val serverDockerfilePath: String? =
-    providers
-      .environmentVariable("COMPOSE_PREVIEW_SERVER_ROOT")
-      .orNull
-      ?.takeIf { it.isNotBlank() }
-      ?.let { File(it, "deploy/image/Dockerfile") }
-      ?.takeIf { it.isFile }
-      ?.absolutePath
-      ?: repoRoot.asFile.parentFile
-        ?.resolve("compose-preview-server/deploy/image/Dockerfile")
-        ?.takeIf { it.isFile }
-        ?.absolutePath
-  if (serverDockerfilePath != null) {
-    representations.from(serverDockerfilePath)
-  }
-
   // The TypeScript reader — the only one that GATES on the schema version — lives in
   // yschimke/compose-preview-vscode. The checker reads it from `COMPOSE_PREVIEW_VSCODE_ROOT`, else
   // a sibling checkout, and walks that tree for unregistered mirrors just as it walks this one.

--- a/scripts/check-daemon-launch-schema.py
+++ b/scripts/check-daemon-launch-schema.py
@@ -93,14 +93,6 @@ JVM_READER_REL = (
 # and this script is wired into `check`, which every contributor runs.
 TS_READER_REL = "src/daemon/daemonProtocol.ts"
 
-# The production image's Dockerfile, which passes the sandbox-count key as a literal in
-# JAVA_TOOL_OPTIONS — a mirror of a Kotlin constant that no Kotlin scan can see. It left this
-# repository with the preview server (yschimke/compose-preview-server owns the image and publishes
-# it), so it resolves from a checkout exactly as the two readers above do. A missing checkout SKIPS
-# that mirror rather than failing, for the same reason: "the other repository is not checked out"
-# is not a drift signal, and this script runs inside `check`.
-SERVER_DOCKERFILE_REL = "deploy/image/Dockerfile"
-
 
 def contracts_root() -> Path | None:
     """Root of a compose-preview-contracts checkout, or None when there is none."""
@@ -130,24 +122,8 @@ def ts_root() -> Path | None:
     return sibling if (sibling / TS_READER_REL).is_file() else None
 
 
-def server_root() -> Path | None:
-    """Root of a compose-preview-server checkout, or None when there is none."""
-    explicit = os.environ.get("COMPOSE_PREVIEW_SERVER_ROOT", "").strip()
-    if explicit:
-        root = Path(explicit).resolve()
-        if not (root / SERVER_DOCKERFILE_REL).is_file():
-            raise SystemExit(
-                f"COMPOSE_PREVIEW_SERVER_ROOT={explicit} does not contain {SERVER_DOCKERFILE_REL}"
-            )
-        return root
-    sibling = REPO_ROOT.parent / "compose-preview-server"
-    return sibling if (sibling / SERVER_DOCKERFILE_REL).is_file() else None
-
-
 _ts_root = ts_root()
 TS_READER = TS_READER_REL if _ts_root is not None else ""
-
-_server_root = server_root()
 
 _contracts_root = contracts_root()
 JVM_READER = JVM_READER_REL if _contracts_root is not None else ""
@@ -168,8 +144,6 @@ def resolve(rel: str) -> Path | None:
         return (root / rel) if root is not None else None
     if rel == JVM_READER_REL:
         return (_contracts_root / rel) if _contracts_root is not None else None
-    if rel == SERVER_DOCKERFILE_REL:
-        return (_server_root / rel) if _server_root is not None else None
     return REPO_ROOT / rel
 
 
@@ -193,9 +167,8 @@ def read(rel: str) -> str:
     path = resolve(rel)
     if path is None:
         raise FileNotFoundError(
-            f"{rel} lives in another repository; set COMPOSE_PREVIEW_VSCODE_ROOT (.ts), "
-            "COMPOSE_PREVIEW_CONTRACTS_ROOT (the JVM reader) or "
-            "COMPOSE_PREVIEW_SERVER_ROOT (the production image)"
+            f"{rel} lives in another repository; set COMPOSE_PREVIEW_VSCODE_ROOT (.ts) or "
+            "COMPOSE_PREVIEW_CONTRACTS_ROOT (the JVM reader)"
         )
     return path.read_text(encoding="utf-8")
 
@@ -1021,19 +994,6 @@ def check_mirrored_constants(allowlist: dict, failures: list[str]) -> None:
                 f"constant but is not declared there."
             )
             continue
-        # A key is not only mirrored by Kotlin constants. The production image passes
-        # `-Dcomposeai.daemon.sandboxCount=3` as a literal in its `JAVA_TOOL_OPTIONS`, so renaming
-        # the key consistently across every Kotlin copy would still leave deployed hosts setting a
-        # property nothing reads — silently falling back to a pool of one.
-        for rel in spec.get("alsoAppearsIn", []):
-            if not available(rel):
-                continue
-            if source.strip('"') not in read(rel):
-                failures.append(
-                    f"  {rel}: does not contain {source}, which it is registered as carrying for "
-                    f"`{name}`.\n    {spec['why']}"
-                )
-
         for rel in spec["mirroredBy"]:
             if not available(rel):
                 continue

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -114,10 +114,7 @@
         "daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt",
         "daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/pool/SandboxProcessPool.kt"
       ],
-      "why": "The descriptor merges this sysprop in via `withSandboxCount()` and the daemon reads it at boot; its own KDoc says 'both sides MUST agree'. Disagreement silently gives every daemon a pool of one.",
-      "alsoAppearsIn": [
-        "deploy/image/Dockerfile"
-      ]
+      "why": "The descriptor merges this sysprop in via `withSandboxCount()` and the daemon reads it at boot; its own KDoc says 'both sides MUST agree'. Disagreement silently gives every daemon a pool of one. The production image also passes the key as a JAVA_TOOL_OPTIONS literal, but that image is yschimke/compose-preview-server's and is checked THERE, against the daemon-protocol artifact that repository resolves \u2014 the version pairing that actually ships. Checking it from here would compare two default branches instead."
     }
   },
   "versionStampAliases": {

--- a/scripts/test_check_daemon_launch_schema.py
+++ b/scripts/test_check_daemon_launch_schema.py
@@ -46,14 +46,6 @@ requires_contracts_checkout = unittest.skipIf(
     "no compose-preview-contracts checkout (set COMPOSE_PREVIEW_CONTRACTS_ROOT)",
 )
 
-# And once more for the production image's Dockerfile, which left with the preview server. It
-# carries the sandbox-count key as a JAVA_TOOL_OPTIONS literal — a mirror no Kotlin scan can see —
-# so without the checkout there is nothing to assert against.
-requires_server_checkout = unittest.skipIf(
-    mod._server_root is None,
-    "no compose-preview-server checkout (set COMPOSE_PREVIEW_SERVER_ROOT)",
-)
-
 class SplitParams(unittest.TestCase):
     def test_a_generic_type_argument_comma_is_not_a_separator(self):
         # The regression that motivated the splitter: `Map<String, String>` was truncated to
@@ -403,15 +395,6 @@ class RealTree(unittest.TestCase):
             self.assertEqual(keys, set(assumed), f"{rel}: assumedTypes must cover every raw read")
             for key, expected in assumed.items():
                 self.assertEqual(writer[key][0], expected, f"{rel}: {key}")
-
-    @requires_server_checkout
-    def test_a_mirrored_key_that_lives_outside_kotlin_is_registered(self):
-        # The production image passes the sandbox-count key as a literal in JAVA_TOOL_OPTIONS. The
-        # image moved to yschimke/compose-preview-server, so this resolves against that checkout.
-        spec = self.allowlist["mirroredConstants"]["SANDBOX_COUNT_PROP"]
-        self.assertIn("deploy/image/Dockerfile", spec.get("alsoAppearsIn", []))
-        for rel in spec["alsoAppearsIn"]:
-            self.assertIn("composeai.daemon.sandboxCount", mod.read(rel))
 
     @requires_ts_checkout
     def test_a_stamp_resolves_by_package_not_by_bare_name(self):


### PR DESCRIPTION
Takes `main` back to green after #4833, by removing the cross-repo hook rather than wiring it up.

## What this replaces

The first commit on this branch added a compose-preview-server checkout to CI so the mirrored-`SANDBOX_COUNT_PROP` rule could keep asserting against that repo's image Dockerfile. That worked, but it was the wrong shape twice over, and the second commit removes the hook instead.

**It inverted the dependency.** compose-preview-server consumes this repository; this repository resolves nothing from it. Checking its source from here makes our CI red for a change in a repo we don't depend on. And the constant isn't even declared here — `declaredBy` resolves to compose-preview-**contracts**, so this repository was hosting an assertion between two *other* repositories:

| Role | Lives in |
| --- | --- |
| `declaredBy` — source of truth | compose-preview-contracts (`:daemon-protocol`) |
| `mirroredBy` — two Kotlin copies | this repository |
| `alsoAppearsIn` — the Dockerfile | compose-preview-server |

**It compared the wrong pair.** The image runs a *pinned* compose-ai-tools (`tools_version`, currently 1.53.0). Comparing the two default branches goes red when the shipped pairing is fine, and green when it isn't.

## What changes

Removed: `SERVER_DOCKERFILE_REL`, `server_root()`, the `resolve()` branch, the `read()` error arm, the `alsoAppearsIn` loop in the checker, its allowlist entry, the gated test, and the Gradle task input. The CI wiring from the first commit is reverted, so `ci.yml` ends up byte-identical to `main`.

The assertion moves to [compose-preview-server](https://github.com/yschimke/compose-preview-server), which owns the Dockerfile and can read `DaemonLaunchDescriptor.SANDBOX_COUNT_PROP` straight off the `daemon-protocol` artifact it already resolves (`server/build.gradle.kts` line 371) — no checkout, no env var, no sibling fallback, and the version pairing that actually ships. `SANDBOX_COUNT_PROP` is a `public const val` and is in the published ABI dump, so this is a supported read rather than a grep.

The allowlist's `why` now records where the image half is checked and why not here.

**The contracts checkout stays.** That direction is right — this repository consumes contracts — and it's already pinned to the release it compiles against.

## Test plan

- `python3 -m unittest discover scripts` — **140 passed, 6 skipped** (one test fewer than before; the removed one).
- **The guard's actual requirement:** with `COMPOSE_PREVIEW_CONTRACTS_ROOT` set, all 5 remaining skips are `no compose-preview-vscode checkout` and none mention the server. CI checks vscode out, so skips go to 0 and the zero-skip guard passes. This matches the #4833 CI log directly, which reported `skipped=1` with both siblings present — that 1 being the server test this PR deletes.
- `./gradlew :cli:ktfmtFormatScripts` — the build script compiles and is formatted.
- `git diff origin/main -- .github/workflows/ci.yml` is empty.

Non-visual change, so no render evidence.

## Follow-up

The vscode half is the same inversion and is tracked separately — it's a larger change, because the repo-wide scan for *unregistered* mirrors reads the allowlist registry that lives here.