### PR TITLE
feat(catalog): publish component parameter metadata

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -10,6 +10,7 @@ import kotlin.metadata.KmValueParameter
 import kotlin.metadata.declaresDefaultValue
 import kotlin.metadata.isNullable
 import kotlin.metadata.jvm.KotlinClassMetadata
+import kotlin.metadata.jvm.annotations
 import kotlin.metadata.jvm.signature
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassReader
@@ -111,28 +112,41 @@ internal object ComposableSignature {
     return renderType(t)
   }
 
-  /** `(A, B) -> R` for a `kotlin/FunctionN` type, using its type arguments (last = return). */
+  /**
+   * `(A, B) -> R`, or `Receiver.(A) -> R` for an extension-function type, using the metadata type
+   * arguments (last = return). Kotlin records the receiver as the first function argument and marks
+   * the type with `kotlin.ExtensionFunctionType`; without reading that marker a slot such as
+   * `RowScope.() -> Unit` misleadingly appears as an ordinary `(RowScope) -> Unit` callback.
+   */
   private fun renderFunctionType(
     type: KmType,
     @Suppress("UNUSED_PARAMETER") simple: String,
   ): String {
     val args = type.arguments
     if (args.isEmpty()) return "() -> Unit"
-    val params = args.dropLast(1).joinToString(", ") { renderProjection(it) }
+    val input = args.dropLast(1)
     val ret = args.last().type?.let { renderType(it) } ?: "Unit"
-    return "($params) -> $ret"
+    val extension =
+      type.annotations.any { it.className == "kotlin/ExtensionFunctionType" } && input.isNotEmpty()
+    if (extension) {
+      val receiver = renderProjection(input.first())
+      val params = input.drop(1).joinToString(", ") { renderProjection(it) }
+      return "$receiver.($params) -> $ret"
+    }
+    return "(${input.joinToString(", ") { renderProjection(it) }}) -> $ret"
   }
 
   private fun isFunctionClassName(name: String): Boolean = name.startsWith("kotlin/Function")
 
   /**
-   * A function-typed parameter — treated as a composable content slot. Metadata doesn't cheaply
-   * expose the `@Composable` *type* annotation here, so this approximates: a `kotlin/FunctionN`
-   * parameter on a composable is, in practice, a `content = { … }` slot. Good enough to let a
-   * consumer render the slot as a trailing-lambda rather than an inline value.
+   * A function-typed parameter annotated `@Composable` — a content slot. Kotlin metadata retains
+   * the type-use annotation, so use it instead of treating every callback (`onClick`,
+   * `onValueChange` and friends) as child content. A consumer can then label and render actual
+   * slots distinctly.
    */
   private fun isComposableFunctionType(type: KmType): Boolean =
-    (type.classifier as? KmClassifier.Class)?.name?.let { isFunctionClassName(it) } == true
+    (type.classifier as? KmClassifier.Class)?.name?.let { isFunctionClassName(it) } == true &&
+      type.annotations.any { it.className == "androidx/compose/runtime/Composable" }
 
   // --- @kotlin.Metadata extraction (ASM, from the class bytes)
   // -------------------------------------

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -48,13 +48,22 @@ class ComposableSignatureTest {
     assertThat(params.first { it.name == "note" }.hasDefault).isTrue()
     assertThat(params.first { it.name == "state" }.hasDefault).isFalse()
     assertThat(params.first { it.name == "labels" }.hasDefault).isFalse()
-    // The function-typed parameter is flagged as a slot.
-    assertThat(params.first { it.name == "onClick" }.composableSlot).isTrue()
+    // An ordinary callback is not child content merely because it is function typed.
+    assertThat(params.first { it.name == "onClick" }.composableSlot).isFalse()
     assertThat(params.first { it.name == "state" }.composableSlot).isFalse()
   }
 
   @Test
   fun `a no-parameter function yields an empty list`() {
     assertThat(parametersOf("noParams")).isEmpty()
+  }
+
+  @Test
+  fun `renders a scoped slot as an extension function type`() {
+    val content = parametersOf("scopedSlotComponent").single()
+
+    assertThat(content.name).isEqualTo("content")
+    assertThat(content.type).isEqualTo("TestRowScope.(Int) -> Unit")
+    assertThat(content.composableSlot).isTrue()
   }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.discovery
 
