### PR TITLE
feat(mcp): add remote UI builder tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ more than a PNG.
 - **[Agents & MCP](https://yschimke.github.io/compose-ai-tools/mcp/)** — a
   push-based, token-frugal agent loop over Compose UI: target by semantic ref,
   observe semantics instead of pixels, diff renders, turn recordings into
-  tests. The aria-snapshot story for Compose.
+  tests. The aria-snapshot story for Compose. The same native MCP process can
+  optionally connect agents to a concurrent preview-server UI-builder session;
+  see the [MCP design reference](docs/daemon/MCP.md#remote-ui-builder-tools).
 - **[Daemon](https://yschimke.github.io/compose-ai-tools/daemon/)** — an
   optional long-lived renderer that keeps Robolectric / Compose-Desktop warm
   so re-renders are fast.

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -296,6 +296,8 @@ internal object CliFlagValidation {
           "--no-codex",
           "--project",
           "--replicas-per-daemon",
+          "--ui-builder-url",
+          "--ui-builder-actor",
           "--verbose",
           "-v",
         ),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -166,6 +166,8 @@ internal object CliFlags {
       "--ref",
       "--repo",
       "--replicas-per-daemon",
+      "--ui-builder-url",
+      "--ui-builder-actor",
       "--since",
       "--source",
       "--title",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -81,6 +81,16 @@ internal class McpCommand(
         --module <gradlePath> Limit to one or more module paths (repeatable)
         --json               Emit a structured envelope on stdout (install, doctor)
 
+      serve: remote UI builder (optional; native MCP profile only):
+        --ui-builder-url <url>
+                             Add the eight UI-builder tools backed by that preview-server URL.
+        --ui-builder-actor <actor>
+                             Override the authenticated actor id. By default it is derived from
+                             the grant token fingerprint.
+        COMPOSE_PREVIEW_UI_BUILDER_TOKEN
+                             Required secret when --ui-builder-url is set. It is read from the
+                             environment and never accepted as an argv value.
+
       install: agent host registration (each defaults to "on" when the host is detected
       locally; opt out with --no-<host>):
         --claude / --no-claude
@@ -577,6 +587,8 @@ internal class McpCommand(
         "--project",
         "--module",
         "--replicas-per-daemon",
+        "--ui-builder-url",
+        "--ui-builder-actor",
         "--antigravity-config",
         "--codex-config",
       )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/CliFlagsRegistryTest.kt
@@ -79,6 +79,12 @@ class CliFlagsRegistryTest {
       2,
       CliFlags.findCommandIndex(arrayOf("--replicas-per-daemon", "2", "mcp", "serve")),
     )
+    assertEquals(
+      2,
+      CliFlags.findCommandIndex(
+        arrayOf("--ui-builder-url", "https://preview.example", "mcp", "serve")
+      ),
+    )
     // --force takes a required reason; the space form must skip the reason (ForceFlagTest pins that
     // `--force <reason>` is supported), or the reason is mistaken for the command.
     assertEquals(2, CliFlags.findCommandIndex(arrayOf("--force", "edit didn't reflect", "render")))

--- a/docs/daemon/MCP-KOTLIN.md
+++ b/docs/daemon/MCP-KOTLIN.md
@@ -32,6 +32,12 @@ HTTP / SSE transports are out of scope. If a remote-agent use case
 materialises, factor `McpSession`'s read/write loops behind a transport
 interface and add an HTTP variant alongside.
 
+The optional UI-builder facade is different: the MCP client still connects to
+this process over stdio, while `UiBuilderMcpAdapter` acts as an authenticated
+HTTP client of preview-server's versioned Design API. It depends only on the
+released protocol artifact and deliberately owns no reducer, persistence,
+catalog, or render implementation.
+
 ## Module layout
 
 ```

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -124,6 +124,36 @@ supervisor stops respawning.
 | `get_preview_extras(uri, kind)` | List non-JSON outputs produced alongside a data product. |
 | `record_preview(uri, fps?, scale?, format?, observe?, events, overrides?, emitTest?)` | Record a scripted preview interaction to APNG/MP4/WebM. `observe` defaults to `frames` — the structured per-frame observation (per-frame sha256 + changed-pixel counts, `changedFrameCount`, on-disk paths) with no inline media; `media` also returns the encoded bytes inline (the artifact is on disk at `videoPath` either way). Token-frugal default since recording bytes scale with fps × duration (issue #1860). With `emitTest: true`, also returns a runnable Compose UI test generated from the interaction (issue #1786) — target-bearing events become `onNodeWith…().performClick()` steps, and each `recording.probe` is diffed against the previous probe's captured semantics into `assertExists()` / `assertDoesNotExist()` assertions (falling back to a TODO stub when nothing assertable was captured). |
 
+### Remote UI-builder tools
+
+The native MCP profile can also expose a remote preview-server UI-builder
+session. Start it with a server base URL and an agent grant token (the token is
+environment-only so it never appears in process arguments):
+
+```sh
+COMPOSE_PREVIEW_UI_BUILDER_TOKEN='<grant>' \
+  compose-preview mcp serve --ui-builder-url https://preview.example/
+```
+
+The adapter owns no design state. Every call uses the released
+`ee.schimke.composeai:ui-builder-protocol:2.2.0` HTTP envelope and reaches the
+same authoritative service used by browser sessions. Request ids are checked
+on every response, and the default actor is
+`agent:<12-character grant-token fingerprint>`. `--ui-builder-actor` is
+available for an operator-provided identity; preview-server still authenticates
+that identity against the token.
+
+| Required grant capability | MCP tools | Typed Design API request |
+|---|---|---|
+| `ui-builder-read` | `open_design`, `list_components`, `get_revision_diff` | `openDesign`, `listCatalogs`, `getDelta` |
+| `ui-builder-write` | `create_design`, `apply_design_operations` | `createDesign`, `applyOperation` |
+| `ui-builder-export` | `render_design`, `export_svg`, `export_compose` | `exportDesign` with `png`, `svg`, or `compose` |
+
+The three capabilities remain independent: a read-only grant cannot mutate or
+export, and a write grant does not implicitly grant export. The Storybook
+compatibility profile never advertises or dispatches these tools, even when
+UI-builder environment variables are present.
+
 The daemon's render queue is single-priority FIFO today, so `setVisible` /
 `setFocus` traffic flows through the wire but doesn't yet reorder the queue.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -342,7 +342,7 @@ coil3 = "3.5.0"
 # here. This repository consumes them; it no longer owns these coordinates. A change to a contract
 # reaches this build only through a release there — see that repository's docs/VERSIONING.md.
 # A point pin, deliberately: a range would let a contract change arrive without a pull request.
-composeai-contracts = "2.1.0"
+composeai-contracts = "2.2.0"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,
@@ -390,6 +390,7 @@ composeai-daemon-protocol = { module = "ee.schimke.composeai:daemon-protocol", v
 composeai-daemon-devices = { module = "ee.schimke.composeai:daemon-devices", version.ref = "composeai-contracts" }
 composeai-daemon-bta = { module = "ee.schimke.composeai:daemon-bta", version.ref = "composeai-contracts" }
 composeai-agent-grant-protocol = { module = "ee.schimke.composeai:agent-grant-protocol", version.ref = "composeai-contracts" }
+composeai-ui-builder-protocol = { module = "ee.schimke.composeai:ui-builder-protocol", version.ref = "composeai-contracts" }
 composeai-data-render-core = { module = "ee.schimke.composeai:data-render-core", version.ref = "composeai-contracts" }
 composeai-data-layoutinspector-core = { module = "ee.schimke.composeai:data-layoutinspector-core", version.ref = "composeai-contracts" }
 composeai-data-theme-core = { module = "ee.schimke.composeai:data-theme-core", version.ref = "composeai-contracts" }

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
   implementation(libs.mcp.kotlin.sdk.server)
   // Okio-based file IO (`SystemFileSystem`) for descriptor reads + PNG/video byte reads.
   implementation(libs.composeai.common.io)
+  implementation(libs.composeai.agent.grant.protocol)
+  implementation(libs.composeai.ui.builder.protocol)
   // `:daemon:core` and `:render-session-api` are advertised as `api` because `:mcp` exposes
   // their types on its public surface (e.g. `SupervisedDaemon.session: RenderSession`,
   // `DaemonClasspathDescriptor`, the protocol message types reused by

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -13,6 +13,8 @@ import java.io.File
  * ```
  * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
  *                     [--replicas-per-daemon <N>]
+ *                     [--ui-builder-url <URL>]
+ *                     [--ui-builder-actor <ACTOR>]
  *                     [--storybook]
  * ```
  *
@@ -42,6 +44,11 @@ object DaemonMcpMain {
   fun main(args: Array<String>) {
     disableKotlinLoggingStartupMessage()
     val replicasPerDaemon = parseReplicasPerDaemon(args)
+    val storybookProfile = parseStorybookProfile(args)
+    // Storybook compatibility is intentionally a closed tool surface. Do not even construct the
+    // remote adapter in that profile: an ambient UI-builder URL must not add tools or make a token
+    // mandatory for a Storybook-only process.
+    val uiBuilderMcp = if (storybookProfile) null else parseUiBuilderMcp(args)
     val supervisor =
       DaemonSupervisor(
         descriptorProvider = DescriptorProvider.readingFromDisk(),
@@ -49,7 +56,7 @@ object DaemonMcpMain {
         replicasPerDaemon = replicasPerDaemon,
       )
     val server =
-      if (parseStorybookProfile(args)) {
+      if (storybookProfile) {
         // Storybook-compat face: present ONLY the Storybook-MCP tools (native tools hidden) and
         // identify as `compose-preview-storybook`, so a Storybook-MCP-trained agent sees a clean
         // Storybook surface. Same daemon core + handlers underneath.
@@ -59,7 +66,7 @@ object DaemonMcpMain {
           profile = McpToolProfile.STORYBOOK,
         )
       } else {
-        DaemonMcpServer(supervisor)
+        DaemonMcpServer(supervisor, uiBuilderMcp = uiBuilderMcp)
       }
 
     parseProjects(args).forEach { (path, name) ->
@@ -88,6 +95,37 @@ object DaemonMcpMain {
         .getMethod("setLogStartupMessage", java.lang.Boolean.TYPE)
         .invoke(instance, false)
     }
+  }
+
+  private fun parseUiBuilderMcp(args: Array<String>): UiBuilderMcpAdapter? {
+    val url =
+      option(args, "--ui-builder-url")
+        ?: System.getProperty("composeai.uiBuilder.url")
+        ?: System.getenv("COMPOSE_PREVIEW_UI_BUILDER_URL")
+        ?: return null
+    val token =
+      System.getenv("COMPOSE_PREVIEW_UI_BUILDER_TOKEN")
+        ?: error("--ui-builder-url requires COMPOSE_PREVIEW_UI_BUILDER_TOKEN")
+    val actor =
+      option(args, "--ui-builder-actor")
+        ?: System.getProperty("composeai.uiBuilder.actor")
+        ?: System.getenv("COMPOSE_PREVIEW_UI_BUILDER_ACTOR")
+    val client =
+      if (actor == null) UiBuilderDesignApiClient.remote(url, token)
+      else UiBuilderDesignApiClient.remote(url, token, actor)
+    return UiBuilderMcpAdapter(client)
+  }
+
+  private fun option(args: Array<String>, name: String): String? {
+    args
+      .firstOrNull { it.startsWith("$name=") }
+      ?.let {
+        return it.substringAfter('=').takeIf(String::isNotBlank) ?: error("$name requires a value")
+      }
+    val index = args.indexOf(name)
+    if (index < 0) return null
+    return args.getOrNull(index + 1)?.takeUnless { it.startsWith("--") }?.takeIf(String::isNotBlank)
+      ?: error("$name requires a value")
   }
 
   private fun parseProjects(args: Array<String>): List<Pair<String, String?>> {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -148,6 +148,8 @@ class DaemonMcpServer(
    * alongside `preview-stories`). Both profiles route through the same handlers.
    */
   private val profile: McpToolProfile = McpToolProfile.NATIVE,
+  /** Optional remote Design API facade; never gives MCP direct reducer or store access. */
+  private val uiBuilderMcp: UiBuilderMcpAdapter? = null,
 ) {
 
   private val fullToolDefsLoader: () -> List<ToolDef> =
@@ -1919,7 +1921,7 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
-    )
+    ) + (uiBuilderMcp?.toolDefs() ?: emptyList())
 
   private fun handleCallTool(
     session: Session,
@@ -1959,7 +1961,12 @@ class DaemonMcpServer(
       "get-documentation-for-story" -> toolStorybookGetDoc(args)
       "preview-stories" -> toolStorybookPreviewStories(args)
       "run-story-tests" -> toolStorybookRunTests(args)
-      else -> errorCallToolResult("unknown tool: $name")
+      else ->
+        if (profile == McpToolProfile.NATIVE) {
+          uiBuilderMcp?.handle(name, args) ?: errorCallToolResult("unknown tool: $name")
+        } else {
+          errorCallToolResult("unknown tool: $name")
+        }
     }
   }
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
@@ -1,0 +1,321 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.mcp.protocol.CallToolResult
+import ee.schimke.composeai.mcp.protocol.ContentBlock
+import ee.schimke.composeai.mcp.protocol.ToolDef
+import ee.schimke.composeai.uibuilder.protocol.ApplyOperationRequestV1
+import ee.schimke.composeai.uibuilder.protocol.CreateDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.DesignDocumentV1
+import ee.schimke.composeai.uibuilder.protocol.DesignSubmissionV1
+import ee.schimke.composeai.uibuilder.protocol.ExportDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.ExportFormatV1
+import ee.schimke.composeai.uibuilder.protocol.GetDeltaRequestV1
+import ee.schimke.composeai.uibuilder.protocol.HttpRequestEnvelopeV1
+import ee.schimke.composeai.uibuilder.protocol.HttpResponseEnvelopeV1
+import ee.schimke.composeai.uibuilder.protocol.ListCatalogsRequestV1
+import ee.schimke.composeai.uibuilder.protocol.OpenDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.UI_BUILDER_SCHEMA_VERSION_V1
+import ee.schimke.composeai.uibuilder.protocol.UiBuilderRequestV1
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.UUID
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.decodeFromJsonElement
+
+/**
+ * Thin MCP facade over preview-server's versioned UI-builder Design API.
+ *
+ * This adapter owns no design state, reducer, renderer, or persistence. Browser and agent edits
+ * therefore meet at the same authenticated service boundary and observe the same revisions.
+ */
+class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesignApiClient) {
+  fun toolDefs(): List<ToolDef> =
+    listOf(
+      tool(
+        "create_design",
+        "Create and persist a UI-builder design from a complete v1 design document.",
+        """{"type":"object","properties":{"document":{"type":"object"}},"required":["document"]}""",
+      ),
+      tool(
+        "open_design",
+        "Open the latest committed snapshot of a persisted UI-builder design.",
+        designIdSchema,
+      ),
+      tool(
+        "list_components",
+        "List the server's pinned UI-builder catalogs and component capability schemas.",
+        emptySchema,
+      ),
+      tool(
+        "apply_design_operations",
+        "Atomically apply a typed v1 operation submission. Returns committed revision, sequence, document hash, and validation/conflict diagnostics.",
+        """{"type":"object","properties":{"submission":{"type":"object"}},"required":["submission"]}""",
+      ),
+      tool(
+        "render_design",
+        "Render a committed design revision as a revision-pinned PNG artifact.",
+        revisionSchema,
+      ),
+      tool(
+        "export_svg",
+        "Export a committed design revision as Figma-compatible, revision-pinned SVG.",
+        revisionSchema,
+      ),
+      tool(
+        "export_compose",
+        "Export a committed design revision as deterministic Compose source with diagnostics.",
+        revisionSchema,
+      ),
+      tool(
+        "get_revision_diff",
+        "Read durable UI-builder events after an exclusive sequence cursor.",
+        """{"type":"object","properties":{"designId":{"type":"string"},"afterSequence":{"type":"integer","minimum":0},"limit":{"type":"integer","minimum":1,"maximum":1000}},"required":["designId","afterSequence"]}""",
+      ),
+    )
+
+  /** Returns null when [name] is not owned by this adapter. */
+  fun handle(name: String, args: JsonObject): CallToolResult? {
+    val request =
+      try {
+        when (name) {
+          "create_design" ->
+            CreateDesignRequestV1(
+              json.decodeFromJsonElement<DesignDocumentV1>(args.required("document"))
+            )
+          "open_design" -> OpenDesignRequestV1(args.requiredString("designId"))
+          "list_components" -> ListCatalogsRequestV1
+          "apply_design_operations" ->
+            ApplyOperationRequestV1(
+              json.decodeFromJsonElement<DesignSubmissionV1>(args.required("submission"))
+            )
+          "render_design" -> args.exportRequest(ExportFormatV1.PNG)
+          "export_svg" -> args.exportRequest(ExportFormatV1.SVG)
+          "export_compose" -> args.exportRequest(ExportFormatV1.COMPOSE)
+          "get_revision_diff" ->
+            GetDeltaRequestV1(
+              designId = args.requiredString("designId"),
+              afterSequence = args.requiredLong("afterSequence", minimum = 0),
+              limit = args.optionalInt("limit", range = 1..1000) ?: 200,
+            )
+          else -> return null
+        }
+      } catch (e: SerializationException) {
+        return error(name, "invalid v1 protocol payload: ${e.message}")
+      } catch (e: IllegalArgumentException) {
+        return error(name, e.message ?: "invalid arguments")
+      }
+
+    return try {
+      val response = client.execute(request)
+      CallToolResult(content = listOf(ContentBlock.Text(json.encodeToString(response))))
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+      error(name, "Design API request interrupted")
+    } catch (e: Exception) {
+      error(name, e.message ?: "Design API request failed")
+    }
+  }
+
+  private fun JsonObject.exportRequest(format: ExportFormatV1): ExportDesignRequestV1 =
+    ExportDesignRequestV1(
+      designId = requiredString("designId"),
+      revision = optionalLong("revision", minimum = 0),
+      format = format,
+    )
+
+  private fun tool(name: String, description: String, schema: String) =
+    ToolDef(name, description, json.parseToJsonElement(schema))
+
+  private fun error(name: String, message: String) =
+    CallToolResult(
+      content = listOf(ContentBlock.Text("$name: $message")),
+      isError = true,
+    )
+
+  private companion object {
+    val json = Json {
+      encodeDefaults = true
+      explicitNulls = false
+      ignoreUnknownKeys = false
+    }
+    const val emptySchema = """{"type":"object","properties":{}}"""
+    const val designIdSchema =
+      """{"type":"object","properties":{"designId":{"type":"string"}},"required":["designId"]}"""
+    const val revisionSchema =
+      """{"type":"object","properties":{"designId":{"type":"string"},"revision":{"type":"integer","minimum":0}},"required":["designId"]}"""
+  }
+}
+
+/** Authenticated HTTP client for one remote preview-server UI-builder service. */
+internal class UiBuilderDesignApiClient(
+  val actorId: String,
+  private val transport: UiBuilderHttpTransport,
+  private val requestId: () -> String = { UUID.randomUUID().toString() },
+) {
+  init {
+    require(actorId.isNotBlank()) { "UI-builder actor id must not be blank" }
+  }
+
+  fun execute(request: UiBuilderRequestV1): HttpResponseEnvelopeV1 {
+    request.requesterActorId()?.let { requesterActorId ->
+      require(requesterActorId == actorId) {
+        "requester actor '$requesterActorId' must match authenticated actor '$actorId'"
+      }
+    }
+    val id = requestId()
+    require(id.isNotBlank()) { "UI-builder request id must not be blank" }
+    val body =
+      json.encodeToString(
+        HttpRequestEnvelopeV1(requestId = id, actorId = actorId, request = request)
+      )
+    val response = transport.post(body)
+    val envelope =
+      try {
+        json.decodeFromString(HttpResponseEnvelopeV1.serializer(), response.body)
+      } catch (e: SerializationException) {
+        throw UiBuilderApiException("Design API returned an invalid response", e)
+      }
+    if (envelope.requestId != id) {
+      throw UiBuilderApiException(
+        "Design API response id '${envelope.requestId}' did not match request '$id'"
+      )
+    }
+    if (envelope.schemaVersion != UI_BUILDER_SCHEMA_VERSION_V1) {
+      throw UiBuilderApiException(
+        "Design API returned unsupported schema version ${envelope.schemaVersion}"
+      )
+    }
+    if (response.status !in 200..299) {
+      throw UiBuilderApiException("Design API returned HTTP ${response.status}")
+    }
+    return envelope
+  }
+
+  companion object {
+    fun remote(
+      baseUrl: String,
+      token: String,
+      actorId: String = "agent:${AgentGrantProtocol.fingerprintOf(token)}",
+    ): UiBuilderDesignApiClient =
+      UiBuilderDesignApiClient(
+        actorId = actorId,
+        transport = JdkUiBuilderHttpTransport(baseUrl, token),
+      )
+
+    private val json = Json {
+      encodeDefaults = true
+      explicitNulls = false
+      ignoreUnknownKeys = false
+    }
+  }
+}
+
+internal fun interface UiBuilderHttpTransport {
+  fun post(body: String): UiBuilderHttpResponse
+}
+
+internal data class UiBuilderHttpResponse(val status: Int, val body: String)
+
+internal class UiBuilderApiException(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)
+
+private class JdkUiBuilderHttpTransport(baseUrl: String, private val token: String) :
+  UiBuilderHttpTransport {
+  private val endpoint = designEndpoint(baseUrl)
+  private val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build()
+
+  init {
+    require(token.isNotBlank()) { "UI-builder token must not be blank" }
+  }
+
+  override fun post(body: String): UiBuilderHttpResponse {
+    val request =
+      HttpRequest.newBuilder(endpoint)
+        .timeout(Duration.ofSeconds(60))
+        .header("Authorization", "Bearer $token")
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body))
+        .build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    val bytes = response.body().use { it.readNBytes(MAX_RESPONSE_BYTES + 1) }
+    if (bytes.size > MAX_RESPONSE_BYTES) {
+      throw UiBuilderApiException("Design API response exceeded $MAX_RESPONSE_BYTES bytes")
+    }
+    return UiBuilderHttpResponse(response.statusCode(), bytes.toString(Charsets.UTF_8))
+  }
+
+  private companion object {
+    const val MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+
+    fun designEndpoint(baseUrl: String): URI {
+      val base = URI(baseUrl.trim().trimEnd('/') + "/")
+      require(base.scheme == "http" || base.scheme == "https") {
+        "UI-builder URL must use http or https"
+      }
+      require(!base.host.isNullOrBlank()) { "UI-builder URL must include a host" }
+      require(base.userInfo == null && base.fragment == null && base.query == null) {
+        "UI-builder URL must not contain credentials, query, or fragment"
+      }
+      return base.resolve("api/ui-builder/v1/requests")
+    }
+  }
+}
+
+private fun UiBuilderRequestV1.requesterActorId(): String? =
+  when (this) {
+    is ApplyOperationRequestV1 -> submission.actorId()
+    else -> null
+  }
+
+private fun DesignSubmissionV1.actorId(): String =
+  when (this) {
+    is ee.schimke.composeai.uibuilder.protocol.DesignCommandV1 -> actorId
+    is ee.schimke.composeai.uibuilder.protocol.UndoCommandV1 -> actorId
+    is ee.schimke.composeai.uibuilder.protocol.RedoCommandV1 -> actorId
+  }
+
+private fun JsonObject.required(name: String): JsonElement =
+  this[name] ?: throw IllegalArgumentException("missing '$name'")
+
+private fun JsonObject.requiredString(name: String): String =
+  (required(name) as? JsonPrimitive)
+    ?.takeIf(JsonPrimitive::isString)
+    ?.contentOrNull
+    ?.takeIf(String::isNotBlank)
+    ?: throw IllegalArgumentException("'$name' must be a non-blank string")
+
+private fun JsonObject.requiredLong(name: String, minimum: Long? = null): Long {
+  val value =
+    (required(name) as? JsonPrimitive)?.takeUnless(JsonPrimitive::isString)?.content?.toLongOrNull()
+      ?: throw IllegalArgumentException("'$name' must be an integer")
+  if (minimum != null && value < minimum) {
+    throw IllegalArgumentException("'$name' must be at least $minimum")
+  }
+  return value
+}
+
+private fun JsonObject.optionalLong(name: String, minimum: Long? = null): Long? {
+  if (name !in this) return null
+  return requiredLong(name, minimum)
+}
+
+private fun JsonObject.optionalInt(name: String, range: IntRange): Int? {
+  if (name !in this) return null
+  val value =
+    (required(name) as? JsonPrimitive)?.takeUnless(JsonPrimitive::isString)?.content?.toIntOrNull()
+      ?: throw IllegalArgumentException("'$name' must be an integer")
+  if (value !in range) {
+    throw IllegalArgumentException("'$name' must be between ${range.first} and ${range.last}")
+  }
+  return value
+}

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -134,6 +134,13 @@ class DaemonMcpServerTest {
         sbSupervisor,
         serverInfo = Implementation(name = "compose-preview-storybook", version = "v0"),
         profile = McpToolProfile.STORYBOOK,
+        uiBuilderMcp =
+          UiBuilderMcpAdapter(
+            UiBuilderDesignApiClient(
+              actorId = "agent:0123456789ab",
+              transport = UiBuilderHttpTransport { error("Storybook dispatched a hidden tool") },
+            )
+          ),
       )
     val (c2s, sfc) = pipedPair()
     val (s2c, cfs) = pipedPair()
@@ -154,10 +161,69 @@ class DaemonMcpServerTest {
           "run-story-tests",
         )
       assertThat(tools.tools.map { it.name }).doesNotContain("render_preview")
+      assertThat(tools.tools.map { it.name }).doesNotContain("create_design")
+      val hidden = sbClient.callTool("list_components")
+      assertThat(hidden.raw["isError"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+      assertThat(hidden.firstTextContent()).isEqualTo("unknown tool: list_components")
     } finally {
       runCatching { sbClient.close() }
       runCatching { sbSession.close() }
       runCatching { sbSupervisor.shutdown() }
+    }
+  }
+
+  @Test
+  fun `native profile advertises and dispatches configured UI builder tools`() {
+    val nativeSupervisor =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = FakeDaemonClientFactory(),
+      )
+    val nativeServer =
+      DaemonMcpServer(
+        nativeSupervisor,
+        uiBuilderMcp =
+          UiBuilderMcpAdapter(
+            UiBuilderDesignApiClient(
+              actorId = "agent:0123456789ab",
+              transport =
+                UiBuilderHttpTransport { body ->
+                  val requestId =
+                    json
+                      .parseToJsonElement(body)
+                      .jsonObject
+                      .getValue("requestId")
+                      .jsonPrimitive
+                      .content
+                  UiBuilderHttpResponse(
+                    status = 200,
+                    body =
+                      """{"schemaVersion":1,"requestId":"$requestId","response":{"type":"catalogs","catalogs":[]}}""",
+                  )
+                },
+              requestId = { "native-call-1" },
+            )
+          ),
+      )
+    val (c2s, sfc) = pipedPair()
+    val (s2c, cfs) = pipedPair()
+    val nativeSession = nativeServer.newSession(input = sfc, output = s2c)
+    nativeSession.start()
+    val nativeClient = McpTestClient(input = cfs, output = c2s)
+    try {
+      nativeClient.initialize()
+      val tools = nativeClient.awaitToolsContaining("create_design")
+      assertThat(tools.tools.map { it.name })
+        .containsAtLeast("create_design", "list_components", "export_svg")
+
+      val result = nativeClient.callTool("list_components")
+      assertThat(result.raw["isError"]?.jsonPrimitive?.contentOrNull).isEqualTo("false")
+      assertThat(result.firstTextContent()).contains("native-call-1")
+      assertThat(result.firstTextContent()).contains("catalogs")
+    } finally {
+      runCatching { nativeClient.close() }
+      runCatching { nativeSession.close() }
+      runCatching { nativeSupervisor.shutdown() }
     }
   }
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
@@ -1,0 +1,295 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.uibuilder.protocol.ApplyOperationRequestV1
+import ee.schimke.composeai.uibuilder.protocol.CatalogReferenceV1
+import ee.schimke.composeai.uibuilder.protocol.CatalogsResponseV1
+import ee.schimke.composeai.uibuilder.protocol.CreateDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.DesignCommandV1
+import ee.schimke.composeai.uibuilder.protocol.DesignDocumentV1
+import ee.schimke.composeai.uibuilder.protocol.DesignEnvironmentV1
+import ee.schimke.composeai.uibuilder.protocol.DesignSubmissionV1
+import ee.schimke.composeai.uibuilder.protocol.ErrorResponseV1
+import ee.schimke.composeai.uibuilder.protocol.ExportDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.ExportFormatV1
+import ee.schimke.composeai.uibuilder.protocol.GetDeltaRequestV1
+import ee.schimke.composeai.uibuilder.protocol.HttpRequestEnvelopeV1
+import ee.schimke.composeai.uibuilder.protocol.HttpResponseEnvelopeV1
+import ee.schimke.composeai.uibuilder.protocol.LayoutDirectionV1
+import ee.schimke.composeai.uibuilder.protocol.ListCatalogsRequestV1
+import ee.schimke.composeai.uibuilder.protocol.OpenDesignRequestV1
+import ee.schimke.composeai.uibuilder.protocol.ServiceErrorCodeV1
+import ee.schimke.composeai.uibuilder.protocol.ServiceErrorV1
+import ee.schimke.composeai.uibuilder.protocol.ThemeV1
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Test
+
+class UiBuilderMcpAdapterTest {
+  private val requests = mutableListOf<HttpRequestEnvelopeV1>()
+  private val transport = UiBuilderHttpTransport { body ->
+    val request = json.decodeFromString(HttpRequestEnvelopeV1.serializer(), body)
+    requests += request
+    UiBuilderHttpResponse(
+      status = 200,
+      body =
+        json.encodeToString(
+          HttpResponseEnvelopeV1(
+            requestId = request.requestId,
+            response = CatalogsResponseV1(emptyList()),
+          )
+        ),
+    )
+  }
+  private val sequence = AtomicInteger()
+  private val client =
+    UiBuilderDesignApiClient(
+      actorId = ACTOR,
+      transport = transport,
+      requestId = { "call-${sequence.incrementAndGet()}" },
+    )
+  private val adapter = UiBuilderMcpAdapter(client)
+
+  @Test
+  fun `advertises the exact eight UI builder tools with object schemas`() {
+    val tools = adapter.toolDefs()
+
+    assertThat(tools.map { it.name })
+      .containsExactly(
+        "create_design",
+        "open_design",
+        "list_components",
+        "apply_design_operations",
+        "render_design",
+        "export_svg",
+        "export_compose",
+        "get_revision_diff",
+      )
+      .inOrder()
+    assertThat(tools.map { it.inputSchema.jsonObject["type"]?.jsonPrimitive?.content }.distinct())
+      .containsExactly("object")
+  }
+
+  @Test
+  fun `maps all eight tools to typed requests and exact authenticated envelopes`() {
+    val calls =
+      listOf(
+        "create_design" to
+          buildJsonObject {
+            put("document", json.encodeToJsonElement(DesignDocumentV1.serializer(), document))
+          },
+        "open_design" to buildJsonObject { put("designId", "design-1") },
+        "list_components" to buildJsonObject {},
+        "apply_design_operations" to
+          buildJsonObject {
+            put("submission", json.encodeToJsonElement(DesignSubmissionV1.serializer(), command))
+          },
+        "render_design" to revisionArgs,
+        "export_svg" to revisionArgs,
+        "export_compose" to revisionArgs,
+        "get_revision_diff" to
+          buildJsonObject {
+            put("designId", "design-1")
+            put("afterSequence", 41)
+            put("limit", 37)
+          },
+      )
+
+    calls.forEach { (name, arguments) ->
+      val result = requireNotNull(adapter.handle(name, arguments))
+      assertThat(result.isError).isNull()
+    }
+
+    assertThat(requests.map { it.schemaVersion }.distinct()).containsExactly(1)
+    assertThat(requests.map { it.requestId })
+      .containsExactly(
+        "call-1",
+        "call-2",
+        "call-3",
+        "call-4",
+        "call-5",
+        "call-6",
+        "call-7",
+        "call-8",
+      )
+      .inOrder()
+    assertThat(requests.map { it.actorId }.distinct()).containsExactly(ACTOR)
+    assertThat(requests[0].request).isEqualTo(CreateDesignRequestV1(document))
+    assertThat(requests[1].request).isEqualTo(OpenDesignRequestV1("design-1"))
+    assertThat(requests[2].request).isEqualTo(ListCatalogsRequestV1)
+    assertThat(requests[3].request).isEqualTo(ApplyOperationRequestV1(command))
+    assertThat(requests.drop(4).take(3).map { (it.request as ExportDesignRequestV1).format })
+      .containsExactly(ExportFormatV1.PNG, ExportFormatV1.SVG, ExportFormatV1.COMPOSE)
+      .inOrder()
+    assertThat(requests.drop(4).take(3).map { (it.request as ExportDesignRequestV1).revision })
+      .containsExactly(7L, 7L, 7L)
+    assertThat(requests[7].request).isEqualTo(GetDeltaRequestV1("design-1", 41, 37))
+  }
+
+  @Test
+  fun `read write and export tools remain distinct protocol capability lanes`() {
+    val byName = adapter.toolDefs().associateBy { it.name }
+
+    assertThat(byName.keys.intersect(READ_TOOLS)).containsExactlyElementsIn(READ_TOOLS)
+    assertThat(byName.keys.intersect(WRITE_TOOLS)).containsExactlyElementsIn(WRITE_TOOLS)
+    assertThat(byName.keys.intersect(EXPORT_TOOLS)).containsExactlyElementsIn(EXPORT_TOOLS)
+    assertThat(READ_TOOLS + WRITE_TOOLS + EXPORT_TOOLS).containsExactlyElementsIn(byName.keys)
+  }
+
+  @Test
+  fun `rejects nested requester actor spoofing before transport`() {
+    val spoofed = command.copy(actorId = "agent:someone-else")
+
+    val result =
+      requireNotNull(
+        adapter.handle(
+          "apply_design_operations",
+          buildJsonObject {
+            put("submission", json.encodeToJsonElement(DesignSubmissionV1.serializer(), spoofed))
+          },
+        )
+      )
+
+    assertThat(result.isError).isTrue()
+    assertThat(requests).isEmpty()
+    assertThat(result.content.single().toString()).contains("must match authenticated actor")
+  }
+
+  @Test
+  fun `rejects malformed and out of range arguments without transport`() {
+    val malformed =
+      listOf(
+        "open_design" to buildJsonObject {},
+        "render_design" to
+          buildJsonObject {
+            put("designId", "design-1")
+            put("revision", -1)
+          },
+        "get_revision_diff" to
+          buildJsonObject {
+            put("designId", "design-1")
+            put("afterSequence", -1)
+          },
+        "get_revision_diff" to
+          buildJsonObject {
+            put("designId", "design-1")
+            put("afterSequence", 0)
+            put("limit", 1001)
+          },
+      )
+
+    malformed.forEach { (name, arguments) ->
+      assertThat(requireNotNull(adapter.handle(name, arguments)).isError).isTrue()
+    }
+    assertThat(requests).isEmpty()
+  }
+
+  @Test
+  fun `rejects mismatched response correlation and hides HTTP response bodies`() {
+    val mismatch =
+      UiBuilderMcpAdapter(
+        UiBuilderDesignApiClient(
+          ACTOR,
+          UiBuilderHttpTransport {
+            UiBuilderHttpResponse(
+              200,
+              json.encodeToString(
+                HttpResponseEnvelopeV1(
+                  requestId = "different-call",
+                  response = CatalogsResponseV1(emptyList()),
+                )
+              ),
+            )
+          },
+          requestId = { "expected-call" },
+        )
+      )
+    val mismatchResult = requireNotNull(mismatch.handle("list_components", JsonObject(emptyMap())))
+    assertThat(mismatchResult.isError).isTrue()
+    assertThat(mismatchResult.content.single().toString()).contains("did not match")
+
+    val secret = "server-body-must-not-escape"
+    val failed =
+      UiBuilderMcpAdapter(
+        UiBuilderDesignApiClient(
+          ACTOR,
+          UiBuilderHttpTransport {
+            UiBuilderHttpResponse(
+              403,
+              json.encodeToString(
+                HttpResponseEnvelopeV1(
+                  requestId = "failed-call",
+                  response =
+                    ErrorResponseV1(ServiceErrorV1(ServiceErrorCodeV1.FORBIDDEN, message = secret)),
+                )
+              ),
+            )
+          },
+          requestId = { "failed-call" },
+        )
+      )
+    val failedResult = requireNotNull(failed.handle("list_components", JsonObject(emptyMap())))
+    assertThat(failedResult.isError).isTrue()
+    assertThat(failedResult.content.single().toString()).doesNotContain(secret)
+  }
+
+  @Test
+  fun `default remote actor is the released grant fingerprint convention`() {
+    val token = "not-a-real-secret"
+    val remote = UiBuilderDesignApiClient.remote("https://preview.example/", token)
+
+    assertThat(remote.actorId).isEqualTo("agent:${AgentGrantProtocol.fingerprintOf(token)}")
+  }
+
+  private companion object {
+    const val ACTOR = "agent:0123456789ab"
+    val READ_TOOLS = setOf("open_design", "list_components", "get_revision_diff")
+    val WRITE_TOOLS = setOf("create_design", "apply_design_operations")
+    val EXPORT_TOOLS = setOf("render_design", "export_svg", "export_compose")
+    val json = Json {
+      encodeDefaults = true
+      explicitNulls = false
+      ignoreUnknownKeys = false
+    }
+    val document =
+      DesignDocumentV1(
+        schema = "compose-preview/ui-builder/v1",
+        id = "design-1",
+        title = "Test design",
+        revision = 0,
+        catalogPin = CatalogReferenceV1("m3-catalog", "rev-1", "digest-1", "runtime-1"),
+        environment =
+          DesignEnvironmentV1(
+            widthDp = 360,
+            heightDp = 800,
+            density = 1.0,
+            theme = ThemeV1.LIGHT,
+            locale = "en-US",
+            fontScale = 1.0,
+            layoutDirection = LayoutDirectionV1.LTR,
+          ),
+        roots = emptyList(),
+        nodes = emptyMap(),
+      )
+    val command =
+      DesignCommandV1(
+        designId = "design-1",
+        operationId = "operation-1",
+        actorId = ACTOR,
+        clientId = "mcp-test",
+        baseRevision = 0,
+        operations = emptyList(),
+      )
+    val revisionArgs = buildJsonObject {
+      put("designId", "design-1")
+      put("revision", 7)
+    }
+  }
+}

--- a/site/mcp.md
+++ b/site/mcp.md
@@ -68,6 +68,22 @@ long-running calls. Data products are read via `list_data_products`,
 For the full tool surface, URI scheme, and wire protocol see
 [`docs/daemon/MCP.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/MCP.md).
 
+### Connect a remote UI-builder session
+
+The native MCP profile can expose eight additional tools backed by the same
+persisted preview-server UI-builder session a browser is editing. Supply the
+server URL as an argument and the temporary agent grant as an environment
+variable, keeping the secret out of process arguments:
+
+```sh
+COMPOSE_PREVIEW_UI_BUILDER_TOKEN='<grant>' \
+  compose-preview mcp serve --ui-builder-url https://preview.example/
+```
+
+Grants keep `ui-builder-read`, `ui-builder-write`, and `ui-builder-export`
+independent. The adapter is a remote protocol client only: it does not copy the
+server's reducer, catalog, renderer, or persistence into this repository.
+
 ## What we tell agents
 
 Point the agent at the


### PR DESCRIPTION
## Summary
- add eight optional MCP tools backed by preview-server's released UI-builder Design API v2.2.0
- preserve exact request correlation and authenticated actor identity, with independent read/write/export grant enforcement at the server boundary
- keep the Storybook profile closed and accept grant secrets only from the environment
- document CLI setup and add deterministic fake-transport and in-process MCP coverage

## Verification
- `./gradlew ktfmtFormat :mcp:check :cli:ktfmtCheck`
- `./gradlew :cli:test`
- focused adapter, native dispatch, Storybook isolation, and CLI flag tests