### PR TITLE
fix(design-artifacts): exempt optional shard captures

### DIFF
--- a/scripts/design-artifacts/bundle-previews.mjs
+++ b/scripts/design-artifacts/bundle-previews.mjs
@@ -146,6 +146,33 @@ export function capturedPreviewIds(bundle, rawIdFor = (_bundle, entry) => entry.
 }
 
 /**
+ * Preview ids for which discovery declared every capture optional.
+ *
+ * An optional capture is allowed to produce no artifact at all. Desktop catalog sheets are the
+ * important example: discovery retains their metadata in `previews.json`, but marks their sole
+ * capture optional because that backend cannot render the sheet. A shard outcome verifier must not
+ * confuse that declared absence with an exclusion that swallowed required work.
+ *
+ * A preview with no captures is not implicitly optional, and a preview with any required capture
+ * remains required. Results use the caller's canonical id namespace, matching [capturedPreviewIds].
+ *
+ * @param {{previews?: Array<{id: string, captures?: Array<{optional?: boolean}>}>}} bundle
+ * @param {(bundle: object, entry: object) => string} [rawIdFor]
+ * @returns {Set<string>} ids whose captures are all explicitly optional.
+ */
+export function optionalCapturePreviewIds(bundle, rawIdFor = (_bundle, entry) => entry.id) {
+  return new Set(
+    (bundle?.previews ?? [])
+      .filter(
+        (preview) =>
+          preview.captures?.length > 0 &&
+          preview.captures.every((capture) => capture.optional === true),
+      )
+      .map((preview) => rawIdFor(bundle, preview)),
+  );
+}
+
+/**
  * True when [bundle] carries at least one `previews/<id>.semantics.json` — i.e. the semantics pass
  * actually ran and produced something.
  *

--- a/scripts/design-artifacts/bundle-previews.test.mjs
+++ b/scripts/design-artifacts/bundle-previews.test.mjs
@@ -7,6 +7,7 @@ import {
   capturedPreviewIds,
   daemonPreviewCellsByFunction,
   daemonPreviewIdsByFunction,
+  optionalCapturePreviewIds,
 } from "./bundle-previews.mjs";
 
 const enc = (s) => new TextEncoder().encode(s);
@@ -223,6 +224,27 @@ test("capturedPreviewIds still resolves a dotted id's multi-extension sidecar", 
     entries: { "previews/pkg.Screen.semantics.json": enc("{}") },
   };
   assert.deepEqual([...capturedPreviewIds(bundle)], ["pkg.Screen"]);
+});
+
+test("optionalCapturePreviewIds exempts only previews whose captures are all optional", () => {
+  const bundle = {
+    previews: [
+      { id: "colorcatalog__Scheme", captures: [{ optional: true }] },
+      { id: "Card_Light", captures: [{ optional: false }] },
+      { id: "Mixed", captures: [{ optional: true }, { optional: false }] },
+      { id: "NoCaptures", captures: [] },
+      { id: "Theme_Catalog", captures: [{ optional: true }, { optional: true }] },
+    ],
+  };
+  const rawIds = new Map([
+    ["colorcatalog__Scheme", "colorcatalog__Scheme"],
+    ["Theme_Catalog", "Theme Catalog"],
+  ]);
+  const rawIdFor = (_bundle, preview) => rawIds.get(preview.id) ?? preview.id;
+  assert.deepEqual(
+    [...optionalCapturePreviewIds(bundle, rawIdFor)].sort(),
+    ["Theme Catalog", "colorcatalog__Scheme"],
+  );
 });
 
 test("bundleCapturedSemantics reports whether the best-effort semantics pass produced anything", () => {

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -412,14 +412,13 @@ export function verifyShardPlans(plans) {
  * otherwise would spend the operator's trust on a false alarm — the very thing that made the
  * original bug expensive.
  *
- * **[exemptIds] covers the PARTIAL version of the same problem.** [semanticsRan] catches a semantics
- * pass that produced nothing at all; the capture is also best-effort *per preview*, so one id's tree
- * can be missing while the rest carry. That only matters for a preview with no render-side artifact
- * to fall back on — and there is exactly one such class, the spec's `"capture": "none"` entries. A
- * `ScrollMode.GIF` capture still leaves its `.gif` and a token sheet its `.catalog.json`, both
- * written by the render itself, so neither depends on semantics succeeding. Passing the declared
- * no-sticker ids here closes the window without a threshold and without guessing at preview shapes
- * — see `noStickerPreviewNames` in `capture-mode.mjs`.
+ * **[exemptIds] covers declared per-preview absences.** [semanticsRan] catches a semantics pass that
+ * produced nothing at all; the capture is also best-effort *per preview*, so one id's tree can be
+ * missing while the rest carry. This matters for a spec's `"capture": "none"` entries and for
+ * previews whose discovered captures are all `optional` (for example catalog sheets on the desktop
+ * backend, which cannot render them). Passing those ids closes the window without a threshold and
+ * without guessing from their names. Required GIF and token-sheet captures still leave their `.gif`
+ * or `.catalog.json`, so they remain covered by the artifact check.
  *
  * Extra ids are not a problem and are not reported: a merged bundle legitimately carries the whole
  * discovery set (exclusion leaves previews listed), and a shard rendering *more* than its share

--- a/scripts/design-artifacts/verify-shard-renders.mjs
+++ b/scripts/design-artifacts/verify-shard-renders.mjs
@@ -25,7 +25,11 @@ import { parseArgs } from "node:util";
 
 import { readPreviewBundle, rawPreviewIdForEntry } from "@design-parity/candidate";
 
-import { bundleCapturedSemantics, capturedPreviewIds } from "./bundle-previews.mjs";
+import {
+  bundleCapturedSemantics,
+  capturedPreviewIds,
+  optionalCapturePreviewIds,
+} from "./bundle-previews.mjs";
 import { noStickerPreviewNames } from "./capture-mode.mjs";
 import { verifyShardRenders } from "./shard-preview-ids.mjs";
 
@@ -50,12 +54,22 @@ const captured = capturedPreviewIds(bundle, rawPreviewIdForEntry);
 // sharding. Tell the check, so it declines to judge rather than crying wolf.
 const semanticsRan = bundleCapturedSemantics(bundle);
 
-// The per-preview version of the same caveat. A `"capture": "none"` entry is the one class with no
-// render-side artifact to fall back on (a GIF capture still leaves its `.gif`, a token sheet its
-// `.catalog.json`), so an individual semantics miss leaves it looking exactly like a preview an
-// exclusion ate. The spec declares them, so exempt them rather than guess. Optional and
-// non-fatal: without a readable spec the check simply keeps its old, slightly noisier reading.
-let exemptIds = [];
+// Discovery's capture contract is authoritative: an all-optional preview is allowed to return no
+// artifact. Desktop catalog sheets are the important case — that backend keeps their metadata but
+// cannot render them, so their sole capture is optional. Do not call their declared absence lost
+// shard work.
+const exemptIds = optionalCapturePreviewIds(bundle, rawPreviewIdForEntry);
+if (exemptIds.size > 0) {
+  console.error(
+    `verify-shard-renders: ${exemptIds.size} preview(s) with only optional captures are exempt.`,
+  );
+}
+
+// The per-preview version of the semantics caveat. A `"capture": "none"` entry also has no
+// render-side artifact to fall back on, so an individual semantics miss leaves it looking exactly
+// like a preview an exclusion ate. The spec declares them, so add them to the exemption set rather
+// than guess. Optional and non-fatal: without a readable spec the check keeps the discovery-derived
+// exemptions above and its old, slightly noisier reading for no-sticker entries.
 if (values.spec) {
   if (existsSync(values.spec)) {
     const noSticker = new Set(noStickerPreviewNames(JSON.parse(readFileSync(values.spec, "utf8"))));
@@ -63,12 +77,13 @@ if (values.spec) {
     // by a filename-safe id while shard plans carry the canonical discovery id, so an id needing
     // sanitising (a space, say) would otherwise be exempted under a name no plan mentions — the
     // exemption would silently do nothing for precisely the ids most likely to need it.
-    exemptIds = bundle.previews
+    const noStickerIds = bundle.previews
       .filter((preview) => noSticker.has(preview.functionName ?? preview.id))
       .map((preview) => rawPreviewIdForEntry(bundle, preview));
-    if (exemptIds.length > 0) {
+    for (const id of noStickerIds) exemptIds.add(id);
+    if (noStickerIds.length > 0) {
       console.error(
-        `verify-shard-renders: ${exemptIds.length} preview(s) declared \`"capture": "none"\` are ` +
+        `verify-shard-renders: ${noStickerIds.length} preview(s) declared \`"capture": "none"\` are ` +
           `exempt — they export no sticker by design.`,
       );
     }


### PR DESCRIPTION
## Summary

- derive shard-render exemptions from previews whose discovered captures are all explicitly optional
- preserve strict verification for previews with any required capture
- keep spec-declared `capture: none` exemptions and canonical preview-id mapping

This fixes the m3-catalog desktop run where 11 catalog/theme metadata previews were correctly marked optional and returned no artifact, but the post-merge verifier reported them as lost shard work.

## Test plan

- `node --test scripts/design-artifacts/bundle-previews.test.mjs scripts/design-artifacts/shard-preview-ids.test.mjs`
- checked the helper against m3-catalog run 33421623351 shard bundle; it identifies the exact 11 reported catalog/theme preview ids
- `git diff --check`