+import androidx.compose.runtime.Composable
+
 // Fixtures for ComposableSignatureTest. Deliberately NOT @Composable — that would drag the Compose
 // runtime onto the discovery test classpath, and ComposableSignature reads only Kotlin @Metadata,
 // which every Kotlin declaration carries regardless. A top-level function compiles into the file
@@ -12,6 +14,11 @@ fun sampleComponent(
   onClick: () -> Unit,
   note: String? = null,
 ) {}
+
+@Suppress("unused", "UNUSED_PARAMETER")
+fun scopedSlotComponent(content: @Composable TestRowScope.(Int) -> Unit) {}
+
+class TestRowScope
 
 @Suppress("unused") fun noParams() {}
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/TestComposableAnnotation.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/TestComposableAnnotation.kt
@@ -1,0 +1,6 @@
+package androidx.compose.runtime
+
+/** Minimal type-use fixture; discovery matches the real annotation by FQN and needs no runtime. */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.BINARY)
+annotation class Composable

--- a/scripts/design-artifacts/apply-component-parameters.mjs
+++ b/scripts/design-artifacts/apply-component-parameters.mjs
@@ -1,0 +1,34 @@
+/**
+ * Stamp discovery's production-composable signature onto the published catalog component.
+ *
+ * `@design-parity/catalog-export` deliberately knows nothing about Kotlin. The bundle does: each
+ * preview's inferred `PreviewTarget` carries the production composable's ordered value parameters.
+ * Keeping this join in the Compose producer means consumers can describe slots and ordinary API
+ * values without parsing source or mistaking the zero-argument preview wrapper for the component.
+ */
+export function applyComponentParameters(manifest, spec, targetsByFunction) {
+  const specByComponentId = new Map(
+    (spec?.groups ?? []).flatMap((group) =>
+      (group.components ?? []).map((component) => [component.componentId, component]),
+    ),
+  );
+  let stamped = 0;
+  for (const component of manifest?.components ?? []) {
+    const authored = specByComponentId.get(component.componentId);
+    const target = authored?.preview ? targetsByFunction?.get(authored.preview) : undefined;
+    // An explicit component override often exists to reject an incorrect inference. Its inferred
+    // signature is usable only when both sources name the same production composable — the same
+    // safety condition Code Connect applies before it emits a call site.
+    if (authored?.component && authored.component !== target?.functionName) continue;
+    const parameters = target?.parameters;
+    if (!Array.isArray(parameters) || parameters.length === 0) continue;
+    component.parameters = parameters.map((parameter) => ({
+      name: parameter.name,
+      type: parameter.type,
+      ...(parameter.hasDefault ? { hasDefault: true } : {}),
+      ...(parameter.composableSlot ? { composableSlot: true } : {}),
+    }));
+    stamped += 1;
+  }
+  return stamped;
+}

