### PR TITLE
feat(design-artifacts): default defer-figma-svg to true

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -129,10 +129,10 @@ on:
         type: boolean
         default: false
       defer-figma-svg:
-        description: 'Generate pure editable compose/figma-svg vectors on demand through the trusted live daemon instead of publishing one static SVG per rendered variant. Hybrid vectors with raster crops remain static. The capture still produces transient vectors for catalog validation, then strips them from the executable delivery bundle. Requires publish-live-bundle.'
+        description: 'Generate pure editable compose/figma-svg vectors on demand through the trusted live daemon instead of publishing one static SVG per rendered variant. Hybrid vectors with raster crops remain static. The capture still produces transient vectors for catalog validation, then strips them from the executable delivery bundle. DEFAULTS ON: publishing one static SVG per variant is the second-largest thing a delivery branch carries, and every one of them is rewritten whenever an otherwise identical render packs in a different order. Meaningless without a daemon to regenerate them, so it is ignored (with a notice) when publish-live-bundle is false rather than failing the run — set it false to keep publishing static vectors from a live catalog.'
         required: false
         type: boolean
-        default: false
+        default: true
       embed-deps:
         description: 'Pass --embed-deps to bundle pack so reachable third-party jars are carried inside the bundle under libs/ instead of referenced as Maven coordinates. Needed with publish-live-bundle when the module depends on artifacts the serve box cannot resolve from Maven Central (e.g. JitPack-only deps): without it the live daemon fails to build its classpath and the catalog silently falls back to baked PNGs (livebundle-unavailable). Larger bundle; leave off when every dep is on Central.'
         required: false
@@ -1300,9 +1300,12 @@ jobs:
             echo "::error title=modules input::modules supports only 'all'; use module for one Gradle path."
             exit 1
           fi
+          # defer-figma-svg defaults ON, so a baked-only catalog reaches here with it set without
+          # having asked for it. Deferring needs a daemon to regenerate the vector on request, so
+          # for those catalogs it is simply inapplicable — say so and carry on. Failing here would
+          # break every caller that never opted in.
           if [ "$INPUT_DEFER_FIGMA_SVG" = "true" ] && [ "$INPUT_PUBLISH_LIVE_BUNDLE" != "true" ]; then
-            echo "::error title=defer-figma-svg::defer-figma-svg requires publish-live-bundle: true; otherwise no trusted daemon can produce the vector on request."
-            exit 1
+            echo "::notice title=defer-figma-svg::ignored — it needs publish-live-bundle: true so a trusted daemon can produce the vector on request. Static vectors will be published as before."
           fi
 
       # Repository-wide publication keeps one executable bundle per Gradle module. Discover the
@@ -1859,7 +1862,12 @@ jobs:
           if [ "$INPUT_ALLOW_INCOMPLETE" = "true" ]; then incomplete=(--allow-incomplete); fi
           live=()
           if [ "$INPUT_PUBLISH_LIVE_BUNDLE" = "true" ]; then live=(--publish-live-bundle); fi
-          if [ "$INPUT_DEFER_FIGMA_SVG" = "true" ]; then live+=(--defer-figma-svg); fi
+          # Gated on the live bundle as well: the driver rejects --defer-figma-svg without
+          # --publish-live-bundle, and with the default now ON that would sink every baked-only
+          # catalog. Matches the notice in "Validate module selector" above.
+          if [ "$INPUT_DEFER_FIGMA_SVG" = "true" ] && [ "$INPUT_PUBLISH_LIVE_BUNDLE" = "true" ]; then
+            live+=(--defer-figma-svg)
+          fi
           if [ "$INPUT_EXTRA_SPLIT_MODE" = "full" ]; then
             # The driver checks --extra-renders / --publish-live-bundle itself; the split flag is
             # only knowable here. Without it the extra module's stickers would carry previewIds
@@ -1970,7 +1978,7 @@ jobs:
       # data product on request, so neither the monolith nor its addressable children need to carry
       # thousands of capture-time copies.
       - name: Defer editable Figma SVGs to the live daemon
-        if: ${{ inputs.defer-figma-svg }}
+        if: ${{ inputs.defer-figma-svg && inputs.publish-live-bundle }}
         run: |
           set -euo pipefail
           node compose-ai-tools/scripts/design-artifacts/strip-published-figma-svg.mjs \
@@ -1983,7 +1991,7 @@ jobs:
       # published output is almost entirely repeated classpath. Re-measure against what was actually
       # published, before the gate reads it.
       - name: Re-measure the carriage against the published bundles
-        if: ${{ inputs.split-per-preview && inputs.defer-figma-svg }}
+        if: ${{ inputs.split-per-preview && inputs.defer-figma-svg && inputs.publish-live-bundle }}
         run: |
           set -euo pipefail
           node compose-ai-tools/scripts/design-artifacts/recompute-carriage-report.mjs \

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -112,16 +112,26 @@ layered `compose/figma-svg` export produced per preview; the catalog pipeline
 carries it in the bundle (`previews/<id>.figma.svg`) and copies it onto the
 branch, exactly as it does the schematic `wireframes/`.
 
