### PR TITLE
ci: give the Maven readiness gate long enough for Central to propagate

### DIFF
--- a/.github/workflows/maven-readiness.yml
+++ b/.github/workflows/maven-readiness.yml
@@ -69,8 +69,16 @@ jobs:
             '}' \
             > "$smoke/build.gradle.kts"
 
+          # Central's CDN propagation is the long pole: the GitHub Release goes public 10-40
+          # minutes before the artifacts resolve (the milestone note below says exactly that), so
+          # the poll budget has to cover that upper bound with headroom. The previous 40-attempt
+          # loop allowed only ~20 minutes and so failed releases that had published perfectly
+          # well: v1.65.0 went public at 21:36 on 2026-09-02, the gate gave up at 22:00, and the
+          # plugin resolved from Central minutes later. 100 attempts is ~55 minutes of wall clock
+          # (30s sleep plus a few seconds of Gradle each), which clears the documented 40.
+          attempts_max=100
           ready=0
-          for attempt in $(seq 1 40); do
+          for attempt in $(seq 1 "$attempts_max"); do
             if GRADLE_USER_HOME="$gradle_home" ./gradlew \
                 -p "$smoke" help --no-daemon --refresh-dependencies \
                 > "$smoke/gradle.log" 2>&1; then
@@ -84,12 +92,12 @@ jobs:
               } >> "$GITHUB_OUTPUT"
               break
             fi
-            echo "plugin ${V} not fully resolvable from public Maven Central (attempt ${attempt}/40)."
+            echo "plugin ${V} not fully resolvable from public Maven Central (attempt ${attempt}/${attempts_max})."
             tail -n 30 "$smoke/gradle.log"
             sleep 30
           done
           [ "$ready" -eq 1 ] \
-            || { echo "::error::plugin ${V} was not resolvable after ~20 minutes"; exit 1; }
+            || { echo "::error::plugin ${V} was not resolvable after ${attempts_max} attempts (~55 minutes)"; exit 1; }
 
           marker="$RUNNER_TEMP/compose-preview-maven-ready-${V}.json"
           printf '{"version":"%s","verifiedAt":"%s"}\n' \


### PR DESCRIPTION
## Summary

`maven-readiness.yml` polled for a shorter time than the workflow's own comments say to expect. Its milestone note states the GitHub Release goes public *"10–40 minutes before this job concludes"*, but the loop ran `seq 1 40` with a 30s sleep — roughly **20 minutes** — and then failed the release.

**v1.65.0 is the proof.** From run [33684081038](https://github.com/yschimke/compose-ai-tools/actions/runs/33684081038):

```
##[error]plugin 1.65.0 was not resolvable after ~20 minutes
##[error]Process completed with exit code 1.
```

Timeline on 2026-09-02:

| time | event |
| --- | --- |
| 21:34 | `publish-gradle-plugin` succeeds |
| 21:36 | `finalize-release` un-drafts the release |
| 21:37 | `verify-maven-readiness` starts polling |
| 22:00 | gate gives up after 40 attempts, run goes red |
| ~22:02 | `compose-preview-plugin:1.65.0` returns 200 from `repo1.maven.org` |

Nothing was wrong with that release — it had published correctly, and Central was simply still propagating. The red Release PR run is indistinguishable, to whoever reads it, from a publish that genuinely broke.

## Change

Budget raised to 100 attempts — about 55 minutes of wall clock (30s sleep plus a few seconds of Gradle per iteration; the 40-attempt loop measured 23 minutes end to end, so ~35s each). That clears the documented 40-minute upper bound with headroom.

The bound now lives in a single `attempts_max` variable, so the progress line and the failure message can't drift from the loop — previously `attempt ${attempt}/40` and `~20 minutes` were three independent literals free to disagree.

No other behaviour changes. The job sets no `timeout-minutes`, so it inherits the 360-minute default and the loop stays the only bound.

## Not fixed here

Two related things on main this does **not** address, both needing a call that isn't mine to make:

- Tag `v1.66.0` points at `e0d33b8`, whose tree still reads `1.65.0` in both `.release-please-manifest.json` and `composeaiReleasedRuntimeVersion`. It is tagged on the wrong commit, and its release is an unpublished draft with no assets. Deleting a published ref is destructive, so it is left alone.
- Any job resolving `composeaiReleasedRuntimeVersion` fails during the window between a release commit landing and Central serving that version — this is what makes Design Artifacts red on main after each release. Widening this gate does not close that window; giving those jobs the same wait would.

## Test plan

- `python3 -c "yaml.safe_load(...)"` on the workflow — parses.
- `bash -n` over the extracted `run:` script — no syntax errors.
- `scripts/check-agent-entrypoints.sh` — passes.
- Behaviour is exercised by the next release: the gate should now report `resolved … on attempt N` instead of failing at 40, and the v1.65.0 timings above say N will land around 45–55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL8UuHZ1NupN94C7EoL1gW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SL8UuHZ1NupN94C7EoL1gW)_