### PR TITLE
fix(figma-svg): preserve indication overlay geometry

### DIFF
--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -7,6 +7,7 @@ import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -159,6 +160,74 @@ class OverrideIntegrationTest {
       } else {
         System.setProperty(PreviewIndex.PREVIEWS_JSON_PATH_PROP, previousPreviewsJson)
       }
+    }
+  }
+
+  /** The Android platform-ripple half of #4639's cross-backend acceptance criteria. */
+  @Test
+  fun materialButtonInteractionVariantsExportTheStateTheyName() {
+    val outputDir = tempFolder.newFolder("renders-material-button-interactions")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val baseId = "MaterialButton_Light"
+    val focusedId = "MaterialButton_Light_VARIANT_focused"
+    val pressedId = "MaterialButton_Light_VARIANT_pressed"
+    fun entry(id: String, interaction: OverrideVariantInteraction? = null) =
+      PreviewManifestEntry(
+        id = id,
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "MaterialButtonInteractionState",
+        widthPx = 96,
+        heightPx = 48,
+        density = 1.0f,
+        outputBaseName = id,
+        overrides =
+          interaction?.let { OverrideVariantSpec(name = it.name.lowercase(), interaction = it) },
+      )
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                entry(baseId),
+                entry(focusedId, OverrideVariantInteraction.Focused),
+                entry(pressedId, OverrideVariantInteraction.Pressed),
+              )
+          )
+      )
+    host.start()
+    try {
+      for (id in listOf(baseId, focusedId, pressedId)) {
+        host.submit(RenderRequest.Render(payload = "previewId=$id"), timeoutMs = 60_000)
+      }
+      val dataDir = outputDir.parentFile!!.resolve("data")
+      fun svg(id: String) = dataDir.resolve(id).resolve("compose-figma.svg").readText()
+      fun png(id: String) = outputDir.resolve("$id.png").readBytes()
+
+      assertNotEquals(
+        "focused Material button PNG must not stay resting",
+        png(baseId).contentHashCode(),
+        png(focusedId).contentHashCode(),
+      )
+      assertNotEquals(
+        "pressed Material button PNG must not stay resting",
+        png(baseId).contentHashCode(),
+        png(pressedId).contentHashCode(),
+      )
+      assertTrue("focused SVG keeps the editable base fill", svg(focusedId).contains("#6750A4"))
+      assertTrue(
+        "focused SVG emits Android's inherited state layer above content",
+        svg(focusedId).contains("id=\"Material State Layer\""),
+      )
+      assertTrue(
+        "pressed SVG emits Android's platform ripple above content",
+        svg(pressedId).contains("id=\"Material Press Ripple\""),
+      )
+      assertNotEquals("focused SVG must not stay resting", svg(baseId), svg(focusedId))
+      assertNotEquals("pressed SVG must not stay resting", svg(baseId), svg(pressedId))
+    } finally {
+      host.shutdown()
     }
   }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -172,6 +172,7 @@ class OverrideIntegrationTest {
     val baseId = "MaterialButton_Light"
     val focusedId = "MaterialButton_Light_VARIANT_focused"
     val pressedId = "MaterialButton_Light_VARIANT_pressed"
+    val restingAfterPressId = "MaterialButton_Light_AFTER_pressed"
     fun entry(id: String, interaction: OverrideVariantInteraction? = null) =
       PreviewManifestEntry(
         id = id,
@@ -193,12 +194,13 @@ class OverrideIntegrationTest {
                 entry(baseId),
                 entry(focusedId, OverrideVariantInteraction.Focused),
                 entry(pressedId, OverrideVariantInteraction.Pressed),
+                entry(restingAfterPressId),
               )
           )
       )
     host.start()
     try {
-      for (id in listOf(baseId, focusedId, pressedId)) {
+      for (id in listOf(baseId, focusedId, pressedId, restingAfterPressId)) {
         host.submit(RenderRequest.Render(payload = "previewId=$id"), timeoutMs = 60_000)
       }
       val dataDir = outputDir.parentFile!!.resolve("data")
@@ -223,6 +225,10 @@ class OverrideIntegrationTest {
       assertTrue(
         "pressed SVG emits Android's platform ripple above content",
         svg(pressedId).contains("id=\"Material Press Ripple\""),
+      )
+      assertTrue(
+        "a retained Android ripple host must not create a press overlay after release",
+        !svg(restingAfterPressId).contains("id=\"Material Press Ripple\""),
       )
       assertNotEquals("focused SVG must not stay resting", svg(baseId), svg(focusedId))
       assertNotEquals("pressed SVG must not stay resting", svg(baseId), svg(pressedId))

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -274,6 +275,16 @@ fun InteractionStateSquare() {
           interactionSource = interactionSource,
         )
   )
+}
+
+/** Android's platform-ripple counterpart to the desktop Material indication fixture. */
+@Composable
+fun MaterialButtonInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Button(onClick = {}, modifier = Modifier.fillMaxSize()) {
+      Box(modifier = Modifier.size(8.dp).background(MaterialTheme.colorScheme.onPrimary))
+    }
+  }
 }
 
 @Composable

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -447,6 +447,88 @@ class OverrideIntegrationTest {
   }
 
   @Test
