### PR TITLE
feat(design-artifacts): let each system project its own design map

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1578,6 +1578,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "Projecting design-map.json for '$INPUT_SYSTEM'."
+          # DELETE FIRST, so the check below proves the command RECREATED the map rather than that
+          # a map exists. In the two-catalog repo this input is for, the committed one at this path
+          # belongs to the OTHER system — so a command that succeeds but writes somewhere else (the
+          # `--out-dir` mistake, which `scripts/design-map.sh` makes easy) would leave it standing,
+          # pass a mere existence check, and publish the other system's mappings under this one's
+          # name. That is the exact failure this step exists to stop, and it would sail through.
+          # Safe because the checkout is disposable: nothing later in the job wants the committed
+          # map back, and a command that writes none fails the step anyway.
+          rm -f design-map.json
           bash -c "$DESIGN_MAP_COMMAND"
           if [ ! -f design-map.json ]; then
             echo "::error title=design-map-command wrote no map::The command ran but left no design-map.json at the repo root, which is the only path the lanes below read. Check that it projects to the root rather than to an --out-dir."

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -265,6 +265,19 @@ on:
         required: false
         type: string
         default: ''
+      design-map-command:
+        description: >-
+          Shell command that projects THIS system's `design-map.json` into the caller repo root,
+          run once before every step that reads it. Same input name and semantics as design-parity's
+          reusable workflow, and for the same reason: a repo publishing TWO catalogs from two modules
+          has one map PATH and two systems needing different maps, so without this the second system
+          is scored against the first one's map — every entry dangles and coverage publishes as 0%.
+          `system`, `spec` and `module` already vary per call; the map is the fourth thing that does.
+          Empty ⇒ the committed map is used as-is, which is right for the single-catalog repos that
+          are the common case.
+        required: false
+        type: string
+        default: ''
       preview-annotations:
         description: 'Whitespace-separated multipreview annotation names to teach the build-free spec pre-flight (e.g. "WearPreviewDevices WearPreviewFontScales"). Required whenever the previews are annotated with a multipreview declared in ANOTHER module — the source scan cannot see it, so the pre-flight reports "discovered 0 @Preview function(s)" and fails every entry. Wear catalogs always need this.'
         required: false
@@ -1533,6 +1546,55 @@ jobs:
       #
       # Fail-soft on purpose: an unrenderable reference is dropped with a warning
       # rather than costing the catalog its render.
