### PR TITLE
ci(renderer-desktop): run forwardComposeSystemThemeTest from `test`, not only `check`

### DIFF
--- a/renderers/desktop/build.gradle.kts
+++ b/renderers/desktop/build.gradle.kts
@@ -193,7 +193,27 @@ val forwardComposeSystemThemeTest =
     shouldRunAfter(tasks.test)
   }
 
+// `check` for anyone running it, and `test` because that is what actually runs.
+//
+// CI never invokes `check`. ci.yml's full branch runs `test jvmTest desktopTest checkKotlinAbi`,
+// its scoped branch runs whatever `.github/ci/affected-gradle-tests.py` resolves — `test`/`jvmTest`
+// per project, plus `checkKotlinAbi` where the project has one — and the only `gradlew …build`
+// invocations in the workflows are `:cli:build` and `:bundle-viewer:build`, neither of which
+// reaches this project. So this gate had never run in CI since it was added.
+//
+// That is the failure its own KDoc above is about, one level up: it explains at length why the
+// forward pin must stay strictly ahead of the production one, because a task running on a levelled
+// graph "passes while covering nothing" — and the task was passing while covering nothing for a
+// simpler reason. `affected-gradle-tests.py`'s docstring records the same trap costing three stale
+// ABI dumps in a day, which is why `checkKotlinAbi` is now named per project rather than left to
+// `check`. `finalizedBy` is the equivalent for a task the resolver does not know about.
+//
+// Nothing is excluded from `test` here, unlike `:daemon:desktop`'s forward task:
+// `UiModeSystemThemeTest` is an invariant that has to hold on both Compose lines, so running it
+// once per runtime is the point rather than a duplicate.
 tasks.check { dependsOn(forwardComposeSystemThemeTest) }
+
+tasks.test { finalizedBy(forwardComposeSystemThemeTest) }
 
 composeAiMavenPublishing {
   coordinates(


### PR DESCRIPTION
Follow-up to #5002, which flagged this while building the equivalent lane for `:daemon:desktop`.

## The gap

`forwardComposeSystemThemeTest` was wired into `check` alone, and **CI never invokes `check`**:

- ci.yml's full branch runs `test jvmTest desktopTest checkKotlinAbi`.
- Its scoped branch runs whatever `.github/ci/affected-gradle-tests.py` resolves — `test`/`jvmTest` per project, plus `checkKotlinAbi` where the project has one.
- The only `gradlew …build` invocations in the workflows are `:cli:build` and `:bundle-viewer:build` (a `build` does pull in that project's `check`, which is how `:cli`'s three boundary guards stay covered — ci.yml has a comment saying so). Neither reaches `:renderer-desktop`.
- The one other `./gradlew check` string in the repo is inside a test fixture in `fix-pr-body-markdown.test.mjs`.

So the task had not run once in CI since it landed.

That is the failure its own KDoc argues against, one level up. It explains at length why `compose-multiplatform-forward` must stay strictly ahead of the production pin — because otherwise the task "runs on an identical or downgraded graph and passes while covering nothing" — and it was passing while covering nothing for a plainer reason. `affected-gradle-tests.py`'s docstring records the same trap costing three stale ABI dumps in a single day, which is why `checkKotlinAbi` is emitted per project now rather than left to `check`. `finalizedBy` is the equivalent for a task that resolver does not know about.

## What changed

One line plus its rationale. `check` keeps its dependency for anyone who runs it; `test` gains `finalizedBy`.

Nothing is excluded from `test` here, unlike `:daemon:desktop`'s forward task — `UiModeSystemThemeTest` is an invariant that has to hold on **both** Compose lines, so running it once per runtime is the point rather than a duplicate.

## The gate is green as found

This turns a dormant gate on; it does not paper over a failing one. Before changing anything I ran it as it stood: `UiModeSystemThemeTest` on CMP 1.12.0-rc01, **4/4 green**, including `night-yes uiMode makes isSystemInDarkTheme report dark in the render` and `forced dark and light renders use different pixels` — the two that actually render through `ImageComposeScene` and compare pixels. The cost of this change is a second Compose resolution on `:renderer-desktop:test`, nothing more.

## Test plan

- `./gradlew :renderer-desktop:forwardComposeSystemThemeTest` — green, 4/4, run **before** the change to establish the gate was dormant rather than red.
- `./gradlew :renderer-desktop:test` — green, and the log shows `> Task :renderer-desktop:test` followed by `> Task :renderer-desktop:forwardComposeSystemThemeTest`, which is the CI path.
- **Negative control:** with the change stashed, `./gradlew :renderer-desktop:test --rerun-tasks` runs `test` and *only* `test` — `forwardComposeSystemThemeTest` never appears. That is the bug, reproduced.
- `./gradlew ktfmtCheckAll` — green.

## Three more of these, not fixed here

Checking every `check { dependsOn(...) }` in the repo while confirming the above: `:cli`'s guards and `:gradle-plugin:functionalTest` are covered (via `:cli:build` and a direct invocation respectively), but by the same reasoning these look dead too:

- `:mcp:checkMcpToolingApiBoundary`
- `composePreviewRender` on `:samples:desktop-daemon-bench` and `:samples:android-daemon-bench`

Out of scope for this one-line fix, and each needs its own "is it green as found?" check before being switched on. Worth a look separately — or a general answer, since this is now the third instance of the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd5GG4qFidyFqEXnajZa1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd5GG4qFidyFqEXnajZa1p)_