### PR TITLE
feat(bundle): carry spatial scenes for WebXR previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -51,10 +51,10 @@ import okio.source
  *
  * # Subcommands
  *
- * - **`pack`** — runs `composePreviewRender` (for the cover) and `composePreviewBundle` against a
- *   Gradle module and writes the resulting `.png` polyglot. Selection is via repeatable `--id`
- *   flags; the first id becomes the cover. `--no-render` skips the render step and packs with a
- *   stub gray cover.
+ * - **`pack`** — runs `composePreviewRenderAll` (for every renderer family, including XR) and
+ *   `composePreviewBundle` against a Gradle module and writes the resulting `.png` polyglot.
+ *   Selection is via repeatable `--id` flags; the first id becomes the cover. `--no-render` skips
+ *   the render step and packs with a stub gray cover.
  * - **`inspect`** — open a bundle file and print its `bundle.json` + `report.json` summary,
  *   including the minimization report (how many module classes were kept vs total, which Maven
  *   coordinates contribute reachable classes). Read-only.
@@ -387,7 +387,7 @@ private class PackSubcommand(private val args: List<String>) {
               )
             }
             val tasks = buildList {
-              if (!noRender) add(":${target.gradlePath}:composePreviewRender")
+              if (!noRender) add(":${target.gradlePath}:composePreviewRenderAll")
               add(":${target.gradlePath}:composePreviewBundle")
             }
               .toTypedArray()
