### PR TITLE
fix(preview-diff): stop every XR composite collapsing onto one render path

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -368,6 +368,15 @@ def _capture_label(capture: dict) -> str:
     return " \u00B7 ".join(parts)
 
 
+# The leaf an `@XrSubspacePreview`'s composite is always written as. Unlike
+# every other capture, this name carries no preview identity: the XR renderer
+# writes a directory per preview (`renders/<sanitizedId>/scene.json` plus a
+# texture per panel) and the compositor bakes the still beside them under this
+# fixed name, so the identity lives in the PARENT DIRECTORY. Emitted as a
+# literal by `PreviewDiscovery.previewOutputPlan`.
+XR_COMPOSITE_LEAF = "composite.png"
+
+
 def _render_basename(png_path: str, preview_id: str) -> str:
     """File basename the diff bot should use when copying/linking a capture.
 
@@ -376,9 +385,28 @@ def _render_basename(png_path: str, preview_id: str) -> str:
     same preview never collide). Fall back to ``<previewId>.png`` when the
     CLI didn't surface a real path — that matches the legacy behaviour for
     missing / unrendered rows.
+
+    The "leaf is already unique" assumption holds for every capture but one:
+    an XR composite is always literally ``composite.png`` (see
+    [XR_COMPOSITE_LEAF]), so taking the leaf bare collapsed every
+    ``@XrSubspacePreview`` in a module onto a single destination —
+    ``renders/<module>/composite.png`` — and whichever rendered last won. The
+    symptom was a preview diff flagging that file on PRs touching nothing near
+    it, showing two unrelated previews as one another's before/after
+    (compose-ai-tools#4853). For that leaf alone, fold in the parent directory
+    (the sanitised preview id) to restore uniqueness.
+
+    Deliberately keyed on the leaf rather than on "is this under a per-preview
+    subdirectory": ``png_path`` is a real resolved filesystem path, so any rule
+    inferred from the enclosing directory's name also fires on flat captures
+    that happen not to sit in a directory called ``renders`` — which would
+    re-key every committed baseline.
     """
     if png_path:
-        name = Path(png_path).name
+        path = Path(png_path)
+        name = path.name
+        if name == XR_COMPOSITE_LEAF and path.parent.name:
+            return f"{path.parent.name}__{name}"
         if name:
             return name
     return f"{preview_id}.png"

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -3238,5 +3238,54 @@ class BaselineSkewNoteTest(unittest.TestCase):
         self.assertNotIn("[!NOTE]", out)
 
 
+class RenderBasenameTest(unittest.TestCase):
+    """`_render_basename` must keep two captures from colliding on one destination.
+
+    Renders are copied to `renders/<module>/<renderBasename>`, so the basename
+    is the whole of a capture's identity within a module.
+    """
+
+    _XR = ("/w/samples/xr-spatial/build/compose-previews/renders/"
+           "com.example.XrKt.{}/composite.png")
+
+    def test_flat_capture_keeps_its_exact_basename(self):
+        # Every non-XR preview. The leaf already carries the preview id and any
+        # dimension suffix, and changing it here would re-key every committed
+        # baseline.
+        for path, want in [
+            ("/w/app/build/compose-previews/renders/pkg.Kt.ButtonPreview.png",
+             "pkg.Kt.ButtonPreview.png"),
+            ("/w/m/build/compose-previews/renders/pkg.Kt.Scroll_SCROLL_end.png",
+             "pkg.Kt.Scroll_SCROLL_end.png"),
+            # Not under a directory called `renders` at all — the rule must key
+            # on the leaf, not on the enclosing directory's name.
+            ("/tmp/whatever/Red.png", "Red.png"),
+        ]:
+            self.assertEqual(cp._render_basename(path, "x"), want)
+
+    def test_two_xr_previews_do_not_collide(self):
+        # The XR compositor bakes every preview's still as the literal
+        # `composite.png`, so the leaf alone is the same string for all of
+        # them. Taking it bare made them overwrite each other in
+        # `renders/<module>/`, and the diff bot reported one preview as
+        # another's "before" (#4853).
+        a = cp._render_basename(self._XR.format("RotateToLookAtUserPreview"), "x")
+        b = cp._render_basename(self._XR.format("SpatialPanelGridPreview"), "y")
+        self.assertNotEqual(a, b)
+        self.assertIn("RotateToLookAtUserPreview", a)
+        self.assertIn("SpatialPanelGridPreview", b)
+        # Still flat, so it addresses one file under `renders/<module>/`.
+        self.assertNotIn("/", a)
+
+    def test_xr_basename_is_stable_across_calls(self):
+        # A baseline is only comparable if one capture maps to one name on
+        # every run.
+        path = self._XR.format("RotateToLookAtUserPreview")
+        self.assertEqual(cp._render_basename(path, "x"), cp._render_basename(path, "x"))
+
+    def test_falls_back_to_preview_id_without_a_path(self):
+        self.assertEqual(cp._render_basename("", "pkg.Kt.Preview"), "pkg.Kt.Preview.png")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #4853.

