### PR TITLE
chore(deps): group design-parity updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,15 @@
       "minimumReleaseAge": "14 days"
     },
     {
+      "description": "Keep the design-parity export toolchain on one release line.",
+      "matchDepNames": [
+        "@design-parity/adapter-figma",
+        "@design-parity/candidate",
+        "@design-parity/catalog-export"
+      ],
+      "groupName": "design-parity export toolchain"
+    },
+    {
       "description": "Never take a `…-compat` backport artifact. JetBrains publishes compatibility variants of the kotlinx libraries under a `<version>-<oldline>.x-compat` suffix (e.g. `kotlinx-datetime:0.8.0-0.6.x-compat`, the 0.8.0 code recompiled against the 0.6.x API) and Renovate's gradle versioning ranks that suffix ABOVE the plain release, so it proposes a *downgrade of API surface* dressed as an upgrade (#3359). Filtering the suffix out of the candidate list — rather than disabling the update — keeps Renovate offering the next genuine release. Declared before the per-dep pins below so those stricter `allowedVersions` still win for their deps.",
       "matchManagers": [
         "gradle"


### PR DESCRIPTION
## Summary
- group `@design-parity/adapter-figma`, `@design-parity/candidate`, and `@design-parity/catalog-export` Renovate updates
- keep the design-parity export toolchain on one release line

## Test plan
- `jq empty .github/renovate.json`
- verify the package rule matches exactly the three requested dependencies
- `git diff --check`