### PR TITLE
fix(ci): let the player-bundle guards skip until the artifact exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,15 +319,34 @@ jobs:
       # The PUBLISHED bundle, not one built from source: the player lives in yschimke/rc-players
       # now, and what this repo ships in the CLI's `rc-player-wasm/` sidecar is exactly these bytes.
       #
-      # Tolerated for exactly as long as it has to be: `rc-player-wasm-dist` first exists at
-      # rc-players 1.55.0, and until then there is nothing to stage and nothing this repo can do
-      # about it. The `require` flag below is not set unless this step actually produced a
-      # distribution, so the job cannot pass by asserting nothing — and it re-arms itself the first
-      # time staging succeeds, with no second commit and no date to remember.
+      # Tolerated for exactly as long as it has to be, and for exactly one reason:
+      # `rc-player-wasm-dist` first exists at rc-players 1.55.0. The step below distinguishes that
+      # from every other way staging can fail — a bare `continue-on-error` would let an outage or a
+      # broken task disarm the guards and report success having asserted nothing.
+      #
+      # The `require` flag is set only when a distribution actually landed, so the job re-arms itself
+      # the first time staging succeeds: no second commit, no date to remember.
       - name: Stage the published Wasm player distribution
         id: stage-wasm-player
-        continue-on-error: true
-        run: ./gradlew stageVendoredRcPlayerWasm
+        run: |
+          set -uo pipefail
+          log="$RUNNER_TEMP/stage-wasm.log"
+          if ./gradlew stageVendoredRcPlayerWasm --quiet >"$log" 2>&1; then
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Tolerate EXACTLY ONE failure: the artifact not being published yet. Any other failure —
+          # a repository outage, a Gradle regression, a broken staging task — must redden the job,
+          # because otherwise it silently disarms the guards below and they report success having
+          # asserted nothing. That is the hole `continue-on-error` on its own leaves open.
+          if grep -q "Could not find ee.schimke.composeai:rc-player-wasm-dist:" "$log"; then
+            echo "staged=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::rc-player-wasm-dist is not published yet — the browser guards will skip."
+            exit 0
+          fi
+          echo "::error::Staging rc-player-wasm-dist failed for a reason other than the artifact being absent."
+          cat "$log" >&2
+          exit 1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
@@ -345,7 +364,7 @@ jobs:
       - name: Run the browser-level player guards
         working-directory: scripts/design-artifacts
         env:
-          RC_CMP_WASM_REQUIRE: ${{ steps.stage-wasm-player.outcome == 'success' && '1' || '0' }}
+          RC_CMP_WASM_REQUIRE: ${{ steps.stage-wasm-player.outputs.staged == 'true' && '1' || '0' }}
           RC_CMP_WASM_DIST: ${{ github.workspace }}/build/vendored-rc-player-wasm
         run: node --test rc-cmp-wasm-*.test.mjs
 
@@ -1151,11 +1170,12 @@ jobs:
       # it is resolved from yschimke/rc-players now, so it has to be staged before the browser
       # tests that load it can assert anything.
       #
-      # Tolerated, and the `require` flag below is why that is not a hole: this succeeds only once
-      # `remote-compose-player-js-dist` is published (rc-players 1.55.0). While it cannot, the tests
-      # skip with the reason; the moment it can, `RC_PLAYER_JS_BUNDLE_REQUIRE=1` is exported and a
-      # skip becomes a failure. So the staging step's own success is what arms the gate — there is
-      # no date to remember and no second commit to make.
+      # Tolerated for one reason only — `remote-compose-player-js-dist` first exists at rc-players
+      # 1.55.0 — and the step below proves that is the reason before skipping. Any other staging
+      # failure reddens the job rather than quietly disarming the guards.
+      #
+      # `RC_PLAYER_JS_BUNDLE_REQUIRE=1` is exported only when a bundle actually landed, so a skip
+      # becomes a failure the moment the artifact resolves.
       #
       # This is the one Gradle invocation in an otherwise Node-only job, which is why the JDK is set
       # up here rather than at the top: it is needed for this step alone, and a reader looking at
