### PR TITLE
ci(design-artifacts): let an import declare the JDK its own build needs

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -299,6 +299,25 @@ on:
         required: false
         type: string
         default: ''
+      upstream-java-version:
+        description: >-
+          Extra JDK to install for an imported project whose Gradle toolchain asks for one this
+          runner does not have — a major version like `24`. Empty ⇒ only the JDK 21 every render
+          uses. Ignored unless upstream-repository is set.
+
+          A third-party build picks its own toolchain and we do not get to choose it: joreilly's
+          ClimateTraceKMP requests 24, so `:composeApp:compileAndroidMain` could not even have its
+          dependencies resolved on a runner holding 21 alone ("Cannot find a Java installation …
+          matching {languageVersion=24}. Toolchain download repositories have not been
+          configured."). Naming the version here installs it ALONGSIDE 21 and points Gradle's
+          toolchain detection at it; JAVA_HOME stays 21, which is what the CLI itself runs on.
+
+          Deliberately an explicit version rather than turning on toolchain auto-provisioning: an
+          import is somebody else's build, and letting it download an arbitrary JDK mid-render is a
+          larger grant than letting it name one this workflow then installs.
+        required: false
+        type: string
+        default: ''
       design-map-command:
         description: >-
           Shell command that projects THIS system's `design-map.json` into the caller repo root,
@@ -1173,6 +1192,27 @@ jobs:
             "https://github.com/${UPSTREAM_REPOSITORY}.git"
           git -c credential.helper= fetch --depth 1 --quiet origin "${UPSTREAM_SHA}"
           git checkout --quiet FETCH_HEAD
+
+      # The imported project's OWN toolchain, when it asks for one this runner lacks. Installed
+      # BEFORE JDK 21 on purpose: `setup-java` points JAVA_HOME at whichever it installed last, and
+      # everything else here — the CLI, the export driver — runs on 21. Only Gradle's toolchain
+      # resolution needs the other one, and it finds it through the path recorded below.
+      - name: Set up the imported project's toolchain
+        if: ${{ inputs.upstream-repository != '' && inputs.upstream-java-version != '' }}
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.upstream-java-version }}
+
+      # Gradle does not auto-detect a JDK under the runner's tool cache — its detection looks at
+      # the current JVM and the usual system locations, and `setup-java` installs to neither. So
+      # name the path explicitly; without this the extra JDK is installed and still not found.
+      - name: Point Gradle's toolchain detection at it
+        if: ${{ inputs.upstream-repository != '' && inputs.upstream-java-version != '' }}
+        run: |
+          set -euo pipefail
+          echo "GRADLE_OPTS=-Dorg.gradle.java.installations.paths=${JAVA_HOME} ${GRADLE_OPTS:-}" \
+            >> "$GITHUB_ENV"
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0


### PR DESCRIPTION
## What

Adds an `upstream-java-version` `workflow_call` input to `design-artifacts-reusable.yml`. When an import names it, the workflow installs that JDK **alongside** JDK 21 and points Gradle's toolchain detection at it.

## Why

An imported project picks its own Gradle toolchain and we do not get to choose it. joreilly's ClimateTraceKMP asks for Java 24, so on a runner holding 21 alone the render failed at 2m23s, before it could resolve a single dependency:

```
Cannot find a Java installation on your machine matching:
{languageVersion=24, vendor=any, implementation=vendor-specific}.
Toolchain download repositories have not been configured.
```

Two details that are load-bearing:

- The extra JDK is installed **before** the `Set up JDK 21` step. `setup-java` points `JAVA_HOME` at whichever it installed last, and everything else in the job — the CLI, the export driver — runs on 21. Only Gradle's toolchain resolution needs the other one.
- Gradle's toolchain auto-detection does **not** scan the runner's tool cache, so installing the JDK is not enough on its own; the path is recorded explicitly via `-Dorg.gradle.java.installations.paths`.

This is deliberately an explicit version rather than turning on toolchain auto-provisioning: an import is somebody else's build, and letting it download an arbitrary JDK mid-render is a larger grant than letting it name one this workflow then installs.

The input defaults to empty and is gated on `upstream-repository != ''`, so nothing changes for any existing caller.

## Test plan

- YAML parses (`yaml.safe_load`) and the `generate` job's step order is `["Set up the imported project's toolchain", "Point Gradle's toolchain detection at it", "Set up JDK 21"]`, so `JAVA_HOME` ends on 21 as before.
- No behaviour change for callers that omit the input — both new steps are `if`-gated on it being non-empty.
- End-to-end verification comes from the follow-up in `compose-preview-imports`, which passes `24` through for `joreilly-climatetracekmp`; that import build currently fails with the error above and should get past dependency resolution.

Non-visual change (CI workflow only), so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_