### PR TITLE
fix(cli): bundle pack dropped --variant; feat(import): render-runtime-projects

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1321,6 +1321,37 @@ jobs:
           esac
           echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
 
+      # The variant, pinned in the throwaway checkout's own gradle.properties.
+      #
+      # `--variant` alone does not reach Gradle from `bundle pack`: that subcommand forwards a
+      # WHITELIST of flags to the inner Command (--module, --verbose, --progress, --timeout), so
+      # --variant is accepted and then dropped, `variantGradleArgs()` produces nothing, and the
+      # plugin falls back to its `debug` convention. On a flavored module that is not harmless — a
+      # bare build type suffix-matches, so home-assistant/android rendered `minimalDebug`, the one
+      # flavor that does not compile, while the run had asked for `fullDebug`.
+      #
+      # The CLI is fixed alongside this, but it is installed from a RELEASE, so the fix is not
+      # reachable until the next one. `composePreview.variant` is an ordinary Gradle project
+      # property, and gradle.properties in this throwaway checkout is a file the workflow already
+      # rewrites for exactly this reason (see the two steps below) — so it applies to the very next
+      # run. Once the released CLI carries the fix the two agree, and the command line wins anyway.
+      - name: Pin the render variant in the upstream checkout
+        if: ${{ inputs.upstream-repository != '' && inputs.variant != '' }}
+        env:
+          GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
+        run: |
+          set -euo pipefail
+          if [ -f "$GRADLE_PROPERTIES" ] &&
+             grep -q '^[[:space:]]*composePreview\.variant[[:space:]]*=' "$GRADLE_PROPERTIES"; then
+            sed -i "s/^[[:space:]]*composePreview\.variant[[:space:]]*=.*/composePreview.variant=${INPUT_VARIANT}/" \
+              "$GRADLE_PROPERTIES"
+            echo "rewrote composePreview.variant=${INPUT_VARIANT} in the throwaway checkout"
+          else
+            printf '\n# compose-preview import: render this variant, not the plugin default.\ncomposePreview.variant=%s\n' \
+              "$INPUT_VARIANT" >> "$GRADLE_PROPERTIES"
+            echo "pinned composePreview.variant=${INPUT_VARIANT} in the throwaway checkout"
+          fi
+
       - name: Disable Isolated Projects in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
         env:
@@ -1938,6 +1969,37 @@ jobs:
               ;;
           esac
           echo "copied $found's wrapper into ${RENDER_DIR} so the render targets that build"
+
+      # The variant, pinned in the throwaway checkout's own gradle.properties.
+      #
+      # `--variant` alone does not reach Gradle from `bundle pack`: that subcommand forwards a
+      # WHITELIST of flags to the inner Command (--module, --verbose, --progress, --timeout), so
+      # --variant is accepted and then dropped, `variantGradleArgs()` produces nothing, and the
+      # plugin falls back to its `debug` convention. On a flavored module that is not harmless — a
+      # bare build type suffix-matches, so home-assistant/android rendered `minimalDebug`, the one
+      # flavor that does not compile, while the run had asked for `fullDebug`.
+      #
+      # The CLI is fixed alongside this, but it is installed from a RELEASE, so the fix is not
+      # reachable until the next one. `composePreview.variant` is an ordinary Gradle project
+      # property, and gradle.properties in this throwaway checkout is a file the workflow already
+      # rewrites for exactly this reason (see the two steps below) — so it applies to the very next
+      # run. Once the released CLI carries the fix the two agree, and the command line wins anyway.
+      - name: Pin the render variant in the upstream checkout
+        if: ${{ inputs.upstream-repository != '' && inputs.variant != '' }}
+        env:
+          GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
+        run: |
+          set -euo pipefail
+          if [ -f "$GRADLE_PROPERTIES" ] &&
+             grep -q '^[[:space:]]*composePreview\.variant[[:space:]]*=' "$GRADLE_PROPERTIES"; then
+            sed -i "s/^[[:space:]]*composePreview\.variant[[:space:]]*=.*/composePreview.variant=${INPUT_VARIANT}/" \
+              "$GRADLE_PROPERTIES"
+            echo "rewrote composePreview.variant=${INPUT_VARIANT} in the throwaway checkout"
+          else
+            printf '\n# compose-preview import: render this variant, not the plugin default.\ncomposePreview.variant=%s\n' \
+              "$INPUT_VARIANT" >> "$GRADLE_PROPERTIES"
+            echo "pinned composePreview.variant=${INPUT_VARIANT} in the throwaway checkout"
+          fi
 
       - name: Disable Isolated Projects in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}

