### PR TITLE
ci: extend the shared Renovate preset and split the composeai trains

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits"
+    "github>yschimke/renovate-config"
   ],
+  "description": "Extends the shared preset at yschimke/renovate-config, which owns the release-train grouping — including the split of the ee.schimke.composeai group into its separate trains (compose-ai-tools, compose-preview-contracts, compose-preview-server, rc-players), which this repo consumes two of. The rules below are repo-specific and are appended AFTER the preset, so they override it. The preset replaces the config:recommended / :dependencyDashboard / :semanticCommits trio this file used to declare, and the `{{manager}} minor/patch` catch-all group is gone with it: one PR per manager per week overrode every release-train group the preset defines, since the last matching rule wins.",
   "schedule": [
     "before 9am on Monday"
   ],
@@ -22,11 +21,14 @@
       "minimumReleaseAge": "14 days"
     },
     {
+      "description": "Hold the preset's auto-land. github>yschimke/renovate-config automerges minor/patch once CI is green, which suits a leaf repo; this one publishes 91 coordinates that three other repositories resolve from Maven Central, so a bump reaches consumers through a release and a human looks at it first. Overrides the preset because repo-local rules are appended after it.",
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest",
+        "pin"
       ],
-      "groupName": "{{manager}} minor/patch"
+      "automerge": false
     },
     {
       "description": "Never take a `\u2026-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list \u2014 rather than disabling the update \u2014 keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps.",


### PR DESCRIPTION
## Summary

This repo now consumes `ee.schimke.composeai` coordinates from two other repositories that version on their own lines — the contracts (`composeai-contracts = 2.1.0`) and the preview server (`composeai-preview-serve = 2.2.0`) — against this repo's own `1.5x.x`. The shared preset at [yschimke/renovate-config](https://github.com/yschimke/renovate-config) now knows those trains apart, so extend it rather than restating `config:recommended` / `:dependencyDashboard` / `:semanticCommits` here.

Two behaviour changes worth a look, both deliberate:

**The `{{manager}} minor/patch` catch-all is gone.** Renovate applies `packageRules` in order and the last match wins, so grouping every gradle minor/patch into one PR overrode *every* release-train group the preset defines — kotlin, androidx, compose-multiplatform, and the contracts and server splits this change is for. It cannot coexist with the preset. Expect more, smaller PRs; `prConcurrentLimit: 10` still throttles them.

**Automerge is explicitly held off.** The preset auto-lands minor/patch once CI is green, which suits a leaf repo. This one publishes 91 coordinates that three other repositories resolve from Maven Central, so a bump reaches consumers through a release and a human looks at it first. A repo-local rule restores today's manual posture.

Everything else is preserved: the weekly Monday schedule, the 7-day soak, `github-actions: enabled false` (Dependabot still owns action pins here), all the compatibility-floor ceilings, the AGP 8 fixture freeze, and the `xr-composite` custom manager. Repo-local rules are appended after the preset, so they still win.

## Test plan

- `renovate-config-validator` passes.
- Simulated the matcher semantics in rule order over 23 representative coordinates against this repo's effective config (preset + local rules): the contracts artifacts group as `compose-preview-contracts`, the server's as `compose-preview-server`, the players as `rc-players`, and the interleaved names land right — `daemon-protocol` is a contract, `daemon-core` is not; `data-render-core` is a contract, `data-render-compose` is not.

Depends on yschimke/renovate-config#1 — merge that first, since `extends` resolves the preset's default branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMPNXAqC6xk4uBtJ3kzt6h)_