### PR TITLE
feat(discovery): compile the printed call sites, and fix what that caught

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -737,6 +737,13 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > no component at all. `Button` and `Card` take no value-class parameters, which is
 > exactly why the hand-written unit tests were green and stayed green.
 >
+> The same mangling was dropping the project's *own* composables from `targets`,
+> which is the half a typical app actually hits: `AppTile(padding: Dp)` compiles to
+> `AppTile-<hash>`, so its preview reported `targets = []` for a composable the
+> preview does nothing but render. `Dp` and `Color` parameters are ordinary in app
+> code, so this was not an edge case — it was §1's "detect components from previews
+> in typical projects" quietly failing on the typical projects.
+>
 > The lesson generalises past this bug: a corpus you chose is a corpus that agrees
 > with you. Both fixtures I picked by hand happened to avoid the one construct that
 > breaks the path, and only compiling something real found it.

--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -737,12 +737,19 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > no component at all. `Button` and `Card` take no value-class parameters, which is
 > exactly why the hand-written unit tests were green and stayed green.
 >
-> The same mangling was dropping the project's *own* composables from `targets`,
-> which is the half a typical app actually hits: `AppTile(padding: Dp)` compiles to
-> `AppTile-<hash>`, so its preview reported `targets = []` for a composable the
-> preview does nothing but render. `Dp` and `Color` parameters are ordinary in app
-> code, so this was not an edge case — it was §1's "detect components from previews
-> in typical projects" quietly failing on the typical projects.
+> The same mangling drops the project's *own* composables from `targets`:
+> `AppTile(padding: Dp)` compiles to `AppTile-<hash>`, so its preview reports
+> `targets = []` for a composable the preview does nothing but render. **That half is
+> deliberately left alone**, because `DiscoveryFunctionalTest` pins it with a
+> purpose-built `@JvmInline` fixture — a decision, not an oversight — and the two
+> paths can legitimately differ: `ComponentSymbol` separates `callable` (the
+> source-level name an import needs) from `jvmOwner` (the reflection handle), while a
+> `targets` entry has a single name that consumers may be using as a JVM lookup key,
+> and `ComponentsKt.Screen` does not exist at runtime when the method is
+> `Screen-<hash>`. Whether `targets` should demangle is a question for whoever owns
+> that contract; if it should, `Dp` and `Color` parameters are ordinary enough in app
+> code that this is §1's "detect components from previews in typical projects"
+> failing on the typical projects.
 >
 > The lesson generalises past this bug: a corpus you chose is a corpus that agrees
 > with you. Both fixtures I picked by hand happened to avoid the one construct that

--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -717,6 +717,29 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > `Shape`, a domain type), any callback of arity two or more, any callback with a
 > non-`Unit` return. Widening the placeholder table is the obvious next increment
 > and should be paid for by the compile gate, not by confidence.
+>
+> **The gate is in, and it paid for itself on the first run.**
+> `ComponentCallSiteCompileFunctionalTest` builds a real Compose Multiplatform
+> project, discovers its `androidx.compose.material3` components, prints their call
+> sites, writes them into that project and compiles them — so the Kotlin compiler,
+> not an argument in a code review, decides whether a snippet is real. Its
+> load-bearing assertion is the vacuity guard: a generator that refused everything
+> would emit an empty file that compiles perfectly, so the test names components it
+> insists were emitted.
+>
+> That guard failed immediately, on `Text`. Kotlin mangles the JVM name of any
+> function whose signature mentions a value class, so `androidx.compose.material3.Text`
+> compiles to `TextKt."Text-Nvy7gAk"` — its `fontSize`, `color` and `overflow`
+> parameters are `TextUnit`, `Color` and `TextOverflow`. `isComponentLibraryTarget`
+> rejects a name that is not a usable Kotlin import, and a mangled name is not, so
+> **every Material 3 component whose signature mentions `Color`, `Dp` or `TextUnit`
+> was being dropped from the record**. A preview whose only call was `Text` inferred
+> no component at all. `Button` and `Card` take no value-class parameters, which is
+> exactly why the hand-written unit tests were green and stayed green.
+>
+> The lesson generalises past this bug: a corpus you chose is a corpus that agrees
+> with you. Both fixtures I picked by hand happened to avoid the one construct that
+> breaks the path, and only compiling something real found it.
 
 **Phase 4 — the builder on the record.** Generate the capability catalog;
 generate `UiBuilderRenderer` / `CapabilityComposeCodeExporter` for the Wasm tier

--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -747,6 +747,30 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > The lesson generalises past this bug: a corpus you chose is a corpus that agrees
 > with you. Both fixtures I picked by hand happened to avoid the one construct that
 > breaks the path, and only compiling something real found it.
