### PR TITLE
fix(discovery): say something when a module's authored previews vanish

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -521,8 +521,8 @@ object PreviewDiscovery {
     }
 
     val previews = mutableListOf<PreviewInfo>()
-    // Populated only on the diagnostics path (failOnEmpty + 0 previews)
-    // so we can tell users whether ClassGraph saw any classes at all,
+    // Counted on every scan; read by the diagnostics paths (failOnEmpty, empty compiled outputs,
+    // and the soft 0-previews warnings) so we can tell users whether ClassGraph saw any classes,
     // and which annotation FQNs it did see — which disambiguates
     // "classpath is wrong" from "@Preview FQN doesn't match" in a
     // single run.
@@ -859,12 +859,29 @@ object PreviewDiscovery {
     // invisible to discovery. Surface the diagnostics so the cause is
     // obvious, but don't fail the build — the user can opt in to a
     // hard failure with `composePreview.failOnEmpty=true`.
-    if (normalized.isEmpty() && previewAnnotationsMissing) {
+    //
+    // The same dump, for the same reason, when the module's own SOURCES declare @Preview and
+    // discovery still found none. That state is not "a module with no previews" — something between
+    // the source and the scan lost them — and until #4890 it was reported by saying nothing at all:
+    // an empty previews.json was written, and the first sign of trouble was composePreviewBundle
+    // failing three tasks later with "previews.json is empty", which names no class dir, no jar and
+    // no annotation. [previewSourceFiles] is the same signal the empty-outputs check above trusts,
+    // so a data layer or a utility module — no @Preview in source — stays as quiet as it was.
+    val sourcePreviewsVanished = normalized.isEmpty() && previewSourceFiles.isNotEmpty()
+    if (normalized.isEmpty() && (previewAnnotationsMissing || sourcePreviewsVanished)) {
       warnings.add(
-        "composePreview: discovered 0 previews in module '${input.moduleName}' — " +
-          "the @Preview annotation class is not on the ClassGraph classpath " +
-          "(dependency-jar filter dropped every jar carrying it). " +
-          "Set composePreview.failOnEmpty=true to make this a hard error."
+        if (previewAnnotationsMissing) {
+          "composePreview: discovered 0 previews in module '${input.moduleName}' — " +
+            "the @Preview annotation class is not on the ClassGraph classpath " +
+            "(dependency-jar filter dropped every jar carrying it). " +
+            "Set composePreview.failOnEmpty=true to make this a hard error."
+        } else {
+          "composePreview: discovered 0 previews in module '${input.moduleName}', but " +
+            "${previewSourceFiles.size} of its source file(s) declare @Preview " +
+            "(${previewSourceFiles.joinToString(", ") { it.name }}) — the compiled classes the " +
+            "scan reached do not carry them. Diagnostics below; set " +
+            "composePreview.failOnEmpty=true to make this a hard error."
+        }
       )
       warnings.addAll(
         buildEmptyDiagnostics(

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryFailureWarningsTest.kt
@@ -316,6 +316,109 @@ class PreviewDiscoveryFailureWarningsTest {
     classFile.writeBytes(cw.toByteArray())
   }
 
+  @Test
+  fun `sources declaring @Preview with zero discovered previews warns instead of saying nothing`() {
+    // Issue #4890. The gap this closes: the @Preview annotation IS on the scan classpath and the
+    // compiled outputs are NOT empty, so neither existing diagnostic path fires — discovery wrote
+    // an empty previews.json and said nothing at all. The first sign of trouble was
+    // composePreviewBundle failing three tasks later with "previews.json is empty", which names no
+    // class dir, no jar and no annotation, and the CI lane runs the CLI without --verbose so even
+    // Gradle's own output is gone. Reproduced by joreilly/BikeShare's :common, whose commonMain
+    // declares @Preview while the classes the scan reached carried none.
+    val classDir = tempDir.newFolder("classes")
+    // Puts the @Preview annotation class itself on the scan classpath, so previewAnnotationsMissing
+    // is false and the OTHER soft-warning branch cannot account for the message.
+    writeAnnotationClass(classDir, internalName = "androidx/compose/ui/tooling/preview/Preview")
+    writeEmptyClass(classDir, internalName = "test/NoPreviewsHere")
+
+    val sourceFile = tempDir.newFile("StationListUI.kt")
+    sourceFile.writeText(
+      """
+      package test
+
+      @Preview
+      @Composable
+      fun StationViewPreview() {}
+      """
+        .trimIndent()
+    )
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classDir),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(sourceFile),
+          moduleName = ":common",
+          variantName = "debug",
+          projectDirectory = classDir,
+          failOnEmpty = false,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val success = outcome as PreviewDiscovery.Outcome.Success
+    assertThat(success.manifest.previews).isEmpty()
+    val joined = success.warnings.joinToString("\n")
+    assertThat(joined).contains("discovered 0 previews in module ':common'")
+    // Names the source file, so the reader knows the previews were authored and where.
+    assertThat(joined).contains("StationListUI.kt")
+    // And carries the same diagnostic dump the other zero-preview paths emit.
+    assertThat(joined).contains("0-previews diagnostics for module ':common'")
+    assertThat(joined).contains("classDirs")
+  }
+
+  @Test
+  fun `a module with no @Preview in its sources stays silent`() {
+    // The other half of the guard above: zero previews is NORMAL for a data layer or a utility
+    // module, and those must not start emitting a diagnostic dump. The discriminator is the
+    // module's own sources, the same signal the empty-compiled-outputs check trusts.
+    val classDir = tempDir.newFolder("classes")
+    writeAnnotationClass(classDir, internalName = "androidx/compose/ui/tooling/preview/Preview")
+    writeEmptyClass(classDir, internalName = "test/DataLayer")
+
+    val sourceFile = tempDir.newFile("Repository.kt")
+    sourceFile.writeText("package test\n\nclass Repository\n")
+
+    val outcome =
+      PreviewDiscovery.discover(
+        PreviewDiscovery.Input(
+          classDirs = listOf(classDir),
+          dependencyJars = emptyList(),
+          sourceFiles = listOf(sourceFile),
+          moduleName = ":data",
+          variantName = "debug",
+          projectDirectory = classDir,
+          failOnEmpty = false,
+        )
+      )
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val joined = (outcome as PreviewDiscovery.Outcome.Success).warnings.joinToString("\n")
+    assertThat(joined).doesNotContain("0-previews diagnostics")
+  }
+
+  /**
+   * Writes a minimal annotation `.class` file, so `scanResult.getClassInfo(fqn)` resolves it and
+   * `reachablePreviewFqns` is non-empty. No members: the tests using it only need the annotation
+   * CLASS to be reachable, never to read attributes off a usage.
+   */
+  private fun writeAnnotationClass(outDir: File, internalName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT or Opcodes.ACC_ANNOTATION,
+      internalName,
+      null,
+      "java/lang/Object",
+      arrayOf("java/lang/annotation/Annotation"),
+    )
+    cw.visitEnd()
+    val classFile = File(outDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+
   /**
    * Writes a minimal empty `.class` file (no methods, no annotations). Used by the soft-warning
    * tests where we want `scanClassCount > 0` but no preview-able methods so discovery returns zero


### PR DESCRIPTION
## The hole

Discovery has three zero-preview outcomes, and one of them said nothing at all:

| state | today |
| --- | --- |
| `@Preview` annotation not on the scan classpath | WARN + diagnostic dump |
| compiled outputs empty while sources declare `@Preview` | hard failure + diagnostic dump |
| **annotation reachable, outputs non-empty, still zero previews** | **silence** |

In that third case discovery wrote an empty `previews.json` and returned `Success`. The first sign of trouble was `composePreviewBundle` failing three tasks later:

```
composePreviewBundle: previews.json is empty — nothing to bundle. Run composePreviewDiscover first.
```

which names no class dir, no jar and no annotation. The import lane runs the CLI without `--verbose`, so Gradle's own output is gone too — the whole failure is unreadable end to end. `joreilly/BikeShare`'s `:common` hit exactly this, and the run log contains nothing beyond that one sentence.

## The change

That state now reuses the diagnostic dump the other two paths already emit, plus a line naming the source files that declared the previews:

```
composePreview: discovered 0 previews in module ':common', but 2 of its source file(s)
declare @Preview (BikeSharePreviews.kt, StationListUI.kt) — the compiled classes the scan
reached do not carry them. Diagnostics below; set composePreview.failOnEmpty=true to make
this a hard error.
```

The discriminator is `previewSourceFiles` — the module's own sources — which is the same signal the empty-compiled-outputs check already trusts. So the noise case the existing comments care about is preserved: a data layer or a utility module with no `@Preview` in source stays exactly as quiet as it was. Still a WARN, not a failure; `composePreview.failOnEmpty=true` remains the opt-in for hard behaviour.

Also corrects a comment claiming the scan counters are populated only on the `failOnEmpty` path — they are counted on every scan, which is what makes them usable here.

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test --tests '*PreviewDiscoveryFailureWarningsTest*'` — green.
- New: sources declare `@Preview`, annotation class written into the class dir (so `previewAnnotationsMissing` is false and cannot account for the message), zero previews discovered → warning names the source file and carries the dump.
- New: same shape with no `@Preview` in source → no dump, asserting the quiet case stays quiet.
- Existing coverage for both other paths unchanged.
- `ktfmtFormat` run on the touched module.

Non-visual change (build-time diagnostics), so no render evidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_