### PR TITLE
fix(import): carry --write-locks and the plugin's dep groups into the render

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -512,7 +512,35 @@ env:
     # coordinate (ee.schimke.composeai.preview:...gradle.plugin), whose POM resolves the implementation
     # from a different group entirely. Trusting the marker alone leaves the implementation unverifiable
     # and the build still fails.
-    GROUPS = ("ee.schimke.composeai.preview", "ee.schimke.composeai")
+    # Our own two groups, plus the groups our plugin DRAGS IN. The first mullvad run proved the
+    # distinction: with only the first two trusted, verification still failed on nine artifacts,
+    # none of them ours —
+    #
+    #   asm-9.10.1.jar (org.ow2.asm), classgraph-4.8.194.jar (io.github.classgraph),
+    #   kotlin-metadata-jvm-2.4.10.jar (org.jetbrains.kotlin), okhttp / okhttp-jvm
+    #   (com.squareup.okhttp3), okio / okio-jvm (com.squareup.okio)
+    #
+    # — the preview plugin's transitive closure, which the imported project has no checksums for
+    # because it never asked for them. They are as much "the coordinates we are the reason for" as
+    # the plugin itself.
+    #
+    # Trusted by GROUP rather than by exact version on purpose: a version list rots at every plugin
+    # bump and fails closed in a way that is tedious to chase, and this edit lives for one render of
+    # a throwaway clone and goes nowhere else. The cost, stated plainly: for that one run the
+    # imported project also stops verifying ITS OWN uses of these groups — Kotlin and okio in
+    # particular are ones it certainly uses. That is the trade being made, deliberately.
+    #
+    # If a future plugin dependency arrives from a group not listed here, the render fails with the
+    # same "N artifacts failed verification" list, which names exactly what to add.
+    GROUPS = (
+        "ee.schimke.composeai.preview",
+        "ee.schimke.composeai",
+        "org.ow2.asm",
+        "io.github.classgraph",
+        "org.jetbrains.kotlin",
+        "com.squareup.okhttp3",
+        "com.squareup.okio",
+    )
 
     TRUST_TAG = re.compile(r"<trust\b[^>]*>")
     ATTR = re.compile(r"""\b([A-Za-z]+)\s*=\s*["']([^"']*)["']""")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -320,7 +320,13 @@ abstract class Command(
     val extensionArgs = extensionGradleArgs()
     val missingRendersArgs = missingRendersGradleArgs()
     val permutationsArgs = permutationsGradleArgs()
-    val withExtras = extra + extensionArgs + missingRendersArgs + permutationsArgs
+    // --write-locks has to be here, not only on the discovery connection: `bundle pack` runs its
+    // Gradle tasks through THIS helper, so wiring it to extraArguments alone left the render still
+    // failing with "Resolved 'ee.schimke.composeai:preview-discovery:…' which is not part of the
+    // dependency lock state" on bitwarden/android, even with COMPOSE_PREVIEW_WRITE_LOCKS=1 set
+    // (yschimke/compose-preview-imports#30).
+    val withExtras =
+      extra + extensionArgs + missingRendersArgs + permutationsArgs + gradleWriteLocksArgs()
     val reason = forceReason ?: return withExtras
     if (forceNoticePrinted.compareAndSet(false, true)) {
       System.err.println(


### PR DESCRIPTION
Two failures from the first live import runs after #4990/#4991/#4992 landed. Both are gaps in **those** fixes, found by running the imports rather than by reading the diffs.

## bitwarden — the flag never reached Gradle

It got to discovery and died on the exact error `--write-locks` exists to prevent:

```
LockOutOfDateException: Resolved 'ee.schimke.composeai:preview-discovery:1.63.0'
  which is not part of the dependency lock state
```

`COMPOSE_PREVIEW_WRITE_LOCKS=1` was set correctly, and #4992 wired the flag to the discovery connection plus three other call sites — but `bundle pack` runs its Gradle tasks through `gradleArgsWithForce`, which was not one of them. Added there, which is the seam every bundle and render path shares.

## mullvad — the trust step worked; the closure was bigger than the plugin

Nine artifacts failed verification and **none of them was ours**:

```
asm-9.10.1.jar (org.ow2.asm)                    okhttp / okhttp-jvm (com.squareup.okhttp3)
classgraph-4.8.194.jar (io.github.classgraph)   okio / okio-jvm (com.squareup.okio)
kotlin-metadata-jvm-2.4.10.jar (org.jetbrains.kotlin)
```

That is the preview plugin's transitive closure — artifacts the imported project has no checksums for because it never asked for them. They are as much "the coordinates we are the reason for" as the plugin itself, so their groups join the trusted set.

**By group, not by exact version.** A version list rots at every plugin bump and fails closed in a way that is tedious to chase; this edit lives for one render of a throwaway clone and goes nowhere else.

**The cost, stated in the code rather than left implicit:** for that one run the imported project also stops verifying its *own* uses of those groups, and Kotlin and okio are ones mullvad certainly uses. That is the trade, made deliberately. If a future plugin dependency arrives from an unlisted group, the render fails with the same "N artifacts failed verification" list, which names exactly what to add.

## Test plan

Trust script exercised via the env value extracted from the **parsed YAML** — the exact text the runner materialises — against mullvad's real 492 KB `verification-metadata.xml`:

- all seven groups appended, file still well-formed;
- idempotent on a second run;
- a project already trusting `org.jetbrains.kotlin` group-wide gets only the remaining six.

Both jobs confirmed to carry identical step bodies. `:cli:test` green in full.

The real check is the next bitwarden and mullvad imports, which I'll run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_