### PR TITLE
test: move VS Code schema gate to its consumer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,23 +548,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # The daemon-launch schema has three copies and one of them — the TypeScript reader, the
-      # only one that GATES on the version — moved to yschimke/compose-preview-vscode. The checker
-      # and its tests SKIP the TypeScript half without a checkout, which is right for a
-      # contributor's `check` and wrong here: CI is where the cross-repo half has to be real.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: yschimke/compose-preview-vscode
-          persist-credentials: false
-          path: .compose-preview-vscode
-          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
       # those diverge, which passes a writer change matching newer source but incompatible with
       # the reader actually on the classpath, and fails unrelated pull requests when external
-      # `main` moves. The extension checkout above is deliberately not pinned the same way:
-      # nothing here resolves it as an artifact, so there is no version to agree with.
+      # `main` moves.
       - id: contracts-ref
         name: Resolve the pinned contracts release
         run: |
@@ -592,11 +581,8 @@ jobs:
       # remove the viewer's only automated coverage.
       - name: Build CLI and bundle viewer
         env:
-          # `:cli:check` runs `checkDaemonLaunchSchema`, whose TypeScript reader lives in the
-          # extension repo. Without this it silently checks only the Kotlin half.
-          COMPOSE_PREVIEW_VSCODE_ROOT: ${{ github.workspace }}/.compose-preview-vscode
-          # And whose JVM reader lives in the contracts repo. Same failure mode: without this it
-          # silently checks one reader instead of two.
+          # `:cli:check` runs `checkDaemonLaunchSchema`, whose JVM reader lives in the contracts
+          # repo. Without this it silently skips the external reader.
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
         run: ./gradlew :cli:build :bundle-viewer:build
 
@@ -907,23 +893,12 @@ jobs:
       # install the way those are: a fallback is right for a diff that can
       # degrade to strict bytes, and wrong for the tests that prove the diff.
       # `PerceptualLibrariesTest` fails the suite if this step is ever dropped.
-      # The daemon-launch schema has three copies and one of them — the TypeScript reader, the
-      # only one that GATES on the version — moved to yschimke/compose-preview-vscode. The checker
-      # and its tests SKIP the TypeScript half without a checkout, which is right for a
-      # contributor's `check` and wrong here: CI is where the cross-repo half has to be real.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: yschimke/compose-preview-vscode
-          persist-credentials: false
-          path: .compose-preview-vscode
-          fetch-depth: 1
       # Pinned to the RELEASE this build compiles against, not the contracts repo's default
       # branch. The gate compares a source file there against bytecode resolved from
       # `composeai-contracts` in the catalog; an unpinned checkout compares the two whenever
       # those diverge, which passes a writer change matching newer source but incompatible with
       # the reader actually on the classpath, and fails unrelated pull requests when external
-      # `main` moves. The extension checkout above is deliberately not pinned the same way:
-      # nothing here resolves it as an artifact, so there is no version to agree with.
+      # `main` moves.
       - id: contracts-ref
         name: Resolve the pinned contracts release
         run: |
@@ -969,22 +944,21 @@ jobs:
       # symbol ratchet and the coupling gate — were removed with `cli/serve` itself (#4732). The
       # boundary they measured is now a Maven coordinate, which cannot be crossed in either
       # direction, so there is nothing left for a source scanner to classify.
-      # `daemon-launch.json` is written by the gradle plugin and read by the daemon JVM, the CLI
-      # doctor and the VS Code extension, each with its own copy of the shape and of the schema
-      # version. Two of those copies carry a comment asking a human to keep them in sync; this is
-      # the gate that makes it enforceable. Runs the check against the real tree too.
+      # `daemon-launch.json` is written by the gradle plugin and subprocess writer, and read by the
+      # daemon JVM and CLI doctor. Their Kotlin copies carry comments asking a human to keep them in
+      # sync; this is the gate that makes those comments enforceable. The VS Code consumer owns its
+      # separate check against the schema metadata published by the plugin release it pins.
       - name: Run daemon-launch schema gate tests
         env:
-          COMPOSE_PREVIEW_VSCODE_ROOT: ${{ github.workspace }}/.compose-preview-vscode
           COMPOSE_PREVIEW_CONTRACTS_ROOT: ${{ github.workspace }}/.compose-preview-contracts
         run: |
           set -euo pipefail
           out=$(python3 scripts/test_check_daemon_launch_schema.py -v 2>&1) || { echo "$out"; exit 1; }
           echo "$out"
-          # A skipped cross-repo test reports the same green as a passing one. Two readers live
-          # outside this repository now, so either checkout failing to resolve has to be loud.
+          # A skipped cross-repo test reports the same green as a passing one. The JVM reader lives
+          # in the contracts repository, so a failed checkout has to be loud.
           if grep -q "skipped" <<<"$out"; then
-            echo "::error::cross-repo schema tests SKIPPED — COMPOSE_PREVIEW_VSCODE_ROOT or COMPOSE_PREVIEW_CONTRACTS_ROOT did not resolve"
+            echo "::error::cross-repo schema tests SKIPPED — COMPOSE_PREVIEW_CONTRACTS_ROOT did not resolve"
             exit 1
           fi
       # The AdaptiveJetStream XR cell renders the sample's Subspaces with OUR compose-testing
@@ -1287,4 +1261,3 @@ jobs:
           else
             gh pr comment "$PR_NUMBER" --body "$body"
           fi
-

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -780,21 +780,19 @@ tasks.named("check") { dependsOn("checkCliDaemonLibraryBoundary") }
 // `ServeCommand.kt`; see the dependency block above for what that still costs and what deciding
 // it would take.
 
-// The four representations of `daemon-launch.json`, checked against each other.
+// This repository's representations of `daemon-launch.json`, checked against each other.
 //
 // The descriptor is written by the gradle plugin and read by the daemon JVM, this CLI's `doctor`
