### PR TITLE
fix(mcp): require pinned UI builder exports

### DIFF
--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -149,6 +149,13 @@ that identity against the token.
 | `ui-builder-write` | `create_design`, `apply_design_operations` | `createDesign`, `applyOperation` |
 | `ui-builder-export` | `render_design`, `export_svg`, `export_compose` | `exportDesign` with `png`, `svg`, or `compose` |
 
+All three export tools require an explicit committed `revision`; they never
+silently export whichever revision happens to be latest when the request is
+handled. `get_revision_diff` is the authoritative polling path for concurrent
+browser/agent sessions. If the server reports that the cursor needs a snapshot,
+call `open_design` to refresh from the latest committed document before
+continuing.
+
 The three capabilities remain independent: a read-only grant cannot mutate or
 export, and a write grant does not implicitly grant export. The Storybook
 compatibility profile never advertises or dispatches these tools, even when

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
@@ -129,7 +129,7 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
   private fun JsonObject.exportRequest(format: ExportFormatV1): ExportDesignRequestV1 =
     ExportDesignRequestV1(
       designId = requiredString("designId"),
-      revision = optionalLong("revision", minimum = 0),
+      revision = requiredLong("revision", minimum = 0),
       format = format,
     )
 
@@ -152,7 +152,7 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
     const val designIdSchema =
       """{"type":"object","properties":{"designId":{"type":"string"}},"required":["designId"]}"""
     const val revisionSchema =
-      """{"type":"object","properties":{"designId":{"type":"string"},"revision":{"type":"integer","minimum":0}},"required":["designId"]}"""
+      """{"type":"object","properties":{"designId":{"type":"string"},"revision":{"type":"integer","minimum":0}},"required":["designId","revision"]}"""
   }
 }
 
@@ -302,11 +302,6 @@ private fun JsonObject.requiredLong(name: String, minimum: Long? = null): Long {
     throw IllegalArgumentException("'$name' must be at least $minimum")
   }
   return value
-}
-
-private fun JsonObject.optionalLong(name: String, minimum: Long? = null): Long? {
-  if (name !in this) return null
-  return requiredLong(name, minimum)
 }
 
 private fun JsonObject.optionalInt(name: String, range: IntRange): Int? {

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
@@ -75,6 +76,19 @@ class UiBuilderMcpAdapterTest {
       .inOrder()
     assertThat(tools.map { it.inputSchema.jsonObject["type"]?.jsonPrimitive?.content }.distinct())
       .containsExactly("object")
+    listOf("render_design", "export_svg", "export_compose").forEach { name ->
+      assertThat(
+          tools
+            .single { it.name == name }
+            .inputSchema
+            .jsonObject
+            .getValue("required")
+            .jsonArray
+            .map { it.jsonPrimitive.content }
+        )
+        .containsExactly("designId", "revision")
+        .inOrder()
+    }
   }
 
   @Test
@@ -167,6 +181,9 @@ class UiBuilderMcpAdapterTest {
     val malformed =
       listOf(
         "open_design" to buildJsonObject {},
+        "render_design" to buildJsonObject { put("designId", "design-1") },
+        "export_svg" to buildJsonObject { put("designId", "design-1") },
+        "export_compose" to buildJsonObject { put("designId", "design-1") },
         "render_design" to
           buildJsonObject {
             put("designId", "design-1")


### PR DESCRIPTION
## Summary

- require an explicit committed revision for PNG, SVG, and Compose UI-builder exports
- align the MCP input schemas with the revision-pinned behavior promised by each tool
- document the authoritative delta/open recovery loop used by concurrent browser and agent sessions

This is a focused follow-up to #4929. The adapter remains a thin client of the released `ui-builder-protocol:2.2.0` HTTP API and does not depend on preview-server internals.

## Test plan

- `./gradlew ktfmtFormat :mcp:check --no-daemon`
- focused `UiBuilderMcpAdapterTest` verifies all export schemas require `revision` and direct handler calls reject omitted pins before transport
