### PR TITLE
fix(render): preserve upstream Remote Compose wrapper

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -2933,8 +2933,8 @@ private class WrapperStack(
  * shadow the chosen one). Two exceptions keep the declared wrapper:
  * - the override doesn't load. On a stale / misspelled FQN `loadWrapperByFqnOrNull` logs and
  *   returns null; falling back to the declared wrapper beats stripping it and misrendering.
- * - the declared wrapper is **structural** ([isStructuralPreviewWrapper]) — it installs the surface
- *   the body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
+ * - the declared wrapper is **structural** ([isStructuralWrapperFqn]) — it installs the surface the
+ *   body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
  *   leaves a `RemoteBox` / `RemoteColumn` / `RemoteRow` body on the plain UI applier and throws
  *   `IllegalStateException: Invalid applier`. Here the theme nests OUTSIDE the structural wrapper
  *   rather than replacing it, so the request is honoured as far as it can be and the render stands
@@ -2949,13 +2949,25 @@ private fun resolveWrapperStack(
 ): WrapperStack {
   val declaredFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec)
   val theme = themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
-  val keepDeclared =
-    theme == null || (declaredFqn != null && isStructuralPreviewWrapper(declaredFqn))
+  val keepDeclared = theme == null || (declaredFqn != null && isStructuralWrapperFqn(declaredFqn))
   return WrapperStack(
     theme = theme,
     declared = if (keepDeclared) declaredFqn?.let { loadWrapperByFqnOrNull(it) } else null,
   )
 }
+
+private const val REMOTE_PREVIEW_WRAPPER_FQN =
+  "androidx.compose.remote.tooling.preview.RemotePreviewWrapper"
+
+/**
+ * Recognises wrappers that establish the preview's composition surface rather than merely styling
+ * it. Remote Compose's upstream wrapper must remain structural even when the optional connector is
+ * absent, because replacing it with a theme provider puts remote layout nodes on the UI applier.
+ * The connector SPI remains responsible for substitutions, recording `.rc` documents, and any
+ * additional structural wrappers.
+ */
+internal fun isStructuralWrapperFqn(wrapperFqn: String): Boolean =
+  wrapperFqn == REMOTE_PREVIEW_WRAPPER_FQN || isStructuralPreviewWrapper(wrapperFqn)
 
 /**
  * Render an IR-backed preview through a connector-provided replay composable resolved by

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperResolutionTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -32,6 +33,13 @@ import org.junit.Test
  * (see [RenderEngine] kdoc) eventually folds back into a shared helper.
  */
 class PreviewWrapperResolutionTest {
+
+  @Test
+  fun `upstream Remote Compose wrapper is structural without connector discovery`() {
+    assertTrue(
+      isStructuralWrapperFqn("androidx.compose.remote.tooling.preview.RemotePreviewWrapper")
+    )
+  }
 
   @Test
   fun `resolveWrapperOrNull with spec FQN returns wrapper Wrap method`() {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -2978,8 +2978,8 @@ private class WrapperStack(
  * shadow the chosen one). Two exceptions keep the declared wrapper:
  * - the override doesn't load. On a stale / misspelled FQN `loadWrapperByFqnOrNull` logs and
  *   returns null; falling back to the declared wrapper beats stripping it and misrendering.
- * - the declared wrapper is **structural** ([isStructuralPreviewWrapper]) — it installs the surface
- *   the body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
+ * - the declared wrapper is **structural** ([isStructuralWrapperFqn]) — it installs the surface the
+ *   body composes against, not a look. Replacing `@PreviewWrapper(RemotePreviewWrapper::class)`
  *   leaves a `RemoteBox` / `RemoteColumn` / `RemoteRow` body on the plain UI applier and throws
  *   `IllegalStateException: Invalid applier`. Here the theme nests OUTSIDE the structural wrapper
  *   rather than replacing it, so the request is honoured as far as it can be and the render stands
@@ -2994,13 +2994,25 @@ private fun resolveWrapperStack(
 ): WrapperStack {
   val declaredFqn = declaredWrapperFqnOrNull(composableMethod, wrapperFqnFromSpec)
   val theme = themeProviderFqn?.takeIf { it.isNotBlank() }?.let { loadWrapperByFqnOrNull(it) }
-  val keepDeclared =
-    theme == null || (declaredFqn != null && isStructuralPreviewWrapper(declaredFqn))
+  val keepDeclared = theme == null || (declaredFqn != null && isStructuralWrapperFqn(declaredFqn))
   return WrapperStack(
     theme = theme,
     declared = if (keepDeclared) declaredFqn?.let { loadWrapperByFqnOrNull(it) } else null,
   )
 }
+
+private const val REMOTE_PREVIEW_WRAPPER_FQN =
+  "androidx.compose.remote.tooling.preview.RemotePreviewWrapper"
+
+/**
+ * Recognises wrappers that establish the preview's composition surface rather than merely styling
+ * it. Remote Compose's upstream wrapper must remain structural even when the optional connector is
+ * absent, because replacing it with a theme provider puts remote layout nodes on the UI applier.
+ * The connector SPI remains responsible for substitutions, recording `.rc` documents, and any
+ * additional structural wrappers.
+ */
+internal fun isStructuralWrapperFqn(wrapperFqn: String): Boolean =
+  wrapperFqn == REMOTE_PREVIEW_WRAPPER_FQN || isStructuralPreviewWrapper(wrapperFqn)
 
 /**
  * Resolves the `@PreviewWrapper`'s `PreviewWrapperProvider` to a `Wrap(content)` method plus an

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperStructureTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewWrapperStructureTest.kt
@@ -1,0 +1,13 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewWrapperStructureTest {
+  @Test
+  fun `upstream Remote Compose wrapper is structural without connector discovery`() {
+    assertTrue(
+      isStructuralWrapperFqn("androidx.compose.remote.tooling.preview.RemotePreviewWrapper")
+    )
+  }
+}

--- a/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
+++ b/samples/remotecompose/src/main/kotlin/com/example/sampleremotecompose/Previews.kt
@@ -12,7 +12,7 @@ import ee.schimke.composeai.daemon.RemoteEmbeddedPreviewWrapper
 import ee.schimke.composeai.preview.AnimatedPreview
 
 /**
- * Two ways to preview a Remote Compose component — same output, different code shape. The
+ * Two ways to preview a Remote Compose component — same pixels, different export behavior. The
  * component-preview dimensions (200×200) are kept small and square so the rendered PNG frames a
  * single button cleanly; bump `widthDp` / `heightDp` if you add components that need more room.
  */
@@ -26,7 +26,9 @@ import ee.schimke.composeai.preview.AnimatedPreview
 // { ... } }`. Verbose for many previews but works today — no reliance on
 // the `@PreviewWrapper` tooling annotation (which only exists in
 // compose-ui 1.11.0-beta+ and isn't yet understood by Android Studio
-// releases paired with stable Compose).
+// releases paired with stable Compose). This renders the pixels but does not expose
+// the recorded Remote Compose document to compose-preview, so it does not emit an
+// `.rc` data product.
 // ---------------------------------------------------------------------------
 
 @Preview(showBackground = true, widthDp = 200, heightDp = 200)
@@ -62,7 +64,10 @@ fun RemoteButtonWithShapePreview() {
 // substitution wires `renderNow.overrides.remoteCompose.namedValues` into the
 // running player's `StateUpdater`, so a binding like
 // `rememberNamedRemoteString("label", "Tap me")` flips when the daemon seeds an
-// override — no annotation change on the preview side.
+// override — no annotation change on the preview side. The substitution also
+// records the Remote Compose document as an `.rc` data product. Keep this wrapper
+// form, and add `data-remotecompose-connector` as a debug dependency, whenever the
+// document itself must be collected in addition to the rendered pixels.
 // ---------------------------------------------------------------------------
 
 @Preview(showBackground = true, widthDp = 200, heightDp = 200)
@@ -78,9 +83,10 @@ fun RemoteButtonWithBorderPreview() {
  * infinite, and [AnimatedPreview.showCurves] is disabled because the moving values live in the
  * Remote Compose document rather than Compose UI's animation inspector.
  *
- * The wrapper path also emits the captured `.rc` document. This variant uses the standard
- * View-backed Remote Compose player; [RemoteIndeterminateCircularProgressIndicatorEmbeddedPreview]
- * renders the identical remote content through the embedded Compose player.
+ * With `:data-remotecompose-connector` on the render classpath, the wrapper path also emits the
+ * captured `.rc` document. This variant uses the standard View-backed Remote Compose player;
+ * [RemoteIndeterminateCircularProgressIndicatorEmbeddedPreview] renders the identical remote
+ * content through the embedded Compose player.
  */
 @Preview(showBackground = true, widthDp = 200, heightDp = 200)
 @PreviewWrapper(RemotePreviewWrapper::class)


### PR DESCRIPTION
## Summary
- always classify the upstream `RemotePreviewWrapper` as structural in Android and desktop daemons
- prevent catalog theme overrides from replacing the Remote Compose applier when the optional connector SPI is absent
- clarify in the sample that in-body `RemoteContentPreview` produces pixels but not recorded `.rc` documents

The connector remains responsible for wrapper substitution, overrides, replay metadata, and `.rc` recording.

## Verification
- `:daemon:android:ktfmtFormat :daemon:desktop:ktfmtFormat :samples:remotecompose:ktfmtFormat`
- `:daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.PreviewWrapperResolutionTest`
- `:daemon:desktop:test --tests ee.schimke.composeai.daemon.PreviewWrapperStructureTest`