The preview diff has been flagging `renders/samples:xr-spatial/composite.png` as changed on PRs that touch nothing near it. I originally filed that as a nondeterministic render and pointed at the seeded head pose. **That was wrong**, and the renders say so plainly — here are three CI renders of that one path:

| baseline (`1a52da22`) | PR #4851 (`68b0905d`) | PR #4852 (`b467a624`) |
|---|---|---|
| ![baseline](https://raw.githubusercontent.com/yschimke/compose-ai-tools/1a52da22309169db9ecbd58f15d0f8f83bfd460a/renders/samples:xr-spatial/composite.png) | ![pr4851](https://raw.githubusercontent.com/yschimke/compose-ai-tools/68b0905de921561c27c18bb960f91ce97cf807d1/renders/samples:xr-spatial/composite.png) | ![pr4852](https://raw.githubusercontent.com/yschimke/compose-ai-tools/b467a624075d7ad954ee92da30944a12aac61d8b/renders/samples:xr-spatial/composite.png) |
| `NowPlayingSpatialPreview` | a 6-panel grid | `RotateToLookAtUserPreview` |

Three **different previews**, not three renders of one. Nothing is unstable; the file is a shared destination.

## Cause

Renders are copied to `renders/<module>/<renderBasename>`, and `_render_basename` returned the leaf of the path the renderer wrote. That is correct for a flat capture — `renders/pkg.Kt.ButtonPreview.png`, whose leaf carries the preview id and any `_SCROLL_end` / `_TIME_500ms` suffix.

An `@XrSubspacePreview` is the one exception. The XR renderer writes a **directory** per preview (`renders/<sanitizedId>/scene.json` plus a texture per panel) and the compositor bakes the still beside them as the literal `composite.png` — emitted as a constant by `PreviewDiscovery.previewOutputPlan`. The identity lives in the directory, so the leaf is the same string for every XR preview in the module, and they overwrote each other in `renders/<module>/`. Last writer won, and which preview that was varied per run.

## Fix

For that leaf alone, fold the parent directory (the sanitised preview id) into the name.

Keyed on **the leaf**, not on "does this sit in a per-preview subdirectory". `pngPath` is a real resolved filesystem path, so a rule inferred from the enclosing directory's name also fires on flat captures that simply are not under a directory called `renders` — which would re-key every committed baseline in the repo. My first draft did exactly that and broke 9 existing tests; this one leaves every flat capture byte-identical.

## Test plan

Four tests over `_render_basename`, run in an isolated directory so nothing depends on cwd:

- `test_two_xr_previews_do_not_collide` — **fails against the unfixed function** with `AssertionError: 'composite.png' == 'composite.png'`, passes with the fix.
- `test_flat_capture_keeps_its_exact_basename` — pins the no-change guarantee for flat captures, including one deliberately outside any `renders/` directory (the case that caught my first draft).
- `test_xr_basename_is_stable_across_calls` — a baseline is only comparable if one capture maps to one name every run.
- `test_falls_back_to_preview_id_without_a_path` — unchanged legacy behaviour.

Full suite: **128 pass, 0 fail** (124 before this change, all still passing; verified the pre-change suite is clean on `origin/main` so no failure here is inherited).

## Expected one-time churn

Each XR preview re-keys to `<sanitizedId>__composite.png` and will show as **new** against the now-orphaned `composite.png` baseline on the first run after this lands. That is the correction arriving, not a regression — and from then on each XR preview is diffed against itself, which is the whole point.

## Not fixed here

`ci.yml`'s composite assertion uses `find … -print -quit`, which picks an arbitrary composite. That is sound for what it asserts ("at least one baked non-empty PNG") and is untouched.