### PR TITLE
feat: publish daemon launch schema metadata

### DIFF
--- a/docs/NON_GRADLE_INTEGRATION.md
+++ b/docs/NON_GRADLE_INTEGRATION.md
@@ -11,7 +11,7 @@ The two contracts you implement against:
 
 | Artifact | Schema | Wire-stable | Producer |
 | --- | --- | --- | --- |
-| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`) | `schemaVersion = 1` | You — or [`DaemonLaunchBuilder`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) / its [`java -cp` CLI](#cli-invocation) |
+| `daemon-launch.json` | [`DaemonClasspathDescriptor.kt`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt) (published as `ee.schimke.composeai:daemon-launch-builder`) | `schemaVersion = 2` | You — or [`DaemonLaunchBuilder`](../gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilder.kt) / its [`java -cp` CLI](#cli-invocation) |
 | `previews.json` | [`PreviewData.kt`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt) (published as `ee.schimke.composeai:preview-discovery`) | `schema = "compose-previews/v1"` | You — or [`PreviewDiscovery`](../gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt) / its [`java -cp` CLI](#cli-invocation) |
 
 The consumer of both is the daemon JVM (`daemon/desktop` or `daemon/android`),
@@ -72,7 +72,7 @@ for the classpath but not the rest):
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "modulePath": ":app",
   "variant": "desktop",
   "enabled": true,
@@ -110,7 +110,7 @@ for the classpath but not the rest):
 
 | Field | Required | Meaning |
 | --- | --- | --- |
-| `schemaVersion` | yes | Pin to `1`. Bumped on breaking changes; the subprocess factory rejects anything else with a clear error. |
+| `schemaVersion` | yes | Pin to `2`. Bumped on breaking changes; the subprocess factory rejects anything else with a clear error. Non-JVM consumers can read it without inspecting bytecode from the `daemon-launch-builder-<version>-schema.json` Maven artifact (`ee.schimke.composeai:daemon-launch-builder:<version>:schema@json`); the same metadata is packaged at `META-INF/compose-preview/daemon-launch-schema.json` inside the JAR. |
 | `modulePath` | yes | Logical module id. The daemon uses it as a label; for non-Gradle callers, anything stable identifying the module is fine (`":app"`, `"app:debug"`, `"compose-desktop"`). |
 | `variant` | yes | Build variant. `"desktop"` for CMP; `"debug"` / `"release"` for Android. Informational. |
 | `enabled` | yes | Mirror of the user's `composePreview.daemon.enabled` switch. `true` for normal use. `RenderSessionConfig.forceEnabled` overrides on the consumer side. |

--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -108,7 +108,7 @@ There is intentionally NO `-PcomposePreview.daemon.enabled=...` property overrid
 
 ## Schema
 
-The descriptor written to `<module>/build/compose-previews/daemon-launch.json` carries the resolved values plus the daemon's spawn parameters (classpath, JVM args, system properties, java launcher path). Schema is versioned via the top-level `schemaVersion` field — VS Code's `daemonProcess.ts` gates on it and forces a re-run on mismatch. See `DaemonClasspathDescriptor` in the Gradle plugin.
+The descriptor written to `<module>/build/compose-previews/daemon-launch.json` carries the resolved values plus the daemon's spawn parameters (classpath, JVM args, system properties, java launcher path). Schema is versioned via the top-level `schemaVersion` field — VS Code's `daemonProcess.ts` gates on it and forces a re-run on mismatch. The published `daemon-launch-builder` coordinate exposes the current value as the plain JSON classifier `daemon-launch-builder-<version>-schema.json`, so non-JVM consumers can validate the release they pin without parsing a class file. See `DaemonClasspathDescriptor` in the Gradle plugin.
 
 The daemon JVM reads the same values back at startup via `composeai.daemon.maxHeapMb` / `composeai.daemon.maxRendersPerSandbox` / `composeai.daemon.warmSpare` / `composeai.daemon.backgroundSandboxBoot` system properties, so a value change requires re-running `composePreviewDaemonStart` to refresh the descriptor.
 

--- a/gradle-plugin/daemon-launch-builder/build.gradle.kts
+++ b/gradle-plugin/daemon-launch-builder/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.publish.maven.MavenPublication
+
 plugins {
   id("composeai.maven-publishing")
   // No version on `kotlin("jvm")` — `kotlin-dsl` in the parent (root) build script of this
@@ -61,5 +63,45 @@ composeAiMavenPublishing {
 tasks.named<Jar>("jar").configure {
   manifest {
     attributes("Main-Class" to "ee.schimke.composeai.daemonlaunch.DaemonLaunchBuilderCli")
+  }
+}
+
+// Publish the descriptor schema version as plain JSON so non-JVM consumers can verify the exact
+// plugin release they pin without parsing a Kotlin class file. The same file rides inside the JAR
+// for classpath consumers and beside it as daemon-launch-builder-<version>-schema.json for tools
+// such as the TypeScript VS Code extension.
+val daemonDescriptorSchemaVersion = 2
+val daemonLaunchSchemaResourcesDir = layout.buildDirectory.dir("generated/daemon-launch-schema")
+val daemonLaunchSchemaMetadata = daemonLaunchSchemaResourcesDir.map {
+  it.file("META-INF/compose-preview/daemon-launch-schema.json")
+}
+val generateDaemonLaunchSchemaMetadata =
+  tasks.register("generateDaemonLaunchSchemaMetadata") {
+    inputs.property("schemaVersion", daemonDescriptorSchemaVersion)
+    outputs.dir(daemonLaunchSchemaResourcesDir)
+    doLast {
+      val output = daemonLaunchSchemaMetadata.get().asFile
+      output.parentFile.mkdirs()
+      output.writeText(
+        """
+        {
+          "schema": "compose-preview-daemon-launch",
+          "schemaVersion": $daemonDescriptorSchemaVersion
+        }
+        """
+          .trimIndent() + "\n"
+      )
+    }
+  }
+
+sourceSets.main.get().resources.srcDir(generateDaemonLaunchSchemaMetadata)
+
+publishing {
+  publications.withType<MavenPublication>().configureEach {
+    artifact(daemonLaunchSchemaMetadata) {
+      classifier = "schema"
+      extension = "json"
+      builtBy(generateDaemonLaunchSchemaMetadata)
+    }
   }
 }

--- a/gradle-plugin/daemon-launch-builder/src/test/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderTest.kt
+++ b/gradle-plugin/daemon-launch-builder/src/test/kotlin/ee/schimke/composeai/daemonlaunch/DaemonLaunchBuilderTest.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.daemonlaunch
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Test
 
 class DaemonLaunchBuilderTest {
@@ -69,5 +72,17 @@ class DaemonLaunchBuilderTest {
     // explicitNulls = true on the canonical encoder; readers can distinguish "missing" from
     // "set to null" without inspecting field presence.
     assertThat(DaemonLaunchBuilder.encode(descriptor)).contains("\"javaLauncher\": null")
+  }
+
+  @Test
+  fun `published schema metadata matches the descriptor schema version`() {
+    val resource =
+      checkNotNull(javaClass.getResource("/META-INF/compose-preview/daemon-launch-schema.json"))
+    val metadata = Json.parseToJsonElement(resource.readText()).jsonObject
+
+    assertThat(metadata["schema"]?.jsonPrimitive?.content)
+      .isEqualTo("compose-preview-daemon-launch")
+    assertThat(metadata["schemaVersion"]?.jsonPrimitive?.content?.toInt())
+      .isEqualTo(DAEMON_DESCRIPTOR_SCHEMA_VERSION)
   }
 }


### PR DESCRIPTION
## Summary
- publish the daemon launch descriptor schema version as a plain JSON Maven classifier
- package the same metadata in the daemon-launch-builder JAR and pin it to the Kotlin constant with a unit test
- update non-Gradle integration docs to schema version 2 and document the machine-readable artifact

This completes the producer-side prerequisite identified in #4836. The consumer-side VS Code gate migration remains separate, so this PR intentionally does not close the issue.

## Test plan
- `./gradlew :gradle-plugin:daemon-launch-builder:test :gradle-plugin:daemon-launch-builder:ktfmtCheck :gradle-plugin:daemon-launch-builder:publishToMavenLocal --no-daemon`
- verified `daemon-launch-builder-1.56.3-SNAPSHOT-schema.json` is present in Maven Local
- verified `META-INF/compose-preview/daemon-launch-schema.json` is present in the built JAR