+
+      # ONE MAP PATH, TWO SYSTEMS. Everything below reads `design-map.json` from the caller repo
+      # root, because that is the contract design-parity's action fixes (`<repoRoot>/design-map.json`)
+      # and this lane follows it. That is right for one catalog per repo and wrong the moment there
+      # are two: `wear-m3-catalog` publishes `wear-m3-catalog` from `:catalog` and `remote-m3` from
+      # `:remote-catalog` out of one checkout, so the second system was scored against the first
+      # one's map. It published `coverage.percent: 0` with all 50 gaps `dangling-mapping`, every one
+      # naming a preview from the OTHER module — not a catalog that maps nothing, a catalog compared
+      # against the wrong thing.
+      #
+      # The caller cannot fix that alone, which is the whole reason this input exists: the path is
+      # deliberately not a parameter, and the escape it leaves is that each job regenerates the map
+      # in its own workspace. design-parity's reusable workflow has taken `design-map-command` for
+      # exactly this since the same repo started publishing two sheets — so its hourly comparison
+      # was right while these artifacts were wrong, same repo, same commit.
+      #
+      # Placed here rather than beside the render: it must precede every consumer (design
+      # references, parity activity, parity findings) and nothing before this point reads the map,
+      # so a caller whose command needs a Gradle discovery pays for it only on a publishing run.
+      #
+      # The command is EXECUTED, by design — it is a build step the caller owns, like
+      # `design-map-command` next door. It reaches the shell through the environment rather than
+      # expression interpolation, so the value cannot alter the surrounding script's syntax, and it
+      # runs at the caller repo root because that is where the map it writes is read from (`spec`
+      # stays repo-root-relative for the same reason, even under `working-directory`).
+      - name: Project this system's design map
+        if: ${{ inputs.design-map-command != '' && (inputs.publish || inputs.upload-out) }}
+        env:
+          DESIGN_MAP_COMMAND: ${{ inputs.design-map-command }}
+        run: |
+          set -euo pipefail
+          echo "Projecting design-map.json for '$INPUT_SYSTEM'."
+          bash -c "$DESIGN_MAP_COMMAND"
+          if [ ! -f design-map.json ]; then
+            echo "::error title=design-map-command wrote no map::The command ran but left no design-map.json at the repo root, which is the only path the lanes below read. Check that it projects to the root rather than to an --out-dir."
+            exit 1
+          fi
+          # Worth printing: the number is what the coverage panel will publish, and a map that is
+          # suddenly a tenth of its usual size is the failure this input exists to prevent, caught
+          # here rather than inferred from a 0% board a day later.
+          node -e '
+            const m = require("./design-map.json");
+            const n = (m.components ?? []).length;
+            console.log(`design-map.json: ${n} component(s) for ${process.argv[1]}`);
+            if (n === 0) {
+              console.log("::warning title=Empty design map::The projected map has no components, so this system will publish 0% coverage.");
+            }
+          ' "$INPUT_SYSTEM"
+
       # The design-parity reference cache, if the caller maintains one. Cloned
       # rather than fetched through the API for the same reason the parity
       # workflow does it: the branch IS the cache, so `git` is the transport and

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -983,6 +983,7 @@ workspace, so it can regenerate the map before anything reads it. Pass the comma
     uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
     with:
       system: wear-m3-catalog
+      spec: catalog.spec.json
       module: ':catalog'
       design-map-command: >
         ./gradlew :catalog:composePreviewDiscover &&
@@ -992,6 +993,7 @@ workspace, so it can regenerate the map before anything reads it. Pass the comma
     uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
     with:
       system: remote-m3
+      spec: remote-catalog/catalog.spec.json
       module: ':remote-catalog'
       design-map-command: >
         ./gradlew :remote-catalog:composePreviewDiscover &&

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -965,6 +965,45 @@ in this repo, because the consumer is a catalog repo whose `design-map.json` is 
 and CI-checked: with no version to pin, a change here turns that repo red for a change
 nobody there made.
 
