### PR TITLE
feat(gradle-plugin): add a renderGraph DSL to exclude modules from the render graph

### DIFF
--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewDsl.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewDsl.kt
@@ -53,6 +53,17 @@ object ComposePreviewDsl {
         .map { it.toBooleanStrictOrNull() ?: false }
         .orElse(false)
     )
+    // `addAll`, not `convention`: the property and the `renderGraph { exclude(…) }` DSL are
+    // additive, so a consumer passing `-PcomposePreview.renderGraphExcludes=…` on one CI job does
+    // not silently drop the exclusions their build script already commits to (a convention would
+    // be replaced wholesale by the first DSL `add`). The provider stays lazy, so the property is
+    // read at resolution time like every other override here.
+    extension.renderGraph.excludes.addAll(
+      project.providers
+        .gradleProperty("composePreview.renderGraphExcludes")
+        .map { RenderGraphExclusion.parse(it) }
+        .orElse(emptyList())
+    )
     return extension
   }
 

--- a/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/gradle-plugin-config/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -364,11 +364,141 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
     action.execute(resourcePreviews)
   }
 
+  /**
+   * Supported control over the dependency graph the renderer resolves in. Today it carries module
+   * exclusions — see [RenderGraphExtension] for what the render graph is and why a consumer would
+   * need to keep something off it.
+   */
+  val renderGraph: RenderGraphExtension = objects.newInstance(RenderGraphExtension::class.java)
+
+  fun renderGraph(action: Action<RenderGraphExtension>) {
+    action.execute(renderGraph)
+  }
+
   /** Persistent preview daemon configuration. Enabled by default for the VS Code extension. */
   val daemon: DaemonExtension = objects.newInstance(DaemonExtension::class.java)
 
   fun daemon(action: Action<DaemonExtension>) {
     action.execute(daemon)
+  }
+}
+
+/**
+ * `composePreview { renderGraph { … } }` — the supported way to shape the configurations the plugin
+ * resolves the renderer in.
+ *
+ * The render configurations (`composePreviewAndroidRenderer<Variant>`, its
+ * `composePreviewAndroidDaemon<Variant>` superset, and the desktop `composePreviewRenderer` /
+ * `composePreviewDesktopDaemon` pair) deliberately `extendsFrom` the consumer's own test/runtime
+ * classpath, so the renderer and the consumer's code resolve as ONE graph and a single coherent
+ * version of every shared module reaches the render classloader. That inheritance is load-bearing
+ * and this block does not undo it.
+ *
+ * What it does undo, module by module, is a dependency that cannot survive that merge. The case
+ * this exists for (issue #4995): a `java-platform` of `strictly(v)` + `reject("(v," )` constraints
+ * on `implementation`. Inherited onto the render configuration, every renderer dependency newer
+ * than one of those pins becomes a hard conflict and the render configuration fails to resolve
+ * before a single preview is rendered. Excluding the platform module keeps the consumer's own
+ * builds strict and lets the render graph resolve:
+ * ```kotlin
+ * composePreview {
+ *   renderGraph { exclude(group = "com.example", module = "version-constraints") }
+ * }
+ * ```
+ *
+ * The equivalent Gradle property, for a build the consumer cannot edit — notably a CLI-driven
+ * render where the plugin is auto-injected — is a comma-separated list of the same coordinates:
+ * ```
+ * -PcomposePreview.renderGraphExcludes=com.example:version-constraints
+ * ```
+ *
+ * The two are additive: property entries and DSL entries all apply.
+ *
+ * Scope: the exclusions land on the configurations the plugin creates and owns, never on the
+ * consumer's own configurations, so a normal build resolves exactly as it did before. The
+ * Kotlin-build-tools configurations (`composePreviewBtaImpl`, `composePreviewBtaPlugin`) are
+ * deliberately NOT covered — they are standalone compiler classpaths that never inherit the
+ * consumer's graph, so nothing a consumer would want to exclude is on them.
+ */
+abstract class RenderGraphExtension @Inject constructor(objects: ObjectFactory) {
+  /**
+   * Modules to keep off the render graph. Prefer the [exclude] helpers; this property is the lazy
+   * plumbing they and the `composePreview.renderGraphExcludes` Gradle property feed.
+   */
+  val excludes: ListProperty<RenderGraphExclusion> =
+    objects.listProperty(RenderGraphExclusion::class.java)
+
+  /**
+   * Excludes a module from the render graph, in the shape of Gradle's own
+   * `Configuration.exclude(group:, module:)`: pass either or both. `group` alone drops every module
+   * in that group; `module` alone drops that module whatever its group.
+   */
+  @JvmOverloads
+  fun exclude(group: String? = null, module: String? = null) {
+    excludes.add(RenderGraphExclusion.of(group, module))
+  }
+
+  /**
+   * Groovy-friendly overload so `renderGraph { exclude group: 'com.example', module: 'x' }` reads
+   * the same in a `build.gradle` as the Kotlin named-argument form does in a `build.gradle.kts`.
+   */
+  fun exclude(notation: Map<String, String>) {
+    val unknown = notation.keys - setOf("group", "module")
+    require(unknown.isEmpty()) {
+      "composePreview.renderGraph.exclude: unknown key(s) ${unknown.sorted()}; " +
+        "supported keys are 'group' and 'module'."
+    }
+    exclude(notation["group"], notation["module"])
+  }
+}
+
+/**
+ * One `group`/`module` exclusion from [RenderGraphExtension]. At least one of the two is non-null —
+ * [of] rejects the empty exclusion, which Gradle would otherwise accept and quietly turn into "drop
+ * everything".
+ *
+ * `Serializable` because the value travels inside a `ListProperty` that the configuration cache
+ * stores.
+ */
+data class RenderGraphExclusion(val group: String?, val module: String?) : java.io.Serializable {
+  /** The `group:module` spelling used by the Gradle property and in error messages. */
+  override fun toString(): String = "${group.orEmpty()}:${module.orEmpty()}"
+
+  companion object {
+    private const val serialVersionUID: Long = 1L
+
+    fun of(group: String?, module: String?): RenderGraphExclusion {
+      val g = group?.trim()?.takeIf { it.isNotEmpty() }
+      val m = module?.trim()?.takeIf { it.isNotEmpty() }
+      require(g != null || m != null) {
+        "composePreview.renderGraph.exclude requires a group, a module, or both — " +
+          "an exclusion with neither would drop every dependency from the render graph."
+      }
+      return RenderGraphExclusion(g, m)
+    }
+
+    /**
+     * Parses the `composePreview.renderGraphExcludes` Gradle property: a comma-separated list of
+     * `group:module` coordinates, either half of which may be empty (`com.example:`,
+     * `:version-constraints`). Blank entries are ignored so a trailing comma is not an error; a
+     * malformed entry fails loudly rather than silently excluding nothing, because the symptom of a
+     * missed exclusion is an unresolvable render configuration whose message never names this
+     * property.
+     */
+    fun parse(spec: String): List<RenderGraphExclusion> =
+      spec
+        .split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .map { entry ->
+          val parts = entry.split(':')
+          require(parts.size == 2) {
+            "composePreview.renderGraphExcludes: '$entry' is not a 'group:module' coordinate. " +
+              "Use 'group:module', 'group:' for a whole group, or ':module' for a module in any " +
+              "group, separating entries with commas."
+          }
+          of(parts[0], parts[1])
+        }
   }
 }
 

