### PR TITLE
fix: capture the font family a Wear clock draws with

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeFigmaSvgDataProduct.kt
@@ -220,13 +220,16 @@ object ComposeFigmaSvgDataProducer {
   /** Sidecar naming the faces the render drew with that the export could not reproduce. */
   const val FILE_FONT_WARNINGS: String = "compose-figma-fonts.warnings.json"
 
-  /** Every family named on a `<text>` in [layer]'s subtree. */
+  /** Every family named on a `<text>` or curved `<textPath>` run in [layer]'s subtree. */
   private fun capturedFamilies(layer: FigmaSvgLayer): Set<String> = buildSet {
     fun walk(node: FigmaSvgLayer) {
       node.text?.let { text ->
         text.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) }
         text.spans?.forEach { span -> span.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) } }
       }
+      // A Wear clock's face counts too: it is drawn text, so leaving it out let the export declare
+      // every face named and embed none of the clock's (compose-preview-server#201).
+      node.curvedTexts.forEach { ct -> ct.fontFamily?.takeIf { it.isNotBlank() }?.let { add(it) } }
       node.children.forEach(::walk)
     }
     walk(layer)
@@ -239,6 +242,7 @@ object ComposeFigmaSvgDataProducer {
         t.content.codePoints().toArray().forEach { add(it) }
         t.lines?.forEach { line -> line.content.codePoints().toArray().forEach { add(it) } }
       }
+      node.curvedTexts.forEach { ct -> ct.text.codePoints().toArray().forEach { add(it) } }
       node.children.forEach(::walk)
     }
     walk(layer)
@@ -408,6 +412,15 @@ object ComposeFigmaSvgDataProducer {
             t.content.substring(start, end).codePoints().toArray().forEach { cps.add(it) }
           }
         }
