### PR TITLE
fix(ci): surface the failing render's test results instead of losing them with the runner

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1551,6 +1551,69 @@ jobs:
             "${embed[@]}" -o "$GITHUB_WORKSPACE/extra-bundle.png" \
             --timeout $INPUT_RENDER_TIMEOUT
 
+      # A failing render reports only "There were failing tests. See the results at: file:///…",
+      # naming a path inside a runner that is about to be destroyed. The actual reason a preview
+      # would not render — the exception and its stack — is in the JUnit XML at that path, and
+      # without this step it dies with the runner and the failure is undiagnosable from CI.
+      #
+      # That is tolerable for a first-party catalog, whose previews a contributor can run locally.
+      # It is not tolerable for an imported third-party project (`upstream-repository`), where the
+      # render is the ONLY place the build has ever run and there is nothing to reproduce locally
+      # without recreating the whole runner.
+      #
+      # Fail-soft throughout: this is diagnostics for an already-failing job, so it must never be
+      # the thing that decides the job's conclusion, and it must not mask the render's own error.
+      - name: Surface the failing render's test results
+        if: failure()
+        run: |
+          set +e
+          root="${GITHUB_WORKSPACE}/${RENDER_DIR:-.}"
+          # Only the render task's own results: other test tasks in the build are not this failure.
+          mapfile -t xml < <(find "$root" -path '*/build/test-results/composePreviewRender/*.xml' -type f 2>/dev/null)
+          if [ "${#xml[@]}" -eq 0 ]; then
+            echo "No composePreviewRender test results under $root — the render failed before it ran any preview."
+            exit 0
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/render-failure-diagnostics"
+          for f in "${xml[@]}"; do
+            cp "$f" "$GITHUB_WORKSPACE/render-failure-diagnostics/" 2>/dev/null
+          done
+          echo "::group::Failing previews"
+          # Print the <failure>/<error> bodies. Deliberately plain text rather than an XML parser:
+          # this runs in a job that is already failing, so it must not need a tool to be installed.
+          for f in "${xml[@]}"; do
+            echo "--- ${f#"$root"/}"
+            # Name the previews that FAILED and print each one's exception. Attribute order is not
+            # guaranteed, so the name is taken from the <testcase …> tag the failure belongs to
+            # rather than by position, and `classname` is excluded explicitly — a bare `name="`
+            # match picks it up instead and reports every preview as the same class.
+            awk '
+              match($0, /<testcase[^>]*/) {
+                tc = substr($0, RSTART, RLENGTH)
+                name = ""
+                if (match(tc, /(^|[[:space:]])name="[^"]*"/)) {
+                  name = substr(tc, RSTART, RLENGTH)
+                  sub(/^[[:space:]]*name="/, "", name); sub(/"$/, "", name)
+                }
+              }
+              /<(failure|error)/ { printf "FAILED: %s\n", (name == "" ? "(unnamed)" : name); show = 1 }
+              show { print }
+              /<\/(failure|error)>/ { show = 0 }
+            ' "$f" | head -200
+          done
+          echo "::endgroup::"
+          exit 0
+
+      - name: Upload the failing render's test results
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.system }}-render-failure-diagnostics
+          path: render-failure-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
       # Save the font cache even when a render step FAILED. A cold-cache run that downloaded
       # some faces before a later one failed to resolve must persist what it got, so the
       # rerun self-heals instead of starting cold again — `actions/cache` only saves on job


### PR DESCRIPTION
## Why

When `composePreviewRender` fails, the entire diagnosis CI offers is:

```
> There were failing tests. See the results at: file:///home/runner/work/…/app/build/test-results/composePreviewRender/
```

That is a path inside a runner that is destroyed seconds later. The exception that actually explains why a preview would not render is in the JUnit XML at that path, and nothing reads or uploads it — so the run tells you *that* a preview failed and never *why*.

For a first-party catalog that is survivable: a contributor can run the render locally. It is not survivable for an **imported third-party project** (`upstream-repository`), where the runner is the only place that build has ever executed. Reproducing locally means recreating the whole runner first, which is exactly the cost the import pipeline exists to avoid.

Hit for real on the first PeopleInSpace import ([run 33311724941](https://github.com/yschimke/compose-preview-imports/actions/runs/33311724941)): `:app:composePreviewDiscover` succeeded, `:app:composePreviewRender` ran and failed, and the failure was unrecoverable from CI.

## What changed

Two steps, both `if: failure()`, placed right after the render steps and before the font-cache save:

- **Surface the failing render's test results** — finds `*/build/test-results/composePreviewRender/*.xml` under `RENDER_DIR`, prints each failing preview's name and its exception in a collapsed log group, and stages the XML.
- **Upload the failing render's test results** — attaches them as `<system>-render-failure-diagnostics`, 7-day retention.

Scoped to the render task's own results, so unrelated test tasks in a third-party build don't get swept in.

Fail-soft by construction: this is diagnostics for an already-failing job, so it must never change the job's conclusion or mask the render's own error. The script runs under `set +e` and always `exit 0`, the upload is `continue-on-error` with `if-no-files-found: ignore`, and a render that died before running any preview says so rather than erroring.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(...)"` parses.
- Extracted the step's `run:` body straight out of the parsed YAML and executed it against a fixture tree containing a JUnit XML with one passing and one failing testcase. It reports `FAILED: PeopleInSpaceCardPreview` with the stack, and stages the XML for upload.
- Ran the same script against a tree with no results: prints the "failed before it ran any preview" line and exits 0.
- The first version used `sed` to pull the testcase name and matched `classname` instead of `name` (every preview reported as the same class). Replaced with `awk` that takes the name from the `<testcase>` tag the failure belongs to and excludes `classname` explicitly; the fixture above is what caught it.
- Action pin matches the three `actions/upload-artifact` pins already in this file (v7.0.1).

Non-visual change, so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_