### PR TITLE
fix(design-pages): enforce the published node cap

### DIFF
--- a/scripts/design-artifacts/design-pages.mjs
+++ b/scripts/design-artifacts/design-pages.mjs
@@ -48,6 +48,9 @@ export const PAGES_INDEX = "index.json";
 /** The `DESIGN_PAGES_VERSION` this producer emits. */
 export const PAGES_VERSION = 2;
 
+/** `ServeDesignPageStore.MAX_NODES_PER_PAGE` — inclusive, after unusable nodes are removed. */
+export const MAX_NODES_PER_PAGE = 500;
+
 /** `ServeDesignPageStore.SAFE_ID` — a page id is a URL path segment on `/{system}/pages/{id}`. */
 const SAFE_ID = /^[A-Za-z0-9._-]{1,160}$/;
 
@@ -533,8 +536,16 @@ export function planDesignPages({ manifest, spec, catalog }) {
     let unresolved = 0;
     let foreign = 0;
     const nodes = [];
-    for (const node of Array.isArray(page.nodes) ? page.nodes : []) {
-      if (!isDrawableNode(node)) continue;
+    const drawableNodes = (Array.isArray(page.nodes) ? page.nodes : []).filter(
+      isDrawableNode,
+    );
+    if (drawableNodes.length > MAX_NODES_PER_PAGE) {
+      warnings.push(
+        `page ${id}: ${drawableNodes.length} usable nodes exceed the supported maximum of ` +
+          `${MAX_NODES_PER_PAGE}; publishing the first ${MAX_NODES_PER_PAGE}`,
+      );
+    }
+    for (const node of drawableNodes.slice(0, MAX_NODES_PER_PAGE)) {
       const declaredLink = LINK_METHODS.has(node?.link)
         ? node.link
         : "unlinked";

--- a/scripts/design-artifacts/design-pages.test.mjs
+++ b/scripts/design-artifacts/design-pages.test.mjs
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  MAX_NODES_PER_PAGE,
   PAGES_VERSION,
   catalogOwnsNode,
   declaringClassOf,
@@ -133,6 +134,30 @@ test("an unlinked node is kept, without a preview id", () => {
   assert.equal(nodes[1].link, "unlinked");
   assert.equal(nodes[1].previewId, undefined);
   assert.equal(nodes[1].code, undefined);
+});
+
+test("the published node cap is inclusive at 500", () => {
+  for (const input of [499, 500, 501]) {
+    const nodes = Array.from({ length: input }, (_, index) => ({
+      ...statusBar,
+      nodeId: `1:${index + 1}`,
+    }));
+    const plan = planDesignPages({
+      manifest: manifest([page(nodes)]),
+      spec,
+      catalog,
+    });
+    assert.equal(
+      plan.manifest.pages[0].nodes.length,
+      Math.min(input, MAX_NODES_PER_PAGE),
+      `input node count ${input}`,
+    );
+    assert.equal(
+      plan.warnings.some((warning) => warning.includes("exceed the supported maximum")),
+      input > MAX_NODES_PER_PAGE,
+      `input node count ${input}`,
+    );
+  }
 });
 
 test("a linked node the catalog publishes no sticker for keeps its mapping and warns", () => {


### PR DESCRIPTION
## Summary
- define the shared inclusive 500-node design-page publication limit
- truncate larger usable-node lists with a visible publisher warning
- cover 499, 500, and 501-node manifests

Pairs with yschimke/compose-preview-server#149, which raises the sanitizer ceiling for the observed 14,576,730-byte Buttons SVG.

Part of #4905

## Verification
- `node --test scripts/design-artifacts/design-pages.test.mjs` (47 passing)