### PR TITLE
fix(preview): preserve accurate desktop phase pins

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -335,7 +335,7 @@ class RenderEngine(
     val outputFile = File(outputDir, "${spec.outputBaseName}.png")
     // A failed retry, an interactive render, or a preview whose exact settle was removed must not
     // leave an earlier render's phase declaration claiming the new output is pinned.
-    DesktopRenderWarningsSidecar.deleteStale(outputFile)
+    DesktopRenderWarningsSidecar.deleteStale(outputFile, fileSystem)
 
     // kind=LOTTIE has no class to reflect — the asset is rendered directly via Compottie below.
     val isLottie = spec.kind == "LOTTIE"
@@ -899,7 +899,9 @@ class RenderEngine(
     DesktopRenderWarningsSidecar.writePhasePinOrDelete(
       pngFile = state.outputFile,
       role = "compose-ai-daemon still '${state.spec.outputBaseName}'",
-      atMs = state.settleWindowMs.takeIf { state.settleIsExact }?.toLong(),
+      // A scroll or interaction drive clears `pinnedFrameNanos` as soon as it advances past the
+      // declared coordinate. Only the retained pin describes the PNG we just wrote.
+      atMs = state.pinnedFrameNanos?.takeIf { state.settleIsExact }?.let { it / 1_000_000L },
       fileSystem = fileSystem,
     )
 
@@ -1535,6 +1537,7 @@ class RenderEngine(
           "RenderEngine: render mode '${spec.renderMode}' requires a previewId on the RenderSpec"
         )
     val startNs = System.nanoTime()
+    val tmpBase = "$previewId$SCROLL_SVG_TMP_SUFFIX"
 
     val baseHeight = spec.heightPx
     val maxHeight = baseHeight + SCROLL_SVG_MAX_EXTRA_PX
@@ -1544,7 +1547,16 @@ class RenderEngine(
     var iterations = 0
     while (iterations < SCROLL_SVG_MAX_GROW_ITERATIONS) {
       iterations++
-      val probe = spec.copy(renderMode = null, heightPx = probeHeight, wrapHeight = false)
+      // Probes never publish a PNG. Give them the same isolated output base as the final tall
+      // render so `setUp` cannot clear the normal still's warnings sidecar while preparing this
+      // unrelated data product.
+      val probe =
+        spec.copy(
+          renderMode = null,
+          heightPx = probeHeight,
+          wrapHeight = false,
+          outputBaseName = tmpBase,
+        )
       val state = setUp(probe, classLoader, inspectionMode = spec.inspectionMode ?: true)
       val measure =
         try {
@@ -1586,7 +1598,6 @@ class RenderEngine(
     // Final render at the settled height into an isolated base so it can't clobber the preview's
     // normal-size products. `previewId = null` makes renderOnce key the figma-svg dir off the
     // (isolated) outputBaseName.
-    val tmpBase = "$previewId$SCROLL_SVG_TMP_SUFFIX"
     val finalSpec =
       spec.copy(
         renderMode = null,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineFigmaSvgScrollTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineFigmaSvgScrollTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.renderer.DesktopRenderWarningsSidecar
 import java.io.File
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -109,6 +110,14 @@ class RenderEngineFigmaSvgScrollTest {
     val dataDir = tempFolder.newFolder("data-long")
     val engine = RenderEngine(outputDir = outputDir, dataDir = dataDir)
     val previewId = "scaffold-list"
+    val still = File(outputDir, "$previewId.png")
+    DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+      pngFile = still,
+      role = "compose-ai-daemon still '$previewId'",
+      atMs = 350L,
+    )
+    val stillWarnings = DesktopRenderWarningsSidecar.pathFor(still)
+    assertTrue(stillWarnings.exists())
     engine.render(
       spec =
         RenderSpec(
@@ -126,6 +135,7 @@ class RenderEngineFigmaSvgScrollTest {
 
     val longSvg = File(File(File(dataDir, previewId), "figma-long"), "compose-figma-long.svg")
     assertTrue("full-page SVG must be produced: ${longSvg.absolutePath}", longSvg.exists())
+    assertTrue("long-SVG probes must preserve the still's phase pin", stillWarnings.exists())
     val text = longSvg.readText()
     runCatching {
       val keep = File("build/figma-svg-scroll-experiment").also { it.mkdirs() }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSettleTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineSettleTest.kt
@@ -133,6 +133,39 @@ class RenderEngineSettleTest {
     assertFalse(revealed(render("ExactEarly").first))
   }
 
+  @Test
+  fun `an exact settle advanced by a later drive does not claim the original phase`() {
+    val previewId = "ExactThenDriven"
+    installPreviewIndex(previewId, """{"afterMs":400,"maxMs":1000}""")
+    val outputDir = tempFolder.newFolder("renders-$previewId")
+    val engine = RenderEngine(outputDir = outputDir)
+    val state =
+      engine.setUp(
+        RenderSpec(
+          previewId = previewId,
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "TimedRevealPreview",
+          widthPx = 100,
+          heightPx = 100,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = previewId,
+        ),
+        classLoader = javaClass.classLoader,
+      )
+    try {
+      engine.applyStaticSettle(state)
+      // END-scroll and static interaction drives advance through this same cursor helper.
+      state.nextVirtualFrameNanos()
+      val result = engine.renderOnce(state, requestId = 1L)
+      val png = File(result.pngPath!!)
+      assertTrue(png.exists())
+      assertFalse(DesktopRenderWarningsSidecar.pathFor(png).exists())
+    } finally {
+      engine.tearDown(state)
+    }
+  }
+
   /** The control, and the regression the fix is measured against: no settle, no reveal. */
   @Test
   fun `a preview with no settle keeps its first frame`() {

--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
   implementation(project(":data-preview-overrides-runtime"))
 
   testImplementation(libs.junit)
+  testImplementation(libs.okio.fakefilesystem)
 
   // Deliberately NOT a test dependency: it is resolved into its own configuration and handed to the
   // test as a path, so `SkikoBridgeShapeTest` can load it in an isolated classloader. Putting it on

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRenderWarningsSidecar.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRenderWarningsSidecar.kt
@@ -37,13 +37,14 @@ object DesktopRenderWarningsSidecar {
     fileSystem: FileSystem = SystemFileSystem,
   ) {
     if (atMs == null) {
-      deleteStale(pngFile)
+      deleteStale(pngFile, fileSystem)
       return
     }
     try {
       val sidecar = pathFor(pngFile)
-      sidecar.parentFile?.mkdirs()
-      fileSystem.write(sidecar.path.toPath()) { writeUtf8(encodePhasePin(role, atMs)) }
+      val sidecarPath = sidecar.path.toPath()
+      sidecarPath.parent?.let { fileSystem.createDirectories(it) }
+      fileSystem.write(sidecarPath) { writeUtf8(encodePhasePin(role, atMs)) }
     } catch (writeFailure: Throwable) {
       System.err.println(
         "Failed to write render-warnings sidecar for ${pngFile.name}: ${writeFailure.message}"
@@ -52,9 +53,10 @@ object DesktopRenderWarningsSidecar {
   }
 
   /** Remove a sidecar left by an earlier pinned render. */
-  fun deleteStale(pngFile: File) {
-    val sidecar = pathFor(pngFile)
-    if (sidecar.exists()) sidecar.delete()
+  @JvmOverloads
+  fun deleteStale(pngFile: File, fileSystem: FileSystem = SystemFileSystem) {
+    val sidecar = pathFor(pngFile).path.toPath()
+    if (fileSystem.exists(sidecar)) fileSystem.delete(sidecar)
   }
 
   internal fun encodePhasePin(role: String, atMs: Long): String = buildString {

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SettledPreviewRenderTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/SettledPreviewRenderTest.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.renderer
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -68,6 +70,29 @@ class SettledPreviewRenderTest {
     // 200ms into a 400ms linear 0→1 ramp.
     val alpha = alphaAt(image)
     assertTrue("expected a mid-ramp alpha, got $alpha", alpha in 100..160)
+  }
+
+  @Test
+  fun `removing a pin deletes its sidecar through the injected filesystem`() {
+    val fileSystem = FakeFileSystem()
+    val png = File("/renders/fake.png")
+    DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+      pngFile = png,
+      role = "preview still",
+      atMs = 350L,
+      fileSystem = fileSystem,
+    )
+    val sidecar = DesktopRenderWarningsSidecar.pathFor(png).path.toPath()
+    assertTrue(fileSystem.exists(sidecar))
+
+    DesktopRenderWarningsSidecar.writePhasePinOrDelete(
+      pngFile = png,
+      role = "preview still",
+      atMs = null,
+      fileSystem = fileSystem,
+    )
+
+    assertFalse(fileSystem.exists(sidecar))
   }
 
   private fun render(


### PR DESCRIPTION
## Summary
- preserve a still phase-pin sidecar while `figma-svg-long` uses isolated probe outputs
- delete stale warning sidecars through the injected Okio filesystem
- emit a daemon phase pin only when the captured frame remains at the exact coordinate

## Test plan
- `./gradlew :renderer-desktop:test --tests ee.schimke.composeai.renderer.SettledPreviewRenderTest :renderer-desktop:ktfmtCheck --no-daemon`
- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.RenderEngineSettleTest --tests ee.schimke.composeai.daemon.RenderEngineFigmaSvgScrollTest :daemon:desktop:ktfmtCheck --no-daemon`
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD`

Follow-up to #4951; addresses its three valid P2 review findings.