### PR TITLE
fix(import): render a verified upstream with lenient verification

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -499,10 +499,22 @@ env:
         > Dependency verification failed for configuration 'classpath'
           3 artifacts failed verification: ee.schimke.composeai.preview.gradle.plugin-...pom ...
 
-    The alternative considered and rejected was rendering with ``--dependency-verification=lenient``,
-    which makes verification non-fatal for EVERY artifact in the build for the sake of getting two of
-    ours through. Appending two ``<trust>`` entries leaves every dependency the project actually
-    declares strictly verified, and trusts only the coordinates we are the reason for.
+    Rendering with ``--dependency-verification=lenient`` was considered and rejected FIRST TIME
+    ROUND, when the failure was three artifacts of ours: making verification non-fatal for every
+    artifact in the build, to get two of ours through, was the wrong trade. Appending ``<trust>``
+    entries left every dependency the project actually declares strictly verified.
+
+    THAT REASONING NO LONGER HOLDS, and the step that runs this now sets lenient as well. Once the
+    plugin's own coordinates were trusted, mullvad failed on 109 artifacts that are NOT ours at all —
+    androidx.activity, org.jetbrains.compose, the project's own declared dependencies — resolved
+    through ``:lib:model:detachedConfiguration1``, a configuration the RENDER creates. The project
+    has no checksums for it because it never resolves it, so no amount of trusting our coordinates
+    can reach it; the only surgical alternative is trusting a hundred-odd third-party groups by hand
+    and re-trusting them at every upstream bump. So lenient it is, for imports only.
+
+    This program is kept because it is still the narrower statement of intent — our coordinates are
+    named, so a reader of the log sees what the import is the reason for — and because it costs
+    nothing. It is no longer what makes a verified project render.
 
     This edits a THROWAWAY checkout, discarded with the CI job. It is never run against a repository
     anyone keeps.
@@ -1070,22 +1082,48 @@ jobs:
       # An imported project may harden its build against precisely what an import does: resolve a
       # plugin it has never heard of. Where it ships dependency verification metadata, the
       # auto-injected preview plugin has no checksum in it and the render dies during configuration
-      # (yschimke/compose-preview-imports#30). Two <trust> entries are appended to the THROWAWAY
-      # checkout, leaving every dependency the project actually declares strictly verified — see
-      # TRUST_PREVIEW_PLUGIN_PY for why that beats --dependency-verification=lenient, and why BOTH
-      # the marker and implementation groups are needed.
-      - name: Trust the preview plugin in the upstream checkout
+      # (yschimke/compose-preview-imports#30). Two things happen to the THROWAWAY checkout here: the
+      # plugin's own groups are trusted, and verification is set to lenient. The second is what
+      # actually makes such a project render — see TRUST_PREVIEW_PLUGIN_PY, which records why the
+      # first was thought sufficient and what disproved it.
+      - name: Relax dependency verification in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
         env:
           METADATA: ${{ env.RENDER_DIR }}/gradle/verification-metadata.xml
+          GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
         run: |
           set -euo pipefail
           if [ ! -f "$METADATA" ]; then
-            echo "no dependency verification in this checkout — nothing to trust"
+            echo "no dependency verification in this checkout — nothing to relax"
             exit 0
           fi
           printf '%s' "$TRUST_PREVIEW_PLUGIN_PY" > "${RUNNER_TEMP}/trust-preview-plugin.py"
           python3 "${RUNNER_TEMP}/trust-preview-plugin.py" "$METADATA"
+
+          # And then lenient, which is what actually makes a verified project render. See
+          # TRUST_PREVIEW_PLUGIN_PY: trusting our own coordinates left mullvad failing on 109
+          # artifacts that are the PROJECT'S OWN, resolved through a detached configuration the
+          # render creates and the project therefore has no checksums for.
+          #
+          # Set in gradle.properties rather than as a CLI flag on purpose. The flag would have to
+          # travel through the CLI, which is installed from a RELEASE — so it would not take effect
+          # until the next one, exactly the lag that left --write-locks written but unreachable for
+          # hours (#4992, #4994). This file is in the throwaway checkout the workflow already
+          # rewrites, so it applies to the very next run.
+          #
+          # Replaced rather than appended when the key is already there: an upstream that pins
+          # `strict` would otherwise win and the render would fail with the property set, which is
+          # the most confusing possible outcome.
+          if [ -f "$GRADLE_PROPERTIES" ] &&
+             grep -q '^[[:space:]]*org\.gradle\.dependency\.verification[[:space:]]*=' "$GRADLE_PROPERTIES"; then
+            sed -i 's/^[[:space:]]*org\.gradle\.dependency\.verification[[:space:]]*=.*/org.gradle.dependency.verification=lenient/' \
+              "$GRADLE_PROPERTIES"
+            echo "rewrote org.gradle.dependency.verification=lenient in the throwaway checkout"
+          else
+            printf '\n# compose-preview import: verification is lenient for this throwaway render.\norg.gradle.dependency.verification=lenient\n' \
+              >> "$GRADLE_PROPERTIES"
+            echo "set org.gradle.dependency.verification=lenient in the throwaway checkout"
+          fi
 
 
       - name: Set up JDK 21
@@ -1425,22 +1463,48 @@ jobs:
       # An imported project may harden its build against precisely what an import does: resolve a
       # plugin it has never heard of. Where it ships dependency verification metadata, the
       # auto-injected preview plugin has no checksum in it and the render dies during configuration
