### PR TITLE
fix(bundle): key AAR extraction on content so a snapshot rebuild can't serve stale classes

### DIFF
--- a/bundle/coordinates/src/main/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolver.kt
+++ b/bundle/coordinates/src/main/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolver.kt
@@ -35,8 +35,9 @@ import okio.openZip
  * 2. **Remote repositories** (when [networkEnabled]) — Maven Central + Google Maven by default,
  *    overridable via [remoteRepositories]. Hit only when the local repos can't satisfy the
  *    coordinate (nothing found, or a v4 hash that no local copy matched). A downloaded jar is
- *    cached under [downloadCacheDir] in Maven layout, so a second resolve — or a later local-only
- *    run — finds it without the network.
+ *    cached under [downloadCacheDir] in Maven layout, fanned one level deeper under the sha256 the
+ *    fetch was made for, so a second resolve — or a later local-only run — finds it without the
+ *    network and two builds of one `-SNAPSHOT` coordinate never overwrite each other.
  *
  * # Verification — warn, never fail
  *
@@ -164,35 +165,49 @@ public class CoordinateResolver(
       // AndroidX libs ship `.aar`). [materialize] turns any `.aar` hit into its `classes.jar`.
       for (fileName in candidateFileNames(coord)) {
         // Maven layout: <root>/<group as path>/<artifact>/<version>/<artifact>-<version>.<ext>
-        val mavenPath =
-          File(
-            root,
-            "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}/$fileName",
-          )
+        val mavenVersionDir =
+          File(root, "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}")
+        val mavenPath = File(mavenVersionDir, fileName)
         if (fileSystem.metadataOrNull(mavenPath.path.toPath())?.isRegularFile == true)
           found += mavenPath
+        // [download] buckets a hashed coordinate one level deeper, under the sha256 it was fetched
+        // for, so two builds of the same `-SNAPSHOT` coordinate coexist instead of overwriting each
+        // other. Scan that level too — the same one-directory-deep sweep the Gradle layout below
+        // gets, and for the same reason: the bytes are fanned under a per-hash dir. Flat entries
+        // from an older cache (and from `~/.m2`, which is never bucketed) still match above.
+        found += subdirectoryHits(mavenVersionDir, fileName)
         // Gradle modules-2 layout fans the artifact under per-hash dirs; collect every match under
         // <root>/<group>/<artifact>/<version>/<hash>/<fileName>. One directory level only, so a
         // huge cache root doesn't turn this into a full filesystem scan.
-        val gradleVersionDir = File(root, "${coord.group}/${coord.artifact}/${coord.version}")
-        if (fileSystem.metadataOrNull(gradleVersionDir.path.toPath())?.isDirectory == true) {
-          fileSystem
-            .listOrNull(gradleVersionDir.path.toPath())
-            ?.asSequence()
-            ?.map { it.toFile() }
-            ?.filter { fileSystem.metadataOrNull(it.path.toPath())?.isDirectory == true }
-            ?.mapNotNull { hashDir ->
-              File(hashDir, fileName).takeIf {
-                fileSystem.metadataOrNull(it.path.toPath())?.isRegularFile == true
-              }
-            }
-            ?.let { found += it }
-        }
+        found +=
+          subdirectoryHits(
+            File(root, "${coord.group}/${coord.artifact}/${coord.version}"),
+            fileName,
+          )
       }
     }
     // Materialize before returning so the hash check (and the caller's classpath) sees real jars:
     // an `.aar` isn't loadable, and the bundle's `sha256` is of the extracted `classes.jar`.
     return found.mapNotNull { materialize(it) }
