### PR TITLE
fix(serve): pair the spec lane's sibling on the kit cell, not the component

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1578,6 +1578,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "Projecting design-map.json for '$INPUT_SYSTEM'."
+          # DELETE FIRST, so the check below proves the command RECREATED the map rather than that
+          # a map exists. In the two-catalog repo this input is for, the committed one at this path
+          # belongs to the OTHER system — so a command that succeeds but writes somewhere else (the
+          # `--out-dir` mistake, which `scripts/design-map.sh` makes easy) would leave it standing,
+          # pass a mere existence check, and publish the other system's mappings under this one's
+          # name. That is the exact failure this step exists to stop, and it would sail through.
+          # Safe because the checkout is disposable: nothing later in the job wants the committed
+          # map back, and a command that writes none fails the step anyway.
+          rm -f design-map.json
           bash -c "$DESIGN_MAP_COMMAND"
           if [ ! -f design-map.json ]; then
             echo "::error title=design-map-command wrote no map::The command ran but left no design-map.json at the repo root, which is the only path the lanes below read. Check that it projects to the root rather than to an --out-dir."

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -265,6 +265,19 @@ on:
         required: false
         type: string
         default: ''
+      design-map-command:
+        description: >-
+          Shell command that projects THIS system's `design-map.json` into the caller repo root,
+          run once before every step that reads it. Same input name and semantics as design-parity's
+          reusable workflow, and for the same reason: a repo publishing TWO catalogs from two modules
+          has one map PATH and two systems needing different maps, so without this the second system
+          is scored against the first one's map — every entry dangles and coverage publishes as 0%.
+          `system`, `spec` and `module` already vary per call; the map is the fourth thing that does.
+          Empty ⇒ the committed map is used as-is, which is right for the single-catalog repos that
+          are the common case.
+        required: false
+        type: string
+        default: ''
       preview-annotations:
         description: 'Whitespace-separated multipreview annotation names to teach the build-free spec pre-flight (e.g. "WearPreviewDevices WearPreviewFontScales"). Required whenever the previews are annotated with a multipreview declared in ANOTHER module — the source scan cannot see it, so the pre-flight reports "discovered 0 @Preview function(s)" and fails every entry. Wear catalogs always need this.'
         required: false
@@ -1533,6 +1546,55 @@ jobs:
       #
       # Fail-soft on purpose: an unrenderable reference is dropped with a warning
       # rather than costing the catalog its render.
