### PR TITLE
feat(import): let an import name the previews it cannot render

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -341,6 +341,11 @@ on:
         required: false
         type: string
         default: ''
+      exclude-preview-ids:
+        description: 'IMPORT MODE ONLY. Extra comma-separated preview-id glob patterns to leave unrendered, appended to the ones this workflow always applies. For the preview an import cannot render standalone — one wanting a CompositionLocal, a Hilt entry point or a process-wide singleton that only the host application installs — where the alternative is failing the whole run over a handful of them. Name the ids rather than reaching for allow-incomplete: this leaves every OTHER render failure fatal, so a real regression still stops the run.'
+        required: false
+        type: string
+        default: ''
       commit-user-name:
         description: 'Author/committer name for the generated delivery-branch commit.'
         required: false
@@ -618,7 +623,16 @@ env:
   # with the job; a developer's working tree is never rewritten because we noticed they lock.
   # A build with no locking resolves this to a no-op.
   COMPOSE_PREVIEW_WRITE_LOCKS: ${{ inputs.upstream-repository != '' && '1' || '' }}
-  IMPORT_EXCLUDE_PREVIEW_IDS: ${{ inputs.upstream-repository != '' && 'activity__*,apptour__*' || '' }}
+  # The two patterns this workflow always applies in import mode, plus whatever the import itself
+  # named. The always-on pair drops the synthetic app-launching previews; the caller's half is for
+  # the preview that cannot render outside its host application — a missing CompositionLocal, a Hilt
+  # entry point, a singleton already installed — which without this fails the ENTIRE run for want of
+  # one render out of fifty-six (bitwarden's BitwardenBasicDialog_preview was exactly that).
+  #
+  # Appended rather than replacing, so an import that names its own ids does not silently lose the
+  # app-launching guard. The comma is the delimiter both consumers below already split on, and an
+  # empty caller input leaves the value byte-identical to what it was before this existed.
+  IMPORT_EXCLUDE_PREVIEW_IDS: ${{ inputs.upstream-repository != '' && (inputs.exclude-preview-ids != '' && format('activity__*,apptour__*,{0}', inputs.exclude-preview-ids) || 'activity__*,apptour__*') || '' }}
   INPUT_LIVE_RERENDER_SOURCE: ${{ inputs.live-rerender-source }}
   INPUT_ALLOW_INCOMPLETE: ${{ inputs.allow-incomplete }}
   INPUT_PUBLISH_LIVE_BUNDLE: ${{ inputs.publish-live-bundle }}


### PR DESCRIPTION
Adds one `workflow_call` input, `exclude-preview-ids`, and appends it to the `IMPORT_EXCLUDE_PREVIEW_IDS` the workflow already owns.

## Why

Some previews only render inside their own application — one that reads a `CompositionLocal` the host installs, resolves a Hilt entry point, or touches a process-wide singleton. There is nothing to fix upstream and nothing to fix in the import; it is simply not a preview an import can produce.

Today one of them fails the entire run. From this evening's re-runs, after #4990–#4994 got these builds past dependency locking and verification:

| Import | Rendered | Failed on |
| --- | --- | --- |
| bitwarden | **55 of 56** | `BitwardenBasicDialog_preview` — `CompositionLocal LocalIntentManager not present` |
| pocketcasts-wear | **24 of 28** | Hilt — `ComponentActivity does not implement…` |
| twine | **21 of 22** | Coil — "the singleton image loader has already been created" |

All three published nothing.

## Why not `allow-incomplete`

That input already exists and would make all three green today, which is exactly the problem: it would also swallow the *next* breakage. An upstream refactor that quietly stops rendering half a catalog would look identical, and the nightly refresh would go on publishing a thinner catalog every night with nothing to show for it.

Naming the ids keeps every **other** render failure fatal, and the list is reviewable — an import's pull request states exactly what it gives up.

## Shape

Appended to the always-on `activity__*,apptour__*` rather than replacing them, so an import naming its own ids does not silently re-enable the synthetic app-launching previews. The comma is the delimiter both render steps already `tr ',' '\n'` over, so there is no new transport. An empty input leaves the variable byte-identical to what it was before this existed, which is every existing caller.

Caller side is compose-preview-imports (`excludePreviewIds` in `import.json`); that pull request follows and depends on this one, since it references this workflow `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_