-      # (yschimke/compose-preview-imports#30). Two <trust> entries are appended to the THROWAWAY
-      # checkout, leaving every dependency the project actually declares strictly verified — see
-      # TRUST_PREVIEW_PLUGIN_PY for why that beats --dependency-verification=lenient, and why BOTH
-      # the marker and implementation groups are needed.
-      - name: Trust the preview plugin in the upstream checkout
+      # (yschimke/compose-preview-imports#30). Two things happen to the THROWAWAY checkout here: the
+      # plugin's own groups are trusted, and verification is set to lenient. The second is what
+      # actually makes such a project render — see TRUST_PREVIEW_PLUGIN_PY, which records why the
+      # first was thought sufficient and what disproved it.
+      - name: Relax dependency verification in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
         env:
           METADATA: ${{ env.RENDER_DIR }}/gradle/verification-metadata.xml
+          GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
         run: |
           set -euo pipefail
           if [ ! -f "$METADATA" ]; then
-            echo "no dependency verification in this checkout — nothing to trust"
+            echo "no dependency verification in this checkout — nothing to relax"
             exit 0
           fi
           printf '%s' "$TRUST_PREVIEW_PLUGIN_PY" > "${RUNNER_TEMP}/trust-preview-plugin.py"
           python3 "${RUNNER_TEMP}/trust-preview-plugin.py" "$METADATA"
+
+          # And then lenient, which is what actually makes a verified project render. See
+          # TRUST_PREVIEW_PLUGIN_PY: trusting our own coordinates left mullvad failing on 109
+          # artifacts that are the PROJECT'S OWN, resolved through a detached configuration the
+          # render creates and the project therefore has no checksums for.
+          #
+          # Set in gradle.properties rather than as a CLI flag on purpose. The flag would have to
+          # travel through the CLI, which is installed from a RELEASE — so it would not take effect
+          # until the next one, exactly the lag that left --write-locks written but unreachable for
+          # hours (#4992, #4994). This file is in the throwaway checkout the workflow already
+          # rewrites, so it applies to the very next run.
+          #
+          # Replaced rather than appended when the key is already there: an upstream that pins
+          # `strict` would otherwise win and the render would fail with the property set, which is
+          # the most confusing possible outcome.
+          if [ -f "$GRADLE_PROPERTIES" ] &&
+             grep -q '^[[:space:]]*org\.gradle\.dependency\.verification[[:space:]]*=' "$GRADLE_PROPERTIES"; then
+            sed -i 's/^[[:space:]]*org\.gradle\.dependency\.verification[[:space:]]*=.*/org.gradle.dependency.verification=lenient/' \
+              "$GRADLE_PROPERTIES"
+            echo "rewrote org.gradle.dependency.verification=lenient in the throwaway checkout"
+          else
+            printf '\n# compose-preview import: verification is lenient for this throwaway render.\norg.gradle.dependency.verification=lenient\n' \
+              >> "$GRADLE_PROPERTIES"
+            echo "set org.gradle.dependency.verification=lenient in the throwaway checkout"
+          fi
 
 
       # The imported project's OWN toolchain, when it asks for one this runner lacks. Installed


### PR DESCRIPTION
## This reverses a call made in #4990, deliberately

`--dependency-verification=lenient` was considered and rejected there, and the reasoning was right **for the case in front of us at the time**: three artifacts of ours failing verification did not justify making it non-fatal for the whole build. Trusting the plugin's own groups was the narrower answer.

It turned out not to be sufficient. With those groups trusted, mullvad now fails on **109 artifacts that are not ours at all**:

```
> Dependency verification failed for configuration ':lib:model:detachedConfiguration1'
  109 artifacts failed verification:
    - activity-1.10.0.module (androidx.activity:activity:1.10.0) from repository Google
    - animation-1.11.1.module (org.jetbrains.compose.animation:animation:1.11.1) …
```

These are the project's **own declared dependencies**, resolved through `:lib:model:detachedConfiguration1` — a configuration *the render creates*. The project has no checksums for it because it never resolves it. No amount of trusting our coordinates can reach that; the only surgical alternative is trusting a hundred-odd third-party groups by hand and re-trusting them at every upstream bump.

## Why gradle.properties, not the CLI flag

The flag would have to travel through the CLI, which is installed from a **release** — so it would not take effect until the next one. That is the exact lag that left `--write-locks` correct but unreachable for hours today (#4992, #4994 merged, imports still failing until 1.64.0 shipped). The properties file lives in the throwaway checkout this job already rewrites, so this applies to the very next run.

The key is **replaced** when already present rather than appended: an upstream pinning `strict` would otherwise win and the render would fail with the property visibly set, which is the most confusing possible outcome.

## Verified against a real Gradle build

Not from documentation — I got the property name from memory and did not trust it:

- Built a probe with `<verify-metadata>true</verify-metadata>` and no checksums. It fails with the same `N artifacts failed verification` shape as mullvad.
- Ran the step's own shell (extracted from the committed workflow) against that probe, then re-ran the build: `RESOLVED 3 file(s)`.
- Exercised the shell over five fixtures — absent file, no key, already lenient, pinned `strict`, and an indented key with spaces around `=` — each ending at exactly one `lenient` value, with other properties preserved.

Both copies of the step are updated (the `generate` and `render-shard` jobs carry identical bodies; a previous change of mine hit only one of them).

The trust program stays: it is still the narrower statement of intent and costs nothing. Its docstring now records why it was thought sufficient and what disproved it, rather than claiming it beats lenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_