### PR TITLE
test(daemon): preserve interleaved JSON-RPC messages

### DIFF
--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -1416,13 +1416,21 @@ class JsonRpcServerIntegrationTest {
     matcher: (JsonObject) -> Boolean,
   ): JsonObject? {
     val deadline = System.currentTimeMillis() + timeoutMs
-    while (System.currentTimeMillis() < deadline) {
-      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
-      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
-      if (matcher(msg)) return msg
-      // Otherwise drop (e.g. an interleaved notification we don't care about).
+    val unmatched = mutableListOf<JsonObject>()
+    try {
+      while (System.currentTimeMillis() < deadline) {
+        val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+        val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+        if (matcher(msg)) return msg
+        // A response and its render notifications are written by different threads, so either can
+        // arrive first. Keep interleaved messages available for the next assertion instead of
+        // silently consuming the event that assertion is waiting for.
+        unmatched.add(msg)
+      }
+      return null
+    } finally {
+      queue.addAll(unmatched)
     }
-    return null
   }
 }
 


### PR DESCRIPTION
## Summary
- preserve unmatched JSON-RPC messages while integration tests wait for a specific response or notification
- prevent fast render notifications from being discarded when they race the renderNow response
- fix the flaky daemon core failure observed on main in run 33404990335

## Test plan
- `./gradlew :daemon:core:test --tests 'ee.schimke.composeai.daemon.JsonRpcServerIntegrationTest' :daemon:core:ktfmtCheck --rerun-tasks --no-daemon`
- `./gradlew :daemon:core:test --no-daemon`