### PR TITLE
fix: validate the resolved Compose floor

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -10,7 +10,6 @@ import ee.schimke.composeai.daemonlaunch.*
 import ee.schimke.composeai.discovery.*
 import java.util.Collections
 import java.util.IdentityHashMap
-import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -680,10 +679,10 @@ internal object AndroidPreviewSupport {
    * instead means the renderer cannot link against it at all — #3590's `NoSuchMethodError`, on
    * every preview, with nothing explaining why.
    *
-   * Both silent outcomes are worse than saying so. `validateExternallyManagedDependencies` cannot:
-   * it checks that coordinates are DECLARED, never what they resolve to, and a BOM consumer
-   * declares no version at all. This fires from the resolution rule, which is the first place the
-   * real version exists.
+   * Both silent outcomes are worse than saying so. [ValidateComposeFloorTask] therefore walks the
+   * resolved render graph at task execution time. It sees Gradle's selected module versions after
+   * platforms, constraints, and conflict resolution have run, including BOM consumers that declare
+   * no versions themselves.
    */
   internal fun composeFloorOptOutMessage(module: String, resolved: String): String =
     """
@@ -732,14 +731,6 @@ internal object AndroidPreviewSupport {
     // exactly the artifact the floor exists to keep off the graph.
     configuration.resolutionStrategy.eachDependency {
       val req = requested
-      // Opt-out: we may not raise this graph, so a below-floor consumer cannot be rendered at all.
-      // Say so here rather than letting every preview die with a Compose-internal stack trace —
-      // resolution is the first point the real version is known (see [composeFloorOptOutMessage]).
-      if (!floorComposeLine && composeLineFloorUpgrade(req.group, req.version) != null) {
-        throw GradleException(
-          composeFloorOptOutMessage("${req.group}:${req.name}", req.version.orEmpty())
-        )
-      }
       val decision = renderGraphTarget(req.group, req.name, req.version, floorComposeLine)
       when {
         decision == null -> Unit
@@ -1929,15 +1920,6 @@ internal object AndroidPreviewSupport {
         // Raising the render graph there would put floor-version classes over the consumer's
         // own resources — the #3484 `R$id` NoSuchFieldError — so opt-out keeps the consumer's
         // line, whatever it is.
-        //
-        // KNOWN GAP: an opt-out consumer whose Compose is BELOW the floor still hits #3590's
-        // NoSuchMethodError, and nothing reports it — `validateExternallyManagedDependencies`
-        // checks that the required coordinates are DECLARED, never what they resolve to. Failing
-        // that validation on a below-floor compose-ui line is the fix, and it wants the resolved
-        // version rather than the declared one (a BOM consumer declares no version at all). Same
-        // root as the `enforcedPlatform` case: whenever the resource graph cannot be moved to the
-        // floor, the honest outcome is a configuration-time failure naming the required version,
-        // not a silently-raised render graph.
         applyRenderGraphResolutionRules(this, floorComposeLine = manageDependencies)
       }
 
@@ -2064,15 +2046,6 @@ internal object AndroidPreviewSupport {
         // Raising the render graph there would put floor-version classes over the consumer's
         // own resources — the #3484 `R$id` NoSuchFieldError — so opt-out keeps the consumer's
         // line, whatever it is.
-        //
-        // KNOWN GAP: an opt-out consumer whose Compose is BELOW the floor still hits #3590's
-        // NoSuchMethodError, and nothing reports it — `validateExternallyManagedDependencies`
-        // checks that the required coordinates are DECLARED, never what they resolve to. Failing
-        // that validation on a below-floor compose-ui line is the fix, and it wants the resolved
-        // version rather than the declared one (a BOM consumer declares no version at all). Same
-        // root as the `enforcedPlatform` case: whenever the resource graph cannot be moved to the
-        // floor, the honest outcome is a configuration-time failure naming the required version,
-        // not a silently-raised render graph.
         applyRenderGraphResolutionRules(this, floorComposeLine = manageDependencies)
       }
 
@@ -2102,6 +2075,29 @@ internal object AndroidPreviewSupport {
         "ee.schimke.composeai:daemon-android:${PluginVersion.value}",
       )
     }
+
+    // `eachDependency` exposes every edge's original requested selector, not the version Gradle
+    // selects after constraints, platforms and conflict resolution (issue #4959). Validate the
+    // authoritative resolved graph lazily at task execution instead. The daemon has a strict
+    // superset graph and can select a different version, so it gets its own validator.
+    val validateComposeFloorTask =
+      if (!manageDependencies) {
+        project.tasks.register(
+          "composePreviewValidateComposeFloor",
+          ValidateComposeFloorTask::class.java,
+        ) {
+          runtimeClasspathRoot.set(rendererConfig.incoming.resolutionResult.rootComponent)
+        }
+      } else null
+    val validateDaemonComposeFloorTask =
+      if (!manageDependencies) {
+        project.tasks.register(
+          "composePreviewValidateDaemonComposeFloor",
+          ValidateComposeFloorTask::class.java,
+        ) {
+          runtimeClasspathRoot.set(daemonRendererConfig.incoming.resolutionResult.rootComponent)
+        }
+      } else null
 
     // Classes used for Gradle's test-class scanning. Local mode: the
     // renderer-android project's compiled output directories. External
@@ -2400,6 +2396,7 @@ internal object AndroidPreviewSupport {
           // loads on the (17-or-newer) render test JVM.
           options.release.set(17)
           dependsOn(generateShardsTask)
+          validateComposeFloorTask?.let { dependsOn(it) }
           // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
           dependsOn(unitTestConfigProducer)
           // …and the screenshotTest classes dir, which `sourceClassDirs` adds to the render
@@ -2468,6 +2465,7 @@ internal object AndroidPreviewSupport {
         // resolved runtime classpath doesn't actually reach a preview-tooling coord (issue #1549).
         // Null when direct tooling was found (validator wasn't registered — nothing to depend on).
         validatePreviewToolingPresentTask?.let { dependsOn(it) }
+        validateComposeFloorTask?.let { dependsOn(it) }
         // Reads AGP's unit-test-config dir via `resolvedClasspath` (see unitTestConfigProducer).
         dependsOn(unitTestConfigProducer)
         // …and the screenshotTest classes dir on the render classpath (see the compile-shards
@@ -2787,6 +2785,7 @@ internal object AndroidPreviewSupport {
           resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
         include("**/ResourcePreviewRenderTest.class")
         useJUnit()
+        validateComposeFloorTask?.let { dependsOn(it) }
         // Same locale exposure as the main render task — resource names reach the report path too.
         configureRenderTaskReporting(this)
 
@@ -2866,6 +2865,7 @@ internal object AndroidPreviewSupport {
       project.tasks.register("composePreviewRenderXr", Test::class.java) {
         group = "compose preview"
         description = "Render XR subspace previews to scene.json via Robolectric"
+        validateComposeFloorTask?.let { dependsOn(it) }
         val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
         testClassesDirs = xrRendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
         // AGP-only extras (unit-test merged R.jar, generated dirs); the module artifacts come
@@ -3351,6 +3351,7 @@ internal object AndroidPreviewSupport {
       "composePreviewDaemonStart",
       ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask::class.java,
     ) {
+      validateDaemonComposeFloorTask?.let { dependsOn(it) }
       // Resolved once when the task is realised — the register {…} block runs lazily at
       // task-graph-resolution time, by which point AGP has registered the unit-test task.
       // Pulling the reference here (rather than wrapping `findByName` in a Provider that

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposeFloorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposeFloorTask.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Validates the Compose line selected for an externally managed Android render graph.
+ *
+ * The check deliberately consumes a [ResolvedComponentResult], rather than inspecting
+ * `ResolutionStrategy.eachDependency`'s `requested` selector. The latter is one original edge in
+ * the graph; platforms, constraints, and conflict resolution can select a different version for the
+ * module. Resolving lazily from a task also avoids resolving the render configuration during
+ * project configuration, which would break configuration-cache and Isolated Projects consumers.
+ */
+@DisableCachingByDefault(
+  because =
+    "Check depends on live render-classpath resolution; caching could stale-pass a dependency version change."
+)
+abstract class ValidateComposeFloorTask : DefaultTask() {
+
+  @get:Internal abstract val runtimeClasspathRoot: Property<ResolvedComponentResult>
+
+  init {
+    group = "compose preview"
+    description = "Validate the resolved Compose version used by an externally managed render"
+  }
+
+  @TaskAction
+  fun validate() {
+    val belowFloor = findBelowFloor(runtimeClasspathRoot.get()) ?: return
+    throw GradleException(
+      AndroidPreviewSupport.composeFloorOptOutMessage(belowFloor.module, belowFloor.version)
+    )
+  }
+
+  internal data class ResolvedComposeModule(val module: String, val version: String)
+
+  internal companion object {
+    /** Returns the first selected Compose module below the renderer's link floor, if any. */
+    internal fun findBelowFloor(root: ResolvedComponentResult): ResolvedComposeModule? {
+      val belowFloor = mutableListOf<ResolvedComposeModule>()
+      val visited = HashSet<ResolvedComponentResult>()
+      val queue = ArrayDeque<ResolvedComponentResult>()
+      queue.add(root)
+      while (queue.isNotEmpty()) {
+        val component = queue.removeFirst()
+        if (!visited.add(component)) continue
+        val id = component.id
+        if (
+          id is ModuleComponentIdentifier &&
+            AndroidPreviewSupport.composeLineFloorUpgrade(id.group, id.version) != null
+        ) {
+          belowFloor += ResolvedComposeModule("${id.group}:${id.module}", id.version)
+        }
+        for (dependency in component.dependencies) {
+          if (dependency is ResolvedDependencyResult) queue.add(dependency.selected)
+        }
+      }
+      return belowFloor.minWithOrNull(compareBy({ it.module }, { it.version }))
+    }
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposeLineFloorTest.kt
@@ -119,9 +119,9 @@ class ComposeLineFloorTest {
     // androidx.compose.ui:ui is on the main variant"). Raising the render graph there would put
     // floor-version classes over the consumer's older resources — the #3484 R$id NoSuchFieldError.
     //
-    // The DECISION is still "do not raise"; the resolution rule additionally throws
-    // composeFloorOptOutMessage for this case, so the consumer gets told rather than silently
-    // rendering nothing. Kept separate so the pure decision stays testable on its own.
+    // The DECISION is still "do not raise"; ValidateComposeFloorTask checks the selected graph
+    // before rendering and reports composeFloorOptOutMessage for this case. Kept separate so the
+    // pure resolution-rule decision stays testable on its own.
     assertThat(
         AndroidPreviewSupport.renderGraphTarget(
           group = "androidx.compose.ui",

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposeFloorTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposeFloorTaskTest.kt
@@ -1,0 +1,91 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ValidateComposeFloorTaskTest {
+
+  @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `requested version below floor passes when a strict constraint selects above floor`() {
+    val repository = temporaryFolder.newFolder("repository")
+    publishModule(repository, "androidx.compose.foundation", "foundation", "1.6.5")
+    publishModule(repository, "androidx.compose.foundation", "foundation", "1.10.2")
+    val project =
+      ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder("project")).build()
+    project.repositories.maven { url = project.uri(repository) }
+    val classpath = project.configurations.create("renderClasspath") { isCanBeResolved = true }
+    project.dependencies.add(classpath.name, "androidx.compose.foundation:foundation:1.6.5")
+    project.dependencies.constraints.add(
+      classpath.name,
+      "androidx.compose.foundation:foundation",
+    ) {
+      version { strictly("1.10.2") }
+    }
+
+    // This used to throw from eachDependency after reading the original 1.6.5 request, before
+    // Gradle could expose the 1.10.2 selection made by the strict constraint.
+    AndroidPreviewSupport.applyRenderGraphResolutionRules(classpath, floorComposeLine = false)
+    val root = classpath.incoming.resolutionResult.rootComponent.get()
+
+    assertThat(ValidateComposeFloorTask.findBelowFloor(root)).isNull()
+    val requestedEdge =
+      root.dependencies
+        .filterIsInstance<org.gradle.api.artifacts.result.ResolvedDependencyResult>()
+        .single { !it.isConstraint }
+    assertThat(requestedEdge.requested.displayName)
+      .contains("androidx.compose.foundation:foundation:1.6.5")
+    assertThat(requestedEdge.selected.id.displayName)
+      .contains("androidx.compose.foundation:foundation:1.10.2")
+  }
+
+  @Test
+  fun `selected version below floor is still rejected`() {
+    val repository = temporaryFolder.newFolder("repository")
+    publishModule(repository, "androidx.compose.ui", "ui", "1.9.5")
+    val project =
+      ProjectBuilder.builder().withProjectDir(temporaryFolder.newFolder("project")).build()
+    project.repositories.maven { url = project.uri(repository) }
+    val classpath = project.configurations.create("renderClasspath") { isCanBeResolved = true }
+    project.dependencies.add(classpath.name, "androidx.compose.ui:ui:1.9.5")
+    AndroidPreviewSupport.applyRenderGraphResolutionRules(classpath, floorComposeLine = false)
+    val root = classpath.incoming.resolutionResult.rootComponent.get()
+
+    assertThat(ValidateComposeFloorTask.findBelowFloor(root))
+      .isEqualTo(ValidateComposeFloorTask.ResolvedComposeModule("androidx.compose.ui:ui", "1.9.5"))
+
+    val task =
+      project.tasks.register("validateComposeFloor", ValidateComposeFloorTask::class.java).get()
+    task.runtimeClasspathRoot.set(root)
+    val failure = assertThrows(GradleException::class.java) { task.validate() }
+    assertThat(failure).hasMessageThat().contains("androidx.compose.ui:ui resolves to 1.9.5")
+    assertThat(failure)
+      .hasMessageThat()
+      .contains(AndroidPreviewSupport.RENDERER_COMPOSE_LINK_FLOOR_VERSION)
+  }
+
+  private fun publishModule(repository: File, group: String, module: String, version: String) {
+    val moduleDir = repository.resolve(group.replace('.', '/')).resolve(module).resolve(version)
+    moduleDir.mkdirs()
+    moduleDir
+      .resolve("$module-$version.pom")
+      .writeText(
+        """
+      <project xmlns="http://maven.apache.org/POM/4.0.0">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>$group</groupId>
+        <artifactId>$module</artifactId>
+        <version>$version</version>
+      </project>
+      """
+          .trimIndent()
+      )
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidatePreviewToolingPresentTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidatePreviewToolingPresentTaskTest.kt
@@ -11,15 +11,36 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.junit.Test
 
 /**
- * Pins the resolved-graph walk used by both the render-path gate
- * ([ValidatePreviewToolingPresentTask.containsPreviewTooling]) and the doctor task's at-action
- * transitive-detection signal.
+ * Pins the resolved-graph walks used by the render-path gates: preview-tooling presence
+ * ([ValidatePreviewToolingPresentTask.containsPreviewTooling]) and the externally managed Compose
+ * floor ([ValidateComposeFloorTask.findBelowFloor]).
  *
  * Hand-rolled stubs for `ResolvedComponentResult` because Gradle's TestKit fixtures don't make
  * isolated graph construction easy. We're only exercising the BFS + coord matching here — the
  * fixture intentionally implements no more than the walk consumes.
  */
 class ValidatePreviewToolingPresentTaskTest {
+
+  @Test
+  fun `compose floor validation uses the selected version rather than the requested edge`() {
+    val selected =
+      moduleNode("androidx.compose.foundation", "foundation", "1.10.2", dependencies = emptyList())
+    val app = moduleNode("com.example", "app", "1.0", dependencies = listOf(resolvedDep(selected)))
+
+    // StubResolvedDependency.requested deliberately throws. A regression to inspecting the
+    // original edge selector (the issue #4959 bug) therefore fails this test, while the selected
+    // 1.10.2 component correctly passes the 1.10.0 floor.
+    assertThat(ValidateComposeFloorTask.findBelowFloor(app)).isNull()
+  }
+
+  @Test
+  fun `compose floor validation reports a selected module below the floor`() {
+    val selected = moduleNode("androidx.compose.ui", "ui", "1.9.5", dependencies = emptyList())
+    val app = moduleNode("com.example", "app", "1.0", dependencies = listOf(resolvedDep(selected)))
+
+    assertThat(ValidateComposeFloorTask.findBelowFloor(app))
+      .isEqualTo(ValidateComposeFloorTask.ResolvedComposeModule("androidx.compose.ui:ui", "1.9.5"))
+  }
 
   @Test
   fun `direct preview tooling coord on the root is detected`() {


### PR DESCRIPTION
## Summary
- move the externally managed Compose floor check from per-edge requested selectors to the resolved component graph
- validate the one-shot, sharded, resource, XR, and daemon render graphs lazily at task execution
- retain the actionable below-floor failure while accepting strict constraints and platforms that select a compatible version

## Tests
- `./gradlew :gradle-plugin:test :gradle-plugin:ktfmtCheck`
- `./gradlew :gradle-plugin:functionalTest`
- real Gradle resolution regression: `foundation:1.6.5` requested, strict `1.10.2` selected
- `./gradlew :gradle-plugin:check` reaches an unrelated failure already present on the current base: `RobolectricRenderTask` lacks a cacheability annotation in `validatePlugins`

Fixes #4959