--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -50,6 +50,25 @@ on:
         required: false
         type: string
         default: ''
+      render-runtime-projects:
+        description: >
+          Comma-separated Gradle project paths to put on the rendered module's RUNTIME classpath
+          for this render only, for an upstream that binds an implementation at runtime and keeps
+          it off the production classpath.
+
+          DroidKaigi/conference-app-2026 is the case. Its `:core:preview:wrapper` declares
+          `compileOnly(project(":core:preview:impl"))` on both `androidMain` and `jvmMain` —
+          "impl stays off production classpaths", as its own comment puts it — and supplies the
+          binding at runtime only from the app and from its screenshot-test convention. A render
+          of `:core:ui` is neither, so every preview dies with
+          `ClassNotFoundException: …preview.impl.DefaultPreviewImageResolver`.
+
+          Import mode only, and appended to the module's build file in the THROWAWAY checkout, on
+          `runtimeOnly`-shaped configurations only: nothing the module compiles against changes,
+          and nothing is written anywhere that outlives the job.
+        required: false
+        type: string
+        default: ''
       variant:
         description: >
           Android variant the preview plugin attaches its tasks to, forwarded to the CLI as
@@ -461,6 +480,7 @@ env:
   INPUT_CATALOG_PATH: ${{ inputs.catalog-path }}
   INPUT_MODULE: ${{ inputs.module }}
   INPUT_VARIANT: ${{ inputs.variant }}
+  INPUT_RENDER_RUNTIME_PROJECTS: ${{ inputs.render-runtime-projects }}
   INPUT_MODULES: ${{ inputs.modules }}
   INPUT_EXTRA_MODULE: ${{ inputs.extra-module }}
   INPUT_RENDER_SHARDS: ${{ inputs.render-shards }}
@@ -1335,6 +1355,88 @@ jobs:
       # property, and gradle.properties in this throwaway checkout is a file the workflow already
       # rewrites for exactly this reason (see the two steps below) — so it applies to the very next
       # run. Once the released CLI carries the fix the two agree, and the command line wins anyway.
