### PR TITLE
feat(design-map): let override variants state absent references

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/OverrideVariant.kt
@@ -152,6 +152,11 @@ package ee.schimke.composeai.preview
  * instead. Kits couple their axes — turning `Icon` on can drag `Icon size` and `Alignment` with it
  * — so the cell that lands on a node the kit actually drew is often a multi-knob one, and it is
  * [kitProps] that lets it say so. See there.
+ *
+ * Where the kit publishes **no cell at all** for this render, [noReference] records why. This is
+ * distinct from a misspelt [kitAxis], [kitValue] or [kitProps]: the former is an authored finding
+ * about the kit, while the latter is an unresolved declaration worth fixing. The reason travels
+ * with the variant into the design-map sidecar so reports can list intentionally nodeless cells.
  */
 @Repeatable
 @Retention(AnnotationRetention.BINARY)
@@ -232,6 +237,15 @@ annotation class OverrideVariant(
    * discovery warning and the cell keeps `kitProps`.
    */
   val kitProps: Array<String> = [],
+  /**
+   * Why the design kit publishes no cell corresponding to this render.
+   *
+   * Empty means no absence was stated, so a resolver that finds no node should diagnose the cell's
+   * kit declaration as unresolved. A non-empty reason is authoritative: the render remains a real
+   * folded cell, but downstream must not try to pair it with the parent's reference or treat its
+   * lack of a node as an authoring failure.
+   */
+  val noReference: String = "",
   /**
    * Whether this cell is **second-tier**: rendered, addressable and paired with its kit node as
    * usual, but left out of the component's variant tree and the viewer's subtree.

--- a/design-map/README.md
+++ b/design-map/README.md
@@ -28,7 +28,7 @@ Every field the projection reads is defined in this repository:
 | `catalog.reference`, `referenceSet`, `noReference`, `referenceContentsOnly`, `kitAxis` | [`@CatalogComponent`](https://github.com/yschimke/compose-ai-tools/blob/main/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/CatalogComponent.kt) |
 | `catalog.props`, `catalog.state`, `catalog.kitValue` | `@CatalogVariant` |
 | `overrides.seeds`, `overrides.props` | `@OverrideVariant` / `@PreviewAxis` |
-| `overrides.kitAxis`, `overrides.kitValue` | `@OverrideVariant` |
+| `overrides.kitAxis`, `overrides.kitValue`, `overrides.noReference` | `@OverrideVariant` |
 
 Rename one of those and the projection has to change in the same commit. Keeping the two on
 opposite sides of a repo boundary is how a manifest reader goes quietly stale — and the reference
@@ -109,7 +109,10 @@ must match that string before reading it. One entry per component that has varia
       "basePreviewId": "…FilledButton_Light",
       "renders": [
         { "previewId": "…FilledButton_Light_VARIANT_l", "name": "l",
-          "seeds": [{ "key": "size", "raw": "l" }, { "key": "shape", "raw": "round" }] }
+          "seeds": [{ "key": "size", "raw": "l" }, { "key": "shape", "raw": "round" }] },
+        { "previewId": "…FilledButton_Light_VARIANT_indeterminate", "name": "indeterminate",
+          "seeds": [{ "key": "progress", "raw": "indeterminate" }],
+          "noReference": "The kit publishes determinate progress cells only." }
       ]
     }
   ]
@@ -118,7 +121,9 @@ must match that string before reading it. One entry per component that has varia
 
 It is a separate file rather than another key on the map because the design-map schema sets
 `additionalProperties: false` — a map carrying an extra key would fail its own validator. No file is
-written when nothing declares an axis.
+written when nothing declares an axis or a stated cell absence. A render carrying `noReference`
+does not enter kit-node resolution; the reason is the result, and remains reportable alongside the
+cells that do resolve.
 
 ## Two things worth knowing
 

--- a/design-map/design-map.mjs
+++ b/design-map/design-map.mjs
@@ -460,7 +460,7 @@ export function variantAbsenceId(preview) {
   // may hold a perfectly good reference: it reads as a finding about the parent, and says nothing
   // about which variant the reason belongs to. The function name is what distinguishes such a
   // variant, so it stands in for the axes it did not give.
-  const label = axes || preview.functionName || captureIdentity(preview).subject;
+  const label = axes || preview.overrides?.name || preview.functionName || captureIdentity(preview).subject;
   return label ? `${parent} [${label}]` : parent;
 }
 
@@ -490,6 +490,10 @@ function variantName(preview, seeds) {
  * the exact failure `kitAxis` exists to remove.
  */
 export function declarationMisses(preview) {
+  // This cell declares that the kit publishes nothing for it, so none of its kit names are meant
+  // to enter resolution. Reporting them as unplaced would turn an authored absence back into the
+  // indistinguishable resolution failure `noReference` exists to prevent.
+  if (preview.overrides?.noReference) return [];
   const catalog = preview.catalog;
   const fold = catalog?.role === "VARIANT" ? foldSeeds(catalog).unattached : [];
   const cell = cellSeeds(preview.overrides, catalog).unattached;
@@ -629,9 +633,11 @@ export function variantRendersByComponent(
     if (!selection.participates(preview)) continue;
 
     // A variant that names no axis says only "this is different", which is not enough to look
-    // anything up in a kit. Dropped rather than guessed at from the function name.
+    // anything up in a kit. Dropped rather than guessed at from the function name — unless it
+    // states that the kit publishes no cell for it. That statement itself belongs in the sidecar
+    // even though there is deliberately nothing to resolve.
     const seeds = variantSeeds(preview);
-    if (!seeds.length) continue;
+    if (!seeds.length && !preview.overrides?.noReference) continue;
 
     // A `@CatalogVariant` may state its OWN kit correspondence, and either spelling changes what a
     // resolver should do with this render. Without reading them here a variant's declaration is
@@ -649,6 +655,12 @@ export function variantRendersByComponent(
       previewId: preview.id,
       name: variantName(preview, seeds),
       seeds,
+      // An authored finding about this CELL, not the parent component. A resolver must preserve it
+      // and skip node lookup; without the field a deliberate nodeless render is indistinguishable
+      // from a typo in kitAxis/kitValue/kitProps.
+      ...(isOverrideVariant && preview.overrides?.noReference
+        ? { noReference: preview.overrides.noReference }
+        : {}),
       // `reference` names the variant's own kit cell. Carried onto the render so a resolver pairs
       // that handle instead of deriving one from the parent's by seed. Additive to the sidecar's
       // shape — a resolver that does not read it sees exactly what it saw before, which is why the
@@ -812,6 +824,21 @@ export function projectDesignMap(previews, opts = {}) {
   unmapped.sort();
   statedAbsent.sort((a, b) => a.componentId.localeCompare(b.componentId));
 
+  /** Folded cells that deliberately correspond to nothing the kit published. */
+  const statedAbsentCells = previews
+    .filter(
+      (preview) =>
+        isVariantCapture(preview) &&
+        preview.overrides?.noReference &&
+        selection.participates(preview),
+    )
+    .map((preview) => ({
+      componentId: variantAbsenceId(preview),
+      previewId: preview.id,
+      reason: preview.overrides.noReference,
+    }))
+    .sort((a, b) => a.componentId.localeCompare(b.componentId));
+
   // Only the captures that participate: a variant declares once, and reporting its dark capture
   // beside its light one would double every line of a list that exists to be acted on.
   const unplacedDeclarations = previews
@@ -824,6 +851,10 @@ export function projectDesignMap(previews, opts = {}) {
     diagnostics: {
       unmapped,
       statedAbsent,
+      // Kept apart from component / `@CatalogVariant` absences. A folded cell is still valid
+      // inventory under plain --strict: its parent maps, its render is real, and its whole point is
+      // to record that the kit has no corresponding node.
+      statedAbsentCells,
       unplacedDeclarations,
       // Composables whose captures name no mode a reference could pair with — several modes, none
       // of them light. Reported rather than guessed at: pairing `Dark` when the kit drew `Coral`

--- a/design-map/design-map.test.mjs
+++ b/design-map/design-map.test.mjs
@@ -185,6 +185,53 @@ test("a folded variant's stated absence is reported under the variant, not its p
   assert.deepEqual(diagnostics.unmapped, []);
 });
 
+test("an OverrideVariant stated absence travels in the sidecar and is reported as a cell", () => {
+  const reason = "the kit publishes determinate progress cells only";
+  const { variants, diagnostics } = projectDesignMap([
+    component("Progress", { reference: ref("1:2") }),
+    overrideVariant("Progress", "indeterminate", {
+      seeds: [{ key: "progress", kind: "STRING", raw: "indeterminate" }],
+      noReference: reason,
+    }),
+  ]);
+
+  assert.deepEqual(variants.components[0].renders, [
+    {
+      previewId: "com.example.CatalogKt.Progress_Light_VARIANT_indeterminate",
+      name: "indeterminate",
+      seeds: [{ key: "progress", raw: "indeterminate" }],
+      noReference: reason,
+    },
+  ]);
+  assert.deepEqual(diagnostics.statedAbsentCells, [
+    {
+      componentId: "Progress [progress=indeterminate]",
+      previewId: "com.example.CatalogKt.Progress_Light_VARIANT_indeterminate",
+      reason,
+    },
+  ]);
+  // It is not a parent/component absence: the parent maps normally, and plain --strict may keep it.
+  assert.deepEqual(diagnostics.statedAbsent, []);
+  assert.deepEqual(diagnostics.unmapped, []);
+});
+
+test("a seedless OverrideVariant can still record that the kit publishes no cell", () => {
+  const { variants } = projectDesignMap([
+    component("Button", { reference: ref("1:2") }),
+    overrideVariant("Button", "pressed", {
+      seeds: [],
+      noReference: "the kit has no pressed cell",
+    }),
+  ]);
+
+  assert.deepEqual(variants.components[0].renders[0], {
+    previewId: "com.example.CatalogKt.Button_Light_VARIANT_pressed",
+    name: "pressed",
+    seeds: [],
+    noReference: "the kit has no pressed cell",
+  });
+});
+
 test("two variants sharing a state but differing in props keep both absences", () => {
   // The label is a Map key. `variantName` narrows to the state alone whenever there is one, so
   // building the label from it collided these two and silently dropped one of the reasons --

--- a/design-map/emit-design-map.mjs
+++ b/design-map/emit-design-map.mjs
@@ -188,6 +188,16 @@ if (diagnostics.statedAbsent.length) {
   }
 }
 
+if (diagnostics.statedAbsentCells?.length) {
+  console.log(
+    `\n${diagnostics.statedAbsentCells.length} folded cell(s) have no design-kit node for a ` +
+      `stated reason — these are valid renders, not unresolved variant declarations:`,
+  );
+  for (const cell of diagnostics.statedAbsentCells) {
+    console.log(`  - ${cell.componentId} — ${cell.reason}`);
+  }
+}
+
 if (diagnostics.unplacedDeclarations?.length) {
   console.log(
     `\n${diagnostics.unplacedDeclarations.length} variant(s) name a kit axis or value that could ` +

--- a/design-map/emit-design-map.test.mjs
+++ b/design-map/emit-design-map.test.mjs
@@ -59,6 +59,17 @@ function run(previews, ...flags) {
 const MAPPED = component("FilledButton", { reference: `figma:${FILE}/1:1` });
 const STATED = component("ButtonGroup", { noReference: "The kit publishes no button-group set." });
 const SILENT = component("Mystery", {});
+const statedCell = {
+  id: "com.example.CatalogKt.FilledButton_VARIANT_pressed",
+  functionName: "FilledButton",
+  sourceFile: "Catalog.kt",
+  catalog: { role: "COMPONENT", componentId: "FilledButton", reference: `figma:${FILE}/1:1` },
+  overrides: {
+    name: "pressed",
+    seeds: [],
+    noReference: "The kit publishes no pressed cell.",
+  },
+};
 
 test("--strict fails on a stated absence, because it says there are no exceptions", () => {
   const { status, all } = run([MAPPED, STATED], "--strict");
@@ -73,6 +84,14 @@ test("--strict --allow-stated-absence accepts an absence somebody wrote down", (
   const { status, all } = run([MAPPED, STATED], "--strict", "--allow-stated-absence");
   assert.equal(status, 0, all);
   assert.match(all, /1 mapped component\(s\)/);
+});
+
+test("--strict accepts a folded cell whose absent kit node is stated", () => {
+  const { status, all, variants } = run([MAPPED, statedCell], "--strict");
+  assert.equal(status, 0, all);
+  assert.match(all, /1 folded cell\(s\) have no design-kit node for a stated reason/);
+  assert.match(all, /FilledButton \[pressed\] — The kit publishes no pressed cell\./);
+  assert.equal(variants.components[0].renders[0].noReference, "The kit publishes no pressed cell.");
 });
 
 test("--allow-stated-absence does NOT excuse silence — that is what strictness is for", () => {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/DeviceDimensions.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/DeviceDimensions.kt
@@ -240,12 +240,14 @@ object DeviceDimensions {
     val lower = device.lowercase()
     if (lower.startsWith("spec:")) {
       val params =
-        lower.removePrefix("spec:").split(',').mapNotNull {
-          val pair = it.split('=', limit = 2)
-          pair.takeIf { it.size == 2 }?.let { values ->
-            values[0].trim() to values[1].trim()
+        lower
+          .removePrefix("spec:")
+          .split(',')
+          .mapNotNull {
+            val pair = it.split('=', limit = 2)
+            pair.takeIf { it.size == 2 }?.let { values -> values[0].trim() to values[1].trim() }
           }
-        }.toMap()
+          .toMap()
       if ("isround" in params || "shape" in params) {
         return params["isround"] == "true" || params["shape"] == "round"
       }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1035,11 +1035,11 @@ enum class CatalogRole {
  *
  * The two [CatalogRole]s reuse one shape: [componentId] is the component's own id for a
  * [CatalogRole.COMPONENT] and the *parent* component id (`@CatalogVariant.of`) for a
- * [CatalogRole.VARIANT]. Fields that only apply to one role are `null`/empty on the other
- * ([group] / [section] are component-only; [state] / [props] are variant-only). The kit
- * correspondence fields — [reference] / [referenceSet] / [noReference] / [referenceContentsOnly] /
- * [parallel] — are carried by **both**: a variant is compared in its own right, so folding a render
- * under a parent does not hand its parity over to that parent.
+ * [CatalogRole.VARIANT]. Fields that only apply to one role are `null`/empty on the other ([group]
+ * / [section] are component-only; [state] / [props] are variant-only). The kit correspondence
+ * fields — [reference] / [referenceSet] / [noReference] / [referenceContentsOnly] / [parallel] —
+ * are carried by **both**: a variant is compared in its own right, so folding a render under a
+ * parent does not hand its parity over to that parent.
  */
 @Serializable
 data class CatalogEntry(
@@ -1055,22 +1055,22 @@ data class CatalogEntry(
   /** Seed-kit handle for the one-off import. */
   val reference: String? = null,
   /**
-   * Handle of the component **family** [reference] is one variant of (a Figma
-   * component set). [reference] must stay one concrete node — that is what a parity run diffs
-   * against — so the family travels separately, for the opposite direction: matching a component
-   * *instance* found on a whole screen, which reports its own variant and its set, back to this
-   * code. A screen rarely uses the exact variant a catalog pictured, so the set is what matches.
+   * Handle of the component **family** [reference] is one variant of (a Figma component set).
+   * [reference] must stay one concrete node — that is what a parity run diffs against — so the
+   * family travels separately, for the opposite direction: matching a component *instance* found on
+   * a whole screen, which reports its own variant and its set, back to this code. A screen rarely
+   * uses the exact variant a catalog pictured, so the set is what matches.
    */
   val referenceSet: String? = null,
   /**
-   * Why there is no [reference], when the absence is a finding rather than a gap. A
-   * null [reference] otherwise means only "nobody has looked yet"; this separates that from "the
-   * kit retired this", which a consumer cannot infer from silence.
+   * Why there is no [reference], when the absence is a finding rather than a gap. A null
+   * [reference] otherwise means only "nobody has looked yet"; this separates that from "the kit
+   * retired this", which a consumer cannot infer from silence.
    */
   val noReference: String? = null,
   /**
-   * Whether a Figma export contains only [reference]'s own content. `false` opts
-   * this one reference into overlapping sheet layers without changing any other preview.
+   * Whether a Figma export contains only [reference]'s own content. `false` opts this one reference
+   * into overlapping sheet layers without changing any other preview.
    */
   val referenceContentsOnly: Boolean = true,
   /** Component id of the counterpart in the `compareWith` sibling system. */
@@ -1191,6 +1191,14 @@ data class OverrideVariantSpec(
    * happen to alias to. See the annotation for why the two are kept apart.
    */
   val kitProps: List<CatalogVariantProp> = emptyList(),
+  /**
+   * Why the design kit publishes no cell for this render — `@OverrideVariant.noReference`.
+   *
+   * Null is silence, not an absence: a resolver that cannot place such a cell should still report
+   * its declaration as unresolved. Kept on the override spec rather than the parent catalog entry
+   * because one folded cell can be nodeless while its siblings and base all resolve normally.
+   */
+  val noReference: String? = null,
   /**
    * Whether this cell is **second-tier** — `@OverrideVariant.secondary`.
    *

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -1555,7 +1555,8 @@ object PreviewDiscovery {
 
   private fun File.declaresPreviewAnnotation(): Boolean = runCatching {
     PREVIEW_SOURCE_ANNOTATION.containsMatchIn(readText().kotlinCodeOnly())
-  }.getOrDefault(false)
+  }
+    .getOrDefault(false)
 
   /**
    * Blank comments and literals while preserving line breaks, so the source-level integrity guard
@@ -1613,8 +1614,7 @@ object PreviewDiscovery {
           blank(c)
           if (!tripleQuoted) {
             if (escaped) escaped = false
-            else if (c == '\\') escaped = true
-            else if (c == quote) quote = null
+            else if (c == '\\') escaped = true else if (c == quote) quote = null
           }
           i++
         }
@@ -2458,6 +2458,12 @@ object PreviewDiscovery {
       // older preview-annotations has no `secondary` parameter, and `getValue` throws for one that
       // is absent rather than answering its default.
       val secondary = (runCatching { pv.getValue("secondary") }.getOrNull() as? Boolean) ?: false
+      // Same compatibility posture as `kitProps` / `secondary`: consumers compiled against an
+      // older annotations artifact have no parameter to read.
+      val noReference =
+        (runCatching { pv.getValue("noReference") }.getOrNull() as? String)?.takeIf {
+          it.isNotBlank()
+        }
       val spec =
         OverrideVariantSpec(
           name = name,
@@ -2467,6 +2473,7 @@ object PreviewDiscovery {
           kitAxis = kitAxis.takeIf { kitProps.isEmpty() },
           kitValue = kitValue.takeIf { kitProps.isEmpty() },
           kitProps = kitProps,
+          noReference = noReference,
           secondary = secondary,
         )
       val existing = specs.putIfAbsent(name, spec)
@@ -3719,7 +3726,8 @@ object PreviewDiscovery {
       (pv.getValue("state") as? AnnotationEnumValue)?.valueName ?: AmbientCaptureState.Ambient.name
     val state = runCatching {
       AmbientCaptureState.valueOf(stateName)
-    }.getOrDefault(AmbientCaptureState.Ambient)
+    }
+      .getOrDefault(AmbientCaptureState.Ambient)
     val burnIn = (pv.getValue("burnInProtectionRequired") as? Boolean) ?: false
     val lowBit = (pv.getValue("deviceHasLowBitAmbient") as? Boolean) ?: false
     return AmbientCapture(
@@ -3966,7 +3974,8 @@ object PreviewDiscovery {
         ?: LauncherWidgetCaptureResizeOrder.WidthFirst.name
     val order = runCatching {
       LauncherWidgetCaptureResizeOrder.valueOf(orderName)
-    }.getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
+    }
+      .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
     val frameDelay = (pv.getValue("frameDelayMs") as? Int)?.coerceAtLeast(0) ?: 600
     val launcherMode = (pv.getValue("launcherMode") as? Boolean) ?: false
     return LauncherWidgetResizeSpec(
@@ -3999,7 +4008,8 @@ object PreviewDiscovery {
         ?: LauncherWidgetCaptureResizeOrder.WidthFirst.name
     val order = runCatching {
       LauncherWidgetCaptureResizeOrder.valueOf(orderName)
-    }.getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
+    }
+      .getOrDefault(LauncherWidgetCaptureResizeOrder.WidthFirst)
     val launcherMode = (pv.getValue("launcherMode") as? Boolean) ?: false
     return LauncherWidgetCapture(
       width = width,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewNameFilter.kt
@@ -14,8 +14,8 @@ package ee.schimke.composeai.discovery
  *
  * Three matching styles, chosen per pattern:
  * - **Anchored** — a pattern prefixed with `=` matches that id or FQN and nothing else:
- *   `=FilledButton_Light` will not touch `FilledButton_Light_VARIANT_off`. See [ANCHOR] for why
- *   any generated id list needs this.
+ *   `=FilledButton_Light` will not touch `FilledButton_Light_VARIANT_off`. See [ANCHOR] for why any
+ *   generated id list needs this.
  * - **Glob** — a pattern containing `*` (any run) or `?` (one char) is anchored and full-matched
  *   against either candidate: `*ExportHelpDialogPreview`, `Export*Preview`, `com.example.*.Foo`.
  * - **Plain** — a pattern with no glob chars matches on equality *or substring* against either
@@ -46,7 +46,6 @@ object PreviewNameFilter {
    * and are path-sanitised), so adding this cannot change the meaning of any existing pattern.
    */
   const val ANCHOR: String = "="
-
 
   /**
    * True when [functionName] (owned by [className]) matches at least one of [patterns], or when

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -193,7 +193,8 @@ object PreviewTargetInference {
         signals = best.signals,
         // The target's real Kotlin value parameters (names / types / defaults) for the call site a
         // consumer renders into Code Connect. Best-effort — empty when metadata can't be read.
-        parameters = ComposableSignature.parametersOf(bestCandidate.classInfo, bestCandidate.method),
+        parameters =
+          ComposableSignature.parametersOf(bestCandidate.classInfo, bestCandidate.method),
       )
     )
   }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/DeviceDimensionsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/DeviceDimensionsTest.kt
@@ -78,7 +78,8 @@ class DeviceDimensionsTest {
     // here (only `landscape` was handled), so `@PreviewScreenSizes`' own "Tablet" entry —
     // `spec:width=1280dp,height=800dp,dpi=240,orientation=portrait` — rendered landscape, pixel for
     // pixel identical to its "Tablet - Landscape" sibling.
-    val spec = DeviceDimensions.resolve("spec:width=1280dp,height=800dp,dpi=240,orientation=portrait")
+    val spec =
+      DeviceDimensions.resolve("spec:width=1280dp,height=800dp,dpi=240,orientation=portrait")
     assertThat(spec.widthDp).isEqualTo(800)
     assertThat(spec.heightDp).isEqualTo(1280)
     assertThat(spec.density).isEqualTo(1.5f)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/LottieAssetDiscoveryTest.kt
@@ -299,12 +299,16 @@ class LottieAssetDiscoveryTest {
            * @Preview
            * fun kdocExample() = Unit
            */
-          val sample = """ + "\"\"\"" + """
+          val sample = """ +
+            "\"\"\"" +
+            """
           @Preview
           fun stringExample() = Unit
-          """ + "\"\"\"" + """
-          """
-            .trimIndent()
+          """ +
+            "\"\"\"" +
+            """
+            """
+              .trimIndent()
         )
       }
     val resources = project.resolve("resources").apply { mkdirs() }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDataTest.kt
@@ -247,6 +247,7 @@ class PreviewDataTest {
                 OverrideSeed(key = "stroke", kind = OverrideSeedKind.STRING, raw = "small"),
               ),
             secondary = true,
+            noReference = "the kit publishes no 13-segment cell",
           ),
       )
     val manifest = PreviewManifest(module = "app", variant = "debug", previews = listOf(preview))
@@ -254,6 +255,8 @@ class PreviewDataTest {
     val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
 
     assertThat(decoded.previews.single().overrides?.secondary).isTrue()
+    assertThat(decoded.previews.single().overrides?.noReference)
+      .isEqualTo("the kit publishes no 13-segment cell")
     // And the seeds are untouched by it: the tier decides the listing, never the render.
     assertThat(decoded.previews.single().overrides?.seeds?.map { it.key })
       .containsExactly("segmentCount", "stroke")
@@ -278,6 +281,7 @@ class PreviewDataTest {
     val decoded = json.decodeFromString<PreviewManifest>(json.encodeToString(manifest))
 
     assertThat(decoded.previews.single().overrides?.secondary).isFalse()
+    assertThat(decoded.previews.single().overrides?.noReference).isNull()
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryOutputUniquenessTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryOutputUniquenessTest.kt
@@ -9,7 +9,8 @@ import org.junit.Test
  * Stem resolution only covers the annotation-derived previews; Lottie/SVG assets, the token
  * catalogs, activities and app tours are all appended afterwards with literal stems, and several
  * land in the same `renders/` directory. These tests pin that the assembled manifest never contains
- * two entries claiming one file — including case-insensitively, which is what APFS and NTFS compare.
+ * two entries claiming one file — including case-insensitively, which is what APFS and NTFS
+ * compare.
  */
 class PreviewDiscoveryOutputUniquenessTest {
 
@@ -26,8 +27,9 @@ class PreviewDiscoveryOutputUniquenessTest {
       dataProducts = dataProducts.map { PreviewDataProduct(kind = "render/test", output = it) },
     )
 
-  private fun outputs(previews: List<PreviewInfo>): List<String> =
-    previews.flatMap { p -> p.captures.map { it.renderOutput } + p.dataProducts.map { it.output } }
+  private fun outputs(previews: List<PreviewInfo>): List<String> = previews.flatMap { p ->
+    p.captures.map { it.renderOutput } + p.dataProducts.map { it.output }
+  }
 
   /** The reported defect: an annotation stem colliding with an appended Lottie asset's stem. */
   @Test
@@ -72,8 +74,7 @@ class PreviewDiscoveryOutputUniquenessTest {
 
     val result = PreviewDiscovery.enforceOutputUniqueness(previews)
 
-    assertThat(result[2].captures.single().renderOutput)
-      .isEqualTo("renders/Untouched-11112222.png")
+    assertThat(result[2].captures.single().renderOutput).isEqualTo("renders/Untouched-11112222.png")
   }
 
   /** Order must not decide who gets renamed — the outcome is a function of the ids. */
@@ -113,7 +114,10 @@ class PreviewDiscoveryOutputUniquenessTest {
     val previews =
       listOf(
         preview("com.example.PreviewsKt.A", "data/render-scroll-gif/Clash.gif"),
-        preview("com.example.PreviewsKt.B", dataProducts = listOf("data/render-scroll-gif/Clash.gif")),
+        preview(
+          "com.example.PreviewsKt.B",
+          dataProducts = listOf("data/render-scroll-gif/Clash.gif"),
+        ),
       )
 
     val result = PreviewDiscovery.enforceOutputUniqueness(previews)
@@ -121,7 +125,10 @@ class PreviewDiscoveryOutputUniquenessTest {
     assertThat(outputs(result).toSet()).hasSize(2)
   }
 
-  /** Every capture of a re-stemmed preview moves together, so its fan-out stays internally consistent. */
+  /**
+   * Every capture of a re-stemmed preview moves together, so its fan-out stays internally
+   * consistent.
+   */
   @Test
   fun `all captures of a colliding preview are retagged consistently`() {
     val previews =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryProjectJarTest.kt
@@ -121,7 +121,7 @@ class PreviewDiscoveryProjectJarTest {
   }
 
   @Test
-  fun `an override variant's tier is read off the annotation`() {
+  fun `an override variant's tier and stated absence are read off the annotation`() {
     // The read matters more than the field: discovery has to answer `false` for a catalog compiled
     // against an annotations jar that predates the parameter (ClassGraph throws for one that is
     // absent rather than handing back its default), and `true` for one that declares it.
@@ -144,7 +144,10 @@ class PreviewDiscoveryProjectJarTest {
 
     val variants = outcome.manifest.previews.mapNotNull { it.overrides }.associateBy { it.name }
     assertThat(variants.getValue("segments-13").secondary).isTrue()
+    assertThat(variants.getValue("segments-13").noReference)
+      .isEqualTo("the kit publishes no 13-segment cell")
     assertThat(variants.getValue("disabled").secondary).isFalse()
+    assertThat(variants.getValue("disabled").noReference).isNull()
   }
 
   @Test
@@ -273,6 +276,7 @@ class PreviewDiscoveryProjectJarTest {
     mv.visitAnnotation("Lee/schimke/composeai/preview/OverrideVariant;", false).apply {
       visit("name", "segments-13")
       visit("secondary", true)
+      visit("noReference", "the kit publishes no 13-segment cell")
       visitArray("ints").apply {
         visit(null, "segmentCount=13")
         visitEnd()

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryRenderStemTest.kt
@@ -14,7 +14,9 @@ import org.junit.Test
  */
 class PreviewDiscoveryRenderStemTest {
 
-  /** `<readable>-<8 hex>` with the digest delimited by the one character sanitisation can't emit. */
+  /**
+   * `<readable>-<8 hex>` with the digest delimited by the one character sanitisation can't emit.
+   */
   private val stemShape = Regex("[A-Za-z0-9_]+-[0-9a-f]{8}")
 
   /**
@@ -57,23 +59,28 @@ class PreviewDiscoveryRenderStemTest {
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
     assertThat(stems.map { it.substringBeforeLast('-') })
-      .containsExactly("ActivityListPreview_Devices_Large_Round", "ButtonPreview_Devices_Large_Round")
+      .containsExactly(
+        "ActivityListPreview_Devices_Large_Round",
+        "ButtonPreview_Devices_Large_Round",
+      )
       .inOrder()
   }
 
   @Test
   fun `collapses runs of separator-like characters into a single underscore`() {
     // ` - ` (space-dash-space) is a run of three "separator" characters in the source name.
-    val stems = listOf(preview("com.example.PreviewsKt.Foo_Devices - Large Round")).let(
-      PreviewDiscovery::resolveRenderStems
-    )
+    val stems =
+      listOf(preview("com.example.PreviewsKt.Foo_Devices - Large Round"))
+        .let(PreviewDiscovery::resolveRenderStems)
     assertThat(stems.single().substringBeforeLast('-')).isEqualTo("Foo_Devices_Large_Round")
   }
 
   @Test
   fun `parens, quotes, and other shell-awkward characters all collapse with adjacent runs`() {
     val stems =
-      PreviewDiscovery.resolveRenderStems(listOf(preview("com.example.PreviewsKt.Foo_tile light (light)")))
+      PreviewDiscovery.resolveRenderStems(
+        listOf(preview("com.example.PreviewsKt.Foo_tile light (light)"))
+      )
     assertThat(stems.single().substringBeforeLast('-')).isEqualTo("Foo_tile_light_light")
   }
 
@@ -123,7 +130,8 @@ class PreviewDiscoveryRenderStemTest {
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
     assertThat(stems.toSet()).hasSize(2)
-    assertThat(stems.map { it.substringBeforeLast('-') }.toSet()).containsExactly("Foo_Pixel_8_light")
+    assertThat(stems.map { it.substringBeforeLast('-') }.toSet())
+      .containsExactly("Foo_Pixel_8_light")
     for (stem in stems) assertThat(stem).matches(stemShape.pattern)
   }
 
@@ -168,7 +176,10 @@ class PreviewDiscoveryRenderStemTest {
   @Test
   fun `a preview named like a structural suffix does not collide with a sibling's sidecar`() {
     val previews =
-      listOf(preview("com.example.PreviewsKt.Logo_animated"), preview("com.example.PreviewsKt.Logo"))
+      listOf(
+        preview("com.example.PreviewsKt.Logo_animated"),
+        preview("com.example.PreviewsKt.Logo"),
+      )
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 
@@ -178,8 +189,8 @@ class PreviewDiscoveryRenderStemTest {
   }
 
   /**
-   * `NAME_MAX` is 255 bytes on ext4/APFS/NTFS. An unbounded stem blew straight past it; the readable
-   * part is now capped and the digest keeps the truncated form unique.
+   * `NAME_MAX` is 255 bytes on ext4/APFS/NTFS. An unbounded stem blew straight past it; the
+   * readable part is now capped and the digest keeps the truncated form unique.
    */
   @Test
   fun `an absurdly long preview name is truncated but stays unique`() {
@@ -193,7 +204,9 @@ class PreviewDiscoveryRenderStemTest {
 
     for (stem in stems) {
       assertThat(stem.length)
-        .isAtMost(PreviewDiscovery.MAX_READABLE_STEM + 1 + PreviewDiscovery.RENDER_STEM_DIGEST_CHARS)
+        .isAtMost(
+          PreviewDiscovery.MAX_READABLE_STEM + 1 + PreviewDiscovery.RENDER_STEM_DIGEST_CHARS
+        )
       assertThat(stem).matches(stemShape.pattern)
     }
     assertThat(stems.toSet()).hasSize(2)
@@ -277,8 +290,7 @@ class PreviewDiscoveryRenderStemTest {
   /** An id whose every character sanitises away still needs a filename. */
   @Test
   fun `an id with no alphanumeric characters falls back to a named stem`() {
-    val previews =
-      listOf(PreviewInfo(id = "***", functionName = "***", className = ""))
+    val previews = listOf(PreviewInfo(id = "***", functionName = "***", className = ""))
 
     val stems = PreviewDiscovery.resolveRenderStems(previews)
 


### PR DESCRIPTION
## Summary
- add `noReference` to `@OverrideVariant` and preserve it through discovery metadata
- carry stated cell absences into `design-map-variants.json` without attempting kit-node resolution
- report deliberately nodeless folded cells while allowing them under plain `--strict`
- apply the current ktfmt rules to pre-existing discovery-module formatting drift required by the formatter gate

## Test plan
- `node --test design-map/*.test.mjs`
- `./gradlew :gradle-plugin:preview-discovery:test --no-daemon`
- `./gradlew :gradle-plugin:preview-discovery:ktfmtCheck :preview-annotations:ktfmtCheck --no-daemon`

Closes #4875