### PR TITLE
fix(ci): say which direction the rc-players pin has drifted

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -2452,6 +2452,10 @@ jobs:
       - name: Check the rc-players pin against the consumed player version
         id: rc-players-pin
         if: ${{ inputs.rc-embedded-lane || inputs.rc-embedded-jvm-lane }}
+        env:
+          # Named in the drift report, so a reader can see WHICH driver commit supplied the
+          # `rcplayers` on the other side of the comparison rather than having to work it out.
+          DRIVER_REF: ${{ needs.driver.outputs.ref }}
         run: |
           set -euo pipefail
           catalog="$GITHUB_WORKSPACE/compose-ai-tools/gradle/libs.versions.toml"
@@ -2463,9 +2467,45 @@ jobs:
             echo "::warning::no 'rcplayers' entry in the driver checkout's gradle/libs.versions.toml; skipping the embedded player lanes"
             exit 0
           fi
+          # Drift has two directions and they are not the same problem, which the single message
+          # here did not say. Both still skip the lanes — a harness on a different build than the
+          # capture is unattributable either way — but only one of them is anyone's to fix.
+          #
+          # PIN AHEAD OF DRIVER is the ordinary, self-healing case, and it happens on every player
+          # bump. `RC_PLAYERS_PIN` lives in this file, which an external caller reads at `@main`, so
+          # it moves the moment the bump merges; `rcplayers` reaches that caller through the DRIVER
+          # PIN, which only advances when release-please cuts a release and Renovate bumps
+          # `.github/design-artifacts-driver-pin.txt`. Between those two events every external
+          # caller drifts. Nothing is broken and nothing needs editing — it clears itself, and on
+          # 3 Sep 2026 (rcplayers 1.56.0 -> 1.56.1) the whole window was 24 minutes. What made it
+          # cost an afternoon was this step saying only "Bump RC_PLAYERS_PIN in this workflow",
+          # which is the WRONG instruction for this direction and sends the reader to edit a file
+          # that is already correct, while two columns quietly vanish from the wall.
+          #
+          # PIN BEHIND DRIVER is a real editing mistake: someone moved `rcplayers` without moving
+          # the literal beside it. That one IS "bump RC_PLAYERS_PIN in this workflow".
           if [ "v${version}" != "$RC_PLAYERS_PIN" ]; then
             echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning title=rc-players pin drift::RC_PLAYERS_PIN is $RC_PLAYERS_PIN but this repo consumes the players at v${version}. Rendering a harness through a different player build than the catalog's own capture makes every column unattributable, so the embedded lanes are skipped. Bump RC_PLAYERS_PIN in this workflow."
+            # `sort -V` decides the direction. The two values are equal-or-not by the test above,
+            # so the older of the pair is whichever sorts first.
+            older="$(printf '%s\n%s\n' "$RC_PLAYERS_PIN" "v${version}" | sort -V | head -n1)"
+            if [ "$older" = "v${version}" ]; then
+              detail="The pin is AHEAD of the driver, which is the ordinary state right after a player bump and needs no edit: this workflow is read at @main so RC_PLAYERS_PIN moved immediately, while rcplayers reaches you through the export-driver pin, which advances only when a release is cut and Renovate bumps .github/design-artifacts-driver-pin.txt. It clears on its own once that pin reaches a release carrying rcplayers=${RC_PLAYERS_PIN#v}."
+            else
+              detail="The pin is BEHIND the driver, which is an editing mistake: rcplayers moved without RC_PLAYERS_PIN beside it. Bump RC_PLAYERS_PIN in this workflow to v${version}."
+            fi
+            echo "::warning title=rc-players pin drift::RC_PLAYERS_PIN is $RC_PLAYERS_PIN but the driver checkout consumes the players at v${version}, so the vendored-Android and cmp-jvm columns are skipped for this run. $detail"
+            {
+              echo ""
+              echo "### Remote Compose embedded lanes skipped"
+              echo ""
+              echo "| | |"
+              echo "| --- | --- |"
+              echo "| \`RC_PLAYERS_PIN\` (this workflow, read at \`@main\`) | \`$RC_PLAYERS_PIN\` |"
+              echo "| \`rcplayers\` (export driver \`${DRIVER_REF:-unknown}\`) | \`v${version}\` |"
+              echo ""
+              echo "Columns lost this run: **vendored Android** and **cmp-jvm**. $detail"
+            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           echo "ok=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Drift has two directions and they are not the same problem, but this step said only *"Bump RC_PLAYERS_PIN in this workflow"* for both.

### The two directions

**Pin AHEAD of driver** is the ordinary, self-healing case, and it happens on *every* player bump. `RC_PLAYERS_PIN` lives in this workflow, which an external caller reads at `@main`, so it moves the moment the bump merges. `rcplayers` reaches that caller through the **export-driver pin**, which advances only once release-please cuts a release and Renovate bumps `.github/design-artifacts-driver-pin.txt`. Every external caller drifts in between.

Nothing is broken and nothing needs editing. Going `1.56.0 → 1.56.1` earlier today the window was **24 minutes**:

| | |
| --- | --- |
| #5043 merged (`rcplayers` → 1.56.1, pin literal → v1.56.1) | 05:38 |
| `chore(main): release 1.68.0` | 05:42 |
| #5046 moved the driver pin to v1.68.0 | 06:02 |

What it cost was an afternoon of reading, because the message named the wrong fix — it sends you to edit a file that is already correct — while the vendored-Android and cmp-jvm columns quietly went missing from the wall with no statement of why.

**Pin BEHIND driver** is a real editing mistake: `rcplayers` moved without the literal beside it. Only *that* one is "bump RC_PLAYERS_PIN".

### What changes

Both directions still skip the lanes — a harness on a different build than the capture is unattributable either way, which is the invariant this guard exists for and it is untouched. What changes is only what the run *tells you*:

- the warning names the **direction**, and for the self-healing one says so rather than prescribing an edit;
- it names the **columns being lost** (vendored Android, cmp-jvm), which the old message never did;
- it names **which driver commit** supplied the `rcplayers` on the other side;
- it writes a small table to the **job summary**, because a step annotation is not where anyone notices two absent columns.

Deliberately *not* done: making the pin readable from the driver checkout so the two move atomically. That removes the drift entirely, but it makes `ref:` computed — CodeQL's "checkout of untrusted code in a privileged context", critical, which is exactly why it is a literal today (see the env-block note, and #5006 review). Not worth reopening for a 24-minute window that clears itself.

### Test plan

- `yaml.safe_load` over the workflow.
- The guard body extracted and run against all four cases:

```
pin ahead   (v1.56.1 vs v1.56.0) -> "AHEAD … needs no edit … clears on its own"
pin behind  (v1.56.0 vs v1.56.1) -> "BEHIND … editing mistake … bump to v1.56.1"
matched     (v1.56.1 vs v1.56.1) -> no drift
v1.10.0 vs v1.9.0                -> AHEAD (confirms `sort -V` orders multi-digit
                                    versions numerically, not lexically)
```

That last case is the one worth having: a lexical compare would have called `v1.10.0` older than `v1.9.0` and printed the wrong instruction.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r


---
_Generated by [Claude Code](https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r)_