--- a/scripts/design-artifacts/apply-component-parameters.test.mjs
+++ b/scripts/design-artifacts/apply-component-parameters.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { applyComponentParameters } from "./apply-component-parameters.mjs";
+
+test("stamps ordered component parameters including slots and defaults", () => {
+  const manifest = {
+    components: [{ componentId: "Layout/Row", images: [] }, { componentId: "Text", images: [] }],
+  };
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "Layout/Row", preview: "RowPreview" },
+          { componentId: "Text", preview: "TextPreview" },
+        ],
+      },
+    ],
+  };
+  const targets = new Map([
+    [
+      "RowPreview",
+      {
+        parameters: [
+          { name: "spacing", type: "Dp", hasDefault: true },
+          {
+            name: "content",
+            type: "RowScope.() -> Unit",
+            hasDefault: false,
+            composableSlot: true,
+          },
+        ],
+      },
+    ],
+  ]);
+
+  assert.equal(applyComponentParameters(manifest, spec, targets), 1);
+  assert.deepEqual(manifest.components[0].parameters, [
+    { name: "spacing", type: "Dp", hasDefault: true },
+    { name: "content", type: "RowScope.() -> Unit", composableSlot: true },
+  ]);
+  assert.equal("parameters" in manifest.components[1], false);
+});
+
+test("leaves an older or uninferred component unchanged", () => {
+  const manifest = { components: [{ componentId: "Unknown", images: [] }] };
+  const spec = {
+    groups: [{ components: [{ componentId: "Unknown", preview: "UnknownPreview" }] }],
+  };
+
+  assert.equal(applyComponentParameters(manifest, spec, new Map()), 0);
+  assert.deepEqual(manifest, { components: [{ componentId: "Unknown", images: [] }] });
+});
+
+test("does not attach an inference rejected by an explicit component override", () => {
+  const manifest = { components: [{ componentId: "Button", images: [] }] };
+  const spec = {
+    groups: [
+      {
+        components: [
+          { componentId: "Button", preview: "ButtonPreview", component: "CorrectButton" },
+        ],
+      },
+    ],
+  };
+  const targets = new Map([
+    ["ButtonPreview", { functionName: "WrongButton", parameters: [{ name: "wrong", type: "Int" }] }],
+  ]);
+
+  assert.equal(applyComponentParameters(manifest, spec, targets), 0);
+  assert.equal("parameters" in manifest.components[0], false);
+});

--- a/scripts/design-artifacts/generate-design-catalog.mjs
+++ b/scripts/design-artifacts/generate-design-catalog.mjs
@@ -102,6 +102,7 @@ import {
 } from "./variant-render-pairing.mjs";
 import { buildCodeConnectManifest } from "./figma-code-connect-emit.mjs";
 import { targetsByFunction } from "./figma-code-connect-target.mjs";
+import { applyComponentParameters } from "./apply-component-parameters.mjs";
 import { renderWireframeSvg, slug } from "./render-wireframe-svg.mjs";
 import { renderLayoutWireframeSvg } from "./render-layout-wireframe-svg.mjs";
 import {
@@ -1421,6 +1422,10 @@ const sourceRoot = rendersPath.endsWith(".zip")
   : rendersPath;
 const result = await writeCatalog(catalog, outPath, { sourceRoot });
 
+// Resolve the production composable once for both catalog API metadata and Code Connect. Each
+// entry is keyed by the preview function named by the spec, not by a flattened render id.
+const targetByFn = combinedBundleMap(allBundles, targetsByFunction);
+
 // Inject the live-preview deep links into catalog.json. Done as a post-process
 // (re-read → annotate → re-write) rather than via writeCatalog's options because
 // the pinned `@design-parity/catalog-export` predates `previewServer`; once a
@@ -1657,6 +1662,12 @@ if (values["publish-live-bundle"]) {
   if (stampedSources > 0) {
     console.log(
       `[${spec.system}] stamped sourceFile on ${stampedSources} component(s) from discovery`,
+    );
+  }
+  const stampedParameters = applyComponentParameters(manifest, spec, targetByFn);
+  if (stampedParameters > 0) {
+    console.log(
+      `[${spec.system}] stamped parameters on ${stampedParameters} component(s) from discovery`,
     );
   }
   for (const component of manifest.components ?? []) {
@@ -2213,7 +2224,7 @@ const codeConnect = buildCodeConnectManifest({
   components: catalog.components,
   fnByComponentId,
   componentByComponentId,
-  targetByFn: combinedBundleMap(allBundles, targetsByFunction),
+  targetByFn,
   slug,
   figmaSvgSlugs,
   figmaSvgBySlug,


### PR DESCRIPTION
## Summary
- publish inferred production-composable parameters on design catalog components
- render extension-function slot types such as `RowScope.() -> Unit` accurately
- distinguish `@Composable` content slots from ordinary callbacks

Supports yschimke/compose-preview-server#157. Consumer UI: yschimke/compose-preview-server#166.

## Verification
- `node --test scripts/design-artifacts/apply-component-parameters.test.mjs scripts/design-artifacts/figma-code-connect-target.test.mjs`
- `./gradlew :gradle-plugin:preview-discovery:ktfmtCheck :gradle-plugin:preview-discovery:test --tests 'ee.schimke.composeai.discovery.ComposableSignatureTest' --no-daemon`