+      }
+      // Curved runs subset like any other: one face key per run, carrying just its digits and
+      // separator. No spans and no italic — a `CurvedTextStyle` run is a single uniform style.
+      layer.curvedTexts.forEach { ct ->
+        val cps =
+          codePointsByFace.getOrPut(Triple(ct.fontFamily, ct.fontWeight ?: 400, false)) {
+            LinkedHashSet()
+          }
+        ct.text.codePoints().toArray().forEach { cps.add(it) }
       }
       layer.children.forEach(::collect)
     }

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1911,6 +1911,21 @@ internal object ComposeLayoutInspector {
           ?.let { runCatching { call(it, "getTypeface") }.getOrNull() }
           ?.let { tf -> call(tf, "getWeight") as? Int }
           ?.takeIf { it in 1..1000 }
+      // The family the run resolved to. `CurvedTextChild` keeps the *merged* style on its private
+      // `actualStyle` (`DefaultCurvedTextStyles + style()`); the `style` lambda alone reports only
+      // the caller's overrides, so a clock that inherits the theme's face would report nothing.
+      // Labelled through the same `fontFamilyLabel` the straight-text paths use, so the export
+      // can't end up with two spellings of one face (compose-preview-server#201: without a family
+      // the `<textPath>` inherited the document default while every straight run named the
+      // theme's).
+      val style = runCatching { field(child, "actualStyle") }.getOrNull()
+      val family = style?.let {
+        layoutTextFontFamilyLabel(
+          call(it, "getFontFamily") as? FontFamily,
+          call(it, "getFontWeight") as? FontWeight,
+          call(it, "getFontStyle") as? FontStyle,
+        )
+      }
       return LayoutInspectorCurvedText(
         text = text,
         centerXPx = cx,
@@ -1922,6 +1937,7 @@ internal object ComposeLayoutInspector {
         fontSizePx = fontSize,
         fontWeight = weight,
         colorArgb = color,
+        fontFamily = family,
       )
     }
 

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/FigmaFontEmbedTest.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsNode
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsPayload
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsTypography
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorBounds
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorCurvedText
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorPayload
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorSize
@@ -213,6 +214,56 @@ class FigmaFontEmbedTest {
     assertFalse(
       "no bare sans-serif default when embedding",
       svg.contains("""font-family="sans-serif""""),
+    )
+  }
+
+  /**
+   * compose-preview-server#201: a Wear clock's face is drawn text like any other, but the export
+   * only looked at `<text>` nodes — so a curved run's family reached neither the "everything the
+   * export can name" set nor the embedder, and the `<textPath>` fell back to the document default.
+   */
+  @Test
+  fun writeSvgEmbedsTheFaceACurvedClockNames() {
+    val clock =
+      LayoutInspectorNode(
+        nodeId = "TimeText",
+        component = "CurvedLayoutKt",
+        bounds = LayoutInspectorBounds(0, 0, 200, 100),
+        size = LayoutInspectorSize(200, 100),
+        curvedTexts =
+          listOf(
+            LayoutInspectorCurvedText(
+              text = "10:10",
+              centerXPx = 100.0,
+              centerYPx = 100.0,
+              radiusPx = 80.0,
+              startAngleRadians = 4.4652,
+              sweepRadians = 0.4944,
+              clockwise = true,
+              fontSizePx = 15.0,
+              fontWeight = 600,
+              fontFamily = "Roboto Flex",
+            )
+          ),
+      )
+    val resolver = FigmaFontResolver { family, weight, italic ->
+      if (family == "Roboto Flex" && weight == 600 && !italic) byteArrayOf(7, 7, 7) else null
+    }
+
+    ComposeFigmaSvgDataProducer.writeSvg(
+      dir,
+      previewId = "clock",
+      layout = LayoutInspectorPayload(clock),
+      fontResolver = resolver,
+    )
+
+    val svg = dir.resolve("clock").resolve(ComposeFigmaSvgDataProducer.FILE_SVG).readText()
+    assertTrue("the clock's face is embedded", svg.contains("data:font/woff2;base64,BwcH"))
+    assertTrue("at the weight the run draws", svg.contains("font-weight:600"))
+    assertTrue("and the run names it", svg.contains("""font-family="Roboto Flex""""))
+    assertFalse(
+      "so nothing is reported as unnameable",
+      dir.resolve("clock").resolve(ComposeFigmaSvgDataProducer.FILE_FONT_WARNINGS).exists(),
     )
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -356,7 +356,7 @@ coil3 = "3.5.0"
 # here. This repository consumes them; it no longer owns these coordinates. A change to a contract
 # reaches this build only through a release there — see that repository's docs/VERSIONING.md.
 # A point pin, deliberately: a range would let a contract change arrive without a pull request.
-composeai-contracts = "2.3.0"
+composeai-contracts = "2.5.0"
 
 # The preview server, published from yschimke/compose-preview-server since its 2.0.0 — the
 # extraction #4732 planned. This repository no longer owns `cli/serve`: `compose-preview serve`,

--- a/preview-server/preview-harness/fixtures/pages/serve-wear-scroll-long-capsule.html
+++ b/preview-server/preview-harness/fixtures/pages/serve-wear-scroll-long-capsule.html
@@ -25,7 +25,7 @@
   <rect x="0" y="0" width="227" height="1201" rx="113" ry="113" fill="#000000"/>
   <g id="WearScrollExtract">
     <g id="ReusableComposeNode">
-      <path id="curve-c0" d="M 93.49 18.2 A 97.37 97.37 0 0 1 133.5 18.2" fill="none"/><text font-size="15" font-weight="599" fill="#C6C6C7" dominant-baseline="alphabetic"><textPath href="#curve-c0" startOffset="50%" text-anchor="middle">10:10</textPath></text>
+      <path id="curve-c0" d="M 93.49 18.2 A 97.37 97.37 0 0 1 133.5 18.2" fill="none"/><text font-size="15" font-family="&apos;Roboto Flex&apos;, sans-serif" font-weight="599" fill="#C6C6C7" dominant-baseline="alphabetic"><textPath href="#curve-c0" startOffset="50%" text-anchor="middle">10:10</textPath></text>
       <g id="ReusableComposeNode">
       </g>
     </g>

--- a/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearCurvedTextFontFamilyTest.kt
+++ b/renderers/android/src/test/kotlin/ee/schimke/composeai/renderer/WearCurvedTextFontFamilyTest.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.renderer
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.LocalInspectionTables
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.text.font.FontFamily
+import androidx.wear.compose.foundation.CurvedTextStyle
+import androidx.wear.compose.material3.TimeText
+import androidx.wear.compose.material3.timeTextCurvedText
+import ee.schimke.composeai.daemon.LayoutInspectorDataProducer
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorCurvedText
+import ee.schimke.composeai.data.layoutinspector.LayoutInspectorNode
+import ee.schimke.composeai.data.render.PreviewContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * A Wear `TimeText` clock is captured by reflecting on `CurvedTextChild`, whose resolved style
+ * lives on a **private `actualStyle` field** — the merged `DefaultCurvedTextStyles + style()`. The
+ * `style` lambda beside it carries only the caller's overrides, so reading that instead would
+ * report nothing for a clock that inherits the theme's face.
+ *
+ * Without the family the figma-svg export emitted a `<textPath>` with no `font-family` at all, so
+ * the clock inherited the document default while every straight run named the theme's face — the
+ * SVG drew the time in the wrong font (yschimke/compose-preview-server#201).
+ *
+ * Like `ComposeInternalFieldContractTest`, this is a **canary over a reflective read**: the read is
+ * wrapped in `runCatching`, so an androidx rename doesn't throw — the family silently goes back to
+ * null and the bug returns with nothing else failing. A generic family is used deliberately: it
+ * needs no font file, and it round-trips through `fontFamilyLabel` as a stable CSS-ish name.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WearCurvedTextFontFamilyTest {
+
+  @Test
+  fun `a curved clock reports the family its resolved style names`() {
+    val curved = captureClock()
+
+    assertNotNull("the clock was captured as a curved run", curved)
+    assertEquals("10:10", curved!!.text)
+    assertEquals("monospace", curved.fontFamily)
+  }
+
+  /** The single curved run of a `TimeText` whose style pins a distinctive family. */
+  private fun captureClock(): LayoutInspectorCurvedText? {
+    RuntimeEnvironment.setQualifiers("w384dp-h384dp-round-xhdpi")
+    @Suppress("DEPRECATION") val rule = createAndroidComposeRule<ComponentActivity>()
+    var captured: LayoutInspectorCurvedText? = null
+    val statement =
+      object : Statement() {
+        override fun evaluate() {
+          val slots = mutableSetOf<CompositionData>()
+          rule.setContent {
+            InspectableCurvedContent(slots) {
+              TimeText {
+                timeTextCurvedText("10:10", CurvedTextStyle(fontFamily = FontFamily.Monospace))
+              }
+            }
+          }
+          rule.waitForIdle()
+          val semRoot = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode()
+          val ctx =
+            PreviewContext.Builder("wear-curved-font", null, null, "wear-curved-font")
+              .rootForTest(semRoot.root as RootForTest)
+              .addSlotTables(slots.toList())
+              .parameterInformationCollected()
+              .build()
+          val layout = LayoutInspectorDataProducer.buildPayload(ctx, density = 2f)!!
+          captured = firstCurvedRun(layout.root)
+        }
+      }
+    rule
+      .apply(statement, Description.createTestDescription(javaClass, "wear-curved-font"))
+      .evaluate()
+    return captured
+  }
+
+  private fun firstCurvedRun(node: LayoutInspectorNode): LayoutInspectorCurvedText? =
+    node.curvedTexts.firstOrNull() ?: node.children.firstNotNullOfOrNull(::firstCurvedRun)
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectableCurvedContent(
+  capture: MutableSet<CompositionData>,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture, content = content)
+}


### PR DESCRIPTION
Closes the second half of yschimke/compose-preview-server#201 — *SVG uses the wrong font for TimeText*. The first half was yschimke/compose-preview-contracts#38, released as contracts **2.5.0**.

## What went wrong

The served sticker embeds the theme's face and names it on every straight run, but the curved `TimeText` run named nothing:

```
<svg … font-family="Roboto">
  <style>@import url('…css2?family=Roboto+Flex:wght@600&display=swap');</style>
  <text font-size="32" font-family="Roboto Flex" font-weight="550" …>Row 1</text>
  <path id="curve-c0" …/><text font-size="30" font-weight="599" …><textPath …>10:10</textPath></text>
</svg>
```

So the clock fell back to the document default `Roboto` — which in `?mode=web` the Google Fonts `@import` does not even fetch. Two causes, both here:

1. **The capture never had the family.** `CurvedTextChild` exposes the *merged* style only on a private `actualStyle` field (`DefaultCurvedTextStyles + style()`); the `style` lambda beside it carries just the caller's overrides, so a clock inheriting the theme's face states nothing there.
2. **The font machinery was straight-text-only.** `capturedFamilies` and `codePointsByFace` walked `<text>` nodes and skipped `curvedTexts` entirely, so even a named curved face would never be embedded or subset.

## What changed

- `CurvedTextExtractor` reads `actualStyle` and labels the family through the same `fontFamilyLabel` the straight-text paths use, so the two capture paths can't spell one face two ways.
- `capturedFamilies` counts curved families (they no longer look unnameable and trip the tofu path) and `codePointsByFace` subsets each curved run's glyphs onto its own face.
- `composeai-contracts` → `2.5.0` for the new `LayoutInspectorCurvedText.fontFamily`.
- The committed wear-scroll capsule fixture is regenerated: its clock now carries `font-family="&apos;Roboto Flex&apos;, sans-serif"`, which is the whole point of the change.

## Test plan

- `:data-layoutinspector-connector:test` and `:renderer-android:testDebugUnitTest --tests '*Wear*' --tests '*FigmaSvg*'` — green, resolving contracts 2.5.0 from Maven Central (not a local snapshot).
- **New `WearCurvedTextFontFamilyTest`** — renders a real Wear `TimeText` under Robolectric with `CurvedTextStyle(fontFamily = FontFamily.Monospace)` and asserts the captured run reports `monospace`. This is a canary over a reflective read, in the spirit of `ComposeInternalFieldContractTest`: the read is `runCatching`-wrapped, so an androidx rename wouldn't throw — the family would silently go back to null and the bug would return with nothing else failing.
- **New case in `FigmaFontEmbedTest`** — a curved run's face is embedded (`data:font/woff2;…`) at the weight it draws, named on the run, and leaves no font-warnings sidecar.
- The drift guard in `WearScrollSvgGrowthTest` failed *before* regeneration with exactly the expected delta (`font-size="15" font-family="&apos;Roboto Flex&apos;, sans-serif" font-weight="599"` vs. no family) — end-to-end evidence through a real Wear render that the clock now names its face.

Visual evidence is deliberately omitted: nothing here changes rendered pixels. The bug and the fix both live in the vector export, and the fixture diff above is the artefact that actually changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8gcuP8saMxsMGSJtqR5cz

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8gcuP8saMxsMGSJtqR5cz)_