--- a/gradle-plugin/gradle-plugin-config/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusionTest.kt
+++ b/gradle-plugin/gradle-plugin-config/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusionTest.kt
@@ -1,0 +1,141 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * The `composePreview { renderGraph { exclude(…) } }` DSL and its
+ * `-PcomposePreview.renderGraphExcludes=…` twin (issue #4995).
+ *
+ * The DSL is the supported replacement for reaching into the plugin's own configuration names from
+ * a consumer's build script — `configurations.matching { it.name.startsWith("composePreview") }` —
+ * so these tests pin the surface a consumer writes against: what an exclusion may omit, what it may
+ * not, and that the two entry points accumulate instead of shadowing each other.
+ */
+class RenderGraphExclusionTest {
+
+  private fun extension(): RenderGraphExtension {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply("ee.schimke.composeai.preview.config")
+    return (project.extensions.getByName(ComposePreviewDsl.EXTENSION_NAME) as PreviewExtension)
+      .renderGraph
+  }
+
+  @Test
+  fun `no exclusions by default`() {
+    // The whole feature is opt-in: an untouched build must present Gradle with an empty rule set,
+    // never an exclusion the consumer did not ask for.
+    assertThat(extension().excludes.get()).isEmpty()
+  }
+
+  @Test
+  fun `exclude records group and module`() {
+    val renderGraph = extension()
+    renderGraph.exclude(group = "com.example", module = "version-constraints")
+
+    assertThat(renderGraph.excludes.get())
+      .containsExactly(RenderGraphExclusion("com.example", "version-constraints"))
+  }
+
+  @Test
+  fun `either half may be omitted`() {
+    val renderGraph = extension()
+    renderGraph.exclude(group = "com.example")
+    renderGraph.exclude(module = "version-constraints")
+
+    // Mirrors Gradle's own `Configuration.exclude(group:, module:)`: a group-only rule drops the
+    // whole group, a module-only rule drops that name in any group.
+    assertThat(renderGraph.excludes.get())
+      .containsExactly(
+        RenderGraphExclusion("com.example", null),
+        RenderGraphExclusion(null, "version-constraints"),
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `an exclusion with neither half is rejected`() {
+    // Gradle would accept `exclude()` and quietly read it as "exclude everything", emptying the
+    // render classpath. Fail at the point the mistake is made instead.
+    val failure = assertThrows(IllegalArgumentException::class.java) { extension().exclude() }
+    assertThat(failure).hasMessageThat().contains("requires a group, a module, or both")
+  }
+
+  @Test
+  fun `blank halves count as absent`() {
+    val failure =
+      assertThrows(IllegalArgumentException::class.java) { extension().exclude(group = "  ") }
+    assertThat(failure).hasMessageThat().contains("requires a group, a module, or both")
+  }
+
+  @Test
+  fun `groovy map notation matches the kotlin named-argument form`() {
+    val renderGraph = extension()
+    // `renderGraph { exclude group: 'com.example', module: 'x' }` in a `build.gradle` arrives here
+    // as a Map — the Groovy DSL has no named arguments.
+    renderGraph.exclude(mapOf("group" to "com.example", "module" to "version-constraints"))
+
+    assertThat(renderGraph.excludes.get())
+      .containsExactly(RenderGraphExclusion("com.example", "version-constraints"))
+  }
+
+  @Test
+  fun `groovy map notation rejects unknown keys`() {
+    // `exclude version: '1.0'` is not a thing; silently ignoring the key would produce an exclusion
+    // that matches far more than the author intended.
+    val failure =
+      assertThrows(IllegalArgumentException::class.java) {
+        extension().exclude(mapOf("group" to "com.example", "version" to "1.0"))
+      }
+    assertThat(failure).hasMessageThat().contains("unknown key(s) [version]")
+  }
+
+  @Test
+  fun `parses the gradle property spec`() {
+    assertThat(
+        RenderGraphExclusion.parse("com.example:version-constraints, com.other:platform-bom")
+      )
+      .containsExactly(
+        RenderGraphExclusion("com.example", "version-constraints"),
+        RenderGraphExclusion("com.other", "platform-bom"),
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `property spec allows either half to be empty`() {
+    assertThat(RenderGraphExclusion.parse("com.example:,:version-constraints"))
+      .containsExactly(
+        RenderGraphExclusion("com.example", null),
+        RenderGraphExclusion(null, "version-constraints"),
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `property spec tolerates blank entries`() {
+    // A trailing comma from a shell-assembled `-P` value is not worth failing a render over.
+    assertThat(RenderGraphExclusion.parse("com.example:version-constraints, ,"))
+      .containsExactly(RenderGraphExclusion("com.example", "version-constraints"))
+  }
+
+  @Test
+  fun `property spec rejects a coordinate that is not group colon module`() {
+    // The symptom of a silently-dropped exclusion is an unresolvable render configuration whose
+    // Gradle error never mentions this property, so a typo has to fail here and say so.
+    val failure =
+      assertThrows(IllegalArgumentException::class.java) {
+        RenderGraphExclusion.parse("version-constraints")
+      }
+    assertThat(failure).hasMessageThat().contains("is not a 'group:module' coordinate")
+  }
+
+  @Test
+  fun `property spec rejects an entry with neither half`() {
+    val failure =
+      assertThrows(IllegalArgumentException::class.java) { RenderGraphExclusion.parse(":") }
+    assertThat(failure).hasMessageThat().contains("requires a group, a module, or both")
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderGraphExcludesFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderGraphExcludesFunctionalTest.kt
@@ -1,0 +1,214 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Real-Gradle proof for `composePreview { renderGraph { exclude(…) } }` (issue #4995): a consumer
+ * whose graph carries a strict-version platform can keep that platform off the render graph, with
+ * no build-script access to the plugin's internal configuration names.
+ *
+ * The reported shape, reproduced here: a `java-platform` project whose constraints are
+ * `strictly(v)` + `reject("(v,")`, applied to `implementation` so every module in the build is
+ * pinned. The render configuration `extendsFrom` the consumer's own classpath on purpose — that
+ * single graph is what keeps one coherent version of each shared module in front of the render
+ * classloader — so it inherits those constraints too, and a renderer dependency newer than one of
+ * them is a conflict Gradle cannot solve. Before this DSL existed, the only way out was
+ * `configurations.matching { it.name.startsWith("composePreview") }`, which depends on names the
+ * consumer cannot see and cannot rely on.
+ *
+ * Guava stands in for "a renderer dependency newer than the consumer's pin": the platform strictly
+ * pins 31.1-jre and rejects anything above it, while the renderer config asks for 33.0.0-jre.
+ */
+class RenderGraphExcludesFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  /**
+   * [renderGraphBlock] is spliced into the `composePreview { }` extension, so one harness covers
+   * the unconfigured build (the failure), the DSL and — via [extraArgs] — the Gradle property.
+   */
+  private fun createTestProject(renderGraphBlock: String = ""): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-render-graph-excludes"
+        include(":constraints")
+        """
+          .trimIndent()
+      )
+
+    // The consumer's version-constraints platform: `strictly` + `reject` on every module it
+    // manages, exactly the shape that makes a newer renderer dependency unresolvable rather than
+    // merely downgraded.
+    File(projectDir, "constraints").mkdirs()
+    File(projectDir, "constraints/build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            `java-platform`
+        }
+        group = "com.example"
+        version = "1.0"
+        dependencies {
+            constraints {
+                api("com.google.guava:guava") {
+                    version {
+                        strictly("31.1-jre")
+                        reject("(31.1-jre,")
+                    }
+                }
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            // The platform on `implementation`, as the reporting consumer applies it: it reaches
+            // `runtimeClasspath`, which the render configuration extends.
+            implementation(platform(project(":constraints")))
+            implementation(compose.desktop.currentOs)
+        }
+        // Stand in for the published renderer: pre-seeding the tool config makes
+        // `ensureRendererDesktopConfig` skip its Maven add for the unpublished
+        // `ee.schimke.composeai:renderer-desktop` coordinate. The seed is a module the consumer's
+        // platform rejects, which is the whole conflict under test.
+        configurations.maybeCreate("composePreviewRenderer")
+        dependencies {
+            "composePreviewRenderer"("com.google.guava:guava:33.0.0-jre")
+        }
+        composePreview {
+            $renderGraphBlock
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+
+        tasks.register("dumpRendererClasspath") {
+            val rendererCfg = configurations.getByName("composePreviewRenderer")
+            doLast {
+                rendererCfg.incoming.artifactView { }.files.forEach { println("RENDERER_JAR ${'$'}{it.name}") }
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  private fun runner(projectDir: File, vararg extraArgs: String) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("dumpRendererClasspath", "-q", "--stacktrace", *extraArgs)
+      .withPluginClasspath()
+
+  private fun rendererJars(output: String): List<String> =
+    output
+      .lineSequence()
+      .filter { it.startsWith("RENDERER_JAR ") }
+      .map { it.removePrefix("RENDERER_JAR ").trim() }
+      .toList()
+
+  @Test
+  fun `without an exclusion the inherited strict platform makes the render graph unresolvable`() {
+    // The bug report, reproduced. This is the baseline the DSL has to move: if this ever starts
+    // passing on its own, the two tests below stop proving anything.
+    val result = runner(createTestProject()).buildAndFail()
+
+    assertThat(result.output).contains("guava")
+    assertThat(result.output).contains("composePreviewRenderer")
+  }
+
+  @Test
+  fun `the renderGraph DSL keeps the platform off the render graph`() {
+    val projectDir =
+      createTestProject(
+        renderGraphBlock =
+          """renderGraph { exclude(group = "com.example", module = "constraints") }"""
+      )
+
+    val result = runner(projectDir).build()
+
+    // Resolution now succeeds AND lands on the renderer's own version: the exclusion removed the
+    // platform's pressure rather than merely tolerating the conflict.
+    assertThat(rendererJars(result.output)).contains("guava-33.0.0-jre.jar")
+  }
+
+  @Test
+  fun `the gradle property is equivalent for a build script the consumer cannot edit`() {
+    // The CLI auto-injects the plugin into builds that never mention it, so there is not always a
+    // `composePreview { }` block to put the DSL in.
+    val result =
+      runner(createTestProject(), "-PcomposePreview.renderGraphExcludes=com.example:constraints")
+        .build()
+
+    assertThat(rendererJars(result.output)).contains("guava-33.0.0-jre.jar")
+  }
+
+  @Test
+  fun `the consumer's own classpath keeps the platform`() {
+    val projectDir =
+      createTestProject(
+        renderGraphBlock =
+          """renderGraph { exclude(group = "com.example", module = "constraints") }"""
+      )
+    File(projectDir, "build.gradle.kts")
+      .appendText(
+        """
+
+        tasks.register("dumpConsumerConstraints") {
+            val runtime = configurations.getByName("runtimeClasspath")
+            doLast {
+                runtime.incoming.resolutionResult.allComponents.forEach {
+                    println("CONSUMER_COMPONENT ${'$'}{it.id.displayName}")
+                }
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("dumpConsumerConstraints", "-q", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    // The exclusion is scoped to configurations the plugin owns. A consumer's normal build — and
+    // every guarantee their platform gives it — must resolve exactly as it did before.
+    assertThat(result.output).contains("CONSUMER_COMPONENT project ':constraints'")
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1859,6 +1859,12 @@ internal object AndroidPreviewSupport {
 
     val testConfig = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
 
+    // `composePreview { renderGraph { exclude(…) } }` / `-PcomposePreview.renderGraphExcludes=…`.
+    // Read once here: this runs inside `onVariants`, so the consumer's build script has already
+    // been evaluated, and Gradle's exclude rules are an eager `Set` on the configuration rather
+    // than a lazy provider — there is nothing to defer.
+    val renderGraphExclusions = extension.renderGraph.excludes.get()
+
     // The default path for external consumers: resolve
     // `ee.schimke.composeai:renderer-android:<plugin-version>` from Maven.
     // The plugin's own version is baked into the jar at build time so the
@@ -1921,6 +1927,11 @@ internal object AndroidPreviewSupport {
         // own resources — the #3484 `R$id` NoSuchFieldError — so opt-out keeps the consumer's
         // line, whatever it is.
         applyRenderGraphResolutionRules(this, floorComposeLine = manageDependencies)
+        // Consumer-declared exclusions, applied AFTER the rules above so a module the consumer
+        // keeps off the graph stays off it even when one of our substitutions would have pulled it
+        // back in. See [RenderGraphExtension] for the strict-constraint platform this exists for
+        // (issue #4995).
+        RenderGraphExclusions.applyTo(project, this, renderGraphExclusions)
       }
 
     if (useLocalRenderer) {
@@ -2051,6 +2062,10 @@ internal object AndroidPreviewSupport {
         // own resources — the #3484 `R$id` NoSuchFieldError — so opt-out keeps the consumer's
         // line, whatever it is.
         applyRenderGraphResolutionRules(this, floorComposeLine = manageDependencies)
+        // Same reason `extendsFrom` does not carry `resolutionStrategy`: exclude rules are not
+        // inherited either. The daemon has to exclude exactly what the render config excludes, or
+        // the two JVMs render the same previews off different graphs.
+        RenderGraphExclusions.applyTo(project, this, renderGraphExclusions)
       }
 
     val daemonRendererProjectDir = project.rootDir.resolve("daemon/android")

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -476,7 +476,12 @@ internal object ComposePreviewTasks {
     val rendererConfig = ensureRendererDesktopConfig(project, "composePreviewRenderer")
     // Resolve the renderer in the consumer's dependency graph so a single coherent Skiko / Compose
     // version wins (issue #1844). See [alignDesktopToolWithConsumerGraph].
-    alignDesktopToolWithConsumerGraph(project, rendererConfig, resolveDependencyConfigName)
+    alignDesktopToolWithConsumerGraph(
+      project,
+      extension,
+      rendererConfig,
+      resolveDependencyConfigName,
+    )
 
     val renderClasspathGuard =
       registerDesktopClasspathGuard(
@@ -834,7 +839,12 @@ internal object ComposePreviewTasks {
     // The daemon JVM puts the consumer's full runtime classpath on its parent `-cp` (below), so it
     // hits the same Skiko skew as the one-shot render path — resolve it in the consumer's graph too
     // (issue #1844). See [alignDesktopToolWithConsumerGraph].
-    alignDesktopToolWithConsumerGraph(project, daemonRendererConfig, dependencyConfigName)
+    alignDesktopToolWithConsumerGraph(
+      project,
+      extension,
+      daemonRendererConfig,
+      dependencyConfigName,
+    )
     if (useLocalDaemon) {
       try {
         project.dependencies.add(
@@ -1113,10 +1123,17 @@ internal object ComposePreviewTasks {
    */
   private fun alignDesktopToolWithConsumerGraph(
     project: Project,
+    extension: PreviewExtension,
     toolConfig: org.gradle.api.artifacts.Configuration,
     dependencyConfigName: () -> String,
   ) {
     project.afterEvaluate {
+      // Consumer-declared render-graph exclusions apply to the desktop configurations for the same
+      // reason they apply to the Android ones: this `extendsFrom` is what puts the consumer's
+      // constraints — including a strict-version platform that no renderer version can satisfy —
+      // onto a configuration we own. Read inside `afterEvaluate`, where `composePreview { … }` has
+      // been evaluated. See [RenderGraphExtension] (issue #4995).
+      RenderGraphExclusions.applyTo(project, toolConfig, extension.renderGraph.excludes.get())
       val depName = dependencyConfigName()
       // androidJvm classpath: the desktop renderer has no matching variant — leave it alone.
       if (depName == "androidRuntimeClasspath") return@afterEvaluate

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusions.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+
+/**
+ * Applies `composePreview { renderGraph { exclude(…) } }` (and its
+ * `-PcomposePreview.renderGraphExcludes=…` twin) to the configurations the plugin creates for
+ * resolving the renderer.
+ *
+ * Why the DSL exists at all, and why the render configurations inherit the consumer's graph in the
+ * first place, is on [RenderGraphExtension]. This object is only the wiring: one place that every
+ * render configuration goes through, so the Android render config, its daemon superset and the two
+ * desktop configurations cannot drift apart the way they would if each call site spelled the
+ * exclusions out. A consumer excluding a module must get the SAME graph in the one-shot render task
+ * and in the daemon, or the two JVMs render the same previews off different classpaths.
+ *
+ * Exclusions land on OUR configurations only — never on the consumer's `…UnitTestRuntimeClasspath`
+ * that we `extendsFrom`, which stays exactly as their own build resolves it.
+ *
+ * Note the deliberate contrast with [AndroidPreviewSupport.addRenderGraphDependency], which carries
+ * the plugin's OWN Rule-3 exclusions on individual dependencies precisely so they cannot reach the
+ * inherited consumer subtree. That restraint is right for a rule the plugin invents; it would be
+ * wrong here. A consumer writing `renderGraph { exclude(…) }` is asking for exactly the config-wide
+ * scope — the module they need gone is one THEY contribute, inherited through `extendsFrom`, and a
+ * dependency-scoped exclude could never reach it.
+ */
+internal object RenderGraphExclusions {
+
+  /**
+   * Adds [exclusions] to [configuration]. Safe to call repeatedly: Gradle stores exclude rules in a
+   * set, and `maybeCreate` plus a second registration pass can reach the same configuration twice.
+   *
+   * Logged at `info` at configuration time (not from a resolve hook, which would capture [project]
+   * into an execution-time callback and break the configuration cache), because the failure this
+   * feature exists to fix — an unresolvable render configuration — and the failure a wrong
+   * exclusion causes — a `ClassNotFoundException` on the render JVM — look nothing alike, and
+   * `--info` is where a consumer checks which of the two they are looking at.
+   */
+  fun applyTo(
+    project: Project,
+    configuration: Configuration,
+    exclusions: List<RenderGraphExclusion>,
+  ) {
+    if (exclusions.isEmpty()) return
+    exclusions.forEach { exclusion ->
+      configuration.exclude(
+        buildMap {
+          exclusion.group?.let { put("group", it) }
+          exclusion.module?.let { put("module", it) }
+        }
+      )
+    }
+    project.logger.info(
+      "compose-preview: excluding ${exclusions.joinToString()} from the render graph " +
+        "(configuration '${configuration.name}', via composePreview.renderGraph)"
+    )
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/RenderGraphExclusionsTest.kt
@@ -1,0 +1,125 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+/**
+ * [RenderGraphExclusions] — where `composePreview { renderGraph { exclude(…) } }` lands
+ * (issue #4995).
+ *
+ * The render configurations `extendsFrom` the consumer's own test/runtime classpath on purpose, so
+ * that renderer and consumer resolve as ONE graph. A consumer whose graph carries a strict-version
+ * platform (`strictly(v)` + `reject("(v,")` on every module) inherits those constraints onto our
+ * configuration too, where any renderer dependency newer than one of them is an unsolvable
+ * conflict. The exclusion is what lets them keep the platform on their own graph and off ours.
+ *
+ * What the tests below pin is that it stays a *scalpel*: rules land on the configuration we own,
+ * the consumer's configuration is never mutated, and an unconfigured build gets no rules at all.
+ */
+class RenderGraphExclusionsTest {
+
+  /**
+   * A render configuration shaped like the real one: ours, extending the consumer's unit-test
+   * runtime classpath.
+   */
+  private fun renderConfiguration(project: Project) =
+    project.configurations.create("composePreviewAndroidRendererDebug").apply {
+      extendsFrom(project.configurations.create("debugUnitTestRuntimeClasspath"))
+    }
+
+  @Test
+  fun `an exclusion becomes an exclude rule on our configuration`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+
+    RenderGraphExclusions.applyTo(
+      project,
+      configuration,
+      listOf(RenderGraphExclusion("com.example", "version-constraints")),
+    )
+
+    assertThat(configuration.excludeRules.map { it.group to it.module })
+      .containsExactly("com.example" to "version-constraints")
+  }
+
+  @Test
+  fun `a half-specified exclusion keeps the other half unconstrained`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+
+    RenderGraphExclusions.applyTo(
+      project,
+      configuration,
+      listOf(RenderGraphExclusion("com.example", null), RenderGraphExclusion(null, "constraints")),
+    )
+
+    // Gradle reads a null half as "any": group-only drops the group, module-only drops that name
+    // wherever it comes from. Writing the empty string instead would match nothing.
+    assertThat(configuration.excludeRules.map { it.group to it.module })
+      .containsExactly("com.example" to null, null to "constraints")
+  }
+
+  @Test
+  fun `no exclusions means no rules`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+
+    RenderGraphExclusions.applyTo(project, configuration, emptyList())
+
+    // The default path for every consumer who never touches the DSL: the render graph is exactly
+    // what it was before this feature existed.
+    assertThat(configuration.excludeRules).isEmpty()
+  }
+
+  @Test
+  fun `the consumer's own configuration is left alone`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+
+    RenderGraphExclusions.applyTo(
+      project,
+      configuration,
+      listOf(RenderGraphExclusion("com.example", "version-constraints")),
+    )
+
+    // The load-bearing half of the design: the consumer's normal build must resolve exactly as it
+    // did before, platform and all. Excluding on the inherited configuration instead of ours would
+    // silently unpin their production graph.
+    assertThat(project.configurations.getByName("debugUnitTestRuntimeClasspath").excludeRules)
+      .isEmpty()
+  }
+
+  @Test
+  fun `applying the same exclusion twice does not duplicate the rule`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+    val exclusions = listOf(RenderGraphExclusion("com.example", "version-constraints"))
+
+    // `maybeCreate` plus a second registration pass can reach one configuration twice.
+    RenderGraphExclusions.applyTo(project, configuration, exclusions)
+    RenderGraphExclusions.applyTo(project, configuration, exclusions)
+
+    assertThat(configuration.excludeRules).hasSize(1)
+  }
+
+  @Test
+  fun `exclusions survive on a configuration that also carries the render resolution rules`() {
+    val project = ProjectBuilder.builder().build()
+    val configuration = renderConfiguration(project)
+
+    // Order matters at the call sites: the KMP-sibling / Hamcrest / compose-floor rules go on
+    // first, the consumer's exclusions after, so a module they keep off the graph is not pulled
+    // back in by one of our substitutions.
+    AndroidPreviewSupport.applyRenderGraphResolutionRules(configuration)
+    RenderGraphExclusions.applyTo(
+      project,
+      configuration,
+      listOf(RenderGraphExclusion("com.example", "version-constraints")),
+    )
+
+    assertThat(configuration.excludeRules.map { it.group to it.module })
+      .containsExactly("com.example" to "version-constraints")
+  }
+}

--- a/site/install.md
+++ b/site/install.md
@@ -317,6 +317,59 @@ module — including your `releaseRuntimeClasspath`. Aligning a family upward is
 usually right for a render classpath and isn't a preview tool's call to make for
 a shipped app, so the decision stays yours.
 
+### Keeping a module off the render graph
+
+Sharing one graph with your unit-test classpath is what keeps a single coherent
+version of each module in front of the render classloader — but it also means
+the render configuration inherits **your** constraints. If your build applies a
+platform whose constraints are `strictly(v)` + `reject("(v,")`, every renderer
+dependency above one of those pins becomes a conflict Gradle cannot solve, and
+the render configuration fails to resolve before a single preview renders.
+
+`renderGraph` removes a module from the configurations the plugin owns, leaving
+your own build exactly as it was:
+
+```kotlin
+composePreview {
+  renderGraph {
+    exclude(group = "com.example", module = "version-constraints")
+  }
+}
+```
+
+In a Groovy build script, the usual map form:
+
+```groovy
+composePreview {
+  renderGraph {
+    exclude group: 'com.example', module: 'version-constraints'
+  }
+}
+```
+
+Either half may be omitted, exactly as in Gradle's own
+`Configuration.exclude(group:, module:)`: `group` alone drops the whole group,
+`module` alone drops that name wherever it comes from.
+
+| Property | Default | Effect |
+| --- | --- | --- |
+| `composePreview.renderGraphExcludes` | *(none)* | Comma-separated `group:module` coordinates, for a build script you can't edit — a CLI-driven render where the plugin is auto-injected, or one CI job. Additive with the DSL. |
+
+```
+./gradlew composePreviewRender -PcomposePreview.renderGraphExcludes=com.example:version-constraints
+```
+
+The exclusions land on the configurations the plugin creates — the Android
+render config, its daemon superset, and the two desktop equivalents — and never
+on the configurations your build declares, so a normal build and everything your
+platform guarantees it are untouched. The Kotlin-build-tools configurations are
+deliberately not covered: they are standalone compiler classpaths that never
+inherit your graph.
+
+This is a scalpel, not a switch. Excluding something the renderer genuinely
+needs trades an unresolvable configuration for a `ClassNotFoundException` on the
+render JVM; `--info` prints one line per configuration naming what was excluded.
+
 ## Requirements
 
 Java 17+, Gradle 8.13+, AGP 8.13.0+ (Android), Kotlin 2.0.21+, Compose


### PR DESCRIPTION
Fixes #4995.

## The problem

The render configurations `extendsFrom` the consumer's own test/runtime classpath on purpose — one graph is what keeps a single coherent version of each shared module in front of the render classloader, and #4995 explicitly agrees with that design. The cost is that the render configuration also inherits the consumer's *constraints*. A repository whose `java-platform` makes every version `strictly(v)` + `reject("(v,")` cannot resolve the render configuration at all: any renderer dependency above one of those pins is a conflict Gradle cannot solve, and the render dies before a preview is discovered.

The only escape was to reach into the plugin's internal configuration names:

```groovy
project.configurations.matching { it.name.startsWith("composePreview") }.all { cfg ->
    cfg.exclude module: "version-constraints"
}
```

which depends on names consumers cannot see, and matches five configurations when only some are relevant.

## The fix

A supported, typed DSL — the option the issue offered and the one requested here:

```kotlin
composePreview {
  renderGraph { exclude(group = "com.example", module = "version-constraints") }
}
```

Groovy gets the usual map form (`exclude group: 'com.example', module: 'version-constraints'`). Either half may be omitted, exactly as in Gradle's own `Configuration.exclude(group:, module:)`; an exclusion with neither is rejected rather than silently emptying the render classpath.

`-PcomposePreview.renderGraphExcludes=com.example:version-constraints` is the **additive** equivalent (comma-separated coordinates) for a build script the consumer cannot edit — notably a CLI-driven render, where the plugin is auto-injected and there is no `composePreview { }` block to write into. The reporter renders through the CLI, so the DSL alone would not have covered their case; the property is not a second API, it is the same list.

Not a step backwards:

- The `extendsFrom` single-graph design is untouched — nothing here re-splits the graphs, and `legacyClasspathUnion` is not involved.
- Exclusions land only on the configurations the plugin creates (`composePreviewAndroidRenderer<Variant>`, `composePreviewAndroidDaemon<Variant>`, `composePreviewRenderer`, `composePreviewDesktopDaemon`) — never on the consumer's own configurations, so a normal build and everything their platform guarantees it resolve exactly as before.
- The render task and the daemon get the **same** exclusions: `extendsFrom` inherits neither `resolutionStrategy` nor exclude rules, so both configurations are wired by hand through one helper rather than each call site spelling it out. Two JVMs rendering the same previews off different graphs is the divergence the single-graph design exists to remove.
- Applied *after* the KMP-sibling / Hamcrest / compose-floor rules, so a module the consumer keeps off the graph is not pulled back in by one of our own substitutions.
- `composePreviewBtaImpl` / `composePreviewBtaPlugin` are deliberately **not** covered: they are standalone Kotlin-build-tools compiler classpaths that never inherit the consumer's graph, so the prefix match the workaround needed is exactly what a real API should not do.
- Opt-in only: an unconfigured build gets zero exclude rules. `--info` prints one line per configuration naming what was excluded, because a wrong exclusion trades an unresolvable configuration for a `ClassNotFoundException` on the render JVM.

Docs: a "Keeping a module off the render graph" section in `site/install.md`, next to the existing render-classpath-conflict guidance.

## Test plan

New tests, all run locally:

- `RenderGraphExcludesFunctionalTest` (functionalTest, real Gradle + real `java-platform` with `strictly`/`reject`) — 4 tests:
  - baseline: without an exclusion the inherited strict platform makes `composePreviewRenderer` unresolvable (this is the bug report, reproduced — it guards the two below from passing vacuously);
  - the DSL resolves the render config and lands on the renderer's own version;
  - the Gradle property is equivalent;
  - the consumer's own `runtimeClasspath` still carries the platform.
- `RenderGraphExclusionsTest` (gradle-plugin unit, 6 tests) — rules land on our configuration, a half-specified exclusion leaves the other half unconstrained, empty means no rules, the inherited consumer configuration is untouched, re-application does not duplicate, and exclusions coexist with the existing render resolution rules.
- `RenderGraphExclusionTest` (config plugin unit, 12 tests) — DSL accumulation, Groovy map notation and its unknown-key rejection, and the property parser (group-only, module-only, blank entries, malformed coordinate).

Also green: `:gradle-plugin:test`, `:gradle-plugin:gradle-plugin-config:test`, `ktfmtCheckAll`.

Non-visual change (dependency resolution + docs), so no render evidence applies.

Branch is `agent/…` per `AGENTS.md`; commit identity is the repository's human identity and the attribution scanner passes on `origin/main..HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQAbM4tGzUhFPYwzxaSLqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQAbM4tGzUhFPYwzxaSLqk)_