### PR TITLE
ci: enable Renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,16 +21,6 @@
       "minimumReleaseAge": "14 days"
     },
     {
-      "description": "Hold the preset's auto-land. github>yschimke/renovate-config automerges minor/patch once CI is green, which suits a leaf repo; this one publishes 91 coordinates that three other repositories resolve from Maven Central, so a bump reaches consumers through a release and a human looks at it first. Overrides the preset because repo-local rules are appended after it.",
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "digest",
-        "pin"
-      ],
-      "automerge": false
-    },
-    {
       "description": "Never take a `…-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list — rather than disabling the update — keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps.",
       "matchManagers": [
         "gradle"
@@ -177,7 +167,7 @@
       "allowedVersions": "/^9\\.7\\.0$/"
     },
     {
-      "description": "The export-driver pin tracks THIS repository's releases, and its whole purpose is to reach external callers promptly — a downstream repo running last release's driver is the failure #4107 was filed for. So it opts out of the weekly schedule and the 7-day soak that suit third-party dependencies: the tag it moves to is one this repo just cut and just tested. Not automerged, matching the rest of this repo's posture. The commit type is pinned to `chore(ci)` deliberately: a squash merge uses the PR title as the headline and release-please cuts a patch release for `fix:`, so a `fix:`-titled bump would make every release propose another release, whose publish opens another bump. The hand-written bumps this lineage replaces were all titled `fix(ci):`, and each of them cut a release of its own.",
+      "description": "The export-driver pin tracks THIS repository's releases, and its whole purpose is to reach external callers promptly — a downstream repo running last release's driver is the failure #4107 was filed for. So it opts out of the weekly schedule and the 7-day soak that suit third-party dependencies: the tag it moves to is one this repo just cut and just tested. The shared preset automerges this minor update after every branch check is green. The commit type is pinned to `chore(ci)` deliberately: a squash merge uses the PR title as the headline and release-please cuts a patch release for `fix:`, so a `fix:`-titled bump would make every release propose another release, whose publish opens another bump. The hand-written bumps this lineage replaces were all titled `fix(ci):`, and each of them cut a release of its own.",
       "matchManagers": [
         "custom.regex"
       ],


### PR DESCRIPTION
## Summary
- remove the repository override that disabled the shared Renovate preset's automerge policy
- auto-merge minor, patch, digest, and pin updates only after every branch check is green
- keep major dependency updates manual with their existing 14-day release-age gate
- document that self-release driver-pin bumps such as #4909 inherit the same policy

## Test plan
- `jq empty .github/renovate.json`
- `npx --yes --package renovate@44.49.0 renovate-config-validator .github/renovate.json`