### PR TITLE
fix: act on missed review findings from the last 48h of PRs

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1932,6 +1932,14 @@ jobs:
               --carriage-report "$carriage_report" \
               -o "$GITHUB_WORKSPACE/out/bundle/previews"
           fi
+          # Exactly which bundles the carriage report describes — recorded HERE, before the
+          # additional-module and extra-module splits below, because the extra split writes into
+          # this same directory. The report covers the primary split only, so a later re-measure
+          # that just scans the directory would divide the primary `repeatedBytes` by a
+          # primary-plus-extra denominator and understate the share — the same understatement the
+          # re-measure exists to correct.
+          find "$GITHUB_WORKSPACE/out/bundle/previews" -maxdepth 1 -type f -name '*.png' | sort \
+            > "$GITHUB_WORKSPACE/split-primary-bundles.txt"
           if [ -d "$GITHUB_WORKSPACE/module-bundles" ]; then
             while IFS= read -r additional_bundle; do
               module_key="$(basename "$additional_bundle" .png)"
@@ -1980,7 +1988,7 @@ jobs:
           set -euo pipefail
           node compose-ai-tools/scripts/design-artifacts/recompute-carriage-report.mjs \
             --report "$GITHUB_WORKSPACE/split-carriage.json" \
-            --bundles-dir "$GITHUB_WORKSPACE/out/bundle/previews"
+            --bundles-from "$GITHUB_WORKSPACE/split-primary-bundles.txt"
 
       # The silent half of #4211. A FULL split pays the shared carriage once per preview, so its
       # cost scales with the preview COUNT — and because any catalog edit rewrites `app.jar`, every

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1968,6 +1968,20 @@ jobs:
           node compose-ai-tools/scripts/design-artifacts/strip-published-figma-svg.mjs \
             --root "$GITHUB_WORKSPACE/out/bundle"
 
