### PR TITLE
feat(discovery): recognise Compose Multiplatform's own @Preview

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -217,6 +217,7 @@ object PreviewDiscovery {
     setOf(
       "androidx.compose.ui.tooling.preview.Preview",
       "androidx.compose.desktop.ui.tooling.preview.Preview",
+      CMP_PREVIEW_FQN,
       TILE_PREVIEW_FQN,
       NOTIFICATION_PREVIEW_FQN,
       GLANCE_APPWIDGET_PREVIEW_FQN,
@@ -231,6 +232,10 @@ object PreviewDiscovery {
       // stacked tile preview (e.g. SMALL_ROUND + LARGE_ROUND on one fn).
       "androidx.wear.tiles.tooling.preview.Preview\$Container",
       "androidx.wear.tiles.tooling.preview.Preview.Container",
+      // CMP's @Preview is @Repeatable too, and its Container lives in its own package rather than
+      // collapsing onto the androidx one.
+      "org.jetbrains.compose.ui.tooling.preview.Preview\$Container",
+      "org.jetbrains.compose.ui.tooling.preview.Preview.Container",
     )
   // androidx.compose.ui:ui-tooling-preview 1.11.0+ — wraps each preview in a custom
   // PreviewWrapperProvider. Matched by FQN so older apps (no such class on classpath)
@@ -321,14 +326,35 @@ object PreviewDiscovery {
       PREVIEW_AXIS_FQN,
       PREVIEW_AXIS_CONTAINER_FQN,
     )
-  // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
-  // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
-  // `expect`/`actual` collapses onto the same `androidx...` class name on
-  // every target we care about.
-  private const val PREVIEW_PARAMETER_FQN = "androidx.compose.ui.tooling.preview.PreviewParameter"
+  // Two FQNs, not one. The comment that used to stand here claimed CMP's
+  // `org.jetbrains.compose.components:components-ui-tooling-preview` collapses onto the same
+  // `androidx...` class name via expect/actual. It does not: unzip
+  // `components-ui-tooling-preview-desktop-1.9.0.jar` and every class in it is under
+  // `org.jetbrains.compose.ui.tooling.preview` — Preview, Preview$Container, PreviewParameter and
+  // PreviewParameterProvider. See [CMP_PREVIEW_FQN].
+  private val PREVIEW_PARAMETER_FQNS =
+    setOf(
+      "androidx.compose.ui.tooling.preview.PreviewParameter",
+      "org.jetbrains.compose.ui.tooling.preview.PreviewParameter",
+    )
   private const val COMPOSER_FQN = "androidx.compose.runtime.Composer"
 
   internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+
+  // Compose Multiplatform's own @Preview, from `compose.components.uiToolingPreview` — the
+  // annotation a commonMain preview gets when the project takes the CMP-bundled artifact rather
+  // than the JetBrains-relocated `org.jetbrains.compose.ui:ui-tooling-preview` (which does ship
+  // the androidx FQN on every target). Same shape as androidx's: BINARY retention so ClassGraph
+  // reads it, @Repeatable so it has a Container, and the same name/group/widthDp/heightDp/
+  // locale/showBackground/backgroundColor attributes — every one of which this file already reads
+  // defensively, so nothing downstream needs to know which of the two it came from.
+  //
+  // Not recognising it made the two most obvious CMP projects unimportable: joreilly/BikeShare's
+  // :common and joreilly/ClimateTraceKMP's :composeApp both author every preview against it, and
+  // discovery reported zero while the source plainly declared eleven. The workaround was to make
+  // the project depend on the relocated coordinate instead — which is fine advice for a project
+  // you own (samples/cmp-shared still does it) and useless for one you are importing.
+  internal const val CMP_PREVIEW_FQN = "org.jetbrains.compose.ui.tooling.preview.Preview"
 
   // Our own opt-in for Android notification previews. Function signature is
   // `(android.content.Context) -> android.app.Notification`; same FQN-match
@@ -3043,7 +3069,7 @@ object PreviewDiscovery {
     val params = method.parameterInfo ?: return null
     for (param in params) {
       val anns = param.annotationInfo ?: continue
-      val ann = anns.firstOrNull { it.name == PREVIEW_PARAMETER_FQN } ?: continue
+      val ann = anns.firstOrNull { it.name in PREVIEW_PARAMETER_FQNS } ?: continue
       val provider =
         when (val value = ann.parameterValues.getValue("provider")) {
           is AnnotationClassRef -> value.name
@@ -4191,7 +4217,7 @@ object PreviewDiscovery {
       LAUNCHER_WIDGET_RESIZE_FQN,
       OVERRIDE_VARIANT_FQN,
       OVERRIDE_VARIANT_CONTAINER_FQN,
-      PREVIEW_PARAMETER_FQN,
+      *PREVIEW_PARAMETER_FQNS.toTypedArray(),
       PREVIEW_WRAPPER_FQN,
       PREVIEW_WRAPPER_CLASS_FQN,
       ROBO_COMPOSE_PREVIEW_OPTIONS_FQN,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -70,6 +70,10 @@ object PreviewTargetInference {
   private const val PREVIEW_FQN = "androidx.compose.ui.tooling.preview.Preview"
   private const val DESKTOP_PREVIEW_FQN = "androidx.compose.desktop.ui.tooling.preview.Preview"
   private const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+  // Compose Multiplatform's own @Preview — see PreviewDiscovery.CMP_PREVIEW_FQN. A CMP project's
+  // previews would otherwise not count as previews here, so a composable called only by them would
+  // look like an ordinary composable and score as a render target.
+  private const val CMP_PREVIEW_FQN = PreviewDiscovery.CMP_PREVIEW_FQN
   private const val COMPOSABLE_FQN = "androidx.compose.runtime.Composable"
 
   /** Single bytecode call site, as captured from the preview method body. */
@@ -419,6 +423,7 @@ object PreviewTargetInference {
     if (
       composable.hasAnnotation(PREVIEW_FQN) ||
         composable.hasAnnotation(DESKTOP_PREVIEW_FQN) ||
+        composable.hasAnnotation(CMP_PREVIEW_FQN) ||
         composable.hasAnnotation(TILE_PREVIEW_FQN)
     ) {
       return null

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/CmpPreviewAnnotationTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/CmpPreviewAnnotationTest.kt
@@ -1,0 +1,127 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+
+/**
+ * Compose Multiplatform's own `@Preview` — `org.jetbrains.compose.ui.tooling.preview.Preview`, from
+ * `compose.components.uiToolingPreview` — must be discovered like the androidx one.
+ *
+ * It was not, and the failure was invisible: the plugin already keeps
+ * `components-ui-tooling-preview` on the discovery classpath, so the annotation class resolved,
+ * `previewAnnotationsMissing` stayed false, and discovery wrote an empty manifest without a word.
+ * joreilly/BikeShare's `:common` declares eleven previews against it and discovery reported zero.
+ *
+ * Hand-rolls `.class` files via ASM rather than round-tripping through a Kotlin compile, matching
+ * the other discovery unit tests: the annotation's BINARY retention means it lands in
+ * `RuntimeInvisibleAnnotations`, which is exactly what `visible = false` writes here.
+ */
+class CmpPreviewAnnotationTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  @Test
+  fun `a CMP @Preview is discovered`() {
+    val classDir = tempDir.newFolder("classes")
+    writeAnnotationClass(classDir, "org/jetbrains/compose/ui/tooling/preview/Preview")
+    writePreviewMethodClass(
+      classDir,
+      internalName = "dev/johnoreilly/common/ui/BikeSharePreviewsKt",
+      methodName = "StationViewPreview",
+      annotationDescriptor = "Lorg/jetbrains/compose/ui/tooling/preview/Preview;",
+    )
+
+    val outcome = discover(classDir, moduleName = ":common")
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val previews = (outcome as PreviewDiscovery.Outcome.Success).manifest.previews
+    assertThat(previews.map { it.functionName }).containsExactly("StationViewPreview")
+  }
+
+  @Test
+  fun `the androidx @Preview still is`() {
+    // Control for the test above: the same fixture shape with the androidx annotation. If this
+    // one ever fails, the CMP result above says nothing about FQN recognition.
+    val classDir = tempDir.newFolder("classes")
+    writeAnnotationClass(classDir, "androidx/compose/ui/tooling/preview/Preview")
+    writePreviewMethodClass(
+      classDir,
+      internalName = "test/AndroidPreviewsKt",
+      methodName = "AndroidPreview",
+      annotationDescriptor = "Landroidx/compose/ui/tooling/preview/Preview;",
+    )
+
+    val outcome = discover(classDir, moduleName = ":app")
+
+    assertThat(outcome).isInstanceOf(PreviewDiscovery.Outcome.Success::class.java)
+    val previews = (outcome as PreviewDiscovery.Outcome.Success).manifest.previews
+    assertThat(previews.map { it.functionName }).containsExactly("AndroidPreview")
+  }
+
+  private fun discover(classDir: File, moduleName: String): PreviewDiscovery.Outcome =
+    PreviewDiscovery.discover(
+      PreviewDiscovery.Input(
+        classDirs = listOf(classDir),
+        dependencyJars = emptyList(),
+        sourceFiles = emptyList(),
+        moduleName = moduleName,
+        variantName = "debug",
+        projectDirectory = classDir,
+        failOnEmpty = false,
+      )
+    )
+
+  /** A public static parameterless method carrying [annotationDescriptor]. */
+  private fun writePreviewMethodClass(
+    outDir: File,
+    internalName: String,
+    methodName: String,
+    annotationDescriptor: String,
+  ) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_FINAL or Opcodes.ACC_SUPER,
+      internalName,
+      null,
+      "java/lang/Object",
+      null,
+    )
+    val mv = cw.visitMethod(Opcodes.ACC_PUBLIC or Opcodes.ACC_STATIC, methodName, "()V", null, null)
+    // `visible = false` mirrors BINARY retention — both @Preview annotations declare it, so both
+    // land in RuntimeInvisibleAnnotations. ClassGraph reads visible and invisible alike.
+    mv.visitAnnotation(annotationDescriptor, false).visitEnd()
+    mv.visitCode()
+    mv.visitInsn(Opcodes.RETURN)
+    mv.visitMaxs(0, 0)
+    mv.visitEnd()
+    cw.visitEnd()
+    write(outDir, internalName, cw)
+  }
+
+  /** The annotation class itself, so `scanResult.getClassInfo(fqn)` resolves it. */
+  private fun writeAnnotationClass(outDir: File, internalName: String) {
+    val cw = ClassWriter(0)
+    cw.visit(
+      Opcodes.V17,
+      Opcodes.ACC_PUBLIC or Opcodes.ACC_INTERFACE or Opcodes.ACC_ABSTRACT or Opcodes.ACC_ANNOTATION,
+      internalName,
+      null,
+      "java/lang/Object",
+      arrayOf("java/lang/annotation/Annotation"),
+    )
+    cw.visitEnd()
+    write(outDir, internalName, cw)
+  }
+
+  private fun write(outDir: File, internalName: String, cw: ClassWriter) {
+    val classFile = File(outDir, "$internalName.class")
+    classFile.parentFile.mkdirs()
+    classFile.writeBytes(cw.toByteArray())
+  }
+}


### PR DESCRIPTION
## The bug

`compose.components.uiToolingPreview` publishes the annotation as `org.jetbrains.compose.ui.tooling.preview.Preview`, **not** the androidx FQN. Discovery only knew the androidx one, so a CMP project that takes the CMP-bundled artifact — the default for a `commonMain` preview — discovered zero previews no matter how many it declared.

The failure was invisible. The plugin already keeps `components-ui-tooling-preview` on the discovery classpath (`AndroidPreviewSupport.kt:180`), so the annotation class resolved, `previewAnnotationsMissing` stayed false, and discovery wrote an empty manifest without a word. The first symptom was `composePreviewBundle` failing three tasks later:

```
composePreviewBundle: previews.json is empty — nothing to bundle.
```

`joreilly/BikeShare`'s `:common` declares eleven previews against it and discovery reported none. `joreilly/ClimateTraceKMP`'s `:composeApp` is the same shape.

The repo already knew — `samples/cmp-shared/build.gradle.kts` depends on the relocated `org.jetbrains.compose.ui:ui-tooling-preview` coordinate specifically to sidestep this, with a comment saying the CMP-bundled one "discovery doesn't recognise". That is fine advice for a project you own and useless for one you are importing.

## The change

The annotation has the same shape as androidx's — BINARY retention, `@Repeatable` with a `Container`, and the same `name` / `group` / `widthDp` / `heightDp` / `locale` / `showBackground` / `backgroundColor` attributes, every one of which `PreviewDiscovery` already reads defensively (`as? T ?: default`). So recognising it is FQN sets, not new parsing:

- `PREVIEW_FQNS` — counts as a direct preview.
- `CONTAINER_FQNS` — the repeated/stacked case; CMP synthesises its own `Preview$Container`.
- `PreviewTargetInference` — so a composable called only from a CMP preview is not mistaken for a render target.
- `PREVIEW_PARAMETER_FQN` becomes `PREVIEW_PARAMETER_FQNS`. The same artifact ships its own `PreviewParameter`, and the comment claiming `expect`/`actual` collapses it onto the androidx name was wrong: every class in `components-ui-tooling-preview-desktop-1.9.0.jar` is under `org.jetbrains.compose.ui.tooling.preview` — `Preview`, `Preview$Container`, `PreviewParameter`, `PreviewParameterProvider`. The corrected comment says so and names the jar.

## Test plan

- New `CmpPreviewAnnotationTest`: an ASM-built class carrying the CMP `@Preview` (written as `RuntimeInvisibleAnnotations`, matching its BINARY retention) with the annotation class on the scan classpath → the preview is discovered. A control case does the same with the androidx annotation, so a pass says something about FQN recognition specifically.
- **Verified the test fails without the fix**: dropping `CMP_PREVIEW_FQN` from `PREVIEW_FQNS` makes `a CMP @Preview is discovered` FAIL while the androidx control still passes.
- `./gradlew :gradle-plugin:preview-discovery:test` and `:gradle-plugin:test` — both green.
- `ktfmtFormat` run on the touched module.

Pairs with #4890, which makes the silent case audible if a different cause ever produces it.

Non-visual change (discovery), so no render evidence — the end-to-end evidence is the BikeShare import going from zero previews to eleven.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134yHmD5U7amNDUz34oRnwE)_