### PR TITLE
fix(discovery): declare, package and correct the component record

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -48,13 +48,17 @@ data class ComponentRecordFile(
  *   overloads. [ComponentSymbol.descriptor] is where it lands; until then a reader that finds two
  *   records with one id should treat the pair as unresolved rather than pick one.
  *
- * @property componentId the published catalog identity, when the preview carried one. An alias, not
- *   the key.
+ * @property componentIds every published catalog identity associated with this symbol, deduplicated
+ *   and ordered. A **list**, not a scalar: one symbol is routinely rendered by several catalog
+ *   entries, and keeping only the first would hand the component an arbitrary,
+ *   manifest-order-dependent alias — or none at all, when an ordinary preview happened to come
+ *   first. Aliases, never the key; [ComponentBinding.componentId] says which preview contributed
+ *   which.
  */
 @Serializable
 data class ComponentRecord(
   val canonicalId: String,
-  val componentId: String? = null,
+  val componentIds: List<String> = emptyList(),
   val symbol: ComponentSymbol,
   val parameters: List<TargetParameter> = emptyList(),
   val slots: List<ComponentSlot> = emptyList(),
@@ -125,5 +129,10 @@ data class ComponentSlot(
  * The render filenames are deliberately not repeated here: they are derived from the preview id by
  * the same rule every consumer already applies to `previews.json`, and duplicating a derived value
  * into a second file is how the two start disagreeing.
+ *
+ * @property componentId the catalog identity *this* preview published the symbol under, when it
+ *   carried one. Per binding rather than per component, because the association belongs to the
+ *   preview: the same `Card` can be one catalog's `Containment/Card` and another preview's
+ *   incidental container.
  */
-@Serializable data class ComponentBinding(val previewId: String)
+@Serializable data class ComponentBinding(val previewId: String, val componentId: String? = null)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -49,7 +49,6 @@ object ComponentRecords {
         into.getOrPut(id) {
           MutableComponent(
             canonicalId = id,
-            componentId = preview.catalog?.componentId?.takeIf { it.isNotBlank() },
             symbol =
               ComponentSymbol(
                 jvmOwner = target.className,
@@ -67,7 +66,11 @@ object ComponentRecords {
       if (target.parameters.size > existing.parameters.size) {
         existing.parameters = target.parameters
       }
-      existing.bindings += ComponentBinding(previewId = preview.id)
+      existing.bindings +=
+        ComponentBinding(
+          previewId = preview.id,
+          componentId = preview.catalog?.componentId?.takeIf { it.isNotBlank() },
+        )
     }
   }
 
@@ -94,7 +97,10 @@ object ComponentRecords {
    * for a case nobody has hit. Recorded as a known limit rather than hidden.
    */
   internal fun callableFqn(target: PreviewTarget): String {
-    val owner = target.className
+    // A nested class, object or companion arrives with the JVM binary separator
+    // (`com.example.Controls$Companion`). Emitting that verbatim would print an import no Kotlin
+    // compiler accepts, which is the one thing this field exists to avoid.
+    val owner = target.className.replace('$', '.')
     val simpleName = owner.substringAfterLast('.')
     if (!simpleName.endsWith("Kt") || simpleName.length == 2) return "$owner.${target.functionName}"
     val packageName = owner.substringBeforeLast('.', missingDelimiterValue = "")
@@ -102,8 +108,8 @@ object ComponentRecords {
   }
 
   /**
-   * A `@Composable` lambda parameter is a slot. The receiver, when the rendered type carries one,
-   * is everything before the `.(` — `RowScope.() -> Unit` yields `RowScope`.
+   * A `@Composable` lambda parameter is a slot, carrying the qualified receiver
+   * ([TargetParameter.composableSlotReceiver]) when it has one.
    */
   internal fun slotsOf(parameters: List<TargetParameter>): List<ComponentSlot> =
     parameters
@@ -112,27 +118,32 @@ object ComponentRecords {
         ComponentSlot(
           name = parameter.name,
           required = !parameter.hasDefault,
-          receiverScope =
-            parameter.type.substringBefore(".(", missingDelimiterValue = "").ifEmpty { null },
+          // The QUALIFIED receiver recorded from metadata, not a slice of the human-readable
+          // rendered type: `RowScope` alone cannot be imported, and two libraries can define it.
+          receiverScope = parameter.composableSlotReceiver,
         )
       }
 
   private class MutableComponent(
     val canonicalId: String,
-    val componentId: String?,
     val symbol: ComponentSymbol,
     var parameters: List<TargetParameter>,
   ) {
     var bindings: List<ComponentBinding> = emptyList()
 
-    fun toRecord(): ComponentRecord =
-      ComponentRecord(
+    fun toRecord(): ComponentRecord {
+      val resolvedBindings = bindings.distinctBy { it.previewId }.sortedBy { it.previewId }
+      return ComponentRecord(
         canonicalId = canonicalId,
-        componentId = componentId,
+        // Every alias any preview published this symbol under, not whichever the manifest listed
+        // first — a shared component such as `Card` is rendered by several previews and would
+        // otherwise take an arbitrary, order-dependent id.
+        componentIds = resolvedBindings.mapNotNull { it.componentId }.distinct().sorted(),
         symbol = symbol,
         parameters = parameters,
         slots = slotsOf(parameters),
-        bindings = bindings.distinctBy { it.previewId }.sortedBy { it.previewId },
+        bindings = resolvedBindings,
       )
+    }
   }
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -131,13 +131,32 @@ internal object ComposableSignature {
     return byName.firstOrNull { it.signature?.descriptor == descriptor } ?: byName.first()
   }
 
-  private fun KmValueParameter.toTargetParameter(): TargetParameter =
-    TargetParameter(
+  private fun KmValueParameter.toTargetParameter(): TargetParameter {
+    val slot = isComposableFunctionType(type)
+    return TargetParameter(
       name = name,
       type = renderType(type),
       hasDefault = declaresDefaultValue,
-      composableSlot = isComposableFunctionType(type),
+      composableSlot = slot,
+      composableSlotReceiver = if (slot) receiverFqnOf(type) else null,
     )
+  }
+
+  /**
+   * The fully-qualified receiver of an extension-function type, or null when it has none.
+   *
+   * Kotlin records the receiver as the first function type argument and marks the type with
+   * `kotlin.ExtensionFunctionType` — the same pair [renderFunctionType] reads to print `RowScope.()
+   * -> Unit`. This keeps the *qualified* classifier rather than the simple name that rendering
+   * deliberately reduces to, because a consumer generating an import or deciding which scoped
+   * modifier APIs are legal cannot use `RowScope` on its own.
+   */
+  private fun receiverFqnOf(type: KmType): String? {
+    if (type.annotations.none { it.className == "kotlin/ExtensionFunctionType" }) return null
+    val receiver = type.arguments.firstOrNull()?.type ?: return null
+    val classifier = (receiver.classifier as? KmClassifier.Class)?.name ?: return null
+    return classifier.replace('/', '.').replace('$', '.')
+  }
 
   /**
    * A short, readable type: the classifier's simple name, a trailing `?` when nullable, and a

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1410,6 +1410,16 @@ data class TargetParameter(
    * True when the parameter is a `@Composable` function-typed slot (a `content = { … }` lambda).
    */
   val composableSlot: Boolean = false,
+  /**
+   * For a [composableSlot], the **fully-qualified** receiver type of the lambda
+   * (`androidx.compose.foundation.layout.RowScope`), or null when it has none.
+   *
+   * Separate from [type], which renders simple classifier names for readability — a scaffolding
+   * hint, not a resolvable reference. A consumer deciding which scoped modifier APIs are legal
+   * inside a slot, or generating an import for the scope, needs the qualified name: two libraries
+   * can define the same simple `RowScope`, and `RowScope` alone cannot be imported.
+   */
+  val composableSlotReceiver: String? = null,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscoveryCli.kt
@@ -55,6 +55,13 @@ public object PreviewDiscoveryCli {
         outcome.warnings.forEach { System.err.println("WARN: $it") }
         parsed.outFile.parentFile?.mkdirs()
         parsed.outFile.writeText(JSON.encodeToString(outcome.manifest))
+        // The component record travels with the manifest on every producer, not just the Gradle
+        // one. Bazel, Amper and anything else driving this CLI run the same discovery library and
+        // get the same manifest, so making the data product conditional on the build system that
+        // happened to invoke it would be an arbitrary hole in the contract.
+        parsed.outFile
+          .resolveSibling("components.json")
+          .writeText(JSON.encodeToString(ComponentRecords.from(outcome.manifest)))
         outcome.infoMessages.forEach { System.err.println(it) }
         exitProcess(0)
       }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
@@ -46,7 +46,8 @@ class ComponentRecordsTest {
           ),
           preview(
             "p2",
-            targets = listOf(target("com.example.HomeKt", "HomeScreen", sourceFile = "src/Home.kt")),
+            targets =
+              listOf(target("com.example.HomeKt", "HomeScreen", sourceFile = "src/Home.kt")),
           ),
         )
       )
@@ -140,20 +141,60 @@ class ComponentRecordsTest {
   }
 
   @Test
+  fun `every catalog id a preview published the symbol under is kept`() {
+    // A shared component is rendered by several previews. Freezing the alias from whichever the
+    // manifest listed first would give it an arbitrary, order-dependent id — or none at all, when
+    // an uncatalogued preview happened to come first.
+    val card = target("androidx.compose.material3.CardKt", "Card")
+    fun catalogued(id: String, componentId: String) =
+      preview(id, componentTargets = listOf(card))
+        .copy(catalog = CatalogEntry(role = CatalogRole.COMPONENT, componentId = componentId))
+
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview("plain", componentTargets = listOf(card)),
+          catalogued("b", "Containment/Card"),
+          catalogued("a", "Media/Card"),
+        )
+      )
+
+    val record = file.components.single()
+    assertThat(record.componentIds).containsExactly("Containment/Card", "Media/Card").inOrder()
+    assertThat(record.bindings.first { it.previewId == "plain" }.componentId).isNull()
+  }
+
+  @Test
+  fun `a nested owner is emitted as a source-level callable`() {
+    // `com.example.Controls${'$'}Companion.Button` is a JVM binary name; no Kotlin import accepts
+    // it.
+    assertThat(
+        ComponentRecords.callableFqn(target("com.example.Controls\u0024Companion", "Button"))
+      )
+      .isEqualTo("com.example.Controls.Companion.Button")
+  }
+
+  @Test
   fun `a composable lambda parameter becomes a slot, carrying its receiver scope`() {
     val slots =
       ComponentRecords.slotsOf(
         listOf(
           TargetParameter("onClick", "() -> Unit"),
           TargetParameter("modifier", "Modifier", hasDefault = true),
-          TargetParameter("content", "RowScope.() -> Unit", composableSlot = true),
+          TargetParameter(
+            "content",
+            "RowScope.() -> Unit",
+            composableSlot = true,
+            composableSlotReceiver = "androidx.compose.foundation.layout.RowScope",
+          ),
           TargetParameter("footer", "() -> Unit", hasDefault = true, composableSlot = true),
         )
       )
 
     // `onClick` is function-typed but not `@Composable`: a callback, not a slot.
     assertThat(slots.map { it.name }).containsExactly("content", "footer").inOrder()
-    assertThat(slots[0].receiverScope).isEqualTo("RowScope")
+    // The QUALIFIED name: `RowScope` alone cannot be imported, and two libraries can define it.
+    assertThat(slots[0].receiverScope).isEqualTo("androidx.compose.foundation.layout.RowScope")
     // Requiredness is about the LAMBDA argument, never about how many children it may emit.
     assertThat(slots[0].required).isTrue()
     // An unscoped slot records no receiver rather than an empty string.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/BundlePreviewTask.kt
@@ -655,6 +655,14 @@ abstract class BundlePreviewTask : DefaultTask() {
       buildZip(
         bundleJson = JSON.encodeToString(BundleManifest.serializer(), bundle),
         previewsJson = JSON.encodeToString(PreviewManifest.serializer(), filteredManifest),
+        // Derived from the FILTERED manifest, not the producer's full one: that filters the records
+        // to the selected previews and makes every binding's previewId one the bundled manifest
+        // actually carries, by construction rather than by a parallel rewrite that could drift.
+        componentsJson =
+          JSON.encodeToString(
+            ComponentRecordFile.serializer(),
+            ComponentRecords.from(filteredManifest),
+          ),
         appJar = appJarBytes,
         inlinedProjectJars = inlinedJars,
         report = JSON.encodeToString(MinimizationReport.serializer(), report),
@@ -1541,6 +1549,7 @@ abstract class BundlePreviewTask : DefaultTask() {
   private fun buildZip(
     bundleJson: String,
     previewsJson: String,
+    componentsJson: String,
     appJar: ByteArray,
     inlinedProjectJars: Map<String, File>,
     report: String,
@@ -1555,6 +1564,11 @@ abstract class BundlePreviewTask : DefaultTask() {
     ZipOutputStream(baos).use { zip ->
       zip.writeFile("bundle.json", bundleJson.toByteArray(Charsets.UTF_8))
       zip.writeFile("previews.json", previewsJson.toByteArray(Charsets.UTF_8))
+      // `components.json` travels with the manifest it was derived from. A detached browser,
+      // builder or MCP consumer reads the bundle and nothing else, so a component record that only
+      // existed in the producer's build directory would be unreachable to exactly the readers the
+      // wire contract names.
+      zip.writeFile("components.json", componentsJson.toByteArray(Charsets.UTF_8))
       // One baked PNG per selected preview under the well-known `previews/` directory.
       previewPngs.forEach { (id, bytes) -> zip.writeFile("$BUNDLE_PREVIEWS_DIR/$id.png", bytes) }
       // Renderer-named APNG/GIF siblings consumed by catalog motion publishing and bundle readers.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1778,6 +1778,7 @@ internal object ComposePreviewTasks {
       // daemon (see `:daemon:android`'s `RenderEngine`). The standalone `composePreviewDiscover`
       // task writes an empty `dataExtensionReports` map.
       outputFile.set(previewOutputDir.map { it.file("previews.json") })
+      componentsFile.set(previewOutputDir.map { it.file("components.json") })
       group = "compose preview"
       description = "Discover @Preview annotations in compiled classes"
       configureDeps()

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -125,6 +125,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:OutputFile abstract val outputFile: RegularFileProperty
 
   /**
+   * `components.json` — the components those previews render (see `ComponentRecordFile`).
+   *
+   * A **declared** output, not a file written beside [outputFile]. This task is `@CacheableTask`,
+   * and Gradle restores only declared outputs from the build cache: an undeclared write would
+   * simply be missing on a cache hit while the task still reported success, and deleting the file
+   * by hand would leave the task up to date so it never came back.
+   */
+  @get:OutputFile abstract val componentsFile: RegularFileProperty
+
+  /**
    * Subdirectory for Lottie capture `renderOutput` paths (see
    * [PreviewDiscovery.Input.lottieRenderSubdir]). Defaults to `"renders"`; the Android task sets a
    * disjoint dir so its JVM Lottie render doesn't share the `renders/` output with the Robolectric
@@ -234,13 +244,13 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val outFile = outputFile.get().asFile
         outFile.parentFile.mkdirs()
         outFile.writeText(json.encodeToString(outcome.manifest))
-        // `components.json` beside `previews.json`: the components those previews render, rather
-        // than the renders themselves. Derived wholly from the manifest, so it never disagrees with
-        // it, and written unconditionally — an empty component list is a fact worth publishing
-        // (it says inference found nothing), not a reason to omit the file.
-        outFile
-          .resolveSibling("components.json")
-          .writeText(json.encodeToString(ComponentRecords.from(outcome.manifest)))
+        // The components those previews render, rather than the renders themselves. Derived wholly
+        // from the manifest, so it never disagrees with it, and written unconditionally — an empty
+        // component list is a fact worth publishing (it says inference found nothing), not a
+        // reason to omit the file.
+        val componentsOut = componentsFile.get().asFile
+        componentsOut.parentFile.mkdirs()
+        componentsOut.writeText(json.encodeToString(ComponentRecords.from(outcome.manifest)))
         outcome.infoMessages.forEach { logger.lifecycle(it) }
       }
       is PreviewDiscovery.Outcome.Failure -> {


### PR DESCRIPTION
Five review findings landed on [#5013](https://github.com/yschimke/compose-ai-tools/pull/5013) minutes before it merged, so they went in unaddressed. All verified against the code, and each one **proven fixed by a run** rather than by reading.

## `components.json` was an undeclared output of a `@CacheableTask`

The real bug of the set. Gradle restores only *declared* outputs from the build cache, so a cache hit produced no file while `composePreviewDiscover` still reported success — and deleting the file by hand left the task up to date, so it never came back.

Now an `@OutputFile` property. Proven:

```
$ rm samples/cmp/build/compose-previews/components.json
$ ./gradlew :samples:cmp:composePreviewDiscover
> Task :samples:cmp:composePreviewDiscover FROM-CACHE
BUILD SUCCESSFUL
$ ls -la .../components.json
-rw-r--r-- 1 root root 21374 …   # restored from cache
```

## The record never reached a packed bundle

Which contradicted the wire contract's own claim that it persists there — and the readers that contract names (a detached browser, builder or MCP client) see the bundle and nothing else.

`buildZip` now writes it, derived from the **filtered** manifest rather than the producer's full one. That scopes records to the selected previews and makes every binding name a preview the bundled manifest carries *by construction*, instead of by a parallel id rewrite that could drift. Proven on the sample bundle:

```
$ unzip -l bundle.png | grep -E 'previews.json|components.json'
   219109  previews.json
    21354  components.json
bundled previews: 75 | components: 12
bindings referencing a preview NOT in the bundled manifest: none
```

## A catalog id was frozen from whichever preview came first

`Card` is rendered by three previews here; the alias it got was arbitrary and manifest-order-dependent — or absent entirely, when an uncatalogued preview sorted first. Ids are now a deduplicated list on the record plus a per-binding scalar, since the association belongs to the *preview*, not the symbol.

## The slot receiver was a simple name, not the qualified one the field documented

Sliced out of the human-readable rendered type, so it produced `RowScope` — which can't be imported, and collides when two libraries define that name. `ComposableSignature` now records the qualified classifier from metadata:

```
androidx.compose.material3.TextButton  slot content | required true | scope androidx.compose.foundation.layout.RowScope
androidx.compose.material3.Card        slot content | required true | scope androidx.compose.foundation.layout.ColumnScope
```

## A nested owner emitted a JVM binary name

An object, companion or nested class arrived as `com.example.Controls$Companion`, so `callable` produced `com.example.Controls$Companion.Button` — an import no Kotlin compiler accepts, which is the one thing that field exists to prevent.

## Also: the non-Gradle CLI now emits it

Bazel, Amper and anything else driving the published `PreviewDiscoveryCli` run the same discovery library against the same manifest. Making a data product conditional on the build system that invoked it would be an arbitrary hole in the contract.

## Test plan

- `:gradle-plugin:preview-discovery:test` — green, with two added tests (every catalog id kept; a nested owner rendered as a source-level callable) and the slot test tightened to the qualified receiver.
- `:samples:cmp:composePreviewDiscover` and `:composePreviewBundle` — green; the cache-restore and bundle-contents evidence above.
- `ktfmtFormat` clean on both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_