+
+      # ONE MAP PATH, TWO SYSTEMS. Everything below reads `design-map.json` from the caller repo
+      # root, because that is the contract design-parity's action fixes (`<repoRoot>/design-map.json`)
+      # and this lane follows it. That is right for one catalog per repo and wrong the moment there
+      # are two: `wear-m3-catalog` publishes `wear-m3-catalog` from `:catalog` and `remote-m3` from
+      # `:remote-catalog` out of one checkout, so the second system was scored against the first
+      # one's map. It published `coverage.percent: 0` with all 50 gaps `dangling-mapping`, every one
+      # naming a preview from the OTHER module — not a catalog that maps nothing, a catalog compared
+      # against the wrong thing.
+      #
+      # The caller cannot fix that alone, which is the whole reason this input exists: the path is
+      # deliberately not a parameter, and the escape it leaves is that each job regenerates the map
+      # in its own workspace. design-parity's reusable workflow has taken `design-map-command` for
+      # exactly this since the same repo started publishing two sheets — so its hourly comparison
+      # was right while these artifacts were wrong, same repo, same commit.
+      #
+      # Placed here rather than beside the render: it must precede every consumer (design
+      # references, parity activity, parity findings) and nothing before this point reads the map,
+      # so a caller whose command needs a Gradle discovery pays for it only on a publishing run.
+      #
+      # The command is EXECUTED, by design — it is a build step the caller owns, like
+      # `design-map-command` next door. It reaches the shell through the environment rather than
+      # expression interpolation, so the value cannot alter the surrounding script's syntax, and it
+      # runs at the caller repo root because that is where the map it writes is read from (`spec`
+      # stays repo-root-relative for the same reason, even under `working-directory`).
+      - name: Project this system's design map
+        if: ${{ inputs.design-map-command != '' && (inputs.publish || inputs.upload-out) }}
+        env:
+          DESIGN_MAP_COMMAND: ${{ inputs.design-map-command }}
+        run: |
+          set -euo pipefail
+          echo "Projecting design-map.json for '$INPUT_SYSTEM'."
+          bash -c "$DESIGN_MAP_COMMAND"
+          if [ ! -f design-map.json ]; then
+            echo "::error title=design-map-command wrote no map::The command ran but left no design-map.json at the repo root, which is the only path the lanes below read. Check that it projects to the root rather than to an --out-dir."
+            exit 1
+          fi
+          # Worth printing: the number is what the coverage panel will publish, and a map that is
+          # suddenly a tenth of its usual size is the failure this input exists to prevent, caught
+          # here rather than inferred from a 0% board a day later.
+          node -e '
+            const m = require("./design-map.json");
+            const n = (m.components ?? []).length;
+            console.log(`design-map.json: ${n} component(s) for ${process.argv[1]}`);
+            if (n === 0) {
+              console.log("::warning title=Empty design map::The projected map has no components, so this system will publish 0% coverage.");
+            }
+          ' "$INPUT_SYSTEM"
+
       # The design-parity reference cache, if the caller maintains one. Cloned
       # rather than fetched through the API for the same reason the parity
       # workflow does it: the branch IS the cache, so `git` is the transport and

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSpec.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeFigmaSpec.kt
@@ -63,6 +63,33 @@ internal object ServeFigmaSpec {
   }
 
   /**
+   * The **kit cell** [reference] names — `<fileKey>/<nodeId>` — or null when it is not a Figma
+   * reference or its handle does not parse.
+   *
+   * Not a link: an identity. Two catalogs reproducing one design kit both point their previews at
+   * that kit's nodes, so this is the one key that means the same thing on both sides without either
+   * catalog knowing how the other names its previews or its components. It is what lets a cell on
+   * one sheet find the SAME cell on the other ([ServeHttpServer.parallelSpecSource]) rather than
+   * whichever preview of the counterpart component the manifest happens to list first.
+   *
+   * Validated exactly as [of] validates it, and for the same reason — a catalog is third-party data
+   * — so a malformed handle yields no key and therefore no pairing, rather than a key that matches
+   * something by accident. The node id is normalised to the `:` form the design map and the API
+   * use, so a producer emitting the `-` URL form still pairs with one emitting `:`.
+   */
+  fun kitCell(reference: DesignReference): String? {
+    val source = reference.source
+    if (!source.provider.trim().equals("figma", ignoreCase = true)) return null
+    val (key, node) = fileKeyAndNode(source) ?: return null
+    if (!FILE_KEY.matches(key) || !NODE_ID.matches(node)) return null
+    return "$key/${node.replace('-', ':')}"
+  }
+
+  /** Every distinct kit cell across [references]; empty when none is Figma-backed. */
+  fun kitCells(references: List<DesignReference>): Set<String> =
+    references.mapNotNullTo(mutableSetOf()) { kitCell(it) }
+
+  /**
    * A deep link to one node of one file, or null when either part is shaped wrong.
    *
    * The same literal-origin reassembly as [of], exposed for the callers that already hold the pair

--- a/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
+++ b/cli/serve/src/main/kotlin/ee/schimke/composeai/cli/serve/ServeHttpServer.kt
@@ -4491,6 +4491,14 @@ class ServeHttpServer(
    *    the spec, not a link we can offer);
    * 5. the sibling has a preview for that component id.
    *
+   * Step 5 then picks WHICH of them, and that is the cell question rather than the component one.
+   * Both sheets reproduce one design kit, so a preview's kit node is a key that means the same on
+   * both sides; matching it pairs `Disabled=Yes` with `Disabled=Yes` instead of with whichever
+   * preview of the counterpart component the sibling's manifest lists first. Where no cell matches
+   * — the preview names no node, the sibling publishes no references, or that sheet genuinely does
+   * not draw the cell — the canonical sticker is still offered, and the provenance says which of
+   * the two pairings produced the panel.
+   *
    * [ServeSessionRegistry.peekHost], never `lease`: this is a metadata read while building a page,
    * and standing a suspended sibling's daemon up to decide whether to draw a button would be a
    * daemon per page view. A suspended sibling therefore offers no lane — fail-soft, like the rest
@@ -4510,11 +4518,30 @@ class ServeHttpServer(
     val componentId = preview.componentId?.takeIf { it.isNotBlank() } ?: return null
     val parallelId = bundle.parallelByComponentId[componentId] ?: return null
     val siblingHost = sessions.peekHost(siblingSystem) ?: return null
-    // The sibling's OWN preview for that component. First match, like the design-reference lane
-    // above: a component with several previews has one canonical sticker and the manifest's order
-    // is the producer's.
-    val siblingPreview =
-      siblingHost.previews.firstOrNull { it.componentId == parallelId } ?: return null
+    // The sibling's OWN previews for that component — every one of them, because a component that
+    // draws a kit set exhaustively has one preview per CELL and they are all real comparisons.
+    val siblingPreviews = siblingHost.previews.filter { it.componentId == parallelId }
+    if (siblingPreviews.isEmpty()) return null
+    // MATCH THE CELL, not the component. Both sheets point their previews at the same design kit,
+    // so the kit node is the one key that means the same thing on both sides — neither catalog has
+    // to name its previews or its variants the way the other does, which is what makes this survive
+    // the renames that broke id-matching (`iconbutton-filled` against `button-icon-filled`, and a
+    // breakpoint suffix on one side only).
+    //
+    // Without it this took the first preview listed for the component, so `Disabled=Yes` on one
+    // sheet was compared against the other sheet's DEFAULT render while both sheets drew the
+    // disabled cell — a difference reported on every variant that is really a difference between
+    // two different cells. `@CatalogVariant.parallel` documents the opposite ("a variant is
+    // compared in its own right, not through its parent"), and this is that promise kept.
+    val cells = ServeFigmaSpec.kitCells(host.designReferencesFor(preview.id))
+    val cellMatch = siblingPreviews.firstOrNull { candidate ->
+      cells.isNotEmpty() &&
+        ServeFigmaSpec.kitCells(siblingHost.designReferencesFor(candidate.id)).any { it in cells }
+    }
+    // The canonical sticker stays the FLOOR, so nothing that paired before stops pairing: a preview
+    // naming no kit node, a sibling that publishes no references at all, and a cell the other sheet
+    // genuinely does not draw all land here and get what they got before.
+    val siblingPreview = cellMatch ?: siblingPreviews.first()
     val siblingBundle = catalogBundleHost(siblingHost)
     val siblingLabel =
       siblingBundle?.title?.takeIf { it.isNotBlank() }
@@ -4543,9 +4570,21 @@ class ServeHttpServer(
       // catalog's RENDER, produced under its own theme, knobs and overrides rather than the ones
       // that produced the render beside it. Saying so is the difference between a comparison and an
       // implied equivalence.
+      //
+      // And it now says WHICH pairing you are looking at, because the two are not equally strong. A
+      // cell match is the same kit node on both sheets and a difference in it is a real finding;
+      // the
+      // fallback is the counterpart component's canonical sticker, which for a variant cell is very
+      // likely a different cell — so a difference there may be nothing but that. Reporting both
+      // under one sentence would make the weaker pairing read as the stronger one, which is the
+      // failure this whole change exists to remove rather than relocate.
       provenance =
         "$siblingLabel's own render of ${siblingPreview.componentId ?: parallelId}, " +
-          "under that catalog's theme and knobs — not this page's.",
+          "under that catalog's theme and knobs — not this page's. " +
+          if (cellMatch != null) "Paired on the design-kit cell both sheets name."
+          else
+            "Paired at component level: that catalog's canonical sticker, which may draw a " +
+              "different cell of this component than the render beside it.",
     )
   }
 

--- a/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSpecLaneParallelSourceTest.kt
+++ b/cli/serve/src/test/kotlin/ee/schimke/composeai/cli/serve/ServeSpecLaneParallelSourceTest.kt
@@ -32,6 +32,13 @@ class ServeSpecLaneParallelSourceTest {
   private val siteHost = "m3.example.test"
   private val token = "t0ken"
 
+  private companion object {
+    /** One kit file, two sheets — which is the premise the cell key rests on. */
+    const val KIT = "B24oss2tTeXAFykyeyusz0"
+    const val DEFAULT_CELL = "10:1"
+    const val DISABLED_CELL = "10:2"
+  }
+
   private fun png(): ByteArray =
     ByteArrayOutputStream()
       .also { ImageIO.write(BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB), "png", it) }