@@ -1166,10 +1186,27 @@ jobs:
           java-version: "17"
       - name: Stage the vendored player bundle
         id: stage-player
-        continue-on-error: true
-        run: ./gradlew stageVendoredRcPlayerJs --quiet
+        run: |
+          set -uo pipefail
+          log="$RUNNER_TEMP/stage-js.log"
+          if ./gradlew stageVendoredRcPlayerJs --quiet >"$log" 2>&1; then
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Tolerate EXACTLY ONE failure: the artifact not being published yet. Any other failure —
+          # a repository outage, a Gradle regression, a broken staging task — must redden the job,
+          # because otherwise it silently disarms the guards below and they report success having
+          # asserted nothing. That is the hole `continue-on-error` on its own leaves open.
+          if grep -q "Could not find ee.schimke.composeai:remote-compose-player-js-dist:" "$log"; then
+            echo "staged=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::remote-compose-player-js-dist is not published yet — the browser guards will skip."
+            exit 0
+          fi
+          echo "::error::Staging remote-compose-player-js-dist failed for a reason other than the artifact being absent."
+          cat "$log" >&2
+          exit 1
       - name: Require the player bundle once it is resolvable
-        if: ${{ steps.stage-player.outcome == 'success' }}
+        if: ${{ steps.stage-player.outputs.staged == 'true' }}
         run: echo "RC_PLAYER_JS_BUNDLE_REQUIRE=1" >> "$GITHUB_ENV"
 
       - name: Run driver tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,15 @@ jobs:
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
       # The PUBLISHED bundle, not one built from source: the player lives in yschimke/rc-players
       # now, and what this repo ships in the CLI's `rc-player-wasm/` sidecar is exactly these bytes.
+      #
+      # Tolerated for exactly as long as it has to be: `rc-player-wasm-dist` first exists at
+      # rc-players 1.55.0, and until then there is nothing to stage and nothing this repo can do
+      # about it. The `require` flag below is not set unless this step actually produced a
+      # distribution, so the job cannot pass by asserting nothing — and it re-arms itself the first
+      # time staging succeeds, with no second commit and no date to remember.
       - name: Stage the published Wasm player distribution
+        id: stage-wasm-player
+        continue-on-error: true
         run: ./gradlew stageVendoredRcPlayerWasm
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -331,11 +339,13 @@ jobs:
         run: npx playwright install --with-deps chromium
       # `RC_CMP_WASM_REQUIRE` turns the test's self-skips into failures. Without it a missing
       # distribution, a missing playwright, or a browser that will not launch all leave this job
-      # green having asserted nothing — which is the hole this job exists to close.
+      # green having asserted nothing — which is the hole this job exists to close. It is set only
+      # when staging above actually produced a distribution: while the artifact is unpublished the
+      # guards skip and say so, and the moment it resolves they must assert again.
       - name: Run the browser-level player guards
         working-directory: scripts/design-artifacts
         env:
-          RC_CMP_WASM_REQUIRE: "1"
+          RC_CMP_WASM_REQUIRE: ${{ steps.stage-wasm-player.outcome == 'success' && '1' || '0' }}
           RC_CMP_WASM_DIST: ${{ github.workspace }}/build/vendored-rc-player-wasm
         run: node --test rc-cmp-wasm-*.test.mjs
 
@@ -1136,6 +1146,32 @@ jobs:
       - name: Install Chromium
         working-directory: scripts/design-artifacts
         run: npx playwright install --with-deps chromium
