### PR TITLE
fix(design-artifacts): pass shard exclusions by file

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -361,16 +361,18 @@ on:
           Split the PRIMARY render across this many parallel jobs. 1 (the default) keeps the
           single-job pipeline byte for byte — no extra jobs, no artifacts, no merge.
 
-          Above 1, each shard runs the same `bundle pack` with `--exclude-preview-id` naming every
-          preview that is not its share, which leaves the excluded previews listed in the bundle
-          without a baked PNG. The shards therefore emit structurally identical bundles differing
-          only in which `previews/<id>.*` slots are filled, and `compose-preview bundle merge` unions
-          them back into the bundle one serial render would have produced. Every shard derives its
-          own partition from its own `compose-preview list --json` (deterministic: the id list is
-          sorted, then round-robined), so there is no serial discover-then-fan-out prefix — and the
-          merge cross-checks the shards' plans before trusting them, then checks the merged bundle
-          back against those plans so a shard that lost work fails the run instead of publishing a
-          thinner catalog on a green tick (m3-catalog#15).
+          Above 1, each shard runs the same `bundle pack` with an
+          `--exclude-preview-id-file` naming every preview that is not its share, which leaves the
+          excluded previews listed in the bundle without a baked PNG. The file transport keeps a
+          large generated exclusion set out of argv. The shards therefore emit structurally
+          identical bundles differing only in which `previews/<id>.*` slots are filled, and
+          `compose-preview bundle merge` unions them back into the bundle one serial render would
+          have produced. Every shard derives its own partition from its own
+          `compose-preview list --json` (deterministic: the id list is sorted, then round-robined),
+          so there is no serial discover-then-fan-out prefix — and the merge cross-checks the
+          shards' plans before trusting them, then checks the merged bundle back against those
+          plans so a shard that lost work fails the run instead of publishing a thinner catalog on
+          a green tick (m3-catalog#15).
 
           What this buys, and what it does not: only the MARGINAL cost divides. Re-measured on
           m3-catalog after #3548 (issue #3559), a single-job render is
@@ -770,7 +772,7 @@ jobs:
           catalog-path: ${{ inputs.catalog-path }}
           github-token: ${{ github.token }}
 
-      # Two capabilities, one probe, because a CLI can have the first without the second and each
+      # Three capabilities, one probe, because a CLI can have one without the others and each
       # failure mode is silent in its own way:
       #
       #  - `bundle merge` reassembles the shard bundles. Without it the fan-out runs to completion
@@ -781,6 +783,8 @@ jobs:
       #    captured 267 of 1095 assigned previews that way, on a GREEN run. An old CLI here does not
       #    fail; it silently publishes a three-quarters-empty catalog, which is strictly worse than
       #    refusing to start, hence the hard error rather than a warning.
+      #  - `--exclude-preview-id-file` keeps a generated exclusion set out of argv. Without it a
+      #    large catalog fails with E2BIG before compose-preview or Gradle can start (#4911).
       - name: Check the CLI can shard and merge
         if: ${{ inputs.cli-source == 'released' }}
         run: |
@@ -795,7 +799,11 @@ jobs:
             echo "::error title=CLI too old for render-shards::${version} has no '=<id>' anchored --exclude-preview-id matching, so each shard's exclusion list would also drop the variants of every id it excludes — the shards would publish a fraction of the catalog without failing. Raise cli-version (or, with cli-version: catalog, the $INPUT_CATALOG_KEY pin in $INPUT_CATALOG_PATH) to a release that carries it, or set render-shards: 1."
             exit 1
           fi
-          echo "✓ $version supports 'bundle merge' and anchored '=<id>' exclusions."
+          if ! grep -q -- '--exclude-preview-id-file' <<<"$help"; then
+            echo "::error title=CLI too old for render-shards::${version} has no '--exclude-preview-id-file', so a large shard exclusion set cannot be passed without exceeding the runner's argv limit. Raise cli-version (or, with cli-version: catalog, the $INPUT_CATALOG_KEY pin in $INPUT_CATALOG_PATH) to a release that carries it, or set render-shards: 1."
+            exit 1
+          fi
+          echo "✓ $version supports 'bundle merge', anchored '=<id>' exclusions, and file-based exclusion transport."
 
   render-shard:
     name: ${{ inputs.system }} · shard ${{ matrix.shard }}/${{ inputs.render-shards }}
@@ -1070,14 +1078,16 @@ jobs:
           # driver refuses import + render-shards > 1, because the planner does not know about
           # these ids — and kept deliberately so that teaching the planner is the only thing that
           # combination needs, rather than a second omission to rediscover. Belt to that brace.
-          shard_ids=""
-          if [ -s "$GITHUB_WORKSPACE/shard-exclude.txt" ]; then
-            shard_ids="$(cat "$GITHUB_WORKSPACE/shard-exclude.txt")"
-          fi
+          # IMPORT_EXCLUDE_PREVIEW_IDS is the workflow-owned comma-separated pair of glob patterns,
+          # so append each as one line to the same delimiter-free transport the planner produced.
           if [ -n "${IMPORT_EXCLUDE_PREVIEW_IDS:-}" ]; then
-            shard_ids="${shard_ids:+${shard_ids},}${IMPORT_EXCLUDE_PREVIEW_IDS}"
+            printf '%s\n' "$IMPORT_EXCLUDE_PREVIEW_IDS" | tr ',' '\n' \
+              >> "$GITHUB_WORKSPACE/shard-exclude.txt"
           fi
-          exclude=(); if [ -n "$shard_ids" ]; then exclude=(--exclude-preview-id "$shard_ids"); fi
+          exclude=()
+          if [ -s "$GITHUB_WORKSPACE/shard-exclude.txt" ]; then
+            exclude=(--exclude-preview-id-file "$GITHUB_WORKSPACE/shard-exclude.txt")
+          fi
           if [ -n "${EXCLUDE_PREVIEW_ROWS:-}" ]; then exclude+=(--exclude-preview-row "$EXCLUDE_PREVIEW_ROWS"); fi
           run compose-preview bundle pack --module "$INPUT_MODULE" --with-semantics --progress \
             "${embed[@]}" "${exclude[@]}" -o "$GITHUB_WORKSPACE/bundle.png" \

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -432,10 +432,10 @@ export function verifyShardRenders(plans, capturedIds, { semanticsRan = true, ex
 //   node shard-preview-ids.mjs --previews discovered.json --shards 6 --index 2 \
 //     [--exclude-file mode-filter.txt] [--render-filter-file render-filter.txt] \
 //     --out exclude.txt --plan-out shard-plan.json
-// Writes the comma-separated `--exclude-preview-id` list this shard passes to `bundle pack`, and a
-// small plan record for the merge-side cross-check. Prints the number of previews this shard renders
-// — 0 means "there was nothing left for you", which a caller should treat as "skip the render", not
-// as an error.
+// Writes the newline-delimited `--exclude-preview-id-file` this shard passes to `bundle pack`, and
+// a small plan record for the merge-side cross-check. Prints the number of previews this shard
+// renders — 0 means "there was nothing left for you", which a caller should treat as "skip the
+// render", not as an error.
 //
 // VERIFY the plans a finished matrix produced, run before merging its bundles:
 //   node shard-preview-ids.mjs --verify shard-plan-1.json shard-plan-2.json …
@@ -525,7 +525,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       console.error(`shard-preview-ids: shard ${index} of ${plan.total} has no previews to render.`);
       console.log("0");
     } else {
-      writeFileSync(values.out, mine.exclude.join(","));
+      writeFileSync(values.out, `${mine.exclude.join("\n")}\n`);
       if (values["plan-out"]) {
         writeFileSync(
           values["plan-out"],

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -1,5 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   ANCHOR,
@@ -14,6 +19,46 @@ import {
 } from "./shard-preview-ids.mjs";
 
 const preview = (id) => ({ id, functionName: id.replace(/_(Light|Dark)$/, "") });
+
+test("the reusable workflow passes shard exclusions by file, not through argv", () => {
+  const workflow = readFileSync(
+    new URL("../../.github/workflows/design-artifacts-reusable.yml", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    workflow,
+    /exclude=\(--exclude-preview-id-file "\$GITHUB_WORKSPACE\/shard-exclude\.txt"\)/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /shard_ids="\$\(cat "\$GITHUB_WORKSPACE\/shard-exclude\.txt"\)"/,
+  );
+});
+
+test("the shard planner writes one exclusion per line for the CLI file transport", () => {
+  const dir = mkdtempSync(join(tmpdir(), "shard-exclusions-"));
+  const previews = join(dir, "previews.json");
+  const exclusions = join(dir, "exclude.txt");
+  writeFileSync(previews, JSON.stringify({ previews: ["a", "b", "c", "d"].map(preview) }));
+
+  execFileSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL("./shard-preview-ids.mjs", import.meta.url)),
+      "--previews",
+      previews,
+      "--shards",
+      "2",
+      "--index",
+      "1",
+      "--out",
+      exclusions,
+    ],
+    { stdio: "pipe" },
+  );
+
+  assert.equal(readFileSync(exclusions, "utf8"), "=b\n=d\n");
+});
 
 test("round-robins the sorted id list so a heavy group is spread, not clustered", () => {
   // Ids sort by group, so contiguous blocks would put every Template preview in one shard.


### PR DESCRIPTION
## Summary
- pass generated shard exclusions via `--exclude-preview-id-file` so large catalogs stay below Linux argv limits
- require released CLIs used for sharding to support the file-based flag
- add a workflow regression assertion that forbids expanding `shard-exclude.txt` into argv

Closes #4911

## Test plan
- `node --test scripts/design-artifacts/shard-preview-ids.test.mjs`
- `git diff --check`

Non-visual workflow change; no before/after render evidence applies.