### PR TITLE
fix: restore Module Unit Tests on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,8 +276,7 @@ jobs:
               -x :samples:remotecompose:test \
               -x :samples:wear:test \
               -x :samples:wear-widget:test \
-              -x :samples:xr-glimmer:test \
-              -x :samples:xr-spatial:test
+              -x :samples:xr-glimmer:test
           elif [ -z "$TEST_TASKS" ] || [ "$TEST_TASKS" = none ]; then
             # The job `if` normally keeps this branch unreached; it's here so a future skew
             # between the two scope configs is a no-op run, never a `gradlew none` failure.

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1384,8 +1384,17 @@ internal object ComposeLayoutInspector {
       // NodeElement may delegate its entire draw to a CacheDrawModifierNode while exposing no
       // `onDraw` lambda for the vector/raster replay tiers (Material 3 wavy progress indicators).
       drawsContent = drawsContent,
+      // `modifiesDrawnContent` asks FigmaSvgModel to flatten this node to a raster, because a draw
+      // modifier alters content the structured children cannot express. With an indication present
+      // that is no longer true: `indicationForegrounds` above captures each after-content pass as
+      // its own child, at the modifier's real paint position, which is exactly the decomposition
+      // the flag exists to fall back from. Leaving both on means the flatten wins and the model
+      // returns a leaf before it reads those children — a `drawWithContent` + `clickable` chain
+      // then exports its focus state layer baked into the capture instead of as an editable
+      // overlay, which is what `OverrideIntegrationTest` catches.
       modifiesDrawnContent =
-        DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
+        indications.isEmpty() &&
+          DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
       transform = ownerTransform,
       // A Material indication draws after its inner content but before the foreground of any outer
       // drawWithContent modifier. ModifierInfo is outer-to-inner, so sorting descending

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1384,17 +1384,8 @@ internal object ComposeLayoutInspector {
       // NodeElement may delegate its entire draw to a CacheDrawModifierNode while exposing no
       // `onDraw` lambda for the vector/raster replay tiers (Material 3 wavy progress indicators).
       drawsContent = drawsContent,
-      // `modifiesDrawnContent` asks FigmaSvgModel to flatten this node to a raster, because a draw
-      // modifier alters content the structured children cannot express. With an indication present
-      // that is no longer true: `indicationForegrounds` above captures each after-content pass as
-      // its own child, at the modifier's real paint position, which is exactly the decomposition
-      // the flag exists to fall back from. Leaving both on means the flatten wins and the model
-      // returns a leaf before it reads those children — a `drawWithContent` + `clickable` chain
-      // then exports its focus state layer baked into the capture instead of as an editable
-      // overlay, which is what `OverrideIntegrationTest` catches.
       modifiesDrawnContent =
-        indications.isEmpty() &&
-          DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
+        DrawContentEffectProbe.modifiesContent(modifiers, captureW, captureH, density),
       transform = ownerTransform,
       // A Material indication draws after its inner content but before the foreground of any outer
       // drawWithContent modifier. ModifierInfo is outer-to-inner, so sorting descending

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
@@ -89,13 +89,26 @@ internal object DrawContentEffectProbe {
     return dark.indices.any { index -> channelDistance(dark[index], light[index]) < CONTENT_FLOOR }
   }
 
-  /** The largest per-channel gap between two opaque calibration pixels. */
-  private fun channelDistance(first: Int, second: Int): Int =
-    maxOf(
-      abs(((first shr 16) and 0xFF) - ((second shr 16) and 0xFF)),
-      abs(((first shr 8) and 0xFF) - ((second shr 8) and 0xFF)),
-      abs((first and 0xFF) - (second and 0xFF)),
-    )
+  /**
+   * How far apart two calibration pixels are once each channel carries its own alpha.
+   *
+   * `readPixels` hands back **unpremultiplied** ARGB, so a draw that attenuates purely through
+   * alpha — a `DstIn` gradient, a save-layer fade bottoming out near 1% opacity — leaves the two
+   * runs' RGB near black and white while both pixels are almost entirely transparent. Comparing raw
+   * channels would call that a 255-unit gap and let a real mask through as editable opaque
+   * descendants. Folding alpha in first collapses both to nearly zero, which is what they paint
+   * like, and the alpha term catches a mask that varies opacity without touching colour.
+   */
+  private fun channelDistance(first: Int, second: Int): Int {
+    val firstAlpha = (first ushr 24) and 0xFF
+    val secondAlpha = (second ushr 24) and 0xFF
+    fun gap(shift: Int): Int =
+      abs(
+        (((first shr shift) and 0xFF) * firstAlpha) / 255 -
+          (((second shr shift) and 0xFF) * secondAlpha) / 255
+      )
+    return maxOf(gap(16), gap(8), gap(0), abs(firstAlpha - secondAlpha))
+  }
 
   private fun render(
     width: Int,

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.layout.ModifierInfo
 import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.abs
 
 /**
  * Detects a draw modifier that obscures pixels produced by `drawContent()`.
@@ -31,6 +32,24 @@ import androidx.compose.ui.unit.LayoutDirection
 internal object DrawContentEffectProbe {
   private const val MAX_PIXELS = 8_000_000
 
+  /**
+   * How little the stand-in content may move a pixel before that pixel counts as obscured.
+   *
+   * The calibration fills are black and white, so an unobscured pixel moves the full 255 and a
+   * clipped, masked or replaced one does not move at all. Between those sits the case this
+   * threshold exists for: a gradient fade, which still lets a little of the content through at its
+   * strongest point. 8/255 is ~3% — content attenuated that far is not something the layout tree
+   * can reconstruct, so those nodes keep their frame crop.
+   *
+   * The pair used to differ by a single unit, which put the measurement on the quantisation floor:
+   * an additive overlay at alpha 0.01 multiplies content by 0.99, and a one-unit difference times
+   * 0.99 rounds back to the same byte for *every* pixel. A plain `drawWithContent { drawContent();
+   * drawRect(…) }` foreground therefore read as a clip and cost `OverrideIntegrationTest` its
+   * exported indication. Measured on that fixture: 1024 of 1024 pixels collided under the one-unit
+   * pair and none under black/white.
+   */
+  private const val CONTENT_FLOOR = 8
+
   fun modifiesContent(
     modifiers: List<ModifierInfo>,
     width: Int,
@@ -50,55 +69,33 @@ internal object DrawContentEffectProbe {
     width: Int,
     height: Int,
     density: Float,
-  ): Boolean =
-    // Two calibrations, and a pixel has to look content-independent under *both* to count.
-    //
-    // The one-step pair alone reports a pixel as obscured whenever the draw merely scales content
-    // toward something else: an additive overlay at alpha 0.01 multiplies the content by 0.99, and
-    // a one-unit input difference times 0.99 quantises back to the same byte. That is a limit of
-    // the probe's own resolution, not evidence the content stopped being visible — the overlay
-    // leaves 99% of it on screen. It made a `drawWithContent { drawContent(); drawRect(…) }`
-    // foreground read as a clip, which flattens the node to a frame crop and cost
-    // `OverrideIntegrationTest` its exported indication.
-    //
-    // A genuinely obscuring draw — a clip, a mask, an opaque replacement, an omitted
-    // `drawContent()` — makes those pixels independent of the content, so they stay identical no
-    // matter how far apart the two calibration fills are. Confirming against black/white keeps
-    // every one of those and drops only the quantisation artefacts, because it puts the input
-    // difference 255 units clear of the rounding floor.
-    contentIndependent(lambda, width, height, density, Color.Black, Color(0xFF010101)) &&
-      contentIndependent(lambda, width, height, density, Color.Black, Color.White)
-
-  /**
-   * Whether any output pixel is unchanged when the stand-in content is redrawn in [second] rather
-   * than [first] — including the degenerate case of a draw that never calls `drawContent()` at all.
-   */
-  private fun contentIndependent(
-    lambda: DrawScope.() -> Unit,
-    width: Int,
-    height: Int,
-    density: Float,
-    first: Color,
-    second: Color,
   ): Boolean {
-    lateinit var firstScope: ProbedContentDrawScope
-    val firstPixels =
+    lateinit var darkScope: ProbedContentDrawScope
+    val dark =
       render(width, height, density) {
-        firstScope = ProbedContentDrawScope(this, first)
-        firstScope.lambda()
+        darkScope = ProbedContentDrawScope(this, Color.Black)
+        darkScope.lambda()
       }
-    if (firstScope.drawContentCalls == 0) return true
+    if (darkScope.drawContentCalls == 0) return true
 
-    lateinit var secondScope: ProbedContentDrawScope
-    val secondPixels =
+    lateinit var lightScope: ProbedContentDrawScope
+    val light =
       render(width, height, density) {
-        secondScope = ProbedContentDrawScope(this, second)
-        secondScope.lambda()
+        lightScope = ProbedContentDrawScope(this, Color.White)
+        lightScope.lambda()
       }
-    if (secondScope.drawContentCalls == 0) return true
+    if (lightScope.drawContentCalls == 0) return true
 
-    return firstPixels.indices.any { index -> firstPixels[index] == secondPixels[index] }
+    return dark.indices.any { index -> channelDistance(dark[index], light[index]) < CONTENT_FLOOR }
   }
+
+  /** The largest per-channel gap between two opaque calibration pixels. */
+  private fun channelDistance(first: Int, second: Int): Int =
+    maxOf(
+      abs(((first shr 16) and 0xFF) - ((second shr 16) and 0xFF)),
+      abs(((first shr 8) and 0xFF) - ((second shr 8) and 0xFF)),
+      abs((first and 0xFF) - (second and 0xFF)),
+    )
 
   private fun render(
     width: Int,

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/DrawContentEffectProbe.kt
@@ -50,24 +50,54 @@ internal object DrawContentEffectProbe {
     width: Int,
     height: Int,
     density: Float,
+  ): Boolean =
+    // Two calibrations, and a pixel has to look content-independent under *both* to count.
+    //
+    // The one-step pair alone reports a pixel as obscured whenever the draw merely scales content
+    // toward something else: an additive overlay at alpha 0.01 multiplies the content by 0.99, and
+    // a one-unit input difference times 0.99 quantises back to the same byte. That is a limit of
+    // the probe's own resolution, not evidence the content stopped being visible — the overlay
+    // leaves 99% of it on screen. It made a `drawWithContent { drawContent(); drawRect(…) }`
+    // foreground read as a clip, which flattens the node to a frame crop and cost
+    // `OverrideIntegrationTest` its exported indication.
+    //
+    // A genuinely obscuring draw — a clip, a mask, an opaque replacement, an omitted
+    // `drawContent()` — makes those pixels independent of the content, so they stay identical no
+    // matter how far apart the two calibration fills are. Confirming against black/white keeps
+    // every one of those and drops only the quantisation artefacts, because it puts the input
+    // difference 255 units clear of the rounding floor.
+    contentIndependent(lambda, width, height, density, Color.Black, Color(0xFF010101)) &&
+      contentIndependent(lambda, width, height, density, Color.Black, Color.White)
+
+  /**
+   * Whether any output pixel is unchanged when the stand-in content is redrawn in [second] rather
+   * than [first] — including the degenerate case of a draw that never calls `drawContent()` at all.
+   */
+  private fun contentIndependent(
+    lambda: DrawScope.() -> Unit,
+    width: Int,
+    height: Int,
+    density: Float,
+    first: Color,
+    second: Color,
   ): Boolean {
-    lateinit var darkScope: ProbedContentDrawScope
-    val dark =
+    lateinit var firstScope: ProbedContentDrawScope
+    val firstPixels =
       render(width, height, density) {
-        darkScope = ProbedContentDrawScope(this, Color.Black)
-        darkScope.lambda()
+        firstScope = ProbedContentDrawScope(this, first)
+        firstScope.lambda()
       }
-    if (darkScope.drawContentCalls == 0) return true
+    if (firstScope.drawContentCalls == 0) return true
 
-    lateinit var lightScope: ProbedContentDrawScope
-    val light =
+    lateinit var secondScope: ProbedContentDrawScope
+    val secondPixels =
       render(width, height, density) {
-        lightScope = ProbedContentDrawScope(this, Color(0xFF010101))
-        lightScope.lambda()
+        secondScope = ProbedContentDrawScope(this, second)
+        secondScope.lambda()
       }
-    if (lightScope.drawContentCalls == 0) return true
+    if (secondScope.drawContentCalls == 0) return true
 
-    return dark.indices.any { index -> dark[index] == light[index] }
+    return firstPixels.indices.any { index -> firstPixels[index] == secondPixels[index] }
   }
 
   private fun render(


### PR DESCRIPTION
## Summary

`CI / Module Unit Tests (push)` has been red on `main` for two independent reasons. This PR fixes both — the second only became visible once the first was out of the way.

### 1. Stale task exclusion killed the job at configuration (`ci.yml`)

[#4972](https://github.com/yschimke/compose-ai-tools/pull/4972) moved the XR renderer to `compose-preview-xr` and dropped `:samples:xr-spatial` from `settings.gradle.kts`, but the full-suite branch still passed `-x :samples:xr-spatial:test`. Gradle rejects an unresolvable exclusion at **configuration** time, so the job died at ~56s before a single test ran:

```
> Selection failed
    Cannot locate excluded tasks that match ':samples:xr-spatial:test' as project 'xr-spatial' not found in project ':samples'.
```

The remaining seven exclusions all still name live projects.

### 2. The obscured-pixel probe measured on the quantisation floor (`DrawContentEffectProbe`)

With the job running again, `:daemon:desktop:test` failed 2 of 360:

```
OverrideIntegrationTest > innerDrawWithContentForegroundRemainsBelowIndication FAILED
OverrideIntegrationTest > outerDrawWithContentForegroundRemainsAboveIndication FAILED
    java.lang.AssertionError: focused state layer must be exported
```

Both tests arrived with [#4973](https://github.com/yschimke/compose-ai-tools/pull/4973), whose CI run was **cancelled** — and every `main` run since #4972 died at configuration, so they had never once executed. They landed red and stayed invisible.

They fail on the *first* assertion: for a chain combining `drawWithContent` with `clickable`, no state layer reached the SVG at all. The node was flattened to a frame crop, with the focus overlay baked into the PNG instead of exported as an editable layer. The flatten is requested by `modifiesDrawnContent`, and instrumenting the probe showed it firing on a draw that should not trip it — `drawWithContent { drawContent(); drawRect(Color.Blue.copy(alpha = 0.01f)) }`, a purely additive foreground the probe's own KDoc says should return `false`.

**Cause.** The probe called a pixel obscured when redrawing the stand-in content in a different colour left it unchanged, using calibration fills one unit apart (`Black` vs `0xFF010101`). That sits on the quantisation floor: an alpha-0.01 overlay scales content by 0.99, and a one-unit difference times 0.99 rounds back to the same byte — on **all 1024** pixels of that fixture.

**Fix.** "Identical" is the wrong predicate; how far the draw *attenuates* its content is the real signal, and the calibration fills set the resolution it can be measured at. Measured black vs white:

| draw | evidence | verdict |
| --- | --- | --- |
| additive overlay (α 0.01) | min channel gap **250** | content plainly visible |
| picker fade (soft gradient) | **1024 px** below 8 | content effectively gone |
| picker mask (hard) | **52 736 px** at 0 | content absent |

So the probe now calibrates black against white and counts a pixel obscured when the content moves it less than 8/255 (~3%). Clips, masks, opaque replacements and an omitted `drawContent()` sit at 0; a gradient fade dips under the floor where it is strongest; an additive foreground never comes close. Channel distances are **premultiplied** by each pixel's own alpha, with the alpha gap taken alongside — `readPixels` returns unpremultiplied ARGB, so an alpha-only mask (`DstIn` gradient, save-layer fade) would otherwise read as a 255-unit gap while both pixels are nearly transparent. `modifiesDrawnContent` itself is unchanged.

Two earlier approaches on this branch were tried and reverted, both caught by existing tests: suppressing `modifiesDrawnContent` whenever an indication was present (too broad — a clip still needs the crop), and requiring pixels to be *identical* under a wide calibration (misses a soft gradient fade, which failed `FigmaSvgWearPickerTest`).

**Known gap, deliberately not fixed here.** A node with no indication and a translucent `drawWithContent` foreground no longer gets the frame crop, and `captureForeground` runs only for indicated nodes, so that paint is dropped. Both remedies conflict with existing behaviour — forcing the crop back fails `FigmaSvgGradientTintedIconButtonRenderTest`, and capturing the foreground unconditionally requires making the graphic-to-child move unconditional too, a design change to the export's child model. Detail in the review thread; flagged for a decision rather than guessed at.

Not UI-affecting in the rendered-preview sense: the preview-diff bot reports no rendered-preview change, and the SVG *export* gains the structured state-layer node these tests assert.

## Test plan

**Configuration fix** — reproduced, then confirmed the task graph resolves:

```
./gradlew --dry-run test jvmTest desktopTest checkKotlinAbi -x :samples:android:test … -x :samples:xr-glimmer:test
→ BUILD SUCCESSFUL (previously failed at configuration)
```

**Probe fix** — reproduced on clean `origin/main` at `5347385` first, so the failure is demonstrably pre-existing:

```
$ git checkout --detach origin/main && ./gradlew :daemon:desktop:test --tests '*OverrideIntegrationTest*'
31 tests completed, 2 failed          # before
$ ./gradlew :daemon:desktop:test --tests '*OverrideIntegrationTest*'
BUILD SUCCESSFUL — 31 tests, 0 failed  # after
```

Full module scope on every suite the connector feeds — **882 tests, 0 failures**:

| suite | tests | covers |
| --- | --- | --- |
| `:renderer-android:testDebugUnitTest` | 310 | `FigmaSvgWearPickerTest`, `FigmaSvgDrawRasterRenderTest`, `FigmaSvgGradientTintedIconButtonRenderTest` |
| `:daemon:desktop:test` | 360 | `OverrideIntegrationTest` (31) |
| `:data-layoutinspector-connector:test` | 212 | probe + semantics |

CI on `6227b17`: **`Module Unit Tests` green** (21 min, full suite), `Renderer Android Unit Tests` green, plus all daemon harnesses, plugin suites, ktfmt and every downstream consumer job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014X2sVi4cbza83m2c5fqb6e