+  fun capturedVectorLeafRetainsItsIndicationOverlay() {
+    val svg = renderFocusedSvg("VectorIndication", "VectorIndicationInteractionState", 96, 48)
+    assertTrue("captured vector path must remain editable", svg.contains("<path"))
+    assertTrue(
+      "vector leaf must retain its final indication child",
+      svg.contains("Material State Layer"),
+    )
+    assertTrue(
+      "indication must paint after the captured vector",
+      svg.lastIndexOf("Material State Layer") > svg.lastIndexOf("<path"),
+    )
+  }
+
+  @Test
+  fun nonUniformScaleTransformsRippleIntoAnEllipse() {
+    val svg = renderFocusedSvg("ScaledIndication", "ScaledIndicationInteractionState", 128, 64)
+    val stateLayer = svg.substringAfter("id=\"Material State Layer\"").substringBefore("</g>")
+    val points =
+      Regex("""[ML](-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)""")
+        .findAll(stateLayer)
+        .map { it.groupValues[1].toDouble() to it.groupValues[2].toDouble() }
+        .toList()
+    assertTrue(
+      "20px radius at scaleX=2 must become 80px wide: $stateLayer",
+      abs(points.maxOf { it.first } - points.minOf { it.first } - 80.0) < 0.01,
+    )
+    assertTrue(
+      "20px radius at scaleY=0.5 must become 20px high: $stateLayer",
+      abs(points.maxOf { it.second } - points.minOf { it.second } - 20.0) < 0.01,
+    )
+    assertTrue(
+      "non-uniformly scaled circle must export an ellipse contour",
+      stateLayer.contains("<path"),
+    )
+  }
+
+  private fun renderFocusedSvg(
+    id: String,
+    functionName: String,
+    widthPx: Int,
+    heightPx: Int,
+  ): String {
+    val outputDir = tempFolder.newFolder("renders-$id")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                PreviewManifestEntry(
+                  id = id,
+                  className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+                  functionName = functionName,
+                  widthPx = widthPx,
+                  heightPx = heightPx,
+                  density = 1.0f,
+                  outputBaseName = id,
+                  overrides =
+                    OverrideVariantSpec(
+                      name = "focused",
+                      interaction = OverrideVariantInteraction.Focused,
+                    ),
+                )
+              )
+          ),
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(FocusPreviewOverrideExtension()))
+          ),
+      )
+    host.start()
+    return try {
+      host.submit(RenderRequest.Render(payload = "previewId=$id"), timeoutMs = 60_000)
+      outputDir.parentFile!!.resolve("data").resolve(id).resolve("compose-figma.svg").readText()
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun widthPxOverrideChangesRenderedDimensions() {
     val outputDir = tempFolder.newFolder("renders-width")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -318,15 +318,23 @@ class OverrideIntegrationTest {
       fun svg(id: String) = dataDir.resolve(id).resolve("compose-figma.svg").readText()
       fun png(id: String) = outputDir.resolve("$id.png").readBytes()
       fun containerPixel(id: String) = ImageIO.read(outputDir.resolve("$id.png")).getRGB(10, 24)
-      fun hasFillNearPixel(svg: String, argb: Int): Boolean {
-        val target = intArrayOf(argb shr 16 and 0xFF, argb shr 8 and 0xFF, argb and 0xFF)
-        return Regex("""fill="(#(?:[0-9A-Fa-f]{6}))""")
-          .findAll(svg)
-          .map { it.groupValues[1].removePrefix("#").toInt(16) }
-          .any { fill ->
-            val actual = intArrayOf(fill shr 16 and 0xFF, fill shr 8 and 0xFF, fill and 0xFF)
-            actual.indices.all { abs(actual[it] - target[it]) <= 1 }
+      fun composite(destination: Int, source: Int, alpha: Float): Int {
+        fun channel(shift: Int): Int {
+          val dst = destination shr shift and 0xFF
+          val src = source shr shift and 0xFF
+          return (src * alpha + dst * (1f - alpha)).toInt()
+        }
+        return channel(16).shl(16) or channel(8).shl(8) or channel(0)
+      }
+      fun assertPixelNear(message: String, expected: Int, actual: Int) {
+        val close =
+          listOf(16, 8, 0).all { shift ->
+            abs((expected shr shift and 0xFF) - (actual shr shift and 0xFF)) <= 1
           }
+        assertTrue(
+          "$message: expected #%06X, actual #%06X".format(expected, actual and 0xFFFFFF),
+          close,
+        )
       }
       assertNotEquals(
         "focused Material button PNG must not stay resting",
@@ -348,13 +356,90 @@ class OverrideIntegrationTest {
         svg(baseId),
         svg(pressedId),
       )
+      assertTrue("focused SVG keeps the editable base fill", svg(focusedId).contains("#6750A4"))
       assertTrue(
-        "focused SVG fill must match the captured Material state-layer pixel",
-        hasFillNearPixel(svg(focusedId), containerPixel(focusedId)),
+        "focused SVG emits the indication after content",
+        svg(focusedId).contains("id=\"Material State Layer\""),
       )
       assertTrue(
-        "pressed SVG fill must match the captured Material ripple pixel",
-        hasFillNearPixel(svg(pressedId), containerPixel(pressedId)),
+        "pressed SVG emits the press ripple after content",
+        svg(pressedId).contains("id=\"Material Press Ripple\""),
+      )
+      val focusedExpected = composite(0x6750A4, 0xFFFFFF, 0.1f)
+      val pressedExpected = composite(focusedExpected, 0xFFFFFF, 0.1f)
+      assertPixelNear(
+        "focused overlay must match the captured Material state-layer pixel",
+        focusedExpected,
+        containerPixel(focusedId),
+      )
+      assertPixelNear(
+        "pressed overlays must match the captured Material ripple pixel",
+        pressedExpected,
+        containerPixel(pressedId),
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /** Follow-up coverage for the geometry, compositing, ordering and tokenless review findings. */
+  @Test
+  fun customIndicationPreservesItsOverlayGeometryAndDrawOrder() {
+    val outputDir = tempFolder.newFolder("renders-custom-indication")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val id = "CustomIndication_Focused"
+    val host =
+      PreviewManifestRouter(
+        manifest =
+          PreviewManifest(
+            previews =
+              listOf(
+                PreviewManifestEntry(
+                  id = id,
+                  className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+                  functionName = "CustomIndicationInteractionState",
+                  widthPx = 96,
+                  heightPx = 48,
+                  density = 1.0f,
+                  outputBaseName = id,
+                  overrides =
+                    OverrideVariantSpec(
+                      name = "focused",
+                      interaction = OverrideVariantInteraction.Focused,
+                    ),
+                )
+              )
+          ),
+        engine =
+          RenderEngine(
+            previewOverrideExtensions =
+              PreviewOverrideExtensions(listOf(FocusPreviewOverrideExtension()))
+          ),
+      )
+    host.start()
+    try {
+      host.submit(RenderRequest.Render(payload = "previewId=$id"), timeoutMs = 60_000)
+      val svg =
+        outputDir.parentFile!!.resolve("data").resolve(id).resolve("compose-figma.svg").readText()
+      assertTrue("gradient ancestor must remain editable", svg.contains("<linearGradient"))
+      assertTrue(
+        "tokenless clickable must emit its state layer",
+        svg.contains("Material State Layer"),
+      )
+      assertTrue(
+        "explicit 20dp ripple radius must export as a 40px circle",
+        svg.contains("width=\"40\" height=\"40\""),
+      )
+      assertFalse(
+        "unbounded indication must not gain a clip path",
+        svg
+          .substringAfter("id=\"Material Indication\"")
+          .substringBefore("</g>")
+          .contains("clip-path"),
+      )
+      assertTrue(
+        "state layer must be emitted after the clickable's green child",
+        svg.lastIndexOf("Material State Layer") > svg.lastIndexOf("#00FF00"),
       )
     } finally {
       host.shutdown()

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -1779,6 +1780,38 @@ fun CustomIndicationInteractionState() {
       ) {
         Box(modifier = Modifier.fillMaxSize().background(Color.Green))
       }
+    }
+  }
+}
+
+/** A clickable Canvas whose ordinary captured-vector leaf must retain its indication above it. */
+@Composable
+fun VectorIndicationInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Canvas(modifier = Modifier.size(32.dp).clickable {}) { drawRect(Color.Green) }
+    }
+  }
+}
+
+/** An unbounded ripple transformed to 2× horizontally and 0.5× vertically. */
+@Composable
+fun ScaledIndicationInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Box(
+        modifier =
+          Modifier.size(width = 32.dp, height = 24.dp)
+            .graphicsLayer {
+              scaleX = 2f
+              scaleY = 0.5f
+            }
+            .clickable(
+              interactionSource = remember { MutableInteractionSource() },
+              indication = ripple(bounded = false, radius = 20.dp),
+            ) {}
+            .background(Color.Green)
+      )
     }
   }
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.lightColorScheme
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -55,6 +56,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
@@ -1752,6 +1754,31 @@ fun MaterialButtonInteractionState() {
   MaterialTheme(colorScheme = lightColorScheme()) {
     Button(onClick = {}, modifier = Modifier.fillMaxSize()) {
       Box(modifier = Modifier.size(8.dp).background(MaterialTheme.colorScheme.onPrimary))
+    }
+  }
+}
+
+/**
+ * An unbounded, tokenless indication above coloured content and a gradient ancestor. This pins the
+ * indication's geometry and draw order without relying on a Material component container fill.
+ */
+@Composable
+fun CustomIndicationInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Box(
+      modifier =
+        Modifier.fillMaxSize().background(Brush.horizontalGradient(listOf(Color.Red, Color.Blue))),
+      contentAlignment = Alignment.Center,
+    ) {
+      Box(
+        modifier =
+          Modifier.size(width = 32.dp, height = 24.dp).clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = ripple(bounded = false, radius = 20.dp),
+          ) {}
+      ) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.Green))
+      }
     }
   }
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1273,8 +1273,44 @@ internal object ComposeLayoutInspector {
           info.coordinates.boundsIn(rootCoords)
         }
       } else null
