### PR TITLE
fix(preview): publish desktop phase pins

### DIFF
--- a/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
+++ b/api/preview-annotations/src/commonMain/kotlin/ee/schimke/composeai/preview/SettledPreview.kt
@@ -85,13 +85,10 @@ package ee.schimke.composeai.preview
  * never-ending animation on auto is the case with nowhere to go, and the one this section exists to
  * redirect.
  *
- * **On Android**, both lanes additionally record the capture as a machine-readable **phase pin** —
- * `phasePinnedCaptures` in `<png>.warnings.json` — so a catalog can publish "this still is a
- * deliberately chosen phase" and assert on it, as distinct from `unsettledCaptures`, which is a bug
- * report. The Compose Desktop lanes land on the same instant but emit no such record: they have no
- * `.warnings.json` writer at all today (`RenderWarningsSidecar` is Android-only, and
- * `DesktopRendererMain` only knows the suffix in order to sweep it). A desktop-only catalog
- * therefore gets the correct pixels and no published claim about them.
+ * Both backends and both still-render lanes additionally record the capture as a machine-readable
+ * **phase pin** — `phasePinnedCaptures` in `<png>.warnings.json` — so a catalog can publish "this
+ * still is a deliberately chosen phase" and assert on it, as distinct from `unsettledCaptures`,
+ * which is a bug report.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -60,6 +60,7 @@ import ee.schimke.composeai.data.theme.ThemePayload
 import ee.schimke.composeai.io.SystemFileSystem
 import ee.schimke.composeai.io.composeAiCacheDir
 import ee.schimke.composeai.preview.lottie.LottiePreview
+import ee.schimke.composeai.renderer.DesktopRenderWarningsSidecar
 import ee.schimke.composeai.renderer.DesktopSettleClock
 import ee.schimke.composeai.renderer.encodePngData
 import ee.schimke.composeai.renderer.settleScene
@@ -332,6 +333,9 @@ class RenderEngine(
     LinkBufferComposer.applyAndDescribe(classLoader)?.let(System.err::println)
     outputDir.mkdirs()
     val outputFile = File(outputDir, "${spec.outputBaseName}.png")
+    // A failed retry, an interactive render, or a preview whose exact settle was removed must not
+    // leave an earlier render's phase declaration claiming the new output is pinned.
+    DesktopRenderWarningsSidecar.deleteStale(outputFile)
 
     // kind=LOTTIE has no class to reflect — the asset is rendered directly via Compottie below.
     val isLottie = spec.kind == "LOTTIE"
@@ -892,6 +896,12 @@ class RenderEngine(
     trace.section("render:writePng") {
       fileSystem.write(state.outputFile.path.toPath()) { write(pngBytes) }
     }
+    DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+      pngFile = state.outputFile,
+      role = "compose-ai-daemon still '${state.spec.outputBaseName}'",
+      atMs = state.settleWindowMs.takeIf { state.settleIsExact }?.toLong(),
+      fileSystem = fileSystem,
+    )
 
     // Display filters — post-capture colour-matrix variants (grayscale/bedtime, invert,
     // daltonizer simulations). Gated on `composeai.displayfilter.filters` being non-empty so the

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSettleTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSettleTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.renderer.DesktopRenderWarningsSidecar
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
@@ -66,7 +67,7 @@ class RenderEngineSettleTest {
     System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, file.absolutePath)
   }
 
