### PR TITLE
fix(ci): publish without checking the calling repository out

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -2070,10 +2070,7 @@ jobs:
       # A repo that has never heard of the feature has no `design/pages/`, and the emitter is a
       # no-op for it. Fail-soft like the reference lane: a page whose export can't be copied is
       # dropped with a warning rather than costing the catalog its render.
-      # Reads the emitter's environment export and re-publishes it as a step output, because the
-      # step that consumes it now lives in another job. Deliberately unconditional: when the emitter
-      # did not run (import mode, or no parity lane) the variable is unset and this yields the empty
-      # string, which is exactly the "branch was readable / nothing to carry" case.
+
       # The calling repo's checked-out HEAD, NOT $GITHUB_SHA: a caller that passes `ref` checks out
       # that ref while $GITHUB_SHA still names the triggering event's commit, and recording the
       # latter would make the publish's traceability actively misleading. Same reasoning the publish
@@ -2082,6 +2079,10 @@ jobs:
         id: source-sha
         run: echo "sha=$(git -C "$GITHUB_WORKSPACE" rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
 
+      # Reads the emitter's environment export and re-publishes it as a step output, because the
+      # step that consumes it now lives in another job. Deliberately unconditional: when the emitter
+      # did not run (import mode, or no parity lane) the variable is unset and this yields the empty
+      # string, which is exactly the "branch was readable / nothing to carry" case.
       - name: Carry the parity-findings readability across the job boundary
         id: parity-findings-readability
         run: echo "unreadable=${PARITY_FINDINGS_UNREADABLE:-}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1071,6 +1071,9 @@ jobs:
       # job's environment, and the catalog push needs it to decide whether to carry the served
       # verdict forward. Environment variables do not cross a job boundary; an output does.
       parity-findings-unreadable: ${{ steps.parity-findings-readability.outputs.unreadable }}
+      # The commit the bundle was rendered from. Published here so the publish job does not have to
+      # check the calling repository out merely to read one SHA — the only thing it wanted it for.
+      source-sha: ${{ steps.source-sha.outputs.sha }}
     steps:
       - name: Check out the calling repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -2071,6 +2074,14 @@ jobs:
       # step that consumes it now lives in another job. Deliberately unconditional: when the emitter
       # did not run (import mode, or no parity lane) the variable is unset and this yields the empty
       # string, which is exactly the "branch was readable / nothing to carry" case.
+      # The calling repo's checked-out HEAD, NOT $GITHUB_SHA: a caller that passes `ref` checks out
+      # that ref while $GITHUB_SHA still names the triggering event's commit, and recording the
+      # latter would make the publish's traceability actively misleading. Same reasoning the publish
+      # step carried when it computed this itself.
+      - name: Record the rendered source revision
+        id: source-sha
+        run: echo "sha=$(git -C "$GITHUB_WORKSPACE" rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Carry the parity-findings readability across the job boundary
         id: parity-findings-readability
         run: echo "unreadable=${PARITY_FINDINGS_UNREADABLE:-}" >> "$GITHUB_OUTPUT"
@@ -2329,14 +2340,6 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out the calling repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # The same ref `generate` rendered, so the HEAD these steps record as the source of the
-          # publish is the commit the bundle actually came from.
-          ref: ${{ inputs.ref }}
-          persist-credentials: false
-
       - name: Check out compose-ai-tools (export driver)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -2359,6 +2362,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SYSTEM: ${{ inputs.system }}
+          SOURCE_SHA: ${{ needs.generate.outputs.source-sha }}
           PARITY_FINDINGS_UNREADABLE: ${{ needs.generate.outputs.parity-findings-unreadable }}
         run: |
           set -euo pipefail
@@ -2368,7 +2372,6 @@ jobs:
           # checks out that ref, while $GITHUB_SHA still names the triggering
           # event's commit. Recording the latter would make the traceability
           # this subject line adds actively misleading.
-          SOURCE_SHA=$(git -C "$GITHUB_WORKSPACE" rev-parse --short=8 HEAD)
 
           cd "$GITHUB_WORKSPACE/out"
           # Append on top of the existing tip rather than force-pushing an orphan,
@@ -2445,6 +2448,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SYSTEM: ${{ inputs.system }}
+          SOURCE_SHA: ${{ needs.generate.outputs.source-sha }}
           PARITY_FINDINGS_UNREADABLE: ${{ needs.generate.outputs.parity-findings-unreadable }}
         run: |
           set -euo pipefail
@@ -2461,7 +2465,6 @@ jobs:
           # Runs even when the catalog push skipped as unchanged. "No render changed" does not imply
           # "the manifest is current" on a branch that has never had one — that reading is exactly
           # what would keep a first publish waiting forever for a render to move.
-          SOURCE_SHA=$(git -C "$GITHUB_WORKSPACE" rev-parse --short=8 HEAD)
           HELPER="$GITHUB_WORKSPACE/compose-ai-tools/.github/actions/apply/lib/push-history.sh"
 
           # The helper comes from the export-driver checkout, which for an external caller is the


### PR DESCRIPTION
Follow-up to #4856, which moved the two force-push steps into a `publish-catalog` job but left that job checking the calling repository out.

## Why

`publish-catalog` holds `contents: write`. It checked out `inputs.ref` for exactly one reason: to run `git rev-parse --short=8 HEAD` and stamp the source revision into the push's subject line. In import mode `inputs.ref` is the *import branch of the caller* — so this was a checkout of caller-controlled content in a job that holds the write token, which is the shape CodeQL flags and, more to the point, the shape the whole `generate`/`publish-catalog` split exists to avoid.

Nothing else in the job read that checkout: `out/` arrives as an artifact, and the push helpers come from the separate `compose-ai-tools` checkout.

## What changed

- `generate` records the rendered source revision as a step output (`source-sha`) and exposes it as a job output. It already has the right checkout, and it is the job that actually did the render — so this is also the more truthful place to compute it.
- `publish-catalog` drops its `actions/checkout` of the calling repo and reads `needs.generate.outputs.source-sha` instead, passing it as `SOURCE_SHA` to both push steps.
- The `ref`-vs-`$GITHUB_SHA` reasoning the publish step carried moves with the computation, so it stays next to the code it justifies.
- Second commit is cosmetic: the new step landed between another step and its explanatory comment, so both comments are back above the steps they describe.

The published subject line is unchanged — same SHA, computed one job earlier.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/design-artifacts-reusable.yml'))"` parses.
- Reviewed every remaining `$GITHUB_WORKSPACE` reference in `publish-catalog`: `out/` (artifact), `compose-ai-tools/` (its own checkout), and a `cd` for a working directory. None need the caller's tree.
- Exercised end-to-end by the `compose-preview-imports` import pipeline, which calls this workflow with `upstream-repository` set.

Non-visual change, so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_