### PR TITLE
fix: restore the Maven Central publish task list in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,14 @@ jobs:
           # to every subproject applying `composeai.maven-publishing`; `:gradle-plugin` is an
           # includeBuild and needs an explicit address.
           #
-          ./gradlew
+          # Name the tasks explicitly. A bare `./gradlew` is not a no-op that fails loudly —
+          # there is no `defaultTasks` in this build, so it runs `help` and exits 0, and the
+          # job goes green having published nothing. That is how v1.56.0 and v1.56.1 shipped
+          # as public GitHub Releases with no artifacts on Central (#4845 deleted this task
+          # list along with the `-x :rc-player-*` exclusions that used to follow it).
+          ./gradlew \
+            :gradle-plugin:publishAndReleaseToMavenCentral \
+            publishAndReleaseToMavenCentral
 
   # The Remote Compose player stack used to be published from here — a macOS job for its Apple
   # klibs, plus an XCFramework job that rewrote `Package.swift` and cut a bare SwiftPM version tag.


### PR DESCRIPTION
## Summary

Releases have published nothing to Maven Central since v1.54.0, while reporting success.

`release.yml`'s publish step had been reduced to a bare `./gradlew`. There is no `defaultTasks` in this build, so that runs `help` and **exits 0** — `publish-gradle-plugin` goes green having published nothing.

#4845 ("consume the Remote Compose players instead of building them") removed the `publish-player-stack` job and the four `-x :rc-player-*` exclusions. The task list those exclusions followed went with them:

```diff
-          ./gradlew \
-            :gradle-plugin:publishAndReleaseToMavenCentral \
-            publishAndReleaseToMavenCentral \
-            -x :rc-player-trace:publishAndReleaseToMavenCentral \
-            …
+          ./gradlew
```

This restores the two task lines. No exclusions are needed now — the `rc-player` modules ship from yschimke/rc-players and survive here only as comments in `settings.gradle.kts`. `snapshot.yml:75` still carries the same shape (`:gradle-plugin:publishToMavenCentral publishToMavenCentral`), which is why snapshot publishing kept working and masked this.

## Impact

| Release | GitHub | Maven Central |
| --- | --- | --- |
| v1.54.0 | published | present — last good |
| v1.56.0 | **published** | absent (404) |
| v1.56.1 | **published** | absent (404) |

Both failed `maven-readiness` — `plugin 1.56.1 was not resolvable after ~20 minutes` (runs [33325739868](https://github.com/yschimke/compose-ai-tools/actions/runs/33325739868), [33334509171](https://github.com/yschimke/compose-ai-tools/actions/runs/33334509171)) — but only after `finalize-release` had already un-drafted them.

**The guard ordering is not at fault and is unchanged here.** `finalize-release` already requires `needs.release.result == 'success'`, with a comment naming this exact hazard ("Finalizing then would un-draft a release whose Gradle plugin/runtime never actually published"). That gate was defeated solely by a publish step that cannot fail. Fixing the step restores it.

Downstream, m3-catalog and wear-m3-catalog pin the action at `@v1.56.1` while their Gradle coordinates are stuck at 1.54.0 — the skew their Renovate rules exist to prevent, and one Renovate cannot close because Central has nothing newer to offer.

## Test plan

- `release.yml` parses; the resolved `run:` block is the two intended tasks, and the fragment passes `bash -n`.
- `publishAndReleaseToMavenCentral` is valid on vanniktech 0.37.0 and explicitly named in `gradle-plugin/build.gradle.kts:283`, which wires its dependency edges onto `:preview-discovery`, `:daemon-launch-builder` and `:gradle-plugin-config`.
- Restored text matches `release.yml` at tag `v1.54.0` verbatim, minus the four obsolete `-x` lines.

Titled `fix:` rather than `ci:` deliberately — this is a release-blocking defect, and letting release-please cut a patch is how the fix reaches Central and proves itself end to end.

## Recovering v1.56.0 / v1.56.1

Not done here, and it needs a decision rather than a guess. Once this lands, `release.yml` can be re-run via `workflow_dispatch` with `tag: v1.56.1`: the workflow definition comes from the chosen ref while the publish job checks out `ref: ${{ env.TAG_NAME }}`, so a repaired `main` publishes the tag's source. Central holds nothing at those GAVs, so there is no immutability conflict. The alternative is to leave them stranded and let the next release supersede them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMPNXAqC6xk4uBtJ3kzt6h)_