+#### Two catalogs in one repo: `design-map-command`
+
+The path is fixed at `<repoRoot>/design-map.json` — design-parity's action reads exactly
+that, and `design-artifacts-reusable.yml` follows it. One catalog per repo is fine. Two are
+not: `wear-m3-catalog` publishes `wear-m3-catalog` from `:catalog` and `remote-m3` from
+`:remote-catalog` out of one checkout, so whichever system does not own the committed map is
+scored against the other one's. It publishes as `coverage.percent: 0` with every gap a
+`dangling-mapping` naming a preview from the other module — which reads like a catalog that
+maps nothing rather than one compared against the wrong file.
+
+The escape the fixed path leaves is that each system is a separate job with its own
+workspace, so it can regenerate the map before anything reads it. Pass the command that does:
+
+```yaml
+  wear:
+    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
+    with:
+      system: wear-m3-catalog
+      module: ':catalog'
+      design-map-command: >
+        ./gradlew :catalog:composePreviewDiscover &&
+        scripts/design-map.sh
+
+  remote:
+    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
+    with:
+      system: remote-m3
+      module: ':remote-catalog'
+      design-map-command: >
+        ./gradlew :remote-catalog:composePreviewDiscover &&
+        scripts/design-map.sh remote-catalog
+```
+
+Same input name and meaning as design-parity's reusable workflow, which has taken it since
+that repo grew its second sheet — so the hourly parity comparison was already correct while
+the published artifacts were not. It runs at the repo root, before the design-reference and
+parity-emitter steps, and fails the run if it leaves no map there. Omit it and the committed
+map is used unchanged, which is what every single-catalog repo wants.
+
 ### Breakpoints and multipreviews: `select`, not a split `@Preview`
 
 A multipreview annotation (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`)


### PR DESCRIPTION
Fixes #4841.

`design-artifacts-reusable.yml` reads `design-map.json` from the caller repo root, unconditionally, for whichever `system` it is publishing. A repo publishing two catalogs from two modules has one map path and two systems needing different maps, so the second is scored against the first one's map.

## The symptom

`wear-m3-catalog` publishes `wear-m3-catalog` (`:catalog`) and `remote-m3` (`:remote-catalog`) from one checkout. `GET /remote-m3/parity.json` today:

```json
"coverage": { "components": 48, "mapped": 0, "unmapped": 48, "percent": 0 }
```

with **50 gaps, every one `dangling-mapping`**, each naming a preview from the *other* module:

```json
"code": "catalog/src/main/kotlin/ee/schimke/wearm3catalog/sections/Buttons.kt#ChildLabelButton"
```

That sheet's 48 components carry 28 kit-node references and their cells carry full `kitProps` vectors — regenerating its map locally resolves **198 distinct kit nodes across 19 components**. It reports 0% because it is compared against the wrong file, which on the board is indistinguishable from a catalog nobody has mapped yet.

## Why the caller cannot fix it

The path is deliberately not a parameter: design-parity's action reads `<repoRoot>/design-map.json` and this lane follows that contract. The escape the contract leaves is that each system is a separate job with its own workspace, so it can regenerate the map before anything reads it.

That is what **`design-map-command`** is for, and design-parity's own reusable workflow has taken an input by that name since the same repo grew its second sheet:

```yaml
      design-map-command: >
        ./gradlew :remote-catalog:composePreviewDiscover --stacktrace &&
        scripts/design-map.sh remote-catalog
```

So its hourly comparison has been correct while these artifacts were wrong — same repo, same commit. This adds the same input, with the same name and semantics.

## The change

- **`design-map-command` input**, default `''`. Empty keeps today's behaviour, which is right for the single-catalog repos that are the common case.
- **A step that runs it at the repo root**, gated on `publish || upload-out`, placed after the fold-in and before every consumer — design references (step 27), parity activity (28), parity findings (29), design pages (30); the new step is 25. A caller whose command needs a Gradle discovery therefore pays for it only on a publishing run.
- The command reaches the shell through `DESIGN_MAP_COMMAND` in `env:`, and the system name through the existing job-level `INPUT_SYSTEM`, per the convention stated at the top of the file — expression interpolation cannot alter the surrounding script's syntax.
- **Two failures named rather than inferred from a 0% board a day later**: a command leaving no map at the root fails the run (the likely mistake being an `--out-dir` projection), and a map projecting zero components warns, since that publishes as 0% coverage too.
- `docs/design/DESIGN_CATALOGS.md` gains a "Two catalogs in one repo" section with the worked two-job example.

## Test plan

Not a UI change — no visual evidence applies. The step body is shell + a `node -e`, so I exercised its three outcomes directly outside Actions:

```
-- case 1: command writes a real map
design-map.json: 2 component(s) for remote-m3
-- case 2: command writes an EMPTY map (the 0%-coverage failure)
design-map.json: 0 component(s) for remote-m3
WARNING: empty design map
-- case 3: command writes nothing (e.g. projected to --out-dir)
ERROR: no map written
OK: step fails as designed
```

Workflow YAML parses, the input is registered on `workflow_call`, and step ordering is asserted above against the consumer indices.

The real proof is the consumer: once this releases and `wear-m3-catalog` passes the two commands, `/remote-m3/parity.json` should move off `percent: 0` with the dangling `:catalog` mappings gone. I'll follow up there.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxnGrAmCM3y1AbrFixVcqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxnGrAmCM3y1AbrFixVcqK)_