-A catalog with a trusted executable live lane can instead set `defer-figma-svg: true` alongside
-`publish-live-bundle: true`. CI still captures the vectors transiently, so coverage and the
-PNG↔SVG pairing are validated from the same render, but `catalog.json` publishes each image's
-`figmaSvg` as `/<system>/render/<id>.svg`. After any per-preview split has used the vector bounds to
-crop its cover, the workflow removes `.figma.svg` and `.figma-raster/` sidecars from every
-published executable bundle; the live daemon regenerates and caches the editable vector on its
-first request. Hybrid vectors remain static under `figma/` for now because their `<image>` layers
-need sibling raster crops, which the single-response live SVG route does not yet expose. The mode
-is rejected without `publish-live-bundle`: a static catalog must never publish a link it cannot
-produce.
+A catalog with a trusted executable live lane defers those vectors instead, and **this is the
+default**: `defer-figma-svg` is `true` unless a caller sets it false. CI still captures the vectors
+transiently, so coverage and the PNG↔SVG pairing are validated from the same render, but
+`catalog.json` publishes each image's `figmaSvg` as `/<system>/render/<id>.svg`. After any
+per-preview split has used the vector bounds to crop its cover, the workflow removes `.figma.svg`
+and `.figma-raster/` sidecars from every published executable bundle; the live daemon regenerates
+and caches the editable vector on its first request. Hybrid vectors remain static under `figma/` for
+now because their `<image>` layers need sibling raster crops, which the single-response live SVG
+route does not yet expose.
+
+Deferral needs a daemon to answer the request, so it applies only alongside `publish-live-bundle:
+true`. Because the input now defaults on, a **baked-only catalog reaches the workflow with it set
+without having asked for it** — so there it is ignored with a notice and static vectors are
+published exactly as before, rather than failing the run. (Until 2026-09-02 the input defaulted off
+and the combination was a hard error; a caller that deliberately set it on a static catalog would
+have been told so. That guard is gone, because with the default on it would have failed every
+caller that never opted in.)
+
+**A live catalog that wants static vectors must now say so** — set `defer-figma-svg: false`.
+Leaving the input out is what changed meaning.
 
 Components carrying an `@InteractionPreview` or `@AnimatedPreview` also ship the
 animated capture itself, under **`motion/`**. Both renderer backends produce them —


### PR DESCRIPTION
## Summary
- `defer-figma-svg` now defaults to `true`
- when `publish-live-bundle` is false it is **ignored with a notice** instead of failing validation
- the driver flag and the strip / carriage-re-measure steps are gated on `publish-live-bundle` to match

## Why
Publishing one static editable SVG per rendered variant is the second-largest thing a delivery branch carries, and because the vectors are coordinate-derived, an otherwise identical render packed in a slightly different order rewrites hundreds of them. Every caller that thought about it has now opted in (m3-catalog, meshcore-mobile, homeassistant-remotecompose, wear-m3-catalog, the `wear-m3` tier here), so it should be the default rather than the thing you remember to set.

`split-per-preview` was checked at the same time and **already** defaults to `false` — the callers were all overriding it, which is why turning the split off was a caller-side change everywhere.

## The compatibility decision, stated plainly
Deferring is meaningless without a daemon to regenerate the vector on request, and the old validation made that a hard error. With the default flipped, that error would fire for **every caller that never opted in** — a baked-only catalog would go red on its next run through `@main` having changed nothing.

So the error becomes a notice and the flag is simply not applied. The driver itself rejects `--defer-figma-svg` without `--publish-live-bundle`, so the gating is required, not cosmetic:

- `Validate module selector` → notice, no exit 1
- the `live` args array → only appends `--defer-figma-svg` when the live bundle is carried
- `Defer editable Figma SVGs to the live daemon` → `if: defer-figma-svg && publish-live-bundle`
- `Re-measure the carriage against the published bundles` → same added condition

**This is still a behaviour change for existing live-bundle callers**: a catalog that carries a live bundle and did *not* set `defer-figma-svg` will stop publishing static pure SVGs on its next run and serve them from the daemon instead. Hybrid vectors with raster crops remain static either way, so crop references stay self-contained. Callers who want the old behaviour set `defer-figma-svg: false`.

## Test plan
- workflow YAML parses; `git diff --check`
- traced every consumer of the input — the two `if:` step conditions, the `INPUT_DEFER_FIGMA_SVG` args block, and the validation step — so no path can now pass `--defer-figma-svg` to the driver without `--publish-live-bundle`
- the on/off combination is already merged and green across five caller repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHCyDw6MTA5wCXhxCPJWqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHCyDw6MTA5wCXhxCPJWqJ)_