### PR TITLE
feat(discovery): infer the library components a preview demonstrates

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1349,6 +1349,20 @@ data class PreviewInfo(
    * unchanged. See [PreviewKnob].
    */
   val knobs: List<PreviewKnob> = emptyList(),
+  /**
+   * The **design-system library components** this preview renders — the composables a catalog
+   * sticker exists to demonstrate, with their real signatures read from `@kotlin.Metadata`.
+   *
+   * Separate from [targets], which answers a different question: *that* list is "which of the
+   * project's own composables does this preview render?", used to correlate a UI change to its
+   * preview, and it deliberately drops `androidx.compose.material3.*` as scaffolding. A catalog
+   * whose every sticker wraps one library component therefore gets an empty [targets] and is
+   * described by this field instead.
+   *
+   * Empty for a preview that calls no design-system component directly, so older manifests and
+   * ordinary application previews are unchanged.
+   */
+  val componentTargets: List<PreviewTarget> = emptyList(),
 )
 
 /**
@@ -1424,6 +1438,12 @@ enum class TargetSignal {
    * -> Unit` parameter) before landing on the candidate.
    */
   WRAPPER_UNWRAPPED,
+  /**
+   * The candidate is a **design-system library** component rather than one of the project's own
+   * composables — the subject a catalog sticker demonstrates. Only ever appears on
+   * [PreviewInfo.componentTargets].
+   */
+  LIBRARY_COMPONENT,
 }
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -2214,6 +2214,18 @@ object PreviewDiscovery {
     // walks the bytecode once instead of N times; tile previews skip the inference entirely
     // (handled in `makePreview`) and the lazy never forces.
     val previewSourceFile = sourceFilePath(classInfo, input)
+    // The design-system components this preview demonstrates — a different question from
+    // `inferredTargets` (see `PreviewInfo.componentTargets`), so a separate lazy walk. Lazy for the
+    // same reason: a multi-preview fans one function into N `PreviewInfo`s and the bytecode does
+    // not change between them.
+    val inferredComponentTargets = lazy {
+      PreviewTargetInference.inferComponents(
+        previewClassInfo = classInfo,
+        previewMethod = method,
+        scanResult = scanResult,
+        projectClassFqns = projectClassFqns,
+      )
+    }
     val inferredTargets = lazy {
       PreviewTargetInference.infer(
         previewClassInfo = classInfo,
@@ -2303,6 +2315,7 @@ object PreviewDiscovery {
             previewParameter,
             previewSourceFile,
             inferredTargets,
+            inferredComponentTargets,
           )
         previews.add(base)
         for (spec in overrideVariantSpecs) previews.add(overrideVariantPreview(base, spec))
@@ -2334,6 +2347,7 @@ object PreviewDiscovery {
           previewParameter,
           previewSourceFile,
           inferredTargets,
+          inferredComponentTargets,
         )
       previews.add(base)
       for (spec in overrideVariantSpecs) previews.add(overrideVariantPreview(base, spec))
@@ -2364,6 +2378,7 @@ object PreviewDiscovery {
           timings,
           previewSourceFile,
           inferredTargets,
+          inferredComponentTargets,
         )
       previews.add(base)
       for (variant in overrideVariantSpecs) previews.add(overrideVariantPreview(base, variant))
@@ -4539,6 +4554,7 @@ object PreviewDiscovery {
     previewParameter: Pair<String, Int>?,
     previewSourceFile: String?,
     inferredTargets: Lazy<List<PreviewTarget>>,
+    inferredComponentTargets: Lazy<List<PreviewTarget>>,
   ): PreviewInfo {
     val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
     return buildPreviewInfo(
@@ -4560,6 +4576,7 @@ object PreviewDiscovery {
       timings,
       previewSourceFile,
       inferredTargets,
+      inferredComponentTargets,
     )
   }
 
@@ -4590,6 +4607,7 @@ object PreviewDiscovery {
     timings: List<Long>,
     previewSourceFile: String?,
     inferredTargets: Lazy<List<PreviewTarget>>,
+    inferredComponentTargets: Lazy<List<PreviewTarget>>,
   ): PreviewInfo {
     val fqn = "${classInfo.name}.${method.name}"
     val id = fqn + buildVariantSuffix(params)
@@ -4614,15 +4632,12 @@ object PreviewDiscovery {
     // Tile / notification previews don't go through @Composable invocations — they return a
     // `TilePreviewData` / `Notification` and the renderer reflects them directly. Skipping the
     // lazy means the bytecode walk never runs for these methods.
-    val targets =
-      if (
-        params.kind == PreviewKind.TILE ||
-          params.kind == PreviewKind.NOTIFICATION ||
-          params.kind == PreviewKind.GLANCE_APPWIDGET ||
-          params.kind == PreviewKind.XR_SUBSPACE
-      )
-        emptyList()
-      else inferredTargets.value
+    val skipTargetInference =
+      params.kind == PreviewKind.TILE ||
+        params.kind == PreviewKind.NOTIFICATION ||
+        params.kind == PreviewKind.GLANCE_APPWIDGET ||
+        params.kind == PreviewKind.XR_SUBSPACE
+    val targets = if (skipTargetInference) emptyList() else inferredTargets.value
     return PreviewInfo(
       id = id,
       functionName = method.name,
@@ -4647,6 +4662,11 @@ object PreviewDiscovery {
       // multi-preview carries the same signature-derived set. Empty for every preview that declares
       // none, which is every `previewOverride*` preview and every parameterless one.
       knobs = ComposableSignature.knobsOf(classInfo, method),
+      // Skipped for the same non-@Composable kinds as `targets` above — those never invoke a
+      // library component, so the bytecode walk would only cost time.
+      // Skipped for the same non-`@Composable` kinds as `targets` above (`skipTargetInference`),
+      // which never invoke a library component through a composition at all.
+      componentTargets = if (skipTargetInference) emptyList() else inferredComponentTargets.value,
     )
   }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -46,6 +46,49 @@ object PreviewTargetInference {
       "org.jetbrains.compose.",
     )
 
+  // The subset of [WRAPPER_FQN_PREFIXES] that names design-system **components** rather than
+  // layout, runtime or drawing primitives.
+  //
+  // Both lists are right about the same packages for different questions. "Which of MY composables
+  // does this preview render?" wants `material3.Button` dropped — it is not the project's UI.
+  // "Which
+  // component does this sticker demonstrate?" wants exactly that call and nothing else, because a
+  // catalog sticker's whole subject is the library component it wraps. m3-catalog's 59 entries
+  // stand
+  // for 148 distinct `androidx.compose.material3.*` symbols, none of which the project-local pass
+  // can name, so a catalog gets no target at all today.
+  //
+  // Deliberately NOT the whole of `WRAPPER_FQN_PREFIXES`: `foundation.layout.Column`,
+  // `runtime.remember` and `ui.Modifier` stay scaffolding under either question, and admitting them
+  // would bury the one call a reader cares about under the frame that positions it.
+  private val COMPONENT_LIBRARY_FQN_PREFIXES =
+    listOf(
+      "androidx.compose.material3.",
+      "androidx.compose.material.",
+      "androidx.wear.compose.material3.",
+      "androidx.wear.compose.material.",
+    )
+
+  // Theme entry points inside the component libraries. They pass every other test here — real
+  // `@Composable`s returning `Unit`, in `material3` — and they are the frame a sticker is drawn in,
+  // not its subject. Nine of `:samples:cmp`'s twelve component-bearing previews reported
+  // `MaterialTheme` before this list existed.
+  //
+  // A denylist rather than a shape rule, because the obvious shape rule does not separate them:
+  // `MaterialTheme(colorScheme, shapes, typography, content)` and
+  // `Card(modifier, shape, colors, elevation, border, content)` are both "defaulted config plus one
+  // `@Composable` content lambda". The set is small, stable and named in every catalog's own
+  // scaffolding rules already (`compose-usage.json` rewrites `Sticker` to `MaterialTheme` for
+  // exactly this reason), so naming it here is cheaper and clearer than a heuristic that would
+  // eventually drop a real component.
+  private val THEME_ENTRY_POINTS =
+    setOf(
+      "androidx.compose.material3.MaterialThemeKt.MaterialTheme",
+      "androidx.compose.material.MaterialThemeKt.MaterialTheme",
+      "androidx.wear.compose.material3.MaterialThemeKt.MaterialTheme",
+      "androidx.wear.compose.material.MaterialThemeKt.MaterialTheme",
+    )
+
   // Stdlib / JVM / Kotlin-runtime owners. Filtered explicitly so we never attempt to look
   // them up as project-local @Composable methods.
   private val STDLIB_FQN_PREFIXES = listOf("java.", "javax.", "kotlin.", "kotlinx.", "sun.", "jdk.")
@@ -107,6 +150,71 @@ object PreviewTargetInference {
    *   parameter; enables the `PARAMETER_FORWARDED` signal when the candidate consumes a value of
    *   the right shape.
    */
+  /**
+   * The **design-system components** [previewMethod] renders — the library composables a catalog
+   * sticker exists to demonstrate, as opposed to [infer]'s "which of the project's own composables
+   * does this preview render?".
+   *
+   * The two answer different questions and neither subsumes the other, so this is a separate list
+   * rather than more entries in `targets`: a consumer correlating a UI change to its preview wants
+   * the project-local answer, while a consumer describing a component's API wants this one. Mixing
+   * them would also silently change what `targets[0]` means for every existing reader.
+   *
+   * Resolution reuses [resolveCandidate], so a candidate must be a real `@Composable` on the scan's
+   * classpath — which already spans dependency jars — and must not itself carry a `@Preview`.
+   * Ordering is by call order, deduped, so a sticker wrapping one component yields exactly one
+   * entry and `HIGH` confidence; several distinct component calls yield several at `MEDIUM`,
+   * because nothing here can tell the subject from its neighbours.
+   *
+   * Parameters come from the same `@kotlin.Metadata` read as [infer]'s, so a library component
+   * arrives with its real signature — which is the point: `Button(onClick, modifier, enabled,
+   * shape, colors, elevation, border, contentPadding, interactionSource, content)` is written down
+   * nowhere in a catalog that spells it `Sticker("button-filled")`.
+   */
+  fun inferComponents(
+    previewClassInfo: ClassInfo,
+    previewMethod: MethodInfo,
+    scanResult: ScanResult,
+    projectClassFqns: Set<String>,
+  ): List<PreviewTarget> {
+    val directCalls =
+      try {
+        extractCalls(previewClassInfo, previewMethod)
+      } catch (_: Throwable) {
+        return emptyList()
+      }
+    val calls =
+      directCalls + extractComposeSingletonLambdaCalls(directCalls, scanResult, projectClassFqns)
+    val candidates =
+      calls
+        .asSequence()
+        .filter { call -> COMPONENT_LIBRARY_FQN_PREFIXES.any { call.ownerFqn.startsWith(it) } }
+        .mapNotNull { resolveCandidate(it, scanResult) }
+        .filter {
+          isComponentLibraryTarget(
+            ownerFqn = it.ownerFqn,
+            methodName = it.method.name,
+            returnsUnit = it.method.typeDescriptor?.resultType?.toString() == "void",
+          )
+        }
+        .distinctBy { it.ownerFqn to it.method.name }
+        .toList()
+    if (candidates.isEmpty()) return emptyList()
+    val confidence = if (candidates.size == 1) TargetConfidence.HIGH else TargetConfidence.MEDIUM
+    return candidates.map { candidate ->
+      PreviewTarget(
+        className = candidate.ownerFqn,
+        functionName = candidate.method.name,
+        // A library symbol has no source file in this build; `sourceFile` stays null and
+        // [PreviewTarget.origin] is what says so, rather than the null being read as "library".
+        sourceFile = null,
+        confidence = confidence,
+        signals = listOf(TargetSignal.LIBRARY_COMPONENT),
+        parameters = ComposableSignature.parametersOf(candidate.classInfo, candidate.method),
+      )
+    }
+  }
+
   fun infer(
     previewClassInfo: ClassInfo,
     previewMethod: MethodInfo,
@@ -411,6 +519,26 @@ object PreviewTargetInference {
     val method: MethodInfo,
     val classInfo: ClassInfo,
   )
+
+  /**
+   * Whether a resolved call in a component library is the **component a sticker demonstrates**.
+   *
+   * Three rules, each earning its place against `:samples:cmp`:
+   * * the name must be usable as a Kotlin import — a mangled or synthetic member is not a call site
+   *   anyone can write;
+   * * [returnsUnit] — a component *emits*, it does not return a value. `MaterialTheme.colorScheme`
+   *   and `MaterialTheme.typography` are `@Composable` property getters that pass every other test
+   *   here, and reporting them would describe a sticker's theme lookup as its subject;
+   * * not a [THEME_ENTRY_POINTS] member — the frame a sticker is drawn in rather than its subject.
+   */
+  internal fun isComponentLibraryTarget(
+    ownerFqn: String,
+    methodName: String,
+    returnsUnit: Boolean,
+  ): Boolean =
+    isValidKotlinImportIdentifier(methodName) &&
+      returnsUnit &&
+      "$ownerFqn.$methodName" !in THEME_ENTRY_POINTS
 
   private fun resolveCandidate(call: Invocation, scanResult: ScanResult): ResolvedCandidate? {
     val classInfo = scanResult.getClassInfo(call.ownerFqn) ?: return null

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -70,4 +70,67 @@ class PreviewTargetInferenceTest {
       )
       .isFalse()
   }
+
+  // --- component-library targets (PreviewInfo.componentTargets) -------------------------------
+
+  @Test
+  fun `a component library composable returning Unit is a component target`() {
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.CardKt",
+          "Card",
+          returnsUnit = true,
+        )
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `a composable property getter is not a component target`() {
+    // `MaterialTheme.colorScheme` / `.typography` are @Composable getters on the theme object.
+    // They pass every other test — real @Composable, in material3 — and reporting one would
+    // describe a sticker's theme lookup as the component it demonstrates. Nine of :samples:cmp's
+    // twelve component-bearing previews reported these before the Unit rule existed.
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.MaterialTheme",
+          "getColorScheme",
+          returnsUnit = false,
+        )
+      )
+      .isFalse()
+  }
+
+  @Test
+  fun `a theme entry point is the frame, not the subject`() {
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.MaterialThemeKt",
+          "MaterialTheme",
+          returnsUnit = true,
+        )
+      )
+      .isFalse()
+    // …on every component library the catalogs use, not just the Android one.
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.wear.compose.material3.MaterialThemeKt",
+          "MaterialTheme",
+          returnsUnit = true,
+        )
+      )
+      .isFalse()
+  }
+
+  @Test
+  fun `a name that is not a usable Kotlin import is rejected`() {
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.CardKt",
+          "Card\u0024lambda\u00240",
+          returnsUnit = true,
+        )
+      )
+      .isFalse()
+  }
 }


