### PR TITLE
fix(import): render the nested build an import named, not its enclosing repo

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1204,6 +1204,72 @@ jobs:
       # a probe with configuration-cache=true, parallel=true and IP=false runs clean; Gradle simply
       # ignores the parallel request. Touching a second property to fix a problem that does not
       # exist would be the riskier change.
+      # `working-directory` names a Gradle build nested inside the upstream repository, and the CLI
+      # finds "the project" by walking UP from its cwd until it sees a `gradlew`
+      # (`findGradleProjectRoot`). A nested build that ships its own wrapper is therefore found
+      # correctly — mullvad/mullvadvpn-app's `android/` has one. thunderbird-android's `components/`
+      # does NOT: it is a complete build (its own `settings.gradle.kts`, `rootProject.name =
+      # "components"`) that borrows the repository root's wrapper. The walk-up sailed past it and
+      # rendered the REPOSITORY ROOT build instead, which is a different build entirely:
+      #
+      #   Module ':ui:bolt' not found or does not apply the compose-ai-tools plugin.
+      #   206 project(s) failed to configure during discovery and were skipped
+      #     :: InvalidUserCodeException: Project ':' cannot access 'Project.buildscript' …
+      #     :app-k9mail: … :app-thunderbird: … :backend:imap: …
+      #
+      # — the root build's 206 projects, under the root build's `isolated-projects=true`, none of
+      # them the three in `components`. Both symptoms are downstream of running the wrong build, so
+      # neither the Isolated Projects step below nor an exclusion list could have fixed it.
+      #
+      # Copying the nearest ancestor's wrapper into the throwaway checkout stops the walk at the
+      # build the import actually named. `gradle-wrapper.properties` is the half that matters to the
+      # Tooling API (it is what pins the distribution); `gradlew` is the half that matters to the
+      # CLI's search. Both are copied, so the nested build resolves the same Gradle the repository
+      # would have used — this is not a version choice being made here.
+      #
+      # Deliberately confined to a directory that is a build root in its own right: without a
+      # settings file the walk-up is the CORRECT behaviour (an ordinary subproject renders from its
+      # parent build), and planting a wrapper there would break it.
+      - name: Give a nested upstream build its own Gradle wrapper
+        if: ${{ inputs.upstream-repository != '' && inputs.working-directory != '' }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "${RENDER_DIR}/settings.gradle" ] && [ ! -f "${RENDER_DIR}/settings.gradle.kts" ]; then
+            echo "${RENDER_DIR} is not a Gradle build root — the walk-up to the enclosing build is correct"
+            exit 0
+          fi
+          if [ -f "${RENDER_DIR}/gradlew" ]; then
+            echo "${RENDER_DIR} ships its own wrapper — nothing to do"
+            exit 0
+          fi
+          # Walk up from the nested build, stopping at the upstream checkout root. `upstream` is
+          # where the fetch step put it, so this cannot wander into the calling repository.
+          dir=$(dirname "${RENDER_DIR}")
+          found=""
+          while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+            if [ -f "$dir/gradlew" ] && [ -f "$dir/gradle/wrapper/gradle-wrapper.properties" ]; then
+              found="$dir"
+              break
+            fi
+            if [ "$dir" = "upstream" ]; then
+              break
+            fi
+            dir=$(dirname "$dir")
+          done
+          if [ -z "$found" ]; then
+            echo "::warning::no Gradle wrapper above ${RENDER_DIR} — the render will use whatever" \
+                 "distribution the Tooling API defaults to"
+            exit 0
+          fi
+          mkdir -p "${RENDER_DIR}/gradle/wrapper"
+          cp "$found/gradlew" "${RENDER_DIR}/gradlew"
+          chmod +x "${RENDER_DIR}/gradlew"
+          if [ -f "$found/gradlew.bat" ]; then
+            cp "$found/gradlew.bat" "${RENDER_DIR}/gradlew.bat"
+          fi
+          cp "$found"/gradle/wrapper/gradle-wrapper.* "${RENDER_DIR}/gradle/wrapper/"
+          echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
+
       - name: Disable Isolated Projects in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
         env:
@@ -1715,6 +1781,72 @@ jobs:
       # a probe with configuration-cache=true, parallel=true and IP=false runs clean; Gradle simply
       # ignores the parallel request. Touching a second property to fix a problem that does not
       # exist would be the riskier change.
