### PR TITLE
fix(figma-svg): preserve indication modifier order

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -461,6 +461,40 @@ class OverrideIntegrationTest {
   }
 
   @Test
+  fun outerDrawWithContentForegroundRemainsAboveIndication() {
+    val svg =
+      renderFocusedSvg(
+        "ForegroundIndication",
+        "ForegroundIndicationInteractionState",
+        96,
+        48,
+      )
+    assertTrue("focused state layer must be exported", svg.contains("Material State Layer"))
+    assertTrue("outer foreground must be exported", svg.contains("Foreground"))
+    assertTrue(
+      "outer drawWithContent foreground must paint after the inner indication",
+      svg.lastIndexOf("Foreground") > svg.lastIndexOf("Material State Layer"),
+    )
+  }
+
+  @Test
+  fun innerDrawWithContentForegroundRemainsBelowIndication() {
+    val svg =
+      renderFocusedSvg(
+        "InnerForegroundIndication",
+        "InnerForegroundIndicationInteractionState",
+        96,
+        48,
+      )
+    assertTrue("focused state layer must be exported", svg.contains("Material State Layer"))
+    assertTrue("inner foreground must be exported", svg.contains("Foreground"))
+    assertTrue(
+      "outer indication must paint after the inner drawWithContent foreground",
+      svg.lastIndexOf("Material State Layer") > svg.lastIndexOf("Foreground"),
+    )
+  }
+
+  @Test
   fun nonUniformScaleTransformsRippleIntoAnEllipse() {
     val svg = renderFocusedSvg("ScaledIndication", "ScaledIndicationInteractionState", 128, 64)
     val stateLayer = svg.substringAfter("id=\"Material State Layer\"").substringBefore("</g>")

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -54,6 +54,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Size
@@ -1790,6 +1791,46 @@ fun VectorIndicationInteractionState() {
   MaterialTheme(colorScheme = lightColorScheme()) {
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
       Canvas(modifier = Modifier.size(32.dp).clickable {}) { drawRect(Color.Green) }
+    }
+  }
+}
+
+/** An outer foreground must unwind above the clickable's indication, not below it. */
+@Composable
+fun ForegroundIndicationInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Canvas(
+        modifier =
+          Modifier.size(32.dp)
+            .drawWithContent {
+              drawContent()
+              drawRect(Color.Blue.copy(alpha = 0.01f))
+            }
+            .clickable {}
+      ) {
+        drawRect(Color.Green)
+      }
+    }
+  }
+}
+
+/** The inverse chain: a clickable outside the foreground must draw its indication last. */
+@Composable
+fun InnerForegroundIndicationInteractionState() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      Canvas(
+        modifier =
+          Modifier.size(32.dp)
+            .clickable {}
+            .drawWithContent {
+              drawContent()
+              drawRect(Color.Blue.copy(alpha = 0.01f))
+            }
+      ) {
+        drawRect(Color.Green)
+      }
     }
   }
 }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1280,6 +1280,33 @@ internal object ComposeLayoutInspector {
       } else null
     val ownerId = semanticsId?.toString() ?: identityId
     val indications = LayoutTreeAccess.indications(modifiers, rootCoords)
+    // A drawWithContent outside clickable paints its foreground after the ripple; one inside it
+    // paints before the ripple. Capture each after-content pass separately so it can be interleaved
+    // with indications by modifier position instead of flattening every indication to the end.
+    val indicationForegrounds =
+      if (indications.isEmpty()) emptyList()
+      else
+        modifiers.mapIndexedNotNull { modifierIndex, info ->
+          DrawRasterCapture.captureForeground(listOf(info), density, fontScale) { candidate ->
+              candidate.coordinates.boundsIn(rootCoords)
+            }
+            ?.let { raster ->
+              val rasterBounds =
+                LayoutInspectorBounds(raster.left, raster.top, raster.right, raster.bottom)
+              modifierIndex to
+                LayoutInspectorNode(
+                  nodeId = "$ownerId-indication-foreground-$modifierIndex",
+                  component = "$ownComponent Foreground",
+                  bounds = rasterBounds,
+                  size =
+                    LayoutInspectorSize(
+                      width = rasterBounds.right - rasterBounds.left,
+                      height = rasterBounds.bottom - rasterBounds.top,
+                    ),
+                  drawRaster = raster,
+                )
+            }
+        }
     val ownerTransform = coordinates.scaleIn(rootCoords)
     val wireModifiers = modifiers.mapNotNull { info ->
       info.toWireModifier(rootCoords, density, fontScale)
@@ -1360,9 +1387,10 @@ internal object ComposeLayoutInspector {
       modifiesDrawnContent =
         DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
       transform = ownerTransform,
-      // A Material indication is a draw-over operation: `RippleNode.draw` calls `drawContent()`
-      // before its focus state layer and press ripple. Keep it as the final child so gradients,
-      // icons, images and tokenless custom content are tinted in the same order as the real frame.
+      // A Material indication draws after its inner content but before the foreground of any outer
+      // drawWithContent modifier. ModifierInfo is outer-to-inner, so sorting descending
+      // reconstructs
+      // the unwind order: deepest foreground/indication first, outermost last.
       children =
         children +
           vectorGraphic
@@ -1378,7 +1406,14 @@ internal object ComposeLayoutInspector {
               )
             }
             .let(::listOfNotNull) +
-          indications.mapIndexed { index, it -> it.toWireNode(ownerId, index) },
+          buildList<Pair<Int, LayoutInspectorNode>> {
+              indications.forEachIndexed { index, indication ->
+                add(indication.modifierIndex to indication.toWireNode(ownerId, index))
+              }
+              addAll(indicationForegrounds)
+            }
+            .sortedByDescending { it.first }
+            .map { it.second },
     )
   }
 