+      # Host-supplied implementations, on the render's runtime classpath only.
+      #
+      # An upstream may bind an implementation at runtime and deliberately keep it off the
+      # production compile classpath. DroidKaigi's `:core:preview:wrapper` is explicit about it —
+      # `compileOnly(project(":core:preview:impl"))` on androidMain and jvmMain, commented "impl
+      # stays off production classpaths" — with the binding supplied by the app and by its own
+      # screenshot-test convention. A render of `:core:ui` is neither of those, so all 450 previews
+      # die with `ClassNotFoundException: …preview.impl.DefaultPreviewImageResolver`.
+      #
+      # Appended to the module's build file rather than injected through an init script, because an
+      # init script that reaches across projects fights configuration cache and Isolated Projects,
+      # which several of these upstreams have on. Appended at the END so it runs after the
+      # `kotlin { }` block that creates the KMP configurations it looks for.
+      #
+      # Deliberately `runtimeOnly`-shaped configurations ONLY. Nothing the module compiles against
+      # changes, so this cannot make a preview compile that would not compile for a real consumer —
+      # it only supplies, for the render, what the upstream supplies for its own screenshot tests.
+      #
+      # The names are tried in KMP-first order because a KMP module has no plain `jvmRuntimeOnly`:
+      # its DECLARABLE configurations are source-set scoped (`jvmMainRuntimeOnly`), and only the
+      # resolvable `jvmRuntimeClasspath` carries the bare target name. Getting that wrong is silent
+      # — `findByName` returns null, nothing is added, and the render fails exactly as it did
+      # before — which is how the first version of this step passed its own fixture test and
+      # changed nothing on the real project. Verified against DroidKaigi by resolving
+      # `jvmRuntimeClasspath` and finding the project in it, not by reading the appended file back.
+      - name: Put host-supplied implementations on the render classpath
+        if: ${{ inputs.upstream-repository != '' && inputs.render-runtime-projects != '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INPUT_MODULE:-}" ] || [ "${INPUT_MODULES:-}" = "all" ]; then
+            echo "::error::render-runtime-projects names configurations on ONE module's build file," \
+                 "so it cannot be used with repository-wide discovery. Name the module with 'module'."
+            exit 1
+          fi
+          # Same resolution as the google-services stub: the settings file gets the first word,
+          # because `project(":app").projectDir = file(…)` puts a module where its path does not say.
+          derived="$(printf '%s' "${INPUT_MODULE#:}" | tr ':' '/')"
+          remapped="$(
+            cat "${RENDER_DIR}"/settings.gradle "${RENDER_DIR}"/settings.gradle.kts 2>/dev/null |
+              sed -n "s|.*project(['\"]${INPUT_MODULE}['\"])\.projectDir[[:space:]]*=[[:space:]]*[Ff]ile(['\"]\([^'\"]*\)['\"]).*|\1|p" |
+              head -1
+          )" || true
+          if [ -n "$remapped" ]; then
+            derived="$remapped"
+          fi
+          module_dir="${RENDER_DIR}/${derived}"
+          build_file=""
+          for candidate in "${module_dir}/build.gradle.kts" "${module_dir}/build.gradle"; do
+            if [ -f "$candidate" ]; then build_file="$candidate"; break; fi
+          done
+          [ -n "$build_file" ] || {
+            echo "::error::no build.gradle.kts or build.gradle under ${module_dir} — is ${INPUT_MODULE} the module being rendered?"
+            exit 1
+          }
+          case "$build_file" in
+            *.kts) ;;
+            *)
+              echo "::error::${build_file} is a Groovy build script; render-runtime-projects appends Kotlin DSL." \
+                   "Teach this step the Groovy form before using it on such a module."
+              exit 1
+              ;;
+          esac
+          {
+            printf '\n// compose-preview import: implementations this upstream binds at runtime and keeps off\n'
+            printf '// its production classpath. Render-only, in a throwaway checkout.\n'
+            printf 'dependencies {\n'
+            printf '    listOf(\n'
+            printf '        "jvmMainRuntimeOnly", "desktopMainRuntimeOnly", "androidMainRuntimeOnly",\n'
+            printf '        "jvmRuntimeOnly", "desktopRuntimeOnly", "runtimeOnly",\n'
+            printf '    ).forEach { composeAiPreviewCfg ->\n'
+            printf '        if (configurations.findByName(composeAiPreviewCfg) != null) {\n'
+            IFS=','
+            for composeai_project in $INPUT_RENDER_RUNTIME_PROJECTS; do
+              printf '            add(composeAiPreviewCfg, project("%s"))\n' "$composeai_project"
+            done
+            unset IFS
+            printf '        }\n'
+            printf '    }\n'
+            printf '}\n'
+          } >> "$build_file"
+          echo "added ${INPUT_RENDER_RUNTIME_PROJECTS} to ${build_file#"$RENDER_DIR/"} on runtimeOnly configurations"
+
       - name: Pin the render variant in the upstream checkout
         if: ${{ inputs.upstream-repository != '' && inputs.variant != '' }}
         env:
@@ -1984,6 +2086,88 @@ jobs:
       # property, and gradle.properties in this throwaway checkout is a file the workflow already
       # rewrites for exactly this reason (see the two steps below) — so it applies to the very next
       # run. Once the released CLI carries the fix the two agree, and the command line wins anyway.