+      # The split wrote the carriage report BEFORE the strip above, because it needs the transient
+      # SVGs to crop each cover — so its `totalBytes` still counts thousands of sidecar copies that
+      # are no longer in the published bundles. Those bytes sit in the DENOMINATOR of `sharePercent`,
+      # so leaving them there understates the share and can hold a catalog under the bound whose
+      # published output is almost entirely repeated classpath. Re-measure against what was actually
+      # published, before the gate reads it.
+      - name: Re-measure the carriage against the published bundles
+        if: ${{ inputs.split-per-preview && inputs.defer-figma-svg }}
+        run: |
+          set -euo pipefail
+          node compose-ai-tools/scripts/design-artifacts/recompute-carriage-report.mjs \
+            --report "$GITHUB_WORKSPACE/split-carriage.json" \
+            --bundles-dir "$GITHUB_WORKSPACE/out/bundle/previews"
+
       # The silent half of #4211. A FULL split pays the shared carriage once per preview, so its
       # cost scales with the preview COUNT — and because any catalog edit rewrites `app.jar`, every
       # publish rewrites all N copies and lays down a fresh delta chain. The delivery branch grows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,25 @@ until someone runs the script. `--no-verify` bypasses the local hooks; CI
 still won't. Why the PR body matters and how a trailer reached `main` anyway:
 [`docs/AGENT_GUIDE.md` → Git conventions](docs/AGENT_GUIDE.md#git-conventions).
 
+**Reviewers: run the detector before reporting an attribution finding.** This is
+the most-reported and least-real finding on this repo — 14 PRs drew a P1 "the
+author and committer are both `Codex`" comment over 2026-08-31/09-01 and not one
+was real. An agent reviewing its own or another agent's PR must not infer the
+commit identity from the fact that an agent wrote the code: the identity is
+whatever `git config user.email` held, and here that is the human. Check it, on
+the real range:
+
+```
+git log --format='%h %an <%ae> | %cn <%ce>' <base>..<head>
+.github/scripts/agent-attribution-scan.sh --range '<base>..<head>'
+```
+
+`Yuri Schimke <yuri@schimke.ee>` is this repository's human identity, and
+`github-actions[bot]` / `renovate[bot]` are exempt bot accounts (see above) — none
+of the three is ever a finding. Report only what the scanner exits 1 on, quote its
+output, and if the `Reject agent attribution` check is already green on the head
+commit there is nothing to report.
+
 <!-- invariant: branch-prefix -->
 ### Branch names are always `agent/…`
 

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -212,6 +212,40 @@ fine; the gate targets AI coding agents only. If you ever see an agent co-author
 an agent commit identity on `main`, treat it as a bug to fix, not a default to
 tolerate.
 
+**The false-positive side, which is now the common one.** The rule that a reviewer
+must run the detector before reporting a finding is in
+[root `AGENTS.md`](../AGENTS.md#the-ci-enforced-invariants); here is why it earned
+its place. Over 2026-08-31/09-01, fourteen PRs — #4912, #4913, #4915, #4917,
+#4920, #4928, #4929, #4930, #4933, #4938, #4939, #4943 (three times), #4944,
+#4945 — each drew a P1 review comment asserting that the reviewed commit recorded
+"both its author and committer as `Codex`", most of them quoting an
+`agent-attribution-scan.sh` invocation and an exit status. Three independent
+checks say otherwise:
+
+* On #4929 the `Reject agent attribution` job ran to completion on the same head
+  the comment flagged and reported **success**.
+* #4943 is the one of the fourteen whose branch still exists, and its head commit
+  is authored by
+  `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` —
+  not by any agent.
+* Every commit `main` gained over the same window is authored by
+  `Yuri Schimke <yuri@schimke.ee>` or an exempt bot account (`renovate[bot]`,
+  `github-actions[bot]`, `dependabot[bot]`), and running the shared detector over
+  that whole range exits 0: "No agent co-author trailers or agent commit
+  identities found."
+
+(Several of the other thirteen merged while their scan job was still running, so
+it shows `cancelled` rather than a verdict — which is its own problem, and the
+reason the workflow header asks for `Reject agent attribution` to be made a
+*required* status check. A cancelled gate is not evidence for the finding either.)
+
+The failure mode is worth naming because it is easy to repeat: an agent reviewing a
+branch an agent wrote reasons from *who did the work* to *what the commit object
+says*, and those are unrelated — the identity is whatever `git config user.email`
+held, which in these sessions was the human's. Repeated P1s that the scanner
+contradicts cost a reviewer more than they save, and they teach the real finding to
+be read as noise. So: run it, quote its output, or do not file it.
+
 **Formatting detail.** `ktfmtCheck` aborts on the first unformatted file, so a
 single stray file hides every other one. Every module must apply
 `composeai.base-conventions` for `ktfmtCheckAll` to see it at all — see

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
@@ -58,7 +58,9 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
       ),
       tool(
         "apply_design_operations",
-        "Atomically apply a typed v1 operation submission. Returns committed revision, sequence, document hash, and validation/conflict diagnostics.",
+        "Atomically apply a typed v1 operation submission. Omit the submission's actorId — it is " +
+          "bound to this connection's authenticated actor; supplying a different one is refused. " +
+          "Returns committed revision, sequence, document hash, and validation/conflict diagnostics.",
         """{"type":"object","properties":{"submission":{"type":"object"}},"required":["submission"]}""",
       ),
       tool(
@@ -96,7 +98,7 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
           "list_components" -> ListCatalogsRequestV1
           "apply_design_operations" ->
             ApplyOperationRequestV1(
-              json.decodeFromJsonElement<DesignSubmissionV1>(args.required("submission"))
+              json.decodeFromJsonElement<DesignSubmissionV1>(args.boundSubmission())
             )
           "render_design" -> args.exportRequest(ExportFormatV1.PNG)
           "export_svg" -> args.exportRequest(ExportFormatV1.SVG)
@@ -124,6 +126,33 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
     } catch (e: Exception) {
       error(name, e.message ?: "Design API request failed")
     }
+  }
+
+  /**
+   * The caller's submission with `actorId` filled in from the authenticated client.
+   *
+   * Every `DesignSubmissionV1` carries a mandatory `actorId`, and the client refuses to transport
+   * one that disagrees with the actor it authenticated as. That pair is correct but was, on its
+   * own, unusable: the actor is derived from the environment's grant token and appears nowhere in
+   * `tools/list`, so a client had no way to author its FIRST mutation except by guessing or by
+   * deliberately provoking the mismatch error to read the expected value out of it.
+   *
+   * Binding it here closes that: omit `actorId` and the authenticated identity is what gets sent.
+   * The mismatch check stays exactly as strict for a submission that names a DIFFERENT actor — that
+   * is a spoofing attempt, not a convenience — so this widens what a legitimate caller can express
+   * without widening what it can claim.
+   */
+  private fun JsonObject.boundSubmission(): JsonObject {
+    val submission =
+      required("submission") as? JsonObject
+        ?: throw IllegalArgumentException("'submission' must be an object")
+    val declared =
+      (submission["actorId"] as? JsonPrimitive)
+        ?.takeIf(JsonPrimitive::isString)
+        ?.contentOrNull
+        ?.takeIf(String::isNotBlank)
+    return if (declared != null) submission
+    else JsonObject(submission + ("actorId" to JsonPrimitive(client.actorId)))
   }
 
   private fun JsonObject.exportRequest(format: ExportFormatV1): ExportDesignRequestV1 =

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapterTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -155,6 +156,53 @@ class UiBuilderMcpAdapterTest {
     assertThat(byName.keys.intersect(WRITE_TOOLS)).containsExactlyElementsIn(WRITE_TOOLS)
     assertThat(byName.keys.intersect(EXPORT_TOOLS)).containsExactlyElementsIn(EXPORT_TOOLS)
     assertThat(READ_TOOLS + WRITE_TOOLS + EXPORT_TOOLS).containsExactlyElementsIn(byName.keys)
+  }
+
+  @Test
+  fun `binds the authenticated actor when the submission omits one`() {
+    // The actor is derived from the environment's grant token and is advertised nowhere in
+    // tools/list, so requiring the caller to restate it made the first mutation unauthorable. It is
+    // now optional, and omitting it means "whoever this connection authenticated as".
+    val submission =
+      json.encodeToJsonElement(DesignSubmissionV1.serializer(), command).jsonObject.filterKeys {
+        it != "actorId"
+      }
+
+    val result =
+      requireNotNull(
+        adapter.handle(
+          "apply_design_operations",
+          buildJsonObject { put("submission", JsonObject(submission)) },
+        )
+      )
+
+    assertThat(result.isError).isNull()
+    assertThat(requests.single().request).isEqualTo(ApplyOperationRequestV1(command))
+  }
+
+  @Test
+  fun `binds the authenticated actor over a blank one rather than failing the call`() {
+    val submission =
+      json.encodeToJsonElement(DesignSubmissionV1.serializer(), command).jsonObject.toMutableMap()
+    submission["actorId"] = JsonPrimitive("   ")
+
+    val result =
+      requireNotNull(
+        adapter.handle(
+          "apply_design_operations",
+          buildJsonObject { put("submission", JsonObject(submission)) },
+        )
+      )
+
+    assertThat(result.isError).isNull()
+    assertThat(requests.single().request).isEqualTo(ApplyOperationRequestV1(command))
+  }
+
+  @Test
+  fun `apply_design_operations says the actor is bound rather than caller-supplied`() {
+    val apply = adapter.toolDefs().single { it.name == "apply_design_operations" }
+
+    assertThat(apply.description).contains("Omit the submission's actorId")
   }
 
   @Test

