### PR TITLE
fix(import): render a locked upstream with --write-locks

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -576,6 +576,20 @@ env:
 
     if __name__ == "__main__":
         sys.exit(main(sys.argv))
+  # An imported project may LOCK its buildscript classpath (bitwarden/android does, with
+  # lockAllConfigurations() and LockMode.STRICT), in which case it rejects every module its lock
+  # state does not name — including the preview plugin auto-inject adds, so the render dies during
+  # configuration before discovery runs (yschimke/compose-preview-imports#30).
+  #
+  # --write-locks is Gradle's own answer: the lock state is REGENERATED to describe what actually
+  # resolved, rather than the injected module being smuggled past validation. Under STRICT mode it
+  # is also the only thing that works — deleting the lockfile makes a strict build fail, not relax.
+  #
+  # Set only in import mode, and read from the environment rather than inferred from a lockfile,
+  # because it rewrites files in the checkout. Here that checkout is a throwaway clone discarded
+  # with the job; a developer's working tree is never rewritten because we noticed they lock.
+  # A build with no locking resolves this to a no-op.
+  COMPOSE_PREVIEW_WRITE_LOCKS: ${{ inputs.upstream-repository != '' && '1' || '' }}
   IMPORT_EXCLUDE_PREVIEW_IDS: ${{ inputs.upstream-repository != '' && 'activity__*,apptour__*' || '' }}
   INPUT_LIVE_RERENDER_SOURCE: ${{ inputs.live-rerender-source }}
   INPUT_ALLOW_INCOMPLETE: ${{ inputs.allow-incomplete }}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -568,6 +568,37 @@ internal fun defaultInitScriptStorageDir(version: String): File =
   File(composeAiCacheDir("init"), version)
 
 /**
+ * `--write-locks` when `COMPOSE_PREVIEW_WRITE_LOCKS=1` is set, otherwise nothing.
+ *
+ * A build that LOCKS its buildscript classpath rejects every module its lock state does not name,
+ * and auto-inject's whole job is to add one it does not name:
+ * ```
+ * > Could not resolve all artifacts for configuration 'classpath'.
+ *    > Resolved 'ee.schimke.composeai.preview:...' which is not part of the dependency lock state
+ * ```
+ *
+ * That fires while the buildscript classpath resolves, so it takes the build out before discovery
+ * runs — bitwarden/android hit it with 51 previews it could never reach
+ * (yschimke/compose-preview-imports#30).
+ *
+ * `--write-locks` is Gradle's own answer: the lock state is regenerated to describe what was
+ * actually resolved, rather than the injected module being smuggled past validation. It is the
+ * mechanism and not a bypass, and it works whatever lock mode the project chose — bitwarden uses
+ * `LockMode.STRICT` with `lockAllConfigurations()`, where simply deleting the lockfile FAILS
+ * instead of relaxing.
+ *
+ * It is deliberately **not** inferred from a lockfile on disk. `--write-locks` rewrites files in
+ * the project, and doing that to a developer's working tree because we noticed they lock is not
+ * ours to decide. The environment variable is set by the import pipeline, where the checkout is a
+ * throwaway clone and the rewrite is discarded with it; everywhere else the caller opts in
+ * explicitly or the build is left exactly as it is.
+ *
+ * Visible for tests.
+ */
+internal fun gradleWriteLocksArgs(env: (String) -> String? = System::getenv): List<String> =
+  if (env("COMPOSE_PREVIEW_WRITE_LOCKS") == "1") listOf("--write-locks") else emptyList()
+
+/**
  * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation, or an empty
  * list when auto-inject is disabled. Materialises the script on first call.
  *

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -350,7 +350,12 @@ abstract class Command(
         // task runs use. Without this, a flavored `:app` would still be
         // invisible to `findPreviewModules()` because its task only registers
         // when `-PcomposePreview.variant=demoDebug` is on the model query too.
-        GradleConnection(root, verbose, progress, extraArguments = injectArgs + variantGradleArgs())
+        GradleConnection(
+          root,
+          verbose,
+          progress,
+          extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
+        )
       }
     connection.use(block)
   }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -351,7 +351,7 @@ class DoctorCommand(
         GradleConnection(
             projectDir,
             verbose = verbose,
-            extraArguments = injectArgs + variantGradleArgs(),
+            extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
           )
           .use { gc ->
             // Daemon-JVM + Gradle-version snapshot. Runs first so other

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -159,7 +159,10 @@ internal class McpCommand(
     val driver =
       GradlePreviewDriver(
         projectDir,
-        DriverOptions(verbose = "--verbose" in args || "-v" in args, extraArguments = injectArgs),
+        DriverOptions(
+          verbose = "--verbose" in args || "-v" in args,
+          extraArguments = injectArgs + gradleWriteLocksArgs(),
+        ),
       )
     driver.use {
       val allModules = driver.discoverModules()
@@ -394,7 +397,10 @@ internal class McpCommand(
 
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = projectDir)
     val driver =
-      GradlePreviewDriver(projectDir, DriverOptions(verbose = false, extraArguments = injectArgs))
+      GradlePreviewDriver(
+        projectDir,
+        DriverOptions(verbose = false, extraArguments = injectArgs + gradleWriteLocksArgs()),
+      )
     driver.use {
       val allModules = driver.discoverModules()
       val modules =

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/GradleWriteLocksTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/GradleWriteLocksTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+
+/**
+ * The Bitwarden shape (https://github.com/bitwarden/android): the build locks its buildscript
+ * classpath with `lockAllConfigurations()` and `LockMode.STRICT`, so it rejects every module its
+ * lock state does not name — and auto-inject's whole job is to add one:
+ * ```
+ * > Could not resolve all artifacts for configuration 'classpath'.
+ *    > Resolved '...' which is not part of the dependency lock state
+ * ```
+ *
+ * That fires while the buildscript classpath resolves, before discovery runs. The import hit it
+ * with 51 previews it could never reach (yschimke/compose-preview-imports#30).
+ *
+ * These tests pin the mechanism rather than a bypass. `--write-locks` regenerates the lock state to
+ * describe what was actually resolved, which is Gradle's own answer to "the classpath changed";
+ * under STRICT mode it is also the only one that works, because deleting the lockfile makes a
+ * strict build fail rather than relax.
+ */
+class GradleWriteLocksTest {
+
+  private val tempDirs = mutableListOf<File>()
+
+  @AfterTest fun cleanup() = tempDirs.forEach { it.deleteRecursively() }
+
+  private fun tempDir(): File =
+    Files.createTempDirectory("compose-preview-write-locks-").toFile().also { tempDirs += it }
+
+  @Test
+  fun `the flag is opt-in through the environment, never inferred`() {
+    // --write-locks REWRITES files in the project. Doing that to a developer's working tree
+    // because we noticed they lock is not ours to decide, so nothing about a lockfile on disk
+    // turns this on — only the import pipeline's explicit environment variable does.
+    assertEquals(emptyList(), gradleWriteLocksArgs { null })
+    assertEquals(
+      emptyList(),
+      gradleWriteLocksArgs { if (it == "COMPOSE_PREVIEW_WRITE_LOCKS") "0" else null },
+    )
+    assertEquals(
+      listOf("--write-locks"),
+      gradleWriteLocksArgs { if (it == "COMPOSE_PREVIEW_WRITE_LOCKS") "1" else null },
+    )
+  }
+
+  /**
+   * A build locked exactly as bitwarden/android locks: strict, every configuration, empty state.
+   */
+  private fun createStrictlyLockedProject(): File {
+    val root = tempDir()
+    File(root, "settings.gradle.kts")
+      .writeText(
+        """
+        dependencyResolutionManagement { repositories { mavenCentral() } }
+        rootProject.name = "write-locks-repro"
+        include(":app")
+        """
+          .trimIndent()
+      )
+    File(root, "build.gradle.kts")
+      .writeText(
+        """
+        buildscript {
+            repositories { mavenCentral() }
+            dependencyLocking {
+                lockAllConfigurations()
+                lockMode.set(LockMode.STRICT)
+            }
+            // Stands in for the module auto-inject adds: something the lock state does not name.
+            dependencies { classpath("com.squareup.okio:okio:3.9.0") }
+        }
+        """
+          .trimIndent()
+      )
+    File(root, "buildscript-gradle.lockfile")
+      .writeText("# This is a Gradle generated file for dependency locking.\nempty=classpath\n")
+    File(root, "app").apply { mkdirs() }.also { File(it, "build.gradle.kts").writeText("") }
+    return root
+  }
+
+  @Test
+  fun `a strictly locked build fails on an unlocked classpath module`() {
+    val project = createStrictlyLockedProject()
+    val result =
+      GradleRunner.create().withProjectDir(project).withArguments(":app:help").buildAndFail()
+    assertTrue(
+      result.output.contains("not part of the dependency lock state"),
+      "expected the Bitwarden failure to reproduce; got:\n${result.output}",
+    )
+  }
+
+  @Test
+  fun `--write-locks clears it and rewrites the lock state to match what resolved`() {
+    val project = createStrictlyLockedProject()
+    GradleRunner.create()
+      .withProjectDir(project)
+      .withArguments(":app:help", *gradleWriteLocksArgs { "1" }.toTypedArray())
+      .build()
+
+    val lockfile = File(project, "buildscript-gradle.lockfile").readText()
+    assertTrue(
+      lockfile.contains("com.squareup.okio:okio:3.9.0=classpath"),
+      "the lock state must now DESCRIBE what was resolved, not have been bypassed; got:\n$lockfile",
+    )
+  }
+}


