### PR TITLE
fix(rc): take the rc-players 1.56.1 image-painter fix, and print the gate's failures

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -727,7 +727,7 @@ env:
   # the same players at. Renovate keeps the two in step (`.github/renovate.json`).
   RC_PLAYERS_REPO: yschimke/rc-players
   # renovate: datasource=github-tags depName=yschimke/rc-players
-  RC_PLAYERS_PIN: v1.56.0
+  RC_PLAYERS_PIN: v1.56.1
 
 jobs:
   # Resolve, ONCE PER RUN, which compose-ai-tools commit this run's export driver
@@ -3582,9 +3582,31 @@ jobs:
 
       # `continue-on-error` above exists only so the evidence upload gets a chance to run. Convert
       # the recorded outcome back into a hard gate before either artifact handoff or publication.
+      #
+      # This step also RE-PRINTS the failing ids, which the lane already printed thousands of lines
+      # earlier. That looks redundant and is not. Acting on this gate means writing an allowlist
+      # entry per id, and the allowlist file tells its next editor to take ids from the lane's own
+      # output — but that output is unreachable from the two places anyone actually reads a failure
+      # from: the GitHub log API returns only the tail of a job (this pipeline's is far longer than
+      # that window, and its per-step env dumps fill it), and the evidence artifact needs a download
+      # that agent egress policies routinely refuse. Printing the list from the LAST step puts it in
+      # the tail by construction. Costs a `jq` over a file the lane already wrote.
       - name: Enforce required CMP/Wasm lane
         if: ${{ always() && inputs.rc-cmp-wasm-lane && (inputs.publish || inputs.upload-out) && steps.rc-compare.outcome == 'failure' }}
         run: |
+          set -uo pipefail
+          summary="$GITHUB_WORKSPACE/out/rc-compare-summary.json"
+          # Best-effort: the lane can fail before it writes a summary (a distribution that would not
+          # build), and that must still exit 1 rather than dying in the reporting.
+          if [ -f "$summary" ]; then
+            jq -r '.cmpWasmGate | "CMP/Wasm gate: \(.rendered // 0)/\(.expected // 0) rendered, \(.allowed // [] | length) allowlisted, \(.failures // [] | length) failing"' \
+              "$summary" || true
+            echo "Failing documents — each needs a player fix or an allowlist entry:"
+            jq -r '.cmpWasmGate.failures[]? | "  \(.id)\n      \(.note)"' "$summary" 2>/dev/null ||
+              echo "  (could not parse $summary)"
+          else
+            echo "no rc-compare-summary.json was written; see the lane's own step above"
+          fi
           echo "::error title=CMP/Wasm parity gate failed::The enabled lane did not build or render every non-allowlisted Remote Compose document."
           exit 1
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -395,7 +395,7 @@ composeai-preview-serve = "2.15.0"
 #
 # During the move these were briefly split across two refs, so that three unpublished coordinates
 # could not pin the five that were already on Central. That is over: one ref again.
-rcplayers = "1.56.0"
+rcplayers = "1.56.1"
 
 [libraries]
 


### PR DESCRIPTION
The CMP/Wasm parity gate has blocked every `remote-m3` publish since wear-m3-catalog#238 changed the lane the sheet renders on. Two things were in the way, and this fixes both.

### The player fix already existed — we were pinned behind it

rc-players **1.56.1** carries [`fix(compose): honor FILTER_BITMAP so an image container painter draws`](https://github.com/yschimke/rc-players/pull/26), written for exactly the image-container documents this gate rejects. We pin **1.56.0**.

Worth recording, because the allowlist says otherwise: the two paint commands those entries blame — **22 (`PAINT_SHADER_MATRIX`) and 24 (`PAINT_TEXTURE`)** — have been accepted by the renderability check since **1.55.1** ([rc-players#21](https://github.com/yschimke/rc-players/pull/21)), so they were already supported at our pinned version. `FILTER_BITMAP` was the gap that actually remained. The reasons in `remote-m3-cmp-wasm-allowlist.json` are stale on that point and should be re-checked once this lands.

Both refs move together — `rcplayers` and `RC_PLAYERS_PIN` must be equal or the drift guard skips the embedded lanes entirely — and the version comment in `libs.versions.toml` already states why the whole stack shares one ref.

### And the failure list was unreadable

Acting on this gate means writing one allowlist entry per failing id, and the allowlist file tells its next editor to *"take ids from the lane's own output — the `CMP/Wasm: n/m rendered` block prints them"*. That output is unreachable from either place a failure actually gets read:

- the **log API returns only a job's tail**, and this pipeline's tail is filled by its per-step env dumps (the `TRUST_PREVIEW_PLUGIN_PY` heredoc alone is ~7 KB, printed at every step);
- the **evidence artifact needs a download** that agent egress policies routinely refuse (`CONNECT tunnel failed, response 403`).

So the **enforce step** — which runs last, and therefore lands in the readable tail by construction — now re-prints the ids and their notes from the `rc-compare-summary.json` the lane already wrote:

```
CMP/Wasm gate: 161/403 rendered, 1 allowlisted, 2 failing
Failing documents — each needs a player fix or an allowlist entry:
  ee.schimke.X.Foo_width_227dp
      PaintData[42]: paint command 24 is not implemented
  ee.schimke.X.Bar
      CoreText[21]: custom font family google:Inter (47) has no DataFont
```

It is best-effort by design: a lane that dies before writing a summary (a distribution that would not build) still exits 1 rather than dying in the reporting. `set -uo pipefail` deliberately omits `-e` for the same reason.

### Not a UI change

No rendered surface moves. The player bump can change *rendered pixels* in the CMP lanes — that is the point of it — and the comparison page is where that shows up, on the next `remote-m3` run.

### Test plan

- Workflow parses: `yaml.safe_load` over `design-artifacts-reusable.yml`.
- Both `jq` programs exercised against a summary carrying failures **and** an allowlisted entry, and against `{}` — the absent-gate case prints zeroes rather than erroring, and the failures selector emits nothing and exits 0.
- **1.56.1 is published**: HTTP 200 on all eight coordinates (`rc-player-{trace,protocol,runtime,compose}`, `rc-player-wasm-dist`, `remote-compose-player-js-dist`, `third-party-rc-embedded-player{,-jvm}`).

The gate itself re-runs on the next `remote-m3` push, which is what will say how many of its failures 1.56.1 clears and what is left to acknowledge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r


---
_Generated by [Claude Code](https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r)_