+
+      # The vendored TypeScript player's bundle. It used to be a committed file in this checkout;
+      # it is resolved from yschimke/rc-players now, so it has to be staged before the browser
+      # tests that load it can assert anything.
+      #
+      # Tolerated, and the `require` flag below is why that is not a hole: this succeeds only once
+      # `remote-compose-player-js-dist` is published (rc-players 1.55.0). While it cannot, the tests
+      # skip with the reason; the moment it can, `RC_PLAYER_JS_BUNDLE_REQUIRE=1` is exported and a
+      # skip becomes a failure. So the staging step's own success is what arms the gate — there is
+      # no date to remember and no second commit to make.
+      #
+      # This is the one Gradle invocation in an otherwise Node-only job, which is why the JDK is set
+      # up here rather than at the top: it is needed for this step alone, and a reader looking at
+      # the job should see the two together.
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Stage the vendored player bundle
+        id: stage-player
+        continue-on-error: true
+        run: ./gradlew stageVendoredRcPlayerJs --quiet
+      - name: Require the player bundle once it is resolvable
+        if: ${{ steps.stage-player.outcome == 'success' }}
+        run: echo "RC_PLAYER_JS_BUNDLE_REQUIRE=1" >> "$GITHUB_ENV"
+
       - name: Run driver tests
         working-directory: scripts/design-artifacts
         env:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -367,16 +367,25 @@ composeai-preview-serve = "2.0.0"
 # the bundle it renders through is exactly the failure this repo already paid for once with the
 # AndroidX alphas.
 #
-# 1.55.0, not a fresh 0.x: `rc-player-*` and `third-party-rc-embedded-player` were published FROM
-# THIS REPO through 1.54.0, so rc-players continues that line rather than restarting one. A lower
-# number would be a downgrade to anything resolving a range or a BOM, and invisible to everything
-# else.
+# TWO refs, because the player coordinates fall into two groups with different availability.
 #
-# This pin names a release THAT DOES NOT EXIST YET — 1.55.0 is the first cut from the new
-# repository, and `rc-player-wasm-dist`, `third-party-rc-embedded-player-jvm` and
-# `remote-compose-player-js-dist` are new coordinates that first appear in it. Until it lands, this
-# build cannot resolve them; that is the known cost of cutting over in one step rather than two.
-rcplayers = "1.55.0"
+# `rcplayers` — the five that were published FROM THIS REPO through 1.54.0 and are on Central right
+# now. rc-players continues that line rather than restarting one (a lower number would be a
+# downgrade to anything resolving a range or a BOM), so these keep resolving throughout the move.
+# They move to 1.55.0 with everything else at the next release; there is no reason to drag them
+# there early.
+rcplayers = "1.54.0"
+
+# `rcplayers-new` — the three coordinates the extraction CREATED. They exist at no version yet:
+# `rc-player-wasm-dist` and `remote-compose-player-js-dist` wrap directories that used to be built
+# in-tree, and `third-party-rc-embedded-player-jvm` never published before. 1.55.0 is the first
+# rc-players release, so it is the first version that can carry them.
+#
+# Keeping them on a ref of their own is what stops the unpublished half blocking the published half:
+# one shared ref pinned every consumer to 1.55.0, including five artifacts that were sitting on
+# Central at 1.54.0, and reddened jobs that had no need to fail. Collapse the two back into one once
+# 1.55.0 is out.
+rcplayers-new = "1.55.0"
 
 [libraries]
 
