### PR TITLE
fix(auto-inject): reach a build that verifies its dependencies

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -568,6 +568,57 @@ internal fun defaultInitScriptStorageDir(version: String): File =
   File(composeAiCacheDir("init"), version)
 
 /**
+ * `--dependency-verification=lenient`, but only for a build that actually verifies its dependencies
+ * and only when the caller has not already decided the question themselves.
+ *
+ * A build shipping `gradle/verification-metadata.xml` with
+ * `<verify-metadata>true</verify-metadata>` refuses any artifact the file carries no checksum for.
+ * Auto-inject resolves a plugin that file has never heard of, so the run dies during configuration:
+ * ```
+ * > Dependency verification failed for configuration 'classpath'
+ *   3 artifacts failed verification:
+ *     - ee.schimke.composeai.preview.gradle.plugin-1.0.pom ...
+ * ```
+ *
+ * mullvad/mullvadvpn-app is the motivating case (yschimke/compose-preview-imports#30) — a VPN
+ * client verifying every artifact it pulls is the file working as intended, and their checkout is
+ * not ours to edit, so writing our checksums into it is out.
+ *
+ * Unlike the locking shape, the `files(...)` injection route does not help: the resolution that
+ * produces those files is itself verified, so the failure only moves. The lever left is the Gradle
+ * invocation, and `lenient` is the narrow end of it — Gradle still performs verification and still
+ * reports every failure, it just does not abort. Nothing is disabled permanently, nothing in the
+ * checkout changes, and the relaxation lasts exactly one throwaway build driven to draw pictures.
+ *
+ * Three things keep it honest:
+ * - it applies only where a verification file exists, so an ordinary build is invoked as before;
+ * - an explicit `--dependency-verification=…` from the caller always wins — someone who has stated
+ *   their own answer does not get ours; and
+ * - it is announced on stderr. Quietly relaxing somebody else's security control would be the wrong
+ *   shape even when the result is right.
+ *
+ * Visible for tests.
+ */
+internal fun dependencyVerificationArgs(
+  args: List<String>,
+  projectRoot: File?,
+  stderr: (String) -> Unit,
+): List<String> {
+  if (projectRoot == null) return emptyList()
+  if (args.any { it.startsWith("--dependency-verification") || it == "-F" }) return emptyList()
+  val metadata = File(projectRoot, "gradle/verification-metadata.xml")
+  if (!metadata.isFile) return emptyList()
+  stderr(
+    "compose-preview: this build verifies its dependencies (${'$'}{metadata.path}), and the " +
+      "auto-injected preview plugin is not in that file. Running this build with " +
+      "--dependency-verification=lenient so verification reports rather than fails; your " +
+      "verification metadata is not modified. Pass --no-auto-inject, or your own " +
+      "--dependency-verification=…, to decide this yourself."
+  )
+  return listOf("--dependency-verification=lenient")
+}
+
+/**
  * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation, or an empty
  * list when auto-inject is disabled. Materialises the script on first call.
  *
@@ -624,7 +675,8 @@ internal fun autoInjectInitScriptArgs(
   val dir = storageDir ?: defaultInitScriptStorageDir(effectiveVersion)
   return try {
     val path = materializeInitScript(dir, effectiveVersion, fileSystem)
-    listOf("--init-script", path.absolutePath)
+    listOf("--init-script", path.absolutePath) +
+      dependencyVerificationArgs(args, projectRoot, stderr)
   } catch (e: Exception) {
     stderr(
       "compose-preview: auto-inject disabled — could not materialise init script in $dir: ${e.message}"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -605,18 +605,46 @@ internal fun dependencyVerificationArgs(
   stderr: (String) -> Unit,
 ): List<String> {
   if (projectRoot == null) return emptyList()
-  if (args.any { it.startsWith("--dependency-verification") || it == "-F" }) return emptyList()
+
+  // A caller who states their own mode gets it FORWARDED, not merely respected. Suppressing ours
+  // and dropping theirs was the worst of both: raw CLI args never reach Gradle — only what this
+  // function returns lands in `GradleConnection.extraArguments` — so the build fell back to strict
+  // and failed, which is exactly what the flag was passed to avoid (PR #4988 review). The flag is
+  // registered in CliFlagValidation.commandBase for the same reason.
+  val attached = args.firstOrNull { it.startsWith("--dependency-verification=") }
+  val spaced =
+    args
+      .zipWithNext()
+      .firstOrNull { (flag, _) -> flag == "--dependency-verification" || flag == "-F" }
+      ?.let { (_, mode) -> "--dependency-verification=$mode" }
+  val callerMode = attached ?: spaced
+  if (callerMode != null) return listOf(callerMode)
+
   val metadata = File(projectRoot, "gradle/verification-metadata.xml")
   if (!metadata.isFile) return emptyList()
+
+  // A build whose metadata ALREADY covers the preview plugin verifies it fine under strict, so
+  // relaxing would cost that project its strict supply-chain guarantee and buy nothing (PR #4988
+  // review). Projects that have deliberately allowlisted the plugin are exactly the ones that
+  // should keep it, so read the file and leave them alone.
+  val metadataText = runCatching { metadata.readText() }.getOrDefault("")
+  if (COMPOSE_AI_PREVIEW_GROUP in metadataText) return emptyList()
+
   stderr(
-    "compose-preview: this build verifies its dependencies (${'$'}{metadata.path}), and the " +
-      "auto-injected preview plugin is not in that file. Running this build with " +
+    "compose-preview: this build verifies its dependencies (${metadata.path}) and its metadata " +
+      "does not cover the auto-injected preview plugin. Running this build with " +
       "--dependency-verification=lenient so verification reports rather than fails; your " +
-      "verification metadata is not modified. Pass --no-auto-inject, or your own " +
-      "--dependency-verification=…, to decide this yourself."
+      "verification metadata is not modified. Lenient means OTHER artifacts can now fail " +
+      "verification without failing the build — Gradle writes every failure to " +
+      "build/reports/dependency-verification, and --verbose shows them inline. Pass " +
+      "--dependency-verification=strict to keep it fatal, or --no-auto-inject to skip injection " +
+      "entirely."
   )
   return listOf("--dependency-verification=lenient")
 }
+
+/** The plugin's Maven group; a verification file naming it already knows about the plugin. */
+private const val COMPOSE_AI_PREVIEW_GROUP = "ee.schimke.composeai.preview"
 
 /**
  * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation, or an empty

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -599,42 +599,81 @@ internal fun defaultInitScriptStorageDir(version: String): File =
  *
  * Visible for tests.
  */