### PR DESCRIPTION
Replaces #4987, which is closed unmerged. Companion to #4990/#4991, which did the same job for dependency *verification*.

An imported project may LOCK its buildscript classpath, in which case it rejects every module its lock state does not name — including the preview plugin auto-inject adds. The render dies during configuration, before discovery runs. `bitwarden/android` hit it with 51 previews it could never reach (yschimke/compose-preview-imports#30):

```
> Could not resolve all artifacts for configuration 'classpath'.
   > Resolved 'ee.schimke.composeai.preview:...' which is not part of the dependency lock state
```

## Why not the `files(...)` trick

That was #4987: inject the plugin as a file dependency, which slips past lock validation because a file dependency is not a module component. It worked, but it was a **bypass** — the project said "the modules on my buildscript classpath are exactly this list" and we quietly added one that wasn't, from a generated init script. It also had a real hazard: file dependencies don't take part in Gradle's version conflict resolution, so our transitive deps would land on the buildscript classpath by classpath order rather than being aligned with AGP/Kotlin.

`--write-locks` is Gradle's own answer to "the classpath changed": the lock state is **regenerated to describe what actually resolved**. It's the mechanism, not a loophole in it, and it leaves an auditable diff in the checkout.

## Verified, not assumed

Bitwarden uses `lockAllConfigurations()` with `LockMode.STRICT`. That matters, and it rules out the obvious alternative: under STRICT, **deleting** the lockfile makes the build fail rather than relax. I probed the real shape before building on it — a plain run reproduces the error above; the same run with `--write-locks` succeeds and rewrites the lockfile to name what it resolved:

```
com.squareup.okio:okio:3.9.0=classpath
```

## Opt-in, never inferred

Carried by `COMPOSE_PREVIEW_WRITE_LOCKS=1`, following the existing `COMPOSE_PREVIEW_NO_AUTO_INJECT` pattern, set only in import mode.

It is deliberately **not** inferred from a lockfile on disk. `--write-locks` rewrites files in the project, and doing that to a developer's working tree because we noticed they lock is not ours to decide. In the pipeline the checkout is a throwaway clone discarded with the job; everywhere else the build is left exactly as it is. A build with no locking resolves it to a no-op.

## Test plan

`GradleWriteLocksTest` drives a strictly-locked TestKit project shaped like Bitwarden's:

1. the failure **reproduces** without the flag;
2. with it the build succeeds **and the lockfile ends up naming the module that resolved** — so the test pins the mechanism rather than merely a green build;
3. the flag is opt-in through the environment and never inferred.

`:cli:test` green in full on this branch.

Non-visual change; the surface is a Gradle invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_