### PR TITLE
docs: correct a false claim about `browse` and serve

### DIFF
--- a/docs/design/PREVIEW_SERVER_SPLIT.md
+++ b/docs/design/PREVIEW_SERVER_SPLIT.md
@@ -13,13 +13,20 @@
 > coordinate is a stronger boundary than a source scanner, so the ratchet had nothing left to
 > measure.
 >
-> Two corrections this document earns, from finishing the job. `browse` no longer touches serve at
-> all — the claim below that it "delegates to `ServeCommand` outright" aged out before the move.
-> And the eleven symbols the seam counted are not eleven server types: **ten of them contain no
-> Ktor**, being the render-host and history plumbing that `bundle render`, `render matrix` and
-> `history manifest` use offline. What the seam measured was a package boundary, not a process
-> boundary. Moving those ten into a shared module is the work that remains, tracked on
+> One correction this document earns, from finishing the job. The eleven symbols the seam counted
+> are not eleven server types: **ten of them contain no Ktor**, being the render-host and history
+> plumbing that `bundle render`, `render matrix` and `history manifest` use offline. What the seam
+> measured was a package boundary, not a process boundary. Moving those ten into a shared module is
+> the work that remains, tracked on
 > [#4732](https://github.com/yschimke/compose-ai-tools/issues/4732).
+>
+> An earlier revision of this note claimed a second correction — that `browse` no longer touches
+> serve. That was wrong, and the sentence it "corrected" was right: `BrowseCommand` still runs
+> `ServeCommand(serveArgs(args), browseProject = true)`, delegating outright. What is true, and what
+> the mistaken grep behind that claim actually showed, is narrower: `browse` names no
+> `ee.schimke.composeai.cli.serve` type *directly*. It reaches all of them through `ServeCommand`,
+> so it is still a command the server's command surface has to account for — see
+> [yschimke/compose-preview-server#9](https://github.com/yschimke/compose-preview-server/issues/9).
 >
 > Everything below is preserved as written, in the tense it was written in.
 


### PR DESCRIPTION
#4839 added a note to `docs/design/PREVIEW_SERVER_SPLIT.md` claiming `browse` no longer touches serve, and calling the document's existing sentence — that `browse` "delegates to `ServeCommand` outright" — aged out.

**The existing sentence was right.** `BrowseCommand.kt` still does:

```kotlin
ServeCommand(serveArgs(args), browseProject = true).run()
```

## Where the mistake came from

I grepped `BrowseCommand.kt` for `serve\.`-qualified types, found none, and treated that as proof. It was answering a narrower question than the sentence it was used to overturn: `browse` names no `ee.schimke.composeai.cli.serve` type **directly**, but it reaches all of them through `ServeCommand`. So `browse` is still a command that depends on the server, and still one the server's own command surface has to account for ([yschimke/compose-preview-server#9](https://github.com/yschimke/compose-preview-server/issues/9)).

The note now records the narrow true statement instead of the broad false one, and says plainly that the earlier revision was wrong — the document is a historical record, so silently deleting the claim would leave the next reader unable to tell which version to trust.

The other correction in that note is untouched and still holds: ten of the eleven crossing symbols contain no Ktor.

## Test plan

Documentation only — no code, no build, no rendered surface changes. Verified the claim against `main` at `a9f0ba4c2` (`BrowseCommand.kt:17`), and swept `docs/AGENT_GUIDE.md` and `AGENTS.md` for the same claim — it appears nowhere else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAKLRyvM392PN1FPmBmGRb)_