### PR TITLE
fix: carry @CaptureGutter through the production Android daemon lane, and two catalog-declaration gaps

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
@@ -156,6 +156,33 @@ annotation class CatalogComponent(
    * `@Preview`, as before.
    */
   val motionPreview: String = "",
+  /**
+   * What this component's **non-base breakpoint** captures mean to the design kit, as
+   * `"<widthDp>=<kitAxis>=<kitValue>"` entries — e.g. `["225=Larger Screen (BP)=Yes"]`.
+   *
+   * A breakpoint capture is the one kind of cell that cannot carry `@OverrideVariant(kitAxis = …,
+   * kitValue = …)`, because it is not an annotation at all: it is the same composable drawn on a
+   * wider screen by a multipreview, folded under its component rather than promoted to one of its
+   * own. So the size reached the resolver as a bare `breakpoint=225`, a value no kit vocabulary
+   * contains, and it reported "no counterpart for `breakpoint=225`" (issue #4827).
+   *
+   * Most kits draw every screen cell at one size and have no size axis at all, which is why this is
+   * opt-in and per component: declaring nothing keeps today's behaviour, and those captures stay
+   * correctly reported as renders with no kit counterpart rather than mispaired against whatever a
+   * guess produced. Declare it only where the kit genuinely publishes screen size as a variant
+   * property — Wear M3's `Picker` set and its `Larger Screen (BP)=Yes` cells are the motivating
+   * case.
+   *
+   * The base breakpoint is unaffected: it carries the component's own matrix, and an
+   * `@OverrideVariant` cell of a non-base breakpoint stays skipped. The product of two axes is
+   * still not wanted.
+   *
+   * Travels as `key=value`-shaped strings for the same reason `@CatalogVariant.props` does —
+   * annotations cannot hold a `Map`. A malformed entry, a non-numeric width or a size this
+   * component never renders is ignored with a warning rather than failing discovery: a mis-typed
+   * mapping should cost the pairing, not the build.
+   */
+  val breakpointKit: Array<String> = [],
 )
 
 /**

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
@@ -60,9 +60,31 @@ package ee.schimke.composeai.preview
  *
  * Auto mode walks the window in frame-sized steps, so it is proportional to [maxMs]: keep the
  * default unless a reveal genuinely runs longer, and prefer an explicit [afterMs] on a component
- * whose timing you know. An animation that never ends (an `InfiniteTransition`, an indeterminate
- * progress indicator) can't quiesce, so it simply captures at the [maxMs] bound — the annotation
- * belongs on a reveal, not on a spinner.
+ * whose timing you know.
+ *
+ * ### Spinners: use an exact [afterMs], not auto
+ *
+ * An animation that never ends — an `InfiniteTransition`, an indeterminate progress indicator —
+ * cannot quiesce. Under **auto** mode it walks the whole budget, gives up, and the render records
+ * `still_changing`, forever. That is the wrong word for it: nothing failed. And because the same
+ * word is what a genuinely broken reveal gets, a consumer cannot act on either — silencing the
+ * spinner's noise silences the real diagnostic (issue #4829).
+ *
+ * An exact [afterMs] is the answer, and it is a different mechanism rather than a longer wait: a
+ * fixed coordinate on a continuous animation is deterministic, so the renderer advances once and
+ * captures, skipping the quiescence probe entirely. Both backends land on the same instant, and the
+ * render records the capture as a **phase pin** (`phasePinnedCaptures` in `<png>.warnings.json`)
+ * rather than as a failure — a positive claim a catalog can publish and assert on:
+ * ```kotlin
+ * @SettledPreview(afterMs = 600)       // "this still is the 600ms phase of a spinner"
+ * @Preview
+ * @Composable fun CircularProgressIndeterminate() = Sticker { CircularProgressIndicator() }
+ * ```
+ *
+ * So: **auto belongs on a reveal; an exact [afterMs] belongs on either** — on a reveal whose timing
+ * you know, and on a spinner, where it is the only way to say which phase you meant. Leaving a
+ * never-ending animation on auto is the case with nowhere to go, and the one this section exists to
+ * redirect.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)

--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
@@ -72,9 +72,8 @@ package ee.schimke.composeai.preview
  *
  * An exact [afterMs] is the answer, and it is a different mechanism rather than a longer wait: a
  * fixed coordinate on a continuous animation is deterministic, so the renderer advances once and
- * captures, skipping the quiescence probe entirely. Both backends land on the same instant, and the
- * render records the capture as a **phase pin** (`phasePinnedCaptures` in `<png>.warnings.json`)
- * rather than as a failure — a positive claim a catalog can publish and assert on:
+ * captures, skipping the quiescence probe entirely. Both backends land on the same instant, and
+ * neither reports a failed settle for it:
  * ```kotlin
  * @SettledPreview(afterMs = 600)       // "this still is the 600ms phase of a spinner"
  * @Preview
@@ -85,6 +84,14 @@ package ee.schimke.composeai.preview
  * you know, and on a spinner, where it is the only way to say which phase you meant. Leaving a
  * never-ending animation on auto is the case with nowhere to go, and the one this section exists to
  * redirect.
+ *
+ * **On Android**, both lanes additionally record the capture as a machine-readable **phase pin** —
+ * `phasePinnedCaptures` in `<png>.warnings.json` — so a catalog can publish "this still is a
+ * deliberately chosen phase" and assert on it, as distinct from `unsettledCaptures`, which is a bug
+ * report. The Compose Desktop lanes land on the same instant but emit no such record: they have no
+ * `.warnings.json` writer at all today (`RenderWarningsSidecar` is Android-only, and
+ * `DesktopRendererMain` only knows the suffix in order to sweep it). A desktop-only catalog
+ * therefore gets the correct pixels and no published claim about them.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -1288,6 +1288,7 @@ class RenderEngine(
       fontFallbacks,
       CoilLoadDiagnostics.drainPreview(),
       ee.schimke.composeai.renderer.VisualSettleDiagnostics.drainPreview(),
+      ee.schimke.composeai.renderer.VisualSettleDiagnostics.drainPinned(),
     )
 
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -734,16 +734,20 @@ class RenderEngine(
             // rather than extending it — otherwise the same `afterMs` would mean one instant on
             // desktop, another 32ms later here. Auto mode has only a bound to walk, so it keeps
             // the default underneath. Mirrors `RobolectricRenderTest`'s `settleTargetMs`.
-            val settleTargetMs =
-              spec.previewId
-                ?.let { loadPreviewIndexLazily().staticSettleFor(it) }
-                ?.let {
-                  settleCaptureTargetMs(
-                    afterMs = it.afterMs,
-                    maxMs = it.maxMs,
-                    captureAdvanceMs = CAPTURE_ADVANCE_MS,
-                  )
-                }
+            val staticSettle = spec.previewId?.let { loadPreviewIndexLazily().staticSettleFor(it) }
+            val settleTargetMs = staticSettle?.let {
+              settleCaptureTargetMs(
+                afterMs = it.afterMs,
+                maxMs = it.maxMs,
+                captureAdvanceMs = CAPTURE_ADVANCE_MS,
+              )
+            }
+            // Whether that coordinate came from `@SettledPreview(afterMs = …)` rather than auto
+            // mode. `settleCaptureTargetMs` collapses both into one number, so the capture branch
+            // below cannot tell them apart without this — and it must, because an exact coordinate
+            // is a chosen instant the quiescence probe would move off. Mirrors
+            // `RobolectricRenderTest`'s `hasExactSettle` / `shouldAdvanceClockForVisualSettling`.
+            val hasExactSettle = (staticSettle?.afterMs ?: 0) > 0
             // Through the same frame split the batch renderer uses, so a coordinate that is not a
             // multiple of 16ms lands on the coordinate here too rather than a frame past it —
             // otherwise a live `compose-preview serve` frame and the published PNG would disagree
@@ -867,7 +871,16 @@ class RenderEngine(
               // An explicit captureAdvanceMs selects an exact animation phase. Sampling later
               // frames would silently move that snapshot by 16–64ms, so only default-timed daemon
               // stills use adaptive settling.
-              if (spec.captureAdvanceMs == null) {
+              //
+              // `@SettledPreview(afterMs = …)` is the same promise written a different way, and
+              // was missing here (issue #4829): the clock advanced to the declared coordinate
+              // above and then the probe walked up to five more frames off it, so a live daemon
+              // frame disagreed with the published PNG for exactly the previews that named an
+              // exact instant — and an indeterminate animation, which cannot quiesce, was reported
+              // `still_changing` on the lane that serves live catalog renders. Same split as
+              // #4822: the batch renderer had the guard (`shouldAdvanceClockForVisualSettling`),
+              // this lane did not.
+              if (spec.captureAdvanceMs == null && !hasExactSettle) {
                 val visuallySettled =
                   ee.schimke.composeai.renderer.captureVisuallySettledFrame(
                     file = outputFile,
@@ -883,6 +896,17 @@ class RenderEngine(
                 )
               } else {
                 capture(outputFile)
+                // The positive claim, on this lane too. Without it `drainPinned` below is always
+                // empty for a daemon render and a pinned spinner stays indistinguishable from an
+                // ordinary static preview — the gap this issue exists to close.
+                if (spec.captureAdvanceMs == null && hasExactSettle) {
+                  settleTargetMs?.let {
+                    ee.schimke.composeai.renderer.VisualSettleDiagnostics.recordPinnedPhase(
+                      "compose-ai-daemon still '${spec.outputBaseName}'",
+                      it,
+                    )
+                  }
+                }
               }
             }
             System.err.println(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1280,6 +1280,27 @@ open class RobolectricHost(
       (inbound["orientation"] ?: base.orientation?.name?.lowercase())?.let {
         append("orientation=").append(it).append(';')
       }
+      // `@CaptureGutter` (#4443) — four dp edges in start,top,end,bottom order, mirroring
+      // [PreviewManifestRouter]. Without this the string round-trip drops the gutter silently:
+      // `RenderSpec.parseFromPayloadOrNull` defaults every edge to 0, so the sandbox composed at
+      // the un-guttered size and every override-driven render came back clipped to the
+      // composable's own frame (#4822). The router is the harness lane; this is the lane the
+      // production bundle daemon and `compose-preview serve` actually take.
+      //
+      // Deliberately NOT traded with the wrap flags on a rotation, for the reason the router
+      // states: a wrap flag names an axis of the frame, a gutter edge names a direction the
+      // component draws in, and a `widthPx ↔ heightPx` swap does not move where a shadow falls.
+      if (base.hasCaptureGutter()) {
+        append("captureGutter=")
+          .append(base.gutterStartDp)
+          .append(',')
+          .append(base.gutterTopDp)
+          .append(',')
+          .append(base.gutterEndDp)
+          .append(',')
+          .append(base.gutterBottomDp)
+          .append(';')
+      }
       inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
       (inbound["inspectionMode"] ?: base.inspectionMode?.toString())?.let {
         append("inspectionMode=").append(it).append(';')

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidCaptureGutterLaneTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidCaptureGutterLaneTest.kt
@@ -88,6 +88,61 @@ class AndroidCaptureGutterLaneTest {
   }
 
   @Test
+  fun `the host-side reshape carries the gutter, which is the lane production takes`() {
+    // The router below is the harness lane. The Android bundle daemon and `compose-preview serve`
+    // never mount one: they resolve `previewId=…` through `RobolectricHost.reshapeRenderPayload`,
+    // which re-serialises the spec into a payload string. That round-trip dropped the gutter
+    // (#4822) — and dropped it silently, because `parseFromPayloadOrNull` defaults every edge to
+    // 0 — so any override that forced a request off the baked lane (a theme, a knob, a Remote
+    // Compose seed) came back clipped to the composable's own frame.
+    val host =
+      RobolectricHost(
+        previewSpecResolver = {
+          RenderSpec(
+            previewId = it,
+            className = "com.example.FooKt",
+            functionName = "Foo",
+            widthPx = 384,
+            heightPx = 128,
+            density = 2.0f,
+            gutterStartDp = 0,
+            gutterTopDp = 8,
+            gutterEndDp = 0,
+            gutterBottomDp = 8,
+          )
+        }
+      )
+
+    val reshaped = host.reshapeRenderPayload("previewId=media-podcastcontrolbuttons;uiMode=light")
+    val spec = RenderSpec.parseFromPayloadOrNull(reshaped)
+
+    assertNotNull("reshaped payload must remain a parseable RenderSpec: $reshaped", spec)
+    assertTrue("the gutter must survive the string round-trip", spec!!.hasCaptureGutter())
+    assertEquals(0, spec.gutterStartDp)
+    assertEquals(8, spec.gutterTopDp)
+    assertEquals(0, spec.gutterEndDp)
+    assertEquals(8, spec.gutterBottomDp)
+    // 8+8 dp down at density 2 ⇒ 32 px, the difference between the reported 384×160 baked render
+    // and the 384×128 the live daemon was returning.
+    assertEquals(0, spec.gutterHorizontalPx())
+    assertEquals(32, spec.gutterVerticalPx())
+  }
+
+  @Test
+  fun `the host-side reshape emits no gutter token for an un-annotated preview`() {
+    // A payload for a preview that declares no gutter must be byte-identical to what it was before
+    // the token existed — the same guarantee the router makes.
+    val host =
+      RobolectricHost(
+        previewSpecResolver = {
+          RenderSpec(previewId = it, className = "com.example.FooKt", functionName = "Foo")
+        }
+      )
+
+    assertTrue(!host.reshapeRenderPayload("previewId=plain").contains("captureGutter="))
+  }
+
+  @Test
   fun `the router resolves a manifest-declared gutter and omits an absent one`() {
     val entry =
       PreviewManifestEntry(

--- a/design-map/README.md
+++ b/design-map/README.md
@@ -156,6 +156,23 @@ one-to-one onto distinct device widths are a size axis and one of them can be pi
 - the sizes the base did not take **fold under it as cells**, seeded `breakpoint=<dp>` and named
   `<dp>dp`, so they are published rather than discarded.
 
+A bare `breakpoint=<dp>` is a value no kit vocabulary contains, so such a cell resolves against
+nothing — correctly, for the majority of kits, which draw every screen cell at one size and have no
+size axis at all. Where a kit *does* publish screen size as a variant property, the component says
+so:
+
+```kotlin
+@CatalogComponent(id = "Picker", breakpointKit = ["225=Larger Screen (BP)=Yes"])
+```
+
+and the 225dp cell is seeded `breakpoint=225` with `kitAxis`/`kitValue` attached, pairing with the
+kit node the picture was always there for. It is a per-component declaration rather than a
+per-run flag because it is a property of one component's kit set, not of the catalog; a size the
+component never draws, or a malformed entry, keeps the bare seed and is reported unresolved rather
+than mispaired. A breakpoint capture is the one kind of cell that cannot carry `@OverrideVariant
+(kitAxis = …)` itself — it is not an annotation at all — which is why the mapping lives on the
+component.
+
 Two captures of the *same* width are still a mode, whatever devices they name: nothing orders them,
 so they stay `ambiguousMode`. An `@OverrideVariant` cell rides the base breakpoint only — the
 product of both axes would multiply the sheet by every size, and the base carries the matrix.

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -511,27 +511,53 @@ export function declarationMisses(preview) {
  * is on the FIRST TWO separators only — `String.split("=")` with a limit would drop the tail.
  *
  * A malformed entry, a non-numeric width or a width this component never renders yields `null`,
- * which restores the bare `breakpoint=<width>` seed. That is the honest degradation: a mistyped
- * mapping should cost the pairing, not silently pair the render against the wrong kit cell.
+ * which restores the bare `breakpoint=<width>` seed. That is the honest degradation — a mistyped
+ * mapping should cost the pairing, not silently pair the render against the wrong kit cell — but
+ * it must not be *silent*: degrading quietly leaves a typo indistinguishable from a deliberately
+ * undeclared mapping, and the only symptom is a generic pairing miss much further downstream. So
+ * a malformed entry is pushed onto [malformed] and reported as `diagnostics.invalidBreakpointKit`,
+ * the same way an unresolvable mode is reported rather than guessed at.
+ *
+ * "Malformed" is only about the entry's *shape*. An entry that is well-formed but names a width
+ * this particular capture is not — the common case, since one declaration serves every size — is
+ * not a fault and is not reported.
  */