+      # Host-supplied implementations, on the render's runtime classpath only.
+      #
+      # An upstream may bind an implementation at runtime and deliberately keep it off the
+      # production compile classpath. DroidKaigi's `:core:preview:wrapper` is explicit about it —
+      # `compileOnly(project(":core:preview:impl"))` on androidMain and jvmMain, commented "impl
+      # stays off production classpaths" — with the binding supplied by the app and by its own
+      # screenshot-test convention. A render of `:core:ui` is neither of those, so all 450 previews
+      # die with `ClassNotFoundException: …preview.impl.DefaultPreviewImageResolver`.
+      #
+      # Appended to the module's build file rather than injected through an init script, because an
+      # init script that reaches across projects fights configuration cache and Isolated Projects,
+      # which several of these upstreams have on. Appended at the END so it runs after the
+      # `kotlin { }` block that creates the KMP configurations it looks for.
+      #
+      # Deliberately `runtimeOnly`-shaped configurations ONLY. Nothing the module compiles against
+      # changes, so this cannot make a preview compile that would not compile for a real consumer —
+      # it only supplies, for the render, what the upstream supplies for its own screenshot tests.
+      #
+      # The names are tried in KMP-first order because a KMP module has no plain `jvmRuntimeOnly`:
+      # its DECLARABLE configurations are source-set scoped (`jvmMainRuntimeOnly`), and only the
+      # resolvable `jvmRuntimeClasspath` carries the bare target name. Getting that wrong is silent
+      # — `findByName` returns null, nothing is added, and the render fails exactly as it did
+      # before — which is how the first version of this step passed its own fixture test and
+      # changed nothing on the real project. Verified against DroidKaigi by resolving
+      # `jvmRuntimeClasspath` and finding the project in it, not by reading the appended file back.
+      - name: Put host-supplied implementations on the render classpath
+        if: ${{ inputs.upstream-repository != '' && inputs.render-runtime-projects != '' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${INPUT_MODULE:-}" ] || [ "${INPUT_MODULES:-}" = "all" ]; then
+            echo "::error::render-runtime-projects names configurations on ONE module's build file," \
+                 "so it cannot be used with repository-wide discovery. Name the module with 'module'."
+            exit 1
+          fi
+          # Same resolution as the google-services stub: the settings file gets the first word,
+          # because `project(":app").projectDir = file(…)` puts a module where its path does not say.
+          derived="$(printf '%s' "${INPUT_MODULE#:}" | tr ':' '/')"
+          remapped="$(
+            cat "${RENDER_DIR}"/settings.gradle "${RENDER_DIR}"/settings.gradle.kts 2>/dev/null |
+              sed -n "s|.*project(['\"]${INPUT_MODULE}['\"])\.projectDir[[:space:]]*=[[:space:]]*[Ff]ile(['\"]\([^'\"]*\)['\"]).*|\1|p" |
+              head -1
+          )" || true
+          if [ -n "$remapped" ]; then
+            derived="$remapped"
+          fi
+          module_dir="${RENDER_DIR}/${derived}"
+          build_file=""
+          for candidate in "${module_dir}/build.gradle.kts" "${module_dir}/build.gradle"; do
+            if [ -f "$candidate" ]; then build_file="$candidate"; break; fi
+          done
+          [ -n "$build_file" ] || {
+            echo "::error::no build.gradle.kts or build.gradle under ${module_dir} — is ${INPUT_MODULE} the module being rendered?"
+            exit 1
+          }
+          case "$build_file" in
+            *.kts) ;;
+            *)
+              echo "::error::${build_file} is a Groovy build script; render-runtime-projects appends Kotlin DSL." \
+                   "Teach this step the Groovy form before using it on such a module."
+              exit 1
+              ;;
+          esac
+          {
+            printf '\n// compose-preview import: implementations this upstream binds at runtime and keeps off\n'
+            printf '// its production classpath. Render-only, in a throwaway checkout.\n'
+            printf 'dependencies {\n'
+            printf '    listOf(\n'
+            printf '        "jvmMainRuntimeOnly", "desktopMainRuntimeOnly", "androidMainRuntimeOnly",\n'
+            printf '        "jvmRuntimeOnly", "desktopRuntimeOnly", "runtimeOnly",\n'
+            printf '    ).forEach { composeAiPreviewCfg ->\n'
+            printf '        if (configurations.findByName(composeAiPreviewCfg) != null) {\n'
+            IFS=','
+            for composeai_project in $INPUT_RENDER_RUNTIME_PROJECTS; do
+              printf '            add(composeAiPreviewCfg, project("%s"))\n' "$composeai_project"
+            done
+            unset IFS
+            printf '        }\n'
+            printf '    }\n'
+            printf '}\n'
+          } >> "$build_file"
+          echo "added ${INPUT_RENDER_RUNTIME_PROJECTS} to ${build_file#"$RENDER_DIR/"} on runtimeOnly configurations"
+
       - name: Pin the render variant in the upstream checkout
         if: ${{ inputs.upstream-repository != '' && inputs.variant != '' }}
         env:

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/BundleCommand.kt
@@ -277,6 +277,8 @@ private class PackSubcommand(private val args: List<String>) {
   private val verbose: Boolean = "--verbose" in args || "-v" in args
   private val progress: Boolean = verbose || "--progress" in args
   private val timeout: String? = args.flagValue("--timeout")
+  /** `--variant <name>`, forwarded to the inner [Command] so it reaches Gradle. */
+  private val variant: String? = args.flagValue("--variant")?.trim()?.takeIf { it.isNotEmpty() }
   private val ids: List<String> = PackPreviewIdExclusions.selectedIds(args)
 
   /**
@@ -320,6 +322,17 @@ private class PackSubcommand(private val args: List<String>) {
       if (progress && !verbose) add("--progress")
       timeout?.let {
         add("--timeout")
+        add(it)
+      }
+      // `bundle pack` forwards a WHITELIST to the inner Command, so a flag missing from it is
+      // accepted at this level and then silently dropped. `--variant` was one: the inner
+      // Command's `variantOverride` stayed null, `variantGradleArgs()` produced nothing, and the
+      // plugin fell back to its `debug` convention. On a flavored module that is not a no-op — a
+      // bare build type suffix-matches, so the render silently ran whichever flavor sorted first
+      // (home-assistant/android's `minimalDebug`, the one that does not compile) while the caller
+      // had asked for `fullDebug` and the CLI had reported no error.
+      variant?.let {
+        add("--variant")
         add(it)
       }
     }
@@ -482,6 +495,11 @@ private class PackSubcommand(private val args: List<String>) {
       }
       if (verbose) add("--verbose")
       if (progress && !verbose) add("--progress")
+      // Same whitelist, same omission — the per-preview path needs the variant just as much.
+      variant?.let {
+        add("--variant")
+        add(it)
+      }
     }
     object : Command(cmdArgs) {
         override fun run() {


### PR DESCRIPTION
Two import blockers, both root-caused against real projects rather than inferred.

## 1. `bundle pack` silently dropped `--variant`

`bundle pack` forwards a **whitelist** of flags to the inner `Command` it builds — `--module`, `--verbose`, `--progress`, `--timeout` — so any flag missing from that list is accepted at the subcommand level and never reaches Gradle. `--variant` was one: `variantOverride` stayed null, `variantGradleArgs()` produced nothing, and the plugin fell back to its `debug` convention with no error.

That is not a no-op on a flavored module. A bare build type suffix-matches every flavored variant, so home-assistant/android's `:app` rendered `minimalDebug` — the one flavor whose screenshotTest sources do not compile — while the run had asked for `fullDebug`. The run log has all three facts:

```
INPUT_VARIANT: fullDebug                         ← the input arrived
"${variant[@]}" … --variant "$INPUT_VARIANT"     ← the flag was passed
[180s] running: :app:compileMinimalDebugKotlin   ← the wrong variant was built
```

Both call sites are fixed — the ordinary pack and the per-preview path, which had the same omission.

The pipeline gets the same fix by a second route, because the CLI is installed from a **release** and this one is not reachable until the next: `composePreview.variant` is an ordinary Gradle project property, so for an import it is pinned in the throwaway checkout's `gradle.properties`, the file the workflow already rewrites for dependency verification and Isolated Projects. Once a released CLI carries the flag fix the two agree, and the command line wins anyway.

## 2. `render-runtime-projects`

An upstream may bind an implementation at runtime and deliberately keep it off the production compile classpath. DroidKaigi's `:core:preview:wrapper` is explicit:

```kotlin
androidMain.dependencies { compileOnly(project(":core:preview:impl")) }
jvmMain.dependencies    { compileOnly(project(":core:preview:impl")) }
// "impl stays off production classpaths"
```

with the binding supplied at runtime only from the app and from the repo's own screenshot-test convention. A render of `:core:ui` is neither, so all 450 previews failed with `ClassNotFoundException: …preview.impl.DefaultPreviewImageResolver` — one cause, every sidecar, which is what made it read as a renderer fault.

Named projects are appended to the module's build file **in the throwaway checkout**, on `runtimeOnly`-shaped configurations only. Nothing the module compiles against changes, so this cannot make a preview compile that would not compile for a real consumer — it supplies for the render what the upstream already supplies for its own screenshot tests. Import mode only; refused with repository-wide discovery, since it edits one module's build file.

### The configuration list is load-bearing

A KMP module has no plain `jvmRuntimeOnly`: its **declarable** configurations are source-set scoped (`jvmMainRuntimeOnly`), and only the **resolvable** `jvmRuntimeClasspath` carries the bare target name. My first version used the bare names, passed its own fixture test, and changed nothing on the real project — `findByName` returned null, nothing was added, and the render failed identically. Worth recording, because the failure mode is completely silent.

## Verification

Against a real DroidKaigi checkout with the plugin applied to `:core:ui`:

| | before | after |
| --- | --- | --- |
| `:core:preview:impl` on `jvmRuntimeClasspath` | absent | present |
| previews rendered | 0 of 450 | PNGs produced |
| distinct sidecar causes | 450 × `ClassNotFoundException: DefaultPreviewImageResolver` | — |

The `gradle.properties` variant-pin step was exercised against a fresh file (appended with its reason) and one already carrying the key (rewritten, not duplicated — the key appears exactly once afterwards). The runtime-projects step was exercised for the single-module case, two projects, and repository-wide discovery (refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_