### PR TITLE
fix(daemon-core): regenerate the ABI dump after DataExtensionDescriptor moved

### DIFF
--- a/daemon/core/api/core.api
+++ b/daemon/core/api/core.api
@@ -442,10 +442,10 @@ public final class ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvent
 	public static final field INSTANCE Lee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents;
 	public static final field KEY_DOWN_EVENT Ljava/lang/String;
 	public static final field KEY_UP_EVENT Ljava/lang/String;
-	public final fun descriptor (Z)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
-	public final fun getDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun descriptor (Z)Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
+	public final fun getDescriptor ()Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
 	public final fun getDescriptors ()Ljava/util/List;
-	public final fun getSupportedDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getSupportedDescriptor ()Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
 }
 
 public final class ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents {
@@ -454,7 +454,7 @@ public final class ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents {
 	public static final field POINTER_DOWN_EVENT Ljava/lang/String;
 	public static final field POINTER_MOVE_EVENT Ljava/lang/String;
 	public static final field POINTER_UP_EVENT Ljava/lang/String;
-	public final fun getDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun getDescriptor ()Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
 	public final fun getDescriptors ()Ljava/util/List;
 	public final fun getWIRED_EVENTS ()Ljava/util/Set;
 }


### PR DESCRIPTION
`:daemon:core:checkKotlinAbi` is failing on `main`, which reddens **`Module Unit Tests` on every PR**:

```
<<<ABI has changed>>>
--- daemon/core/api/core.api
+++ daemon/core/build/kotlin/abi/core.api
-	public final fun descriptor (Z)Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
-	public final fun getDescriptor ()Lee/schimke/composeai/data/render/extensions/DataExtensionDescriptor;
+	public final fun descriptor (Z)Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
+	public final fun getDescriptor ()Lee/schimke/composeai/daemon/protocol/DataExtensionDescriptor;
```

## Cause

`DataExtensionDescriptor` moved from `data.render.extensions` to `daemon.protocol` in #4798 (*consume compose-preview-contracts 2.1.0*). The **sources** were updated — `daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt:3` imports `ee.schimke.composeai.daemon.protocol.DataExtensionDescriptor` — but the checked-in dump in `daemon/core/api/core.api` was not regenerated. The reference and the real surface have disagreed since; `git log -- daemon/core/api/core.api` shows the dump was last touched in #4715, well before that move.

## Fix

The dump is the *record* of the public surface, so it follows the move rather than the move being reverted to satisfy it. Regenerated with the task the gate itself names, and nothing wider:

```
./gradlew :daemon:core:updateKotlinAbi
```

Four lines, all the same rename. **No source change** — nothing about the published surface changes here, only the file that describes it. The rename was already effective at #4798; this makes the record agree.

## Test plan

- **Reproduced on `origin/main`** with no other change in the tree — this is not something a PR introduced:
  ```
  $ git log --oneline -1
  f14d5049e fix: stop pinning published player coordinates to a version that does not exist (#4850)
  $ ./gradlew :daemon:core:checkKotlinAbi
  BUILD FAILED   (the diff above)
  ```
- **After regenerating**, on this branch:
  ```
  $ ./gradlew :daemon:core:checkKotlinAbi
  > Task :daemon:core:checkKotlinAbi
  BUILD SUCCESSFUL
  ```

Found while driving #4852 to green; that PR's `Module Unit Tests` failure is this one, not its own. Text-only change to a generated record, so no visual evidence applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H4EyHFtrpmmyZdEGVA3ofX)_