### PR TITLE
fix(ci): publish-catalog never ran for a single-shard caller

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -2491,7 +2491,19 @@ jobs:
   publish-catalog:
     name: ${{ inputs.system }} · publish
     needs: [driver, generate]
-    if: ${{ inputs.publish }}
+    # THE SAME GUARD `generate` CARRIES, and for the same reason: this job is downstream of the same
+    # skipped ones. `shard-matrix` and `render-shard` are gated on `render-shards > 1`, so on the
+    # single-shard path — the default, and what a caller gets unless it opts in — both skip.
+    # `generate` overrides that with `!cancelled()` and runs, but the skip propagates down the whole
+    # chain: a dependent whose own `if` does not override it is skipped too, even though `generate`
+    # succeeded.
+    #
+    # Without this, the job never ran for any single-shard caller. The render succeeded, the bundle
+    # uploaded, and nothing was pushed to `design-artifacts/<system>` — silently, because a skipped
+    # job is not a failed one and the run still reports green.
+    if: >-
+      ${{ inputs.publish && !cancelled() && !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') }}
     runs-on: ${{ inputs.runs-on }}
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
Every external caller on the default single-shard path has silently stopped publishing since #4856.

## The chain

#4856 moved the push into its own job so it runs none of the rendered code. Good change — but:

```yaml
publish-catalog:
  needs: [driver, generate]
  if: ${{ inputs.publish }}
```

`shard-matrix` and `render-shard` are both gated `if: ${{ inputs.render-shards > 1 && … }}`, so on the single-shard path — **the default**, and what a caller gets unless it opts in — both **skip**. `generate` already handles that, and its comment says exactly why:

```yaml
generate:
  # Skipped needs are the single-shard path, not a failure: with render-shards at its default the
  # two jobs above never run, and this job must still start. `!cancelled()` plus an explicit
  # failure check is the pattern that distinguishes "skipped" from "broke".
  needs: [driver, shard-matrix, render-shard]
  if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
```

A skip propagates down the **whole** chain, so `publish-catalog` is skipped too — even though `generate` succeeded. It needed the same guard and didn't get it.

## Why it went unnoticed

It is a silent no-op, not a failure. The render succeeds, the bundle uploads, `publish-catalog` is skipped, nothing reaches `design-artifacts/<system>` — and **the run reports green**, because a skipped job is not a failed one.

## Evidence

`yschimke/wear-m3-catalog`, whose `design-artifacts/remote-m3` branch has not moved since **09:22** despite green runs all day. In [run 33332697482](https://github.com/yschimke/wear-m3-catalog/actions/runs/33332697482):

| job | result |
|---|---|
| `wear-m3-catalog / wear-m3-catalog` (generate) | success |
| `remote-m3 / remote-m3` (generate) | success |
| `wear-m3-catalog / … · publish` | **skipped** |
| `remote-m3 / … · publish` | **skipped** |
| `… · plan` (shard-matrix), `… · shard` (render-shard) | skipped |

That `inputs.publish` was genuinely **true** is provable from the same run: the `Upload catalog bundle` step is gated `if: ${{ inputs.publish || inputs.upload-out }}`, that caller sets no `upload-out`, and the step **succeeded**. Both skipped publish jobs also show `completed_at` preceding `created_at`, GitHub's marker for a job skipped at graph evaluation rather than one that ran.

## The fix

The same guard `generate` carries:

```yaml
if: >-
  ${{ inputs.publish && !cancelled() && !contains(needs.*.result, 'failure') &&
  !contains(needs.*.result, 'cancelled') }}
```

`inputs.publish` still gates it, so `publish: false` callers are unaffected, and a failed or cancelled `generate` still stops the push rather than publishing a half-rendered bundle.

## Swept for the same shape

Walked every job's `needs` against its `if`. Only `publish-catalog` was exposed. `render-shard` looks similar but shares `shard-matrix`'s gate exactly, so those two skip or run together.

## Test plan

- YAML parses; the rendered condition is asserted directly off the parsed job rather than eyeballed.
- Not verifiable further from here: the failure only reproduces in a real Actions graph, so **CI on this PR — and the next external publish — are the real test.** The check to watch is that `· publish` reports something other than `skipped` on a `render-shards: 1` caller.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxnGrAmCM3y1AbrFixVcqK)_