### PR TITLE
feat(discovery): publish components.json beside previews.json

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -1,0 +1,129 @@
+package ee.schimke.composeai.discovery
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire version of `components.json`.
+ *
+ * A published data product needs one from the start: the file persists in bundles and is read by
+ * the preview browser, the UI builder and MCP clients, so an old bundle and a detached consumer
+ * must be able to tell an additive record from an incompatible future one — the lesson
+ * `docs/API_STABILITY.md` records for `previews.json`.
+ *
+ * Evolution rules: an added field with a default bumps nothing; a removed field, or one whose
+ * meaning changes, bumps this. A reader that does not know a major version refuses the file rather
+ * than guessing at it.
+ */
+const val COMPONENT_RECORD_SCHEMA_VERSION: Int = 1
+
+/**
+ * `components.json` — the **components** a module's previews render, as opposed to
+ * `previews.json`'s *renders*.
+ *
+ * The distinction is the point. A preview is one capture of one configuration; a component is the
+ * API underneath, and until now it was written down nowhere: a catalog's 59 `@CatalogComponent`
+ * entries stand for 148 distinct library symbols whose signatures appear in no artifact. This file
+ * is that missing record, derived rather than authored — every field comes from `@kotlin.Metadata`
+ * or from discovery's own inference, so there is nothing to keep in sync by hand.
+ */
+@Serializable
+data class ComponentRecordFile(
+  val schemaVersion: Int = COMPONENT_RECORD_SCHEMA_VERSION,
+  val module: String,
+  val variant: String,
+  val components: List<ComponentRecord>,
+)
+
+/**
+ * One composable, with the previews that render it.
+ *
+ * @property canonicalId the always-present identity — `<module>/<jvmOwner>.<name>`. Deliberately
+ *   not [componentId]: a catalog id comes from `@CatalogComponent`, which an ordinary application
+ *   preview does not carry, so it is absent for exactly the typical-app records this file exists to
+ *   publish, and several absent ids would collide as a key.
+ *
+ *   **Overloads collide here, and that is a known v1 limitation.** Distinguishing them needs the
+ *   JVM descriptor, which discovery does not record yet — the same gap `:renderer-android`'s
+ *   `findDefaultedComposableMethod` names when it refuses to guess between two fully-defaulted
+ *   overloads. [ComponentSymbol.descriptor] is where it lands; until then a reader that finds two
+ *   records with one id should treat the pair as unresolved rather than pick one.
+ *
+ * @property componentId the published catalog identity, when the preview carried one. An alias, not
+ *   the key.
+ */
+@Serializable
+data class ComponentRecord(
+  val canonicalId: String,
+  val componentId: String? = null,
+  val symbol: ComponentSymbol,
+  val parameters: List<TargetParameter> = emptyList(),
+  val slots: List<ComponentSlot> = emptyList(),
+  val bindings: List<ComponentBinding> = emptyList(),
+)
+
+/**
+ * How to name a component — three ways, because one name cannot serve all three readers.
+ *
+ * @property jvmOwner the reflection handle. For a top-level function this is the synthetic file
+ *   facade (`androidx.compose.material3.ButtonKt`), which is what `Class.forName` needs.
+ * @property callable the **source-level** FQN generated Kotlin imports
+ *   (`androidx.compose.material3.Button`). Deriving an import from [jvmOwner] would print `import
+ *   androidx.compose.material3.ButtonKt`, which does not resolve.
+ * @property descriptor the JVM method descriptor, once discovery records one. Null in v1 — see
+ *   [ComponentRecord.canonicalId] for what that costs.
+ * @property origin where the symbol lives. Explicit rather than inferred from [sourceFile] being
+ *   null, which also happens for a project-local file discovery could not resolve (a generated
+ *   source, say) — reading that null as "library" would send a local component down the sources-jar
+ *   path and discard the KDoc and fixtures available from the project.
+ * @property sourceFile availability only, never a proxy for [origin].
+ * @property docs where KDoc and default expressions came from. `"unavailable"` in v1 for every
+ *   symbol: Kotlin metadata carries neither, and resolving a `-sources.jar` is the next step. Said
+ *   explicitly so a consumer can tell "no KDoc" from "KDoc not recovered".
+ */
+@Serializable
+data class ComponentSymbol(
+  val jvmOwner: String,
+  val callable: String,
+  val name: String,
+  val origin: ComponentOrigin,
+  val descriptor: String? = null,
+  val sourceFile: String? = null,
+  val docs: String = "unavailable",
+)
+
+@Serializable
+enum class ComponentOrigin {
+  /** Compiled from this project's own sources. */
+  PROJECT,
+  /** A dependency's symbol — a design-system component. */
+  LIBRARY,
+}
+
+/**
+ * A `@Composable` lambda parameter: somewhere a child can go.
+ *
+ * @property required whether the **lambda argument** must be supplied. This is all the signature
+ *   decides. It is emphatically *not* child cardinality: `Button`'s required `content` lambda may
+ *   legally emit zero children or five, so projecting `required` as a minimum of one would reject
+ *   valid documents.
+ * @property receiverScope the lambda's receiver (`androidx.compose.foundation.layout.RowScope`), or
+ *   null when it has none. Recorded because it decides what a child's modifier may call —
+ *   `Modifier.weight` compiles inside a `RowScope` slot and nowhere else. It does **not** determine
+ *   which components are accepted; that stays authored policy, absent from this record by design
+ *   rather than by omission.
+ */
+@Serializable
+data class ComponentSlot(
+  val name: String,
+  val required: Boolean,
+  val receiverScope: String? = null,
+)
+
+/**
+ * One preview that renders this component.
+ *
+ * The render filenames are deliberately not repeated here: they are derived from the preview id by
+ * the same rule every consumer already applies to `previews.json`, and duplicating a derived value
+ * into a second file is how the two start disagreeing.
+ */
+@Serializable data class ComponentBinding(val previewId: String)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -1,0 +1,138 @@
+package ee.schimke.composeai.discovery
+
+/**
+ * Builds [ComponentRecordFile] from a discovered [PreviewManifest].
+ *
+ * A pure function of the manifest, deliberately: everything it needs — the resolved targets, their
+ * signatures, the preview ids — is already recorded there, so the record can be rebuilt from a
+ * published manifest without re-scanning, and this can be tested without a ClassGraph scan.
+ */
+object ComponentRecords {
+
+  /**
+   * Group every preview's targets by component and invert the relation: `previews.json` says "this
+   * render came from that component", this says "this component is rendered by those previews".
+   *
+   * Both [PreviewInfo.componentTargets] and [PreviewInfo.targets] contribute, because they answer
+   * different questions and a module can have either or both: a catalog sticker wrapping
+   * `material3.Button` has only the former, an application preview of `HomeScreen` only the latter.
+   * [ComponentSymbol.origin] is what tells them apart in the output, so a consumer never has to
+   * know which list a record came from.
+   *
+   * Components are emitted in a stable order (by [ComponentRecord.canonicalId]) and bindings in
+   * preview-id order, so the file is byte-reproducible across runs — a data product that reorders
+   * itself between builds is a diff nobody can read.
+   */
+  fun from(manifest: PreviewManifest): ComponentRecordFile {
+    val byId = linkedMapOf<String, MutableComponent>()
+    for (preview in manifest.previews) {
+      collect(preview, preview.componentTargets, ComponentOrigin.LIBRARY, manifest.module, byId)
+      collect(preview, preview.targets, ComponentOrigin.PROJECT, manifest.module, byId)
+    }
+    return ComponentRecordFile(
+      module = manifest.module,
+      variant = manifest.variant,
+      components = byId.values.map { it.toRecord() }.sortedBy { it.canonicalId },
+    )
+  }
+
+  private fun collect(
+    preview: PreviewInfo,
+    targets: List<PreviewTarget>,
+    origin: ComponentOrigin,
+    module: String,
+    into: MutableMap<String, MutableComponent>,
+  ) {
+    for (target in targets) {
+      val id = canonicalId(module, target)
+      val existing =
+        into.getOrPut(id) {
+          MutableComponent(
+            canonicalId = id,
+            componentId = preview.catalog?.componentId?.takeIf { it.isNotBlank() },
+            symbol =
+              ComponentSymbol(
+                jvmOwner = target.className,
+                callable = callableFqn(target),
+                name = target.functionName,
+                origin = origin,
+                sourceFile = target.sourceFile,
+              ),
+            parameters = target.parameters,
+          )
+        }
+      // One component, many previews: keep the richest signature seen. A target resolved through a
+      // path that could not read metadata reports no parameters, and letting that overwrite a
+      // populated signature would lose the API for everyone.
+      if (target.parameters.size > existing.parameters.size) {
+        existing.parameters = target.parameters
+      }
+      existing.bindings += ComponentBinding(previewId = preview.id)
+    }
+  }
+
+  /**
+   * `<module>/<jvmOwner>.<name>` — always present, unlike a catalog id.
+   *
+   * The module prefix keeps two projects' same-named components apart in an aggregated view; the
+   * JVM owner keeps a top-level function apart from a same-named member of a class in the same
+   * package. Overloads still collide — see [ComponentRecord.canonicalId].
+   */
+  internal fun canonicalId(module: String, target: PreviewTarget): String =
+    "$module/${target.className}.${target.functionName}"
+
+  /**
+   * The source-level callable FQN a generated import would name.
+   *
+   * A top-level function compiles into a synthetic `<File>Kt` facade, so its callable is the
+   * package plus the function name — `androidx.compose.material3.ButtonKt` + `Button` becomes
+   * `androidx.compose.material3.Button`. A member of a real class keeps its owner.
+   *
+   * The `Kt` suffix is a heuristic and it can be wrong: a hand-written class genuinely named
+   * `FooKt` would be unwrapped here. Kotlin's own convention makes that rare, and the alternative —
+   * reading the `@kotlin.Metadata` kind for every target — costs a class-file read per component
+   * for a case nobody has hit. Recorded as a known limit rather than hidden.
+   */
+  internal fun callableFqn(target: PreviewTarget): String {
+    val owner = target.className
+    val simpleName = owner.substringAfterLast('.')
+    if (!simpleName.endsWith("Kt") || simpleName.length == 2) return "$owner.${target.functionName}"
+    val packageName = owner.substringBeforeLast('.', missingDelimiterValue = "")
+    return if (packageName.isEmpty()) target.functionName else "$packageName.${target.functionName}"
+  }
+
+  /**
+   * A `@Composable` lambda parameter is a slot. The receiver, when the rendered type carries one,
+   * is everything before the `.(` — `RowScope.() -> Unit` yields `RowScope`.
+   */
+  internal fun slotsOf(parameters: List<TargetParameter>): List<ComponentSlot> =
+    parameters
+      .filter { it.composableSlot }
+      .map { parameter ->
+        ComponentSlot(
+          name = parameter.name,
+          required = !parameter.hasDefault,
+          receiverScope =
+            parameter.type.substringBefore(".(", missingDelimiterValue = "").ifEmpty { null },
+        )
+      }
+
+  private class MutableComponent(
+    val canonicalId: String,
+    val componentId: String?,
+    val symbol: ComponentSymbol,
+    var parameters: List<TargetParameter>,
+  ) {
+    var bindings: List<ComponentBinding> = emptyList()
+
+    fun toRecord(): ComponentRecord =
+      ComponentRecord(
+        canonicalId = canonicalId,
+        componentId = componentId,
+        symbol = symbol,
+        parameters = parameters,
+        slots = slotsOf(parameters),
+        bindings = bindings.distinctBy { it.previewId }.sortedBy { it.previewId },
+      )
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
@@ -1,0 +1,172 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ComponentRecordsTest {
+
+  private fun target(
+    className: String,
+    functionName: String,
+    parameters: List<TargetParameter> = emptyList(),
+    sourceFile: String? = null,
+  ) =
+    PreviewTarget(
+      className = className,
+      functionName = functionName,
+      sourceFile = sourceFile,
+      confidence = TargetConfidence.HIGH,
+      parameters = parameters,
+    )
+
+  private fun preview(
+    id: String,
+    componentTargets: List<PreviewTarget> = emptyList(),
+    targets: List<PreviewTarget> = emptyList(),
+  ) =
+    PreviewInfo(
+      id = id,
+      functionName = id.substringAfterLast('.'),
+      className = "com.example.PreviewsKt",
+      targets = targets,
+      componentTargets = componentTargets,
+    )
+
+  private fun manifest(vararg previews: PreviewInfo) =
+    PreviewManifest(module = "app", variant = "debug", previews = previews.toList())
+
+  @Test
+  fun `a library target and a project target are both recorded, and told apart by origin`() {
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            componentTargets = listOf(target("androidx.compose.material3.CardKt", "Card")),
+          ),
+          preview(
+            "p2",
+            targets = listOf(target("com.example.HomeKt", "HomeScreen", sourceFile = "src/Home.kt")),
+          ),
+        )
+      )
+
+    assertThat(file.components.map { it.symbol.origin })
+      .containsExactly(ComponentOrigin.LIBRARY, ComponentOrigin.PROJECT)
+      .inOrder()
+    assertThat(file.schemaVersion).isEqualTo(COMPONENT_RECORD_SCHEMA_VERSION)
+  }
+
+  @Test
+  fun `the relation is inverted - one component lists every preview that renders it`() {
+    // previews.json says "this render came from that component"; this says the reverse, which is
+    // what makes a component addressable at all.
+    val card = target("androidx.compose.material3.CardKt", "Card")
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview("b", componentTargets = listOf(card)),
+          preview("a", componentTargets = listOf(card)),
+        )
+      )
+
+    val record = file.components.single()
+    assertThat(record.bindings.map { it.previewId }).containsExactly("a", "b").inOrder()
+  }
+
+  @Test
+  fun `components and bindings are ordered, so the file is byte-reproducible`() {
+    // A data product that reorders itself between builds is a diff nobody can read.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "z",
+            componentTargets = listOf(target("androidx.compose.material3.TextKt", "Text")),
+          ),
+          preview(
+            "a",
+            componentTargets = listOf(target("androidx.compose.material3.CardKt", "Card")),
+          ),
+        )
+      )
+
+    assertThat(file.components.map { it.canonicalId }).isInOrder()
+  }
+
+  @Test
+  fun `the richest signature wins when one component is seen twice`() {
+    // A target resolved through a path that could not read metadata reports no parameters. Letting
+    // that overwrite a populated signature would lose the API for every consumer.
+    val withParams =
+      target(
+        "androidx.compose.material3.CardKt",
+        "Card",
+        parameters = listOf(TargetParameter("modifier", "Modifier", hasDefault = true)),
+      )
+    val withNone = target("androidx.compose.material3.CardKt", "Card")
+
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview("a", componentTargets = listOf(withNone)),
+          preview("b", componentTargets = listOf(withParams)),
+        )
+      )
+
+    assertThat(file.components.single().parameters.map { it.name }).containsExactly("modifier")
+  }
+
+  @Test
+  fun `a top-level function's callable drops the synthetic file facade`() {
+    // Deriving an import from the JVM owner would print `androidx.compose.material3.ButtonKt`,
+    // which does not resolve.
+    assertThat(
+        ComponentRecords.callableFqn(target("androidx.compose.material3.ButtonKt", "Button"))
+      )
+      .isEqualTo("androidx.compose.material3.Button")
+  }
+
+  @Test
+  fun `a member of a real class keeps its owner`() {
+    assertThat(ComponentRecords.callableFqn(target("com.example.Screens", "Home")))
+      .isEqualTo("com.example.Screens.Home")
+  }
+
+  @Test
+  fun `canonicalId is module-qualified and always present`() {
+    assertThat(ComponentRecords.canonicalId("app", target("com.example.HomeKt", "HomeScreen")))
+      .isEqualTo("app/com.example.HomeKt.HomeScreen")
+  }
+
+  @Test
+  fun `a composable lambda parameter becomes a slot, carrying its receiver scope`() {
+    val slots =
+      ComponentRecords.slotsOf(
+        listOf(
+          TargetParameter("onClick", "() -> Unit"),
+          TargetParameter("modifier", "Modifier", hasDefault = true),
+          TargetParameter("content", "RowScope.() -> Unit", composableSlot = true),
+          TargetParameter("footer", "() -> Unit", hasDefault = true, composableSlot = true),
+        )
+      )
+
+    // `onClick` is function-typed but not `@Composable`: a callback, not a slot.
+    assertThat(slots.map { it.name }).containsExactly("content", "footer").inOrder()
+    assertThat(slots[0].receiverScope).isEqualTo("RowScope")
+    // Requiredness is about the LAMBDA argument, never about how many children it may emit.
+    assertThat(slots[0].required).isTrue()
+    // An unscoped slot records no receiver rather than an empty string.
+    assertThat(slots[1].receiverScope).isNull()
+    assertThat(slots[1].required).isFalse()
+  }
+
+  @Test
+  fun `a module with no inferred targets still produces a file`() {
+    // An empty component list is a fact worth publishing — it says inference found nothing.
+    val file = ComponentRecords.from(manifest(preview("p1")))
+
+    assertThat(file.components).isEmpty()
+    assertThat(file.module).isEqualTo("app")
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.discovery.ComponentRecords
 import ee.schimke.composeai.discovery.PreviewDiscovery
 import java.io.File
 import kotlinx.serialization.json.Json
@@ -233,6 +234,13 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val outFile = outputFile.get().asFile
         outFile.parentFile.mkdirs()
         outFile.writeText(json.encodeToString(outcome.manifest))
+        // `components.json` beside `previews.json`: the components those previews render, rather
+        // than the renders themselves. Derived wholly from the manifest, so it never disagrees with
+        // it, and written unconditionally — an empty component list is a fact worth publishing
+        // (it says inference found nothing), not a reason to omit the file.
+        outFile
+          .resolveSibling("components.json")
+          .writeText(json.encodeToString(ComponentRecords.from(outcome.manifest)))
         outcome.infoMessages.forEach { logger.lifecycle(it) }
       }
       is PreviewDiscovery.Outcome.Failure -> {


### PR DESCRIPTION
Second piece of the component-record track, on top of [#5010](https://github.com/yschimke/compose-ai-tools/pull/5010) (merged).

`previews.json` describes **renders**: one capture of one configuration. This describes the **components** underneath, which until now were written down nowhere — a catalog's 59 `@CatalogComponent` entries stand for 148 distinct library symbols whose signatures appear in no artifact.

## What it looks like

Real output from `:samples:cmp:composePreviewDiscover` — 12 components, library and project alike:

```
schemaVersion 1 | module cmp | components 12

  cmp/androidx.compose.material3.ButtonKt.TextButton
    callable: androidx.compose.material3.TextButton | origin: LIBRARY | docs: unavailable
    params: onClick: () -> Unit, modifier: Modifier, enabled: Boolean, shape: Shape, colors: ButtonColors …
    slots: [(content, required, RowScope)]
    rendered by: 1 preview(s)

  cmp/androidx.compose.material3.CardKt.Card
    callable: androidx.compose.material3.Card | origin: LIBRARY | docs: unavailable
    slots: [(content, required, ColumnScope)]
    rendered by: 3 preview(s)

  cmp/com.example.samplecmp.PreviewModeMatrixKt.CanvasProbe
    callable: com.example.samplecmp.CanvasProbe | origin: PROJECT | docs: unavailable
    params: label: String
    rendered by: 12 preview(s)
```

`content`'s receiver comes out right per component — `RowScope` for `TextButton`, `ColumnScope` for `Card` — which is the "slots are derived from `@Composable` lambda parameters" claim actually working.

## Design choices worth stating

- **Derived wholly from the manifest**, by a pure function of it. It cannot disagree with `previews.json`, it is unit-testable without a ClassGraph scan, and it could be rebuilt from a published manifest without re-scanning.
- **`schemaVersion` from the start** — the file persists in bundles and is read by the browser, builder and MCP clients.
- **`canonicalId`, not `componentId`, is the key.** A catalog id comes from `@CatalogComponent`, which an ordinary app preview doesn't carry — absent for exactly the typical-app records this exists to publish, and several absent ids would collide.
- **`origin` is explicit**, not inferred from a null `sourceFile` (which also means "couldn't resolve", e.g. a generated source).
- **`docs: "unavailable"` on every symbol in v1**, said out loud so a consumer can tell *no KDoc* from *KDoc not recovered*. Kotlin metadata carries neither KDoc nor default expressions; resolving a `-sources.jar` is the next step.
- **A slot's `required` is about the lambda argument, never child cardinality** — a required `content` may legally emit zero children.

## Known limit, recorded rather than papered over

Overloads collide on `canonicalId` until discovery records a JVM descriptor — the same gap `:renderer-android`'s `findDefaultedComposableMethod` names when it refuses to guess between two fully-defaulted overloads. `ComponentSymbol.descriptor` is where it lands.

## Test plan

- `:gradle-plugin:preview-discovery:test` — green, 9 new tests covering the inversion, ordering/reproducibility, richest-signature-wins, the file-facade heuristic and its limit, slot derivation with and without a receiver, and the empty case.
- `:samples:cmp:composePreviewDiscover` — green, output above.
- `ktfmtFormat` clean on both modules.

Note: `:gradle-plugin:compileKotlin` hits a pre-existing configuration-cache problem in `:gradle-plugin:daemon-launch-builder:generateDaemonLaunchSchemaMetadata` ("cannot serialize Gradle script object references"), unrelated to this change — it builds and runs fine with `--no-configuration-cache`, and the sample discovery run above exercises the plugin end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_