--- a/scripts/design-artifacts/recompute-carriage-report.mjs
+++ b/scripts/design-artifacts/recompute-carriage-report.mjs
@@ -1,0 +1,118 @@
+/**
+ * Re-measure a split carriage report against the bundles that were actually published.
+ *
+ * `bundle split --carriage-report` writes `totalBytes` as the sum of the per-preview bundles *at
+ * split time*, and `sharePercent` as `repeatedBytes / totalBytes`. That is the right measurement
+ * for a plain split. It stops being the right measurement the moment a later step removes bytes
+ * from those same files: with `defer-figma-svg`, the split needs the transient
+ * `compose/figma-svg` sidecars to crop each cover, so they are stripped only *afterwards* — and the
+ * carriage gate then divides the repeated payload by a denominator that still counts thousands of
+ * sidecar copies that are no longer on disk.
+ *
+ * The direction of the error is the dangerous one. Sidecar bytes inflate `totalBytes`, which
+ * *deflates* `sharePercent`, so a catalog whose published bundles are overwhelmingly repeated
+ * classpath can sit under the 50% bound and keep the `auto` default — which is exactly the silent,
+ * unbounded delivery-branch growth the gate exists to stop.
+ *
+ * So: re-sum the published bundles and restate `totalBytes` / `sharePercent` / `dominates` from
+ * what is really there. `repeatedBytes` and `carriageBytesPerBundle` are untouched — the shared
+ * carriage is `classes/app.jar`, `libs/` and the Android payload, none of which a figma-svg strip
+ * touches.
+ *
+ * Pure and dependency-free (bar `node:fs`) so it unit-tests without an `npm ci`, matching
+ * `split-carriage-gate.mjs` next to it.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Sum the on-disk size of every `*.png` bundle directly in [dir]. Missing dir → 0 bytes, 0 files. */
+export function publishedBundleBytes(dir, { readdir = fs.readdirSync, stat = fs.statSync } = {}) {
+  let bytes = 0;
+  let files = 0;
+  let entries;
+  try {
+    entries = readdir(dir, { withFileTypes: true });
+  } catch {
+    return { bytes, files };
+  }
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".png")) continue;
+    bytes += stat(path.join(dir, entry.name)).size;
+    files += 1;
+  }
+  return { bytes, files };
+}
+
+/**
+ * Restate [report] against a measured [totalBytes].
+ *
+ * @returns {{report: object, changed: boolean, note: string}} the rewritten report, whether the
+ *   numbers actually moved, and one line for the run log.
+ */
+export function restateCarriage(report, totalBytes, { reportThresholdPercent = 50 } = {}) {
+  const before = Number(report?.totalBytes ?? 0);
+  const repeatedBytes = Number(report?.repeatedBytes ?? 0);
+  const bundles = Number(report?.bundles ?? 0);
+  const sharePercent = totalBytes <= 0 ? 0 : (repeatedBytes * 100) / totalBytes;
+  const rounded = Math.round(sharePercent * 10) / 10;
+  const threshold = Number(report?.reportThresholdPercent ?? reportThresholdPercent);
+  const restated = {
+    ...report,
+    totalBytes,
+    sharePercent: rounded,
+    dominates: bundles > 1 && sharePercent >= threshold,
+    // Keep the split-time number rather than discarding it: when the gate fails, the two together
+    // say how much of the output was deferred rather than merely how big the share now is.
+    totalBytesAtSplit: before,
+  };
+  const changed = before !== totalBytes;
+  const note = changed
+    ? `carriage report restated against published bundles: totalBytes ${before} -> ${totalBytes}, ` +
+      `sharePercent ${report?.sharePercent ?? 0} -> ${rounded}`
+    : `carriage report unchanged: published bundles still total ${totalBytes} bytes`;
+  return { report: restated, changed, note };
+}
+
+function flag(argv, name, fallback = "") {
+  const i = argv.indexOf(name);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : fallback;
+}
+
+function main(argv) {
+  const reportPath = flag(argv, "--report");
+  const bundlesDir = flag(argv, "--bundles-dir");
+  if (!reportPath || !bundlesDir) {
+    console.error(
+      "usage: recompute-carriage-report.mjs --report <split-carriage.json> --bundles-dir <dir>",
+    );
+    return 2;
+  }
+  if (!fs.existsSync(reportPath)) {
+    // An older pinned CLI writes no report at all; `split-carriage-gate.mjs` already says so and
+    // carries on with the historic behaviour. Restating a report that does not exist is a no-op,
+    // not a failure — this step must not be the thing that breaks those callers.
+    console.log(`no carriage report at ${reportPath}; nothing to restate`);
+    return 0;
+  }
+  let report;
+  try {
+    report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  } catch (e) {
+    console.error(`carriage report ${reportPath} is not valid JSON: ${e.message}`);
+    return 1;
+  }
+  const { bytes, files } = publishedBundleBytes(bundlesDir);
+  if (files === 0) {
+    console.error(`no published *.png bundles under ${bundlesDir}; leaving the report as written`);
+    return 0;
+  }
+  const { report: restated, note } = restateCarriage(report, bytes);
+  fs.writeFileSync(reportPath, `${JSON.stringify(restated, null, 2)}\n`);
+  console.log(`${note} (measured across ${files} published bundle(s))`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/design-artifacts/recompute-carriage-report.mjs
+++ b/scripts/design-artifacts/recompute-carriage-report.mjs
@@ -24,24 +24,37 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 
-/** Sum the on-disk size of every `*.png` bundle directly in [dir]. Missing dir → 0 bytes, 0 files. */
-export function publishedBundleBytes(dir, { readdir = fs.readdirSync, stat = fs.statSync } = {}) {
+/**
+ * Sum the current on-disk size of exactly the bundles named in [manifest], one path per line.
+ *
+ * A manifest rather than a directory scan, and that is load-bearing. The primary split, the
+ * additional-module splits and the extra-module split all run in one workflow step, and the EXTRA
+ * split writes into the same `previews/` directory as the primary one — while the carriage report
+ * describes the primary split alone. Scanning the directory afterwards would therefore divide the
+ * primary `repeatedBytes` by a primary-plus-extra denominator and understate the share, which is
+ * the very understatement this re-measure exists to correct. The workflow snapshots the primary
+ * file list before those later splits run; this reads it back.
+ *
+ * A path that has since vanished counts as zero rather than throwing — the strip rewrites bundles
+ * in place and never removes them, so a missing entry is a real anomaly that the caller's count
+ * check below will catch and report, not something to crash on here.
+ */
+export function manifestBundleBytes(manifest, { read = fs.readFileSync, stat = fs.statSync } = {}) {
   let bytes = 0;
   let files = 0;
-  let entries;
-  try {
-    entries = readdir(dir, { withFileTypes: true });
-  } catch {
-    return { bytes, files };
-  }
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".png")) continue;
-    bytes += stat(path.join(dir, entry.name)).size;
+  let missing = 0;
+  for (const line of String(read(manifest, "utf8")).split("\n")) {
+    const file = line.trim();
+    if (file.length === 0) continue;
     files += 1;
+    try {
+      bytes += stat(file).size;
+    } catch {
+      missing += 1;
+    }
   }
-  return { bytes, files };
+  return { bytes, files, missing };
 }
 
 /**
@@ -81,10 +94,11 @@ function flag(argv, name, fallback = "") {
 
 function main(argv) {
   const reportPath = flag(argv, "--report");
-  const bundlesDir = flag(argv, "--bundles-dir");
-  if (!reportPath || !bundlesDir) {
+  const manifest = flag(argv, "--bundles-from");
+  if (!reportPath || !manifest) {
     console.error(
-      "usage: recompute-carriage-report.mjs --report <split-carriage.json> --bundles-dir <dir>",
+      "usage: recompute-carriage-report.mjs --report <split-carriage.json> " +
+        "--bundles-from <primary-bundle-list.txt>",
     );
     return 2;
   }
@@ -102,14 +116,36 @@ function main(argv) {
     console.error(`carriage report ${reportPath} is not valid JSON: ${e.message}`);
     return 1;
   }
-  const { bytes, files } = publishedBundleBytes(bundlesDir);
+  let measured;
+  try {
+    measured = manifestBundleBytes(manifest);
+  } catch (e) {
+    console.error(`cannot read the primary bundle manifest ${manifest}: ${e.message}`);
+    return 1;
+  }
+  const { bytes, files, missing } = measured;
   if (files === 0) {
-    console.error(`no published *.png bundles under ${bundlesDir}; leaving the report as written`);
+    console.error(`the primary bundle manifest ${manifest} is empty; leaving the report as written`);
     return 0;
+  }
+  // Fail closed rather than restate against a set that is not what the report measured. A count
+  // that disagrees with `bundles` means the manifest and the report describe different splits, and
+  // silently dividing by the wrong denominator is precisely the failure this step exists to fix.
+  const declared = Number(report?.bundles ?? 0);
+  if (Number.isInteger(declared) && declared > 0 && declared !== files) {
+    console.error(
+      `the manifest names ${files} primary bundle(s) but the carriage report declares ${declared}; ` +
+        "refusing to restate the share against a different set of files",
+    );
+    return 1;
+  }
+  if (missing > 0) {
+    console.error(`${missing} of ${files} manifested bundle(s) are gone; refusing to restate`);
+    return 1;
   }
   const { report: restated, note } = restateCarriage(report, bytes);
   fs.writeFileSync(reportPath, `${JSON.stringify(restated, null, 2)}\n`);
-  console.log(`${note} (measured across ${files} published bundle(s))`);
+  console.log(`${note} (measured across ${files} primary bundle(s))`);
   return 0;
 }
 

--- a/scripts/design-artifacts/recompute-carriage-report.test.mjs
+++ b/scripts/design-artifacts/recompute-carriage-report.test.mjs
@@ -4,30 +4,41 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import {
-  publishedBundleBytes,
-  restateCarriage,
-} from "./recompute-carriage-report.mjs";
+import { manifestBundleBytes, restateCarriage } from "./recompute-carriage-report.mjs";
 
 import { evaluateSplitCarriage } from "./split-carriage-gate.mjs";
 
-function bundleDir(sizes) {
+/** A previews/ directory plus the manifest the workflow snapshots after the PRIMARY split. */
+function split(primarySizes, extraSizes = []) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "carriage-"));
-  sizes.forEach((size, i) => fs.writeFileSync(path.join(dir, `p${i}.png`), Buffer.alloc(size)));
-  return dir;
+  const primary = primarySizes.map((size, i) => {
+    const file = path.join(dir, `p${i}.png`);
+    fs.writeFileSync(file, Buffer.alloc(size));
+    return file;
+  });
+  const manifest = path.join(dir, "primary.txt");
+  fs.writeFileSync(manifest, `${primary.join("\n")}\n`);
+  // Written into the SAME directory afterwards, exactly as the extra-module split does.
+  extraSizes.forEach((size, i) =>
+    fs.writeFileSync(path.join(dir, `extra${i}.png`), Buffer.alloc(size)),
+  );
+  return { dir, manifest, primary };
 }
 