@@ -158,6 +165,158 @@ class ServeSpecLaneParallelSourceTest {
     try {
       val (_, html) = get(server, "/compose-m3/p/button-filled")
       assertEquals("/wear-m3/render/chip-filled.png", parallelSrc(html))
+    } finally {
+      server.stop()
+    }
+  }
+
+  /**
+   * A catalog whose component draws SEVERAL kit cells: one preview per cell, each naming the kit
+   * node it reproduces. [cells] is `previewId to figmaNode`.
+   *
+   * A null node still emits a reference, just not a Figma-backed one — a checked-in PNG, which is
+   * what a catalog comparing against a hand-drawn mock has. It has to carry SOMETHING: the spec
+   * lane only exists for a preview with a reference, so a preview with none never reaches the
+   * pairing at all and could not exercise its fallback.
+   */
+  private fun cellCatalog(
+    label: String,
+    componentId: String,
+    cells: List<Pair<String, String?>>,
+    compareWith: String? = null,
+    parallel: String? = null,
+  ): ServeBundleHost {
+    val dir = Files.createTempDirectory("cells-$label").toFile().also { it.deleteOnExit() }
+    File(dir, "index.html").writeText("<html></html>")
+    File(dir, "previews").mkdirs()
+    File(dir, ServeDesignReferenceStore.DIRECTORY).mkdirs()
+    val refs = mutableListOf<String>()
+    for ((previewId, node) in cells) {
+      File(dir, "previews/$previewId.png").writeBytes(png())
+      File(dir, "${ServeDesignReferenceStore.DIRECTORY}/$previewId-ref.png").writeBytes(png())
+      val source =
+        if (node == null) """{"provider":"png"}"""
+        else """{"provider":"figma","uri":"figma:$KIT/$node"}"""
+      refs +=
+        """
+        {"id":"$previewId-ref","previewId":"$previewId","label":"$previewId",
+         "source":$source,
+         "raster":{"path":"references/$previewId-ref.png"}}
+        """
+          .trimIndent()
+    }
+    File(dir, "previews/variants.json")
+      .writeText(
+        cells.joinToString(",", "{", "}") { """"${it.first}":{"componentId":"$componentId"}""" }
+      )
+    File(dir, "${ServeDesignReferenceStore.DIRECTORY}/${ServeDesignReferenceStore.INDEX_FILE}")
+      .writeText(
+        """{"schema":"${DesignReferenceManifest.SCHEMA}","references":[${refs.joinToString(",")}]}"""
+      )
+    return ServeBundleHost(
+      dir,
+      label = label,
+      title = label,
+      compareWithSystem = compareWith,
+      parallelByComponentId = parallel?.let { mapOf(componentId to it) } ?: emptyMap(),
+    )
+  }
+
+  /**
+   * Both sheets draw the same component's cells, and the sibling lists its DEFAULT first — which is
+   * what the pairing used to take for every cell.
+   */
+  private fun cellServer(): ServeHttpServer {
+    val registry = ServeSessionRegistry(open = { null })
+    registry.register(
+      "compose-m3",
+      host =
+        cellCatalog(
+          "compose-m3",
+          componentId = "Button/Filled",
+          // `no-cell` carries a PNG reference rather than a Figma one: the fallback case, kept in
+          // the same
+          // fixture so both paths are proved against one sibling rather than two differently-built
+          // ones.
+          cells =
+            listOf(
+              "button-filled" to DEFAULT_CELL,
+              "button-disabled" to DISABLED_CELL,
+              "button-no-cell" to null,
+            ),
+          compareWith = "wear-m3",
+          parallel = "Button/Filled",
+        ),
+      pinned = true,
+    )
+    registry.register(
+      "wear-m3",
+      host =
+        cellCatalog(
+          "wear-m3",
+          componentId = "Button/Filled",
+          cells = listOf("chip-filled" to DEFAULT_CELL, "chip-disabled" to DISABLED_CELL),
+        ),
+      pinned = true,
+    )
+    return ServeHttpServer(
+        host = "127.0.0.1",
+        requestedPort = 0,
+        token = token,
+        sessions = registry,
+        defaultSessionId = "compose-m3",
+        isPublic = true,
+        catalogSessions = listOf("compose-m3", "wear-m3"),
+      )
+      .also { it.start() }
+  }
+
+  @Test
+  fun `a variant cell pairs with the same kit cell, not the sibling's canonical sticker`() {
+    val server = cellServer()
+    try {
+      // The default cell pairs with the default cell — true before this change too, because the
+      // sibling happens to list it first.
+      val (_, base) = get(server, "/compose-m3/p/button-filled")
+      assertEquals("/wear-m3/render/chip-filled.png", parallelSrc(base))
+
+      // THE REGRESSION THIS GUARDS. `Disabled=Yes` used to be compared against the sibling's
+      // DEFAULT render, so every disabled cell reported a difference that was really the difference
+      // between an enabled button and a disabled one.
+      val (_, disabled) = get(server, "/compose-m3/p/button-disabled")
+      assertEquals("/wear-m3/render/chip-disabled.png", parallelSrc(disabled))
+      assertTrue(
+        disabled.contains("Paired on the design-kit cell"),
+        "a cell match says so in its provenance: $disabled",
+      )
+    } finally {
+      server.stop()
+    }
+  }
+
+  @Test
+  fun `a preview naming no kit cell still pairs, and says the pairing is weaker`() {
+    val server = cellServer()
+    try {
+      val (code, html) = get(server, "/compose-m3/p/button-no-cell")
+      assertEquals(200, code)
+      // Still offered — the canonical sticker is the floor, so nothing that paired before stops.
+      val src = parallelSrc(html)
+      assertTrue(src != null && src.startsWith("/wear-m3/render/"), "still pairs: $html")
+      // WHICH sibling preview is deliberately not asserted. The fallback takes the manifest's
+      // first,
+      // and the manifest's order is the producer's — here it happens to be alphabetical, which puts
+      // `chip-disabled` ahead of `chip-filled` and makes the "canonical sticker" the disabled cell.
+      // Pinning that would pin an accident of naming, and it is exactly the fragility the cell key
+      // exists to route around: the fallback is a floor to keep old pairings working, not a claim
+      // about which cell you are looking at.
+      //
+      // Which is why the only thing worth asserting is that it does NOT dress itself up as one.
+      assertTrue(
+        html.contains("Paired at component level"),
+        "the fallback declares itself: $html",
+      )
+      assertFalse(html.contains("Paired on the design-kit cell"))
     } finally {
       server.stop()
     }

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -983,6 +983,7 @@ workspace, so it can regenerate the map before anything reads it. Pass the comma
     uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
     with:
       system: wear-m3-catalog
+      spec: catalog.spec.json
       module: ':catalog'
       design-map-command: >
         ./gradlew :catalog:composePreviewDiscover &&
@@ -992,6 +993,7 @@ workspace, so it can regenerate the map before anything reads it. Pass the comma
     uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
     with:
       system: remote-m3
+      spec: remote-catalog/catalog.spec.json
       module: ':remote-catalog'
       design-map-command: >
         ./gradlew :remote-catalog:composePreviewDiscover &&

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -965,6 +965,45 @@ in this repo, because the consumer is a catalog repo whose `design-map.json` is 
 and CI-checked: with no version to pin, a change here turns that repo red for a change
 nobody there made.
 
+#### Two catalogs in one repo: `design-map-command`
+
+The path is fixed at `<repoRoot>/design-map.json` — design-parity's action reads exactly
+that, and `design-artifacts-reusable.yml` follows it. One catalog per repo is fine. Two are
+not: `wear-m3-catalog` publishes `wear-m3-catalog` from `:catalog` and `remote-m3` from
+`:remote-catalog` out of one checkout, so whichever system does not own the committed map is
+scored against the other one's. It publishes as `coverage.percent: 0` with every gap a
+`dangling-mapping` naming a preview from the other module — which reads like a catalog that
+maps nothing rather than one compared against the wrong file.
+
+The escape the fixed path leaves is that each system is a separate job with its own
+workspace, so it can regenerate the map before anything reads it. Pass the command that does:
+
+```yaml
+  wear:
+    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
+    with:
+      system: wear-m3-catalog
+      module: ':catalog'
+      design-map-command: >
+        ./gradlew :catalog:composePreviewDiscover &&
+        scripts/design-map.sh
+
+  remote:
+    uses: yschimke/compose-ai-tools/.github/workflows/design-artifacts-reusable.yml@main
+    with:
+      system: remote-m3
+      module: ':remote-catalog'
+      design-map-command: >
+        ./gradlew :remote-catalog:composePreviewDiscover &&
+        scripts/design-map.sh remote-catalog
+```
+
+Same input name and meaning as design-parity's reusable workflow, which has taken it since
+that repo grew its second sheet — so the hourly parity comparison was already correct while
+the published artifacts were not. It runs at the repo root, before the design-reference and
+parity-emitter steps, and fails the run if it leaves no map there. Omit it and the committed
+map is used unchanged, which is what every single-catalog repo wants.
+
 ### Breakpoints and multipreviews: `select`, not a split `@Preview`
 
 A multipreview annotation (`@WearPreviewDevices`, a local `@CatalogWearBreakpoints`)


### PR DESCRIPTION
Gap 1 of #4838. The compare wall and the typography/theme layers in that issue are untouched — see **Not in this PR** below.

## The bug

`parallelSpecSource` resolved the counterpart by taking the sibling's first preview for the component:

```kotlin
val siblingPreview =
  siblingHost.previews.firstOrNull { it.componentId == parallelId } ?: return null
```

So every **cell** of a component was compared against one canonical sticker. `Disabled=Yes` on one sheet was scored against the other sheet's **default** render — while both sheets drew the disabled cell — and the difference reported was mostly the difference between an enabled button and a disabled one. `@CatalogVariant.parallel` documents the opposite: *"a variant is compared in its own right, not through its parent."*

## The key

Both sheets reproduce one design kit, so the **kit node** is a key that means the same thing on both sides. It is already published — a Figma-backed reference carries `figma:<fileKey>/<nodeId>` — so this only projects it out:

```kotlin
fun kitCell(reference: DesignReference): String?   // "<fileKey>/<nodeId>"
fun kitCells(references: List<DesignReference>): Set<String>
```

and the pairing prefers a sibling preview sharing one. Neither catalog has to name its previews, variants or components the way the other does — which is what makes this survive the renames that defeat id-matching (`iconbutton-filled` vs `button-icon-filled`; a breakpoint suffix on one side only). Node ids are normalised to the `:` form, so a producer emitting the `-` URL form still pairs with one emitting `:`. Parsing is the same strict validation `of()` already does, for the same reason: a catalog is third-party data, so a malformed handle yields no key and therefore no pairing, rather than a key that matches something by accident.

## The floor is unchanged

The canonical sticker remains the fallback, so **nothing that paired before stops pairing**: a preview naming no kit node, a sibling publishing no Figma references, and a cell the other sheet genuinely does not draw all keep exactly what they had.

## The provenance now says which pairing you got

The two are not equally strong, and conflating them would relocate the bug rather than remove it:

- cell match → *"Paired on the design-kit cell both sheets name."*
- fallback → *"Paired at component level: that catalog's canonical sticker, which may draw a different cell of this component than the render beside it."*

A difference in a cell match is a real finding. A difference in the fallback may be nothing but the fact that it is a different cell.

## Tests

Two, against one fixture whose sibling draws two cells:

- the disabled cell pairs with the **disabled** cell, and its provenance says so;
- a preview whose reference is a **PNG** rather than Figma still pairs, and declares itself component-level.

The fallback's *identity* is deliberately not asserted. It follows the manifest's order — the producer's — and in this fixture that happens to be alphabetical, which puts `chip-disabled` ahead of `chip-filled` and makes the "canonical sticker" the disabled cell. Pinning that would pin an accident of naming, and it is precisely the fragility the cell key routes around.

Two things the fixture work turned up, both recorded in comments so the next person does not rediscover them: the spec lane only exists for a preview that has **some** reference, so a preview with none never reaches this code at all; and the existing tests in this file keep exercising the fallback path, because their reference declares `provider: "figma"` with no URI.

## Verification

`:cli:serve:test` green in full (not just the touched class), `ktfmtFormat` clean.

## Not in this PR

Gap 2 of #4838 — the compare wall, and the typography / theme / layout diff layers. Those are additive surfaces rather than a correction to an existing one, and this pairing is the thing they would be built on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxnGrAmCM3y1AbrFixVcqK)_