+    val ownerId = semanticsId?.toString() ?: identityId
+    val indications = LayoutTreeAccess.indications(modifiers, rootCoords)
+    val resolvedTokens =
+      ModifierTokenResolver.resolve(
+          modifierInfo = modifiers,
+          measurePolicy = measurePolicy,
+          sizeWidthPx = width,
+          sizeHeightPx = height,
+          density = density,
+        )
+        // The box the fill/ring modifier drew into, measured off its own coordinator in the same
+        // root space as `placedBounds` — the direct answer to the question `paintInset` and the
+        // measured-size growth heuristic can only estimate (issue #3572).
+        //
+        // The FILL's modifier is preferred over a ring's, matching the precedence the resolver
+        // itself uses: one box cannot describe both when a chain pads between them, and the fill
+        // is the layer's dominant paint (a ring that resolves fully transparent is dropped by the
+        // renderer outright, so taking its outer box would stretch a visible background over a
+        // region nothing painted). A ring-only node — an `OutlinedCard`, a divider — still gets
+        // its own box from the `border`.
+        ?.let { resolved ->
+          val hasVisibleFill =
+            resolved.backgroundGradient != null ||
+              resolved.backgroundColor?.let { color ->
+                color.length >= 3 && !color.substring(1, 3).equals("00", ignoreCase = true)
+              } == true
+          val paint =
+            modifiers.firstOrNull {
+              hasVisibleFill && ModifierTokenResolver.fillsContainer(it.modifier)
+            } ?: modifiers.firstOrNull { ModifierTokenResolver.ringsContainer(it.modifier) }
+          paint
+            ?.coordinates
+            ?.boundsIn(rootCoords)
+            ?.takeIf { it.right > it.left && it.bottom > it.top }
+            ?.let { resolved.copy(paintBox = it) } ?: resolved
+        }
     return LayoutInspectorNode(
-      nodeId = semanticsId?.toString() ?: identityId,
+      nodeId = ownerId,
       component = ownComponent,
       displayName = displayComponent.takeIf { it != ownComponent },
       source = source?.source,
@@ -1291,41 +1327,7 @@ internal object ComposeLayoutInspector {
       // chain + measure policy + measured size this node already carries — `layout/inspector` is
       // the
       // canonical home for the modifier-derived token projection.
-      tokens =
-        ModifierTokenResolver.resolve(
-            modifierInfo = modifiers,
-            measurePolicy = measurePolicy,
-            sizeWidthPx = width,
-            sizeHeightPx = height,
-            density = density,
-          )
-          // The box the fill/ring modifier drew into, measured off its own coordinator in the same
-          // root space as `placedBounds` — the direct answer to the question `paintInset` and the
-          // measured-size growth heuristic can only estimate (issue #3572).
-          //
-          // The FILL's modifier is preferred over a ring's, matching the precedence the resolver
-          // itself uses: one box cannot describe both when a chain pads between them, and the fill
-          // is the layer's dominant paint (a ring that resolves fully transparent is dropped by the
-          // renderer outright, so taking its outer box would stretch a visible background over a
-          // region nothing painted). A ring-only node — an `OutlinedCard`, a divider — still gets
-          // its own box from the `border`.
-          ?.let { resolved ->
-            val hasVisibleFill =
-              resolved.backgroundGradient != null ||
-                resolved.backgroundColor?.let { color ->
-                  color.length >= 3 && !color.substring(1, 3).equals("00", ignoreCase = true)
-                } == true
-            val paint =
-              modifiers.firstOrNull {
-                hasVisibleFill && ModifierTokenResolver.fillsContainer(it.modifier)
-              } ?: modifiers.firstOrNull { ModifierTokenResolver.ringsContainer(it.modifier) }
-            paint
-              ?.coordinates
-              ?.boundsIn(rootCoords)
-              ?.takeIf { it.right > it.left && it.bottom > it.top }
-              ?.let { resolved.copy(paintBox = it) } ?: resolved
-          }
-          ?.let { resolved -> applyStateLayers(resolved, LayoutTreeAccess.stateLayers(modifiers)) },
+      tokens = resolvedTokens,
       curvedTexts = curvedTexts,
       vectorGraphic = vectorGraphic,
       // The content-loading placeholder this chain declares, plus whether it is currently visible
@@ -1347,7 +1349,10 @@ internal object ComposeLayoutInspector {
       modifiesDrawnContent =
         DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
       transform = coordinates.scaleIn(rootCoords),
-      children = children,
+      // A Material indication is a draw-over operation: `RippleNode.draw` calls `drawContent()`
+      // before its focus state layer and press ripple. Keep it as the final child so gradients,
+      // icons, images and tokenless custom content are tinted in the same order as the real frame.
+      children = children + indications.mapIndexed { index, it -> it.toWireNode(ownerId, index) },
     )
   }
 
@@ -1410,54 +1415,54 @@ internal object ComposeLayoutInspector {
     return transform.takeIf { it.scaled || it.rotated }
   }
 
-  /**
-   * Composites the live Material ripple node's settled state layers into the editable container
-   * fill.
-   *
-   * Material's indication is a delegated [androidx.compose.ui.node.DrawModifierNode], not an
-   * inspectable modifier element. The frame therefore draws focus / hover / press correctly while
-   * the token-only SVG keeps the resting fill. A settled opacity indication is still a flat fill:
-   * folding it into [ComposeSemanticsTokens.backgroundColor] preserves the editable shape and its
-   * children instead of rasterising the whole component.
-   */
-  private fun applyStateLayers(
-    tokens: ComposeSemanticsTokens,
-    layers: List<LayoutTreeAccess.StateLayer>,
-  ): ComposeSemanticsTokens {
-    if (layers.isEmpty()) return tokens
-    val destination = parseArgb(tokens.backgroundColor) ?: 0
-    var alpha = ((destination ushr 24) and 0xFF) / 255f
-    var red = ((destination ushr 16) and 0xFF).toFloat()
-    var green = ((destination ushr 8) and 0xFF).toFloat()
-    var blue = (destination and 0xFF).toFloat()
-    for (layer in layers) {
-      val sourceAlpha = ((layer.argb ushr 24) and 0xFF) / 255f * layer.alpha.coerceIn(0f, 1f)
-      val outputAlpha = sourceAlpha + alpha * (1f - sourceAlpha)
-      if (outputAlpha <= 0f) continue
-      fun channel(source: Int, destination: Float): Float =
-        (source * sourceAlpha + destination * alpha * (1f - sourceAlpha)) / outputAlpha
-      red = channel((layer.argb ushr 16) and 0xFF, red)
-      green = channel((layer.argb ushr 8) and 0xFF, green)
-      blue = channel(layer.argb and 0xFF, blue)
-      alpha = outputAlpha
-    }
-    // Skia converts its floating paint result to 8-bit channels by truncation. Keep the whole
-    // stack in float until here (focus + press otherwise rounds twice), then match that conversion.
-    val composited =
-      (alpha * 255f).toInt().coerceIn(0, 255).shl(24) or
-        red.toInt().coerceIn(0, 255).shl(16) or
-        green.toInt().coerceIn(0, 255).shl(8) or
-        blue.toInt().coerceIn(0, 255)
-    return tokens.copy(backgroundColor = "#%08X".format(composited))
+  /** Turns one live Material opacity indication into an editable, correctly ordered SVG subtree. */
+  private fun LayoutTreeAccess.Indication.toWireNode(
+    ownerId: String,
+    index: Int,
+  ): LayoutInspectorNode {
+    val centerX = (bounds.left + bounds.right) / 2f
+    val centerY = (bounds.top + bounds.bottom) / 2f
+    val circleBounds =
+      LayoutInspectorBounds(
+        left = (centerX - radiusPx).roundToInt(),
+        top = (centerY - radiusPx).roundToInt(),
+        right = (centerX + radiusPx).roundToInt(),
+        bottom = (centerY + radiusPx).roundToInt(),
+      )
+    val circle =
+      LayoutInspectorNode(
+        nodeId = "$ownerId-indication-$index-circle",
+        component = if (pressed) "Material Press Ripple" else "Material State Layer",
+        bounds = circleBounds,
+        size =
+          LayoutInspectorSize(
+            width = circleBounds.right - circleBounds.left,
+            height = circleBounds.bottom - circleBounds.top,
+          ),
+        tokens =
+          ComposeSemanticsTokens(
+            backgroundColor = colorWithOpacity(argb, alpha),
+            shape = "circle",
+          ),
+      )
+    return LayoutInspectorNode(
+      nodeId = "$ownerId-indication-$index",
+      component = "Material Indication",
+      bounds = bounds,
+      size =
+        LayoutInspectorSize(
+          width = bounds.right - bounds.left,
+          height = bounds.bottom - bounds.top,
+        ),
+      tokens = ComposeSemanticsTokens(clipsContent = true).takeIf { bounded },
+      children = listOf(circle),
+    )
   }
 
-  private fun parseArgb(value: String?): Int? {
-    val hex = value?.removePrefix("#") ?: return null
-    return when (hex.length) {
-      6 -> (0xFF000000L or hex.toLong(16)).toInt()
-      8 -> hex.toLong(16).toInt()
-      else -> null
-    }
+  private fun colorWithOpacity(argb: Int, opacity: Float): String {
+    val sourceAlpha = (argb ushr 24 and 0xFF) / 255f
+    val alpha = (sourceAlpha * opacity.coerceIn(0f, 1f) * 255f).roundToInt().coerceIn(0, 255)
+    return "#%08X".format(alpha.shl(24) or (argb and 0x00FFFFFF))
   }
 
   private fun ModifierInfo.toWireModifier(
@@ -2406,32 +2411,67 @@ internal object ComposeLayoutInspector {
       (call(node, "getModifierInfo") as? Iterable<*>)?.filterIsInstance<ModifierInfo>()
         ?: emptyList()
 
-    data class StateLayer(val argb: Int, val alpha: Float)
+    data class Indication(
+      val argb: Int,
+      val alpha: Float,
+      val bounds: LayoutInspectorBounds,
+      val radiusPx: Float,
+      val bounded: Boolean,
+      val pressed: Boolean,
+    )
 
     /**
-     * Reads settled opacity state from Material's delegated ripple node.
+     * Reads settled opacity state from Material's delegated ripple node on both backends.
      *
      * `ModifierInfo` exposes the `ClickableElement`, but the active state lives on a delegate of
      * the coordinator's modifier-node chain. Reflection keeps this compatible across Compose
-     * versions and makes an unavailable node a no-op. Only the legacy opacity ripple is flattened;
-     * Material 3's inset focus-ring node has non-uniform geometry and must remain outside this
-     * flat-fill path.
+     * versions and makes an unavailable node a no-op. `CommonRippleNode` owns its press animations
+     * directly; `AndroidRippleNode` delegates the active press to a `RippleHostView`. Both inherit
+     * the focus/hover state layer, target radius and boundedness from `RippleNode`.
+     *
+     * The result retains the indication coordinator's own box, radius and boundedness. The SVG
+     * projection can therefore draw the real circle at the correct z-order and clip it at the same
+     * box instead of recolouring an unrelated container fill.
      */
-    fun stateLayers(modifiers: List<ModifierInfo>): List<StateLayer> {
+    fun indications(
+      modifiers: List<ModifierInfo>,
+      rootCoordinates: LayoutCoordinates?,
+    ): List<Indication> {
       val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
-      val layers = mutableListOf<StateLayer>()
-      fun visit(candidate: Any?) {
+      val layers = mutableListOf<Indication>()
+      fun visit(candidate: Any?, fallbackCoordinates: LayoutCoordinates) {
         if (candidate == null || !seen.add(candidate)) return
-        val className = candidate.javaClass.name
-        if (className == "androidx.compose.material.ripple.CommonRippleNode") {
+        val rippleClass =
+          generateSequence(candidate.javaClass as Class<*>?) { it.superclass }
+            .firstOrNull { it.name == "androidx.compose.material.ripple.RippleNode" }
+        if (rippleClass != null) {
+          val coordinates =
+            sequenceOf(
+                "getCoordinator\$ui_release",
+                "getCoordinator\$ui",
+                "getCoordinator",
+              )
+              .mapNotNull { call(candidate, it) as? LayoutCoordinates }
+              .firstOrNull() ?: fallbackCoordinates
+          val bounds = coordinates.boundsIn(rootCoordinates)
+          val targetRadius = reflectedField(candidate, "targetRadius") as? Float
+          val bounded = reflectedField(candidate, "bounded") as? Boolean ?: true
           val stateLayer = reflectedField(candidate, "stateLayer")
           val color = (call(candidate, "getRippleColor-0d7_KjU") as? Long)?.let(::packedColorToArgb)
           val stateAlpha =
             stateLayer
               ?.let { reflectedField(it, "animatedAlpha") }
               ?.let { call(it, "getValue") as? Float }
-          if (color != null && stateAlpha != null && stateAlpha > 0f) {
-            layers += StateLayer(color, stateAlpha)
+          if (
+            color != null &&
+              stateAlpha != null &&
+              stateAlpha > 0f &&
+              targetRadius != null &&
+              targetRadius > 0f &&
+              bounds.right > bounds.left &&
+              bounds.bottom > bounds.top
+          ) {
+            layers += Indication(color, stateAlpha, bounds, targetRadius, bounded, pressed = false)
           }
 
           val rippleAlphaConfig =
@@ -2444,34 +2484,65 @@ internal object ComposeLayoutInspector {
               reflectedField(animation ?: continue, "animatedAlpha")?.let {
                 call(it, "getValue") as? Float
               } ?: continue
-            val radius =
+            val radiusPercent =
               reflectedField(animation, "animatedRadiusPercent")?.let {
                 call(it, "getValue") as? Float
               } ?: continue
-            // Before the ripple reaches its target radius it is a circle, not a flat container
-            // overlay. Static interaction capture settles it to 1; decline anything mid-flight
-            // rather than flattening geometry that is not flat.
-            if (color != null && radius >= 0.999f && animationAlpha > 0f && pressedAlpha > 0f) {
-              layers += StateLayer(color, animationAlpha * pressedAlpha)
+            // Static interaction capture settles the radius and centre to their targets. Decline a
+            // mid-flight animation rather than claiming its target geometry describes this frame.
+            if (
+              color != null &&
+                radiusPercent >= 0.999f &&
+                animationAlpha > 0f &&
+                pressedAlpha > 0f &&
+                targetRadius != null
+            ) {
+              if (targetRadius > 0f && bounds.right > bounds.left && bounds.bottom > bounds.top) {
+                layers +=
+                  Indication(
+                    color,
+                    animationAlpha * pressedAlpha,
+                    bounds,
+                    targetRadius,
+                    bounded,
+                    pressed = true,
+                  )
+              }
             }
+          }
+
+          // Android keeps the active press in a platform RippleDrawable rather than the common
+          // animation map. A non-null host is the active pressed state; its draw path receives the
+          // same target radius, colour and pressed alpha immediately before capture.
+          if (
+            candidate.javaClass.name == "androidx.compose.material.ripple.AndroidRippleNode" &&
+              reflectedField(candidate, "rippleHostView") != null &&
+              color != null &&
+              pressedAlpha > 0f &&
+              targetRadius != null &&
+              targetRadius > 0f &&
+              bounds.right > bounds.left &&
+              bounds.bottom > bounds.top
+          ) {
+            layers += Indication(color, pressedAlpha, bounds, targetRadius, bounded, pressed = true)
           }
         }
         sequenceOf("getDelegate\$ui_release", "getDelegate\$ui", "getDelegate")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let(::visit)
+          ?.let { visit(it, fallbackCoordinates) }
         sequenceOf("getParent\$ui_release", "getParent\$ui", "getParent")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let(::visit)
+          ?.let { visit(it, fallbackCoordinates) }
         sequenceOf("getChild\$ui_release", "getChild\$ui", "getChild")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let(::visit)
+          ?.let { visit(it, fallbackCoordinates) }
       }
       modifiers.forEach { info ->
         val tail = call(info.coordinates, "getTail")
-        tail?.let(::visit)
+        tail?.let { visit(it, info.coordinates) }
       }
       return layers
     }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -46,7 +46,12 @@ import ee.schimke.composeai.io.SystemFileSystem
 import java.io.File
 import java.lang.reflect.Method
 import java.util.Locale
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
 import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import okio.FileSystem
@@ -1275,6 +1280,10 @@ internal object ComposeLayoutInspector {
       } else null
     val ownerId = semanticsId?.toString() ?: identityId
     val indications = LayoutTreeAccess.indications(modifiers, rootCoords)
+    val ownerTransform = coordinates.scaleIn(rootCoords)
+    val wireModifiers = modifiers.mapNotNull { info ->
+      info.toWireModifier(rootCoords, density, fontScale)
+    }
     val resolvedTokens =
       ModifierTokenResolver.resolve(
           modifierInfo = modifiers,
@@ -1321,15 +1330,17 @@ internal object ComposeLayoutInspector {
       placed = placed,
       attached = attached,
       zIndex = zIndex,
-      modifiers =
-        modifiers.mapNotNull { info -> info.toWireModifier(rootCoords, density, fontScale) },
+      modifiers = wireModifiers,
       // Resolved tokens are computed by the shared resolver (issue #1903) from the same modifier
       // chain + measure policy + measured size this node already carries — `layout/inspector` is
       // the
       // canonical home for the modifier-derived token projection.
       tokens = resolvedTokens,
       curvedTexts = curvedTexts,
-      vectorGraphic = vectorGraphic,
+      // A captured vector is normally a leaf in FigmaSvgModel. When an indication is active, move
+      // the vector into a synthetic first child so the model's leaf return cannot discard the
+      // overlay that must paint after it.
+      vectorGraphic = vectorGraphic.takeIf { indications.isEmpty() },
       // The content-loading placeholder this chain declares, plus whether it is currently visible
       // (issue #2646). Resolved from the same modifier chain + measured size as `tokens`, by the
       // same resolver — the placeholder's own shape/colour, which `tokens` deliberately refuses as
@@ -1348,11 +1359,26 @@ internal object ComposeLayoutInspector {
       drawsContent = drawsContent,
       modifiesDrawnContent =
         DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
-      transform = coordinates.scaleIn(rootCoords),
+      transform = ownerTransform,
       // A Material indication is a draw-over operation: `RippleNode.draw` calls `drawContent()`
       // before its focus state layer and press ripple. Keep it as the final child so gradients,
       // icons, images and tokenless custom content are tinted in the same order as the real frame.
-      children = children + indications.mapIndexed { index, it -> it.toWireNode(ownerId, index) },
+      children =
+        children +
+          vectorGraphic
+            ?.takeIf { indications.isNotEmpty() }
+            ?.let {
+              LayoutInspectorNode(
+                nodeId = "$ownerId-indication-content",
+                component = "$ownComponent Graphic",
+                bounds = placedBounds,
+                size = LayoutInspectorSize(width = width, height = height),
+                vectorGraphic = it,
+                transform = ownerTransform,
+              )
+            }
+            .let(::listOfNotNull) +
+          indications.mapIndexed { index, it -> it.toWireNode(ownerId, index) },
     )
   }
 
@@ -1420,15 +1446,28 @@ internal object ComposeLayoutInspector {
     ownerId: String,
     index: Int,
   ): LayoutInspectorNode {
-    val centerX = (bounds.left + bounds.right) / 2f
-    val centerY = (bounds.top + bounds.bottom) / 2f
+    val centerX = (bounds.left + bounds.right) / 2.0
+    val centerY = (bounds.top + bounds.bottom) / 2.0
+    val scaleX = abs(transform?.scaleX?.toDouble() ?: 1.0)
+    val scaleY = abs(transform?.scaleY?.toDouble() ?: 1.0)
+    val angle = Math.toRadians((transform?.rotationDegrees ?: 0f).toDouble())
+    // The circle is measured in the ripple node's local pixels. Map its two axes into root space
+    // before constructing the captured AABB; FigmaSvgModel uses the local size + transform below
+    // to recover and rotate the actual ellipse from this box.
+    val halfWidth =
+      radiusPx.toDouble() *
+        sqrt((scaleX * cos(angle)).let { it * it } + (scaleY * sin(angle)).let { it * it })
+    val halfHeight =
+      radiusPx.toDouble() *
+        sqrt((scaleX * sin(angle)).let { it * it } + (scaleY * cos(angle)).let { it * it })
     val circleBounds =
       LayoutInspectorBounds(
-        left = (centerX - radiusPx).roundToInt(),
-        top = (centerY - radiusPx).roundToInt(),
-        right = (centerX + radiusPx).roundToInt(),
-        bottom = (centerY + radiusPx).roundToInt(),
+        left = (centerX - halfWidth).roundToInt(),
+        top = (centerY - halfHeight).roundToInt(),
+        right = (centerX + halfWidth).roundToInt(),
+        bottom = (centerY + halfHeight).roundToInt(),
       )
+    val nonUniformScale = abs(scaleX - scaleY) > 0.001
     val circle =
       LayoutInspectorNode(
         nodeId = "$ownerId-indication-$index-circle",
@@ -1436,14 +1475,18 @@ internal object ComposeLayoutInspector {
         bounds = circleBounds,
         size =
           LayoutInspectorSize(
-            width = circleBounds.right - circleBounds.left,
-            height = circleBounds.bottom - circleBounds.top,
+            width = (radiusPx * 2f).roundToInt(),
+            height = (radiusPx * 2f).roundToInt(),
           ),
         tokens =
           ComposeSemanticsTokens(
             backgroundColor = colorWithOpacity(argb, alpha),
-            shape = "circle",
+            shape = "circle".takeUnless { nonUniformScale },
+            // A non-uniformly scaled circle is an ellipse, not the capsule produced by applying
+            // CircleShape to a rectangular box. The unit contour scales with the recovered box.
+            shapePath = UNIT_CIRCLE_PATH.takeIf { nonUniformScale },
           ),
+        transform = transform,
       )
     return LayoutInspectorNode(
       nodeId = "$ownerId-indication-$index",
@@ -1451,13 +1494,27 @@ internal object ComposeLayoutInspector {
       bounds = bounds,
       size =
         LayoutInspectorSize(
-          width = bounds.right - bounds.left,
-          height = bounds.bottom - bounds.top,
+          width = localWidthPx,
+          height = localHeightPx,
         ),
       tokens = ComposeSemanticsTokens(clipsContent = true).takeIf { bounded },
       children = listOf(circle),
+      transform = transform,
     )
   }
+
+  private val UNIT_CIRCLE_PATH: String =
+    (0 until 48)
+      .joinToString(" ") { index ->
+        val angle = 2.0 * PI * index / 48.0
+        val x = (0.5 + 0.5 * cos(angle)).roundedPathCoordinate()
+        val y = (0.5 + 0.5 * sin(angle)).roundedPathCoordinate()
+        "${if (index == 0) 'M' else 'L'}$x,$y"
+      }
+      .plus(" Z")
+
+  private fun Double.roundedPathCoordinate(): Double =
+    kotlin.math.round(this * 1_000_000.0) / 1_000_000.0
 
   private fun colorWithOpacity(argb: Int, opacity: Float): String {
     val sourceAlpha = (argb ushr 24 and 0xFF) / 255f
@@ -2418,6 +2475,9 @@ internal object ComposeLayoutInspector {
       val radiusPx: Float,
       val bounded: Boolean,
       val pressed: Boolean,
+      val localWidthPx: Int,
+      val localHeightPx: Int,
+      val transform: LayoutInspectorTransform?,
     )
 
     /**
@@ -2454,6 +2514,7 @@ internal object ComposeLayoutInspector {
               .mapNotNull { call(candidate, it) as? LayoutCoordinates }
               .firstOrNull() ?: fallbackCoordinates
           val bounds = coordinates.boundsIn(rootCoordinates)
+          val transform = coordinates.scaleIn(rootCoordinates)
           val targetRadius = reflectedField(candidate, "targetRadius") as? Float
           val bounded = reflectedField(candidate, "bounded") as? Boolean ?: true
           val stateLayer = reflectedField(candidate, "stateLayer")
@@ -2471,7 +2532,18 @@ internal object ComposeLayoutInspector {
               bounds.right > bounds.left &&
               bounds.bottom > bounds.top
           ) {
-            layers += Indication(color, stateAlpha, bounds, targetRadius, bounded, pressed = false)
+            layers +=
+              Indication(
+                color,
+                stateAlpha,
+                bounds,
+                targetRadius,
+                bounded,
+                pressed = false,
+                coordinates.size.width,
+                coordinates.size.height,
+                transform,
+              )
           }
 
           val rippleAlphaConfig =
@@ -2506,17 +2578,26 @@ internal object ComposeLayoutInspector {
                     targetRadius,
                     bounded,
                     pressed = true,
+                    coordinates.size.width,
+                    coordinates.size.height,
+                    transform,
                   )
               }
             }
           }
 
           // Android keeps the active press in a platform RippleDrawable rather than the common
-          // animation map. A non-null host is the active pressed state; its draw path receives the
-          // same target radius, colour and pressed alpha immediately before capture.
+          // animation map. The host survives release for the exit animation and reuse, so gate on
+          // the drawable's actual pressed state rather than host allocation.
+          val androidHost =
+            if (candidate.javaClass.name == "androidx.compose.material.ripple.AndroidRippleNode")
+              reflectedField(candidate, "rippleHostView")
+            else null
+          val androidRipple = androidHost?.let { reflectedField(it, "ripple") }
+          val androidPressed =
+            (androidRipple?.let { call(it, "getState") } as? IntArray)?.contains(16842919) == true
           if (
-            candidate.javaClass.name == "androidx.compose.material.ripple.AndroidRippleNode" &&
-              reflectedField(candidate, "rippleHostView") != null &&
+            androidPressed &&
               color != null &&
               pressedAlpha > 0f &&
               targetRadius != null &&
@@ -2524,7 +2605,18 @@ internal object ComposeLayoutInspector {
               bounds.right > bounds.left &&
               bounds.bottom > bounds.top
           ) {
-            layers += Indication(color, pressedAlpha, bounds, targetRadius, bounded, pressed = true)
+            layers +=
+              Indication(
+                color,
+                pressedAlpha,
+                bounds,
+                targetRadius,
+                bounded,
+                pressed = true,
+                coordinates.size.width,
+                coordinates.size.height,
+                transform,
+              )
           }
         }
         sequenceOf("getDelegate\$ui_release", "getDelegate\$ui", "getDelegate")


### PR DESCRIPTION
## Summary
- export Material focus/hover/press indications as ordered SVG overlay nodes instead of flattening them into container fills
- preserve ripple bounds, radius and bounded clipping while retaining gradients, child content and tokenless clickable targets
- support both desktop common ripples and Android platform ripple hosts
- add desktop geometry/compositing/order coverage and Android real-Material regression coverage

Follow-up to #4961 and #4639. Addresses the unresolved review findings on the merged PR.

## Visual evidence
The rendered interaction state remains pixel-correct while its SVG is now represented as an editable overlay rather than a destructively composited fill.

| Before: focused SVG stayed resting | After: focused state exported |
| --- | --- |
| ![Before focused](https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/docs/evidence/material-button-state-svg/before-focused.png) | ![After focused](https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/docs/evidence/material-button-state-svg/after-focused.png) |

![Pressed state exported](https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/docs/evidence/material-button-state-svg/after-pressed.png)

## Verification
- `:data-layoutinspector-connector:ktfmtCheck :data-layoutinspector-connector:test`
- `:daemon:desktop:ktfmtCheck :daemon:desktop:test --tests ee.schimke.composeai.daemon.OverrideIntegrationTest`
- `:daemon:android:ktfmtCheck :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.OverrideIntegrationTest`
- focused desktop custom indication regression
- focused desktop and Android real Material button regressions