-test("sums only the *.png bundles directly in the directory", () => {
-  const dir = bundleDir([100, 250]);
-  fs.writeFileSync(path.join(dir, "manifest.json"), "{}");
-  fs.mkdirSync(path.join(dir, "nested"));
-  fs.writeFileSync(path.join(dir, "nested", "deep.png"), Buffer.alloc(9999));
+test("measures only the manifested primary bundles, not the extra split beside them", () => {
+  // The extra-module split writes into the same previews/ directory, and the carriage report
+  // describes the primary split alone. Counting the extra bundles would inflate the denominator
+  // and understate the share — the same understatement this whole step exists to correct.
+  const { manifest } = split([100, 250], [9000, 9000]);
 
-  assert.deepEqual(publishedBundleBytes(dir), { bytes: 350, files: 2 });
+  assert.deepEqual(manifestBundleBytes(manifest), { bytes: 350, files: 2, missing: 0 });
 });
 
-test("a missing directory measures as nothing rather than throwing", () => {
-  assert.deepEqual(publishedBundleBytes("/definitely/not/here"), { bytes: 0, files: 0 });
+test("a manifested bundle that has vanished is counted as missing, not thrown on", () => {
+  const { manifest, primary } = split([100, 250]);
+  fs.rmSync(primary[1]);
+
+  assert.deepEqual(manifestBundleBytes(manifest), { bytes: 100, files: 2, missing: 1 });
 });
 
 test("restating after a strip raises the share the gate reads", () => {

--- a/scripts/design-artifacts/recompute-carriage-report.test.mjs
+++ b/scripts/design-artifacts/recompute-carriage-report.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  publishedBundleBytes,
+  restateCarriage,
+} from "./recompute-carriage-report.mjs";
+
+import { evaluateSplitCarriage } from "./split-carriage-gate.mjs";
+
+function bundleDir(sizes) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "carriage-"));
+  sizes.forEach((size, i) => fs.writeFileSync(path.join(dir, `p${i}.png`), Buffer.alloc(size)));
+  return dir;
+}
+
+test("sums only the *.png bundles directly in the directory", () => {
+  const dir = bundleDir([100, 250]);
+  fs.writeFileSync(path.join(dir, "manifest.json"), "{}");
+  fs.mkdirSync(path.join(dir, "nested"));
+  fs.writeFileSync(path.join(dir, "nested", "deep.png"), Buffer.alloc(9999));
+
+  assert.deepEqual(publishedBundleBytes(dir), { bytes: 350, files: 2 });
+});
+
+test("a missing directory measures as nothing rather than throwing", () => {
+  assert.deepEqual(publishedBundleBytes("/definitely/not/here"), { bytes: 0, files: 0 });
+});
+
+test("restating after a strip raises the share the gate reads", () => {
+  // The shape of #4930: the split measured 1000 bytes across two bundles while the figma-svg
+  // sidecars were still inside them; stripping left 600. 480 repeated bytes is 48% of the
+  // split-time total (under the bound) and 80% of what was actually published (over it).
+  const report = {
+    bundles: 2,
+    carriageBytesPerBundle: 240,
+    repeatedBytes: 480,
+    totalBytes: 1000,
+    sharePercent: 48,
+    reportThresholdPercent: 50,
+    dominates: false,
+  };
+
+  const { report: restated, changed, note } = restateCarriage(report, 600);
+
+  assert.equal(changed, true);
+  assert.equal(restated.totalBytes, 600);
+  assert.equal(restated.sharePercent, 80);
+  assert.equal(restated.dominates, true);
+  assert.equal(restated.totalBytesAtSplit, 1000);
+  assert.equal(restated.repeatedBytes, 480, "the shared carriage is not what a strip removes");
+  assert.match(note, /1000 -> 600/);
+
+  // And the gate, which is the whole point, now fails the default instead of passing it.
+  assert.equal(evaluateSplitCarriage({ mode: "auto", report }).level, "notice");
+  assert.equal(evaluateSplitCarriage({ mode: "auto", report: restated }).level, "error");
+});
+
+test("restating an unstripped split leaves the numbers alone", () => {
+  const report = {
+    bundles: 3,
+    carriageBytesPerBundle: 10,
+    repeatedBytes: 30,
+    totalBytes: 900,
+    sharePercent: 3.3,
+    reportThresholdPercent: 50,
+    dominates: false,
+  };
+
+  const { report: restated, changed, note } = restateCarriage(report, 900);
+
+  assert.equal(changed, false);
+  assert.equal(restated.sharePercent, 3.3);
+  assert.equal(restated.dominates, false);
+  assert.match(note, /unchanged/);
+});
+
+test("an explicit mode still only reports, never fails, after restating", () => {
+  const report = { bundles: 2, repeatedBytes: 480, totalBytes: 1000, reportThresholdPercent: 50 };
+  const { report: restated } = restateCarriage(report, 600);
+
+  assert.equal(evaluateSplitCarriage({ mode: "full", report: restated }).level, "notice");
+  assert.equal(
+    evaluateSplitCarriage({ mode: "full-shared-classpath", report: restated }).level,
+    "notice",
+  );
+});

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -557,7 +557,21 @@ ${details}
       if (edges) frameGutter(hero, edges);
       return;
     }
-    fetch(link.getAttribute("href"))
+    var href = link.getAttribute("href");
+    // A deferred catalog publishes no static vector: the href is an ABSOLUTE live-render URL and
+    // the daemon generates the SVG per request, from a small pool of live seats. Fetching one per
+    // card to compute a crop box would start a render for every component in the catalog the
+    // instant the gallery loads — thousands, on the large catalogs deferral exists for — spending
+    // the seats on bounding boxes and answering the visitors who actually asked for a vector with
+    // 503s. The declared gutter already answers the same question offline, so use it and leave the
+    // vector to be fetched when someone clicks the link.
+    // Character classes, not \/ — this script is emitted from a template literal, where a
+    // backslash escape collapses and would end the regex literal at the first bare slash.
+    if (/^[a-z][a-z0-9+.-]*:|^[/][/]/i.test(href)) {
+      if (edges) frameGutter(hero, edges);
+      return;
+    }
+    fetch(href)
       .then(function (r) { return r.ok ? r.text() : null; })
       .then(function (txt) {
         // The vector wins where it applies — it answers the tighter question of where the component

--- a/scripts/design-artifacts/render-index-html.mjs
+++ b/scripts/design-artifacts/render-index-html.mjs
@@ -557,30 +557,42 @@ ${details}
       if (edges) frameGutter(hero, edges);
       return;
     }
-    var href = link.getAttribute("href");
-    // A deferred catalog publishes no static vector: the href is an ABSOLUTE live-render URL and
-    // the daemon generates the SVG per request, from a small pool of live seats. Fetching one per
-    // card to compute a crop box would start a render for every component in the catalog the
-    // instant the gallery loads — thousands, on the large catalogs deferral exists for — spending
-    // the seats on bounding boxes and answering the visitors who actually asked for a vector with
-    // 503s. The declared gutter already answers the same question offline, so use it and leave the
-    // vector to be fetched when someone clicks the link.
-    // Character classes, not \/ — this script is emitted from a template literal, where a
-    // backslash escape collapses and would end the regex literal at the first bare slash.
-    if (/^[a-z][a-z0-9+.-]*:|^[/][/]/i.test(href)) {
-      if (edges) frameGutter(hero, edges);
+    // Fetch the vector only once the card is actually near the viewport.
+    //
+    // A deferred catalog publishes no static vector: the href is an absolute live-render URL and
+    // the daemon generates the SVG per request, from a small pool of live seats. Fetching every
+    // card's on load would start a render for the whole catalog the instant the gallery opens —
+    // thousands, on the large catalogs deferral exists for — spending the seats on bounding boxes
+    // and answering the visitors who actually asked for a vector with 503s.
+    //
+    // Deferring the same fetch to visibility fixes that without giving up the crop: the vector is
+    // the only source of the content box for a card with no declared gutter (an ordinary 454x454
+    // Wear canvas, say), so skipping it outright would leave those heroes uncropped in the full
+    // device canvas. Only what someone looks at is rendered, at the pace they scroll.
+    var pending = function () {
+      fetch(link.getAttribute("href"))
+        .then(function (r) { return r.ok ? r.text() : null; })
+        .then(function (txt) {
+          // The vector wins where it applies — it answers the tighter question of where the
+          // component sits on a canvas it was drawn on — and the gutter answers when it does not.
+          var box = txt ? parseBox(txt) : null;
+          if (box) frame(hero, box, edges);
+          else if (edges) frameGutter(hero, edges);
+        })
+        .catch(function () { if (edges) frameGutter(hero, edges); });
+    };
+    if (typeof IntersectionObserver !== "function") {
+      pending();
       return;
     }
-    fetch(href)
-      .then(function (r) { return r.ok ? r.text() : null; })
-      .then(function (txt) {
-        // The vector wins where it applies — it answers the tighter question of where the component
-        // sits on a canvas it was drawn on — and the gutter answers when it does not.
-        var box = txt ? parseBox(txt) : null;
-        if (box) frame(hero, box, edges);
-        else if (edges) frameGutter(hero, edges);
-      })
-      .catch(function () { if (edges) frameGutter(hero, edges); });
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        observer.unobserve(entry.target);
+        pending();
+      });
+    }, { rootMargin: "400px" });
+    observer.observe(card);
   });
 })();
 </script>

