### PR TITLE
build: bump compose-preview-server to 2.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -360,7 +360,7 @@ composeai-contracts = "2.1.0"
 # link a web server (yschimke/compose-preview-server#38, this repository's #4832). ONE version ref
 # for both, deliberately: they are cut from one build and one tag over there, and a skew between the
 # server and the render host it sits on top of is not a state that repository can produce.
-composeai-preview-serve = "2.2.0"
+composeai-preview-serve = "2.3.2"
 
 # The Remote Compose players, published by yschimke/rc-players (the CMP player stack, the vendored
 # AndroidX embedded player, and the Wasm browser bundle). They were project deps here until the


### PR DESCRIPTION
## Summary

`composeai-preview-serve` 2.2.0 → **2.3.2**.

The server versions on its own 2.x line, independent of this repository's 1.5x.x and of the contracts' 2.1.0 — the four-train split the shared Renovate preset now models (#4879). The other two refs are already current and are untouched:

| Ref | Version | Train |
| --- | --- | --- |
| `composeai-contracts` | 2.1.0 | compose-preview-contracts — current |
| `composeai-preview-serve` | 2.2.0 → **2.3.2** | compose-preview-server |
| `rcplayers` | 1.55.0 | rc-players — current |

## Test plan

Both coordinates on this ref were verified present at 2.3.2 on `repo1.maven.org` before pinning: `compose-preview-serve` and `compose-preview-render-host`. They share one ref deliberately — cut from one build and one tag over there — so neither can skew.

CI resolves and builds against them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMPNXAqC6xk4uBtJ3kzt6h)_