### PR TITLE
feat(mcp): add shared UI builder HTTP transport

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -23,9 +23,8 @@ import okio.Path.Companion.toPath
  *
  * Three subcommands cover the full agent-attach lifecycle:
  *
- * - `serve` — start the MCP server on stdio. Writes nothing to stdout itself; the only stdout
- *   traffic is the JSON-RPC frames the [DaemonMcpMain] reader/writer pair owns. Status / errors go
- *   to stderr.
+ * - `serve` — start the MCP server on stdio, or the shared UI Builder's authenticated Streamable
+ *   HTTP endpoint with `--streamable-http`. Status / errors go to stderr.
  * - `install` — bootstrap descriptors for every module that applies the plugin, flip each
  *   descriptor's `enabled` flag to `true` (`composePreview.daemon { enabled = true }` isn't
  *   required up-front this way), run `composePreviewDiscover`, and print or install the MCP host
@@ -88,8 +87,21 @@ internal class McpCommand(
                              Override the authenticated actor id. By default it is derived from
                              the grant token fingerprint.
         COMPOSE_PREVIEW_UI_BUILDER_TOKEN
-                             Required secret when --ui-builder-url is set. It is read from the
-                             environment and never accepted as an argv value.
+                             Required secret for stdio when --ui-builder-url is set. It is read
+                             from the environment and never accepted as an argv value. Streamable
+                             HTTP instead accepts each client's Authorization bearer.
+
+      serve: shared UI builder over Streamable HTTP:
+        --streamable-http    Serve only the eight remote UI-builder tools over MCP Streamable HTTP.
+                             Each client supplies its preview-server grant as Authorization: Bearer.
+        --http-host <host>   Bind host (default 127.0.0.1; use a reverse proxy for public TLS).
+        --http-port <port>   Bind port (default 8788).
+        --http-path <path>   MCP endpoint path (default /mcp).
+        --http-allowed-host <host>
+                             Accepted Host header; repeat for aliases. Required for non-loopback
+                             binds and normally set to the shared server's public hostname.
+        --http-allowed-origin <host>
+                             Accepted browser Origin hostname; repeat to narrow independently.
 
       install: agent host registration (each defaults to "on" when the host is detected
       locally; opt out with --no-<host>):

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -96,7 +96,7 @@ internal class McpCommand(
                              Each client supplies its preview-server grant as Authorization: Bearer.
         --http-host <host>   Bind host (default 127.0.0.1; use a reverse proxy for public TLS).
         --http-port <port>   Bind port (default 8788).
-        --http-path <path>   MCP endpoint path (default /mcp).
+        --http-path <path>   MCP endpoint path (default /ui-builder/mcp).
         --http-allowed-host <host>
                              Accepted Host header; repeat for aliases. Required for non-loopback
                              binds and normally set to the shared server's public hostname.

--- a/docs/daemon/MCP-KOTLIN.md
+++ b/docs/daemon/MCP-KOTLIN.md
@@ -10,33 +10,30 @@ high-level mapping.
 message types and spawns daemon JVMs over stdio via launch descriptors
 emitted by `composePreviewDaemonStart`.
 
-## Why hand-rolled (not on the MCP Kotlin SDK)
+## SDK boundary
 
-The implementation is hand-rolled rather than built on
-[`io.modelcontextprotocol:kotlin-sdk`](https://github.com/modelcontextprotocol/kotlin-sdk):
-
-- The SDK auto-registers internal handlers for `resources/list` /
-  `resources/read` / `subscribe`, making the dynamic catalog + push
-  subscription model awkward to bolt on.
-- Rolling our own keeps the wire layer self-contained and mirrors the
-  proven `:daemon:core` `JsonRpcServer` framing.
+The official [`io.modelcontextprotocol:kotlin-sdk`](https://github.com/modelcontextprotocol/kotlin-sdk)
+owns MCP framing, negotiation, sessions, stdio, and Streamable HTTP. `DaemonMcpServer` still owns
+the dynamic catalog and installs its handlers directly on each SDK session so early pipelined calls
+cannot race the handler registration.
 
 ## Transport
 
-**stdio only.** The MCP server reads framed JSON-RPC from stdin, writes
-to stdout. Same `Content-Length:` LSP framing as the daemon
-([PROTOCOL.md § 1](PROTOCOL.md#1-transport)) — reused from
-`JsonRpcServer`.
+The local preview-daemon profile uses **stdio**.
 
-HTTP / SSE transports are out of scope. If a remote-agent use case
-materialises, factor `McpSession`'s read/write loops behind a transport
-interface and add an HTTP variant alongside.
+The shared UI-builder profile additionally uses the SDK's stateful **Streamable HTTP** transport at
+`/mcp`. It exposes only the remote UI-builder tools: a hosted service cannot safely make local
+filesystem paths or project-daemon controls meaningful. POST, GET/SSE and DELETE all require the
+same preview-server agent grant. The first authenticated request validates the grant through the
+Design API, then the MCP session id is bound to its fingerprint so another valid grant cannot take
+over that session.
 
-The optional UI-builder facade is different: the MCP client still connects to
-this process over stdio, while `UiBuilderMcpAdapter` acts as an authenticated
-HTTP client of preview-server's versioned Design API. It depends only on the
-released protocol artifact and deliberately owns no reducer, persistence,
-catalog, or render implementation.
+This is not the legacy standalone SSE transport. SSE is used only as Streamable HTTP's response and
+notification stream when negotiated by the MCP client.
+
+In both transports `UiBuilderMcpAdapter` is an authenticated HTTP client of preview-server's
+versioned Design API. It depends only on the released protocol artifact and deliberately owns no
+reducer, persistence, catalog, or render implementation.
 
 ## Module layout
 
@@ -50,6 +47,7 @@ mcp/
     ├── DaemonMcpMain.kt        — entry point; arg parsing; supervisor wiring
     ├── DaemonMcpServer.kt      — load-bearing wiring layer
     ├── McpServer.kt            — McpSession + handler interface
+    ├── UiBuilderStreamableHttp.kt — authenticated hosted `/mcp` transport
     ├── DaemonClient.kt         — JSON-RPC client of one daemon JVM
     ├── DaemonSupervisor.kt     — owns per-(workspace, module) daemons
     ├── PreviewResource.kt      — URI parsing (PreviewUri / HistoryUri / WorkspaceId / FqnGlob)
@@ -212,7 +210,7 @@ The respawn cap recovers when the user re-registers via
 
 ### MCP client disconnect
 
-`McpSession.runReader` exits on stdin EOF. `DaemonMcpMain.main` calls
+The SDK stdio transport closes on stdin EOF. `DaemonMcpMain.main` calls
 `supervisor.shutdown()` after the session exits, which sends `shutdown`
 + `exit` to every daemon and waits for them to drain.
 

--- a/docs/daemon/MCP-KOTLIN.md
+++ b/docs/daemon/MCP-KOTLIN.md
@@ -22,7 +22,7 @@ cannot race the handler registration.
 The local preview-daemon profile uses **stdio**.
 
 The shared UI-builder profile additionally uses the SDK's stateful **Streamable HTTP** transport at
-`/mcp`. It exposes only the remote UI-builder tools: a hosted service cannot safely make local
+`/ui-builder/mcp`. It exposes only the remote UI-builder tools: a hosted service cannot safely make local
 filesystem paths or project-daemon controls meaningful. POST, GET/SSE and DELETE all require the
 same preview-server agent grant. The first authenticated request validates the grant through the
 Design API, then the MCP session id is bound to its fingerprint so another valid grant cannot take
@@ -47,7 +47,7 @@ mcp/
     ├── DaemonMcpMain.kt        — entry point; arg parsing; supervisor wiring
     ├── DaemonMcpServer.kt      — load-bearing wiring layer
     ├── McpServer.kt            — McpSession + handler interface
-    ├── UiBuilderStreamableHttp.kt — authenticated hosted `/mcp` transport
+    ├── UiBuilderStreamableHttp.kt — authenticated hosted `/ui-builder/mcp` transport
     ├── DaemonClient.kt         — JSON-RPC client of one daemon JVM
     ├── DaemonSupervisor.kt     — owns per-(workspace, module) daemons
     ├── PreviewResource.kt      — URI parsing (PreviewUri / HistoryUri / WorkspaceId / FqnGlob)

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -136,7 +136,7 @@ COMPOSE_PREVIEW_UI_BUILDER_TOKEN='<grant>' \
 ```
 
 The adapter owns no design state. Every call uses the released
-`ee.schimke.composeai:ui-builder-protocol:2.2.0` HTTP envelope and reaches the
+`ee.schimke.composeai:ui-builder-protocol` HTTP envelope and reaches the
 same authoritative service used by browser sessions. Request ids are checked
 on every response, and the default actor is
 `agent:<12-character grant-token fingerprint>`. `--ui-builder-actor` is
@@ -160,6 +160,19 @@ The three capabilities remain independent: a read-only grant cannot mutate or
 export, and a write grant does not implicitly grant export. The Storybook
 compatibility profile never advertises or dispatches these tools, even when
 UI-builder environment variables are present.
+
+For a shared deployment, the same adapter can instead be served as a remote MCP endpoint:
+
+```sh
+compose-preview mcp serve --streamable-http \
+  --ui-builder-url http://127.0.0.1:8791 \
+  --http-allowed-host preview.example.com
+```
+
+Proxy the public `https://preview.example.com/mcp` route to the sidecar's loopback port. This mode
+is deliberately UI-builder-only and accepts each client's grant in `Authorization: Bearer`; the
+sidecar itself has no operator token. Browser and MCP traffic therefore reaches the same persisted
+Design API while the preview server remains free of MCP transport dependencies.
 
 The daemon's render queue is single-priority FIFO today, so `setVisible` /
 `setFocus` traffic flows through the wire but doesn't yet reorder the queue.

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -169,7 +169,7 @@ compose-preview mcp serve --streamable-http \
   --http-allowed-host preview.example.com
 ```
 
-Proxy the public `https://preview.example.com/mcp` route to the sidecar's loopback port. This mode
+Proxy the public `https://preview.example.com/ui-builder/mcp` route to the sidecar's loopback port. This mode
 is deliberately UI-builder-only and accepts each client's grant in `Authorization: Bearer`; the
 sidecar itself has no operator token. Browser and MCP traffic therefore reaches the same persisted
 Design API while the preview server remains free of MCP transport dependencies.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -448,6 +448,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 # can't skew and re-trip the strict slf4j pin in :cli (see cli/build.gradle.kts constraints).
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 # WebSockets plugin for the embedded server — backs the `serve` streamed-frame lane (`/ws/{id}`).
 # Same `ktor` version ref so it can't skew the slf4j pin in :cli.
 ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -3,7 +3,9 @@
 A [Model Context Protocol](https://modelcontextprotocol.io/) server that
 exposes [`@Preview`](https://developer.android.com/jetpack/compose/tooling/previews)
 composables — Jetpack Compose (Android via Robolectric) and Compose
-Multiplatform (Desktop via Skiko) — to MCP-aware agents over stdio.
+Multiplatform (Desktop via Skiko) — to MCP-aware agents over stdio. Its remote UI-builder profile
+can also be hosted over authenticated MCP Streamable HTTP so several agents and browsers meet at
+one shared preview server.
 
 The server is a thin, transport-agnostic shim around the per-module
 [preview daemon](../docs/daemon/DESIGN.md): it spawns daemons on demand,
@@ -112,6 +114,41 @@ claude mcp add compose-preview-mcp \
 `--project=<path>[:<rootProjectName>]` pre-registers a workspace at
 startup; you can also call the `register_project` tool from the agent
 later.
+
+### Shared UI builder over Streamable HTTP
+
+Run the MCP process beside the shared preview server and proxy `/mcp` to it. This mode exposes only
+the eight remote UI-builder tools; filesystem/project and preview-daemon tools stay on local stdio.
+Each MCP client sends its own preview-server agent grant as `Authorization: Bearer`, and that grant
+is bound to the MCP session id for its lifetime.
+
+```bash
+compose-preview mcp serve \
+  --streamable-http \
+  --ui-builder-url http://127.0.0.1:8791 \
+  --http-host 127.0.0.1 \
+  --http-port 8788 \
+  --http-allowed-host preview.example.com
+```
+
+The loopback default is intentional: terminate public TLS and route `/mcp` in the same reverse
+proxy that serves the UI builder. Preserve `Authorization`, `Mcp-Session-Id`, `Last-Event-ID`, and
+the response content type; disable proxy buffering for `text/event-stream` responses. Repeat
+`--http-allowed-host` for aliases and `--http-allowed-origin` when browser origins should be
+narrower than the host list.
+
+Codex can then connect directly to the shared endpoint:
+
+```toml
+[mcp_servers.compose-preview-ui-builder]
+url = "https://preview.example.com/mcp"
+bearer_token_env_var = "COMPOSE_PREVIEW_UI_BUILDER_TOKEN"
+required = true
+```
+
+The environment variable belongs to the Codex host, not the MCP sidecar. Obtain it with
+`compose-preview auth request` using the `ui-builder-read`, `ui-builder-write`, and
+`ui-builder-export` capabilities. Restart or reload the MCP host after changing its configuration.
 
 ### 4. From the agent
 
@@ -230,8 +267,8 @@ re-renders.
 
 ## Subscriptions and watch sets
 
-Both are session-scoped — a session is one connected MCP client (in v0,
-one stdio stream). On disconnect the supervisor drops everything that
+Both are session-scoped — a session is one connected MCP client (one stdio stream in the local
+profile). On disconnect the supervisor drops everything that
 session registered.
 
 `subscribe(uri)` is the cheap per-URI hook. `watch(workspaceId,
@@ -273,8 +310,9 @@ equivalent that integrates with `:mcp:test`.
   daemon unless the descriptor reports `enabled: true`. Flip via
   `composePreview.daemon { enabled = true }` in the
   consumer's build script.
-- **Multi-session.** A single MCP server process can serve N agents
-  over N stdio connections (HTTP transport later may multiplex).
+- **Multi-session.** A local stdio process serves one agent connection. The remote UI-builder
+  Streamable HTTP mode multiplexes authenticated MCP sessions while the shared preview server owns
+  all design state and revision ordering.
   Daemons are shared across sessions when they target the same
   `(workspace, module)`, so two agents reading the same preview both
   benefit from the warm sandbox.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -117,7 +117,7 @@ later.
 
 ### Shared UI builder over Streamable HTTP
 
-Run the MCP process beside the shared preview server and proxy `/mcp` to it. This mode exposes only
+Run the MCP process beside the shared preview server and proxy `/ui-builder/mcp` to it. This mode exposes only
 the eight remote UI-builder tools; filesystem/project and preview-daemon tools stay on local stdio.
 Each MCP client sends its own preview-server agent grant as `Authorization: Bearer`, and that grant
 is bound to the MCP session id for its lifetime.
@@ -131,7 +131,7 @@ compose-preview mcp serve \
   --http-allowed-host preview.example.com
 ```
 
-The loopback default is intentional: terminate public TLS and route `/mcp` in the same reverse
+The loopback default is intentional: terminate public TLS and route `/ui-builder/mcp` in the same reverse
 proxy that serves the UI builder. Preserve `Authorization`, `Mcp-Session-Id`, `Last-Event-ID`, and
 the response content type; disable proxy buffering for `text/event-stream` responses. Repeat
 `--http-allowed-host` for aliases and `--http-allowed-origin` when browser origins should be
@@ -141,7 +141,7 @@ Codex can then connect directly to the shared endpoint:
 
 ```toml
 [mcp_servers.compose-preview-ui-builder]
-url = "https://preview.example.com/mcp"
+url = "https://preview.example.com/ui-builder/mcp"
 bearer_token_env_var = "COMPOSE_PREVIEW_UI_BUILDER_TOKEN"
 required = true
 ```

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.mcp.kotlin.sdk.server)
+  // CIO hosts the optional remote UI-builder Streamable HTTP endpoint. The MCP SDK owns the
+  // protocol route (POST/GET/DELETE + SSE); this module only supplies the engine and auth bridge.
+  implementation(libs.ktor.server.cio)
   // Okio-based file IO (`SystemFileSystem`) for descriptor reads + PNG/video byte reads.
   implementation(libs.composeai.common.io)
   implementation(libs.composeai.agent.grant.protocol)
@@ -69,6 +72,7 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.truth)
   testImplementation(libs.kotlinx.coroutines.core)
+  testImplementation(libs.ktor.server.test.host)
 }
 
 tasks.withType<Test>().configureEach {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -15,6 +15,7 @@ import java.io.File
  *                     [--replicas-per-daemon <N>]
  *                     [--ui-builder-url <URL>]
  *                     [--ui-builder-actor <ACTOR>]
+ *                     [--streamable-http --http-port <PORT>]
  *                     [--storybook]
  * ```
  *
@@ -43,6 +44,16 @@ object DaemonMcpMain {
   @JvmStatic
   fun main(args: Array<String>) {
     disableKotlinLoggingStartupMessage()
+    parseStreamableHttp(args)?.let { config ->
+      require(parseProjects(args).isEmpty()) {
+        "--streamable-http serves the shared UI Builder only; --project is stdio-only"
+      }
+      require(!parseStorybookProfile(args)) {
+        "--streamable-http serves the shared UI Builder only; --storybook is stdio-only"
+      }
+      runUiBuilderStreamableHttp(config)
+      return
+    }
     val replicasPerDaemon = parseReplicasPerDaemon(args)
     val storybookProfile = parseStorybookProfile(args)
     // Storybook compatibility is intentionally a closed tool surface. Do not even construct the
@@ -126,6 +137,53 @@ object DaemonMcpMain {
     if (index < 0) return null
     return args.getOrNull(index + 1)?.takeUnless { it.startsWith("--") }?.takeIf(String::isNotBlank)
       ?: error("$name requires a value")
+  }
+
+  private fun options(args: Array<String>, name: String): List<String> {
+    val values = mutableListOf<String>()
+    var index = 0
+    while (index < args.size) {
+      when {
+        args[index] == name -> {
+          val value = args.getOrNull(index + 1)?.takeUnless { it.startsWith("--") }
+          require(!value.isNullOrBlank()) { "$name requires a value" }
+          values += value
+          index += 2
+        }
+        args[index].startsWith("$name=") -> {
+          values +=
+            args[index].substringAfter('=').takeIf(String::isNotBlank)
+              ?: error("$name requires a value")
+          index++
+        }
+        else -> index++
+      }
+    }
+    return values
+  }
+
+  private fun parseStreamableHttp(args: Array<String>): UiBuilderStreamableHttpConfig? {
+    if ("--streamable-http" !in args) return null
+    val uiBuilderUrl =
+      option(args, "--ui-builder-url")
+        ?: System.getProperty("composeai.uiBuilder.url")
+        ?: System.getenv("COMPOSE_PREVIEW_UI_BUILDER_URL")
+        ?: error("--streamable-http requires --ui-builder-url")
+    val host = option(args, "--http-host") ?: "127.0.0.1"
+    val portRaw = option(args, "--http-port") ?: "8788"
+    val port = portRaw.toIntOrNull() ?: error("--http-port must be an integer")
+    val allowedHosts = options(args, "--http-allowed-host").ifEmpty { null }
+    if (host !in setOf("127.0.0.1", "localhost", "::1") && allowedHosts == null) {
+      error("non-loopback --http-host requires at least one --http-allowed-host")
+    }
+    return UiBuilderStreamableHttpConfig(
+      uiBuilderUrl = uiBuilderUrl,
+      host = host,
+      port = port,
+      path = option(args, "--http-path") ?: "/mcp",
+      allowedHosts = allowedHosts,
+      allowedOrigins = options(args, "--http-allowed-origin").ifEmpty { null },
+    )
   }
 
   private fun parseProjects(args: Array<String>): List<Pair<String, String?>> {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -180,7 +180,7 @@ object DaemonMcpMain {
       uiBuilderUrl = uiBuilderUrl,
       host = host,
       port = port,
-      path = option(args, "--http-path") ?: "/mcp",
+      path = option(args, "--http-path") ?: "/ui-builder/mcp",
       allowedHosts = allowedHosts,
       allowedOrigins = options(args, "--http-allowed-origin").ifEmpty { null },
     )

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -251,7 +251,7 @@ internal fun composePreviewServerOptions(): ServerOptions =
       )
   )
 
-private fun ToolDef.toSdkTool(): Tool {
+internal fun ToolDef.toSdkTool(): Tool {
   val schemaObject = inputSchema.jsonObject
   return Tool(
     name = name,
@@ -282,7 +282,7 @@ private fun ee.schimke.composeai.mcp.protocol.ResourceContents.toSdkResourceCont
       BlobResourceContents(blob = blob, uri = uri, mimeType = mimeType)
   }
 
-private fun CallToolResult.toSdkCallToolResult():
+internal fun CallToolResult.toSdkCallToolResult():
   io.modelcontextprotocol.kotlin.sdk.types.CallToolResult =
   io.modelcontextprotocol.kotlin.sdk.types.CallToolResult(
     content = content.map { it.toSdkContent() },

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderMcpAdapter.kt
@@ -17,6 +17,10 @@ import ee.schimke.composeai.uibuilder.protocol.ListCatalogsRequestV1
 import ee.schimke.composeai.uibuilder.protocol.OpenDesignRequestV1
 import ee.schimke.composeai.uibuilder.protocol.UI_BUILDER_SCHEMA_VERSION_V1
 import ee.schimke.composeai.uibuilder.protocol.UiBuilderRequestV1
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -128,6 +132,24 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
     }
   }
 
+  /** A remote-safe MCP server containing only the shared UI-builder tools. */
+  internal fun sdkServer(): Server =
+    Server(
+      serverInfo = Implementation(name = "compose-preview-ui-builder", version = "v1"),
+      options =
+        ServerOptions(
+          capabilities = ServerCapabilities(tools = ServerCapabilities.Tools(listChanged = false))
+        ),
+    ) {
+      toolDefs().forEach { definition ->
+        addTool(definition.toSdkTool()) { request ->
+          val arguments = request.arguments ?: JsonObject(emptyMap())
+          (handle(request.name, arguments) ?: errorCallToolResult("unknown tool: ${request.name}"))
+            .toSdkCallToolResult()
+        }
+      }
+    }
+
   /**
    * The caller's submission with `actorId` filled in from the authenticated client.
    *
@@ -183,6 +205,19 @@ class UiBuilderMcpAdapter internal constructor(private val client: UiBuilderDesi
     const val revisionSchema =
       """{"type":"object","properties":{"designId":{"type":"string"},"revision":{"type":"integer","minimum":0}},"required":["designId","revision"]}"""
   }
+}
+
+/**
+ * Authenticates one remote MCP session against the authoritative UI-builder service.
+ *
+ * The catalog read happens before an MCP session is allocated: it proves that the bearer is
+ * currently accepted and has `ui-builder-read`. Every later operation still carries the same
+ * bearer, so expiry and revocation remain enforced by preview-server.
+ */
+internal fun authenticatedUiBuilderMcp(baseUrl: String, token: String): UiBuilderMcpAdapter {
+  val client = UiBuilderDesignApiClient.remote(baseUrl, token)
+  client.execute(ListCatalogsRequestV1)
+  return UiBuilderMcpAdapter(client)
 }
 
 /** Authenticated HTTP client for one remote preview-server UI-builder service. */

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttp.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttp.kt
@@ -1,0 +1,188 @@
+package ee.schimke.composeai.mcp
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.request.header
+import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import io.ktor.util.AttributeKey
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStreamableHttp
+import java.net.URI
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal const val MCP_SESSION_ID_HEADER = "Mcp-Session-Id"
+
+internal data class UiBuilderStreamableHttpConfig(
+  val uiBuilderUrl: String,
+  val host: String = "127.0.0.1",
+  val port: Int = 8788,
+  val path: String = "/mcp",
+  val allowedHosts: List<String>? = null,
+  val allowedOrigins: List<String>? = null,
+) {
+  init {
+    require(uiBuilderUrl.isNotBlank()) { "--ui-builder-url is required for Streamable HTTP" }
+    val upstream = URI(uiBuilderUrl)
+    require(upstream.scheme == "http" || upstream.scheme == "https") {
+      "--ui-builder-url must use http or https"
+    }
+    require(!upstream.host.isNullOrBlank()) { "--ui-builder-url must include a host" }
+    require(upstream.userInfo == null && upstream.query == null && upstream.fragment == null) {
+      "--ui-builder-url must not contain credentials, query, or fragment"
+    }
+    require(port in 0..65535) { "--http-port must be between 0 and 65535" }
+    require(path.startsWith('/') && path.length > 1) {
+      "--http-path must be an absolute non-root path"
+    }
+    require('\n' !in path && '\r' !in path) { "--http-path must not contain newlines" }
+  }
+}
+
+internal data class AuthenticatedUiBuilderSession(
+  val tokenBinding: String,
+  val adapter: UiBuilderMcpAdapter,
+)
+
+internal fun interface UiBuilderSessionAuthenticator {
+  fun authenticate(token: String): AuthenticatedUiBuilderSession
+}
+
+/**
+ * Installs the stateful MCP Streamable HTTP endpoint for the shared UI builder.
+ *
+ * Authentication is deliberately outside the MCP SDK route so it applies to POST, GET/SSE and
+ * DELETE alike. The first request validates the preview-server grant; the returned MCP session id
+ * is then bound to that grant fingerprint. A different valid grant therefore cannot take over an
+ * existing MCP session if its id leaks.
+ */
+internal fun Application.installUiBuilderStreamableHttp(
+  config: UiBuilderStreamableHttpConfig,
+  authenticator: UiBuilderSessionAuthenticator = UiBuilderSessionAuthenticator { token ->
+    AuthenticatedUiBuilderSession(
+      tokenBinding = tokenSessionBinding(token),
+      adapter = authenticatedUiBuilderMcp(config.uiBuilderUrl, token),
+    )
+  },
+) {
+  val authenticatedCall = AttributeKey<AuthenticatedUiBuilderSession>("ui-builder-mcp-auth")
+  val sessionGrants = ConcurrentHashMap<String, String>()
+
+  intercept(ApplicationCallPipeline.Plugins) {
+    if (call.request.path() != config.path) return@intercept
+
+    val token = call.bearerToken()
+    if (token == null) {
+      call.response.header(HttpHeaders.WWWAuthenticate, "Bearer")
+      call.respondText("Bearer authentication required", status = HttpStatusCode.Unauthorized)
+      finish()
+      return@intercept
+    }
+
+    val tokenBinding = tokenSessionBinding(token)
+    val requestedSession = call.request.header(MCP_SESSION_ID_HEADER)
+    val authenticated =
+      if (requestedSession == null) {
+        val result =
+          withContext(Dispatchers.IO) { runCatching { authenticator.authenticate(token) } }
+            .getOrElse {
+              call.response.header(HttpHeaders.WWWAuthenticate, "Bearer")
+              call.respondText(
+                "Bearer token rejected by UI Builder server",
+                status = HttpStatusCode.Unauthorized,
+              )
+              finish()
+              return@intercept
+            }
+        if (result.tokenBinding != tokenBinding) {
+          call.respondText(
+            "Authenticator returned a mismatched identity",
+            status = HttpStatusCode.Forbidden,
+          )
+          finish()
+          return@intercept
+        }
+        call.attributes.put(authenticatedCall, result)
+        result
+      } else {
+        val expected = sessionGrants[requestedSession]
+        when {
+          expected == null -> {
+            call.respondText("MCP session not found", status = HttpStatusCode.NotFound)
+            finish()
+            return@intercept
+          }
+          expected != tokenBinding -> {
+            call.respondText(
+              "MCP session belongs to another grant",
+              status = HttpStatusCode.Forbidden,
+            )
+            finish()
+            return@intercept
+          }
+        }
+        null
+      }
+
+    try {
+      proceed()
+    } finally {
+      val establishedSession = call.response.headers[MCP_SESSION_ID_HEADER]
+      if (establishedSession != null && authenticated != null) {
+        sessionGrants.putIfAbsent(establishedSession, authenticated.tokenBinding)
+      }
+      if (call.request.httpMethod == HttpMethod.Delete && requestedSession != null) {
+        sessionGrants.remove(requestedSession, tokenBinding)
+      }
+    }
+  }
+
+  mcpStreamableHttp(
+    path = config.path,
+    enableDnsRebindingProtection = true,
+    allowedHosts = config.allowedHosts,
+    // The SDK intentionally skips Origin checks for custom hosts unless origins are supplied.
+    // Same-host is the safe default for the shared deployment; operators may narrow it further.
+    allowedOrigins = config.allowedOrigins ?: config.allowedHosts,
+  ) {
+    call.attributes[authenticatedCall].adapter.sdkServer()
+  }
+}
+
+internal fun runUiBuilderStreamableHttp(config: UiBuilderStreamableHttpConfig) {
+  System.err.println(
+    "compose-preview-mcp: UI Builder Streamable HTTP listening on " +
+      "http://${config.host}:${config.port}${config.path}; upstream=${config.uiBuilderUrl}"
+  )
+  embeddedServer(CIO, host = config.host, port = config.port) {
+      installUiBuilderStreamableHttp(config)
+    }
+    .start(wait = true)
+}
+
+private fun ApplicationCall.bearerToken(): String? {
+  val value = request.header(HttpHeaders.Authorization)?.trim() ?: return null
+  if (!value.startsWith("Bearer ", ignoreCase = true)) return null
+  return value.substringAfter(' ').trim().takeIf(String::isNotEmpty)?.takeUnless {
+    it.any(Char::isWhitespace)
+  }
+}
+
+/**
+ * Full token digest for an authorization binding; the short audit fingerprint is not sufficient.
+ */
+internal fun tokenSessionBinding(token: String): String =
+  MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.UTF_8)).joinToString("") {
+    "%02x".format(it)
+  }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttp.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttp.kt
@@ -28,7 +28,7 @@ internal data class UiBuilderStreamableHttpConfig(
   val uiBuilderUrl: String,
   val host: String = "127.0.0.1",
   val port: Int = 8788,
-  val path: String = "/mcp",
+  val path: String = "/ui-builder/mcp",
   val allowedHosts: List<String>? = null,
   val allowedOrigins: List<String>? = null,
 ) {

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttpTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttpTest.kt
@@ -58,11 +58,11 @@ class UiBuilderStreamableHttpTest {
       )
     }
 
-    val missing = client.post("/mcp") { mcpBody(INITIALIZE) }
+    val missing = client.post("/ui-builder/mcp") { mcpBody(INITIALIZE) }
     assertThat(missing.status).isEqualTo(HttpStatusCode.Unauthorized)
 
     val initialized =
-      client.post("/mcp") {
+      client.post("/ui-builder/mcp") {
         bearer(TOKEN_A)
         mcpBody(INITIALIZE)
       }
@@ -74,7 +74,7 @@ class UiBuilderStreamableHttpTest {
     assertThat(initialized.bodyAsText()).contains("compose-preview-ui-builder")
 
     val tools =
-      client.post("/mcp") {
+      client.post("/ui-builder/mcp") {
         bearer(TOKEN_A)
         header(MCP_SESSION_ID_HEADER, sessionId!!)
         mcpBody(TOOLS_LIST)
@@ -103,7 +103,7 @@ class UiBuilderStreamableHttpTest {
       .inOrder()
 
     val crossedGrant =
-      client.post("/mcp") {
+      client.post("/ui-builder/mcp") {
         bearer(TOKEN_B)
         header(MCP_SESSION_ID_HEADER, sessionId)
         mcpBody(TOOLS_LIST)
@@ -111,7 +111,7 @@ class UiBuilderStreamableHttpTest {
     assertThat(crossedGrant.status).isEqualTo(HttpStatusCode.Forbidden)
 
     val called =
-      client.post("/mcp") {
+      client.post("/ui-builder/mcp") {
         bearer(TOKEN_A)
         header(MCP_SESSION_ID_HEADER, sessionId)
         mcpBody(LIST_COMPONENTS)
@@ -121,7 +121,7 @@ class UiBuilderStreamableHttpTest {
     assertThat(upstreamRequests).hasSize(1)
 
     val deleted =
-      client.delete("/mcp") {
+      client.delete("/ui-builder/mcp") {
         bearer(TOKEN_A)
         header(MCP_SESSION_ID_HEADER, sessionId)
         header(HttpHeaders.Host, "localhost")
@@ -130,7 +130,7 @@ class UiBuilderStreamableHttpTest {
     assertThat(deleted.status.value).isIn(listOf(200, 202, 204))
 
     val afterDelete =
-      client.post("/mcp") {
+      client.post("/ui-builder/mcp") {
         bearer(TOKEN_A)
         header(MCP_SESSION_ID_HEADER, sessionId)
         mcpBody(TOOLS_LIST)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttpTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/UiBuilderStreamableHttpTest.kt
@@ -1,0 +1,169 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.agentgrants.AgentGrantProtocol
+import ee.schimke.composeai.uibuilder.protocol.CatalogsResponseV1
+import ee.schimke.composeai.uibuilder.protocol.HttpRequestEnvelopeV1
+import ee.schimke.composeai.uibuilder.protocol.HttpResponseEnvelopeV1
+import io.ktor.client.request.delete
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+class UiBuilderStreamableHttpTest {
+  @Test
+  fun `streamable HTTP authenticates and binds a grant to the MCP session`() = testApplication {
+    val upstreamRequests = mutableListOf<HttpRequestEnvelopeV1>()
+    val adapter =
+      UiBuilderMcpAdapter(
+        UiBuilderDesignApiClient(
+          actorId = "agent:${AgentGrantProtocol.fingerprintOf(TOKEN_A)}",
+          transport =
+            UiBuilderHttpTransport { body ->
+              val request = json.decodeFromString(HttpRequestEnvelopeV1.serializer(), body)
+              upstreamRequests += request
+              UiBuilderHttpResponse(
+                status = 200,
+                body =
+                  json.encodeToString(
+                    HttpResponseEnvelopeV1(
+                      requestId = request.requestId,
+                      response = CatalogsResponseV1(emptyList()),
+                    )
+                  ),
+              )
+            },
+        )
+      )
+    application {
+      installUiBuilderStreamableHttp(
+        UiBuilderStreamableHttpConfig(uiBuilderUrl = "https://preview.example/"),
+        UiBuilderSessionAuthenticator { token ->
+          require(token == TOKEN_A) { "rejected" }
+          AuthenticatedUiBuilderSession(tokenSessionBinding(token), adapter)
+        },
+      )
+    }
+
+    val missing = client.post("/mcp") { mcpBody(INITIALIZE) }
+    assertThat(missing.status).isEqualTo(HttpStatusCode.Unauthorized)
+
+    val initialized =
+      client.post("/mcp") {
+        bearer(TOKEN_A)
+        mcpBody(INITIALIZE)
+      }
+    assertWithMessage(initialized.bodyAsText())
+      .that(initialized.status)
+      .isEqualTo(HttpStatusCode.OK)
+    val sessionId = initialized.headers[MCP_SESSION_ID_HEADER]
+    assertThat(sessionId).isNotNull()
+    assertThat(initialized.bodyAsText()).contains("compose-preview-ui-builder")
+
+    val tools =
+      client.post("/mcp") {
+        bearer(TOKEN_A)
+        header(MCP_SESSION_ID_HEADER, sessionId!!)
+        mcpBody(TOOLS_LIST)
+      }
+    assertThat(tools.status).isEqualTo(HttpStatusCode.OK)
+    val toolNames =
+      json
+        .parseToJsonElement(tools.bodyAsText())
+        .jsonObject
+        .getValue("result")
+        .jsonObject
+        .getValue("tools")
+        .jsonArray
+        .map { it.jsonObject.getValue("name").jsonPrimitive.content }
+    assertThat(toolNames)
+      .containsExactly(
+        "create_design",
+        "open_design",
+        "list_components",
+        "apply_design_operations",
+        "render_design",
+        "export_svg",
+        "export_compose",
+        "get_revision_diff",
+      )
+      .inOrder()
+
+    val crossedGrant =
+      client.post("/mcp") {
+        bearer(TOKEN_B)
+        header(MCP_SESSION_ID_HEADER, sessionId)
+        mcpBody(TOOLS_LIST)
+      }
+    assertThat(crossedGrant.status).isEqualTo(HttpStatusCode.Forbidden)
+
+    val called =
+      client.post("/mcp") {
+        bearer(TOKEN_A)
+        header(MCP_SESSION_ID_HEADER, sessionId)
+        mcpBody(LIST_COMPONENTS)
+      }
+    assertThat(called.status).isEqualTo(HttpStatusCode.OK)
+    assertThat(called.bodyAsText()).contains("catalogs")
+    assertThat(upstreamRequests).hasSize(1)
+
+    val deleted =
+      client.delete("/mcp") {
+        bearer(TOKEN_A)
+        header(MCP_SESSION_ID_HEADER, sessionId)
+        header(HttpHeaders.Host, "localhost")
+        header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+      }
+    assertThat(deleted.status.value).isIn(listOf(200, 202, 204))
+
+    val afterDelete =
+      client.post("/mcp") {
+        bearer(TOKEN_A)
+        header(MCP_SESSION_ID_HEADER, sessionId)
+        mcpBody(TOOLS_LIST)
+      }
+    assertThat(afterDelete.status).isEqualTo(HttpStatusCode.NotFound)
+  }
+
+  private fun io.ktor.client.request.HttpRequestBuilder.bearer(token: String) {
+    header(HttpHeaders.Authorization, "Bearer $token")
+  }
+
+  private fun io.ktor.client.request.HttpRequestBuilder.mcpBody(body: String) {
+    header(HttpHeaders.Host, "localhost")
+    contentType(ContentType.Application.Json)
+    header(
+      HttpHeaders.Accept,
+      "${ContentType.Application.Json}, ${ContentType.Text.EventStream}",
+    )
+    setBody(body)
+  }
+
+  private companion object {
+    const val TOKEN_A = "grant-a"
+    const val TOKEN_B = "grant-b"
+    const val INITIALIZE =
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"""
+    const val TOOLS_LIST = """{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"""
+    const val LIST_COMPONENTS =
+      """{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_components","arguments":{}}}"""
+    val json = Json {
+      encodeDefaults = true
+      explicitNulls = false
+      ignoreUnknownKeys = false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a stateful MCP Streamable HTTP endpoint exposing only the eight shared UI Builder tools
- authenticate each remote client with its preview-server agent grant and bind the MCP session to the grant
- keep the endpoint loopback-first with DNS-rebinding host/origin protection and document same-origin reverse-proxy and Codex setup
- preserve the existing stdio preview-daemon and optional UI Builder flows

## Verification
- `./gradlew :mcp:check :cli:test :cli:ktfmtCheckMain --no-daemon`
- `./gradlew :mcp:installDist --no-daemon`

Non-visual transport change; no UI evidence required.