-export function breakpointKitNames(entries, widthDp) {
+export function breakpointKitNames(entries, widthDp, malformed = []) {
   for (const entry of entries ?? []) {
-    if (typeof entry !== "string") continue;
+    if (typeof entry !== "string") {
+      malformed.push({ entry: String(entry), reason: "not a string" });
+      continue;
+    }
     const firstEq = entry.indexOf("=");
-    if (firstEq < 0) continue;
-    const secondEq = entry.indexOf("=", firstEq + 1);
-    if (secondEq < 0) continue;
-    const width = Number(entry.slice(0, firstEq).trim());
-    if (!Number.isFinite(width) || width !== widthDp) continue;
+    const secondEq = firstEq < 0 ? -1 : entry.indexOf("=", firstEq + 1);
+    if (secondEq < 0) {
+      malformed.push({ entry, reason: "expected <widthDp>=<kitAxis>=<kitValue>" });
+      continue;
+    }
+    const rawWidth = entry.slice(0, firstEq).trim();
+    const width = Number(rawWidth);
+    if (rawWidth === "" || !Number.isFinite(width)) {
+      malformed.push({ entry, reason: `width '${rawWidth}' is not a number` });
+      continue;
+    }
     const kitAxis = entry.slice(firstEq + 1, secondEq).trim();
     const kitValue = entry.slice(secondEq + 1).trim();
-    if (!kitAxis || !kitValue) continue;
+    if (!kitAxis || !kitValue) {
+      malformed.push({ entry, reason: "kitAxis and kitValue must both be non-empty" });
+      continue;
+    }
+    // Well-formed but for another size: not a fault, and the overwhelmingly common case.
+    if (width !== widthDp) continue;
     return { kitAxis, kitValue };
   }
   return null;
 }
 
-export function variantRendersByComponent(previews, selection = selectCaptures(previews)) {
+export function variantRendersByComponent(
+  previews,
+  selection = selectCaptures(previews),
+  invalidBreakpointKit = [],
+) {
   const byComponent = new Map();
   for (const preview of previews) {
     const catalog = preview.catalog;
@@ -572,7 +598,11 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
       // Opt-in and per component, because most kits draw every screen cell at one size and have no
       // size axis at all. Declaring nothing keeps the bare seed, so those captures stay honestly
       // reported as renders with no kit counterpart rather than mispaired.
-      const kit = breakpointKitNames(catalog.breakpointKit, widthDp);
+      const malformed = [];
+      const kit = breakpointKitNames(catalog.breakpointKit, widthDp, malformed);
+      for (const bad of malformed) {
+        invalidBreakpointKit.push({ componentId: catalog.componentId, ...bad });
+      }
       const seeds = [
         {
           key: "breakpoint",
@@ -632,7 +662,8 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
  */
 export function projectDesignMap(previews, opts = {}) {
   const selection = selectCaptures(previews, { baseBreakpointDp: opts.baseBreakpointDp });
-  const variantRenders = variantRendersByComponent(previews, selection);
+  const invalidBreakpointKit = [];
+  const variantRenders = variantRendersByComponent(previews, selection, invalidBreakpointKit);
 
   const components = [];
   const declarations = [];
@@ -797,6 +828,16 @@ export function projectDesignMap(previews, opts = {}) {
           !referencelessSubjects.has(a.subject) &&
           (!a.componentIds.length || a.componentIds.some((id) => !referencelessIds.has(id))),
       ),
+      // `@CatalogComponent(breakpointKit = …)` entries that do not parse. Reported rather than
+      // dropped: the degradation is to the bare `breakpoint=<dp>` seed, which is exactly what an
+      // undeclared component produces, so a typo would otherwise be invisible until someone
+      // wondered why a kit cell never paired. Deduplicated — one declaration is re-read once per
+      // non-base capture of the component, and the same typo is one fault, not four.
+      invalidBreakpointKit: [
+        ...new Map(
+          invalidBreakpointKit.map((e) => [`${e.componentId}\u0000${e.entry}`, e]),
+        ).values(),
+      ],
       variantRenders: declarations.reduce((n, d) => n + d.renders.length, 0),
       withSet: components.filter((c) => c.refSet).length,
     },

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -503,6 +503,34 @@ export function declarationMisses(preview) {
  * this projection, which is why a FAB size axis read as unauthored while `FabSmall`/`FabMedium`/
  * `FabLarge` sat in the catalog all along.
  */
+/**
+ * The kit axis/value a component declares for a non-base breakpoint width, or `null`.
+ *
+ * [entries] are `@CatalogComponent.breakpointKit` strings, `"<widthDp>=<kitAxis>=<kitValue>"`. The
+ * `kitValue` half may itself contain `=` (a kit is free to name a cell `Size=Large`), so the split
+ * is on the FIRST TWO separators only — `String.split("=")` with a limit would drop the tail.
+ *
+ * A malformed entry, a non-numeric width or a width this component never renders yields `null`,
+ * which restores the bare `breakpoint=<width>` seed. That is the honest degradation: a mistyped
+ * mapping should cost the pairing, not silently pair the render against the wrong kit cell.
+ */
+export function breakpointKitNames(entries, widthDp) {
+  for (const entry of entries ?? []) {
+    if (typeof entry !== "string") continue;
+    const firstEq = entry.indexOf("=");
+    if (firstEq < 0) continue;
+    const secondEq = entry.indexOf("=", firstEq + 1);
+    if (secondEq < 0) continue;
+    const width = Number(entry.slice(0, firstEq).trim());
+    if (!Number.isFinite(width) || width !== widthDp) continue;
+    const kitAxis = entry.slice(firstEq + 1, secondEq).trim();
+    const kitValue = entry.slice(secondEq + 1).trim();
+    if (!kitAxis || !kitValue) continue;
+    return { kitAxis, kitValue };
+  }
+  return null;
+}
+
 export function variantRendersByComponent(previews, selection = selectCaptures(previews)) {
   const byComponent = new Map();
   for (const preview of previews) {
@@ -535,7 +563,24 @@ export function variantRendersByComponent(previews, selection = selectCaptures(p
     if (!isOverrideVariant && !isCatalogVariant) {
       const widthDp = catalog.role === "COMPONENT" ? selection.breakpointOf(preview) : null;
       if (widthDp === null) continue;
-      const seeds = [{ key: "breakpoint", raw: String(widthDp) }];
+      // `@CatalogComponent(breakpointKit = ["225=Larger Screen (BP)=Yes"])` says what this size
+      // MEANS to the kit. Without it the seed is a bare `breakpoint=225` — a value no kit
+      // vocabulary contains — and the resolver can only report "no counterpart for
+      // `breakpoint=225`", even where the kit publishes the very cells the render would pair with
+      // (issue #4827).
+      //
+      // Opt-in and per component, because most kits draw every screen cell at one size and have no
+      // size axis at all. Declaring nothing keeps the bare seed, so those captures stay honestly
+      // reported as renders with no kit counterpart rather than mispaired.
+      const kit = breakpointKitNames(catalog.breakpointKit, widthDp);
+      const seeds = [
+        {
+          key: "breakpoint",
+          raw: String(widthDp),
+          ...(kit?.kitAxis ? { kitAxis: kit.kitAxis } : {}),
+          ...(kit?.kitValue ? { kitValue: kit.kitValue } : {}),
+        },
+      ];
       const list = byComponent.get(catalog.componentId) ?? [];
       list.push({ previewId: preview.id, name: `${widthDp}dp`, seeds });
       byComponent.set(catalog.componentId, list);

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -911,6 +911,45 @@ test("an undeclared size keeps its bare seed, so it is reported unresolved rathe
   ]);
 });
 
+test("a malformed breakpointKit entry is reported, not silently ignored", () => {
+  // The degradation for a typo is the bare `breakpoint=<dp>` seed — which is exactly what an
+  // undeclared component produces — so without a diagnostic a mistyped mapping is invisible until
+  // someone wonders why a kit cell never paired.
+  const { variants, diagnostics } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)", "oops=Axis=Yes", "225==Yes"],
+    }),
+  ]);
+  assert.deepEqual(
+    diagnostics.invalidBreakpointKit.map((e) => e.entry).sort(),
+    ["225==Yes", "225=Larger Screen (BP)", "oops=Axis=Yes"],
+  );
+  assert.equal(diagnostics.invalidBreakpointKit[0].componentId, "Picker");
+  // …and the cell still degrades to the bare seed rather than pairing against a guess.
+  assert.deepEqual(variants.components[0].renders.find((r) => r.name === "225dp").seeds, [
+    { key: "breakpoint", raw: "225" },
+  ]);
+});
+
+test("a well-formed entry for another size is not a fault", () => {
+  // One declaration serves every size, so it is re-read at each non-base capture. A 240dp capture
+  // reading a 225dp declaration is the ordinary case, not a typo.
+  const { diagnostics } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)=Yes"],
+    }),
+    atWidth("Picker", 240, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)=Yes"],
+    }),
+  ]);
+  assert.deepEqual(diagnostics.invalidBreakpointKit, []);
+});
+
 test("a themed pair is still a mode, never a breakpoint — neither capture names a device", () => {
   const { diagnostics } = projectDesignMap([
     { ...component("Themed", { reference: ref("1:2") }), id: "com.example.CatalogKt.Themed_Dark" },

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -879,6 +879,38 @@ test("the sizes the base did not take fold under it as cells, seeded with their 
   ]);
 });
 
+test("a breakpoint cell names its kit axis when the component declares one", () => {
+  // #4827. The kit's `Picker` set publishes `Larger Screen (BP)=Yes` cells, and the catalog already
+  // renders the picture — it was just handed to the resolver as a bare `breakpoint=225`, a value no
+  // kit vocabulary contains, so 21 published kit cells sat uncompared.
+  const { variants } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)=Yes"],
+    }),
+  ]);
+  assert.deepEqual(variants.components[0].renders.find((r) => r.name === "225dp").seeds, [
+    { key: "breakpoint", raw: "225", kitAxis: "Larger Screen (BP)", kitValue: "Yes" },
+  ]);
+});
+
+test("an undeclared size keeps its bare seed, so it is reported unresolved rather than mispaired", () => {
+  // The majority case: a kit that draws every screen cell at one size has no size axis at all, and
+  // the other unresolved breakpoint captures are CORRECTLY unresolved. Guessing an axis for them
+  // would pair a render against a kit cell that does not describe it.
+  const { variants } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 240, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)=Yes"],
+    }),
+  ]);
+  assert.deepEqual(variants.components[0].renders.find((r) => r.name === "240dp").seeds, [
+    { key: "breakpoint", raw: "240" },
+  ]);
+});
+
 test("a themed pair is still a mode, never a breakpoint — neither capture names a device", () => {
   const { diagnostics } = projectDesignMap([
     { ...component("Themed", { reference: ref("1:2") }), id: "com.example.CatalogKt.Themed_Dark" },

--- a/docs/RENDER_LANE_PARITY.md
+++ b/docs/RENDER_LANE_PARITY.md
@@ -276,6 +276,18 @@ daemon rows use their own smaller fixtures (`DesktopCaptureGutterLaneTest`,
 `AndroidCaptureGutterLaneTest`) at density 2 and 1 respectively; each Δ is the declared dp
 resolved at that render's own density, which is the arithmetic every lane shares.
 
+Both daemon rows are measured through a `PreviewManifestRouter`, which is the harness lane. The
+lane production takes is the host-side payload reshape — the Android bundle daemon and
+`compose-preview serve` never mount a router; they resolve `previewId=…` through
+`RobolectricHost.reshapeRenderPayload` (desktop: `DesktopHost.specFromPreviewIdPayload`). That
+distinction is not academic: the Android reshape re-serialises the spec into a payload *string* and
+omitted the `captureGutter=` token, so every override-driven render came back clipped while the
+router fixture stayed green
+([#4822](https://github.com/yschimke/compose-ai-tools/issues/4822)). `AndroidCaptureGutterLaneTest`
+now drives `reshapeRenderPayload` directly as well, so the production lane is under test and not
+only the one the parity table measures. Desktop was never exposed: it does `base.copy(…)` and never
+round-trips through a string.
+
 The motion row is the one that used to disagree. Frame 0 of the fixture's `@AnimatedPreview`,
 before and after, against the guttered still's canvas (pink outline):
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1089,6 +1089,16 @@ data class CatalogEntry(
    */
   val perBreakpoint: Boolean = false,
   /**
+   * COMPONENT only: `@CatalogComponent.breakpointKit` — what this component's non-base breakpoint
+   * captures mean to the design kit, as `"<widthDp>=<kitAxis>=<kitValue>"` entries.
+   *
+   * Carried verbatim rather than parsed here: `design-map.mjs` is the only consumer, the projector
+   * already owns every other seed-naming rule, and parsing in two places is how the two come to
+   * disagree. Empty ⇒ a breakpoint capture is seeded with its bare width, exactly as before
+   * (issue #4827).
+   */
+  val breakpointKit: List<String> = emptyList(),
+  /**
    * COMPONENT only: `@CatalogComponent.motionPreview` — the exact `@Preview` function name whose
    * animated/interaction captures publish on this component, when the recording lives on a function
    * of its own (an `@OverrideVariant` fan-out that would duplicate it, or a pinned motion canvas

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1217,6 +1217,7 @@ object PreviewDiscovery {
       kitAxis = annStringOrNull(component, "kitAxis"),
       motionPreview = annStringOrNull(component, "motionPreview"),
       perBreakpoint = annBoolean(component, "perBreakpoint"),
+      breakpointKit = annStringArray(component, "breakpointKit"),
     )
   }
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -153,6 +153,43 @@ class PreviewDataTest {
   }
 
   @Test
+  fun `breakpointKit round-trips, and is absent for a component that declares none`() {
+    // #4827. A breakpoint capture is the one kind of cell that cannot carry
+    // `@OverrideVariant(kitAxis = …)` — it is not an annotation at all, just the same composable
+    // drawn wider by a multipreview — so the mapping rides on the component and reaches
+    // `design-map.mjs` through here.
+    val declared =
+      PreviewInfo(
+        id = "test.Picker_wearos_225",
+        functionName = "Picker",
+        className = "test.CatalogKt",
+        catalog =
+          CatalogEntry(
+            role = CatalogRole.COMPONENT,
+            componentId = "Picker",
+            breakpointKit = listOf("225=Larger Screen (BP)=Yes"),
+          ),
+      )
+    val undeclared =
+      PreviewInfo(
+        id = "test.Button_wearos_225",
+        functionName = "Button",
+        className = "test.CatalogKt",
+        catalog = CatalogEntry(role = CatalogRole.COMPONENT, componentId = "Button"),
+      )
+    val manifest =
+      PreviewManifest(module = "app", variant = "debug", previews = listOf(declared, undeclared))
+
+    val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
+
+    assertThat(decoded.previews[0].catalog?.breakpointKit)
+      .containsExactly("225=Larger Screen (BP)=Yes")
+    // Empty rather than null, and empty is what keeps the bare `breakpoint=<dp>` seed — the
+    // majority case, where the kit has no size axis and the capture is correctly unresolved.
+    assertThat(decoded.previews[1].catalog?.breakpointKit).isEmpty()
+  }
+
+  @Test
   fun `a whole kit assignment round-trips through the preview manifest`() {
     // The coupled-axis case: the Wear kit's `Button` set has no
     // `Icon=Yes, Icon size=n/a, Alignment=Center` node, so the cell that lands on a real one turns

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderWarningsSidecar.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RenderWarningsSidecar.kt
@@ -17,6 +17,13 @@ import okio.Path.Companion.toPath
  * - a still capture's quiescence probe ran out its sample budget (see [VisualSettleDiagnostics]),
  *   so the PNG is a half-drawn frame or the frame before a reveal that hadn't started.
  *
+ * It also carries one thing that is **not** a warning: `phasePinnedCaptures`, a still taken at an
+ * author-declared `@SettledPreview(afterMs = …)` coordinate. It rides here because it is the answer
+ * to the same question a consumer asks of `unsettledCaptures` — "is this still trustworthy?" — and
+ * the two are only useful together: without it, a spinner pinned to a deliberate phase and an
+ * ordinary static preview are indistinguishable, so a catalog that wants to assert its renders are
+ * settled has nothing to assert against (issue #4829).
+ *
  * Either way the PNG is kept and the warning rides alongside it.
  *
  * Hand-rolled JSON for the same reason as [RenderErrorSidecar]: the renderer-android runtime
@@ -37,10 +44,14 @@ object RenderWarningsSidecar {
   fun pathFor(pngFile: File): File = File(pngFile.parentFile, pngFile.name + ".warnings.json")
 
   /**
-   * Write [fallbacks], [imageLoads] and [unsettled] as the warnings sidecar for [pngFile], or
-   * delete any stale sidecar when all three are empty (a now-clean render must not keep yesterday's
+   * Write [fallbacks], [imageLoads], [unsettled] and [pinned] as the sidecar for [pngFile], or
+   * delete any stale sidecar when all four are empty (a now-clean render must not keep yesterday's
    * warning). Best-effort — a write failure prints to stderr but never derails the render,
    * mirroring [RenderErrorSidecar].
+   *
+   * [pinned] counts towards writing the file even though it is not a warning: it is a positive
+   * claim a consumer can assert on, and withholding it whenever the render was otherwise clean
+   * would make it available only on previews that also had something wrong with them.
    */
   @JvmOverloads
   fun writeOrDelete(
@@ -48,9 +59,10 @@ object RenderWarningsSidecar {
     fallbacks: List<FontResolutionDiagnostics.FontFallback>,
     imageLoads: List<CoilLoadDiagnostics.UnresolvedLoad> = emptyList(),
     unsettled: List<VisualSettleDiagnostics.UnsettledCapture> = emptyList(),
+    pinned: List<VisualSettleDiagnostics.PinnedCapture> = emptyList(),
     fileSystem: FileSystem = SystemFileSystem,
   ) {
-    if (fallbacks.isEmpty() && imageLoads.isEmpty() && unsettled.isEmpty()) {
+    if (fallbacks.isEmpty() && imageLoads.isEmpty() && unsettled.isEmpty() && pinned.isEmpty()) {
       deleteStale(pngFile)
       return
     }
@@ -58,7 +70,7 @@ object RenderWarningsSidecar {
       val sidecar = pathFor(pngFile)
       sidecar.parentFile?.mkdirs()
       fileSystem.write(sidecar.path.toPath()) {
-        writeUtf8(encode(fallbacks, imageLoads, unsettled))
+        writeUtf8(encode(fallbacks, imageLoads, unsettled, pinned))
       }
     } catch (writeFailure: Throwable) {
       System.err.println(
@@ -76,14 +88,16 @@ object RenderWarningsSidecar {
   /**
    * The JSON body. Pure + internal so a unit test can assert the shape without touching disk.
    *
-   * `unresolvedImages` and `unsettledCaptures` are additive: a reader that only knows about
-   * `fontFallbacks` (every reader that predates issue #2952) keeps working unchanged, and an empty
-   * array is still written when there are no warnings of that kind so the shape is stable.
+   * `unresolvedImages`, `unsettledCaptures` and `phasePinnedCaptures` are additive: a reader that
+   * only knows about `fontFallbacks` (every reader that predates issue #2952) keeps working
+   * unchanged, and an empty array is still written when there are none of that kind so the shape is
+   * stable.
    */
   internal fun encode(
     fallbacks: List<FontResolutionDiagnostics.FontFallback>,
     imageLoads: List<CoilLoadDiagnostics.UnresolvedLoad> = emptyList(),
     unsettled: List<VisualSettleDiagnostics.UnsettledCapture> = emptyList(),
+    pinned: List<VisualSettleDiagnostics.PinnedCapture> = emptyList(),
   ): String {
     val sb = StringBuilder()
     sb.append('{')
@@ -118,6 +132,16 @@ object RenderWarningsSidecar {
       sb.append("\"role\":").append(jsonString(capture.role)).append(',')
       sb.append("\"outcome\":").append(jsonString(capture.outcome.name.lowercase())).append(',')
       sb.append("\"samples\":").append(capture.samples).append(',')
+      sb.append("\"message\":").append(jsonString(VisualSettleDiagnostics.describe(capture)))
+      sb.append('}')
+    }
+    sb.append("],\"phasePinnedCaptures\":[")
+    pinned.forEachIndexed { i, capture ->
+      if (i > 0) sb.append(',')
+      sb.append('{')
+      sb.append("\"role\":").append(jsonString(capture.role)).append(',')
+      sb.append("\"outcome\":").append(jsonString("phase_pinned")).append(',')
+      sb.append("\"atMs\":").append(capture.atMs).append(',')
       sb.append("\"message\":").append(jsonString(VisualSettleDiagnostics.describe(capture)))
       sb.append('}')
     }

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1053,6 +1053,11 @@ abstract class RobolectricRenderTestBase(
         fontFallbacks,
         CoilLoadDiagnostics.drainPreview(),
         VisualSettleDiagnostics.drainPreview(),
+        // Not a warning: a still captured at a declared `@SettledPreview(afterMs = …)` coordinate.
+        // It rides in the same sidecar because it answers the same question — "is this still
+        // trustworthy?" — and because without it a spinner pinned to a deliberate phase and an
+        // ordinary static preview are indistinguishable to a consumer (issue #4829).
+        VisualSettleDiagnostics.drainPinned(),
       )
       // Render succeeded: if the preview's flavour captured an IR, write it beside the PNG as
       // the `renders/<stem>.<ext>` sidecar `BundlePreviewTask.resolvePreviewIr` packs.
@@ -2358,6 +2363,17 @@ abstract class RobolectricRenderTestBase(
                 resolveCaptureRoot()
                   .interaction
                   .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+                // An exact `@SettledPreview(afterMs = …)` skipped the probe on purpose — the
+                // coordinate IS the answer, and probing would move off it. Record that as a phase
+                // pin so the declaration reaches a consumer (issue #4829). Without it a spinner
+                // pinned to a deliberate phase looks exactly like an ordinary static preview, and
+                // the only alternative — auto settle on an animation that cannot quiesce — reports
+                // `still_changing` forever, which is the same word used for a broken reveal.
+                if (job.hasExactSettle) {
+                  job.settleTargetMs?.let {
+                    VisualSettleDiagnostics.recordPinnedPhase("Preview '${preview.id}' still", it)
+                  }
+                }
               }
             }
 

--- a/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/VisualSettleDiagnostics.kt
+++ b/renderers/android/src/main/kotlin/ee/schimke/composeai/renderer/VisualSettleDiagnostics.kt
@@ -26,12 +26,61 @@ object VisualSettleDiagnostics {
     val samples: Int = VISUAL_SETTLE_MAX_SAMPLES,
   )
 
-  private val unsettled = java.util.Collections.synchronizedList(mutableListOf<UnsettledCapture>())
+  /**
+   * One still captured at an author-declared exact coordinate — `@SettledPreview(afterMs = …)`.
+   *
+   * The positive claim, and the reason it needs a record of its own (issue #4829). An animation
+   * that never ends — an `InfiniteTransition`, an indeterminate progress indicator — cannot
+   * quiesce, so under auto settle it walks the whole budget and reports
+   * [VisualSettleOutcome .STILL_CHANGING] forever. That outcome then means two unrelated things:
+   * "your reveal is broken" and "this is a spinner, working exactly as designed". A consumer cannot
+   * act on either, because silencing the second silences the first.
+   *
+   * An exact `afterMs` already resolves the *capture*: it is a deterministic coordinate, so
+   * `shouldAdvanceClockForVisualSettling` skips the quiescence probe entirely and the still is
+   * taken at that instant on both backends. What was missing was the *declaration* reaching a
+   * consumer — nothing was recorded, which is indistinguishable from an ordinary static preview.
+   * Recording it makes "deterministic phase of a continuous animation" a thing a catalog can
+   * publish and assert on, as distinct from "did not settle", which is a bug report.
+   */
+  data class PinnedCapture(
+    /** What was captured, as the render loop names it. */
+    val role: String,
+    /** The virtual-time coordinate the author pinned, in milliseconds. */
+    val atMs: Long,
+  )
 
-  /** Reset the per-preview buffer. Called by the render loop before each preview's render. */
+  private val unsettled = java.util.Collections.synchronizedList(mutableListOf<UnsettledCapture>())
+  private val pinned = java.util.Collections.synchronizedList(mutableListOf<PinnedCapture>())
+
+  /** Reset the per-preview buffers. Called by the render loop before each preview's render. */
   fun beginPreview() {
     synchronized(unsettled) { unsettled.clear() }
+    synchronized(pinned) { pinned.clear() }
   }
+
+  /**
+   * Record that the still for [role] was captured at the exact coordinate [atMs].
+   *
+   * Not a warning, so nothing is echoed to stderr: this is the author's declaration being honoured,
+   * and a spinner that says where its phase is has done the right thing.
+   */
+  fun recordPinnedPhase(role: String, atMs: Long) {
+    synchronized(pinned) { pinned.add(PinnedCapture(role = role, atMs = atMs)) }
+  }
+
+  /** Snapshot and clear the phase pins the just-finished preview render recorded. */
+  fun drainPinned(): List<PinnedCapture> =
+    synchronized(pinned) {
+      val all = pinned.toList()
+      pinned.clear()
+      all
+    }
+
+  /** The human-readable line for [capture]. */
+  fun describe(capture: PinnedCapture): String =
+    "${capture.role}: captured at the declared ${capture.atMs}ms phase; " +
+      "a chosen coordinate, not a failed settle."
 
   /**
    * Record [outcome] for a capture in [role], and echo its diagnostic to stderr. Quiescent outcomes

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/VisualSettleDiagnosticsTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/VisualSettleDiagnosticsTest.kt
@@ -38,6 +38,54 @@ class VisualSettleDiagnosticsTest {
   }
 
   @Test
+  fun `a phase pin is recorded on its own channel, and drained once`() {
+    // #4829. An exact `@SettledPreview(afterMs = …)` skips the quiescence probe — the coordinate is
+    // the answer — so nothing used to be recorded at all, and a spinner pinned to a deliberate
+    // phase was indistinguishable from an ordinary static preview.
+    VisualSettleDiagnostics.recordPinnedPhase("preview still", 600L)
+    // Not a warning: it must not appear among the unsettled captures a consumer fails its build on.
+    assertTrue(VisualSettleDiagnostics.drainPreview().isEmpty())
+    val drained = VisualSettleDiagnostics.drainPinned()
+    assertEquals(1, drained.size)
+    assertEquals("preview still", drained.single().role)
+    assertEquals(600L, drained.single().atMs)
+    assertTrue(VisualSettleDiagnostics.drainPinned().isEmpty())
+  }
+
+  @Test
+  fun `the sidecar distinguishes a chosen phase from a failed settle`() {
+    // The whole point of the issue: `still_changing` used to mean both "your reveal is broken" and
+    // "this is a spinner, working as designed", so a consumer could act on neither.
+    val json =
+      RenderWarningsSidecar.encode(
+        fallbacks = emptyList(),
+        imageLoads = emptyList(),
+        unsettled = emptyList(),
+        pinned = listOf(VisualSettleDiagnostics.PinnedCapture(role = "preview still", atMs = 600L)),
+      )
+    assertTrue(json, json.contains("\"phasePinnedCaptures\":["))
+    assertTrue(json, json.contains("\"outcome\":\"phase_pinned\""))
+    assertTrue(json, json.contains("\"atMs\":600"))
+    assertTrue(json, json.contains("a chosen coordinate, not a failed settle"))
+    // The warning channel stays empty — a pin is not a warning, and a catalog that fails its build
+    // on `unsettledCaptures` must not go red for a spinner that said where its phase is.
+    assertTrue(json, json.contains("\"unsettledCaptures\":[]"))
+  }
+
+  @Test
+  fun `a clean render with a phase pin still writes the sidecar`() {
+    // Withholding the pin whenever the render was otherwise clean would make it available only on
+    // previews that also had something wrong with them — i.e. never on the spinners it is for.
+    val json =
+      RenderWarningsSidecar.encode(
+        fallbacks = emptyList(),
+        pinned = listOf(VisualSettleDiagnostics.PinnedCapture(role = "preview still", atMs = 250L)),
+      )
+    assertTrue(json, json.contains("\"atMs\":250"))
+    assertTrue(json, json.contains("\"fontFallbacks\":[]"))
+  }
+
+  @Test
   fun `the sidecar carries the outcome and its message`() {
     val json =
       RenderWarningsSidecar.encode(


### PR DESCRIPTION
Three issues that are genuinely this repository's. Six of the nine I was given have moved with the preview server or the extension; those are tracked separately (see the tail of this description).

## 1. `@CaptureGutter` dropped by `RobolectricHost.reshapeRenderPayload` — #4822

Confirmed exactly as reported. `reshapeRenderPayload` re-serialises a resolved `RenderSpec` into a payload *string* and emitted no `captureGutter=` token, so the sandbox composed at the un-guttered size and the render came back clipped to the composable's own frame.

The loss was **silent**, which is why the suite missed it twice over: `RenderSpec.parseFromPayloadOrNull` defaults every edge to `0` when the token is absent, so a guttered preview lost its gutter rather than failing. And `AndroidCaptureGutterLaneTest`, named for "the live daemon lane, Android half", stood up a `PreviewManifestRouter` — the harness-only router, which *does* emit the token. Nothing exercised the bridge the production `bundle daemon` / `compose-preview serve` path actually takes.

Fixed by emitting the token, mirroring `PreviewManifestRouter`. Deliberately **not** traded with the wrap flags on a rotation, for the reason the router already states: a wrap flag names an axis of the frame, a gutter edge names a direction the component draws in, and a `widthPx ↔ heightPx` swap does not move where a shadow falls.

Desktop was never exposed — `DesktopHost.specFromPreviewIdPayload` does `base.copy(…)` and never round-trips through a string.

`AndroidCaptureGutterLaneTest` now drives `reshapeRenderPayload` directly, and `docs/RENDER_LANE_PARITY.md` records which lane its rows actually measure, so the table no longer asserts a lane production never takes.

## 2. A spinner has no way to declare its still is a chosen phase — #4829

The issue's own closing question was whether `afterMs` on a never-ending animation is deterministic today, and **it is**: `shouldAdvanceClockForVisualSettling` returns `false` when `hasExactSettle`, so an exact coordinate skips the quiescence probe entirely and both backends land on the same instant. So this is the documentation-and-diagnostics change the issue hoped for, not a capture one.

What was missing was the declaration reaching a consumer. An exact-`afterMs` still recorded **nothing** — indistinguishable from an ordinary static preview — so a catalog had nothing to assert against, and the only alternative (auto settle) reports `still_changing` forever, which is the same word a broken reveal gets.

- `VisualSettleDiagnostics` records a `PinnedCapture` on its own channel. Not a warning: no stderr echo, and it does **not** appear among the `unsettledCaptures` a consumer fails its build on — a spinner that said where its phase is must not turn a catalog red.
- The sidecar grows `phasePinnedCaptures`, additively, and is written even for an otherwise clean render. Withholding it whenever nothing was wrong would make it available only on previews that also had something wrong with them, i.e. never on the spinners it is for.
- `@SettledPreview`'s KDoc said *"the annotation belongs on a reveal, not on a spinner"*, which steered authors away from the one thing that solves their problem. It now distinguishes auto (a reveal) from an exact `afterMs` (either), and names the phase-pin outcome.

## 3. A breakpoint capture cannot name its kit axis — #4827

Took shape 1 from the issue rather than the projector flag, for the reason the issue gives itself: it is a property of one component's kit set, not per-run configuration.

```kotlin
@CatalogComponent(id = "Picker", breakpointKit = ["225=Larger Screen (BP)=Yes"])
```

Travels as `key=value`-shaped strings for the same reason `@CatalogVariant.props` does — annotations cannot hold a `Map` — and is carried verbatim through discovery rather than parsed twice, since `design-map.mjs` already owns every other seed-naming rule.

**Opt-in, and it stays opt-in on purpose.** Most kits draw every screen cell at one size and have no size axis at all, so the other unresolved breakpoint captures are *correctly* unresolved; guessing an axis for them would pair a render against a kit cell that does not describe it. Declaring nothing keeps the bare `breakpoint=<dp>` seed, and so does a malformed entry or a size the component never draws.

The base breakpoint still carries the component's matrix, and an `@OverrideVariant` cell of a non-base breakpoint stays skipped — the product of two axes is still not wanted.

## Test plan

- `:renderer-android:testDebugUnitTest --tests '*VisualSettleDiagnosticsTest*'` and `:daemon:android:testDebugUnitTest --tests '*AndroidCaptureGutterLaneTest*' --tests '*RobolectricHostPayloadRoutingTest*'` — **BUILD SUCCESSFUL**, with two new gutter cases (the reshape carries the gutter; an un-annotated preview still emits no token) and three new settle cases (a pin is recorded on its own channel; the sidecar distinguishes a chosen phase from a failed settle; a clean render with a pin still writes the sidecar).
- `design-map`: `node --test` — **72 passing**, including two new cases (a declared size names its kit axis; an undeclared one keeps its bare seed).
- `:preview-discovery:test --tests '*PreviewDataTest*'` — passing, with a new `breakpointKit` round-trip case asserting an undeclared component decodes to empty rather than null.
- Full compile of `:renderer-android`, `:daemon:android` (main + unit test) and `:preview-annotations` — **BUILD SUCCESSFUL**.
- `ktfmtFormat` run for every touched module.

Note on formatting: running `ktfmtFormat` under the `gradle-plugin` included build reformats files it did not touch — its ktfmt config differs from the root's on `.getOrDefault` chain wrapping and comment rewrapping. I reverted that churn and hand-wrote the three `preview-discovery` edits in the surrounding style; worth a look on its own, since it means that build's formatter and the root's disagree.

No visual evidence: all three are non-visual. #4822 does change rendered pixels, but the honest before/after needs a live Android daemon serving a guttered preview under an override, which this sandbox has no SDK for — the arithmetic is pinned by the new unit tests instead (384×128 → 384×160, the 8+8dp at density 2 the report measured).

## The other six issues

Not in this PR, and mostly not in this repository:

- **#4820** (serve-web capture dead-ends) and **#4821** (native catalog divergence) — the code moved to compose-preview-server. Fixed there in yschimke/compose-preview-server#32; six of #4820's seven items turned out to be already fixed.
- **#4838** (cross-catalog pairing) — entirely in compose-preview-server now; commented there with the blocker (`kitAxis`/`kitValue` do not reach the server at all today).
- **#4819**, **#4832**, **#4836** — commented with scoped proposals. Each needs a decision before code: where wasm visual coverage lives (and what to do about `cli/serve-wasm` being a byte-identical fork of the server's `wasm-ui`), which module the render/history types land in now that the arrow points the other way, and whether the schema version can be published machine-readably at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQFk74rVPhctFqHFyYeobF)_