### PR TITLE
fix(ci): pin download-artifact to a SHA that exists

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -2509,7 +2509,7 @@ jobs:
           persist-credentials: false
 
       - name: Download the rendered catalog
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f28c025e4dfd1ca53b3 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.system }}-catalog-out
           path: ${{ github.workspace }}/out


### PR DESCRIPTION
## This is a live break on `main`, and I introduced it

`publish-catalog` pins `actions/download-artifact` to `018cc2cf5baa6db3ef3c5f28c025e4dfd1ca53b3`, which is **not a commit in `actions/download-artifact`**. GitHub cannot resolve it, so the job dies in *Set up job* — before any step runs:

```
##[error]Unable to resolve action `actions/download-artifact@018cc2cf5baa6db3ef3c5f28c025e4dfd1ca53b3`,
unable to find version `018cc2cf5baa6db3ef3c5f28c025e4dfd1ca53b3`
```

**Any catalog publish fails**, first-party included — the render completes, uploads its bundle, and then the job that would push it cannot start.

I added it in [#4856](https://github.com/yschimke/compose-ai-tools/pull/4856), the generate/publish split. It has been on `main` since, latent only because no publish has run:

```
$ git log -S018cc2cf5baa6db3ef3c5f28c025e4dfd1ca53b3 -- .github/workflows/design-artifacts-reusable.yml
83de8c485 refactor(ci): publish from a job that runs none of the rendered code (#4856)
```

Found because it broke the first PeopleInSpace publish ([run 33318777406](https://github.com/yschimke/compose-preview-imports/actions/runs/33318777406)) — the render succeeded and the `publish` job failed at setup with the identical error, from the identical bad pin copied into `import.yml`. That repo gets its own fix; this one is the more serious of the two.

## The fix

Use `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1` — the pin the other two `download-artifact` steps in this same file already use, in place since [#4771](https://github.com/yschimke/compose-ai-tools/pull/4771) and exercised on every sharded render. All three uses now agree.

## Test plan

- `yaml.safe_load` parses.
- Audited **every** action pin my recent PRs (#4846, #4856, #4859, #4860, #4862) added to this workflow, against `4e961c6a0`:

  | pin | uses in repo | existed before my work |
  | --- | --- | --- |
  | `actions/checkout@3d3c42e5aa` | 85 | yes |
  | `actions/upload-artifact@043fb46d1a` | 48 | yes |
  | `actions/download-artifact@018cc2cf5b` | **1** | **no** |

  The bad pin is the only one I introduced from nowhere, and the only one used exactly once. Every other pin I added was already load-bearing elsewhere.
- The replacement is verified by use rather than by assertion: `018cc2cf…` is used once and never resolved; `3e5f45b2…` is used by "Download shard renders" and "Download section bundle to fold in", both of which run in production. I could not check either SHA against `actions/download-artifact` directly — this sandbox's proxy returns 403 for repositories outside the session's scope — so "exercised in this repo's own green runs" is the strongest evidence available here, and it is stronger than an API lookup would have been anyway.

**A pin nothing else in the repo uses is worth a second look.** That is the lesson I'd take from this: the audit above would have caught it at review time in #4856, and it is a cheap check to run on any PR that adds a pinned action.

Non-visual change, so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_