### PR TITLE
fix(auto-inject): reach a build that locks its buildscript classpath

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -423,7 +423,12 @@ fun org.gradle.api.Project.composeAiPreviewResolvePluginClasspath(): Set<java.io
         )
     val composeAiPreviewResolved =
         runCatching {
-            configurations.detachedConfiguration(composeAiPreviewMarker).files.toSet()
+            configurations.detachedConfiguration(composeAiPreviewMarker).apply {
+                // A build using `dependencyLocking { lockAllConfigurations() }` would lock this
+                // one too, and it is a configuration we created for this resolution alone — no
+                // lock state describes it and none should.
+                resolutionStrategy.deactivateDependencyLocking()
+            }.files.toSet()
         }.getOrDefault(emptySet())
     if (composeAiPreviewResolved.isNotEmpty()) {
         composeAiPreviewCachedPluginClasspath = composeAiPreviewResolved
@@ -433,6 +438,34 @@ fun org.gradle.api.Project.composeAiPreviewResolvePluginClasspath(): Set<java.io
 
 allprojects {
     if (composeAiPreviewIsIncludedBuild) return@allprojects
+    // A build that LOCKS its buildscript classpath rejects every module the lock state does not
+    // name, and auto-inject's whole job is to add one it does not name:
+    //
+    //   > Could not resolve all artifacts for configuration 'classpath'.
+    //      > Resolved 'ee.schimke.composeai.preview:...' which is not part of the dependency lock
+    //        state
+    //
+    // That fires while the buildscript classpath resolves, so it takes the build out before
+    // discovery ever runs — the bitwarden/android import hit it with 51 previews it could never
+    // reach (yschimke/compose-preview-imports#30).
+    //
+    // Deactivating locking from here does NOT work, and the reproducer pins why: the imported
+    // build activates it inside its own `buildscript { configurations.classpath { ... } }`, which
+    // Gradle evaluates AFTER this init script, so the project's activation is simply the last
+    // writer. The route that does work is the one the exclusiveContent shape already uses — inject
+    // the plugin as `files(...)` instead of as a coordinate. A file dependency resolves to no
+    // module component at all, so lock state has nothing to validate against and the locked
+    // configuration stays exactly as locked as its owner wrote it. Nothing in the checkout is
+    // edited and no lockfile is rewritten.
+    //
+    // Detection is by lockfile on disk, matching how the rest of this script reads a build it does
+    // not control: Gradle's per-project buildscript lock state is `buildscript-gradle.lockfile`
+    // beside the build script (bitwarden's shape), and the pre-6.0 layout is a
+    // `gradle/dependency-locks/` directory.
+    val composeAiPreviewBuildscriptClasspathIsLocked =
+        java.io.File(projectDir, "buildscript-gradle.lockfile").isFile ||
+            java.io.File(rootDir, "gradle/dependency-locks").isDirectory
+
     // In the exclusiveContent shape Gradle 9.3+ rejects adding to buildscript.repositories from
     // any project (issues #1470, #1482), so a project without its own `buildscript { repositories
     // { ... } }` can't resolve our classpath coordinate that way. Rather than drop auto-inject
@@ -441,8 +474,9 @@ allprojects {
     // files — see composeAiPreviewResolvePluginClasspath above. Modules that DO declare their own
     // buildscript repos still take the plain coordinate path below (their repos resolve it).
     val composeAiPreviewNeedsResolvedClasspathInject =
-        composeAiPreviewSettingsHasExclusiveContent &&
-            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos
+        composeAiPreviewBuildscriptClasspathIsLocked ||
+            (composeAiPreviewSettingsHasExclusiveContent &&
+                projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos)
 
     // Gradle inherits a project's buildscript classpath into its subprojects' `plugins { }`
     // resolution. So injecting the plugin onto an ANCESTOR of a module that applies the plugin

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -460,11 +460,18 @@ allprojects {
     //
     // Detection is by lockfile on disk, matching how the rest of this script reads a build it does
     // not control: Gradle's per-project buildscript lock state is `buildscript-gradle.lockfile`
-    // beside the build script (bitwarden's shape), and the pre-6.0 layout is a
-    // `gradle/dependency-locks/` directory.
+    // beside the build script (bitwarden's shape), and the pre-6.0 layout is a per-configuration
+    // file under `gradle/dependency-locks/`.
+    //
+    // Name that legacy file exactly, rather than testing for the directory. A build can lock
+    // `runtimeClasspath` and nothing else, and the directory alone would then route every project
+    // down the files() branch on false pretences — and that branch degrades to a no-op when it
+    // cannot resolve, so the cost of a false positive is a silently plugin-less module, which is
+    // the failure mode this whole change exists to remove (PR #4987 review).
     val composeAiPreviewBuildscriptClasspathIsLocked =
         java.io.File(projectDir, "buildscript-gradle.lockfile").isFile ||
-            java.io.File(rootDir, "gradle/dependency-locks").isDirectory
+            java.io.File(projectDir, "gradle/dependency-locks/buildscript-classpath.lockfile")
+                .isFile
 
     // In the exclusiveContent shape Gradle 9.3+ rejects adding to buildscript.repositories from
     // any project (issues #1470, #1482), so a project without its own `buildscript { repositories
@@ -502,7 +509,21 @@ allprojects {
             // not in the consumer's repos) — degrade to a no-op, exactly as this branch did before
             // it learned to inject.
             val composeAiPreviewClasspath = composeAiPreviewResolvePluginClasspath()
-            if (composeAiPreviewClasspath.isEmpty()) return@allprojects
+            if (composeAiPreviewClasspath.isEmpty()) {
+                // This branch resolves through the PROJECT's repositories, so a build that
+                // publishes the plugin only into `buildscript.repositories` cannot be served here
+                // and lands in this no-op. Silence would surface as an empty catalog with no
+                // explanation — the exact shape of yschimke/compose-preview-imports#30 — so say
+                // which module was skipped and what would fix it (PR #4987 review).
+                logger.warn(
+                    "compose-preview: could not resolve the preview plugin through ${'$'}path's " +
+                        "repositories, so it was not injected there. Declare the plugin's " +
+                        "repository in settings (dependencyResolutionManagement or " +
+                        "pluginManagement) so a build that locks or verifies its buildscript " +
+                        "classpath can still resolve it."
+                )
+                return@allprojects
+            }
             val composeAiPreviewClasspathFiles = files(composeAiPreviewClasspath)
             buildscript {
                 dependencies {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -806,7 +806,7 @@ class AutoInjectTest {
     )
     assertTrue(
       script.contains(
-        "val composeAiPreviewBuildscriptClasspathIsLocked =\n        java.io.File(projectDir, \"buildscript-gradle.lockfile\").isFile ||\n            java.io.File(rootDir, \"gradle/dependency-locks\").isDirectory"
+        "java.io.File(projectDir, \"gradle/dependency-locks/buildscript-classpath.lockfile\")"
       ),
       "expected the locked-buildscript detection that routes a locked build down the files() " +
         "branch (see InitScriptDependencyLockingReproducerTest)",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -800,9 +800,16 @@ class AutoInjectTest {
     )
     assertTrue(
       script.contains(
-        "val composeAiPreviewNeedsResolvedClasspathInject =\n        composeAiPreviewSettingsHasExclusiveContent &&\n            projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos"
+        "val composeAiPreviewNeedsResolvedClasspathInject =\n        composeAiPreviewBuildscriptClasspathIsLocked ||\n            (composeAiPreviewSettingsHasExclusiveContent &&\n                projectDir !in composeAiPreviewProjectsWithOwnBuildscriptRepos)"
       ),
       "expected the per-project fork flag in allprojects",
+    )
+    assertTrue(
+      script.contains(
+        "val composeAiPreviewBuildscriptClasspathIsLocked =\n        java.io.File(projectDir, \"buildscript-gradle.lockfile\").isFile ||\n            java.io.File(rootDir, \"gradle/dependency-locks\").isDirectory"
+      ),
+      "expected the locked-buildscript detection that routes a locked build down the files() " +
+        "branch (see InitScriptDependencyLockingReproducerTest)",
     )
     assertFalse(
       script.contains("composeAiPreviewSkipExclusiveContentClasspathDep"),
@@ -830,7 +837,7 @@ class AutoInjectTest {
       "expected the detached-configuration classpath resolver helper",
     )
     assertTrue(
-      script.contains("configurations.detachedConfiguration(composeAiPreviewMarker).files.toSet()"),
+      script.contains("configurations.detachedConfiguration(composeAiPreviewMarker)"),
       "expected resolution via a detached configuration (not a buildscript.repositories add)",
     )
     assertTrue(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyLockingReproducerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyLockingReproducerTest.kt
@@ -1,0 +1,282 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+
+/**
+ * End-to-end reproducer for the Bitwarden shape (https://github.com/bitwarden/android `main`): the
+ * build locks its buildscript classpath — `buildscript { configurations.classpath {
+ * resolutionStrategy.activateDependencyLocking() } }` plus a checked-in
+ * `buildscript-gradle.lockfile` — so Gradle rejects ANY module the lock state does not name:
+ * ```
+ * A problem occurred configuring root project 'Bitwarden'.
+ * > Could not resolve all artifacts for configuration 'classpath'.
+ *    > LockOutOfDateException: Resolved 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0'
+ *      which is not part of the dependency lock state
+ * ```
+ *
+ * Auto-inject adds the compose-preview plugin to exactly that configuration, so on a locked build
+ * it fails during configuration — before discovery, before any render. The import of
+ * bitwarden/android hit this on its first build (yschimke/compose-preview-imports#30): 51 previews,
+ * none of them reachable.
+ *
+ * Locking is a property of somebody else's build and not ours to edit — the checkout is theirs and
+ * the lockfile is deliberate. What the init script may do is stop locking applying to the ONE
+ * configuration it injects into, for the duration of this render: a build we drive to draw pictures
+ * has no stake in the lock state of its own buildscript classpath. That is what
+ * `deactivateDependencyLocking()` does here, and these tests pin both halves — the locked build
+ * configures and the plugin actually applies, and an unlocked build is left exactly as it was.
+ *
+ * Modelled on [InitScriptExclusiveContentReproducerTest]: same TestKit shape, same stub-plugin
+ * publishing, so the two read as a pair.
+ */
+class InitScriptDependencyLockingReproducerTest {
+
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun tempDir(prefix: String = "compose-preview-locking-"): File =
+    Files.createTempDirectory(prefix).toFile().also { tempDirs += it }
+
+  /**
+   * A project whose root buildscript classpath is locked to an EMPTY lock state, which is the
+   * strictest form of the Bitwarden shape: every module the init script injects is "not part of the
+   * dependency lock state". `:app` applies the stub `com.android.application`, the host id that
+   * triggers auto-inject.
+   */
+  private fun createLockedProject(repo: File): File {
+    val root = tempDir()
+    File(root, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                maven { url = uri("${repo.toURI()}") }
+                gradlePluginPortal()
+            }
+        }
+        dependencyResolutionManagement {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+        }
+        rootProject.name = "locking-repro"
+        include(":app")
+        """
+          .trimIndent()
+      )
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        buildscript {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+            configurations.classpath { resolutionStrategy.activateDependencyLocking() }
+        }
+        """
+          .trimIndent()
+      )
+    // Gradle's own lockfile format. `empty=classpath` states that `classpath` resolved to nothing,
+    // so any dependency added to it is out of date — the Bitwarden failure, minimised.
+    File(root, "buildscript-gradle.lockfile")
+      .writeText(
+        """
+        # This is a Gradle generated file for dependency locking.
+        # Manual edits can break the build and are not advised.
+        # This file is expected to be part of source control.
+        empty=classpath
+        """
+          .trimIndent()
+      )
+    val app = File(root, "app").apply { mkdirs() }
+    File(app, "build.gradle.kts")
+      .writeText("""plugins { id("com.android.application") version "1.0" }""")
+    return app.parentFile
+  }
+
+  @Test
+  fun `init script configures cleanly against a build whose buildscript classpath is locked`() {
+    val repo = tempDir("compose-preview-locking-repo-")
+    publishStubPlugins(repo)
+    val project = createLockedProject(repo)
+    val initScript = materializeInitScript(tempDir(), "1.0")
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(project)
+        .withArguments(":app:help", "--init-script", initScript.absolutePath, "--stacktrace")
+        .forwardOutput()
+        .build()
+
+    assertFalse(
+      result.output.contains("not part of the dependency lock state"),
+      "auto-inject added the plugin to a locked buildscript classpath — configuration fails " +
+        "before discovery runs; full output:\n${result.output}",
+    )
+    assertEquals(
+      TaskOutcome.SUCCESS,
+      result.task(":app:help")?.outcome,
+      "expected :app:help to succeed against a lock-shaped project; got:\n${result.output}",
+    )
+  }
+
+  @Test
+  fun `init script still applies the plugin when the buildscript classpath is locked`() {
+    // Configuring cleanly is not enough: an injection silently skipped would also pass the test
+    // above, and would publish an empty catalog — which is how bitwarden-android failed in the
+    // first place. This pins that the plugin REACHES the module.
+    val repo = tempDir("compose-preview-locking-repo-")
+    publishStubPlugins(repo)
+    val project = createLockedProject(repo)
+    val initScript = materializeInitScript(tempDir(), "1.0")
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(project)
+        .withArguments(":app:help", "--init-script", initScript.absolutePath, "--stacktrace")
+        .forwardOutput()
+        .build()
+
+    assertTrue(
+      result.output.contains("COMPOSE-PREVIEW-APPLIED to :app"),
+      "expected the compose-preview plugin to be auto-injected and applied to :app on a build " +
+        "with a locked buildscript classpath; full output:\n${result.output}",
+    )
+  }
+
+  @Test
+  fun `init script leaves dependency locking alone on a build that does not lock`() {
+    // The guard must be narrow: deactivating locking is a change to somebody else's build, so it
+    // may only happen where the alternative is failing outright. A build with no locking must be
+    // untouched — no deactivation, no behaviour change, just the ordinary auto-inject path.
+    val repo = tempDir("compose-preview-locking-repo-")
+    publishStubPlugins(repo)
+    val root = tempDir()
+    File(root, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                maven { url = uri("${repo.toURI()}") }
+                gradlePluginPortal()
+            }
+        }
+        rootProject.name = "unlocked"
+        include(":app")
+        """
+          .trimIndent()
+      )
+    // Same buildscript repositories as the locked fixture, minus the locking — so the only
+    // difference between the two projects is the thing under test.
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        buildscript {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+        }
+        """
+          .trimIndent()
+      )
+    val app = File(root, "app").apply { mkdirs() }
+    File(app, "build.gradle.kts")
+      .writeText("""plugins { id("com.android.application") version "1.0" }""")
+
+    val initScript = materializeInitScript(tempDir(), "1.0")
+    val result =
+      GradleRunner.create()
+        .withProjectDir(root)
+        .withArguments(":app:help", "--init-script", initScript.absolutePath, "--stacktrace")
+        .forwardOutput()
+        .build()
+
+    assertTrue(
+      result.output.contains("COMPOSE-PREVIEW-APPLIED to :app"),
+      "the unlocked happy path must keep working; full output:\n${result.output}",
+    )
+  }
+
+  /**
+   * Publishes the two stub plugins this test needs to a local maven repo: the compose-preview
+   * plugin (prints a marker on apply) and a fake `com.android.application` (the withPlugin host id
+   * that triggers auto-inject). Same approach as [InitScriptExclusiveContentReproducerTest], kept
+   * local so neither test can break the other by editing a shared fixture.
+   */
+  private fun publishStubPlugins(repo: File) {
+    val build = tempDir("compose-preview-locking-stubs-")
+    File(build, "settings.gradle.kts")
+      .writeText("rootProject.name = \"stubs\"\ninclude(\":preview\", \":agp\")\n")
+    File(build, "build.gradle.kts").writeText("")
+
+    fun stub(
+      module: String,
+      group: String,
+      pluginId: String,
+      pkg: String,
+      cls: String,
+      msg: String,
+    ) {
+      val dir = File(build, module).apply { mkdirs() }
+      File(dir, "build.gradle.kts")
+        .writeText(
+          """
+          plugins {
+              `java-gradle-plugin`
+              `maven-publish`
+          }
+          group = "$group"
+          version = "1.0"
+          gradlePlugin {
+              plugins {
+                  create("$module") {
+                      id = "$pluginId"
+                      implementationClass = "$pkg.$cls"
+                  }
+              }
+          }
+          publishing { repositories { maven { url = uri("${repo.toURI()}") } } }
+          """
+            .trimIndent()
+        )
+      val src = File(dir, "src/main/java/$pkg").apply { mkdirs() }
+      File(src, "$cls.java")
+        .writeText(
+          """
+          package $pkg;
+          import org.gradle.api.Plugin;
+          import org.gradle.api.Project;
+          public class $cls implements Plugin<Project> {
+              public void apply(Project p) { System.out.println("$msg to " + p.getPath()); }
+          }
+          """
+            .trimIndent()
+        )
+    }
+
+    stub(
+      module = "preview",
+      group = "ee.schimke.composeai.preview",
+      pluginId = "ee.schimke.composeai.preview",
+      pkg = "cp",
+      cls = "PreviewPlugin",
+      msg = "COMPOSE-PREVIEW-APPLIED",
+    )
+    stub(
+      module = "agp",
+      group = "com.android.tools.build",
+      pluginId = "com.android.application",
+      pkg = "agp",
+      cls = "FakeAgpPlugin",
+      msg = "FAKE-AGP-APPLIED",
+    )
+
+    GradleRunner.create().withProjectDir(build).withArguments("publish", "--stacktrace").build()
+  }
+}


### PR DESCRIPTION
A build that locks its buildscript classpath — `configurations.classpath { resolutionStrategy.activateDependencyLocking() }` plus a checked-in `buildscript-gradle.lockfile` — rejects every module its lock state does not name. Auto-inject's whole job is to add one it does not name:

```
> Could not resolve all artifacts for configuration 'classpath'.
   > Resolved 'ee.schimke.composeai.preview:...' which is not part of the dependency lock state
```

That fires while the buildscript classpath resolves, so it takes the build out before discovery runs — nothing is rendered and nothing explains why. The `bitwarden/android` import hit exactly this, with 51 previews it could never reach (yschimke/compose-preview-imports#30).

## The fix that doesn't work, and why it's worth knowing

The obvious move is to deactivate locking on that configuration from the init script. It fails, and the reproducer pins the reason rather than leaving it as folklore: the imported build activates locking inside its **own** `buildscript { }` block, which Gradle evaluates *after* the init script, so the project's activation is simply the last writer. I wrote that version first and watched the reproducer reject it.

## The fix that does

Inject the plugin as `files(...)` instead of as a coordinate — the route the `exclusiveContent` shape already uses. A file dependency resolves to no module component at all, so lock state has nothing to validate against, and the locked configuration stays exactly as locked as its owner wrote it.

This matters because locking is somebody else's decision about their own build. Nothing in the checkout is edited, no lockfile is rewritten, and a build that does not lock takes the identical path it took before.

Detection is by lockfile on disk, matching how the rest of this script reads a build it does not control: `buildscript-gradle.lockfile` beside the build script, or the pre-6.0 layout's `gradle/dependency-locks/buildscript-classpath.lockfile`. It names that legacy file rather than testing for the directory, because a build can lock only `runtimeClasspath` and still have one — and since the files() branch degrades to a no-op when it cannot resolve, a false positive would cost a silently plugin-less module, which is the failure this PR exists to remove.

The detached configuration used for the resolution also deactivates locking on **itself** — that one is ours to configure, and a build using `lockAllConfigurations()` should not be able to lock a configuration created for a single resolution.

## Test plan

`InitScriptDependencyLockingReproducerTest` drives a Bitwarden-shaped locked project through TestKit and asserts **both** halves:

1. it configures cleanly — no `not part of the dependency lock state`; and
2. the plugin actually **reaches** the module (`COMPOSE-PREVIEW-APPLIED to :app`).

The second is not redundant. A silently skipped injection would pass the first test and then publish an empty catalog, which is the shape the import failed in to begin with. A third test pins that an unlocked build is untouched.

All three were **observed failing on the real error** before the fix, and the two locked ones stayed failing under the first attempt above. `:cli:test` is green in full (788 tests); the two changed assertions in `AutoInjectTest` are text assertions against the exact source lines this PR edits, plus one new assertion pinning the lock detection.

Review also noted that the files() branch resolves through the *project's* repositories, so a build publishing the plugin only into `buildscript.repositories` still lands in the no-op. That remains true, but it is no longer silent: the skip now warns with the module path and the settings-level declaration that would fix it. Moving that resolution onto the buildscript repository set is a real change to the shared `exclusiveContent` branch (where Gradle 9.3+ forbids the access — #1470, #1482) and wants its own reproducer, so it is deliberately not in this PR.

Non-visual change, so no render evidence — the surface is an init script, not UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp