### PR TITLE
ci(mcp): run checkMcpToolingApiBoundary from `test`, not only `check`

### DIFF
--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -130,4 +130,20 @@ val checkMcpToolingApiBoundary =
     runtimeClasspath.from(configurations.named("runtimeClasspath"))
   }
 
+// `check` for anyone running it, and `test` because that is what actually runs.
+//
+// CI never invokes `check`. ci.yml's full branch runs `test jvmTest desktopTest checkKotlinAbi`,
+// its scoped branch runs whatever `.github/ci/affected-gradle-tests.py` resolves — `test`/`jvmTest`
+// per project, plus `checkKotlinAbi` where the project has one — and the only `gradlew …build`
+// invocations in the workflows are `:cli:build` and `:bundle-viewer:build`. `:cli` does depend on
+// this project, but `build` runs the *calling* project's `check`, not its dependencies', so that
+// does not reach here either. Nothing named this guard, so it had never run in CI.
+//
+// `affected-gradle-tests.py`'s own docstring records the same trap costing three stale ABI dumps
+// in a single day, which is why `checkKotlinAbi` is emitted per project now rather than left to
+// `check`; `finalizedBy` is the equivalent for a guard that resolver does not know about. Ordering
+// is deliberate: a boundary violation and a test failure surface in the same run rather than
+// costing two cycles.
 tasks.named("check") { dependsOn(checkMcpToolingApiBoundary) }
+
+tasks.named("test") { finalizedBy(checkMcpToolingApiBoundary) }

--- a/samples/android-daemon-bench/build.gradle.kts
+++ b/samples/android-daemon-bench/build.gradle.kts
@@ -808,6 +808,17 @@ tasks.register<BenchCompileStagesTask>("benchCompileStages") {
 
 // --- CI smoke (issue #1586) -----------------------------------------------------------------
 // The full benches are deliberately slow (run on the reference machine, not per-PR). To keep this
-// module from bit-rotting, `check` renders the five trivial previews — a cheap proof the module
+// module from bit-rotting, the five trivial previews are rendered — a cheap proof the module
 // builds, discovery wires up, and the renderer path is intact.
+//
+// CI does that by **naming `composePreviewRender` directly**, in ci.yml's `build-samples-full`
+// job, which is gated `if: github.event_name != 'pull_request'` because these render-heavy checks
+// "routinely make Build Samples the slowest CI leg". It is not reached through `check`: nothing in
+// CI invokes `check` at all (see `:mcp` and `:renderer-desktop` for the two guards that had to be
+// moved onto `test` for exactly that reason), and this module has no `test` task to move it to —
+// only a `main` source set, and `affected-gradle-tests.py` ignores `samples/**` outright.
+//
+// So the hook below is a local convenience: `./gradlew :samples:<this>:check` renders. Deliberately
+// NOT wired onto a PR-path task — that would drag a Robolectric/Compose-Desktop render onto every
+// pull request, which is the cost `build-samples-full` exists to keep off it.
 tasks.named("check") { dependsOn("composePreviewRender") }

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -954,6 +954,17 @@ tasks.register<BenchCompileStagesTask>("benchCompileStages") {
 
 // --- CI smoke (issue #1586) -----------------------------------------------------------------
 // The full benches are deliberately slow (run on the reference machine, not per-PR). To keep this
-// module from bit-rotting, `check` renders the five trivial previews — a cheap proof the module
+// module from bit-rotting, the five trivial previews are rendered — a cheap proof the module
 // builds, discovery wires up, and the renderer path is intact.
+//
+// CI does that by **naming `composePreviewRender` directly**, in ci.yml's `build-samples-full`
+// job, which is gated `if: github.event_name != 'pull_request'` because these render-heavy checks
+// "routinely make Build Samples the slowest CI leg". It is not reached through `check`: nothing in
+// CI invokes `check` at all (see `:mcp` and `:renderer-desktop` for the two guards that had to be
+// moved onto `test` for exactly that reason), and this module has no `test` task to move it to —
+// only a `main` source set, and `affected-gradle-tests.py` ignores `samples/**` outright.
+//
+// So the hook below is a local convenience: `./gradlew :samples:<this>:check` renders. Deliberately
+// NOT wired onto a PR-path task — that would drag a Robolectric/Compose-Desktop render onto every
+// pull request, which is the cost `build-samples-full` exists to keep off it.
 tasks.named("check") { dependsOn("composePreviewRender") }


### PR DESCRIPTION
Follows #5007, which fixed the same shape in `:renderer-desktop` and listed three more suspects. **One of the three was real. The other two were my mistake, and this PR corrects the record rather than "fixing" them.**

## `:mcp:checkMcpToolingApiBoundary` — real dead gate

Nothing in any workflow names it. `:cli` *does* depend on `:mcp`, but `./gradlew :cli:build` runs the **calling** project's `check`, not its dependencies' — so the route that keeps `:cli`'s own three boundary guards alive doesn't reach this one. And CI never invokes `check` anywhere: the full branch runs `test jvmTest desktopTest checkKotlinAbi`, the scoped branch runs what `affected-gradle-tests.py` resolves (`test`/`jvmTest` per project plus `checkKotlinAbi`).

So the guard had never run. `:mcp` has a real test suite, so it gets the same `finalizedBy` treatment as #5007 — `finalizedBy` rather than `dependsOn` so a boundary violation and a test failure surface in the same run instead of costing two cycles.

**Green as found**, so this switches a dormant guard on rather than papering over a live `gradle-tooling-api` leak.

## The daemon-bench pair — not dead, and wiring them would be a regression

I flagged `composePreviewRender` on `:samples:desktop-daemon-bench` and `:samples:android-daemon-bench` in #5007. I was wrong, and I only found out by checking before changing anything:

1. **They are covered.** ci.yml has a `Render daemon-bench samples (smoke)` step naming both tasks directly. It lives in `build-samples-full`, gated `if: github.event_name != 'pull_request'`, with a comment saying these render-heavy checks "routinely make Build Samples the slowest CI leg. Run them on main and nightly instead." Issue #1586's anti-bit-rot intent is met — deliberately off the PR path.
2. **There is no `test` task to move them to.** Both modules have only a `main` source set, and `affected-gradle-tests.py` ignores `samples/**` outright.

Wiring a Robolectric / Compose-Desktop render onto a PR-path task would reverse a deliberate cost decision. What was actually wrong is the comment: it said "`check` renders the five trivial previews", which reads as though `check` were the CI mechanism, and is exactly what misled me. Both comments now name the real invocation, say why it is off the PR path, and record that the module has no `test` task — so the next reader doesn't repeat the mistake or "fix" it into CI.

## Revised count

Two genuinely dead gates this session, `:renderer-desktop` and `:mcp`, both now closed — not four. That weakens the suggestion I made in #5007 that this needs a resolver-level answer; at two instances, both fixed, a general mechanism looks like more machinery than the problem warrants.

## Test plan

- `./gradlew :mcp:checkMcpToolingApiBoundary` — green, run **before** the change to establish the guard was dormant rather than red.
- `./gradlew :mcp:test` — green, and the log shows `> Task :mcp:checkMcpToolingApiBoundary` running off it, which is the CI path.
- **Negative control:** with the change stashed, `./gradlew :mcp:test --rerun-tasks` runs `test` and *only* `test` — the guard never appears. That is the bug, reproduced.
- `./gradlew ktfmtCheckAll` — green.
- The bench modules are comment-only: no task graph or CI behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd5GG4qFidyFqEXnajZa1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd5GG4qFidyFqEXnajZa1p)_