+      # `working-directory` names a Gradle build nested inside the upstream repository, and the CLI
+      # finds "the project" by walking UP from its cwd until it sees a `gradlew`
+      # (`findGradleProjectRoot`). A nested build that ships its own wrapper is therefore found
+      # correctly — mullvad/mullvadvpn-app's `android/` has one. thunderbird-android's `components/`
+      # does NOT: it is a complete build (its own `settings.gradle.kts`, `rootProject.name =
+      # "components"`) that borrows the repository root's wrapper. The walk-up sailed past it and
+      # rendered the REPOSITORY ROOT build instead, which is a different build entirely:
+      #
+      #   Module ':ui:bolt' not found or does not apply the compose-ai-tools plugin.
+      #   206 project(s) failed to configure during discovery and were skipped
+      #     :: InvalidUserCodeException: Project ':' cannot access 'Project.buildscript' …
+      #     :app-k9mail: … :app-thunderbird: … :backend:imap: …
+      #
+      # — the root build's 206 projects, under the root build's `isolated-projects=true`, none of
+      # them the three in `components`. Both symptoms are downstream of running the wrong build, so
+      # neither the Isolated Projects step below nor an exclusion list could have fixed it.
+      #
+      # Copying the nearest ancestor's wrapper into the throwaway checkout stops the walk at the
+      # build the import actually named. `gradle-wrapper.properties` is the half that matters to the
+      # Tooling API (it is what pins the distribution); `gradlew` is the half that matters to the
+      # CLI's search. Both are copied, so the nested build resolves the same Gradle the repository
+      # would have used — this is not a version choice being made here.
+      #
+      # Deliberately confined to a directory that is a build root in its own right: without a
+      # settings file the walk-up is the CORRECT behaviour (an ordinary subproject renders from its
+      # parent build), and planting a wrapper there would break it.
+      - name: Give a nested upstream build its own Gradle wrapper
+        if: ${{ inputs.upstream-repository != '' && inputs.working-directory != '' }}
+        run: |
+          set -euo pipefail
+          if [ ! -f "${RENDER_DIR}/settings.gradle" ] && [ ! -f "${RENDER_DIR}/settings.gradle.kts" ]; then
+            echo "${RENDER_DIR} is not a Gradle build root — the walk-up to the enclosing build is correct"
+            exit 0
+          fi
+          if [ -f "${RENDER_DIR}/gradlew" ]; then
+            echo "${RENDER_DIR} ships its own wrapper — nothing to do"
+            exit 0
+          fi
+          # Walk up from the nested build, stopping at the upstream checkout root. `upstream` is
+          # where the fetch step put it, so this cannot wander into the calling repository.
+          dir=$(dirname "${RENDER_DIR}")
+          found=""
+          while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+            if [ -f "$dir/gradlew" ] && [ -f "$dir/gradle/wrapper/gradle-wrapper.properties" ]; then
+              found="$dir"
+              break
+            fi
+            if [ "$dir" = "upstream" ]; then
+              break
+            fi
+            dir=$(dirname "$dir")
+          done
+          if [ -z "$found" ]; then
+            echo "::warning::no Gradle wrapper above ${RENDER_DIR} — the render will use whatever" \
+                 "distribution the Tooling API defaults to"
+            exit 0
+          fi
+          mkdir -p "${RENDER_DIR}/gradle/wrapper"
+          cp "$found/gradlew" "${RENDER_DIR}/gradlew"
+          chmod +x "${RENDER_DIR}/gradlew"
+          if [ -f "$found/gradlew.bat" ]; then
+            cp "$found/gradlew.bat" "${RENDER_DIR}/gradlew.bat"
+          fi
+          cp "$found"/gradle/wrapper/gradle-wrapper.* "${RENDER_DIR}/gradle/wrapper/"
+          echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
+
       - name: Disable Isolated Projects in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
         env:

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1257,9 +1257,15 @@ jobs:
             dir=$(dirname "$dir")
           done
           if [ -z "$found" ]; then
-            echo "::warning::no Gradle wrapper above ${RENDER_DIR} — the render will use whatever" \
-                 "distribution the Tooling API defaults to"
-            exit 0
+            # Failing here rather than continuing. There is no benign outcome further on: the
+            # walk-up does not stop at `upstream`, so it either leaves the checkout entirely and
+            # lands on some unrelated `gradlew` in the runner workspace, or finds none and the CLI
+            # exits with "Cannot find Gradle project root" — a message that says nothing about the
+            # nested build being the reason. Neither is a Tooling-API default worth waiting for.
+            echo "::error::${RENDER_DIR} is a Gradle build root but neither it nor any directory" \
+                 "up to the upstream checkout has a Gradle wrapper, so the render has no" \
+                 "distribution to run and would silently target some other build"
+            exit 1
           fi
           mkdir -p "${RENDER_DIR}/gradle/wrapper"
           cp "$found/gradlew" "${RENDER_DIR}/gradlew"