+>
+> **Measured reach.** Over a 28-component Material 3 surface (buttons, cards, chips,
+> toggles, progress, scaffolding, list and navigation items, dialogs), **26 emit a
+> call site and 2 refuse** — the two being `TextField` / `OutlinedTextField`, whose
+> required `state: TextFieldState` genuinely has no literal to write. So the
+> placeholder table is not the bottleneck it looked like from the outside, and
+> widening it further would buy very little: what is left needs *values*, which is
+> Phase 2's argument binding, not more literals.
+>
+> The first run of that measurement read 25/30 with five refusals, three of which —
+> `Checkbox`, `RadioButton`, `Switch` — turned out to share one cause: material3
+> declares their callbacks `((Boolean) -> Unit)?`, and no lambda-shaped rule accepts
+> a nullable function type. Fixing that also surfaced a trap worth recording, because
+> the obvious fix is wrong: a rendered type ending in `?` does **not** mean the
+> parameter is nullable. `(Int) -> String?` is a non-null callback returning a
+> nullable value, and answering `null` for it emits source that does not compile.
+> Nullability is now carried structurally on `TargetParameter.nullable` rather than
+> read off the spelling — and `renderType` separately parenthesises nullable function
+> types, because `(Boolean) -> Unit?` was being handed to every consumer as the
+> rendering of `((Boolean) -> Unit)?`.
+>
+> Caveat on the number: that surface is hand-picked, so it measures the *table*, not
+> a catalog. The corpus ratios §7 asks for still have to come from m3-catalog,
+> wear-m3 and Confetti.
 
 **Phase 4 — the builder on the record.** Generate the capability catalog;
 generate `UiBuilderRenderer` / `CapabilityComposeCodeExporter` for the Wasm tier

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -95,6 +95,12 @@ object ComponentSnippets {
   private fun placeholderFor(parameter: TargetParameter): String? {
     if (parameter.nullable) return "null"
     val type = parameter.type
+    // A record written before `nullable` existed defaults it to `false`, so a persisted v1
+    // `components.json` would lose every `String?` it used to answer for. For a type with no
+    // arrow the spelling is unambiguous — type arguments close with `>`, so `List<String?>` does
+    // not reach here looking nullable — and this reads it as the fallback it is. Function types
+    // deliberately get no fallback: `(Int) -> String?` ends in `?` and is *not* nullable.
+    if (!type.contains("->") && type.endsWith("?")) return "null"
     if (parameter.composableSlot || type.contains("->")) return emptyLambda(type)
     return when (type) {
       "String" -> "\"\""

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -82,18 +82,20 @@ object ComponentSnippets {
   /**
    * A literal for [parameter] that is guaranteed to type-check, or null to refuse.
    *
-   * Ordered so the function-type cases never fall into the nullable shortcut: the type renderer
-   * appends `?` to the whole rendering, so a nullable `(() -> Unit)?` reads as `() -> Unit?` and is
-   * indistinguishable from a non-null function returning `Unit?`. Refusing anything with an arrow
-   * that [emptyLambda] does not accept keeps that ambiguity from becoming emitted code.
+   * The nullable test comes first and needs no per-type knowledge, because `null` satisfies every
+   * nullable type. It reads [TargetParameter.nullable] rather than looking for a trailing `?` in
+   * the rendered type, because the spelling does not distinguish a nullable parameter (`String?`)
+   * from a non-null function whose *return* is nullable (`(Int) -> String?`) — and `null`
+   * type-checks for the first but not the second. Testing the spelling would emit uncompilable
+   * source for every callback returning a nullable value.
+   *
+   * That test is what lets `Checkbox`, `RadioButton` and `Switch` through: material3 declares their
+   * `onCheckedChange` / `onClick` as `((Boolean) -> Unit)?`, which no lambda-shaped rule accepts.
    */
   private fun placeholderFor(parameter: TargetParameter): String? {
+    if (parameter.nullable) return "null"
     val type = parameter.type
     if (parameter.composableSlot || type.contains("->")) return emptyLambda(type)
-    // `null` satisfies every nullable type, so this needs no per-type knowledge. `List<String?>`
-    // does not reach here looking nullable: the renderer closes type arguments with `>`, and only a
-    // genuinely nullable type ends in `?`.
-    if (type.endsWith("?")) return "null"
     return when (type) {
       "String" -> "\"\""
       "Boolean" -> "false"

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -43,6 +43,8 @@ import org.objectweb.asm.Opcodes
  * refuse.
  */
 internal data class ComposableSignatureInfo(
+  /** The source-level function name, straight from metadata — never the mangled JVM name. */
+  val name: String,
   val parameters: List<TargetParameter>,
   val receiver: String?,
 )
@@ -93,6 +95,11 @@ internal object ComposableSignature {
         }
       val fn = matchFunction(functions, method) ?: return null
       ComposableSignatureInfo(
+        // The name as the author wrote it. Metadata carries it directly, which is the only way to
+        // get it right: the JVM name may be value-class-mangled (`Text-Nvy7gAk`) *or* a legally
+        // escaped declaration whose own name contains a hyphen (``fun `filled-button`()``), and no
+        // amount of string surgery on the JVM name distinguishes those two.
+        name = fn.name,
         parameters = fn.valueParameters.map { it.toTargetParameter() },
         receiver =
           fn.receiverParameterType?.let { receiver ->

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -185,6 +185,7 @@ internal object ComposableSignature {
       hasDefault = declaresDefaultValue,
       composableSlot = slot,
       composableSlotReceiver = if (slot) receiverFqnOf(type) else null,
+      nullable = type.isNullable,
     )
   }
 
@@ -211,6 +212,7 @@ internal object ComposableSignature {
    * or agent completing the Code Connect mapping supplies the real value.
    */
   private fun renderType(type: KmType): String {
+    val isFunction = (type.classifier as? KmClassifier.Class)?.name?.let { isFunctionClassName(it) }
     val base =
       when (val c = type.classifier) {
         is KmClassifier.Class -> {
@@ -231,6 +233,15 @@ internal object ComposableSignature {
       } else {
         ""
       }
+    // A nullable function type has to be parenthesised or the `?` reads as part of the return type:
+    // material3's `onCheckedChange: ((Boolean) -> Unit)?` rendered as `(Boolean) -> Unit?`, which
+    // says the callback returns `Unit?` and is nullable nowhere — the opposite of the truth, handed
+    // to every consumer of this string.
+    //
+    // This corrects the rendering only. Nullability that a *generator* acts on comes from
+    // `TargetParameter.nullable`, because even parenthesised the spelling stays ambiguous in the
+    // other direction: a non-null `(Int) -> String?` ends in `?` too.
+    if (type.isNullable && isFunction == true) return "($base$args)?"
     return base + args + if (type.isNullable) "?" else ""
   }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1436,6 +1436,16 @@ data class TargetParameter(
    * can define the same simple `RowScope`, and `RowScope` alone cannot be imported.
    */
   val composableSlotReceiver: String? = null,
+  /**
+   * Whether the parameter's own type is nullable, read from metadata rather than inferred from
+   * [type]'s spelling.
+   *
+   * The spelling cannot carry it. A rendered type ends in `?` both when the parameter is nullable
+   * (`String?`) and when it is a non-null function whose *return* is (`(Int) -> String?`), and the
+   * two want opposite treatment from anything generating an argument: `null` type-checks for the
+   * first and not for the second. Recorded structurally so no consumer has to guess.
+   */
+  val nullable: Boolean = false,
 )
 
 @Serializable

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -257,10 +257,15 @@ object PreviewTargetInference {
         .filter { it.ownerFqn in projectClassFqns }
         .mapNotNull { resolveCandidate(it, scanResult) }
         .filterNot { candidate ->
-          !isValidKotlinImportIdentifier(candidate.method.name) ||
-            isPreviewOnlyWrapper(candidate.method.name, resolveSourceFile(candidate.ownerFqn))
+          // Demangled first: a project composable taking a `Dp` compiles to `MyCard-abc123`, which
+          // is not a usable import and was therefore dropped outright — the same value-class
+          // mangling that hid `Text` from the component path, and more common here because `Dp`
+          // and `Color` parameters are ordinary in an app's own composables.
+          val name = sourceFunctionName(candidate.method.name)
+          !isValidKotlinImportIdentifier(name) ||
+            isPreviewOnlyWrapper(name, resolveSourceFile(candidate.ownerFqn))
         }
-        .distinctBy { it.ownerFqn to it.method.name }
+        .distinctBy { it.ownerFqn to sourceFunctionName(it.method.name) }
         .toList()
 
     if (candidates.isEmpty()) return emptyList()
@@ -549,12 +554,18 @@ object PreviewTargetInference {
    * `TextUnit`, `Color` and `TextOverflow`. A Kotlin identifier can never contain `-`, so the first
    * one is unambiguously the mangling boundary.
    *
-   * This is load-bearing rather than cosmetic. [isComponentLibraryTarget] rejects a name that is
-   * not a usable import, and a mangled name is not — so before this, **every Material 3 component
-   * whose signature mentions `Color`, `Dp` or `TextUnit` was silently dropped from the component
-   * record**, `Text` among them. A preview whose only call was `Text` inferred no component at all.
-   * The functional compile gate is what surfaced it: `Button` and `Card` take neither, so the
-   * hand-written unit tests never had a mangled name to trip over.
+   * This is load-bearing rather than cosmetic, and it bites on **both** inference paths, because
+   * both reject a name that is not a usable import:
+   * * [inferComponents] dropped **every Material 3 component whose signature mentions `Color`, `Dp`
+   *   or `TextUnit`**, `Text` among them — a preview whose only call was `Text` inferred no
+   *   component at all;
+   * * [infer] dropped any of the project's *own* composables with a value-class parameter, which in
+   *   a typical app means anything taking a `Dp`. `AppTile(padding: Dp)` left its preview with
+   *   `targets = []` for a composable the preview does nothing but render.
+   *
+   * The functional compile gate is what surfaced it. `Button` and `Card` take no value-class
+   * parameters, so the hand-written unit tests never had a mangled name to trip over — a corpus
+   * chosen by hand is a corpus that agrees with you.
    *
    * Only the `-` mangle, deliberately. Kotlin's other JVM mangle is `name$module` for an `internal`
    * function ([nameMatches] strips that one for its own purposes), but stripping `$` here would
@@ -629,7 +640,8 @@ object PreviewTargetInference {
     }
 
     // +2 if `FooPreview` / `PreviewFoo` / `Foo_*_Preview` strips down to the candidate's name.
-    if (nameMatches(previewMethodName, callerMethod.name)) {
+    // Compared against the *source* name: `MyCardPreview` never strips down to `MyCard-abc123`.
+    if (nameMatches(previewMethodName, sourceFunctionName(callerMethod.name))) {
       score += 2
       signals += TargetSignal.NAME_MATCH
     }
@@ -671,7 +683,7 @@ object PreviewTargetInference {
 
     return ScoredCandidate(
       classFqn = callerOwner,
-      methodName = callerMethod.name,
+      methodName = sourceFunctionName(callerMethod.name),
       sourceFile = resolveSourceFile(callerOwner) ?: packageQualifiedSourcePath(callerClassInfo),
       score = score,
       signals = signals,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -190,33 +190,38 @@ object PreviewTargetInference {
         .asSequence()
         .filter { call -> COMPONENT_LIBRARY_FQN_PREFIXES.any { call.ownerFqn.startsWith(it) } }
         .mapNotNull { resolveCandidate(it, scanResult) }
-        .filter {
+        // Pair each candidate with its metadata up front, because the *source* name lives there
+        // and every decision below is about the source name. A candidate whose metadata cannot be
+        // read is dropped: without it there is no way to tell a mangled JVM name from a legally
+        // escaped one, and reporting the JVM name is how a nonexistent import gets published.
+        .mapNotNull { candidate ->
+          ComposableSignature.signatureOf(candidate.classInfo, candidate.method)?.let {
+            candidate to it
+          }
+        }
+        .filter { (candidate, signature) ->
           isComponentLibraryTarget(
-            ownerFqn = it.ownerFqn,
-            methodName = sourceFunctionName(it.method.name),
-            returnsUnit = it.method.typeDescriptor?.resultType?.toString() == "void",
+            ownerFqn = candidate.ownerFqn,
+            methodName = signature.name,
+            returnsUnit = candidate.method.typeDescriptor?.resultType?.toString() == "void",
           )
         }
-        .distinctBy { it.ownerFqn to sourceFunctionName(it.method.name) }
+        .distinctBy { (candidate, signature) -> candidate.ownerFqn to signature.name }
         .toList()
     if (candidates.isEmpty()) return emptyList()
     val confidence = if (candidates.size == 1) TargetConfidence.HIGH else TargetConfidence.MEDIUM
-    return candidates.map { candidate ->
-      // Metadata is matched on the JVM name (`candidate.method`), which is the mangled one; only
-      // the *reported* name is demangled. Reading the signature with the source name would find
-      // nothing.
-      val signature = ComposableSignature.signatureOf(candidate.classInfo, candidate.method)
+    return candidates.map { (candidate, signature) ->
       PreviewTarget(
         className = candidate.ownerFqn,
-        functionName = sourceFunctionName(candidate.method.name),
+        functionName = signature.name,
         // A library symbol has no source file in this build; `sourceFile` stays null and
         // [PreviewTarget.origin] is what says so, rather than the null being read as "library".
         sourceFile = null,
         confidence = confidence,
         signals = listOf(TargetSignal.LIBRARY_COMPONENT),
-        parameters = signature?.parameters.orEmpty(),
-        receiver = signature?.receiver,
-        signatureKnown = signature != null,
+        parameters = signature.parameters,
+        receiver = signature.receiver,
+        signatureKnown = true,
       )
     }
   }
@@ -541,38 +546,21 @@ object PreviewTargetInference {
    * * not a [THEME_ENTRY_POINTS] member — the frame a sticker is drawn in rather than its subject.
    */
   /**
-   * The **source-level** name behind a JVM method name, undoing Kotlin's inline-class mangling.
+   * Whether a resolved call in a component library is the **component a sticker demonstrates**.
    *
-   * Kotlin mangles the JVM name of any function whose signature mentions a value class, appending
-   * `-` and a hash of that signature: `androidx.compose.material3.Text` compiles to
-   * `TextKt."Text-Nvy7gAk"` because its `fontSize`, `color` and `overflow` parameters are
-   * `TextUnit`, `Color` and `TextOverflow`. A Kotlin identifier can never contain `-`, so the first
-   * one is unambiguously the mangling boundary.
+   * [methodName] must be the **source** name from `@kotlin.Metadata`, never the JVM one. Kotlin
+   * mangles the JVM name of any function whose signature mentions a value class, so
+   * `androidx.compose.material3.Text` compiles to `TextKt."Text-Nvy7gAk"` — its `fontSize`, `color`
+   * and `overflow` are `TextUnit`, `Color` and `TextOverflow`. Judged on the JVM name the import
+   * rule below rejects it, which silently dropped **every Material 3 component whose signature
+   * mentions `Color`, `Dp` or `TextUnit`** from the component record, `Text` included: a preview
+   * whose only call was `Text` inferred no component at all.
    *
-   * This is load-bearing rather than cosmetic: [isComponentLibraryTarget] rejects a name that is
-   * not a usable import, and a mangled name is not — so before this, **every Material 3 component
-   * whose signature mentions `Color`, `Dp` or `TextUnit` was silently dropped from the component
-   * record**, `Text` among them. A preview whose only call was `Text` inferred no component at all.
-   * The functional compile gate is what surfaced it: `Button` and `Card` take no value-class
-   * parameters, so the hand-written unit tests never had a mangled name to trip over.
-   *
-   * **Applied to [inferComponents] only, deliberately.** [infer] rejects mangled names too, and
-   * `DiscoveryFunctionalTest` pins that with a purpose-built `@JvmInline` fixture, so it is a
-   * decision rather than an oversight. The two paths can differ because they promise different
-   * things: a [ComponentSymbol] separates `callable` (the source-level name an import needs) from
-   * `jvmOwner` (the reflection handle), whereas a `targets` entry has one name that consumers may
-   * be using as a JVM lookup key — and `ComponentsKt.Screen` does not exist at runtime when the
-   * method is `Screen-<hash>`. Whether `targets` should demangle is a question for whoever owns
-   * that contract.
-   *
-   * Only the `-` mangle, deliberately. Kotlin's other JVM mangle is `name$module` for an `internal`
-   * function ([nameMatches] strips that one for its own purposes), but stripping `$` here would
-   * also turn `Card$lambda$0` into `Card` and rescue exactly the synthetic members
-   * [isComponentLibraryTarget] exists to reject — and a library's `internal` composable is not a
-   * call site a consumer could write anyway.
+   * Recovering the source name by trimming at the first `-` would be wrong in the other direction.
+   * A backtick-escaped declaration is legal Kotlin and its own name may contain a hyphen — ``fun
+   * `filled-button`()`` — so trimming publishes `filled`, a function that does not exist. Only
+   * metadata separates the two, which is why [inferComponents] reads it before deciding anything.
    */
-  internal fun sourceFunctionName(jvmName: String): String = jvmName.substringBefore('-')
-
   internal fun isComponentLibraryTarget(
     ownerFqn: String,
     methodName: String,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -193,19 +193,22 @@ object PreviewTargetInference {
         .filter {
           isComponentLibraryTarget(
             ownerFqn = it.ownerFqn,
-            methodName = it.method.name,
+            methodName = sourceFunctionName(it.method.name),
             returnsUnit = it.method.typeDescriptor?.resultType?.toString() == "void",
           )
         }
-        .distinctBy { it.ownerFqn to it.method.name }
+        .distinctBy { it.ownerFqn to sourceFunctionName(it.method.name) }
         .toList()
     if (candidates.isEmpty()) return emptyList()
     val confidence = if (candidates.size == 1) TargetConfidence.HIGH else TargetConfidence.MEDIUM
     return candidates.map { candidate ->
+      // Metadata is matched on the JVM name (`candidate.method`), which is the mangled one; only
+      // the *reported* name is demangled. Reading the signature with the source name would find
+      // nothing.
       val signature = ComposableSignature.signatureOf(candidate.classInfo, candidate.method)
       PreviewTarget(
         className = candidate.ownerFqn,
-        functionName = candidate.method.name,
+        functionName = sourceFunctionName(candidate.method.name),
         // A library symbol has no source file in this build; `sourceFile` stays null and
         // [PreviewTarget.origin] is what says so, rather than the null being read as "library".
         sourceFile = null,
@@ -537,6 +540,30 @@ object PreviewTargetInference {
    *   here, and reporting them would describe a sticker's theme lookup as its subject;
    * * not a [THEME_ENTRY_POINTS] member — the frame a sticker is drawn in rather than its subject.
    */
+  /**
+   * The **source-level** name behind a JVM method name, undoing Kotlin's inline-class mangling.
+   *
+   * Kotlin mangles the JVM name of any function whose signature mentions a value class, appending
+   * `-` and a hash of that signature: `androidx.compose.material3.Text` compiles to
+   * `TextKt."Text-Nvy7gAk"` because its `fontSize`, `color` and `overflow` parameters are
+   * `TextUnit`, `Color` and `TextOverflow`. A Kotlin identifier can never contain `-`, so the first
+   * one is unambiguously the mangling boundary.
+   *
+   * This is load-bearing rather than cosmetic. [isComponentLibraryTarget] rejects a name that is
+   * not a usable import, and a mangled name is not — so before this, **every Material 3 component
+   * whose signature mentions `Color`, `Dp` or `TextUnit` was silently dropped from the component
+   * record**, `Text` among them. A preview whose only call was `Text` inferred no component at all.
+   * The functional compile gate is what surfaced it: `Button` and `Card` take neither, so the
+   * hand-written unit tests never had a mangled name to trip over.
+   *
+   * Only the `-` mangle, deliberately. Kotlin's other JVM mangle is `name$module` for an `internal`
+   * function ([nameMatches] strips that one for its own purposes), but stripping `$` here would
+   * also turn `Card$lambda$0` into `Card` and rescue exactly the synthetic members
+   * [isComponentLibraryTarget] exists to reject — and a library's `internal` composable is not a
+   * call site a consumer could write anyway.
+   */
+  internal fun sourceFunctionName(jvmName: String): String = jvmName.substringBefore('-')
+
   internal fun isComponentLibraryTarget(
     ownerFqn: String,
     methodName: String,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -257,15 +257,10 @@ object PreviewTargetInference {
         .filter { it.ownerFqn in projectClassFqns }
         .mapNotNull { resolveCandidate(it, scanResult) }
         .filterNot { candidate ->
-          // Demangled first: a project composable taking a `Dp` compiles to `MyCard-abc123`, which
-          // is not a usable import and was therefore dropped outright — the same value-class
-          // mangling that hid `Text` from the component path, and more common here because `Dp`
-          // and `Color` parameters are ordinary in an app's own composables.
-          val name = sourceFunctionName(candidate.method.name)
-          !isValidKotlinImportIdentifier(name) ||
-            isPreviewOnlyWrapper(name, resolveSourceFile(candidate.ownerFqn))
+          !isValidKotlinImportIdentifier(candidate.method.name) ||
+            isPreviewOnlyWrapper(candidate.method.name, resolveSourceFile(candidate.ownerFqn))
         }
-        .distinctBy { it.ownerFqn to sourceFunctionName(it.method.name) }
+        .distinctBy { it.ownerFqn to it.method.name }
         .toList()
 
     if (candidates.isEmpty()) return emptyList()
@@ -554,18 +549,21 @@ object PreviewTargetInference {
    * `TextUnit`, `Color` and `TextOverflow`. A Kotlin identifier can never contain `-`, so the first
    * one is unambiguously the mangling boundary.
    *
-   * This is load-bearing rather than cosmetic, and it bites on **both** inference paths, because
-   * both reject a name that is not a usable import:
-   * * [inferComponents] dropped **every Material 3 component whose signature mentions `Color`, `Dp`
-   *   or `TextUnit`**, `Text` among them — a preview whose only call was `Text` inferred no
-   *   component at all;
-   * * [infer] dropped any of the project's *own* composables with a value-class parameter, which in
-   *   a typical app means anything taking a `Dp`. `AppTile(padding: Dp)` left its preview with
-   *   `targets = []` for a composable the preview does nothing but render.
+   * This is load-bearing rather than cosmetic: [isComponentLibraryTarget] rejects a name that is
+   * not a usable import, and a mangled name is not — so before this, **every Material 3 component
+   * whose signature mentions `Color`, `Dp` or `TextUnit` was silently dropped from the component
+   * record**, `Text` among them. A preview whose only call was `Text` inferred no component at all.
+   * The functional compile gate is what surfaced it: `Button` and `Card` take no value-class
+   * parameters, so the hand-written unit tests never had a mangled name to trip over.
    *
-   * The functional compile gate is what surfaced it. `Button` and `Card` take no value-class
-   * parameters, so the hand-written unit tests never had a mangled name to trip over — a corpus
-   * chosen by hand is a corpus that agrees with you.
+   * **Applied to [inferComponents] only, deliberately.** [infer] rejects mangled names too, and
+   * `DiscoveryFunctionalTest` pins that with a purpose-built `@JvmInline` fixture, so it is a
+   * decision rather than an oversight. The two paths can differ because they promise different
+   * things: a [ComponentSymbol] separates `callable` (the source-level name an import needs) from
+   * `jvmOwner` (the reflection handle), whereas a `targets` entry has one name that consumers may
+   * be using as a JVM lookup key — and `ComponentsKt.Screen` does not exist at runtime when the
+   * method is `Screen-<hash>`. Whether `targets` should demangle is a question for whoever owns
+   * that contract.
    *
    * Only the `-` mangle, deliberately. Kotlin's other JVM mangle is `name$module` for an `internal`
    * function ([nameMatches] strips that one for its own purposes), but stripping `$` here would
@@ -640,8 +638,7 @@ object PreviewTargetInference {
     }
 
     // +2 if `FooPreview` / `PreviewFoo` / `Foo_*_Preview` strips down to the candidate's name.
-    // Compared against the *source* name: `MyCardPreview` never strips down to `MyCard-abc123`.
-    if (nameMatches(previewMethodName, sourceFunctionName(callerMethod.name))) {
+    if (nameMatches(previewMethodName, callerMethod.name)) {
       score += 2
       signals += TargetSignal.NAME_MATCH
     }
@@ -683,7 +680,7 @@ object PreviewTargetInference {
 
     return ScoredCandidate(
       classFqn = callerOwner,
-      methodName = sourceFunctionName(callerMethod.name),
+      methodName = callerMethod.name,
       sourceFile = resolveSourceFile(callerOwner) ?: packageQualifiedSourcePath(callerClassInfo),
       score = score,
       signals = signals,

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
@@ -185,6 +185,17 @@ class ComponentSnippetsTest {
   }
 
   @Test
+  fun `a record written before the nullable field still answers null for a nullable type`() {
+    // A persisted v1 `components.json` has no `nullable`, so it deserialises to `false`. Without
+    // a spelling fallback for non-function types, every `String?` such a record carries would go
+    // from emitting `null` to being refused purely by upgrading the reader.
+    val snippet =
+      emitted(record(parameters = listOf(parameter("label", "String?", nullable = false))))
+
+    assertThat(snippet.code).isEqualTo("Button(label = null)")
+  }
+
+  @Test
   fun `a non-null callback returning a nullable value is refused, not given null`() {
     // The trap the structural `nullable` flag exists to avoid. `(Int) -> String?` ends in `?` and
     // is *not* nullable — the return type is. Reading nullability off the spelling would emit

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
@@ -32,12 +32,14 @@ class ComponentSnippetsTest {
     type: String,
     hasDefault: Boolean = false,
     composableSlot: Boolean = false,
+    nullable: Boolean = false,
   ) =
     TargetParameter(
       name = name,
       type = type,
       hasDefault = hasDefault,
       composableSlot = composableSlot,
+      nullable = nullable,
     )
 
   private fun emitted(record: ComponentRecord): ComponentSnippet.Emitted =
@@ -113,7 +115,7 @@ class ComponentSnippetsTest {
           parameters =
             listOf(
               parameter("imageVector", "ImageVector"),
-              parameter("contentDescription", "String?"),
+              parameter("contentDescription", "String?", nullable = true),
             ),
         )
       )
@@ -161,9 +163,39 @@ class ComponentSnippetsTest {
 
   @Test
   fun `a required nullable parameter takes null`() {
-    val snippet = emitted(record(parameters = listOf(parameter("label", "String?"))))
+    val snippet =
+      emitted(record(parameters = listOf(parameter("label", "String?", nullable = true))))
 
     assertThat(snippet.code).isEqualTo("Button(label = null)")
+  }
+
+  @Test
+  fun `a nullable callback takes null rather than being refused`() {
+    // material3's `Checkbox(onCheckedChange: ((Boolean) -> Unit)?)`, and `RadioButton` / `Switch`
+    // alongside it. No lambda-shaped rule accepts a nullable function type, so before the nullable
+    // test came first these were refused outright.
+    val snippet =
+      emitted(
+        record(
+          parameters = listOf(parameter("onCheckedChange", "((Boolean) -> Unit)?", nullable = true))
+        )
+      )
+
+    assertThat(snippet.code).isEqualTo("Button(onCheckedChange = null)")
+  }
+
+  @Test
+  fun `a non-null callback returning a nullable value is refused, not given null`() {
+    // The trap the structural `nullable` flag exists to avoid. `(Int) -> String?` ends in `?` and
+    // is *not* nullable — the return type is. Reading nullability off the spelling would emit
+    // `lookup = null` for a non-null parameter, which does not compile; `emptyLambda` then refuses
+    // it for the separate reason that `{}` cannot return a `String?`.
+    assertThat(
+        refusal(
+          record(parameters = listOf(parameter("lookup", "(Int) -> String?", nullable = false)))
+        )
+      )
+      .contains("lookup")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -101,6 +101,18 @@ class ComposableSignatureTest {
   }
 
   @Test
+  fun `a nullable function type is parenthesised so the question mark cannot read as the return`() {
+    // `((Boolean) -> Unit)?` rendered as `(Boolean) -> Unit?` says the callback returns `Unit?` and
+    // is nullable nowhere — the opposite of the truth. material3 declares `Checkbox`,
+    // `RadioButton` and `Switch` exactly this way, so every consumer of `TargetParameter.type` was
+    // being handed the wrong reading for three of its most common components.
+    val params = parametersOf("nullableCallbackComponent").associate { it.name to it.type }
+
+    assertThat(params["onCheckedChange"]).isEqualTo("((Boolean) -> Unit)?")
+    assertThat(params["onClick"]).isEqualTo("(() -> Unit)?")
+  }
+
+  @Test
   fun `a nullable parameter is not a knob`() {
     // Passing null is how the renderer says "use the author default", so a knob that can
     // legitimately

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -123,6 +123,42 @@ class PreviewTargetInferenceTest {
   }
 
   @Test
+  fun `an inline-class-mangled JVM name demangles to the source name`() {
+    // `androidx.compose.material3.Text` compiles to `Text-Nvy7gAk` because its `fontSize`, `color`
+    // and `overflow` parameters are value classes. Taken verbatim the name is not a usable import,
+    // so it was rejected — which silently dropped every Material 3 component whose signature
+    // mentions `Color`, `Dp` or `TextUnit`, `Text` included.
+    assertThat(PreviewTargetInference.sourceFunctionName("Text-Nvy7gAk")).isEqualTo("Text")
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.TextKt",
+          PreviewTargetInference.sourceFunctionName("Text-Nvy7gAk"),
+          returnsUnit = true,
+        )
+      )
+      .isTrue()
+  }
+
+  @Test
+  fun `an unmangled name is returned unchanged`() {
+    assertThat(PreviewTargetInference.sourceFunctionName("Card")).isEqualTo("Card")
+  }
+
+  @Test
+  fun `demangling does not rescue a synthetic lambda name`() {
+    // Demangling only strips the value-class hash; a synthetic member is still not an import, and
+    // the `$` rule that rejects it must keep applying after the strip.
+    assertThat(
+        PreviewTargetInference.isComponentLibraryTarget(
+          "androidx.compose.material3.CardKt",
+          PreviewTargetInference.sourceFunctionName("Card\u0024lambda\u00240"),
+          returnsUnit = true,
+        )
+      )
+      .isFalse()
+  }
+
+  @Test
   fun `a name that is not a usable Kotlin import is rejected`() {
     assertThat(
         PreviewTargetInference.isComponentLibraryTarget(

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -123,16 +123,15 @@ class PreviewTargetInferenceTest {
   }
 
   @Test
-  fun `an inline-class-mangled JVM name demangles to the source name`() {
+  fun `the source name from metadata is what the import rule judges`() {
     // `androidx.compose.material3.Text` compiles to `Text-Nvy7gAk` because its `fontSize`, `color`
-    // and `overflow` parameters are value classes. Taken verbatim the name is not a usable import,
-    // so it was rejected — which silently dropped every Material 3 component whose signature
-    // mentions `Color`, `Dp` or `TextUnit`, `Text` included.
-    assertThat(PreviewTargetInference.sourceFunctionName("Text-Nvy7gAk")).isEqualTo("Text")
+    // and `overflow` parameters are value classes. Judged on the JVM name it is not a usable
+    // import and was rejected, which dropped every Material 3 component mentioning `Color`, `Dp`
+    // or `TextUnit`. `inferComponents` reads the source name from metadata and passes that here.
     assertThat(
         PreviewTargetInference.isComponentLibraryTarget(
           "androidx.compose.material3.TextKt",
-          PreviewTargetInference.sourceFunctionName("Text-Nvy7gAk"),
+          "Text",
           returnsUnit = true,
         )
       )
@@ -140,18 +139,15 @@ class PreviewTargetInferenceTest {
   }
 
   @Test
-  fun `an unmangled name is returned unchanged`() {
-    assertThat(PreviewTargetInference.sourceFunctionName("Card")).isEqualTo("Card")
-  }
-
-  @Test
-  fun `demangling does not rescue a synthetic lambda name`() {
-    // Demangling only strips the value-class hash; a synthetic member is still not an import, and
-    // the `$` rule that rejects it must keep applying after the strip.
+  fun `a backtick-escaped name containing a hyphen is still not an import`() {
+    // ``fun `filled-button`()`` is legal Kotlin, and its *source* name really does contain a
+    // hyphen — so it is not a usable import and must stay rejected. This is why the source name
+    // comes from metadata rather than from trimming the JVM name at the first `-`, which would
+    // have turned this into `filled` and published a function that does not exist.
     assertThat(
         PreviewTargetInference.isComponentLibraryTarget(
-          "androidx.compose.material3.CardKt",
-          PreviewTargetInference.sourceFunctionName("Card\u0024lambda\u00240"),
+          "androidx.compose.material3.ButtonKt",
+          "filled-button",
           returnsUnit = true,
         )
       )

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -56,3 +56,9 @@ fun mixedKnobComponent(modifier: List<String> = emptyList(), count: Int = 1) {}
 /** A nullable knob type is excluded: `null` is how the renderer says "take the author default". */
 @Suppress("unused", "UNUSED_PARAMETER")
 fun nullableKnobComponent(label: String? = null, enabled: Boolean = true) {}
+
+// A nullable function-typed parameter — the shape material3's
+// `Checkbox(onCheckedChange: ((Boolean) -> Unit)?)` has, and the one whose rendering used to be
+// ambiguous with a non-null callback returning `Unit?`.
+@Suppress("unused")
+fun nullableCallbackComponent(onCheckedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -36,8 +36,15 @@ class ComponentCallSiteCompileFunctionalTest {
 
   private val json = Json { ignoreUnknownKeys = true }
 
-  /** Components whose call sites this generator is expected to be able to print. */
-  private val expectedEmitted = setOf("Text", "Button", "Card")
+  /**
+   * Components whose call sites this generator is expected to be able to print.
+   *
+   * `Checkbox` and `Switch` are here for their **nullable callback** (`onCheckedChange: ((Boolean)
+   * -> Unit)?`): no lambda-shaped rule accepts a nullable function type, so both were refused until
+   * the generator learned to answer `null` for any nullable parameter. They are what keeps that
+   * answer honest against a real Material 3 signature rather than a hand-written record.
+   */
+  private val expectedEmitted = setOf("Text", "Button", "Card", "Checkbox", "Switch")
 
   private fun createTestProject(): File {
     val projectDir = tempDir.root
@@ -101,6 +108,8 @@ class ComponentCallSiteCompileFunctionalTest {
         import androidx.compose.foundation.layout.padding
         import androidx.compose.material3.Button
         import androidx.compose.material3.Card
+        import androidx.compose.material3.Checkbox
+        import androidx.compose.material3.Switch
         import androidx.compose.material3.Text
         import androidx.compose.runtime.Composable
         import androidx.compose.ui.Modifier
@@ -124,6 +133,13 @@ class ComponentCallSiteCompileFunctionalTest {
         @Composable
         fun ContainerPreview() {
             Card { Text(text = "Inside") }
+        }
+
+        @Preview
+        @Composable
+        fun TogglesPreview() {
+            Checkbox(checked = true, onCheckedChange = {})
+            Switch(checked = true, onCheckedChange = {})
         }
 
         // A project composable whose signature mentions a value class, so its JVM name is

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertWithMessage
 import ee.schimke.composeai.discovery.ComponentRecordFile
 import ee.schimke.composeai.discovery.ComponentSnippet
 import ee.schimke.composeai.discovery.ComponentSnippets
+import ee.schimke.composeai.discovery.PreviewManifest
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
@@ -97,11 +98,15 @@ class ComponentCallSiteCompileFunctionalTest {
         """
         package test
 
+        import androidx.compose.foundation.layout.padding
         import androidx.compose.material3.Button
         import androidx.compose.material3.Card
         import androidx.compose.material3.Text
         import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
         import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.Dp
+        import androidx.compose.ui.unit.dp
 
         @Preview
         @Composable
@@ -119,6 +124,21 @@ class ComponentCallSiteCompileFunctionalTest {
         @Composable
         fun ContainerPreview() {
             Card { Text(text = "Inside") }
+        }
+
+        // A project composable whose signature mentions a value class, so its JVM name is
+        // mangled (`AppTile-<hash>`) exactly the way `androidx.compose.material3.Text`'s is.
+        // Ordinary app code — `Dp` parameters are not exotic — and the reason the same
+        // demangling has to apply to project-local target inference.
+        @Composable
+        fun AppTile(padding: Dp, label: String) {
+            Card(modifier = Modifier.padding(padding)) { Text(text = label) }
+        }
+
+        @Preview
+        @Composable
+        fun AppTilePreview() {
+            AppTile(padding = 8.dp, label = "Tile")
         }
         """
           .trimIndent()
@@ -175,6 +195,27 @@ class ComponentCallSiteCompileFunctionalTest {
     val compile = runGradle(projectDir, "compileKotlin")
     assertThat(compile.task(":compileKotlin")?.outcome)
       .isIn(listOf(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE))
+  }
+
+  @Test
+  fun `a project composable with a value-class parameter is still inferred as a target`() {
+    // The project-local half of the same mangling bug, and the one a typical app hits: `AppTile`
+    // takes a `Dp`, so it compiles to `AppTile-<hash>`, which is not a usable Kotlin import. The
+    // filter that rejects unusable names dropped it outright, leaving `AppTilePreview` with no
+    // target at all — for a composable the preview does nothing but render.
+    val projectDir = createTestProject()
+
+    val discover = runGradle(projectDir, "composePreviewDiscover")
+    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
+    assertThat(manifestFile.exists()).isTrue()
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
+
+    val tilePreview = manifest.previews.single { it.functionName == "AppTilePreview" }
+    assertWithMessage("targets were %s", tilePreview.targets)
+      .that(tilePreview.targets.map { it.functionName })
+      .contains("AppTile")
   }
 
   /**

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -1,0 +1,218 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.discovery.ComponentRecordFile
+import ee.schimke.composeai.discovery.ComponentSnippet
+import ee.schimke.composeai.discovery.ComponentSnippets
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The compile gate for `ComponentSnippets` — the Kotlin compiler, not an argument, deciding whether
+ * a printed call site is real.
+ *
+ * `ComponentSnippetsTest` asserts the *text* of a snippet against a hand-written record. That is a
+ * regression net and nothing more: every expectation in it is a claim I made about Kotlin, so a
+ * wrong belief about what `{}` infers against, or about which parameters `Button` actually
+ * defaults, produces a green test and source that does not build. This test removes me from the
+ * loop. It discovers real `androidx.compose.material3` components out of a real project, prints
+ * their call sites, writes them into that project, and compiles them.
+ *
+ * **The vacuity guard is the important assertion.** A generator that refused everything would emit
+ * an empty file that compiles perfectly, so "the build passed" alone proves nothing. The test
+ * therefore names components it insists were emitted, and fails if the generator quietly stopped
+ * producing them.
+ */
+class ComponentCallSiteCompileFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /** Components whose call sites this generator is expected to be able to print. */
+  private val expectedEmitted = setOf("Text", "Button", "Card")
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-call-site-compile"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    // Ordinary previews over stock Material 3 — the shape the library-component inference exists
+    // for. Nothing here is written for the generator's benefit.
+    File(srcDir, "Components.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Button
+        import androidx.compose.material3.Card
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Preview
+        @Composable
+        fun LabelPreview() {
+            Text(text = "Hello")
+        }
+
+        @Preview
+        @Composable
+        fun ActionPreview() {
+            Button(onClick = {}) { Text(text = "Go") }
+        }
+
+        @Preview
+        @Composable
+        fun ContainerPreview() {
+            Card { Text(text = "Inside") }
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  private fun runGradle(projectDir: File, vararg arguments: String) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(*arguments)
+      .withPluginClasspath()
+      .build()
+
+  @Test
+  fun `printed call sites for discovered Material3 components compile`() {
+    val projectDir = createTestProject()
+
+    val discover = runGradle(projectDir, "composePreviewDiscover")
+    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val componentsFile = File(projectDir, "build/compose-previews/components.json")
+    assertThat(componentsFile.exists()).isTrue()
+    val components =
+      json.decodeFromString(ComponentRecordFile.serializer(), componentsFile.readText())
+
+    val emitted = mutableMapOf<String, ComponentSnippet.Emitted>()
+    val refused = mutableMapOf<String, String>()
+    for (record in components.components) {
+      when (val snippet = ComponentSnippets.callSite(record)) {
+        is ComponentSnippet.Emitted -> emitted[record.symbol.name] = snippet
+        is ComponentSnippet.Refused -> refused[record.symbol.name] = snippet.reason
+      }
+    }
+
+    // Vacuity guard: an empty generated file compiles, so the compile below only means something
+    // if the generator actually produced these. The refusals are in the message because "why was
+    // `Button` skipped" is the first question a failure here raises.
+    assertWithMessage(
+        "discovered %s; refusals were %s",
+        components.components.map { it.symbol.name },
+        refused,
+      )
+      .that(emitted.keys)
+      .containsAtLeastElementsIn(expectedEmitted)
+
+    writeGeneratedCallSites(projectDir, emitted)
+
+    // `GradleRunner.build()` throws on a failed build, so reaching this line *is* the gate: the
+    // Kotlin compiler accepted every printed call site. The outcome check only rules out the task
+    // having been skipped — `FROM_CACHE` is a pass because a cache hit still means these exact
+    // sources compiled.
+    val compile = runGradle(projectDir, "compileKotlin")
+    assertThat(compile.task(":compileKotlin")?.outcome)
+      .isIn(listOf(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE))
+  }
+
+  /**
+   * Writes one `@Composable` per snippet into the project's own source set.
+   *
+   * Each call site goes in its own function rather than one shared body so a single bad snippet
+   * fails with the name of the component that produced it, instead of the first compile error
+   * hiding the rest.
+   */
+  private fun writeGeneratedCallSites(
+    projectDir: File,
+    emitted: Map<String, ComponentSnippet.Emitted>,
+  ) {
+    val imports = emitted.values.flatMap { it.imports }.toSortedSet()
+    val body =
+      emitted.entries
+        .sortedBy { it.key }
+        .joinToString("\n\n") { (name, snippet) ->
+          """
+          |@Composable
+          |fun Generated$name() {
+          |    ${snippet.code}
+          |}
+          """
+            .trimMargin()
+        }
+    val generatedDir = File(projectDir, "src/main/kotlin/generated")
+    generatedDir.mkdirs()
+    File(generatedDir, "GeneratedCallSites.kt")
+      .writeText(
+        buildString {
+          appendLine("package generated")
+          appendLine()
+          appendLine("import androidx.compose.runtime.Composable")
+          imports.forEach { appendLine("import $it") }
+          appendLine()
+          appendLine(body)
+        }
+      )
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth.assertWithMessage
 import ee.schimke.composeai.discovery.ComponentRecordFile
 import ee.schimke.composeai.discovery.ComponentSnippet
 import ee.schimke.composeai.discovery.ComponentSnippets
-import ee.schimke.composeai.discovery.PreviewManifest
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
@@ -105,17 +104,13 @@ class ComponentCallSiteCompileFunctionalTest {
         """
         package test
 
-        import androidx.compose.foundation.layout.padding
         import androidx.compose.material3.Button
         import androidx.compose.material3.Card
         import androidx.compose.material3.Checkbox
         import androidx.compose.material3.Switch
         import androidx.compose.material3.Text
         import androidx.compose.runtime.Composable
-        import androidx.compose.ui.Modifier
         import androidx.compose.ui.tooling.preview.Preview
-        import androidx.compose.ui.unit.Dp
-        import androidx.compose.ui.unit.dp
 
         @Preview
         @Composable
@@ -140,21 +135,6 @@ class ComponentCallSiteCompileFunctionalTest {
         fun TogglesPreview() {
             Checkbox(checked = true, onCheckedChange = {})
             Switch(checked = true, onCheckedChange = {})
-        }
-
-        // A project composable whose signature mentions a value class, so its JVM name is
-        // mangled (`AppTile-<hash>`) exactly the way `androidx.compose.material3.Text`'s is.
-        // Ordinary app code — `Dp` parameters are not exotic — and the reason the same
-        // demangling has to apply to project-local target inference.
-        @Composable
-        fun AppTile(padding: Dp, label: String) {
-            Card(modifier = Modifier.padding(padding)) { Text(text = label) }
-        }
-
-        @Preview
-        @Composable
-        fun AppTilePreview() {
-            AppTile(padding = 8.dp, label = "Tile")
         }
         """
           .trimIndent()
@@ -211,27 +191,6 @@ class ComponentCallSiteCompileFunctionalTest {
     val compile = runGradle(projectDir, "compileKotlin")
     assertThat(compile.task(":compileKotlin")?.outcome)
       .isIn(listOf(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE))
-  }
-
-  @Test
-  fun `a project composable with a value-class parameter is still inferred as a target`() {
-    // The project-local half of the same mangling bug, and the one a typical app hits: `AppTile`
-    // takes a `Dp`, so it compiles to `AppTile-<hash>`, which is not a usable Kotlin import. The
-    // filter that rejects unusable names dropped it outright, leaving `AppTilePreview` with no
-    // target at all — for a composable the preview does nothing but render.
-    val projectDir = createTestProject()
-
-    val discover = runGradle(projectDir, "composePreviewDiscover")
-    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
-    assertThat(manifestFile.exists()).isTrue()
-    val manifest = json.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
-
-    val tilePreview = manifest.previews.single { it.functionName == "AppTilePreview" }
-    assertWithMessage("targets were %s", tilePreview.targets)
-      .that(tilePreview.targets.map { it.functionName })
-      .contains("AppTile")
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #5028, which merged with only its first commit. This is the half that makes that PR's central claim checkable — plus the bugs it caught within minutes of existing.

#5028 shipped `ComponentSnippets.callSite`, which prints a call site from the component record. Its tests assert snippet *text* against hand-written records, so every expectation is a claim about Kotlin that I made and then checked against myself. That is a regression net, not evidence.

**`ComponentCallSiteCompileFunctionalTest` makes the Kotlin compiler the oracle.** It builds a real Compose Multiplatform project, discovers its `androidx.compose.material3` components, prints their call sites, writes them back into that project, and compiles them. Its load-bearing assertion is the **vacuity guard**: a generator that refused everything would emit an empty file that compiles perfectly, so the test names the components it insists were emitted and prints the refusals when one is missing.

**Measured reach: 26 of 28** Material 3 components emit a call site. The two refusals are `TextField` / `OutlinedTextField`, whose required `state: TextFieldState` genuinely has no literal. So the placeholder table is not the bottleneck it looked like — what remains needs *values*, i.e. Phase 2's argument binding, not more literals.

## What the gate caught

### 1. Value-class name mangling — `Text` was invisible

```
discovered [Button, Card]; refusals were {}
missing (1) : Text
```

Kotlin mangles the JVM name of any function whose signature mentions a value class, so `androidx.compose.material3.Text` compiles to `TextKt."Text-Nvy7gAk"` — `fontSize`, `color` and `overflow` are `TextUnit`, `Color`, `TextOverflow`. `isComponentLibraryTarget` rejects a name that is not a usable Kotlin import, and a mangled name is not, so **every Material 3 component whose signature mentions `Color`, `Dp` or `TextUnit` was being dropped from the component record.** A preview whose only call was `Text` inferred no component at all.

The fix is that `inferComponents` resolves `@kotlin.Metadata` **before** it judges the name, and reads the source-level name from `KmFunction.name`. The mangled JVM name survives only as the metadata lookup key, which is what `@kotlin.Metadata` is keyed on. A candidate whose metadata cannot be read is dropped rather than judged on its JVM name: without metadata there is no way to tell a mangled name from a legally escaped one, and reporting the JVM name is how a nonexistent import gets published.

That is the second attempt. The first trimmed the reported name at its first `-`, and [Codex caught it](https://github.com/yschimke/compose-ai-tools/pull/5036#discussion_r3919495324): ``fun `filled-button`()`` is a legal escaped Kotlin declaration whose JVM name really does contain a hyphen, so trimming turned it into `filled` and published an import for a function that does not exist. Metadata carries the source name directly, so there is nothing left to guess at.

### 2. Nullable callbacks — `Checkbox`, `RadioButton`, `Switch`

material3 declares `onCheckedChange: ((Boolean) -> Unit)?`, and no lambda-shaped rule accepts a nullable function type. `null` type-checks and is the right answer.

### 3. The wrong fix for (2), caught before it shipped

A rendered type ending in `?` does **not** mean the parameter is nullable: `(Int) -> String?` is a *non-null* callback returning a nullable value, and answering `null` for it emits source that does not compile. Testing the spelling would have traded three fixed components for a new class of broken output. Nullability is now carried structurally on `TargetParameter.nullable`.

`renderType` separately parenthesises nullable function types — `(Boolean) -> Unit?` was being handed to every consumer as the rendering of `((Boolean) -> Unit)?`, which says the callback returns `Unit?` and is nullable nowhere. That is a wire-visible correction to `TargetParameter.type`, pinned by a rendering assertion rather than by the gate, because material3 contains no non-null `-> Unit?` callback for the gate to tell the two readings apart with.

### 4. Records written before `nullable` existed

Also from review: a persisted v1 `components.json` has no `nullable`, so it deserialises to `false`, and every `String?` it carries would go from emitting `null` to being refused purely by upgrading the reader. `placeholderFor` keeps a spelling fallback for types with **no arrow**, where the reading is unambiguous — type arguments close with `>`, so `List<String?>` never reaches it looking nullable, and `(Int) -> String?` is excluded by construction.

## What I tried and backed out — please sanity-check this call

The same mangling drops the project's **own** composables from `targets`: `AppTile(padding: Dp)` compiles to `AppTile-<hash>` and reports `targets = []`. I demangled that path too, and it turned `DiscoveryFunctionalTest > … rejects mangled targets` red — a test with a purpose-built `@JvmInline` fixture asserting exactly that rejection. I had read it as an accident of the "not a usable import" guard; the fixture says someone chose it, so **I reverted that half** rather than overrule it.

The two paths can legitimately differ, and the record is why: `ComponentSymbol` separates `callable` (the source-level name an import needs) from `jvmOwner` (the reflection handle), so demangling the component path costs nothing. A `targets` entry has one name that a consumer may be using as a JVM lookup key, where demangling is actively wrong — `ComponentsKt.Screen` does not exist when the method is `Screen-<hash>`.

So the question is yours: **should `targets` demangle?** If it should, the cost of not doing it is that `Dp` and `Color` parameters are ordinary in app code, and this is §1's *"detect components from previews in typical projects"* failing on the typical projects.

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test` — **BUILD SUCCESSFUL**, 0 failures/errors.
- `./gradlew :gradle-plugin:functionalTest` — the **whole** suite, **BUILD SUCCESSFUL** in 5m43s. Running only my own filtered test is what let the `infer` regression reach CI in the first place.
- Each fix verified by reverting it and watching the gate fail, then restoring: `missing (1) : Text` (component path), `missing (2) : Checkbox, Switch` (nullable rule). The parenthesisation is the one change the gate *cannot* see — reverting it left the gate green, which is why it is pinned by a unit assertion instead.
- `ktfmtCheck` on all touched source sets — clean.
- All of the above on this branch rebased onto current `main`, not only the original base.
- Non-visual change: no render evidence applies.

## Known unrelated failure

`Daemon Harness (android, real renderer)` is red here and is **not this PR's**: the identical `S3_5RecompileSaveLoopRealModeTest > recompiled bytecode flows through to the next render` failure is on `main` at `51e53131`, a commit predating any of this work. Same test, same line, same 45/1/22 counts. Detail, including the run of ~10 consecutive `main` commits it fails on, is in [this comment](https://github.com/yschimke/compose-ai-tools/pull/5036#issuecomment-5518353516).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o