-  private fun render(previewId: String): BufferedImage {
+  private fun render(previewId: String): Pair<BufferedImage, File> {
     val outputDir = tempFolder.newFolder("renders-$previewId")
     val engine = RenderEngine(outputDir = outputDir)
     val result =
@@ -92,7 +93,7 @@ class RenderEngineSettleTest {
       val keep = File("build/settle-daemon-evidence").also { it.mkdirs() }
       png.copyTo(File(keep, "$previewId.png"), overwrite = true)
     }
-    return ImageIO.read(png)
+    return ImageIO.read(png) to png
   }
 
   /** Whether the fixture's green reveal square is painted at the centre of [image]. */
@@ -104,14 +105,21 @@ class RenderEngineSettleTest {
     installPreviewIndex("AutoSettled", """{"afterMs":0,"maxMs":1000}""")
     assertTrue(
       "the auto walk must run the fixture's 200ms delay out before capturing",
-      revealed(render("AutoSettled")),
+      revealed(render("AutoSettled").first),
     )
   }
 
   @Test
   fun `an exact settle past the reveal captures the revealed component`() {
     installPreviewIndex("ExactSettled", """{"afterMs":400,"maxMs":1000}""")
-    assertTrue(revealed(render("ExactSettled")))
+    val (image, png) = render("ExactSettled")
+    assertTrue(revealed(image))
+    val sidecar = DesktopRenderWarningsSidecar.pathFor(png)
+    assertTrue("daemon exact settle must publish a phase pin", sidecar.exists())
+    val json = sidecar.readText()
+    assertTrue(json.contains("\"outcome\":\"phase_pinned\""))
+    assertTrue(json.contains("\"atMs\":400"))
+    assertTrue(json.contains("\"unsettledCaptures\":[]"))
   }
 
   /**
@@ -122,15 +130,16 @@ class RenderEngineSettleTest {
   @Test
   fun `an exact settle short of the reveal captures the frame before it`() {
     installPreviewIndex("ExactEarly", """{"afterMs":100,"maxMs":1000}""")
-    assertFalse(revealed(render("ExactEarly")))
+    assertFalse(revealed(render("ExactEarly").first))
   }
 
   /** The control, and the regression the fix is measured against: no settle, no reveal. */
   @Test
   fun `a preview with no settle keeps its first frame`() {
     installPreviewIndex("Unsettled", settleJson = null)
-    val image = render("Unsettled")
+    val (image, png) = render("Unsettled")
     assertFalse("without a settle the daemon must capture the pre-reveal frame", revealed(image))
+    assertFalse(DesktopRenderWarningsSidecar.pathFor(png).exists())
     // …and that frame is the fixture's black container, not an empty or transparent one — proof
     // the render itself is sound and only the reveal is missing.
     assertEquals(0x000000, image.getRGB(image.width / 2, image.height / 2) and 0xFFFFFF)

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRenderWarningsSidecar.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRenderWarningsSidecar.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.io.SystemFileSystem
+import java.io.File
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+/**
+ * Desktop writer for the renderer's `<png>.warnings.json` contract.
+ *
+ * Desktop has no font, image-load, or visual-quiescence warning producers yet, but an exact
+ * `@SettledPreview(afterMs = …)` is a positive declaration that must reach consumers on both
+ * backends. Keeping the same schema and all four arrays means a catalog can inspect Android and
+ * Desktop renders without a backend-specific parser (issue #4829).
+ *
+ * Public because `:daemon:desktop` writes the same sidecar after its live render path. The
+ * standalone renderer and daemon deliberately share this encoder so their JSON cannot drift.
+ */
+object DesktopRenderWarningsSidecar {
+
+  const val SCHEMA: String = "compose-preview-warnings/v1"
+
+  /** The sidecar paired with [pngFile]. */
+  fun pathFor(pngFile: File): File = File(pngFile.parentFile, pngFile.name + ".warnings.json")
+
+  /**
+   * Write one declared phase pin, or remove a stale sidecar when [atMs] is `null`.
+   *
+   * Best-effort, like the Android writer: diagnostics must never turn a valid PNG into a failed
+   * render.
+   */
+  @JvmOverloads
+  fun writePhasePinOrDelete(
+    pngFile: File,
+    role: String,
+    atMs: Long?,
+    fileSystem: FileSystem = SystemFileSystem,
+  ) {
+    if (atMs == null) {
+      deleteStale(pngFile)
+      return
+    }
+    try {
+      val sidecar = pathFor(pngFile)
+      sidecar.parentFile?.mkdirs()
+      fileSystem.write(sidecar.path.toPath()) { writeUtf8(encodePhasePin(role, atMs)) }
+    } catch (writeFailure: Throwable) {
+      System.err.println(
+        "Failed to write render-warnings sidecar for ${pngFile.name}: ${writeFailure.message}"
+      )
+    }
+  }
+
+  /** Remove a sidecar left by an earlier pinned render. */
+  fun deleteStale(pngFile: File) {
+    val sidecar = pathFor(pngFile)
+    if (sidecar.exists()) sidecar.delete()
+  }
+
+  internal fun encodePhasePin(role: String, atMs: Long): String = buildString {
+    append('{')
+    append("\"schema\":").append(jsonString(SCHEMA)).append(',')
+    append("\"fontFallbacks\":[],")
+    append("\"unresolvedImages\":[],")
+    append("\"unsettledCaptures\":[],")
+    append("\"phasePinnedCaptures\":[{")
+    append("\"role\":").append(jsonString(role)).append(',')
+    append("\"outcome\":\"phase_pinned\",")
+    append("\"atMs\":").append(atMs).append(',')
+    append("\"message\":")
+      .append(
+        jsonString(
+          "$role: captured at the declared ${atMs}ms phase; " +
+            "a chosen coordinate, not a failed settle."
+        )
+      )
+    append("}]}")
+  }
+
+  private fun jsonString(value: String): String =
+    buildString(value.length + 2) {
+      append('"')
+      value.forEach { char ->
+        when (char) {
+          '"' -> append("\\\"")
+          '\\' -> append("\\\\")
+          '\b' -> append("\\b")
+          '\n' -> append("\\n")
+          '\r' -> append("\\r")
+          '\t' -> append("\\t")
+          else -> if (char < ' ') append("\\u%04x".format(char.code)) else append(char)
+        }
+      }
+      append('"')
+    }
+}

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -525,6 +525,10 @@ fun main(args: Array<String>) {
       // VS Code would surface yesterday's exception as if it were current.
       val sidecar = errorSidecarFor(targetFile)
       if (sidecar.exists()) sidecar.delete()
+      // A render that removed or changed an exact `@SettledPreview(afterMs = …)` must not keep
+      // yesterday's phase declaration beside today's PNG. The successful path below rewrites it
+      // when this capture is still pinned.
+      DesktopRenderWarningsSidecar.deleteStale(targetFile)
       if (interactionSpec != null) {
         // `@InteractionPreview` — dispatch the declared gesture script against the live composition
         // on a paused clock and encode the frames. Checked ahead of the animation branch because a
@@ -658,6 +662,15 @@ fun main(args: Array<String>) {
             settleAfterMs = settleAfterMs,
             settleMaxMs = settleMaxMs,
             captureGutter = captureGutter,
+          )
+        } else {
+          // The focused renderer is the only successful still path that does not funnel through
+          // `renderPreview`, so publish its exact phase declaration here. Motion and scroll
+          // products intentionally do not inherit the still's phase pin.
+          DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+            pngFile = targetFile,
+            role = "Preview '${targetFile.nameWithoutExtension}' still",
+            atMs = settleAfterMs.takeIf { it > 0 }?.toLong(),
           )
         }
       } else if (scrollDispatchMode != null) {
@@ -1008,9 +1021,9 @@ private val NO_PARAM = Any()
  * behind forever (see [deleteStaleFanoutFiles]).
  *
  * `.error.json` is written by [writeErrorSidecar] here and by `RenderErrorSidecar` on the Android
- * side; `.warnings.json` (`RenderWarningsSidecar`) only has an Android writer today, but the sweep
- * covers it on both backends so the cleanup contract doesn't depend on which renderer produced the
- * directory. Kept in sync with `PreviewManifestLoader.RENDER_COMPANION_SUFFIXES`.
+ * side; `.warnings.json` is written by [DesktopRenderWarningsSidecar] here and
+ * `RenderWarningsSidecar` on Android. Kept in sync with
+ * `PreviewManifestLoader.RENDER_COMPANION_SUFFIXES`.
  */
 internal val RENDER_COMPANION_SUFFIXES = listOf(".error.json", ".warnings.json")
 
@@ -1487,6 +1500,13 @@ internal fun renderPreview(
     } else {
       fileSystem.write(outputFile.path.toPath()) { write(pngData.bytes) }
     }
+
+    DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+      pngFile = outputFile,
+      role = "Preview '${outputFile.nameWithoutExtension}' still",
+      atMs = settleAfterMs.takeIf { it > 0 }?.toLong(),
+      fileSystem = fileSystem,
+    )
 
     // Released in the `finally` below rather than here, so a throw between the scene's
     // construction and this point cannot strand its Skia surface.

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SettledPreviewRenderTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SettledPreviewRenderTest.kt
@@ -4,6 +4,7 @@ import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -44,6 +45,12 @@ class SettledPreviewRenderTest {
     val image = render("exact", "DelayedReveal", settleAfterMs = 350, settleMaxMs = 1000)
     val alpha = alphaAt(image)
     assertTrue("expected a mid-fade alpha, got $alpha", alpha in 100..180)
+    val sidecar = DesktopRenderWarningsSidecar.pathFor(outputFile("exact"))
+    assertTrue("exact settle must publish a phase pin", sidecar.exists())
+    val json = sidecar.readText()
+    assertTrue(json.contains("\"outcome\":\"phase_pinned\""))
+    assertTrue(json.contains("\"atMs\":350"))
+    assertTrue(json.contains("\"unsettledCaptures\":[]"))
   }
 
   @Test
@@ -52,6 +59,7 @@ class SettledPreviewRenderTest {
     // silent stretch of the bound the author asked for.
     val image = render("short", "DelayedReveal", settleAfterMs = 0, settleMaxMs = 100)
     assertEquals(0, alphaAt(image))
+    assertFalse(DesktopRenderWarningsSidecar.pathFor(outputFile("short")).exists())
   }
 
   @Test
@@ -68,7 +76,8 @@ class SettledPreviewRenderTest {
     settleAfterMs: Int = -1,
     settleMaxMs: Int = 0,
   ): BufferedImage {
-    val out = File(tempFolder.newFolder(name), "$name.png")
+    val out = outputFile(name)
+    out.parentFile.mkdirs()
     renderPreview(
       className = fixtureClass,
       functionName = function,
@@ -88,6 +97,8 @@ class SettledPreviewRenderTest {
     )
     return ImageIO.read(out)
   }
+
+  private fun outputFile(name: String): File = File(tempFolder.root, "$name/$name.png")
 
   private fun alphaAt(image: BufferedImage): Int =
     (image.getRGB(image.width / 2, image.height / 2) ushr 24) and 0xFF


### PR DESCRIPTION
## Summary
- emit `phasePinnedCaptures` in Desktop `<png>.warnings.json` sidecars for exact `@SettledPreview(afterMs = …)` stills
- cover both the standalone renderer and desktop daemon while keeping motion/scroll products unclassified
- remove stale phase claims and update the annotation documentation to describe backend parity

## Test plan
- `./gradlew :renderer-desktop:test --tests ee.schimke.composeai.renderer.SettledPreviewRenderTest --no-daemon`
- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.RenderEngineSettleTest :daemon:desktop:ktfmtCheck --no-daemon`
- `./gradlew :renderer-desktop:ktfmtCheck :daemon:desktop:ktfmtCheck :preview-annotations:ktfmtCheck --no-daemon`
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD`

Closes #4829