@@ -1268,6 +1274,35 @@ jobs:
             cp "$found/gradlew.bat" "${RENDER_DIR}/gradlew.bat"
           fi
           cp "$found"/gradle/wrapper/gradle-wrapper.* "${RENDER_DIR}/gradle/wrapper/"
+
+          # A `distributionUrl` with no scheme is resolved RELATIVE TO the directory holding
+          # gradle-wrapper.properties, so copying the file further down the tree silently repoints
+          # it — a repository vendoring its distribution at `gradle/wrapper/gradle-x.y-bin.zip`
+          # would have the nested copy look for it under the nested build instead, and fail. Re-
+          # anchor it against the wrapper's original directory so it names the same file the
+          # ancestor's wrapper named. A value with a scheme (`https\://…`, the overwhelmingly common case) and
+          # an absolute path are both already location-independent and are left alone.
+          wrapper_properties="${RENDER_DIR}/gradle/wrapper/gradle-wrapper.properties"
+          url=$(sed -n -E 's/^[[:space:]]*distributionUrl[[:space:]]*=[[:space:]]*//p' \
+                  "$wrapper_properties" | head -1)
+          case "$url" in
+            "" | /*) ;;
+            *)
+              if printf '%s' "$url" | grep -qE '^[A-Za-z][A-Za-z0-9+.-]*\\?:'; then
+                :
+              else
+                # The base is the directory holding the PROPERTIES FILE, not the build directory,
+                # so the hop is from `<found>/gradle/wrapper` to `<render>/gradle/wrapper` — one
+                # `../` per level of the nesting does NOT reach it. Let the path library say it.
+                prefix=$(python3 -c \
+                  'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]) + "/")' \
+                  "$found/gradle/wrapper" "${RENDER_DIR}/gradle/wrapper")
+                sed -i -E "s#^([[:space:]]*distributionUrl[[:space:]]*=[[:space:]]*)#\\1${prefix}#" \
+                  "$wrapper_properties"
+                echo "re-anchored the relative distributionUrl '$url' as '${prefix}${url}'"
+              fi
+              ;;
+          esac
           echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
 
       - name: Disable Isolated Projects in the upstream checkout
@@ -1834,9 +1869,15 @@ jobs:
             dir=$(dirname "$dir")
           done
           if [ -z "$found" ]; then
-            echo "::warning::no Gradle wrapper above ${RENDER_DIR} — the render will use whatever" \
-                 "distribution the Tooling API defaults to"
-            exit 0
+            # Failing here rather than continuing. There is no benign outcome further on: the
+            # walk-up does not stop at `upstream`, so it either leaves the checkout entirely and
+            # lands on some unrelated `gradlew` in the runner workspace, or finds none and the CLI
+            # exits with "Cannot find Gradle project root" — a message that says nothing about the
+            # nested build being the reason. Neither is a Tooling-API default worth waiting for.
+            echo "::error::${RENDER_DIR} is a Gradle build root but neither it nor any directory" \
+                 "up to the upstream checkout has a Gradle wrapper, so the render has no" \
+                 "distribution to run and would silently target some other build"
+            exit 1
           fi
           mkdir -p "${RENDER_DIR}/gradle/wrapper"
           cp "$found/gradlew" "${RENDER_DIR}/gradlew"
@@ -1845,6 +1886,35 @@ jobs:
             cp "$found/gradlew.bat" "${RENDER_DIR}/gradlew.bat"
           fi
           cp "$found"/gradle/wrapper/gradle-wrapper.* "${RENDER_DIR}/gradle/wrapper/"
+
+          # A `distributionUrl` with no scheme is resolved RELATIVE TO the directory holding
+          # gradle-wrapper.properties, so copying the file further down the tree silently repoints
+          # it — a repository vendoring its distribution at `gradle/wrapper/gradle-x.y-bin.zip`
+          # would have the nested copy look for it under the nested build instead, and fail. Re-
+          # anchor it against the wrapper's original directory so it names the same file the
+          # ancestor's wrapper named. A value with a scheme (`https\://…`, the overwhelmingly common case) and
+          # an absolute path are both already location-independent and are left alone.
+          wrapper_properties="${RENDER_DIR}/gradle/wrapper/gradle-wrapper.properties"
+          url=$(sed -n -E 's/^[[:space:]]*distributionUrl[[:space:]]*=[[:space:]]*//p' \
+                  "$wrapper_properties" | head -1)
+          case "$url" in
+            "" | /*) ;;
+            *)
+              if printf '%s' "$url" | grep -qE '^[A-Za-z][A-Za-z0-9+.-]*\\?:'; then
+                :
+              else
+                # The base is the directory holding the PROPERTIES FILE, not the build directory,
+                # so the hop is from `<found>/gradle/wrapper` to `<render>/gradle/wrapper` — one
+                # `../` per level of the nesting does NOT reach it. Let the path library say it.
+                prefix=$(python3 -c \
+                  'import os, sys; print(os.path.relpath(sys.argv[1], sys.argv[2]) + "/")' \
+                  "$found/gradle/wrapper" "${RENDER_DIR}/gradle/wrapper")
+                sed -i -E "s#^([[:space:]]*distributionUrl[[:space:]]*=[[:space:]]*)#\\1${prefix}#" \
+                  "$wrapper_properties"
+                echo "re-anchored the relative distributionUrl '$url' as '${prefix}${url}'"
+              fi
+              ;;
+          esac
           echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
 
       - name: Disable Isolated Projects in the upstream checkout


### PR DESCRIPTION
`workingDirectory` names a Gradle build nested inside the upstream repository, but the CLI resolves "the project" by walking **up** from its cwd to the first directory holding a `gradlew` (`findGradleProjectRoot`, `cli/.../VersionPin.kt`). A nested build that ships its own wrapper is found correctly — mullvad/mullvadvpn-app's `android/` has one, which is why that import was never affected. thunderbird-android's `components/` does not: it is a complete build (own `settings.gradle.kts`, `rootProject.name = "components"`) that borrows the repository root's wrapper.

So the walk-up sailed past it and rendered the repository **root** build:

```
Module ':ui:bolt' not found or does not apply the compose-ai-tools plugin.
206 project(s) failed to configure during discovery and were skipped
  :: InvalidUserCodeException: Project ':' cannot access 'Project.buildscript' …
  :app-k9mail: … :app-thunderbird: … :backend:imap: …
```

206 is the root build's project count, under the root build's `isolated-projects=true`; `components` has three, and none of them appears in that list. Both symptoms are downstream of running the wrong build.

## Why the previous diagnosis was wrong

That `InvalidUserCodeException` looked like the Isolated Projects failure #5022 addresses, and #5022 was merged and carried by the failing run (`referenced_workflows` sha `37db480e`). It changed nothing, because it writes to `${RENDER_DIR}/gradle.properties` = `components/gradle.properties`, which never had the property — the `isolated-projects=true` is at thunderbird's **repository root**, i.e. in the build that was being run by mistake.

Verified rather than assumed: configuring `components/` directly with Gradle 9.7 and the same `allprojects { buildscript { … } }` injection auto-inject performs probes Isolated Projects as **inactive** and configures clean. A separate probe ruled out `org.gradle.configuration-cache.parallel=true` (which `components/gradle.properties` does set) as an alternative source of the same restriction, on both 8.14.3 and 9.7.

## The fix

Copy the nearest ancestor's wrapper into the throwaway checkout, so the walk stops at the build the import actually named. `gradle-wrapper.properties` is the half that matters to the Tooling API — it pins the distribution — and `gradlew` is the half the CLI's search looks for; both are copied, so the nested build resolves the same Gradle the repository would have used. No version choice is being made here.

Confined to a directory that is a build root in its own right: without a settings file the walk-up is the **correct** behaviour (an ordinary subproject renders from its parent build), and planting a wrapper there would break it.

## Testing

The step's script was extracted from the workflow and exercised against five fixtures:

| fixture | result |
| --- | --- |
| thunderbird shape — nested build root, no wrapper, ancestor has one | wrapper copied |
| mullvad shape — nested build ships its own wrapper | left alone |
| ordinary subdirectory, not a build root | left alone |
| nested build root, no wrapper anywhere above | warns, continues |
| two-level nesting | wrapper copied |

Then against a real sparse checkout of thunderbird-android: after the copy, a walk-up from `upstream/components` stops at `upstream/components`, on the same `gradle-9.7.0-all.zip` the repository pins.

`--range origin/main..HEAD` passes `agent-attribution-scan.sh`; the workflow parses as YAML.

## Follow-up

The underlying CLI behaviour is still worth fixing at the source — a directory with its own settings file is a Gradle build root whether or not it has a wrapper, and `findGradleProjectRoot` could stop there while taking the distribution from the nearest ancestor wrapper. That change only reaches imports on the next CLI release, which is why the pipeline-side fix lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_