@@ -2478,6 +2513,7 @@ internal object ComposeLayoutInspector {
       val localWidthPx: Int,
       val localHeightPx: Int,
       val transform: LayoutInspectorTransform?,
+      val modifierIndex: Int,
     )
 
     /**
@@ -2499,7 +2535,7 @@ internal object ComposeLayoutInspector {
     ): List<Indication> {
       val seen = java.util.Collections.newSetFromMap(java.util.IdentityHashMap<Any, Boolean>())
       val layers = mutableListOf<Indication>()
-      fun visit(candidate: Any?, fallbackCoordinates: LayoutCoordinates) {
+      fun visit(candidate: Any?, fallbackCoordinates: LayoutCoordinates, fallbackIndex: Int) {
         if (candidate == null || !seen.add(candidate)) return
         val rippleClass =
           generateSequence(candidate.javaClass as Class<*>?) { it.superclass }
@@ -2513,6 +2549,9 @@ internal object ComposeLayoutInspector {
               )
               .mapNotNull { call(candidate, it) as? LayoutCoordinates }
               .firstOrNull() ?: fallbackCoordinates
+          val modifierIndex =
+            modifiers.indexOfFirst { it.coordinates === coordinates }.takeIf { it >= 0 }
+              ?: fallbackIndex
           val bounds = coordinates.boundsIn(rootCoordinates)
           val transform = coordinates.scaleIn(rootCoordinates)
           val targetRadius = reflectedField(candidate, "targetRadius") as? Float
@@ -2543,6 +2582,7 @@ internal object ComposeLayoutInspector {
                 coordinates.size.width,
                 coordinates.size.height,
                 transform,
+                modifierIndex,
               )
           }
 
@@ -2581,6 +2621,7 @@ internal object ComposeLayoutInspector {
                     coordinates.size.width,
                     coordinates.size.height,
                     transform,
+                    modifierIndex,
                   )
               }
             }
@@ -2616,25 +2657,26 @@ internal object ComposeLayoutInspector {
                 coordinates.size.width,
                 coordinates.size.height,
                 transform,
+                modifierIndex,
               )
           }
         }
         sequenceOf("getDelegate\$ui_release", "getDelegate\$ui", "getDelegate")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let { visit(it, fallbackCoordinates) }
+          ?.let { visit(it, fallbackCoordinates, fallbackIndex) }
         sequenceOf("getParent\$ui_release", "getParent\$ui", "getParent")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let { visit(it, fallbackCoordinates) }
+          ?.let { visit(it, fallbackCoordinates, fallbackIndex) }
         sequenceOf("getChild\$ui_release", "getChild\$ui", "getChild")
           .mapNotNull { call(candidate, it) }
           .firstOrNull()
-          ?.let { visit(it, fallbackCoordinates) }
+          ?.let { visit(it, fallbackCoordinates, fallbackIndex) }
       }
-      modifiers.forEach { info ->
+      modifiers.forEachIndexed { index, info ->
         val tail = call(info.coordinates, "getTail")
-        tail?.let { visit(it, info.coordinates) }
+        tail?.let { visit(it, info.coordinates, index) }
       }
       return layers
     }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawRasterCapture.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawRasterCapture.kt
@@ -71,6 +71,30 @@ internal object DrawRasterCapture {
     density: Float,
     fontScale: Float = 1f,
     boundsOf: (ModifierInfo) -> LayoutInspectorBounds?,
+  ): LayoutInspectorDrawRaster? =
+    capture(modifiers, density, fontScale, boundsOf, CapturePass.BEHIND_CONTENT)
+
+  /**
+   * Captures only paint emitted after `drawContent()`.
+   *
+   * This is kept separate from [capture] because an outer `drawWithContent` foreground belongs
+   * above an inner indication in the modifier chain. The caller can therefore insert this raster at
+   * the modifier's actual paint position instead of flattening it into the node's background.
+   */
+  fun captureForeground(
+    modifiers: List<ModifierInfo>,
+    density: Float,
+    fontScale: Float = 1f,
+    boundsOf: (ModifierInfo) -> LayoutInspectorBounds?,
+  ): LayoutInspectorDrawRaster? =
+    capture(modifiers, density, fontScale, boundsOf, CapturePass.AFTER_CONTENT)
+
+  private fun capture(
+    modifiers: List<ModifierInfo>,
+    density: Float,
+    fontScale: Float,
+    boundsOf: (ModifierInfo) -> LayoutInspectorBounds?,
+    pass: CapturePass,
   ): LayoutInspectorDrawRaster? {
     val draws = modifiers.mapNotNull { info ->
       // A `Modifier.placeholder`'s own draw is not the node's art (issue #2646): loaded, it is a
@@ -118,7 +142,9 @@ internal object DrawRasterCapture {
     if (width <= 0 || height <= 0 || width.toLong() * height > MAX_PIXELS) return null
 
     val pixels =
-      runCatching { render(draws, left, top, scaleX, scaleY, width, height, density, fontScale) }
+      runCatching {
+        render(draws, left, top, scaleX, scaleY, width, height, density, fontScale, pass)
+      }
         .getOrNull() ?: return null
     if (pixels.none { (it ushr 24) != 0 }) return null
     val png = runCatching { encodePng(pixels, width, height) }.getOrNull() ?: return null
@@ -129,6 +155,11 @@ internal object DrawRasterCapture {
       bottom = bottom,
       pngBase64 = Base64.getEncoder().encodeToString(png),
     )
+  }
+
+  private enum class CapturePass {
+    BEHIND_CONTENT,
+    AFTER_CONTENT,
   }
 
   /**
@@ -170,6 +201,7 @@ internal object DrawRasterCapture {
     height: Int,
     density: Float,
     fontScale: Float,
+    pass: CapturePass,
   ): IntArray {
     val target = ImageBitmap(width, height)
     val canvas = Canvas(target)
@@ -188,7 +220,10 @@ internal object DrawRasterCapture {
       canvas.translate(dx, dy)
       scope.draw(densityScope, LayoutDirection.Ltr, canvas, size) {
         val lambda = draw.lambda
-        IsolatedContentDrawScope(this, scratch).lambda()
+        when (pass) {
+          CapturePass.BEHIND_CONTENT -> IsolatedContentDrawScope(this, scratch).lambda()
+          CapturePass.AFTER_CONTENT -> ForegroundContentDrawScope(this, scratch).lambda()
+        }
       }
       canvas.restore()
     }
@@ -217,6 +252,22 @@ internal object DrawRasterCapture {
   ) : ContentDrawScope, DrawScope by delegate {
     override fun drawContent() {
       delegate.drawContext.canvas = scratch
+    }
+  }
+
+  /** The inverse isolation: discard pre-content paint and retain only the foreground pass. */
+  private class ForegroundContentDrawScope(
+    private val delegate: DrawScope,
+    scratch: Canvas,
+  ) : ContentDrawScope, DrawScope by delegate {
+    private val target = delegate.drawContext.canvas
+
+    init {
+      delegate.drawContext.canvas = scratch
+    }
+
+    override fun drawContent() {
+      delegate.drawContext.canvas = target
     }
   }
 }


### PR DESCRIPTION
## Summary
- associate active Material indications with their modifier-chain position
- capture `drawWithContent` foreground passes independently and interleave them with ripples in Compose paint order
- cover both outer-foreground/inner-ripple and outer-ripple/inner-foreground chains

Follow-up to the post-merge review on #4964: https://github.com/yschimke/compose-ai-tools/pull/4964#discussion_r3910335610

## Visual evidence
Generated SVG structure now matches Compose unwind order:
- outer foreground: `Material State Layer` then `… Foreground`
- inner foreground: `… Foreground` then `Material State Layer`

Both orders are asserted against rendered focused-state fixtures.

## Verification
- `:data-layoutinspector-connector:ktfmtCheck :data-layoutinspector-connector:test`
- `:daemon:desktop:ktfmtCheck :daemon:desktop:test --tests ee.schimke.composeai.daemon.OverrideIntegrationTest`
- `:daemon:android:ktfmtCheck :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.OverrideIntegrationTest`