### PR TITLE
fix(import): surface the renderer's .error.json sidecars when a render fails

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -2579,13 +2579,60 @@ jobs:
         run: |
           set +e
           root="${GITHUB_WORKSPACE}/${RENDER_DIR:-.}"
+          mkdir -p "$GITHUB_WORKSPACE/render-failure-diagnostics"
+
+          # The renderer writes a `.error.json` beside where each PNG would have gone, on BOTH
+          # lanes. Collect those first, because on the desktop lane they are the ONLY per-preview
+          # evidence that exists: `composePreviewRenderAll` (Robolectric) reads its sidecars back
+          # into the Gradle failure message, but `composePreviewRender` (desktop) only points at
+          # them —
+          #
+          #   composePreviewRender: 90 capture(s) were drawn and none produced a file. … check the
+          #   `Render failed for …` lines above and the `.error.json` sidecars beside the expected
+          #   outputs
+          #
+          # — and neither the `Render failed for …` lines (they need --verbose) nor the sidecars
+          # reach CI. A desktop-lane render that fails wholesale therefore leaves a log saying only
+          # that it failed, which is what made DroidKaigi's :core:ui undiagnosable from a CI run.
+          #
+          # Printed as well as uploaded: an artifact is the wrong place for the one fact a reader
+          # needs, and downloading one is not always possible from where the log is being read.
+          mapfile -t sidecars < <(find "$root" -name '*.error.json' -type f 2>/dev/null | sort)
+          if [ "${#sidecars[@]}" -gt 0 ]; then
+            echo "::group::Per-preview render errors (${#sidecars[@]} .error.json sidecar(s))"
+            for f in "${sidecars[@]}"; do
+              rel="${f#"$root"/}"
+              mkdir -p "$GITHUB_WORKSPACE/render-failure-diagnostics/$(dirname "$rel")"
+              cp "$f" "$GITHUB_WORKSPACE/render-failure-diagnostics/$rel" 2>/dev/null
+            done
+            # Bounded on purpose: one wholesale failure produces one sidecar per preview, all
+            # saying the same thing, and 300 copies of it buries the rest of the log. The upload
+            # above keeps every one of them.
+            for f in "${sidecars[@]:0:25}"; do
+              echo "--- ${f#"$root"/}"
+              head -c 4000 "$f"
+              echo
+            done
+            if [ "${#sidecars[@]}" -gt 25 ]; then
+              echo "… and $(( ${#sidecars[@]} - 25 )) more, in the uploaded diagnostics artifact"
+            fi
+            echo "::endgroup::"
+          fi
+
           # Only the render task's own results: other test tasks in the build are not this failure.
           mapfile -t xml < <(find "$root" -path '*/build/test-results/composePreviewRender/*.xml' -type f 2>/dev/null)
           if [ "${#xml[@]}" -eq 0 ]; then
-            echo "No composePreviewRender test results under $root — the render failed before it ran any preview."
+            # Two very different situations, and saying the wrong one sends the reader off in the
+            # wrong direction. JUnit results exist only on the Robolectric lane, so their absence
+            # beside sidecars is expected rather than evidence of anything.
+            if [ "${#sidecars[@]}" -gt 0 ]; then
+              echo "No composePreviewRender JUnit results under $root — expected on the desktop lane," \
+                   "which writes none. The per-preview errors are the sidecars above."
+            else
+              echo "No composePreviewRender test results under $root — the render failed before it ran any preview."
+            fi
             exit 0
           fi
-          mkdir -p "$GITHUB_WORKSPACE/render-failure-diagnostics"
           for f in "${xml[@]}"; do
             cp "$f" "$GITHUB_WORKSPACE/render-failure-diagnostics/" 2>/dev/null
           done


### PR DESCRIPTION
The two render lanes are asymmetric about their own diagnostics. `composePreviewRenderAll` (Robolectric) reads its sidecars back into the Gradle failure message, so an Android-lane failure names the exception — that is how element-x's `ClassNotFoundException: androidx.customview.poolingcontainer.R$id` was identifiable from CI. The desktop lane's `composePreviewRender` only points at them:

```
composePreviewRender: 90 capture(s) were drawn and none produced a file.
… check the `Render failed for …` lines above and the `.error.json` sidecars
beside the expected outputs
```

Neither half reaches CI. The `Render failed for …` lines need `--verbose`, and the sidecars were never collected — the diagnostics step looked only for `composePreviewRender` JUnit XML, which the desktop lane does not write. A wholesale desktop-lane failure therefore leaves a log that says it failed and nothing about why, which is what left DroidKaigi's `:core:ui` undiagnosable from a CI run (yschimke/compose-preview-imports#5027).

## Changes

- Collect `.error.json` sidecars on both lanes, into the uploaded diagnostics **and** the log. An artifact is the wrong home for the one fact a reader needs, and downloading one is not always possible from wherever the log is being read.
- Cap the printed set at 25. A wholesale failure writes one sidecar per preview, all saying the same thing; 300 copies would bury the rest of the log. Every one still goes into the artifact.
- Fix the trailing message, which was becoming a lie: JUnit results exist only on the Robolectric lane, so their absence beside a pile of sidecars is expected rather than evidence of an early failure. It now distinguishes the two.

## Testing

Step script extracted from the workflow and run against three fixtures:

| fixture | result |
| --- | --- |
| sidecars + JUnit XML | both surfaced, both collected |
| 30 sidecars, no XML (the desktop shape) | 25 printed, 30 collected, "expected on the desktop lane" message |
| empty tree | original "failed before it ran any preview" message, exit 0 |

## Follow-up

The narrower fix belongs in the plugin: `RenderPreviewsTask` could read its sidecars into the failure message the way `ComposePreviewTasks` already does for the Robolectric lane, so the asymmetry disappears for every consumer rather than just CI. That needs a release cycle; this does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_