@@ -405,16 +414,16 @@ rcplayer-compose = { module = "ee.schimke.composeai:rc-player-compose", version.
 # `dist` classifier is the distribution directory packaged for Maven; see that module's build file
 # in yschimke/rc-players for why it is a module of its own rather than a second publication on the
 # wasmJs one.
-rcplayer-wasm-dist = { module = "ee.schimke.composeai:rc-player-wasm-dist", version.ref = "rcplayers" }
+rcplayer-wasm-dist = { module = "ee.schimke.composeai:rc-player-wasm-dist", version.ref = "rcplayers-new" }
 # The vendored, locally patched AndroidX embedded player — the Android comparison lane. NOT a
 # supported API; pinned to one AndroidX alpha and versioned with the player stack rather than with
 # upstream.
 rcplayer-embedded-android = { module = "ee.schimke.composeai:third-party-rc-embedded-player", version.ref = "rcplayers" }
 # The desktop-JVM cut of the same vendored player, staged into `lib-rcjvm/` for serve's cmp-jvm lane.
-rcplayer-embedded-jvm = { module = "ee.schimke.composeai:third-party-rc-embedded-player-jvm", version.ref = "rcplayers" }
+rcplayer-embedded-jvm = { module = "ee.schimke.composeai:third-party-rc-embedded-player-jvm", version.ref = "rcplayers-new" }
 # The vendored TypeScript player's browser bundle — the client-side render lane the `rc-*` browser
 # tests and the design-artifacts job drive with `--player <bundle.js>`. A zip, `dist` classifier.
-rcplayer-js-dist = { module = "ee.schimke.composeai:remote-compose-player-js-dist", version.ref = "rcplayers" }
+rcplayer-js-dist = { module = "ee.schimke.composeai:remote-compose-player-js-dist", version.ref = "rcplayers-new" }
 # `@com.android.tools.screenshot.PreviewTest` — the marker Google's screenshot plugin requires on a
 # `@Preview` before it will render it (alpha15+ discovers nothing without it). Only the Studio-parity
 # fixtures in `:samples:android-screenshot-test` need it, on the `screenshotTest` classpath; version

--- a/scripts/design-artifacts/rc-font-data.test.mjs
+++ b/scripts/design-artifacts/rc-font-data.test.mjs
@@ -12,7 +12,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { RC_PLAYER_JS_BUNDLE } from "./rc-player-bundle.mjs";
+import { RC_PLAYER_JS_BUNDLE, rcPlayerBundleIssue } from "./rc-player-bundle.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "../..");
@@ -26,6 +26,11 @@ let browser;
 let skip = false;
 
 before(async () => {
+  const bundleIssue = rcPlayerBundleIssue();
+  if (bundleIssue) {
+    skip = bundleIssue;
+    return;
+  }
   try {
     const { chromium } = await import("playwright");
     browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] });

--- a/scripts/design-artifacts/rc-player-bundle.mjs
+++ b/scripts/design-artifacts/rc-player-bundle.mjs
@@ -25,14 +25,23 @@ export const RC_PLAYER_JS_BUNDLE =
 /**
  * The reason the bundle cannot be used, or `null` when it can.
  *
- * Returned rather than thrown so each suite keeps its own skip-or-fail policy — several of these
- * tests self-skip without a bundle, and turning that into a hard throw here would change behaviour
- * in six places at once.
+ * Returned rather than thrown so each suite keeps its own skip-or-fail policy — these tests already
+ * self-skip on a missing playwright or an unlaunchable chromium, and this is the same kind of
+ * missing prerequisite.
+ *
+ * `RC_PLAYER_JS_BUNDLE_REQUIRE=1` turns that skip into a hard failure, the same lever
+ * `RC_CMP_WASM_REQUIRE` is for the Wasm guards. CI sets it **only when staging actually produced a
+ * bundle**, which is what keeps this from rotting: while `remote-compose-player-js-dist` is
+ * unpublished the tests skip and say so, and the moment it resolves a skip becomes a failure again
+ * rather than staying quietly green.
  */
 export function rcPlayerBundleIssue() {
   if (fs.existsSync(RC_PLAYER_JS_BUNDLE)) return null;
-  return (
+  const reason =
     `no player bundle at ${RC_PLAYER_JS_BUNDLE} — run \`./gradlew stageVendoredRcPlayerJs\` ` +
-    `to unpack the published one, or set RC_PLAYER_JS_BUNDLE`
-  );
+    `to unpack the published one, or set RC_PLAYER_JS_BUNDLE`;
+  if (process.env.RC_PLAYER_JS_BUNDLE_REQUIRE === "1") {
+    throw new Error(`RC_PLAYER_JS_BUNDLE_REQUIRE is set but ${reason}`);
+  }
+  return reason;
 }

--- a/scripts/design-artifacts/rc-webfonts.test.mjs
+++ b/scripts/design-artifacts/rc-webfonts.test.mjs
@@ -22,7 +22,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { DEFAULT_FONTS_DIR } from "./rc-fonts.mjs";
-import { RC_PLAYER_JS_BUNDLE } from "./rc-player-bundle.mjs";
+import { RC_PLAYER_JS_BUNDLE, rcPlayerBundleIssue } from "./rc-player-bundle.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const BUNDLE = RC_PLAYER_JS_BUNDLE;
@@ -47,6 +47,11 @@ before(async () => {
     ({ chromium } = await import("playwright"));
   } catch {
     skip = "playwright is not installed";
+    return;
+  }
+  const bundleIssue = rcPlayerBundleIssue();
+  if (bundleIssue) {
+    skip = bundleIssue;
     return;
   }
   const fontPath = path.join(DEFAULT_FONTS_DIR, FIXTURE_FILE);


### PR DESCRIPTION
`main` is red on **Design Artifacts Driver Tests**. My fault, from #4845 — fixing it as a fresh change since that PR is merged.

## What broke

#4845 turned the vendored TypeScript player's bundle from a committed file into a resolved artifact, but left two of the six browser suites reading it unconditionally. `rc-webfonts` has no bundle guard at all, so all 15 of its tests died on `ENOENT .../build/vendored-rc-player-js/bundle.js`. `rc-font-data` had the same hole and survived only because its single test skips for want of chromium first.

`rc-round-clip`, `rc-size-modifier` and `rc-font-axis-order` already guarded the bundle and were unaffected — which is exactly why the gap was easy to miss.

## The fix, and why it isn't just a skip

Both suites now check the bundle the way they already check playwright and the vendored fixture font: a missing prerequisite, stated.

A skip that reports green is the failure mode this repo refuses elsewhere, so it is **armed rather than trusted**. `RC_PLAYER_JS_BUNDLE_REQUIRE=1` turns the skip into a hard failure — the lever `RC_CMP_WASM_REQUIRE` already is for the Wasm guards — and CI exports it *only when staging actually produced a bundle*:

```yaml
- name: Stage the vendored player bundle
  id: stage-player
  continue-on-error: true
  run: ./gradlew stageVendoredRcPlayerJs --quiet
- name: Require the player bundle once it is resolvable
  if: ${{ steps.stage-player.outcome == 'success' }}
  run: echo "RC_PLAYER_JS_BUNDLE_REQUIRE=1" >> "$GITHUB_ENV"
```

The staging step's own success is what arms the gate. While `remote-compose-player-js-dist` is unpublished the tests skip and say why; the first run where it resolves, they must assert again. No date to remember, no second commit.

The Wasm frame-pacing job had the identical defect one level up — it staged `rc-player-wasm-dist` with no tolerance and hard-set `RC_CMP_WASM_REQUIRE=1`, so it could only be red until rc-players releases. Same treatment, same self-arming.

## Test plan

| | |
| --- | --- |
| `node --test rc-font-data.test.mjs` | 1 skipped, 0 failed — with the reason |
| `node --test rc-webfonts.test.mjs` | 15 skipped, 0 failed — exactly the 15 that were failing |
| `RC_PLAYER_JS_BUNDLE_REQUIRE=1 node --test rc-font-data.test.mjs` | 1 **failed**, with the reason — the gate works in both directions |
| `python3 .github/ci/test_path_scope.py` | 11 passed |
| `ci.yml` | parses |

`rc-size-modifier` and `rc-font-axis-order` fail in my sandbox on a missing `pngjs` (no `npm ci`), not on this change — and neither was among the 15 CI failures.

## Cost, stated plainly

16 browser assertions are skipped on `main` until rc-players cuts 1.55.0. That is strictly better than the current state, where they fail, but it is not free — the self-arming flag is what stops it becoming permanent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4EyHFtrpmmyZdEGVA3ofX)_