### PR TITLE
fix(serve-wasm): bump the upstream pin and port the malformed-font-family fix

### DIFF
--- a/.github/ci/serve-wasm-upstream-pin.json
+++ b/.github/ci/serve-wasm-upstream-pin.json
@@ -1,3 +1,3 @@
 {
-  "sha": "e544e22dfb2d017c765bc3584cf829c5257b5c7b"
+  "sha": "f8c398b28147af5a1b4d4f0dad8936799a19348d"
 }

--- a/.github/ci/serve-wasm-upstream/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/CatalogFonts.kt
+++ b/.github/ci/serve-wasm-upstream/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/CatalogFonts.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.text.platform.Font
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * The typefaces the native catalog lane composes with.
@@ -66,23 +66,31 @@ internal fun parseFontsManifest(raw: String): List<ManifestFont> {
   val root =
     runCatching { Json { ignoreUnknownKeys = true }.parseToJsonElement(raw) as? JsonObject }
       .getOrNull() ?: return emptyList()
-  return root["families"]?.jsonArray.orEmpty().flatMap { entry ->
+  // `as?` at every field, never `.jsonPrimitive` / `.jsonArray`. Those accessors THROW on a
+  // wrong-typed element, and the only `runCatching` in this path is `loadCatalogFonts`'s, which
+  // wraps the whole call: one family whose `name` was an object, or whose `fonts` was not an array,
+  // therefore collapsed the entire manifest to `emptyList()` and cost the catalog every other
+  // family. That is precisely the "skipped, not fatal" this function's contract promises, so it has
+  // to hold per entry rather than per parse.
+  val families = root["families"] as? JsonArray ?: return emptyList()
+  return families.flatMap { entry ->
     val family = entry as? JsonObject ?: return@flatMap emptyList()
-    val name = family["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
-    val role = family["role"]?.jsonPrimitive?.contentOrNull.orEmpty()
+    val name = (family["name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+    val role = (family["role"] as? JsonPrimitive)?.contentOrNull.orEmpty()
     if (role.isEmpty()) return@flatMap emptyList()
-    family["fonts"]?.jsonArray.orEmpty().mapNotNull { value ->
+    val fonts = family["fonts"] as? JsonArray ?: return@flatMap emptyList()
+    fonts.mapNotNull { value ->
       val font = value as? JsonObject ?: return@mapNotNull null
       val file =
-        font["file"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        (font["file"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
           ?: return@mapNotNull null
       ManifestFont(
         role = role,
         family = name,
         file = file,
         // Absent weight is Regular, which is what a single-face family means by omitting it.
-        weight = font["weight"]?.jsonPrimitive?.intOrNull ?: 400,
-        italic = font["italic"]?.jsonPrimitive?.booleanOrNull ?: false,
+        weight = (font["weight"] as? JsonPrimitive)?.intOrNull ?: 400,
+        italic = (font["italic"] as? JsonPrimitive)?.booleanOrNull ?: false,
       )
     }
   }

--- a/.github/ci/serve-wasm-upstream/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/CatalogFontsTest.kt
+++ b/.github/ci/serve-wasm-upstream/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/CatalogFontsTest.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.servewasm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `parseFontsManifest` is `internal` and top-level precisely so these rules can be asserted without
+ * a browser, and the rule that matters most is the fail-soft one: a dropped face looks like a
+ * working render, so nothing else in the system will report it.
+ */
+class CatalogFontsTest {
+
+  @Test
+  fun `a well-formed manifest flattens to its faces`() {
+    val faces =
+      parseFontsManifest(
+        """
+        {"families":[
+          {"role":"default","name":"Roboto","fonts":[
+            {"file":"Roboto-Regular.ttf"},
+            {"file":"Roboto-Medium.ttf","weight":500},
+            {"file":"Roboto-Italic.ttf","italic":true}
+          ]}
+        ]}
+        """
+      )
+    assertEquals(3, faces.size)
+    assertEquals(listOf("default", "default", "default"), faces.map { it.role })
+    // An absent weight is Regular — what a single-face family means by omitting it.
+    assertEquals(listOf(400, 500, 400), faces.map { it.weight })
+    assertEquals(listOf(false, false, true), faces.map { it.italic })
+  }
+
+  @Test
+  fun `one malformed family does not cost the others`() {
+    // The regression this test exists for. `.jsonPrimitive` / `.jsonArray` THROW on a wrong-typed
+    // element, and the only `runCatching` in this path wraps the whole call in `loadCatalogFonts` —
+    // so a single family whose `name` was an object, or whose `fonts` was not an array, collapsed
+    // the entire manifest to nothing and every native preview silently fell back to the CMP
+    // bundled font. Each of these entries used to take Roboto down with it.
+    for (broken in
+      listOf(
+        """{"role":"generic","name":{"nested":"object"},"fonts":[{"file":"a.ttf"}]}""",
+        """{"role":"generic","name":"X","fonts":{"not":"an array"}}""",
+        """{"role":["not","a","string"],"name":"X","fonts":[{"file":"a.ttf"}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":{"nested":"object"}}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":"a.ttf","weight":"heavy"}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":"a.ttf","italic":"yes"}]}""",
+        """"a bare string, not an object"""",
+      )) {
+      val faces =
+        parseFontsManifest(
+          """{"families":[$broken,{"role":"default","name":"Roboto","fonts":[{"file":"R.ttf"}]}]}"""
+        )
+      assertTrue(
+        faces.any { it.role == "default" && it.file == "R.ttf" },
+        "the valid family was dropped alongside: $broken",
+      )
+    }
+  }
+
+  @Test
+  fun `a malformed weight or italic falls back rather than dropping the face`() {
+    val faces =
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[
+             {"file":"R.ttf","weight":"heavy","italic":"yes"}]}]}"""
+      )
+    assertEquals(1, faces.size)
+    assertEquals(400, faces.single().weight)
+    assertEquals(false, faces.single().italic)
+  }
+
+  @Test
+  fun `an entry without a role or a file is skipped`() {
+    // Both are load-bearing: the role is how a face is looked up, and the file is what is fetched.
+    // A face missing either cannot be used, so it is dropped rather than half-registered.
+    assertEquals(
+      emptyList(),
+      parseFontsManifest("""{"families":[{"name":"R","fonts":[{"file":"R.ttf"}]}]}"""),
+    )
+    assertEquals(
+      emptyList(),
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[{"weight":400}]}]}"""
+      ),
+    )
+    assertEquals(
+      emptyList(),
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[{"file":"  "}]}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `unparseable or unexpected json yields nothing rather than throwing`() {
+    // `loadCatalogFonts` turns an empty manifest into today's bundled-font behaviour, which is the
+    // correct degradation. Throwing would not be.
+    assertEquals(emptyList(), parseFontsManifest("not json at all"))
+    assertEquals(emptyList(), parseFontsManifest("[]"))
+    assertEquals(emptyList(), parseFontsManifest("{}"))
+    assertEquals(emptyList(), parseFontsManifest("""{"families":"not an array"}"""))
+    assertEquals(emptyList(), parseFontsManifest(""))
+  }
+}

--- a/cli/serve-wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/CatalogFonts.kt
+++ b/cli/serve-wasm/src/wasmJsMain/kotlin/ee/schimke/composeai/servewasm/CatalogFonts.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.text.platform.Font
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * The typefaces the native catalog lane composes with.
@@ -70,23 +70,31 @@ internal fun parseFontsManifest(raw: String): List<ManifestFont> {
   val root =
     runCatching { Json { ignoreUnknownKeys = true }.parseToJsonElement(raw) as? JsonObject }
       .getOrNull() ?: return emptyList()
-  return root["families"]?.jsonArray.orEmpty().flatMap { entry ->
+  // `as?` at every field, never `.jsonPrimitive` / `.jsonArray`. Those accessors THROW on a
+  // wrong-typed element, and the only `runCatching` in this path is `loadCatalogFonts`'s, which
+  // wraps the whole call: one family whose `name` was an object, or whose `fonts` was not an array,
+  // therefore collapsed the entire manifest to `emptyList()` and cost the catalog every other
+  // family. That is precisely the "skipped, not fatal" this function's contract promises, so it has
+  // to hold per entry rather than per parse.
+  val families = root["families"] as? JsonArray ?: return emptyList()
+  return families.flatMap { entry ->
     val family = entry as? JsonObject ?: return@flatMap emptyList()
-    val name = family["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
-    val role = family["role"]?.jsonPrimitive?.contentOrNull.orEmpty()
+    val name = (family["name"] as? JsonPrimitive)?.contentOrNull.orEmpty()
+    val role = (family["role"] as? JsonPrimitive)?.contentOrNull.orEmpty()
     if (role.isEmpty()) return@flatMap emptyList()
-    family["fonts"]?.jsonArray.orEmpty().mapNotNull { value ->
+    val fonts = family["fonts"] as? JsonArray ?: return@flatMap emptyList()
+    fonts.mapNotNull { value ->
       val font = value as? JsonObject ?: return@mapNotNull null
       val file =
-        font["file"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }
+        (font["file"] as? JsonPrimitive)?.contentOrNull?.takeIf { it.isNotBlank() }
           ?: return@mapNotNull null
       ManifestFont(
         role = role,
         family = name,
         file = file,
         // Absent weight is Regular, which is what a single-face family means by omitting it.
-        weight = font["weight"]?.jsonPrimitive?.intOrNull ?: 400,
-        italic = font["italic"]?.jsonPrimitive?.booleanOrNull ?: false,
+        weight = (font["weight"] as? JsonPrimitive)?.intOrNull ?: 400,
+        italic = (font["italic"] as? JsonPrimitive)?.booleanOrNull ?: false,
       )
     }
   }

--- a/cli/serve-wasm/src/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/CatalogFontsTest.kt
+++ b/cli/serve-wasm/src/wasmJsTest/kotlin/ee/schimke/composeai/servewasm/CatalogFontsTest.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.servewasm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `parseFontsManifest` is `internal` and top-level precisely so these rules can be asserted without
+ * a browser, and the rule that matters most is the fail-soft one: a dropped face looks like a
+ * working render, so nothing else in the system will report it.
+ */
+class CatalogFontsTest {
+
+  @Test
+  fun `a well-formed manifest flattens to its faces`() {
+    val faces =
+      parseFontsManifest(
+        """
+        {"families":[
+          {"role":"default","name":"Roboto","fonts":[
+            {"file":"Roboto-Regular.ttf"},
+            {"file":"Roboto-Medium.ttf","weight":500},
+            {"file":"Roboto-Italic.ttf","italic":true}
+          ]}
+        ]}
+        """
+      )
+    assertEquals(3, faces.size)
+    assertEquals(listOf("default", "default", "default"), faces.map { it.role })
+    // An absent weight is Regular — what a single-face family means by omitting it.
+    assertEquals(listOf(400, 500, 400), faces.map { it.weight })
+    assertEquals(listOf(false, false, true), faces.map { it.italic })
+  }
+
+  @Test
+  fun `one malformed family does not cost the others`() {
+    // The regression this test exists for. `.jsonPrimitive` / `.jsonArray` THROW on a wrong-typed
+    // element, and the only `runCatching` in this path wraps the whole call in `loadCatalogFonts` —
+    // so a single family whose `name` was an object, or whose `fonts` was not an array, collapsed
+    // the entire manifest to nothing and every native preview silently fell back to the CMP
+    // bundled font. Each of these entries used to take Roboto down with it.
+    for (broken in
+      listOf(
+        """{"role":"generic","name":{"nested":"object"},"fonts":[{"file":"a.ttf"}]}""",
+        """{"role":"generic","name":"X","fonts":{"not":"an array"}}""",
+        """{"role":["not","a","string"],"name":"X","fonts":[{"file":"a.ttf"}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":{"nested":"object"}}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":"a.ttf","weight":"heavy"}]}""",
+        """{"role":"generic","name":"X","fonts":[{"file":"a.ttf","italic":"yes"}]}""",
+        """"a bare string, not an object"""",
+      )) {
+      val faces =
+        parseFontsManifest(
+          """{"families":[$broken,{"role":"default","name":"Roboto","fonts":[{"file":"R.ttf"}]}]}"""
+        )
+      assertTrue(
+        faces.any { it.role == "default" && it.file == "R.ttf" },
+        "the valid family was dropped alongside: $broken",
+      )
+    }
+  }
+
+  @Test
+  fun `a malformed weight or italic falls back rather than dropping the face`() {
+    val faces =
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[
+             {"file":"R.ttf","weight":"heavy","italic":"yes"}]}]}"""
+      )
+    assertEquals(1, faces.size)
+    assertEquals(400, faces.single().weight)
+    assertEquals(false, faces.single().italic)
+  }
+
+  @Test
+  fun `an entry without a role or a file is skipped`() {
+    // Both are load-bearing: the role is how a face is looked up, and the file is what is fetched.
+    // A face missing either cannot be used, so it is dropped rather than half-registered.
+    assertEquals(
+      emptyList(),
+      parseFontsManifest("""{"families":[{"name":"R","fonts":[{"file":"R.ttf"}]}]}"""),
+    )
+    assertEquals(
+      emptyList(),
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[{"weight":400}]}]}"""
+      ),
+    )
+    assertEquals(
+      emptyList(),
+      parseFontsManifest(
+        """{"families":[{"role":"default","name":"R","fonts":[{"file":"  "}]}]}"""
+      ),
+    )
+  }
+
+  @Test
+  fun `unparseable or unexpected json yields nothing rather than throwing`() {
+    // `loadCatalogFonts` turns an empty manifest into today's bundled-font behaviour, which is the
+    // correct degradation. Throwing would not be.
+    assertEquals(emptyList(), parseFontsManifest("not json at all"))
+    assertEquals(emptyList(), parseFontsManifest("[]"))
+    assertEquals(emptyList(), parseFontsManifest("{}"))
+    assertEquals(emptyList(), parseFontsManifest("""{"families":"not an array"}"""))
+    assertEquals(emptyList(), parseFontsManifest(""))
+  }
+}


### PR DESCRIPTION
The follow-up #4871 promised: [compose-preview-server#42](https://github.com/yschimke/compose-preview-server/pull/42) landed as `f8c398b`, so the pin moves from `e544e22` to `f8c398b` and the fix comes across into the fork.

## Why this is not just bookkeeping

#4871 fixed `parseFontsManifest` **upstream rather than here**, precisely so the two copies would not drift while the gate was being added. That left this repository holding the buggy copy — `compose-preview`'s bundled `preview-ui/` shipping a defect `compose-preview serve` no longer has. That is the exact failure mode the gate exists to catch, so leaving it unported would have been the second instance of #4821 in a week.

The bug: `.jsonPrimitive` / `.jsonArray` **throw** on a wrong-typed element, and the only `runCatching` in the path wraps the whole call. One family whose `name` was an object, or whose `fonts` was not an array, collapsed the **entire** manifest to `emptyList()` and hit `loadCatalogFonts`'s early return — so every native catalog preview composed with the CMP bundled font while claiming to reproduce snapshots the Android renderer rasterized with Roboto. Silent in the way that matters: a fallback font is not an error, it just renders.

`CatalogFontsTest` comes across with it. Its malformed cases each place a broken entry **beside a valid one** and assert the valid family survives — the property that was actually violated; a test asserting only "the broken entry is absent" would have passed before the fix too.

## How it was ported

Not by hand. The two files were copied out of the freshly vendored tree and this repository's side of the one recorded `ALLOWED_DELTAS` entry re-applied programmatically (the inverse of the gate's own `normalise()`), so the permitted KDoc paragraph — where the fonts are staged from, which cannot be true in both repositories — is reproduced verbatim rather than retyped.

## Test plan

- `python3 .github/ci/check_serve_wasm_fork.py --update f8c398b28147af5a1b4d4f0dad8936799a19348d` — vendored 10 files.
- **The gate did its job before it passed.** Immediately after the pin bump it exited 1, naming both halves of the drift: `CatalogFontsTest.kt: upstream has it, cli/serve-wasm does not`, plus the `as?`-vs-`.jsonPrimitive` diff in `CatalogFonts.kt`. Post-port it exits 0 — `10 shared files, 1 recorded delta(s), 1 per-repository file(s) not compared`. The derived inventory is what caught the missing test file; a hard-coded list would not have. CI's `Serve-Wasm Fork Drift` job agrees, green on the new pin.
- `python3 .github/ci/test_check_serve_wasm_fork.py` — 14/14 green.
- `./gradlew :cli:serve-wasm:compileKotlinWasmJs :cli:serve-wasm:compileTestKotlinWasmJs` — green, so the new test compiles against this repository's catalog.
- `./gradlew :cli:serve-wasm:ktfmtFormatWasmJsMain :ktfmtFormatWasmJsTest` — applied, and it left both ported files byte-unchanged (both repositories use googleStyle), so the gate is still green after formatting.

## Correction: these tests do not run in CI, here or anywhere

I first wrote that CI would be the first real run of `CatalogFontsTest`. That was wrong, and the truth is worse. **`cli/serve-wasm`'s unit tests have never executed in this repository's CI at all** — not on this PR, not on #4871.

`Module Unit Tests` is driven by `.github/ci/affected-gradle-tests.py`, which emits tasks from the graph's `jvmTestTasks`, and that field is an allowlist: `['test', 'jvmTest', 'desktopTest']`. `:cli:serve-wasm` registers **none** of those — `./gradlew :cli:serve-wasm:tasks` shows `wasmJsTest` and nothing else — so the resolver emits nothing for it and the job skips. It skipped on this PR, whose only source changes are in that module.

This is the same shape as the `jvmTest` gap that script's own docstring documents (#4819), one platform further out. Four test files are affected: `CatalogFontsTest`, `NativeCatalogTest`, `OverrideSeedsTest`, `UiComposerTest`.

**I have not fixed it here, deliberately.** Adding `wasmJsTest` to that allowlist looks like a one-line change, and `cli/serve-wasm` is the only module with `wasmJsTest` sources so the blast radius is small — but the comment above that list already excludes the wasm/browser lane *on purpose*, because the job lacks the toolchain and the author judged that "turning a coverage fix into a platform-provisioning problem". Overriding a documented decision, with a change I cannot validate in my sandbox (`:kotlinWasmToolingSetup` cannot reach the yarn registry, failing the same way on a clean `main`), is not something to slip into a pin bump. Recorded on #4819 instead.

What this PR's assertions do rest on: the byte-identical `CatalogFontsTest` **ran green in CI upstream** on compose-preview-server#42's `gradle` job. That is real coverage of the logic, just not against this repository's catalog.

Non-visual in the diff sense: no `@Preview`, theme or asset changed. It restores correct *font* rendering in the bundled `preview-ui/`.

## Unrelated, already filed

The preview-diff bot flags `RotateToLookAtUserPreview` on PRs that touch nothing near it. That is [#4872](https://github.com/yschimke/compose-ai-tools/issues/4872) — the preview is nondeterministic and the committed baseline has `rotateToLookAtUser` not applied, so it is the wrong picture. Not caused by, and not fixed in, this PR.