+/**
+ * The caller's own `--dependency-verification` mode, as an argument list, or empty when they did
+ * not state one. Both spellings are accepted (`--dependency-verification=off`,
+ * `--dependency-verification off`, `-F off`) and normalised to the attached form.
+ *
+ * This is FORWARDED, never merely suppressed. Raw argv does not reach Gradle — only what
+ * [autoInjectInitScriptArgs] returns lands in `GradleConnection.extraArguments` — so dropping the
+ * caller's flag on the way through leaves the build on Gradle's strict default, which is the exact
+ * failure the flag was passed to avoid (PR #4988 review).
+ *
+ * Visible for tests.
+ */
+internal fun callerDependencyVerificationArg(args: List<String>): List<String> {
+  args
+    .firstOrNull { it.startsWith("--dependency-verification=") }
+    ?.let {
+      return listOf(it)
+    }
+  args
+    .zipWithNext()
+    .firstOrNull { (flag, _) -> flag == "--dependency-verification" || flag == "-F" }
+    ?.let { (_, mode) ->
+      return listOf("--dependency-verification=$mode")
+    }
+  return emptyList()
+}
+
+/**
+ * `--dependency-verification=lenient`, but only for a build that actually verifies AND whose
+ * metadata does not already cover the plugin version being injected.
+ *
+ * A build shipping `gradle/verification-metadata.xml` with `verify-metadata` on refuses any
+ * artifact the file carries no checksum for. Auto-inject resolves a plugin that file has never
+ * heard of, so the run dies during configuration:
+ * ```
+ * > Dependency verification failed for configuration 'classpath'
+ *   3 artifacts failed verification:
+ *     - ee.schimke.composeai.preview.gradle.plugin-1.0.pom ...
+ * ```
+ *
+ * mullvad/mullvadvpn-app is the motivating case (yschimke/compose-preview-imports#30) — a VPN
+ * client verifying every artifact it pulls is the file working as intended, and their checkout is
+ * not ours to edit, so writing our checksums into it is out.
+ *
+ * Unlike the locking shape, the `files(...)` injection route does not help: the resolution that
+ * produces those files is itself verified, so the failure only moves. The lever left is the Gradle
+ * invocation, and `lenient` is the narrow end of it — Gradle still performs verification and still
+ * reports every failure, it just does not abort. Nothing is disabled permanently and nothing in the
+ * checkout changes.
+ *
+ * [alreadyVerifiable] is what keeps this from costing a project that has *already* allowlisted the
+ * plugin its strict guarantee — and it is version-aware on purpose, because Gradle verifies
+ * components version-specifically: metadata carrying checksums for 0.9 does not cover the 1.0 we
+ * are injecting, and treating it as coverage would leave the very common upgrade-the-CLI case
+ * failing under strict with no relaxation applied (PR #4988 review).
+ *
+ * Visible for tests.
+ */
 internal fun dependencyVerificationArgs(
-  args: List<String>,
   projectRoot: File?,
+  pluginVersion: String,
   stderr: (String) -> Unit,
 ): List<String> {
   if (projectRoot == null) return emptyList()
-
-  // A caller who states their own mode gets it FORWARDED, not merely respected. Suppressing ours
-  // and dropping theirs was the worst of both: raw CLI args never reach Gradle — only what this
-  // function returns lands in `GradleConnection.extraArguments` — so the build fell back to strict
-  // and failed, which is exactly what the flag was passed to avoid (PR #4988 review). The flag is
-  // registered in CliFlagValidation.commandBase for the same reason.
-  val attached = args.firstOrNull { it.startsWith("--dependency-verification=") }
-  val spaced =
-    args
-      .zipWithNext()
-      .firstOrNull { (flag, _) -> flag == "--dependency-verification" || flag == "-F" }
-      ?.let { (_, mode) -> "--dependency-verification=$mode" }
-  val callerMode = attached ?: spaced
-  if (callerMode != null) return listOf(callerMode)
-
   val metadata = File(projectRoot, "gradle/verification-metadata.xml")
   if (!metadata.isFile) return emptyList()
 
-  // A build whose metadata ALREADY covers the preview plugin verifies it fine under strict, so
-  // relaxing would cost that project its strict supply-chain guarantee and buy nothing (PR #4988
-  // review). Projects that have deliberately allowlisted the plugin are exactly the ones that
-  // should keep it, so read the file and leave them alone.
   val metadataText = runCatching { metadata.readText() }.getOrDefault("")
-  if (COMPOSE_AI_PREVIEW_GROUP in metadataText) return emptyList()
+  if (alreadyVerifiable(metadataText, pluginVersion)) return emptyList()
 
   stderr(
     "compose-preview: this build verifies its dependencies (${metadata.path}) and its metadata " +
-      "does not cover the auto-injected preview plugin. Running this build with " +
-      "--dependency-verification=lenient so verification reports rather than fails; your " +
-      "verification metadata is not modified. Lenient means OTHER artifacts can now fail " +
+      "does not cover version $pluginVersion of the auto-injected preview plugin. Running this " +
+      "build with --dependency-verification=lenient so verification reports rather than fails; " +
+      "your verification metadata is not modified. Lenient means OTHER artifacts can now fail " +
       "verification without failing the build — Gradle writes every failure to " +
       "build/reports/dependency-verification, and --verbose shows them inline. Pass " +
       "--dependency-verification=strict to keep it fatal, or --no-auto-inject to skip injection " +
@@ -643,7 +682,31 @@ internal fun dependencyVerificationArgs(
   return listOf("--dependency-verification=lenient")
 }
 
-/** The plugin's Maven group; a verification file naming it already knows about the plugin. */
+/**
+ * True when [metadataText] already covers the preview plugin at [pluginVersion], so strict
+ * verification would have succeeded and relaxing it would cost the project its guarantee for
+ * nothing.
+ *
+ * Two shapes count, and the distinction is Gradle's, not ours: a `<trust>` rule naming the group is
+ * version-agnostic and covers whatever we inject, whereas `<component>` checksums are pinned to one
+ * version — so those only count when the version we are about to inject is among them.
+ *
+ * Visible for tests.
+ */
+internal fun alreadyVerifiable(metadataText: String, pluginVersion: String): Boolean {
+  if (COMPOSE_AI_PREVIEW_GROUP !in metadataText) return false
+  val trustsGroup =
+    Regex("""<trust\b[^>]*group\s*=\s*["']${Regex.escape(COMPOSE_AI_PREVIEW_GROUP)}["']""")
+  if (trustsGroup.containsMatchIn(metadataText)) return true
+  val componentAtVersion =
+    Regex(
+      """<component\b[^>]*group\s*=\s*["']${Regex.escape(COMPOSE_AI_PREVIEW_GROUP)}["'][^>]*""" +
+        """version\s*=\s*["']${Regex.escape(pluginVersion)}["']"""
+    )
+  return componentAtVersion.containsMatchIn(metadataText)
+}
+
+/** The plugin's Maven group; a verification file naming it may already know about the plugin. */
 private const val COMPOSE_AI_PREVIEW_GROUP = "ee.schimke.composeai.preview"
 
 /**
@@ -680,16 +743,22 @@ internal fun autoInjectInitScriptArgs(
   stderr: (String) -> Unit = System.err::println,
   fileSystem: FileSystem = SystemFileSystem,
 ): List<String> {
-  if ("--no-auto-inject" in args) return emptyList()
-  if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return emptyList()
-  if (projectRoot != null && hasIncludedPluginBuild(projectRoot)) return emptyList()
+  // A mode the caller stated is theirs whether or not we inject anything. It has to survive every
+  // early return below, or `render --no-auto-inject --dependency-verification=off` silently drops
+  // it and runs a manually-applied build under strict (PR #4988 review) — raw argv never reaches
+  // Gradle, so what this function returns is the only way a mode gets there.
+  val callerVerification = callerDependencyVerificationArg(args)
+
+  if ("--no-auto-inject" in args) return callerVerification
+  if (env("COMPOSE_PREVIEW_NO_AUTO_INJECT") == "1") return callerVerification
+  if (projectRoot != null && hasIncludedPluginBuild(projectRoot)) return callerVerification
   if (projectRoot != null && includedBuildProvidesComposeAiPreviewPlugin(projectRoot)) {
     stderr(
       "compose-preview: auto-inject disabled — an included build supplies the " +
         "ee.schimke.composeai.preview plugin (applied via a convention plugin). The CLI will use " +
         "the plugin your build already applies. Pass --no-auto-inject to silence this note."
     )
-    return emptyList()
+    return callerVerification
   }
   val effectiveVersion =
     pluginVersion
@@ -704,12 +773,14 @@ internal fun autoInjectInitScriptArgs(
   return try {
     val path = materializeInitScript(dir, effectiveVersion, fileSystem)
     listOf("--init-script", path.absolutePath) +
-      dependencyVerificationArgs(args, projectRoot, stderr)
+      (callerVerification.ifEmpty {
+        dependencyVerificationArgs(projectRoot, effectiveVersion, stderr)
+      })
   } catch (e: Exception) {
     stderr(
       "compose-preview: auto-inject disabled — could not materialise init script in $dir: ${e.message}"
     )
-    emptyList()
+    callerVerification
   }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlagValidation.kt
@@ -34,6 +34,11 @@ internal object CliFlagValidation {
       "--permutations",
       "--missing-renders",
       "--no-auto-inject",
+      // Auto-inject relaxes dependency verification on a build that verifies (see
+      // dependencyVerificationArgs); this is how someone states their own answer instead. It has to
+      // be a REGISTERED flag or the caller override is a promise the CLI rejects as unknown before
+      // it can be honoured (PR #4988 review).
+      "--dependency-verification",
     )
 
   private val reportFlags = commandBase + setOf("--json", "--fail-on")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/CliFlags.kt
@@ -28,6 +28,9 @@ internal object CliFlags {
   val VALUE_FLAGS: Set<String> =
     setOf(
       "--module",
+      // Accepts the space form (`--dependency-verification lenient`) as well as the attached one,
+      // so command detection must skip its value.
+      "--dependency-verification",
       "--filter",
       "--id",
       "--id-file",

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
@@ -152,6 +152,80 @@ class InitScriptDependencyVerificationReproducerTest {
     repo.delete()
   }
 
+  @Test
+  fun `a caller's own verification mode is forwarded to Gradle, not merely suppressed`() {
+    // Review found the original escape hatch was a promise the CLI could not keep: raw argv never
+    // reaches Gradle — only what this function returns lands in extraArguments — so suppressing
+    // ours and dropping theirs left the build on strict, the very failure the flag was passed to
+    // avoid. Both spellings must come back out.
+    val root = tempDir()
+    File(root, "gradle").mkdirs()
+    File(root, "gradle/verification-metadata.xml").writeText("<verification-metadata/>")
+
+    fun args(vararg a: String) =
+      autoInjectInitScriptArgs(
+        args = a.toList(),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = root,
+        stderr = {},
+      )
+
+    assertTrue(
+      "--dependency-verification=off" in args("--dependency-verification=off"),
+      "the attached form must be forwarded verbatim",
+    )
+    assertTrue(
+      "--dependency-verification=strict" in args("--dependency-verification", "strict"),
+      "the space form must be forwarded as a mode Gradle understands",
+    )
+    assertTrue(
+      args("--dependency-verification=off").none { it.contains("lenient") },
+      "our lenient default must not be added alongside the caller's own mode",
+    )
+  }
+
+  @Test
+  fun `a build whose metadata already covers the plugin keeps strict verification`() {
+    // Relaxing a build that has deliberately allowlisted the preview plugin costs it the strict
+    // guarantee and buys nothing — strict would have succeeded (PR #4988 review).
+    val root = tempDir()
+    File(root, "gradle").mkdirs()
+    File(root, "gradle/verification-metadata.xml")
+      .writeText(
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <verification-metadata>
+           <configuration>
+              <verify-metadata>true</verify-metadata>
+              <trusted-artifacts>
+                 <trust group="ee.schimke.composeai.preview"/>
+              </trusted-artifacts>
+           </configuration>
+        </verification-metadata>
+        """
+          .trimIndent()
+      )
+
+    val notes = mutableListOf<String>()
+    val injectArgs =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = root,
+        stderr = { notes += it },
+      )
+
+    assertTrue(
+      injectArgs.none { it.contains("dependency-verification") },
+      "a build that already trusts the plugin must be left on strict; got $injectArgs",
+    )
+    assertTrue(notes.isEmpty(), "and must not be told we relaxed anything; notes were: $notes")
+  }
+
   /**
    * Publishes the two stub plugins this test needs: the compose-preview plugin (prints a marker on
    * apply) and a fake `com.android.application` (the withPlugin host id that triggers auto-inject).

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
@@ -4,6 +4,8 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.gradle.testkit.runner.GradleRunner
 
@@ -183,6 +185,69 @@ class InitScriptDependencyVerificationReproducerTest {
     assertTrue(
       args("--dependency-verification=off").none { it.contains("lenient") },
       "our lenient default must not be added alongside the caller's own mode",
+    )
+  }
+
+  @Test
+  fun `a caller's mode survives every path that disables auto-inject`() {
+    // The forwarding used to sit only on the injecting path, so `--no-auto-inject
+    // --dependency-verification=off` dropped the mode and ran a manually-applied build under
+    // strict (PR #4988 review). Raw argv never reaches Gradle, so this list is the only carrier.
+    val root = tempDir()
+    File(root, "gradle").mkdirs()
+    File(root, "gradle/verification-metadata.xml").writeText("<verification-metadata/>")
+
+    val viaFlag =
+      autoInjectInitScriptArgs(
+        args = listOf("--no-auto-inject", "--dependency-verification=off"),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = root,
+        stderr = {},
+      )
+    assertEquals(listOf("--dependency-verification=off"), viaFlag)
+
+    val viaEnv =
+      autoInjectInitScriptArgs(
+        args = listOf("--dependency-verification=off"),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { if (it == "COMPOSE_PREVIEW_NO_AUTO_INJECT") "1" else null },
+        projectRoot = root,
+        stderr = {},
+      )
+    assertEquals(listOf("--dependency-verification=off"), viaEnv)
+  }
+
+  @Test
+  fun `metadata covering only an older plugin version still relaxes`() {
+    // Gradle verifies components version-specifically, so checksums for 0.9 do not cover the 1.0
+    // being injected. Treating any mention of the group as coverage left the ordinary
+    // upgrade-the-CLI case failing under strict with no relaxation (PR #4988 review).
+    val stale =
+      """
+      <verification-metadata>
+         <components>
+            <component group="ee.schimke.composeai.preview" name="preview" version="0.9"/>
+         </components>
+      </verification-metadata>
+      """
+        .trimIndent()
+    assertFalse(
+      alreadyVerifiable(stale, "1.0"),
+      "checksums for 0.9 must not count as coverage for 1.0",
+    )
+    assertTrue(
+      alreadyVerifiable(stale, "0.9"),
+      "and the version they DO cover must still be recognised",
+    )
+    assertTrue(
+      alreadyVerifiable(
+        """<trust group="ee.schimke.composeai.preview"/>""",
+        "1.0",
+      ),
+      "a trust rule on the group is version-agnostic, so it covers whatever is injected",
     )
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/InitScriptDependencyVerificationReproducerTest.kt
@@ -1,0 +1,230 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+
+/**
+ * End-to-end reproducer for the Mullvad shape (https://github.com/mullvad/mullvadvpn-app
+ * `android/`): the build ships a checked-in `gradle/verification-metadata.xml` with
+ * `<verify-metadata>true</verify-metadata>`, so Gradle refuses any artifact the file does not carry
+ * a checksum for. Auto-inject resolves a plugin that file has never heard of, so the render fails
+ * before it starts:
+ * ```
+ * Dependency verification failed for configuration ':classpath'
+ * One artifact failed verification: ee.schimke.composeai.preview.gradle.plugin-1.0.pom
+ * ```
+ *
+ * That is not a bug in their build — a VPN client verifying every artifact it pulls is the whole
+ * point of the file, and their checkout is not ours to edit. What the CLI can do is ask Gradle to
+ * report verification failures instead of failing on them, for the one throwaway run it drives to
+ * draw pictures, and say so on stderr rather than doing it quietly.
+ *
+ * Unlike the locking shape ([InitScriptDependencyLockingReproducerTest]), injecting the plugin as
+ * `files(...)` does not help here: the resolution that produces those files is itself verified, so
+ * the failure just moves. The lever has to be the Gradle invocation, which is why this test drives
+ * [autoInjectInitScriptArgs] — the CLI-level seam every command shares — rather than only
+ * [materializeInitScript].
+ */
+class InitScriptDependencyVerificationReproducerTest {
+
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest
+  fun cleanup() {
+    tempDirs.forEach { it.deleteRecursively() }
+  }
+
+  private fun tempDir(prefix: String = "compose-preview-verification-"): File =
+    Files.createTempDirectory(prefix).toFile().also { tempDirs += it }
+
+  /**
+   * A project that verifies metadata for every artifact and trusts nothing — the strictest form of
+   * the Mullvad shape, and the one that makes the injected plugin unverifiable by construction.
+   */
+  private fun createVerifyingProject(repo: File): File {
+    val root = tempDir()
+    File(root, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+        }
+        dependencyResolutionManagement {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+        }
+        rootProject.name = "verification-repro"
+        include(":app")
+        """
+          .trimIndent()
+      )
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        buildscript {
+            repositories { maven { url = uri("${repo.toURI()}") } }
+        }
+        """
+          .trimIndent()
+      )
+    File(root, "gradle").mkdirs()
+    File(root, "gradle/verification-metadata.xml")
+      .writeText(
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <verification-metadata>
+           <configuration>
+              <verify-metadata>true</verify-metadata>
+              <verify-signatures>false</verify-signatures>
+           </configuration>
+           <components/>
+        </verification-metadata>
+        """
+          .trimIndent()
+      )
+    val app = File(root, "app").apply { mkdirs() }
+    File(app, "build.gradle.kts")
+      .writeText("""plugins { id("com.android.application") version "1.0" }""")
+    return root
+  }
+
+  @Test
+  fun `auto-inject reaches a build that verifies every dependency`() {
+    val repo = tempDir("compose-preview-verification-repo-")
+    publishStubPlugins(repo)
+    val project = createVerifyingProject(repo)
+
+    val notes = mutableListOf<String>()
+    val injectArgs =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = project,
+        stderr = { notes += it },
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(project)
+        .withArguments(listOf(":app:help") + injectArgs + "--stacktrace")
+        .forwardOutput()
+        .build()
+
+    assertTrue(
+      result.output.contains("COMPOSE-PREVIEW-APPLIED to :app"),
+      "expected the compose-preview plugin to be auto-injected and applied to :app on a build " +
+        "that verifies its dependencies; full output:\n${result.output}",
+    )
+    assertTrue(
+      notes.any { it.contains("verification") },
+      "relaxing somebody else's dependency verification must be said out loud on stderr, not " +
+        "done quietly; notes were: $notes",
+    )
+  }
+
+  @Test
+  fun `a build with no verification metadata is invoked exactly as before`() {
+    // The relaxation must be scoped to builds that actually verify: a project without the file
+    // must get the plain init-script args and nothing else.
+    val repo = tempDir("compose-preview-verification-repo-")
+    val root = tempDir()
+    File(root, "settings.gradle.kts").writeText("rootProject.name = \"unverified\"\n")
+
+    val injectArgs =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0",
+        storageDir = tempDir(),
+        env = { null },
+        projectRoot = root,
+        stderr = {},
+      )
+
+    assertTrue(
+      injectArgs.none { it.contains("dependency-verification") },
+      "a build that does not verify must not be told anything about verification; got $injectArgs",
+    )
+    repo.delete()
+  }
+
+  /**
+   * Publishes the two stub plugins this test needs: the compose-preview plugin (prints a marker on
+   * apply) and a fake `com.android.application` (the withPlugin host id that triggers auto-inject).
+   * Same approach as the sibling reproducers, kept local so neither can break the other.
+   */
+  private fun publishStubPlugins(repo: File) {
+    val build = tempDir("compose-preview-verification-stubs-")
+    File(build, "settings.gradle.kts")
+      .writeText("rootProject.name = \"stubs\"\ninclude(\":preview\", \":agp\")\n")
+    File(build, "build.gradle.kts").writeText("")
+
+    fun stub(
+      module: String,
+      group: String,
+      pluginId: String,
+      pkg: String,
+      cls: String,
+      msg: String,
+    ) {
+      val dir = File(build, module).apply { mkdirs() }
+      File(dir, "build.gradle.kts")
+        .writeText(
+          """
+          plugins {
+              `java-gradle-plugin`
+              `maven-publish`
+          }
+          group = "$group"
+          version = "1.0"
+          gradlePlugin {
+              plugins {
+                  create("$module") {
+                      id = "$pluginId"
+                      implementationClass = "$pkg.$cls"
+                  }
+              }
+          }
+          publishing { repositories { maven { url = uri("${repo.toURI()}") } } }
+          """
+            .trimIndent()
+        )
+      val src = File(dir, "src/main/java/$pkg").apply { mkdirs() }
+      File(src, "$cls.java")
+        .writeText(
+          """
+          package $pkg;
+          import org.gradle.api.Plugin;
+          import org.gradle.api.Project;
+          public class $cls implements Plugin<Project> {
+              public void apply(Project p) { System.out.println("$msg to " + p.getPath()); }
+          }
+          """
+            .trimIndent()
+        )
+    }
+
+    stub(
+      "preview",
+      "ee.schimke.composeai.preview",
+      "ee.schimke.composeai.preview",
+      "cp",
+      "PreviewPlugin",
+      "COMPOSE-PREVIEW-APPLIED",
+    )
+    stub(
+      "agp",
+      "com.android.tools.build",
+      "com.android.application",
+      "agp",
+      "FakeAgpPlugin",
+      "FAKE-AGP-APPLIED",
+    )
+
+    GradleRunner.create().withProjectDir(build).withArguments("publish", "--stacktrace").build()
+  }
+}


### PR DESCRIPTION
A build shipping `gradle/verification-metadata.xml` with `verify-metadata` set to true refuses any artifact the file carries no checksum for. Auto-inject resolves a plugin that file has never heard of, so the run dies during configuration, before anything is rendered:

```
> Dependency verification failed for configuration 'classpath'
  3 artifacts failed verification:
    - ee.schimke.composeai.preview.gradle.plugin-1.0.pom ...
```

`mullvad/mullvadvpn-app` is the motivating case (yschimke/compose-preview-imports#30) — 21 previews unreachable. A VPN client verifying every artifact it pulls is the file working exactly as intended, and their checkout is not ours to edit, so writing our own checksums into it is out.

## Why not the trick from #4987

The `files(...)` route that fixes the *locking* shape does not transfer here. The resolution that produces those files is itself verified, so the failure only moves. The lever left is the Gradle invocation.

`--dependency-verification=lenient` is the narrow end of it: Gradle still performs verification and still reports every failure, it just does not abort. Nothing is disabled permanently and nothing in the checkout changes.

## What keeps it honest

Relaxing somebody else's security control is not something to do casually, so three constraints — each of which review sharpened, and two of which it caught me getting wrong:

- **Scoped to builds that verify *and are not already covered*.** No `gradle/verification-metadata.xml`, no flag. And if the metadata already covers the plugin, strict would have succeeded, so the build is left on strict with no notice — nothing was relaxed. That check is version-aware, because Gradle verifies components version-specifically: a `<trust>` rule on the group covers any version, while `<component>` checksums count only for the version they name, so metadata carrying 0.9 does not excuse injecting 1.0.
- **The caller's own mode is forwarded, not merely respected.** Raw argv never reaches Gradle — only what `autoInjectInitScriptArgs` returns lands in `extraArguments` — so an override has to be carried explicitly or it is lost. `--dependency-verification` is registered in `CliFlagValidation.commandBase` and `CliFlags.VALUE_FLAGS`, all three spellings are accepted, and the mode survives **every** early return, including `--no-auto-inject` and `COMPOSE_PREVIEW_NO_AUTO_INJECT=1`.
- **It is announced on stderr**, naming the file and the version it found no coverage for, stating that lenient lets *other* artifacts fail without failing the build, and pointing at `build/reports/dependency-verification` and `--verbose` for reading them. Doing this quietly would be the wrong shape even where the result is right.

## Test plan

`InitScriptDependencyVerificationReproducerTest` builds a Mullvad-shaped project (metadata verification on, trusting nothing) and drives it through TestKit via `autoInjectInitScriptArgs` — the CLI-level seam all five call sites share — rather than only `materializeInitScript`, because the invocation is what's under test.

Six tests: the plugin reaches the module on a verifying build and the relaxation is reported; a build with no metadata is invoked unchanged; the caller's mode is forwarded in both spellings with no lenient default beside it; that mode survives `--no-auto-inject` and the env-var path; metadata already trusting the plugin keeps strict silently; and checksums for 0.9 do not count as coverage for 1.0 while a trust rule on the group does.

The first was **observed failing on the real error** (`Dependency verification failed for configuration 'classpath'`, all three plugin artifacts) before the fix. `:cli:test` is green in full on this branch.

Non-visual change, so no render evidence — the surface is a Gradle invocation.

One review point is deliberately left for a separate PR: replaying lenient-mode verification failures that `GradleConnection.runTasks` captures and discards on a *successful* build. The notice points at the report Gradle writes regardless; actually plumbing that stream touches output shared by every command and wants its own test.

Independent of #4987 and based on `main`, not stacked on it; the two fix different hardening features that happen to break the same injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp