### PR TITLE
fix(render): a theme fan-out's suffixed outputs count as written

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -521,11 +521,35 @@ abstract class RenderPreviewsTask : DefaultTask() {
     internal fun emptyRunFailure(attempted: List<java.io.File>): String? {
       if (attempted.isEmpty()) return null
       if (attempted.any { it.isFile && it.length() > 0L }) return null
+      // A capture does not always land on the exact path it was scheduled at. A preview that fans
+      // out over themes writes one sibling per theme — `Foo-<hash>_DeepTeal.png`,
+      // `Foo-<hash>_SakuraPlum.png` … — and never the bare `Foo-<hash>.png` this list holds. Judged
+      // on exact paths alone, DroidKaigi's `:core:ui` rendered 450 files across 90 previews and
+      // still failed this gate with "none produced a file", which is both wrong and the opposite of
+      // actionable. So a stem match counts too: the question this gate exists to ask is whether the
+      // renderer produced ANYTHING, not whether it used the filename we predicted.
+      if (attempted.any { candidate -> hasSuffixedSibling(candidate) }) return null
       return "composePreviewRender: ${attempted.size} capture(s) were drawn and none produced a " +
         "file. That is a renderer or classpath fault rather than a broken preview — check the " +
         "`Render failed for …` lines above and the `.error.json` sidecars beside the expected " +
         "outputs, and `validateComposePreviewDesktopRenderClasspath` for a version skew. " +
         "Expected e.g. ${attempted.first().absolutePath}"
+    }
+
+    /**
+     * True when [candidate]'s directory holds a non-empty file with the same stem and an added
+     * `_suffix` — the shape a theme or variant fan-out writes instead of the exact path.
+     */
+    private fun hasSuffixedSibling(candidate: java.io.File): Boolean {
+      val stem = candidate.nameWithoutExtension
+      val extension = candidate.extension
+      val siblings = candidate.parentFile?.listFiles() ?: return false
+      return siblings.any {
+        it.isFile &&
+          it.length() > 0L &&
+          it.extension == extension &&
+          it.nameWithoutExtension.startsWith("${stem}_")
+      }
     }
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/EmptyRunFailureTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/EmptyRunFailureTest.kt
@@ -43,6 +43,42 @@ class EmptyRunFailureTest {
   }
 
   @Test
+  fun `a theme fan-out's suffixed siblings count as written`() {
+    // DroidKaigi's :core:ui fans every preview over five named themes, so the renderer writes
+    // `Foo-<hash>_DeepTeal.png` and friends and never the bare path the capture was scheduled at.
+    // Judged on exact paths it produced 450 files and still failed with "none produced a file".
+    png("CollapsingHeaderLayoutPreview-b2afa1fb_DeepTeal.png", 8)
+    png("CollapsingHeaderLayoutPreview-b2afa1fb_SakuraPlum.png", 8)
+    assertThat(
+        RenderPreviewsTask.emptyRunFailure(
+          listOf(File(tmp.root, "CollapsingHeaderLayoutPreview-b2afa1fb.png"))
+        )
+      )
+      .isNull()
+  }
+
+  @Test
+  fun `an unrelated file sharing no stem is not a surviving capture`() {
+    // The stem match must not degrade into "something is in the directory": a genuinely empty run
+    // that happens to sit beside another preview's output is still an empty run.
+    png("SomethingElse_DeepTeal.png", 8)
+    assertThat(RenderPreviewsTask.emptyRunFailure(listOf(File(tmp.root, "Foo.png")))).isNotNull()
+  }
+
+  @Test
+  fun `an empty suffixed sibling does not count as written`() {
+    png("Foo_DeepTeal.png", 0)
+    assertThat(RenderPreviewsTask.emptyRunFailure(listOf(File(tmp.root, "Foo.png")))).isNotNull()
+  }
+
+  @Test
+  fun `a stem that is a prefix of another preview's name is not a match`() {
+    // `Foo` must not be satisfied by `FooBar_DeepTeal.png` — the separator is part of the match.
+    png("FooBar_DeepTeal.png", 8)
+    assertThat(RenderPreviewsTask.emptyRunFailure(listOf(File(tmp.root, "Foo.png")))).isNotNull()
+  }
+
+  @Test
   fun `a run that scheduled nothing is not a failure`() {
     // A filtered or preview-less module renders zero captures and no-ops cleanly, as it always has.
     assertThat(RenderPreviewsTask.emptyRunFailure(emptyList())).isNull()


### PR DESCRIPTION
The empty-run gate asks whether the renderer produced **anything**, and answers it by looking for the exact paths the captures were scheduled at. A preview that fans out over themes never writes those paths: it writes one sibling per theme — `Foo-<hash>_DeepTeal.png`, `Foo-<hash>_SakuraPlum.png` … — and no bare `Foo-<hash>.png`.

So DroidKaigi's `:core:ui` rendered **450 files across 90 previews** and still failed:

```
composePreviewRender: 90 capture(s) were drawn and none produced a file.
That is a renderer or classpath fault rather than a broken preview …
```

Both halves of that are wrong. Files were produced, and it is not a classpath fault — but the message sends the reader looking for one, which is where three CI rounds of that import went. I only found it by rendering the project locally and listing the directory the message said was empty:

```
$ ls renders/ | grep -i collapsing
CollapsingHeaderLayoutPreview-b2afa1fb_CampfireNight.png
CollapsingHeaderLayoutPreview-b2afa1fb_DeepTeal.png
CollapsingHeaderLayoutPreview-b2afa1fb_MorningMist.png
CollapsingHeaderLayoutPreview-b2afa1fb_SakuraPlum.png
CollapsingHeaderLayoutPreview-b2afa1fb_Terracotta.png
```

## What changes

The gate's intent is unchanged and still all-or-nothing: a single broken preview is an ordinary fact about a catalog, reported through its `.error.json` sidecar, while a run where nothing survived is an environment fault worth stopping for. What changes is that "survived" now includes a non-empty sibling with the same stem and an added `_suffix` — because the question is whether the renderer produced anything, not whether it used the filename we predicted.

The stem match is deliberately narrow: the separator is part of it, so `Foo` is not satisfied by `FooBar_DeepTeal.png`, and an unrelated preview's output sitting in the same directory does not rescue a genuinely empty run.

## Testing

Four cases added to `EmptyRunFailureTest` — the fan-out, an unrelated file, an empty sibling, and the prefix collision. All eight tests pass:

```
tests=8 failures=0 errors=0
```

The original guard's own cases (nothing written fails; one survivor is enough; an empty file doesn't count; an empty schedule is fine) are untouched and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXFgrNVx7S1jsk1ridhagp)_