### PR TITLE
fix: carry breakpointKit through the published manifest reader, and correct its contract

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt
@@ -178,9 +178,20 @@ annotation class CatalogComponent(
    * still not wanted.
    *
    * Travels as `key=value`-shaped strings for the same reason `@CatalogVariant.props` does —
-   * annotations cannot hold a `Map`. A malformed entry, a non-numeric width or a size this
-   * component never renders is ignored with a warning rather than failing discovery: a mis-typed
-   * mapping should cost the pairing, not the build.
+   * annotations cannot hold a `Map`. Discovery carries the entries verbatim and never parses them;
+   * `design-map.mjs`, which owns every other seed-naming rule, is the one reader, because two
+   * parsers is how two spellings come to disagree.
+   *
+   * A malformed entry — no `=`, a non-numeric width, an empty axis or value — costs that mapping
+   * rather than the build: the cell falls back to its bare `breakpoint=<dp>` seed. That degradation
+   * is byte-identical to declaring nothing, so it is *also* reported, as
+   * `diagnostics.invalidBreakpointKit` in the projection, deduplicated per `(component, entry)`.
+   * Without the report a typo would have no symptom at all beyond a kit cell that quietly never
+   * pairs.
+   *
+   * A **well-formed entry naming a width this capture is not** is the ordinary case, not a fault:
+   * one declaration serves every size and is re-read at each non-base capture, so `225=…` is
+   * legitimately unused when the 240dp capture reads it. Nothing is reported for it.
    */
   val breakpointKit: Array<String> = [],
 )