@@ -541,7 +541,7 @@ private class PackSubcommand(private val args: List<String>) {
               val rendered =
                 runGradle(
                   gradle,
-                  ":${target.gradlePath}:composePreviewRender",
+                  ":${target.gradlePath}:composePreviewRenderAll",
                   arguments = gradleArgsWithForce(sharedArgs),
                 )
               if (!rendered) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -3272,6 +3272,15 @@ internal object AndroidPreviewSupport {
     // render
     // classpath links (`androidLottieResourceDirs`), so the assetPath discovery recorded resolves.
     bundleTask.configure { moduleResourceRoots.from(androidLottieResourceDirs(project)) }
+    if (xrPreviewsEnabled) {
+      // `renderFiles` tracks the shared renders tree, including XR scene directories. Preserve
+      // render-less packing, but order a combined render+bundle invocation after both XR writers
+      // so Gradle never sees the bundle reading their outputs concurrently.
+      bundleTask.configure {
+        mustRunAfter("composePreviewRenderXr")
+        mustRunAfter("composePreviewCompositeXr")
+      }
+    }
 
     // Feed the variant's OWN compiled classes into the bundle packer via AGP's scoped-artifact API,
     // mirroring the identical `forScope(PROJECT).toGet(CLASSES, …)` wiring `composePreviewDiscover`

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -242,11 +242,12 @@ abstract class BundlePreviewTask : DefaultTask() {
   @get:Internal abstract val rendersDir: DirectoryProperty
 
   /**
-   * The render PNGs under [rendersDir], tracked as a proper input so up-to-date checks and the
-   * build cache key reflect them. Without this, the bundle could be skipped/restored stale: someone
-   * packs before rendering (or restores such a cached bundle), then renders and re-packs with the
-   * same manifest/classes, and `composePreviewBundle` would otherwise see unchanged inputs and keep
-   * the render-less bundle despite fresh PNGs on disk (Codex review, PR #1627).
+   * The render products under [rendersDir] — PNGs plus portable XR scene directories — tracked as
+   * proper inputs so up-to-date checks and the build cache key reflect them. Without this, the
+   * bundle could be skipped/restored stale: someone packs before rendering (or restores such a
+   * cached bundle), then renders and re-packs with the same manifest/classes, and
+   * `composePreviewBundle` would otherwise see unchanged inputs and keep the render-less bundle
+   * despite fresh PNGs on disk (Codex review, PR #1627).
    *
    * Modelled as an `@InputFiles` collection rather than `@InputDirectory` precisely so an absent
    * `renders/` dir snapshots as empty instead of failing the build — the reason [rendersDir] itself
@@ -592,6 +593,7 @@ abstract class BundlePreviewTask : DefaultTask() {
     val overrideFiles = LinkedHashMap<String, ByteArray>()
     for (preview in selected) {
       val bundleId = bundleIds.getValue(preview.id)
+      overrideFiles.putAll(spatialBundleEntries(rendersDir.orNull?.asFile, preview.id, bundleId))
       resolvePreviewRenderError(preview)?.let {
         overrideFiles["$BUNDLE_PREVIEWS_DIR/$bundleId.$BUNDLE_RENDER_ERROR_SIDECAR_EXT"] = it
       }
@@ -1817,6 +1819,55 @@ internal fun resolveIrSidecar(rendersRoot: File, stem: String, ext: String): Fil
  * keep dot-vs-underscore-distinct ids distinct). Kept top-level + internal so it's unit-testable.
  */
 internal fun sanitizeBundleEntryId(id: String): String = id.replace(Regex("[^A-Za-z0-9._-]"), "_")
+
+/**
+ * Portable WebGL/WebXR scene entries for one XR render. The XR renderer writes a directory named
+ * from the raw preview id under `renders/`; the bundle gives it the collision-safe bundle id and a
+ * `.spatial/` suffix so it cannot be mistaken for an ordinary preview PNG.
+ *
+ * The allowlist mirrors the server's ingestion boundary. A render directory is producer-owned, but
+ * keeping executable or unrelated files out here makes the portable shape explicit and prevents a
+ * future renderer scratch file from silently becoming public bundle content.
+ */
+internal fun spatialBundleEntries(
+  rendersDir: File?,
+  rawPreviewId: String,
+  bundleId: String,
+): Map<String, ByteArray> {
+  val source = rendersDir?.resolve(sanitizeBundleEntryId(rawPreviewId)) ?: return emptyMap()
+  val sceneFile = source.resolve(SPATIAL_SCENE_FILE).takeIf { it.isFile } ?: return emptyMap()
+  val referencedTextures = runCatching {
+    val scene = Json.parseToJsonElement(sceneFile.readText()) as JsonObject
+    sequenceOf("panels", "orbiters")
+      .flatMap { key -> (scene[key] as? JsonArray).orEmpty().asSequence() }
+      .mapNotNull { panel ->
+        (panel as? JsonObject)?.get("texture")?.jsonPrimitive?.content?.takeIf { texture ->
+          texture.isNotBlank() && '/' !in texture && '\\' !in texture
+        }
+      }
+      .toSet()
+  }
+    .getOrDefault(emptySet())
+  return source
+    .listFiles()
+    .orEmpty()
+    .asSequence()
+    .filter { file ->
+      file.isFile &&
+        file.length() > 0 &&
+        (file.name == SPATIAL_SCENE_FILE ||
+          (file.name in referencedTextures &&
+            SPATIAL_IMAGE_SUFFIXES.any { file.name.endsWith(it, ignoreCase = true) }))
+    }
+    .sortedBy { it.name }
+    .associateTo(LinkedHashMap()) { file ->
+      "$BUNDLE_PREVIEWS_DIR/$bundleId$SPATIAL_BUNDLE_SUFFIX/${file.name}" to file.readBytes()
+    }
+}
+
+private const val SPATIAL_BUNDLE_SUFFIX = ".spatial"
+private const val SPATIAL_SCENE_FILE = "scene.json"
+private val SPATIAL_IMAGE_SUFFIXES = listOf(".png", ".jpg", ".jpeg", ".webp")
 
 /**
  * Assign a collision-free bundle-entry id to every preview in [rawIds], preserving order. Preview

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SpatialBundleEntriesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/SpatialBundleEntriesTest.kt
@@ -1,0 +1,46 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SpatialBundleEntriesTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `scene and image textures use the portable spatial bundle layout`() {
+    val renders = tmp.newFolder("renders")
+    val rawId = "com.example/Xr Preview"
+    val scene = File(renders, sanitizeBundleEntryId(rawId)).apply { mkdirs() }
+    File(scene, "scene.json")
+      .writeText("""{"version":1,"panels":[{"texture":"panel.png"}],"orbiters":[]}""")
+    File(scene, "panel.png").writeBytes(byteArrayOf(1, 2, 3))
+    File(scene, "composite.png").writeBytes(byteArrayOf(4, 5, 6))
+    File(scene, "debug.log").writeText("not public")
+    File(scene, "script.js").writeText("not executable")
+
+    val entries = spatialBundleEntries(renders, rawId, "xr-preview")
+
+    assertThat(entries.keys)
+      .containsExactly(
+        "previews/xr-preview.spatial/scene.json",
+        "previews/xr-preview.spatial/panel.png",
+      )
+    assertThat(entries.getValue("previews/xr-preview.spatial/panel.png"))
+      .isEqualTo(byteArrayOf(1, 2, 3))
+  }
+
+  @Test
+  fun `a preview without a scene publishes no spatial directory`() {
+    val renders = tmp.newFolder("renders-empty")
+    File(renders, sanitizeBundleEntryId("flat")).apply {
+      mkdirs()
+      resolve("panel.png").writeBytes(byteArrayOf(1))
+    }
+
+    assertThat(spatialBundleEntries(renders, "flat", "flat")).isEmpty()
+  }
+}


### PR DESCRIPTION
## Summary

- run every renderer family when `compose-preview bundle pack` prepares previews, so XR scenes are produced alongside flat captures
- package each XR `scene.json` and only its referenced image textures under the portable `previews/<id>.spatial/` layout
- order bundle reads after XR render/composite writers while preserving render-less bundle creation
- add focused coverage for the spatial bundle layout and asset allowlist

Server consumer: yschimke/compose-preview-server#81

## Test plan

- `:gradle-plugin:ktfmtCheckMain :gradle-plugin:ktfmtCheckTest`
- `:gradle-plugin:test --tests ee.schimke.composeai.plugin.SpatialBundleEntriesTest --tests ee.schimke.composeai.plugin.BundleRenderOrderingTest`
- `:cli:compileTestKotlin`