--- a/scripts/design-artifacts/render-index-html.test.mjs
+++ b/scripts/design-artifacts/render-index-html.test.mjs
@@ -65,28 +65,69 @@ test("a deferred figma-svg links to the image's live vector route", () => {
   assert.match(html, /class="wf figma-svg-link"/);
 });
 
-test("the crop script never fetches a deferred (live) vector, only a published file", () => {
-  // #4930: with defer-figma-svg the href is an absolute live-render URL and the daemon renders it
-  // on demand from a small pool of seats. One eager bbox fetch per card would start a render for
-  // every component in the catalog on page load and 503 the visitors who actually wanted a vector,
-  // so the gallery falls back to the declared gutter for those and fetches only same-origin files.
+// Run the gallery's emitted crop script against a minimal fake DOM. It touches only
+// `document.querySelectorAll`, `IntersectionObserver` and `fetch`, so the whole environment is
+// three stubs — and driving the real emitted source is the point: an earlier version of this fix
+// was dead on arrival because a `\/` escape collapses inside the template literal that emits it,
+// and only executing the shipped text catches that.
+function runCropScript(html, { hasIntersectionObserver = true } = {}) {
+  const script = html.slice(html.lastIndexOf("<script>") + 8, html.lastIndexOf("</script>"));
+  const fetched = [];
+  const observed = [];
+  const hero = { style: {}, classList: { add() {}, remove() {} }, getAttribute: () => null };
+  const link = { getAttribute: () => "https://preview.coo.ee/wear-m3/render/b.svg" };
+  const card = {
+    querySelector: (sel) => (sel === "a.shot" ? hero : sel === "a.figma-svg-link" ? link : null),
+  };
+  const document = { querySelectorAll: (sel) => (sel === ".card" ? [card] : []) };
+  const fetch = (url) => {
+    fetched.push(url);
+    return { then: () => ({ then: () => ({ catch: () => {} }) }) };
+  };
+  class FakeIntersectionObserver {
+    constructor(cb) {
+      this.cb = cb;
+      observed.push(this);
+    }
+    observe(target) {
+      this.target = target;
+    }
+    unobserve() {}
+    trigger() {
+      this.cb([{ isIntersecting: true, target: this.target }]);
+    }
+  }
+  const globals = hasIntersectionObserver
+    ? { document, fetch, IntersectionObserver: FakeIntersectionObserver }
+    : { document, fetch, IntersectionObserver: undefined };
+  new Function(...Object.keys(globals), script)(...Object.values(globals));
+  return { fetched, observers: observed };
+}
+
+test("the crop script fetches no vector until a card is near the viewport", () => {
+  // #4930 asked for no eager render-per-card on load; the follow-up asked that deferred cards keep
+  // their crop, since the vector is the only content box a card without a declared gutter has.
+  // Lazy-loading is what satisfies both: nothing on load, the real fetch once it is looked at.
   const html = renderIndexHtml(catalog, { figmaSvgSlugs: new Set(["filled-button"]) });
 
-  // Pull the guard out of the SHIPPED script rather than restating it, so the two cannot drift.
-  const guard = html.match(/if \((\/\^\[a-z\][^\n]*?)\.test\(href\)\) \{/);
-  assert.ok(guard, "the crop script carries an absolute-URL guard before fetching");
-  const isDeferred = new Function("re", "u", "return re.test(u)").bind(null, eval(guard[1]));
+  const { fetched, observers } = runCropScript(html);
+  assert.deepEqual(fetched, [], "no vector is fetched while the card is off-screen");
+  assert.equal(observers.length, 1, "the card is observed instead");
 
-  for (const live of [
-    "https://preview.coo.ee/wear-m3/render/filled-button.svg",
-    "http://localhost:8080/render/filled-button.svg",
-    "//cdn.example/filled-button.svg",
-  ]) {
-    assert.equal(isDeferred(live), true, live);
-  }
-  for (const published of ["figma/filled-button.svg", "figma/a_width=227dp,dpi=320.svg"]) {
-    assert.equal(isDeferred(published), false, published);
-  }
+  observers[0].trigger();
+  assert.deepEqual(
+    fetched,
+    ["https://preview.coo.ee/wear-m3/render/b.svg"],
+    "the same fetch happens once the card comes into view, so the crop is not lost",
+  );
+});
+
+test("the crop script still fetches where IntersectionObserver is unavailable", () => {
+  const html = renderIndexHtml(catalog, { figmaSvgSlugs: new Set(["filled-button"]) });
+
+  const { fetched } = runCropScript(html, { hasIntersectionObserver: false });
+
+  assert.equal(fetched.length, 1, "no observer means the old eager behaviour, not a lost crop");
 });
 
 test("a declared capture gutter rides on the hero as data-gutter, in render pixels", () => {

--- a/scripts/design-artifacts/render-index-html.test.mjs
+++ b/scripts/design-artifacts/render-index-html.test.mjs
@@ -65,6 +65,30 @@ test("a deferred figma-svg links to the image's live vector route", () => {
   assert.match(html, /class="wf figma-svg-link"/);
 });
 
+test("the crop script never fetches a deferred (live) vector, only a published file", () => {
+  // #4930: with defer-figma-svg the href is an absolute live-render URL and the daemon renders it
+  // on demand from a small pool of seats. One eager bbox fetch per card would start a render for
+  // every component in the catalog on page load and 503 the visitors who actually wanted a vector,
+  // so the gallery falls back to the declared gutter for those and fetches only same-origin files.
+  const html = renderIndexHtml(catalog, { figmaSvgSlugs: new Set(["filled-button"]) });
+
+  // Pull the guard out of the SHIPPED script rather than restating it, so the two cannot drift.
+  const guard = html.match(/if \((\/\^\[a-z\][^\n]*?)\.test\(href\)\) \{/);
+  assert.ok(guard, "the crop script carries an absolute-URL guard before fetching");
+  const isDeferred = new Function("re", "u", "return re.test(u)").bind(null, eval(guard[1]));
+
+  for (const live of [
+    "https://preview.coo.ee/wear-m3/render/filled-button.svg",
+    "http://localhost:8080/render/filled-button.svg",
+    "//cdn.example/filled-button.svg",
+  ]) {
+    assert.equal(isDeferred(live), true, live);
+  }
+  for (const published of ["figma/filled-button.svg", "figma/a_width=227dp,dpi=320.svg"]) {
+    assert.equal(isDeferred(published), false, published);
+  }
+});
+
 test("a declared capture gutter rides on the hero as data-gutter, in render pixels", () => {
   // The renderer grew this canvas by 11/11/11/13px so a shadow could fall outside the component's
   // bounds. A card fitting the whole canvas to its column draws the component that much smaller

--- a/scripts/design-artifacts/shard-preview-ids.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.mjs
@@ -183,7 +183,12 @@ export function verifyShardExclusionFile(plan, text) {
   }
 
   const raw = String(text ?? "");
-  const physicalLines = raw.length === 0 ? [] : raw.replace(/\n$/, "").split("\n");
+  // Strip the trailing terminator FIRST, then decide whether anything is left. Splitting a lone
+  // "\n" yields [""], which is one blank pattern rather than the zero patterns it means — and an
+  // export driver pinned from an older `main` still writes exactly that for an empty shard, so
+  // tolerating it here is what keeps this gate from failing a correct render.
+  const body = raw.replace(/\n$/, "");
+  const physicalLines = body.length === 0 ? [] : body.split("\n");
   const lines = physicalLines.map((line) => line.replace(/\r$/, ""));
   if (lines.some((line) => line.trim().length === 0)) {
     problems.push("exclusion file contains a blank line");
@@ -609,7 +614,12 @@ if (import.meta.url === `file://${process.argv[1]}`) {
       console.error(`shard-preview-ids: shard ${index} of ${plan.total} has no previews to render.`);
       console.log("0");
     } else {
-      writeFileSync(values.out, `${mine.exclude.join("\n")}\n`);
+      // `[].join("\n")` is "", so a naive template writes a lone "\n" for a shard that excludes
+      // nothing — one physical blank line where the plan declares zero. The verifier below reads
+      // that as a blank exclusion pattern AND a count mismatch, and the workflow then refuses to
+      // render the single shard that had the whole (one-preview) catalog to itself. Zero exclusions
+      // is an EMPTY file; a terminator only follows a pattern.
+      writeFileSync(values.out, mine.exclude.length === 0 ? "" : `${mine.exclude.join("\n")}\n`);
       if (values["plan-out"]) {
         writeFileSync(
           values["plan-out"],

--- a/scripts/design-artifacts/shard-preview-ids.test.mjs
+++ b/scripts/design-artifacts/shard-preview-ids.test.mjs
@@ -121,6 +121,21 @@ test("accepts one anchored exclusion per line, including comma-bearing ids", () 
   });
 });
 
+test("treats an empty file and a lone terminator alike as zero exclusions", () => {
+  // A one-preview catalog sharded into one shard excludes nothing. The planner writes "" today and
+  // an older pinned driver writes "\n"; neither is a blank *pattern*, and reading either as one
+  // would fail the only shard that had anything to render.
+  const plan = {
+    index: 1,
+    exclusionFormat: SHARD_EXCLUSION_FORMAT,
+    excluded: 0,
+  };
+  for (const text of ["", "\n"]) {
+    const result = verifyShardExclusionFile(plan, text);
+    assert.deepEqual(result, { ok: true, problems: [], lines: [] }, `for ${JSON.stringify(text)}`);
+  }
+});
+
 test("round-robins the sorted id list so a heavy group is spread, not clustered", () => {
   // Ids sort by group, so contiguous blocks would put every Template preview in one shard.
   const ids = [


### PR DESCRIPTION
Swept every PR touched in the last 48 hours across `compose-ai-tools` and `compose-preview-server` for unresolved review threads. Two clusters came out of it: four real findings still live on `main`, and one large cluster of false alarms that was burying them.

`compose-preview-server` had no review threads at all in the window — and, checking further, no review comments and no submitted reviews on any of its 25 PRs either. Nothing reviews that repo; that is a settings gap, not something this PR can fix.

## The real findings (all still reproducible on `main`)

**Carriage gate reads a pre-strip `totalBytes`** — from #4930, unresolved P1.
`bundle split --carriage-report` measures the per-preview bundles while the transient `compose/figma-svg` sidecars are still inside them, because the split needs those to crop each cover. With `defer-figma-svg` they are stripped in the very next step, but they stay in the denominator of `sharePercent`. The error runs the dangerous way: sidecar bytes inflate `totalBytes`, which deflates the share, so a catalog whose published bundles are overwhelmingly repeated classpath can sit under the 50% bound and keep the `auto` default — precisely the silent unbounded delivery-branch growth the gate exists to stop. New `recompute-carriage-report.mjs` re-sums the published bundles and restates `totalBytes` / `sharePercent` / `dominates` between the strip and the gate. `repeatedBytes` is untouched: a figma-svg strip does not touch `app.jar`, `libs/` or the Android payload.

**The gallery started a live render per card** — from #4930, unresolved P1.
With `defer-figma-svg` the `figma-svg-link` href is an absolute live-render URL served by the daemon from a small pool of seats. The hero crop script fetched every one of them on page load to compute a bounding box, so an ordinary gallery visit to a large catalog (the cited case is 4,120 images) starts thousands of live SVG renders, spends the seats on bboxes and answers the people who actually clicked a vector with `503`s. The fetch now sits behind an `IntersectionObserver`, so nothing is requested on load and only what someone actually scrolls to is rendered.

**A shard excluding nothing wrote a blank line** — from #4917, unresolved P2.
`[].join("\n")` is `""`, so the planner wrote a lone `"\n"` while declaring `excluded: 0`. The verifier read that as one blank pattern *and* a count mismatch and refused to render — failing the single shard that had the whole one-preview catalog to itself. Zero exclusions is now an empty file, and the verifier strips the terminator before deciding whether anything is left, so an export driver pinned from an older `main` still passes.

**`apply_design_operations` demanded an actor id it never advertised** — from #4929, unresolved P1.
Every `DesignSubmissionV1` carries a mandatory `actorId`, and the client refuses to transport one that disagrees with the authenticated actor. Correct, but jointly unusable: the actor is derived from the environment's grant token and appears nowhere in `tools/list`, so a client had no way to author its *first* mutation except by guessing or by provoking the mismatch error to read the expected value out of it. It is now bound from the authenticated client when omitted or blank. A submission naming a *different* actor is still refused, unchanged — that is spoofing, not convenience.

## Follow-up review on this PR (6b24ffb)

Two real findings from Codex's review of the first commit, both fixed:

- **The re-measure was scoped too widely.** The extra-module split writes into the same `out/bundle/previews` directory, in the same workflow step, after the primary split — so summing the directory divided the primary `repeatedBytes` by a primary-plus-extra denominator. Same error class as the one being fixed. The workflow now snapshots the primary file list before the additional- and extra-module splits, and the script takes `--bundles-from` that manifest, failing closed when its count disagrees with the report's `bundles` or a manifested bundle has gone missing.
- **Skipping the deferred fetch cost those cards their crop.** The vector is the only content box a hero without a declared `captureGutter` has — an ordinary 454×454 Wear canvas would have rendered uncropped. Hence the `IntersectionObserver` above rather than an outright skip: it satisfies the original P1 (nothing on load) without losing fidelity, and it is the third option the original #4930 review offered. Static published bounds would remove the live fetch entirely and are the better long-term answer, but they need the generator to emit the bbox before the sidecar is stripped — wider than this PR should carry.

## The false-alarm cluster

Fourteen PRs — #4912, #4913, #4915, #4917, #4920, #4928, #4929, #4930, #4933, #4938, #4939, #4943 (three times), #4944, #4945 — each drew a P1 review comment asserting the reviewed commit recorded "both its author and committer as `Codex`", most quoting an `agent-attribution-scan.sh` invocation and an exit status. None of it holds:

- `Reject agent attribution` ran to completion on #4929's flagged head and reported **success**;
- #4943 is the only one of the fourteen whose branch still exists, and its head is authored by `github-actions[bot]`;
- every commit `main` gained in the window is authored by `Yuri Schimke` or an exempt bot, and running the shared detector over that whole range exits 0.

A fifteenth arrived on this PR, filed against the very paragraph asking that such findings be verified first. It quotes `713984be9276728b921328656c53e0bd3c8b6c79` as the failing record; that SHA is not an object in this repository, the one commit in the range is authored and committed by `Yuri Schimke`, and `Reject agent attribution` is green on both heads.

Nothing to fix in the history, so nothing was changed there. The docs are what changed: `AGENTS.md` now requires a reviewer to run the detector and quote its output before filing an attribution finding, and names the human identity and the exempt bot accounts that are never findings. `docs/AGENT_GUIDE.md` carries the evidence and the reasoning error behind it — an agent reviewing a branch an agent wrote inferring the commit identity from *who did the work*, when the identity is only ever whatever `git config user.email` held.

One thing surfaced that this PR does not fix, because it is a repository setting rather than a diff: several of those fourteen merged while their `Reject agent attribution` job was still running, so it shows `cancelled` rather than a verdict. The workflow header already asks for it to be made a **required** status check on the Protect Main ruleset; it still is not one.

## Test plan

- `node --test 'scripts/design-artifacts/*.test.mjs'` — 1325 pass, 0 fail, 30 skipped. New coverage: the carriage restatement (including an end-to-end assertion that the same report flips `evaluateSplitCarriage` from `notice` to `error` once restated), the extra-bundle exclusion and missing-file cases, and empty-vs-lone-terminator exclusion files.
- The crop script is tested by **executing the emitted source** against a fake DOM rather than pattern-matching it: no fetch before intersection, the same fetch after, plus the no-`IntersectionObserver` fallback. That harness earned itself twice — it caught an earlier version of this fix being inert, because a `\/` escape collapses inside the template literal that emits the script.
- Manual end-to-end run of `recompute-carriage-report.mjs` with a 50 KB extra bundle dropped into the previews directory after the manifest was taken: excluded correctly (`totalBytes 1000 -> 600`, `sharePercent 48 -> 80`, `dominates` true), and a deliberately mismatched manifest exits 1.
- `./gradlew :mcp:ktfmtFormatMain :mcp:ktfmtFormatTest :mcp:test` — BUILD SUCCESSFUL. Three new adapter tests: omitted actor, blank actor, and the tool description advertising it; the existing spoofing test is unchanged and still passes.
- `scripts/check-agent-entrypoints.sh --report` — all invariants reachable from every agent; `AGENTS.md` is 8931 bytes, 27% of Codex's 32 KiB budget.
- `.github/scripts/agent-attribution-scan.sh` over the window's range on `main` — exit 0.
- `yaml.safe_load` on the edited reusable workflow.

Text-only PR: nothing here changes a rendered surface. The gallery change defers when the crop is fetched, not what it draws — the same two code paths (`frame` from the vector, `frameGutter` from the declared gutter) produce the same result they do today.

I also checked whether the 8 test files failing in a fresh sandbox were a real regression on `main` — they are not. They were `ERR_MODULE_NOT_FOUND` for `fflate`, `pngjs` and `@design-parity/catalog-export`; after `npm ci` in `scripts/design-artifacts/` the full suite is green. No fix needed.