### PR DESCRIPTION
First working piece of the component-record track. Closes the gap [#5008](https://github.com/yschimke/compose-ai-tools/pull/5008) documented as blocking the plan's primary corpus.

## The gap

`PreviewTargetInference` answers *"which of the project's own composables does this preview render?"* — and to do that it drops every owner matching `WRAPPER_FQN_PREFIXES` (which lists `androidx.compose.material3.` explicitly) and then keeps only owners `in projectClassFqns`. Both filters are correct for that question, and both make `androidx.compose.material3.Button` unreachable.

So a catalog whose every sticker wraps one library component got **no target at all**. m3-catalog's 59 entries stand for 148 distinct `material3` symbols, none of them nameable.

## What this adds

`PreviewInfo.componentTargets` — the design-system composables a preview renders, with their real signatures from `@kotlin.Metadata`.

A **separate list**, not more entries in `targets`: a consumer correlating a UI change to its preview wants the project-local answer; one describing a component's API wants this one. Mixing them would also silently change what `targets[0]` means for every existing reader (`apply-component-parameters.mjs` among them).

Three narrowing rules, each earned against `:samples:cmp` rather than guessed:

1. **Owner is a component package** — `material3`, `material`, and the Wear equivalents. Deliberately *not* all of `WRAPPER_FQN_PREFIXES`: `foundation.layout.Column`, `runtime.remember` and `ui.Modifier` stay scaffolding under either question.
2. **The method returns `Unit`.** A component emits; it does not return a value. `MaterialTheme.colorScheme` and `.typography` are `@Composable` property getters that pass every other test — reporting one describes a sticker's *theme lookup* as its subject.
3. **Not a theme entry point.** `MaterialTheme` is the frame a sticker is drawn in, and accounted for **nine of twelve** hits before this rule. A denylist rather than a shape rule, because the obvious shape rule can't separate `MaterialTheme(colorScheme, shapes, typography, content)` from `Card(modifier, shape, colors, elevation, border, content)`.

Resolution reuses `resolveCandidate`, so a candidate must be a real `@Composable` on the scan's classpath — which already spans dependency jars — and must not carry a `@Preview` of its own.

## Test plan

`./gradlew :samples:cmp:composePreviewDiscover` — green, and `previews.json` now carries real signatures:

```
componentTargets on 3 of 75 previews
  ExpandableMenuInteractionPreview -> CardKt.Card (6 params)
  ExpandableMenuInteractionPreview -> ButtonKt.TextButton (10 params)
  OverridableListPreview           -> CardKt.Card (6 params)
  ParameterKnobListPreview         -> CardKt.Card (6 params)
```

3 of 75 is the honest number: `:samples:cmp` is mostly shader, Lottie, SVG and scrolling previews that wrap no Material component. The three that do are identified with full parameter lists — e.g. `TextButton(onClick, modifier, enabled, shape, colors, elevation, …)`, which is written down nowhere today.

`:gradle-plugin:preview-discovery:test` — green, including four new tests pinning each rule (the getter case documents the nine-of-twelve regression it prevents). `ktfmtFormat` clean.

Purely additive: the field defaults to empty, so older manifests and every preview that calls no design-system component are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_