+  }
+
+  /**
+   * Every `<versionDir>/<*>/<fileName>` — one directory level only, so a huge cache root never
+   * turns this into a filesystem walk. Both fanned layouts this resolver reads are exactly one
+   * level deep: Gradle's `modules-2` per-sha1 dirs, and [download]'s own per-sha256 buckets.
+   */
+  private fun subdirectoryHits(versionDir: File, fileName: String): List<File> {
+    if (fileSystem.metadataOrNull(versionDir.path.toPath())?.isDirectory != true) return emptyList()
+    return fileSystem
+      .listOrNull(versionDir.path.toPath())
+      .orEmpty()
+      .map { it.toFile() }
+      .filter { fileSystem.metadataOrNull(it.path.toPath())?.isDirectory == true }
+      .mapNotNull { dir ->
+        File(dir, fileName).takeIf {
+          fileSystem.metadataOrNull(it.path.toPath())?.isRegularFile == true
+        }
+      }
   }
 
   /**
@@ -202,16 +217,27 @@ public class CoordinateResolver(
    *
    * A previously-cached download is *not* short-circuited here: [locate] already searches
    * [downloadCacheDir], so reaching this method means either nothing was cached, or the cached
-   * bytes didn't match the bundle's hash and we want fresh bytes (which overwrite the stale copy).
+   * bytes didn't match the bundle's hash and we want fresh bytes. Those land in this coordinate's
+   * own per-hash bucket, so they replace only an earlier fetch made for the same expected content —
+   * never another catalog's copy of the same `-SNAPSHOT` path.
    */
   private fun download(coord: BundleReader.ClasspathEntry.Maven): File? {
     val versionDir = "${coord.group.replace('.', '/')}/${coord.artifact}/${coord.version}"
+    // A coordinate carrying a hash is cached one level deeper, in a bucket named for the sha256 it
+    // was fetched to satisfy. `<artifact>-1.0.0-SNAPSHOT.<ext>` is the same literal path for every
+    // build of a snapshot, so a flat cache makes two catalogs on two androidx.dev builds overwrite
+    // each other's bytes on every materialization — a torn file when they run concurrently, and an
+    // endless re-download when they don't. The bucket is the EXPECTED hash, not the file's own (for
+    // an `.aar` the recorded sha256 is of the extracted `classes.jar`); it is a per-content
+    // partition of the cache, not a claim about what is in it. Unhashed coordinates (pre-v4
+    // bundles) keep the flat path, which is also where older caches already hold their downloads —
+    // [locate] reads both.
+    val cacheRel = coord.sha256?.let { "$versionDir/$it" } ?: versionDir
     // Try the recorded type, then `.aar` — same fallback as [locate], for the same reasons.
     for (fileName in candidateFileNames(coord)) {
-      val rel = "$versionDir/$fileName"
       // The cache always keys on the LITERAL `<artifact>-<version>.<ext>` name, even when the
       // remote served a timestamped snapshot file, so [locate] finds the download next time.
-      val dest = File(downloadCacheDir, rel)
+      val dest = File(downloadCacheDir, "$cacheRel/$fileName")
       for (base in remoteRepositories) {
         val remoteName = remoteFileName(base, coord, versionDir, fileName)
         val url = base.trimEnd('/') + "/" + versionDir + "/" + remoteName
@@ -274,13 +300,19 @@ public class CoordinateResolver(
    */
   private fun materialize(file: File): File? {
     if (!file.name.endsWith(".aar", ignoreCase = true)) return file
-    // Key the extraction dir on the source path so distinct candidates (hash disambiguation) don't
-    // collide, and a re-resolve reuses the already-extracted jar.
-    val dest =
-      File(
-        downloadCacheDir,
-        "extracted/${file.absolutePath.hashCode().toUInt().toString(16)}/classes.jar",
-      )
+    // Key the extraction dir on the AAR's CONTENT, never on its path. A path is not unique to a
+    // set of bytes: `<artifact>-1.0.0-SNAPSHOT.aar` is the literal name [download] caches every
+    // build of a snapshot under, so two catalogs built against two androidx.dev snapshot builds
+    // write the same path. Keyed on the path, the first extraction wins forever — [download]
+    // overwrites the AAR with the right bytes, `dest` already exists, and the STALE `classes.jar`
+    // is handed back. That is how meshcore-mobile's render lane died: its
+    // `remote-player-core:1.0.0-SNAPSHOT` resolved to another catalog's build while its
+    // `remote-core` (a `.jar`, so never extracted) came back fresh, putting two Remote Compose
+    // builds on one classpath and killing every IR replay with `NoSuchFieldError: class
+    // androidx.compose.remote.core.RemoteClock does not have member field ... SYSTEM`
+    // (compose-preview-server#187). Content keying makes a stale extraction unreachable, and two
+    // paths holding the same bytes still share one extraction.
+    val dest = File(downloadCacheDir, "extracted/${sha256Hex(file)}/classes.jar")
     val destPath = dest.path.toPath()
     if ((fileSystem.metadataOrNull(destPath)?.size ?: 0L) > 0L) return dest
     return try {

--- a/bundle/coordinates/src/test/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolverTest.kt
+++ b/bundle/coordinates/src/test/kotlin/ee/schimke/composeai/bundle/coordinates/CoordinateResolverTest.kt
@@ -243,8 +243,9 @@ class CoordinateResolverTest {
     assertTrue(r.downloaded, "should have come from the remote repo")
     assertTrue(r.verified)
     assertFalse(r.mismatch)
-    // Cached in Maven layout for next time.
-    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.jar")
+    // Cached in Maven layout for next time, bucketed under the sha the fetch was made for so two
+    // bundles pinning one `-SNAPSHOT` coordinate at different builds can't overwrite each other.
+    val cached = File(cacheDir, "com/example/foo/widgets/1.2.3/${sha256(bytes)}/widgets-1.2.3.jar")
     assertTrue(cached.isFile)
     assertEquals(bytes.toList(), cached.readBytes().toList())
   }
@@ -377,8 +378,10 @@ class CoordinateResolverTest {
     assertEquals("classes.jar", r.file?.name)
     assertTrue(r.downloaded)
     assertTrue(r.verified)
-    // The raw aar is cached under the aar filename; the extracted jar lives under extracted/.
-    assertTrue(File(cacheDir, "com/example/foo/widgets/1.2.3/widgets-1.2.3.aar").isFile)
+    // The raw aar is cached under the aar filename in its per-hash bucket; the extracted jar lives
+    // under extracted/, keyed on the aar's own content.
+    val sha = sha256(classesBytes)
+    assertTrue(File(cacheDir, "com/example/foo/widgets/1.2.3/$sha/widgets-1.2.3.aar").isFile)
   }
 
   @Test
@@ -500,6 +503,90 @@ class CoordinateResolverTest {
     s.start()
     server = s
     return "http://127.0.0.1:${s.address.port}"
+  }
+
+  @Test
+  fun `a re-downloaded snapshot aar is extracted fresh, not served from the stale extraction`() {
+    // compose-preview-server#187, the whole failure in one test. Two catalogs pin
+    // `androidx.compose.remote:*:1.0.0-SNAPSHOT` from two androidx.dev builds. Build A resolves
+    // first and its `.aar` lands in the download cache; build B then resolves the SAME coordinate,
+    // rejects the cached copy on hash, and re-downloads. Keyed on the AAR's path — the literal
+    // `widgets-1.0.0-SNAPSHOT.aar` both builds share — the extraction cache would hand back build
+    // A's `classes.jar` forever, while a sibling `.jar` coordinate (never extracted) came back
+    // fresh: two builds of one library on one classpath, and every render dead on
+    // `NoSuchFieldError`. Keyed on content, build B gets build B.
+    val buildA = byteArrayOf(0xA, 0xA, 0xA)
+    val buildB = byteArrayOf(0xB, 0xB, 0xB, 0xB)
+    val coord = { classes: ByteArray ->
+      BundleReader.ClasspathEntry.Maven(
+        group = "com.example.foo",
+        artifact = "widgets",
+        version = "1.0.0-SNAPSHOT",
+        type = "aar",
+        sha256 = sha256(classes),
+      )
+    }
+
+    val repoA = startRoutedRepo(mapOf(SNAPSHOT_AAR to makeAar(buildA)))
+    val a = assertNotNull(networkResolver(repoA).resolve(coord(buildA)).file)
+    assertEquals(buildA.toList(), a.readBytes().toList())
+    server?.stop(0)
+
+    val repoB = startRoutedRepo(mapOf(SNAPSHOT_AAR to makeAar(buildB)))
+    val r = networkResolver(repoB).resolve(coord(buildB))
+
+    assertEquals(
+      buildB.toList(),
+      assertNotNull(r.file).readBytes().toList(),
+      "the second build's classes.jar must not be shadowed by the first's extraction",
+    )
+    assertTrue(r.verified, "fresh bytes must verify against the bundle's hash: $warnings")
+    assertTrue(warnings.isEmpty(), "no hash mismatch should be reported: $warnings")
+  }
+
+  @Test
+  fun `two builds of one snapshot coordinate coexist in the download cache`() {
+    // The flat cache path is the same for every build of a `-SNAPSHOT`, so each resolve overwrote
+    // the other's bytes: a torn file when two catalogs materialize at once, and a re-download every
+    // time when they don't. A hashed coordinate is bucketed under the sha it was fetched for, and
+    // [locate] reads that level back, so build A still resolves offline after build B has run.
+    val buildA = byteArrayOf(1, 1, 1)
+    val buildB = byteArrayOf(2, 2, 2, 2)
+    val coordA = snapshotJarCoord(sha256(buildA))
+    val coordB = snapshotJarCoord(sha256(buildB))
+
+    val repoA = startRoutedRepo(mapOf(SNAPSHOT_JAR to buildA))
+    assertTrue(networkResolver(repoA).resolve(coordA).verified)
+    server?.stop(0)
+    val repoB = startRoutedRepo(mapOf(SNAPSHOT_JAR to buildB))
+    assertTrue(networkResolver(repoB).resolve(coordB).verified)
+
+    // Build A, offline, with only the cache to go on: its bytes must still be there.
+    val offline =
+      CoordinateResolver(
+        repositoryRoots = listOf(root),
+        warn = { warnings += it },
+        networkEnabled = false,
+        downloadCacheDir = cacheDir,
+      )
+    val again = offline.resolve(coordA)
+    assertEquals(buildA.toList(), assertNotNull(again.file).readBytes().toList())
+    assertTrue(again.verified, "build A must survive build B caching the same coordinate")
+    assertTrue(warnings.isEmpty(), "neither build should report a mismatch: $warnings")
+  }
+
+  private fun snapshotJarCoord(sha: String) =
+    BundleReader.ClasspathEntry.Maven(
+      group = "com.example.foo",
+      artifact = "widgets",
+      version = "1.0.0-SNAPSHOT",
+      type = "jar",
+      sha256 = sha,
+    )
+
+  private companion object {
+    const val SNAPSHOT_AAR = "/com/example/foo/widgets/1.0.0-SNAPSHOT/widgets-1.0.0-SNAPSHOT.aar"
+    const val SNAPSHOT_JAR = "/com/example/foo/widgets/1.0.0-SNAPSHOT/widgets-1.0.0-SNAPSHOT.jar"
   }
 
   private fun assertNotNullFile(f: File?) =


### PR DESCRIPTION
Fixes the resolver half of yschimke/compose-preview-server#187.

## The bug

`CoordinateResolver.materialize` cached an AAR's extracted `classes.jar` under a hash of the AAR's **path**:

```kotlin
File(downloadCacheDir, "extracted/${file.absolutePath.hashCode()…}/classes.jar")
```

A path is not unique to a set of bytes. `download` caches every build of a `-SNAPSHOT` under the literal `<artifact>-1.0.0-SNAPSHOT.<ext>`, so two catalogs built against two androidx.dev snapshot builds write the same file. Keyed on the path, the **first** extraction wins forever: `download` overwrites the AAR with the right bytes, `dest` already exists and is non-empty, and the stale `classes.jar` is handed back.

## What it cost

`meshcore-mobile`'s live render lane on `preview.coo.ee`, latched behind the fatal breaker within minutes of every boot. Its whole Remote Compose runtime is pinned at `1.0.0-SNAPSHOT` from one androidx.dev build (`.../builds/16113093/...`, recorded in the bundle's `repositories`). `remote-player-core` is an `.aar` and got another catalog's build from the stale extraction; `remote-core` is a `.jar`, never extracted, and came back fresh. Two Remote Compose lines on one classpath:

```
java.lang.NoSuchFieldError: Class androidx.compose.remote.core.RemoteClock
  does not have member field 'androidx.compose.remote.core.RemoteClock SYSTEM'
	at androidx.compose.remote.player.core.RemoteDocument.<clinit>(RemoteDocument.java:44)
	at ee.schimke.composeai.daemon.RemoteComposeIrReplay.Replay(RemoteComposeIrReplay.kt:40)
```

`RenderCircuitBreaker` classifies `NoSuchFieldError` as non-recoverable — correctly, retrying a linkage error cannot help — so 197 previews fell back to baked PNGs and the theme optimizer parked.

Nothing was *unresolved*, which is why this never surfaced as a classpath gap: the resolver hashed the stale extraction, warned `hash mismatch … Rendering with it anyway`, and returned it.

## The fix

- **`materialize` keys the extraction on the AAR's own content hash.** A stale extraction becomes unreachable, and two paths holding identical bytes still share one extraction.
- **`download` buckets a hashed coordinate one level deeper**, under the sha256 the fetch was made for, and **`locate` reads that level back** (the same one-directory-deep sweep the Gradle `modules-2` layout already got, now factored into `subdirectoryHits`). Two builds of one `-SNAPSHOT` coordinate coexist instead of overwriting each other on every materialization — a torn file when two catalogs materialize concurrently, an endless re-download when they don't. Unhashed pre-v4 coordinates keep the flat path, which is also where older caches already hold their downloads.

The bucket name is the **expected** hash, not the file's own (for an `.aar` the recorded sha256 is of the extracted `classes.jar`) — it is a per-content partition of the cache, not a claim about what is in it.

## Test plan

Two new `CoordinateResolverTest` cases, both verified failing against the pre-fix source and passing after:

- `a re-downloaded snapshot aar is extracted fresh, not served from the stale extraction` — the whole production failure, as two loopback repos serving two builds of one coordinate.
- `two builds of one snapshot coordinate coexist in the download cache` — build A still resolves offline after build B has cached the same coordinate.

Two existing assertions on the flat cache path updated for the bucketed layout. `./gradlew :bundle-coordinates:ktfmtFormatMain :bundle-coordinates:ktfmtFormatTest :bundle-coordinates:test` green (21 tests).

Non-visual change, so no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfBAUfX591yPokvuxLug2C


---
_Generated by [Claude Code](https://claude.ai/code/session_01WfBAUfX591yPokvuxLug2C)_