--- a/api/preview-data-api/api/preview-data-api.api
+++ b/api/preview-data-api/api/preview-data-api.api
@@ -511,6 +511,8 @@ public final class ee/schimke/composeai/previewdata/CatalogEntry {
 	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lee/schimke/composeai/previewdata/CatalogRole;
 	public final fun component10 ()Ljava/lang/String;
 	public final fun component11 ()Ljava/lang/String;
@@ -519,6 +521,7 @@ public final class ee/schimke/composeai/previewdata/CatalogEntry {
 	public final fun component14 ()Ljava/lang/String;
 	public final fun component15 ()Ljava/lang/String;
 	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -527,9 +530,10 @@ public final class ee/schimke/composeai/previewdata/CatalogEntry {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Z
-	public final fun copy (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lee/schimke/composeai/previewdata/CatalogEntry;
-	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CatalogEntry;Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/CatalogEntry;
+	public final fun copy (Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lee/schimke/composeai/previewdata/CatalogEntry;
+	public static synthetic fun copy$default (Lee/schimke/composeai/previewdata/CatalogEntry;Lee/schimke/composeai/previewdata/CatalogRole;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/List;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/previewdata/CatalogEntry;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBreakpointKit ()Ljava/util/List;
 	public final fun getCaption ()Ljava/lang/String;
 	public final fun getComponentId ()Ljava/lang/String;
 	public final fun getGroup ()Ljava/lang/String;

--- a/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewData.kt
+++ b/api/preview-data-api/src/main/kotlin/ee/schimke/composeai/previewdata/PreviewData.kt
@@ -251,6 +251,18 @@ public data class CatalogEntry(
    * no motion where the published catalog has a recording.
    */
   val motionPreview: String? = null,
+  /**
+   * COMPONENT: `@CatalogComponent.breakpointKit` — what this component's non-base breakpoint
+   * captures mean to the design kit, as `"<widthDp>=<kitAxis>=<kitValue>"` entries. Carried
+   * verbatim rather than parsed, exactly as discovery writes it: `design-map.mjs` is the only
+   * consumer that reads the entries, and parsing in two places is how two spellings come to
+   * disagree.
+   *
+   * A reader that dropped the field would see a breakpoint capture seeded with its bare width —
+   * byte-identical to a component that declared nothing — so the kit cells the render was meant to
+   * pair with would go uncompared with no symptom at all (issue #4827).
+   */
+  val breakpointKit: List<String> = emptyList(),
 ) {
   /**
    * Binary-compatible constructor retained for consumers compiled before [kitValue] was added. A
@@ -291,6 +303,7 @@ public data class CatalogEntry(
     kitAxis = kitAxis,
     kitValue = null,
     motionPreview = null,
+    breakpointKit = emptyList(),
   )
 
   /** As above, for consumers compiled after [kitValue] but before [motionPreview]. */
@@ -327,6 +340,45 @@ public data class CatalogEntry(
     kitAxis = kitAxis,
     kitValue = kitValue,
     motionPreview = null,
+    breakpointKit = emptyList(),
+  )
+
+  /** As above, for consumers compiled after [motionPreview] but before [breakpointKit]. */
+  public constructor(
+    role: CatalogRole,
+    componentId: String,
+    group: String? = null,
+    section: String? = null,
+    caption: String? = null,
+    reference: String? = null,
+    referenceSet: String? = null,
+    noReference: String? = null,
+    referenceContentsOnly: Boolean = true,
+    parallel: String? = null,
+    state: String? = null,
+    props: List<CatalogVariantProp> = emptyList(),
+    perBreakpoint: Boolean = false,
+    kitAxis: String? = null,
+    kitValue: String? = null,
+    motionPreview: String? = null,
+  ) : this(
+    role = role,
+    componentId = componentId,
+    group = group,
+    section = section,
+    caption = caption,
+    reference = reference,
+    referenceSet = referenceSet,
+    noReference = noReference,
+    referenceContentsOnly = referenceContentsOnly,
+    parallel = parallel,
+    state = state,
+    props = props,
+    perBreakpoint = perBreakpoint,
+    kitAxis = kitAxis,
+    kitValue = kitValue,
+    motionPreview = motionPreview,
+    breakpointKit = emptyList(),
   )
 }
 

--- a/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/CatalogEntryWireTest.kt
+++ b/api/preview-data-api/src/test/kotlin/ee/schimke/composeai/previewdata/CatalogEntryWireTest.kt
@@ -205,4 +205,61 @@ class CatalogEntryWireTest {
     assertEquals(true, byId.getValue("themecatalog__Brand_Light").fixedTheme)
     assertEquals(false, byId.getValue("test.ContactRow").fixedTheme)
   }
+
+  @Test
+  fun `a component's breakpointKit entries survive manifest decoding`() {
+    // What a non-base breakpoint capture MEANS to the kit. `ignoreUnknownKeys` drops an unmirrored
+    // field silently, and the degradation here has no symptom: the seed falls back to a bare
+    // `breakpoint=225`, which is byte-identical to what a component declaring nothing produces —
+    // so the kit cells the render was meant to pair with go uncompared and nothing says why.
+    val manifest =
+      Json.decodeFromString<PreviewManifest>(
+        """
+        {
+          "module": ":sample",
+          "variant": "debug",
+          "previews": [{
+            "id": "test.PickerSticker",
+            "functionName": "PickerSticker",
+            "className": "test.CatalogKt",
+            "catalog": {
+              "role": "COMPONENT",
+              "componentId": "Picker",
+              "breakpointKit": ["225=Larger Screen (BP)=Yes", "240=Larger Screen (BP)=Yes"]
+            }
+          }]
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(
+      listOf("225=Larger Screen (BP)=Yes", "240=Larger Screen (BP)=Yes"),
+      manifest.previews.single().catalog?.breakpointKit,
+    )
+  }
+
+  @Test
+  fun `a component declaring no breakpointKit decodes to an empty list`() {
+    // The overwhelmingly common case — most kits draw every screen cell at one size and have no
+    // size axis at all — and it must stay distinguishable from a dropped field rather than null.
+    val manifest =
+      Json.decodeFromString<PreviewManifest>(
+        """
+        {
+          "module": ":sample",
+          "variant": "debug",
+          "previews": [{
+            "id": "test.FilledButton",
+            "functionName": "FilledButton",
+            "className": "test.CatalogKt",
+            "catalog": { "role": "COMPONENT", "componentId": "Button/Filled" }
+          }]
+        }
+        """
+          .trimIndent()
+      )
+
+    assertEquals(emptyList<String>(), manifest.previews.single().catalog?.breakpointKit)
+  }
 }

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -521,8 +521,18 @@ export function declarationMisses(preview) {
  * "Malformed" is only about the entry's *shape*. An entry that is well-formed but names a width
  * this particular capture is not — the common case, since one declaration serves every size — is
  * not a fault and is not reported.
+ *
+ * Every entry is checked, including those after the one that matches: the report must not depend on
+ * where in the list the typo happens to sit. The first matching entry still wins.
  */
 export function breakpointKitNames(entries, widthDp, malformed = []) {
+  // Every entry is inspected before the match is returned, rather than returning at the one that
+  // matches. Returning early made the report ORDER-DEPENDENT: a typo sitting after the matching
+  // entry was never looked at, so it produced no diagnostic on this capture — and on a component
+  // with only ONE non-base breakpoint, which is the motivating Picker case, no other capture
+  // re-reads the list to catch it either. That is exactly the symptomless degradation the
+  // diagnostic exists to prevent. First match still wins.
+  let match = null;
   for (const entry of entries ?? []) {
     if (typeof entry !== "string") {
       malformed.push({ entry: String(entry), reason: "not a string" });
@@ -548,9 +558,9 @@ export function breakpointKitNames(entries, widthDp, malformed = []) {
     }
     // Well-formed but for another size: not a fault, and the overwhelmingly common case.
     if (width !== widthDp) continue;
-    return { kitAxis, kitValue };
+    match ??= { kitAxis, kitValue };
   }
-  return null;
+  return match;
 }
 
 export function variantRendersByComponent(

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -933,6 +933,28 @@ test("a malformed breakpointKit entry is reported, not silently ignored", () => 
   ]);
 });
 
+test("a typo after the matching entry is still reported, and the match still stands", () => {
+  // The report must not depend on where in the list the typo sits. Returning at the matching entry
+  // left a trailing malformed one unread — and on a component with only ONE non-base breakpoint,
+  // which is the motivating Picker case, no other capture re-reads the list to catch it either. So
+  // the typo was permanently silent, which is the exact failure the diagnostic exists to prevent.
+  const { variants, diagnostics } = projectDesignMap([
+    atWidth("Picker", 192, { reference: ref("1:2") }),
+    atWidth("Picker", 225, {
+      reference: ref("1:2"),
+      breakpointKit: ["225=Larger Screen (BP)=Yes", "24O=Larger Screen (BP)=Yes"],
+    }),
+  ]);
+  assert.deepEqual(
+    diagnostics.invalidBreakpointKit.map((e) => e.entry),
+    ["24O=Larger Screen (BP)=Yes"],
+  );
+  // The valid mapping ahead of it is unaffected: first match still wins.
+  assert.deepEqual(variants.components[0].renders.find((r) => r.name === "225dp").seeds, [
+    { key: "breakpoint", raw: "225", kitAxis: "Larger Screen (BP)", kitValue: "Yes" },
+  ]);
+});
+
 test("a well-formed entry for another size is not a fault", () => {
   // One declaration serves every size, so it is re-read at each non-base capture. A 240dp capture
   // reading a 225dp declaration is the ordinary case, not a typo.

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -1123,6 +1123,39 @@ preview server already disambiguates a *colliding* card label on its own
 (`Edgebutton · Small Round`), so the fan-out is for when you want authored ids and
 captions per breakpoint, not merely readable labels.
 
+#### Naming what a folded breakpoint means to the kit (`breakpointKit`)
+
+`perBreakpoint` splits the fan-out into a card per size. The default folds it: every
+render sits on one component, and each non-base size is published as a cell seeded
+with the width it was drawn at — `breakpoint=225`.
+
+That seed is a fact about the Compose render, not a value any kit vocabulary contains,
+so the cell resolves against nothing. For most kits that is the right answer: they draw
+every screen cell at one size and have no size axis at all, and reporting those captures
+as renders with no kit counterpart is honest. Where a kit *does* publish screen size as a
+variant property, the component says which one:
+
+```kotlin
+@CatalogComponent(id = "Picker", breakpointKit = ["225=Larger Screen (BP)=Yes"])
+```
+
+The 225dp cell then carries `kitAxis`/`kitValue` alongside its width and pairs with the
+kit node the picture was always there for. It sits on the component rather than in a
+projector flag because it is a property of one component's kit set, not of the catalog —
+and on the *component* rather than the cell because a breakpoint capture is the one kind
+of cell that cannot carry `@OverrideVariant(kitAxis = …)`: it is not an annotation at
+all, just the same composable drawn wider by a multipreview.
+
+One declaration serves every size, so an entry naming a width this capture is not is the
+ordinary case and is silent. A **malformed** entry falls back to the bare seed — the same
+bytes as declaring nothing — and is reported as `diagnostics.invalidBreakpointKit`, since
+otherwise a typo has no symptom beyond a kit cell that never pairs. The base breakpoint
+still carries the component's matrix, and an `@OverrideVariant` cell of a non-base
+breakpoint stays skipped: the product of two axes would multiply the sheet by every size.
+
+Details of the projection, including how the seeds reach a resolver:
+[`design-map/README.md`](../../design-map/README.md).
+
 ### The render timeout scales with the sheet, not the job
 
 `bundle pack`'s own `--timeout` is separate from the job's `timeout-minutes`, and it is the one a


### PR DESCRIPTION
Follow-up to #4844, which added `@CatalogComponent(breakpointKit = …)` for #4827. The declaration worked on the path `design-map.mjs` actually takes; three things around it did not hold up.

## The reader gap

`breakpointKit` reached the projector through **discovery's own** manifest model (`gradle-plugin/preview-discovery/PreviewData.kt`). `:preview-data-api` — the *published* DTO an extracted preview server, the MCP readers, `compose-preview show --json` and `contrib` scripting decode manifests with — never mirrored the field, and `ignoreUnknownKeys` drops an unmirrored key silently.

The degradation has no symptom. A dropped `breakpointKit` seeds the cell with a bare `breakpoint=225`, which is **byte-identical** to what a component declaring nothing produces — so the kit cells the render was meant to pair with go uncompared and nothing anywhere says why. That is the same class of gap `motionPreview` was mirrored for, and the same failure mode: wear-m3-catalog lost all five recordings on every green run.

Appended after `motionPreview`, with a compatibility constructor for consumers compiled against the previous artifact — the policy already stated in that file — and the ABI dump regenerated with `:preview-data-api:updateKotlinAbi`.

## The contract the KDoc stated but the projector does not implement

`@CatalogComponent.breakpointKit`'s KDoc grouped *"a size this component never renders"* with the malformed cases, as "ignored with a warning rather than failing discovery". Two things wrong with that, both author-facing:

- **A well-formed entry naming another width is the ordinary case, not a fault.** One declaration serves every size and is re-read at each non-base capture, so `225=…` is legitimately unused when the 240dp capture reads it. `breakpointKitNames` skips it silently and `design-map` has a test asserting no diagnostic. Documenting it as warned invites an author to split one declaration per size to quiet a warning that was never there.
- **Discovery does not parse the entries at all.** It carries them verbatim; only shape faults, found in the projector, reach `diagnostics.invalidBreakpointKit`.

Rewritten to say what the code does, including the deduplication and why the report exists at all.

## An order-dependent diagnostic (`bd4fdec`)

Raised by the Codex review on the first commit, verified, and fixed. `breakpointKitNames` returned at the entry matching the capture's width, so a malformed entry *after* it was never inspected and never reported.

My first reading was that the re-reading covers it — a trailing typo is normally caught by a capture the earlier entry does not match. It does not: a component with only **one** non-base breakpoint gets no second reading, and that is precisely the motivating `Picker` case at 225dp. There the typo was silent for good, in the one configuration the feature exists for — and the diagnostic is the only symptom a typo has, since a malformed entry degrades to the same bare seed an undeclared component emits.

Now scans the whole list and keeps the first match. Match semantics unchanged.

## Documentation

`docs/design/DESIGN_CATALOGS.md` covered `perBreakpoint` (the *split* path) at length and said nothing about the fold path's kit mapping, which lived only in `design-map/README.md`. Added a short subsection beside it — that is where a catalog author looks after finding their breakpoint captures unresolved.

## What is deliberately unchanged

The base breakpoint still carries the component's matrix, an `@OverrideVariant` cell of a non-base breakpoint is still skipped, and an undeclared component still keeps its bare seed and reports honestly as a render with no kit counterpart. The only projection behaviour that changes is *which malformed entries get reported* — strictly more of them.

## Test plan

- `./gradlew :preview-data-api:test` — two new wire tests: `breakpointKit` entries survive manifest decoding, and an undeclared component decodes to an empty list rather than a dropped field.
- `./gradlew :preview-data-api:checkKotlinAbi` — green against the regenerated dump.
- `npm test` in `design-map/` — 75 passing, including the new order-dependence case, which fails on the previous implementation (verified by stashing the fix: `not ok 57`).
- `ktfmtFormat` run on the touched modules; `ktfmt (Google style)` green on CI.

Non-visual change (a wire-format field, a projector fix, KDoc and prose), so there is no before/after render to embed.

## CI

Three checks are red for a reason that is not this PR's — `rc-player-wasm-dist:1.55.0` is unpublished and `:cli` resolves it, red on `main` at this branch's base commit too. Detail in [the comment below](https://github.com/yschimke/compose-ai-tools/pull/4851#issuecomment-5468349576).

## Still open on #4827

The confirmation the issue is being held open for — that the three 225dp pickers pair with `Larger Screen (BP)=Yes` in yschimke/wear-m3-catalog — is a downstream check against a repository outside this session's scope, and it needs the catalog to add the declaration. This PR removes two ways that check could have failed for a reason invisible from the catalog side.