-// and the VS Code extension. Each declares its own copy of the shape and of the schema version,
-// and nothing in the build knows they describe one file. Two of the copies carry a comment asking
-// a human to keep them in sync — `SubprocessRenderSession.kt`'s "mirrors the gradle plugin's
-// writer" and `McpCommand.kt`'s "Keep in sync — bump together". This is that comment, enforced.
+// and the subprocess writer. Two copies carry a comment asking a human to keep them in sync —
+// `SubprocessRenderSession.kt`'s "mirrors the gradle plugin's writer" and `McpCommand.kt`'s
+// "Keep in sync — bump together". This is that comment, enforced.
 //
 // It lives on `:cli` because the check spans modules that sit in different builds (the writer is
-// inside the `gradle-plugin` composite) plus a TypeScript file that is in no Gradle build at all,
-// so no single owning module exists. `:cli` runs on every PR and holds one of the four sites
-// itself. (The retired `checkServeSeam` sat here for the same reason.)
+// inside the `gradle-plugin` composite and the JVM reader is in the pinned contracts checkout), so
+// no single owning module exists. `:cli` runs on every PR and holds one of the sites itself.
 abstract class CheckDaemonLaunchSchema : DefaultTask() {
   /**
-   * Every Kotlin/TypeScript source in the repo, not just the seven representations.
+   * Every Kotlin source in the repo, not just the registered representations.
    *
    * The checker's strongest rule is repo-wide: it fails on a schema-version constant, or a
    * descriptor construction stamping one, that is not registered. That rule reads files nobody
@@ -815,16 +813,6 @@ abstract class CheckDaemonLaunchSchema : DefaultTask() {
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val checker: RegularFileProperty
 
-  /**
-   * Path to a `compose-preview-vscode` checkout, when there is one.
-   *
-   * An `@Input` in its own right, not just a carrier for [representations]: moving the checkout, or
-   * gaining/losing one, changes what the checker covers even when no file's content differs. The
-   * checker skips its TypeScript half without a checkout, so a run with one and a run without one
-   * are not the same check and must not share an up-to-date stamp.
-   */
-  @get:Input @get:Optional abstract val vscodeRoot: Property<String>
-
   /** Root of a compose-preview-contracts checkout, when one is present. */
   @get:Input @get:Optional abstract val contractsRoot: Property<String>
 
@@ -839,7 +827,6 @@ abstract class CheckDaemonLaunchSchema : DefaultTask() {
       commandLine("python3", checker.get().asFile.absolutePath)
       // Passed explicitly rather than inherited, so what the checker sees is what Gradle
       // fingerprinted above. An inherited value could differ from the declared input.
-      vscodeRoot.orNull?.let { environment("COMPOSE_PREVIEW_VSCODE_ROOT", it) }
       contractsRoot.orNull?.let { environment("COMPOSE_PREVIEW_CONTRACTS_ROOT", it) }
     }
     stamp.get().asFile.writeText("ok\n")
@@ -853,7 +840,7 @@ tasks.register<CheckDaemonLaunchSchema>("checkDaemonLaunchSchema") {
   val repoRoot = rootProject.layout.projectDirectory
   representations.from(
     rootProject.fileTree(repoRoot) {
-      include("**/*.kt", "**/*.ts")
+      include("**/*.kt")
       exclude(
         "**/build/**",
         "**/node_modules/**",
@@ -865,36 +852,9 @@ tasks.register<CheckDaemonLaunchSchema>("checkDaemonLaunchSchema") {
       )
     }
   )
-  // The TypeScript reader — the only one that GATES on the schema version — lives in
-  // yschimke/compose-preview-vscode. The checker reads it from `COMPOSE_PREVIEW_VSCODE_ROOT`, else
-  // a sibling checkout, and walks that tree for unregistered mirrors just as it walks this one.
-  // Those files are inputs for the same reason the repo-wide tree above is: without them the first
-  // successful run stamps this task UP-TO-DATE and every later edit or pull of the external reader
-  // is invisible, so the cross-repo drift the gate exists to catch is exactly what it stops seeing.
-  //
-  // Resolved eagerly to a plain String at configuration time, deliberately. Doing it inside a
-  // `map {}` on the provider defers it to execution time, and the lambda then has to capture
-  // `rootProject` to build the file tree — which the configuration cache cannot serialize.
-  val vscodeRootPath: String? =
-    providers.environmentVariable("COMPOSE_PREVIEW_VSCODE_ROOT").orNull?.takeIf { it.isNotBlank() }
-      ?: repoRoot.asFile.parentFile
-        ?.resolve("compose-preview-vscode")
-        ?.takeIf { it.resolve("src/daemon/daemonProtocol.ts").isFile }
-        ?.absolutePath
-  if (vscodeRootPath != null) {
-    vscodeRoot.set(vscodeRootPath)
-    representations.from(
-      rootProject.fileTree(vscodeRootPath) {
-        include("**/*.ts")
-        exclude("**/build/**", "**/node_modules/**", "**/.git/**", "**/out/**", "**/dist/**")
-      }
-    )
-  }
-
   // The JVM reader moved to yschimke/compose-preview-contracts with the wire contracts, so it is
-  // resolved and declared exactly like the TypeScript one above — and for the same reason. Without
-  // it as an input the first successful run stamps this task UP-TO-DATE and every later edit to
-  // the reader is invisible, which is the drift this gate exists to catch.
+  // declared as an input. Without it the first successful run stamps this task UP-TO-DATE and every
+  // later edit to the reader is invisible, which is the drift this gate exists to catch.
   //
   // Eagerly to a String, for the configuration-cache reason given above.
   val contractsRootPath: String? =

--- a/scripts/check-daemon-launch-schema.py
+++ b/scripts/check-daemon-launch-schema.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Keep the four representations of `daemon-launch.json` from drifting apart.
+"""Keep this repository's `daemon-launch.json` representations from drifting apart.
 
 `<module>/build/compose-previews/daemon-launch.json` is written by the Gradle
-plugin and read by the daemon JVM, the CLI doctor, and the VS Code extension.
-Nothing in the build knows those are the same file. Each side declares its own
-copy of the shape and its own copy of the schema version, and two of them carry
+plugin and read by the daemon JVM and the CLI doctor. Nothing in the build knows
+those are the same file. Each side declares its own copy of the shape and its
+own copy of the schema version, and two of them carry
 a comment asking a human to remember:
 
     render-session/subprocess/.../SubprocessRenderSession.kt
@@ -17,9 +17,7 @@ a comment asking a human to remember:
         internal const val EXPECTED_DESCRIPTOR_SCHEMA_VERSION: Int = 2
 
 A comment is not a gate. Bumping the writer alone leaves those two writing and
-expecting v2 with nothing failing, and the VS Code reader — the only one that
-checks the version at all — rejecting every descriptor the plugin produces
-(`daemonProcess.ts`: `parsed.schemaVersion !== DAEMON_DESCRIPTOR_SCHEMA_VERSION`).
+expecting v2 with nothing failing.
 
 This matters for the preview-server split (#3824) beyond ordinary tidiness:
 `:render-session-subprocess` is one of the twelve published contract modules an
@@ -35,20 +33,16 @@ What this checks
    registered. An unregistered copy fails: a new mirror must be declared here,
    which is the point at which someone can ask whether it should exist at all.
 
-2. **Structural agreement** — for each reader (`DaemonLaunchDescriptor` in
-   `:daemon:core`, and the TypeScript interface in the extension):
+2. **Structural agreement** — for the JVM reader (`DaemonLaunchDescriptor`):
    every field the reader *requires* is emitted by the writer, shared fields
    carry corresponding types, and any reader-only field is optional. A required
    field the writer never writes is a parse failure at runtime.
 
-3. **`BtaCompileConfig` field-for-field** between Kotlin and TypeScript, which
-   its own KDoc claims and nothing enforced.
-
-4. **Unknown-key tolerance** — the JVM reader keeps `ignoreUnknownKeys = true`.
+3. **Unknown-key tolerance** — the JVM reader keeps `ignoreUnknownKeys = true`.
    That is the single line making the writer's `btaCompile` (which the JVM
    reader does not declare) safe rather than fatal.
 
-5. **Sysprop key mirrors** — string constants the descriptor carries that are
+4. **Sysprop key mirrors** — string constants the descriptor carries that are
    re-declared elsewhere, e.g. `SANDBOX_COUNT_PROP`, whose own KDoc says "both
    sides MUST agree".
 
@@ -76,22 +70,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 ALLOWLIST = Path(__file__).resolve().parent / "daemon-launch-schema-allowlist.json"
 
 WRITER = "gradle-plugin/daemon-launch-builder/src/main/kotlin/ee/schimke/composeai/daemonlaunch/DaemonClasspathDescriptor.kt"
-# The JVM reader moved to yschimke/compose-preview-contracts with the wire contracts, and is
-# resolved the same way as the TypeScript one below. Same reasoning: it is one of the three copies
-# of this schema, so dropping it would retire half the check rather than relocate it.
+# The JVM reader moved to yschimke/compose-preview-contracts with the wire contracts. It remains
+# part of this check because this repository resolves that exact published contracts release.
 JVM_READER_REL = (
     "daemon/protocol/src/main/kotlin/ee/schimke/composeai/daemon/protocol/DaemonLaunchDescriptor.kt"
 )
-# The TypeScript reader moved to yschimke/compose-preview-vscode with the extension. It is still
-# one of the three copies of this schema — and the only reader that *gates* on the version — so
-# dropping it from this checker would retire the check that matters most, on the copy furthest from
-# the writer.
-#
-# It is resolved from a checkout instead: `COMPOSE_PREVIEW_VSCODE_ROOT` (what CI sets), then a
-# sibling `../compose-preview-vscode`. When neither is present the TypeScript half SKIPS and the
-# Kotlin half still runs, because "the other repository is not checked out" is not a drift signal
-# and this script is wired into `check`, which every contributor runs.
-TS_READER_REL = "src/daemon/daemonProtocol.ts"
 
 
 def contracts_root() -> Path | None:
@@ -108,23 +91,6 @@ def contracts_root() -> Path | None:
     return sibling if (sibling / JVM_READER_REL).is_file() else None
 
 
-def ts_root() -> Path | None:
-    """Root of a compose-preview-vscode checkout, or None when there is none."""
-    explicit = os.environ.get("COMPOSE_PREVIEW_VSCODE_ROOT", "").strip()
-    if explicit:
-        root = Path(explicit).resolve()
-        if not (root / TS_READER_REL).is_file():
-            raise SystemExit(
-                f"COMPOSE_PREVIEW_VSCODE_ROOT={explicit} does not contain {TS_READER_REL}"
-            )
-        return root
-    sibling = REPO_ROOT.parent / "compose-preview-vscode"
-    return sibling if (sibling / TS_READER_REL).is_file() else None
-
-
-_ts_root = ts_root()
-TS_READER = TS_READER_REL if _ts_root is not None else ""
-
 _contracts_root = contracts_root()
 JVM_READER = JVM_READER_REL if _contracts_root is not None else ""
 
@@ -132,16 +98,11 @@ JVM_READER = JVM_READER_REL if _contracts_root is not None else ""
 def resolve(rel: str) -> Path | None:
     """Map a path from this script or the allowlist onto disk.
 
-    Two of the three copies now live elsewhere. A `.ts` path is the VS Code extension's and a
-    `.kt` path is this repository's — except the JVM reader, which moved to
-    compose-preview-contracts with the wire contracts. Each resolves against the checkout its
-    `*_root()` found, and is None when there is none, so a missing sibling SKIPS that half rather
-    than failing: "the other repository is not checked out" is not a drift signal, and this script
-    is wired into `check`, which every contributor runs.
+    The JVM reader moved to compose-preview-contracts with the wire contracts. It resolves against
+    the pinned checkout when present and is unavailable otherwise, so a missing sibling SKIPS that
+    half rather than failing: "the other repository is not checked out" is not a drift signal, and
+    this script is wired into `check`, which every contributor runs.
     """
-    if rel.endswith(".ts"):
-        root = _ts_root
-        return (root / rel) if root is not None else None
     if rel == JVM_READER_REL:
         return (_contracts_root / rel) if _contracts_root is not None else None
     return REPO_ROOT / rel
@@ -150,12 +111,10 @@ def resolve(rel: str) -> Path | None:
 def available(rel: str) -> bool:
     """Whether `rel` is present in this checkout.
 
-    False only for a path that lives in another repository whose checkout is absent — the
-    TypeScript reader without a compose-preview-vscode checkout, or anything under the wire
-    contracts without a compose-preview-contracts one. Callers that walk allowlist-supplied paths
-    use this to skip rather than crash, for the same reason the reader checks are guarded: "the
-    other repository is not checked out" is not a drift signal, and this script runs inside
-    `check`, which every contributor runs.
+    False only for a path under the wire contracts whose compose-preview-contracts checkout is
+    absent. Callers that walk allowlist-supplied paths use this to skip rather than crash, for the
+    same reason the reader checks are guarded: "the other repository is not checked out" is not a
+    drift signal, and this script runs inside `check`, which every contributor runs.
 
     CI is where the cross-repo half must be real, and it checks both repositories out; the
     schema-gate step there fails if any test reports a skip.
@@ -167,18 +126,17 @@ def read(rel: str) -> str:
     path = resolve(rel)
     if path is None:
         raise FileNotFoundError(
-            f"{rel} lives in another repository; set COMPOSE_PREVIEW_VSCODE_ROOT (.ts) or "
-            "COMPOSE_PREVIEW_CONTRACTS_ROOT (the JVM reader)"
+            f"{rel} lives in another repository; set COMPOSE_PREVIEW_CONTRACTS_ROOT"
         )
     return path.read_text(encoding="utf-8")
 
 
 def stripped(rel: str) -> str:
-    """`read` with comments removed under the rules of the file's own language."""
-    return strip_comments(read(rel), nested=not rel.endswith(".ts"))
+    """`read` with comments removed."""
+    return strip_comments(read(rel))
 
 
-def strip_comments(text: str, nested: bool = True) -> str:
+def strip_comments(text: str) -> str:
     """Remove comments, keeping string literals intact.
 
     String-aware on purpose. A stripper that only looks for `//` and `/*` truncates
@@ -187,18 +145,15 @@ def strip_comments(text: str, nested: bool = True) -> str:
     behind an ordinary URL. It keeps the contents because mirrored constants ARE strings
     (`"composeai.daemon.sandboxCount"`), so blanking them would defeat the comparison.
 
-    Handles Kotlin raw strings and char literals and TypeScript template literals. `nested`
-    selects the language's block-comment rule and is not cosmetic: Kotlin's `/*` nests, TypeScript's
-    does not. Applying Kotlin's rule to TypeScript means `/* showing /* */` leaves the scanner
-    inside a comment after the real closer and swallows whatever follows — which for a repo-wide
-    scanner is a place a mirror could hide.
+    Handles Kotlin raw strings and char literals. Kotlin block comments nest, so the scanner tracks
+    their depth rather than stopping at the first closer.
     """
     out: list[str] = []
     i, n, depth = 0, len(text), 0
     while i < n:
         c, two, three = text[i], text[i : i + 2], text[i : i + 3]
         if depth:
-            if two == "/*" and nested:
+            if two == "/*":
                 depth += 1
                 i += 2
             elif two == "*/":
@@ -209,10 +164,6 @@ def strip_comments(text: str, nested: bool = True) -> str:
         elif two == "/*":
             depth = 1
             i += 2
-            if not nested:
-                j = text.find("*/", i)
-                i = len(text) if j < 0 else j + 2
-                depth = 0
         elif two == "//":
             j = text.find("\n", i)
             i = n if j < 0 else j
@@ -388,69 +339,6 @@ def kotlin_consts(rel: str) -> dict[str, str]:
 
 
 # --------------------------------------------------------------------------
-# TypeScript
-# --------------------------------------------------------------------------
-
-TS_FIELD = re.compile(r"(\w+)(\??)\s*:\s*([^;]+?);")
-
-
-def ts_interface(rel: str, name: str) -> dict[str, tuple[str, bool]]:
-    """`{field: (type, optional)}` for a TS interface. `optional` = declared `field?:`."""
-    text = stripped(rel)
-    m = re.search(r"\binterface\s+" + re.escape(name) + r"\s*\{", text)
-    if not m:
-        raise LookupError(f"interface {name} not found in {rel}")
-    body = balanced(text, m.end() - 1, "{", "}")
-    return {f.group(1): (f.group(3).strip(), f.group(2) == "?") for f in TS_FIELD.finditer(body)}
-
-
-# `export` is optional. A module-local `const DAEMON_DESCRIPTOR_SCHEMA_VERSION = 2` is a mirror
-# like any other — it can compare a descriptor against its own stale copy without ever constructing
-# a DTO, so discovery-by-use cannot see it either.
-TS_CONST = re.compile(r"(?:export\s+)?const (\w+)\s*(?::\s*\w+\s*)?=\s*(.+?);", re.M)
-
-
-def ts_consts(rel: str) -> dict[str, str]:
-    return {m.group(1): m.group(2).strip() for m in TS_CONST.finditer(stripped(rel))}
-
-
-# --------------------------------------------------------------------------
-# Kotlin type -> TypeScript type
-# --------------------------------------------------------------------------
-
-
-def kotlin_to_ts(kt: str) -> str:
-    """The TS spelling a Kotlin descriptor field must have. Total over the types in use."""
-    kt = kt.strip()
-    if kt.endswith("?"):
-        return f"{kotlin_to_ts(kt[:-1])} | null"
-    if kt in ("Int", "Long", "Double", "Float"):
-        return "number"
-    if kt == "String":
-        return "string"
-    if kt == "Boolean":
-        return "boolean"
-    m = re.fullmatch(r"List<(.+)>", kt)
-    if m:
-        return f"{kotlin_to_ts(m.group(1))}[]"
-    m = re.fullmatch(r"Map<\s*String\s*,\s*(.+)>", kt)
-    if m:
-        return f"Record<string, {kotlin_to_ts(m.group(1))}>"
-    return kt  # a named type: same name on both sides
-
-
-def ts_types_agree(kt: str, ts: str) -> bool:
-    want = kotlin_to_ts(kt)
-    norm = lambda s: re.sub(r"\s+", " ", s).strip()
-    if norm(want) == norm(ts):
-        return True
-    # `string | null` and `null | string` are the same type.
-    return sorted(p.strip() for p in norm(want).split("|")) == sorted(
-        p.strip() for p in norm(ts).split("|")
-    )
-
-
-# --------------------------------------------------------------------------
 # Checks
 # --------------------------------------------------------------------------
 
@@ -462,9 +350,7 @@ def check_versions(allowlist: dict, failures: list[str]) -> None:
 
     for site in sites:
         rel, symbol = site["file"], site["symbol"]
-        if rel.endswith(".ts") and _ts_root is None:
-            continue  # extension not checked out; see `ts_root`
-        consts = ts_consts(rel) if rel.endswith(".ts") else kotlin_consts(rel)
+        consts = kotlin_consts(rel)
         if symbol not in consts:
             failures.append(
                 f"  {rel}: `{symbol}` is registered as a schema-version mirror but no longer "
@@ -499,9 +385,6 @@ def check_versions(allowlist: dict, failures: list[str]) -> None:
     # does (no import needed), or imports it by name.
     by_package: dict[str, set[str]] = {}
     for s in sites:
-        # TypeScript sites have no Kotlin package and, post-split, may not be on disk at all.
-        if s["file"].endswith(".ts"):
-            continue
         by_package.setdefault(s["symbol"], set()).add(package_declared_in(s["file"]))
     # Scoped, not global. Binding `schemaVersionSites` by package while leaving aliases as a bare
     # name set was an inconsistency in my own fix: any writer with a local `schemaVersion` property
@@ -715,7 +598,7 @@ PACKAGE_LINE = re.compile(r"^\s*package\s+([\w.]+)", re.M)
 
 
 def package_declared_in(rel: str) -> str:
-    """The Kotlin package a file declares, or its directory for TypeScript."""
+    """The Kotlin package a file declares."""
     m = PACKAGE_LINE.search(stripped(rel))
     return m.group(1) if m else rel.rsplit("/", 1)[0]
 
@@ -772,43 +655,32 @@ PRUNE = {"build", "node_modules", ".git", ".gradle", "out", "dist", "scripts"}
 
 
 def walk_sources() -> list[tuple[str, str]]:
-    """`(relative path, comment-stripped text)` for every Kotlin/TypeScript source in the repo.
+    """`(relative path, comment-stripped text)` for every Kotlin source in the relevant trees.
 
     Prunes whole directories rather than filtering paths after the walk: `node_modules` and the
     per-module `build/` trees hold far more sources than the repo does, and descending into them
     to discard the results costs more than every other check here put together.
     """
     out: list[tuple[str, str]] = []
-    # Both roots, so the "unregistered mirror" arm still sees TypeScript. The extension's sources
-    # left this repo with it; scanning only REPO_ROOT would let a new TS mirror appear unregistered
-    # and keep reporting green — the exact blindness this discovery exists to prevent. Paths from
-    # the extension are relative to ITS root, which is how the allowlist spells them.
-    # Every root that can hold a copy of this schema. `daemon/protocol` used to be under
+    # Every root that can hold a Kotlin copy of this schema. `daemon/protocol` used to be under
     # REPO_ROOT, so its sources were walked for free; after the cutover they are in the contracts
     # repository and a new production file there could declare an unregistered mirror, or copy a
-    # descriptor with a stale literal, without this gate seeing it — the same blindness the
-    # extension's TypeScript would have had. Paths from an external root are relative to THAT
-    # root, which is how the allowlist spells them.
-    roots = (
-        [REPO_ROOT]
-        + ([_ts_root] if _ts_root is not None else [])
-        + ([_contracts_root] if _contracts_root is not None else [])
-    )
+    # descriptor with a stale literal, without this gate seeing it. Paths from the external root
+    # are relative to that root, which is how the allowlist spells them.
+    roots = [REPO_ROOT] + ([_contracts_root] if _contracts_root is not None else [])
     for root in roots:
         for dirpath, dirnames, filenames in os.walk(root):
             dirnames[:] = sorted(
                 d for d in dirnames if d not in PRUNE and not d.startswith(".")
             )
             for filename in sorted(filenames):
-                if not filename.endswith((".kt", ".ts")):
+                if not filename.endswith(".kt"):
                     continue
                 path = Path(dirpath) / filename
                 out.append(
                     (
                         path.relative_to(root).as_posix(),
-                        strip_comments(
-                            path.read_text(encoding="utf-8"), nested=not filename.endswith(".ts")
-                        ),
+                        strip_comments(path.read_text(encoding="utf-8")),
                     )
                 )
     return out
@@ -828,7 +700,6 @@ def check_reader(
     writer: dict[str, tuple[str, bool]],
     allowlist: dict,
     failures: list[str],
-    ts: bool,
 ) -> None:
     reader_only = allowlist["readerOnlyFields"].get(label, {})
 
@@ -860,12 +731,10 @@ def check_reader(
             continue
 
         wtype = writer[field][0]
-        agree = ts_types_agree(wtype, rtype) if ts else wtype == rtype
-        if not agree:
-            want = kotlin_to_ts(wtype) if ts else wtype
+        if wtype != rtype:
             failures.append(
                 f"  {rel}: `{field}` is `{rtype}` in the {label} reader but `{wtype}` in the "
-                f"writer (expected `{want}`)."
+                f"writer (expected `{wtype}`)."
             )
 
     for field, (wtype, has_default) in writer.items():
@@ -1025,24 +894,6 @@ def check() -> int:
             writer,
             allowlist,
             failures,
-            ts=False,
-        )
-    if TS_READER:
-        check_reader(
-            "vscode",
-            TS_READER,
-            ts_interface(TS_READER, "DaemonLaunchDescriptor"),
-            writer,
-            allowlist,
-            failures,
-            ts=True,
-        )
-    else:
-        print(
-            "check-daemon-launch-schema: SKIPPING the TypeScript reader — no "
-            "compose-preview-vscode checkout (set COMPOSE_PREVIEW_VSCODE_ROOT). "
-            "The Kotlin reader is still checked.",
-            file=sys.stderr,
         )
     check_unknown_key_tolerance(allowlist, failures)
     check_mirrored_constants(allowlist, failures)
@@ -1095,26 +946,6 @@ def check() -> int:
                 f"than letting it through unexamined."
             )
 
-    # `BtaCompileConfig` claims to be field-for-field across the two languages. Only checkable
-    # with the extension checked out; see `ts_root`. Guarded with `if`, never an early `return` —
-    # the exit-code handling below has to run either way.
-    if TS_READER:
-        kt_bta = kotlin_data_class(WRITER, "BtaCompileConfig")
-        ts_bta = ts_interface(TS_READER, "BtaCompileConfig")
-        if list(kt_bta) != list(ts_bta):
-            failures.append(
-                f"  BtaCompileConfig is not field-for-field across the two languages.\n"
-                f"    kotlin: {list(kt_bta)}\n    typescript: {list(ts_bta)}"
-            )
-        else:
-            for field, (ktype, _) in kt_bta.items():
-                if not ts_types_agree(ktype, ts_bta[field][0]):
-                    failures.append(
-                        f"  BtaCompileConfig.{field}: `{ktype}` in Kotlin vs "
-                        f"`{ts_bta[field][0]}` in TypeScript "
-                        f"(expected `{kotlin_to_ts(ktype)}`)."
-                    )
-
     if failures:
         print("check-daemon-launch-schema: FAILED", file=sys.stderr)
         for f in failures:
@@ -1125,8 +956,8 @@ def check() -> int:
     # Name the readers actually compared, and say which were skipped. A fixed "2 readers agree"
     # was fine while both lived here; now either can be absent, and a summary that claims two
     # while checking one is the failure this gate exists to prevent, printed in its own output.
-    checked = [name for name, rel in (("jvm", JVM_READER), ("vscode", TS_READER)) if rel]
-    skipped = [name for name, rel in (("jvm", JVM_READER), ("vscode", TS_READER)) if not rel]
+    checked = ["jvm"] if JVM_READER else []
+    skipped = [] if JVM_READER else ["jvm"]
     readers = f"{len(checked)} reader(s) agree ({', '.join(checked) or 'none'})"
     if skipped:
         readers += f", {len(skipped)} SKIPPED ({', '.join(skipped)}) — no checkout"

--- a/scripts/daemon-launch-schema-allowlist.json
+++ b/scripts/daemon-launch-schema-allowlist.json
@@ -1,6 +1,6 @@
 {
   "_doc": [
-    "The four representations of `<module>/build/compose-previews/daemon-launch.json`, and the",
+    "This repository's representations of `<module>/build/compose-previews/daemon-launch.json`,",
     "divergences between them that are correct on purpose. Checked by",
     "`scripts/check-daemon-launch-schema.py`. A debt register, not a config file: an entry is a",
     "claim someone made deliberately, with the reason written down, not an exemption to add when",
@@ -9,14 +9,15 @@
     "schemaVersionSites: every place the descriptor's schema version is declared. The check fails",
     "if any disagrees with the writer, and fails again if a `*DESCRIPTOR_SCHEMA_VERSION` appears",
     "anywhere that is not listed \u2014 a new mirror has to be declared here, which is the moment",
-    "someone can ask whether it should exist at all. The right long-term number of entries is 2",
-    "(the writer, and the TypeScript reader that cannot import Kotlin); the other two are Kotlin",
-    "and could read the writer's constant directly if `:render-session-subprocess` and `:cli`",
+    "someone can ask whether it should exist at all. The extension owns its TypeScript registry",
+    "and checks the published schema metadata for the plugin release it pins. The right long-term",
+    "number of entries here is 1: the other two are Kotlin and could read the writer's constant",
+    "directly if `:render-session-subprocess` and `:cli`",
     "took a dependency on `:gradle-plugin:daemon-launch-builder`. Until then they are mirrors,",
     "and mirrors need a gate rather than a comment asking a human to remember.",
     "",
     "readerOnlyFields: a field a reader declares that the plugin's writer never emits. Each must",
-    "carry a Kotlin default (or be `?:` in TypeScript), because a plugin-written descriptor will",
+    "carry a Kotlin default, because a plugin-written descriptor will",
     "not contain it. The check enforces that.",
     "",
     "writerOnlyFields: a field the writer emits that a reader does not declare. Safe only while",
@@ -62,12 +63,6 @@
       "why": "The source of truth. `DaemonLaunchBuilder` stamps it into every descriptor it writes, and it participates in `DaemonBootstrapTask`'s up-to-date fingerprint."
     },
     {
-      "file": "src/daemon/daemonProtocol.ts",
-      "symbol": "DAEMON_DESCRIPTOR_SCHEMA_VERSION",
-      "role": "reader",
-      "why": "The only reader that gates on the version: `daemonProcess.ts` refuses a descriptor whose `schemaVersion` differs. Cannot import the Kotlin constant, so this copy is unavoidable \u2014 which is exactly why it needs checking."
-    },
-    {
       "file": "render-session/subprocess/src/main/kotlin/ee/schimke/composeai/render/session/subprocess/SubprocessRenderSession.kt",
       "symbol": "DAEMON_DESCRIPTOR_SCHEMA_VERSION",
       "role": "second writer",
@@ -90,8 +85,7 @@
         "writtenBy": "the CLI's serve path (ServeBundleDaemon.kt, ServeCommand.kt) via DaemonLaunchDescriptor.jailed()",
         "why": "Wall-clock deadline after which the spawner force-kills a sandboxed daemon. Same sandbox-only origin as jailCommand; null by default."
       }
-    },
-    "vscode": {}
+    }
   },
   "writerOnlyFields": {
     "btaCompile": {

--- a/scripts/test_check_daemon_launch_schema.py
+++ b/scripts/test_check_daemon_launch_schema.py
@@ -3,12 +3,11 @@
 
 Pure stdlib (unittest). Run: python3 scripts/test_check_daemon_launch_schema.py -v
 
-Three things are worth pinning. The parsers, because a parser that silently
+Two things are worth pinning. The parsers, because a parser that silently
 mis-reads a declaration turns this gate into decoration — `Map<String, String>`
 in particular, whose top-level comma broke the first cut of the splitter and
-made an identical pair of declarations compare unequal. The Kotlin-to-TypeScript
-type correspondence, because that is the actual claim the check makes about two
-languages. And the real committed tree, which must be green and must have every
+made an identical pair of declarations compare unequal. And the real committed
+tree, which must be green and must have every
 registered site still present — the allowlist has to keep describing the code.
 """
 
@@ -25,17 +24,6 @@ _spec = importlib.util.spec_from_file_location(
 )
 mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mod)
-
-
-
-# The TypeScript half of this checker reads yschimke/compose-preview-vscode, which is a separate
-# repository. These tests need a checkout; without one they skip rather than fail, since "you have
-# not cloned the other repo" is not a drift signal. CI sets COMPOSE_PREVIEW_VSCODE_ROOT, so the
-# coverage is not lost where it counts.
-requires_ts_checkout = unittest.skipIf(
-    mod._ts_root is None,
-    "no compose-preview-vscode checkout (set COMPOSE_PREVIEW_VSCODE_ROOT)",
-)
 
 # Same again for the JVM reader, which moved to yschimke/compose-preview-contracts. The checker
 # itself skips the JVM half without a checkout; these tests reach past `check()` into
@@ -108,31 +96,6 @@ class StripComments(unittest.TestCase):
         self.assertEqual(list(mod.KT_FIELD.finditer(mod.strip_comments(src)))[0].group(1), "real")
 
 
-class KotlinToTypeScript(unittest.TestCase):
-    def test_scalars(self):
-        self.assertEqual(mod.kotlin_to_ts("Int"), "number")
-        self.assertEqual(mod.kotlin_to_ts("Long"), "number")
-        self.assertEqual(mod.kotlin_to_ts("String"), "string")
-        self.assertEqual(mod.kotlin_to_ts("Boolean"), "boolean")
-
-    def test_nullable_becomes_a_union_with_null(self):
-        self.assertEqual(mod.kotlin_to_ts("String?"), "string | null")
-
-    def test_collections(self):
-        self.assertEqual(mod.kotlin_to_ts("List<String>"), "string[]")
-        self.assertEqual(mod.kotlin_to_ts("Map<String, String>"), "Record<string, string>")
-
-    def test_a_named_type_keeps_its_name(self):
-        self.assertEqual(mod.kotlin_to_ts("BtaCompileConfig?"), "BtaCompileConfig | null")
-
-    def test_union_order_does_not_matter(self):
-        self.assertTrue(mod.ts_types_agree("String?", "null | string"))
-
-    def test_a_genuine_mismatch_is_still_a_mismatch(self):
-        self.assertFalse(mod.ts_types_agree("List<String>", "string"))
-        self.assertFalse(mod.ts_types_agree("String", "string | null"))
-
-
 class Parsers(unittest.TestCase):
     def test_the_writer_parses_to_the_fields_the_descriptor_documents(self):
         w = mod.kotlin_data_class(mod.WRITER, "DaemonClasspathDescriptor")
@@ -140,31 +103,6 @@ class Parsers(unittest.TestCase):
         self.assertEqual(w["javaLauncher"][0], "String?")
         self.assertFalse(w["schemaVersion"][1], "schemaVersion must have no default")
         self.assertTrue(w["btaCompile"][1], "btaCompile must default to null")
-
-    @requires_ts_checkout
-    def test_the_ts_reader_parses_and_marks_required_fields(self):
-        t = mod.ts_interface(mod.TS_READER, "DaemonLaunchDescriptor")
-        self.assertEqual(t["systemProperties"][0], "Record<string, string>")
-        self.assertFalse(t["schemaVersion"][1], "schemaVersion is not declared optional")
-
-
-class CommentNestingIsLanguageAware(unittest.TestCase):
-    """Kotlin's block comments nest; TypeScript's do not. Using one rule for both hides code."""
-
-    def test_typescript_ends_at_the_first_closer(self):
-        self.assertEqual(
-            mod.strip_comments("/* a /* b */ const x = 1", nested=False), " const x = 1"
-        )
-
-    def test_kotlin_needs_the_matching_closer(self):
-        self.assertEqual(
-            mod.strip_comments("/* a /* b */ z */ const x = 1", nested=True), " const x = 1"
-        )
-
-    def test_kotlin_would_swallow_what_typescript_keeps(self):
-        # The concrete hazard: under Kotlin's rule the TS declaration disappears from the scan.
-        self.assertNotIn("const x", mod.strip_comments("/* a /* b */ const x = 1", nested=True))
-
 
 class TestSourceSets(unittest.TestCase):
     """Excluding only `src/test` and `src/functionalTest` missed most of this repo's test trees."""
@@ -184,17 +122,6 @@ class TestSourceSets(unittest.TestCase):
 
     def test_main_is_not_a_test_source(self):
         self.assertFalse(mod.is_test_source("a/src/main/B.kt"))
-
-
-class TypeScriptConstants(unittest.TestCase):
-    def test_a_module_local_const_is_still_a_mirror(self):
-        # `export` is not what makes a constant dangerous; declaring a version is.
-        self.assertIn("X", dict(mod.TS_CONST.findall("const X = 2;")))
-        self.assertIn("Y", dict(mod.TS_CONST.findall("export const Y = 2;")))
-
-    def test_discovery_matches_a_non_exported_version_name(self):
-        found = mod.VERSION_NAME.findall("const ROGUE_DESCRIPTOR_SCHEMA_VERSION = 2;")
-        self.assertEqual(["ROGUE_DESCRIPTOR_SCHEMA_VERSION"], found)
 
 
 class WireFingerprint(unittest.TestCase):
@@ -240,14 +167,11 @@ class RealTree(unittest.TestCase):
     def test_repo_is_green(self):
         self.assertEqual(mod.check(), 0)
 
-    @requires_ts_checkout
     def test_every_registered_version_site_still_declares_its_symbol(self):
         for site in self.allowlist["schemaVersionSites"]:
             rel, symbol = site["file"], site["symbol"]
-            consts = mod.ts_consts(rel) if rel.endswith(".ts") else mod.kotlin_consts(rel)
-            self.assertIn(symbol, consts, f"{rel} no longer declares {symbol}")
+            self.assertIn(symbol, mod.kotlin_consts(rel), f"{rel} no longer declares {symbol}")
 
-    @requires_ts_checkout
     def test_discovery_finds_every_registered_site(self):
         # If discovery stopped seeing a site, rule 1's "unregistered mirror" arm would go blind
         # while everything still reported green.
@@ -266,13 +190,9 @@ class RealTree(unittest.TestCase):
             self.assertIn(field, jvm)
             self.assertTrue(jvm[field][1], f"{field} must default — the plugin never writes it")
 
-    @requires_ts_checkout
     @requires_contracts_checkout
     def test_each_writer_only_field_really_is_absent_from_the_readers_it_claims(self):
-        readers = {
-            "jvm": mod.kotlin_data_class(mod.JVM_READER, "DaemonLaunchDescriptor"),
-            "vscode": mod.ts_interface(mod.TS_READER, "DaemonLaunchDescriptor"),
-        }
+        readers = {"jvm": mod.kotlin_data_class(mod.JVM_READER, "DaemonLaunchDescriptor")}
         for field, spec in self.allowlist["writerOnlyFields"].items():
             for label in spec["invisibleTo"]:
                 self.assertNotIn(
@@ -312,11 +232,10 @@ class RealTree(unittest.TestCase):
     def test_no_registered_site_names_a_file_that_left_the_repository(self):
         # The allowlist is only a gate while every path in it resolves: a site whose file is gone is
         # checked vacuously, which is how serve's entry would have rotted after #4732 had it been
-        # left behind. The two readers that legitimately live in a sibling checkout
-        # (compose-preview-vscode, compose-preview-contracts) are exempt — the check already
-        # resolves those through `ts_root()` / `contracts_root()` and reports them as SKIPPED when
-        # no checkout is present, which is a stated outcome rather than silent rot.
-        external = {mod.TS_READER_REL, mod.JVM_READER_REL}
+        # left behind. The JVM reader legitimately lives in the contracts checkout and is exempt —
+        # the check resolves it through `contracts_root()` and reports it as SKIPPED when no
+        # checkout is present, which is a stated outcome rather than silent rot.
+        external = {mod.JVM_READER_REL}
         for site in self.allowlist["schemaVersionSites"]:
             if site["file"] in external:
                 continue
@@ -419,7 +338,6 @@ class RealTree(unittest.TestCase):
             for key, expected in assumed.items():
                 self.assertEqual(writer[key][0], expected, f"{rel}: {key}")
 
-    @requires_ts_checkout
     def test_a_stamp_resolves_by_package_not_by_bare_name(self):
         # `DaemonLaunchBuilder.kt` stamps a constant declared in a sibling file of the same
         # package, which must pass; a same-named symbol in an unrelated package must not.


### PR DESCRIPTION
## Summary
- remove the compose-preview-vscode checkout and environment plumbing from both CI jobs
- remove TypeScript parsing, cross-language shape comparison, and VS Code mirror registration from the provider-side checker
- retain the immutable provider wire fingerprint, Kotlin mirror discovery, pinned contracts reader comparison, and the contracts zero-skip CI guard
- reduce the gate by 324 net lines while preserving all 43 remaining schema tests

Depends on yschimke/compose-preview-vscode#26. That consumer PR validates its reader constant against schema metadata from the exact plugin release it pins and owns its repository-wide TypeScript mirror scan. Do not merge this cleanup before that consumer gate lands.

Closes #4836.

## Test plan
- `COMPOSE_PREVIEW_CONTRACTS_ROOT=/tmp/compose-preview-contracts-4836 python3 scripts/test_check_daemon_launch_schema.py -v` (43 passing, zero skipped)
- `COMPOSE_PREVIEW_CONTRACTS_ROOT=/tmp/compose-preview-contracts-4836 ./gradlew :cli:checkDaemonLaunchSchema :cli:ktfmtCheck --no-daemon`
- `./gradlew ktfmtFormat --no-daemon`
- `.github/scripts/agent-attribution-scan.sh --range origin/main..HEAD`