### PR TITLE
fix(cli): resolve the build root by settings file, and name the plugin publication race

### DIFF
--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
@@ -545,6 +545,7 @@ class GradleConnection(
 internal fun inheritedWrapperDistribution(
   projectDir: File,
   warn: (String) -> Unit = System.err::println,
+  gradleUserHome: File? = defaultGradleUserHome(),
 ): URI? {
   if (wrapperProperties(projectDir) != null) return null
   var dir: File? = projectDir.parentFile
@@ -554,17 +555,22 @@ internal fun inheritedWrapperDistribution(
         val loaded = Properties().apply { props.inputStream().use { load(it) } }
         val url = loaded.getProperty("distributionUrl")?.trim()?.takeIf { it.isNotEmpty() }
         val resolved = url?.let { wrapperDistributionUri(it, props) } ?: return@runCatching null
-        // The Tooling API's `useDistribution(URI)` carries a URL and nothing else — there is no
-        // way to hand it the `distributionSha256Sum` the wrapper would have verified. Say so
-        // rather than silently dropping a repository's integrity pin: the distribution is taken
-        // from the shared wrapper cache, which is where `../gradlew` put the copy it verified.
-        if (loaded.getProperty("distributionSha256Sum")?.isNotBlank() == true) {
+        val pinned = loaded.getProperty("distributionSha256Sum")?.trim()?.takeIf { it.isNotEmpty() }
+        if (pinned != null && !distributionAlreadyInstalled(resolved, gradleUserHome)) {
+          // The Tooling API's `useDistribution(URI)` carries a URL and nothing else — there is
+          // no way to hand it the `distributionSha256Sum` the wrapper would have verified. So
+          // when the distribution is not already in the wrapper's cache, inheriting the URL
+          // would mean downloading and executing it with the repository's integrity pin
+          // dropped. Refuse instead: the Tooling API falls back to its own distribution, which
+          // is at least not a checksum this build asked for and did not get.
           warn(
-            "compose-preview: ${props.path} pins distributionSha256Sum, which the Gradle " +
-              "Tooling API cannot be given. Using the wrapper's distribution URL as-is " +
-              "($resolved); run ./gradlew once from ${props.parentFile?.parentFile?.parent} to " +
-              "have the wrapper download and verify it first."
+            "compose-preview: not inheriting the Gradle distribution from ${props.path} — it " +
+              "pins distributionSha256Sum, the Tooling API cannot be given a checksum, and " +
+              "${redactedDistribution(resolved)} is not in the wrapper cache yet. Run " +
+              "./gradlew once from ${props.parentFile?.parentFile?.path} (which verifies and " +
+              "caches it), or give this build its own gradle/wrapper/gradle-wrapper.properties."
           )
+          return@runCatching null
         }
         resolved
       }
@@ -585,6 +591,39 @@ private fun wrapperDistributionUri(url: String, props: File): URI? = runCatching
   if (uri.isAbsolute) uri else props.parentFile.toURI().resolve(url)
 }
   .getOrNull()
+
+/**
+ * True when [distribution] is already unpacked in the wrapper's own cache, which means the wrapper
+ * downloaded it and — where a `distributionSha256Sum` was pinned — verified it. Reusing that copy
+ * involves no download, so no unverified bytes reach this build.
+ *
+ * Matched by the cache's directory layout (`wrapper/dists/<name>/<hash>/…` with the `.ok` marker
+ * Gradle writes after a successful unpack), not by recomputing Gradle's internal URL hash — the
+ * layout is stable and public, the hash function is neither.
+ */
+private fun distributionAlreadyInstalled(distribution: URI, gradleUserHome: File?): Boolean {
+  val home = gradleUserHome ?: return false
+  val name = distribution.path?.substringAfterLast('/')?.removeSuffix(".zip") ?: return false
+  val dists = File(home, "wrapper/dists/$name")
+  val versions = dists.listFiles()?.filter { it.isDirectory } ?: return false
+  return versions.any { dir -> dir.listFiles()?.any { it.name.endsWith(".ok") } == true }
+}
+
+internal fun defaultGradleUserHome(): File? =
+  System.getenv("GRADLE_USER_HOME")?.takeIf { it.isNotBlank() }?.let(::File)
+    ?: System.getProperty("user.home")?.takeIf { it.isNotBlank() }?.let { File(it, ".gradle") }
+
+/**
+ * A distribution URL safe to print: userinfo and query string removed.
+ *
+ * A private distribution can carry credentials in either — `https://user:token@host/…` or a signed
+ * `?X-Amz-Signature=…` — and a warning goes to stderr, which in CI means the build log.
+ */
+internal fun redactedDistribution(uri: URI): String = runCatching {
+  URI(uri.scheme, null, uri.host, uri.port, uri.path, null, null).toString() +
+    if (uri.rawQuery != null) "?…" else ""
+}
+  .getOrElse { "(distribution URL withheld)" }
 
 private fun wrapperProperties(dir: File): File? =
   File(dir, "gradle/wrapper/gradle-wrapper.properties").takeIf { it.isFile }

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
@@ -52,6 +52,7 @@ class GradleConnection(
    * manually wired it in their `build.gradle.kts`. See [autoInjectInitScriptArgs] for the source.
    */
   private val extraArguments: List<String> = emptyList(),
+) : AutoCloseable {
   /**
    * Optional second opinion on a build failure: given everything this connection saw of it
    * (Gradle's captured stderr plus the exception chain), returns one message to print after the
@@ -61,9 +62,15 @@ class GradleConnection(
    * CLI supplies the knowledge, because that is where it lives. Today the CLI uses it to name the
    * publication race behind an unresolvable plugin marker (issue #5034), which otherwise arrives as
    * a configuration failure in the consumer's own project and is diagnosed as one.
+   *
+   * A settable property rather than a constructor parameter **on purpose**: this module is a
+   * published library, and adding a defaulted parameter would change the primary constructor's JVM
+   * descriptor and its synthetic defaults constructor — every consumer compiled against the
+   * previous release would get a `NoSuchMethodError` on `GradleConnection(…)`, whether or not they
+   * ever wanted failure advice. Adding a property only adds methods.
    */
-  private val failureAdvice: (String) -> String? = { null },
-) : AutoCloseable {
+  var failureAdvice: ((String) -> String?)? = null
+
   companion object {
     /**
      * Wall-clock budget a Gradle invocation gets before it is cancelled.
@@ -335,7 +342,7 @@ class GradleConnection(
       }
     }
 
-    failureAdvice((captured + "\n" + messages.joinToString("\n")).trim())?.let {
+    failureAdvice?.invoke((captured + "\n" + messages.joinToString("\n")).trim())?.let {
       System.err.println()
       System.err.println(it)
     }
@@ -535,7 +542,10 @@ class GradleConnection(
  * Only the ancestor case is interesting: a build root with its own wrapper is already handled by
  * `forProjectDirectory`, and overriding it here would change which Gradle drives it.
  */
-internal fun inheritedWrapperDistribution(projectDir: File): URI? {
+internal fun inheritedWrapperDistribution(
+  projectDir: File,
+  warn: (String) -> Unit = System.err::println,
+): URI? {
   if (wrapperProperties(projectDir) != null) return null
   var dir: File? = projectDir.parentFile
   while (dir != null) {
@@ -543,7 +553,20 @@ internal fun inheritedWrapperDistribution(projectDir: File): URI? {
       return runCatching {
         val loaded = Properties().apply { props.inputStream().use { load(it) } }
         val url = loaded.getProperty("distributionUrl")?.trim()?.takeIf { it.isNotEmpty() }
-        url?.let { URI(it) }?.takeIf { it.isAbsolute }
+        val resolved = url?.let { wrapperDistributionUri(it, props) } ?: return@runCatching null
+        // The Tooling API's `useDistribution(URI)` carries a URL and nothing else — there is no
+        // way to hand it the `distributionSha256Sum` the wrapper would have verified. Say so
+        // rather than silently dropping a repository's integrity pin: the distribution is taken
+        // from the shared wrapper cache, which is where `../gradlew` put the copy it verified.
+        if (loaded.getProperty("distributionSha256Sum")?.isNotBlank() == true) {
+          warn(
+            "compose-preview: ${props.path} pins distributionSha256Sum, which the Gradle " +
+              "Tooling API cannot be given. Using the wrapper's distribution URL as-is " +
+              "($resolved); run ./gradlew once from ${props.parentFile?.parentFile?.parent} to " +
+              "have the wrapper download and verify it first."
+          )
+        }
+        resolved
       }
         .getOrNull()
     }
@@ -551,6 +574,17 @@ internal fun inheritedWrapperDistribution(projectDir: File): URI? {
   }
   return null
 }
+
+/**
+ * A wrapper `distributionUrl` as a URI, resolving a **relative** value against the directory
+ * holding [props] the way the Gradle wrapper itself does (a locally vendored distribution is
+ * normally written that way). Null when the value cannot be parsed.
+ */
+private fun wrapperDistributionUri(url: String, props: File): URI? = runCatching {
+  val uri = URI(url)
+  if (uri.isAbsolute) uri else props.parentFile.toURI().resolve(url)
+}
+  .getOrNull()
 
 private fun wrapperProperties(dir: File): File? =
   File(dir, "gradle/wrapper/gradle-wrapper.properties").takeIf { it.isFile }

--- a/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
+++ b/api/gradle-preview-driver/src/main/kotlin/ee/schimke/composeai/previewdriver/GradleConnector.kt
@@ -4,7 +4,9 @@ import ee.schimke.composeai.previewdata.PreviewModule
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.OutputStream
+import java.net.URI
 import java.util.Collections
+import java.util.Properties
 import org.gradle.tooling.CancellationTokenSource
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.events.FailureResult
@@ -50,6 +52,17 @@ class GradleConnection(
    * manually wired it in their `build.gradle.kts`. See [autoInjectInitScriptArgs] for the source.
    */
   private val extraArguments: List<String> = emptyList(),
+  /**
+   * Optional second opinion on a build failure: given everything this connection saw of it
+   * (Gradle's captured stderr plus the exception chain), returns one message to print after the
+   * failure report, or null when it recognises nothing.
+   *
+   * The driver deliberately knows nothing about *why* a particular string is worth explaining — the
+   * CLI supplies the knowledge, because that is where it lives. Today the CLI uses it to name the
+   * publication race behind an unresolvable plugin marker (issue #5034), which otherwise arrives as
+   * a configuration failure in the consumer's own project and is diagnosed as one.
+   */
+  private val failureAdvice: (String) -> String? = { null },
 ) : AutoCloseable {
   companion object {
     /**
@@ -69,7 +82,16 @@ class GradleConnection(
     const val DEFAULT_TIMEOUT_SECONDS: Long = 600
   }
 
-  private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
+  private val connector =
+    GradleConnector.newConnector().forProjectDirectory(projectDir).apply {
+      // `forProjectDirectory` takes the distribution from *that* directory's
+      // gradle/wrapper/gradle-wrapper.properties, and silently falls back to the Tooling API's own
+      // default when there is none. A nested build that borrows its parent repository's wrapper
+      // (issue #5031) has none of its own, so without this it would be driven by a Gradle the
+      // repository never chose. Inherit the nearest ancestor's wrapper distribution instead, which
+      // is exactly what `../gradlew` would have used.
+      inheritedWrapperDistribution(projectDir)?.let { useDistribution(it) }
+    }
   private val connection = connector.connect()
   private var modelAccessFailure: GradleAccessFailure? = null
 
@@ -313,6 +335,11 @@ class GradleConnection(
       }
     }
 
+    failureAdvice((captured + "\n" + messages.joinToString("\n")).trim())?.let {
+      System.err.println()
+      System.err.println(it)
+    }
+
     System.err.println()
     System.err.println("Run with --verbose for full build output.")
   }
@@ -499,6 +526,34 @@ class GradleConnection(
       )
   }
 }
+
+/**
+ * The `distributionUrl` of the nearest **ancestor** wrapper of [projectDir], or null when
+ * [projectDir] has a wrapper of its own (the Tooling API reads that one itself), when no ancestor
+ * has one, or when the URL is unusable (missing, relative, unparseable).
+ *
+ * Only the ancestor case is interesting: a build root with its own wrapper is already handled by
+ * `forProjectDirectory`, and overriding it here would change which Gradle drives it.
+ */
+internal fun inheritedWrapperDistribution(projectDir: File): URI? {
+  if (wrapperProperties(projectDir) != null) return null
+  var dir: File? = projectDir.parentFile
+  while (dir != null) {
+    wrapperProperties(dir)?.let { props ->
+      return runCatching {
+        val loaded = Properties().apply { props.inputStream().use { load(it) } }
+        val url = loaded.getProperty("distributionUrl")?.trim()?.takeIf { it.isNotEmpty() }
+        url?.let { URI(it) }?.takeIf { it.isAbsolute }
+      }
+        .getOrNull()
+    }
+    dir = dir.parentFile
+  }
+  return null
+}
+
+private fun wrapperProperties(dir: File): File? =
+  File(dir, "gradle/wrapper/gradle-wrapper.properties").takeIf { it.isFile }
 
 private object NullOutputStream : OutputStream() {
   override fun write(b: Int) {}

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.previewdriver
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Which Gradle distribution drives a build root that has no wrapper of its own (issue #5031).
+ *
+ * `GradleConnector.forProjectDirectory` reads the distribution from *that* directory's wrapper
+ * properties and falls back to the Tooling API's own default when there is none — so a nested build
+ * borrowing its parent repository's wrapper would be driven by a Gradle the repository never chose.
+ * [inheritedWrapperDistribution] supplies the ancestor's instead, and stays out of the way when the
+ * directory has a wrapper of its own.
+ */
+class InheritedWrapperDistributionTest {
+
+  private val tmp: File = Files.createTempDirectory("wrapper-dist").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    tmp.deleteRecursively()
+  }
+
+  private fun wrapper(dir: File, distributionUrl: String) {
+    File(dir, "gradle/wrapper").mkdirs()
+    File(dir, "gradle/wrapper/gradle-wrapper.properties")
+      .writeText("distributionBase=GRADLE_USER_HOME\ndistributionUrl=$distributionUrl\n")
+  }
+
+  private fun dir(path: String): File = File(tmp, path).apply { mkdirs() }
+
+  @Test
+  fun `inherits the nearest ancestor's distribution`() {
+    val repo = dir("repo")
+    // Written the way the wrapper writes it: a properties file escapes the scheme colon.
+    wrapper(repo, "https\\://services.gradle.org/distributions/gradle-9.7-bin.zip")
+    val nested = dir("repo/components")
+
+    assertEquals(
+      "https://services.gradle.org/distributions/gradle-9.7-bin.zip",
+      inheritedWrapperDistribution(nested)?.toString(),
+    )
+  }
+
+  @Test
+  fun `leaves a directory with its own wrapper alone`() {
+    val repo = dir("own")
+    wrapper(repo, "https\\://services.gradle.org/distributions/gradle-9.7-bin.zip")
+    assertNull(inheritedWrapperDistribution(repo))
+  }
+
+  @Test
+  fun `null when no ancestor has a wrapper`() {
+    assertNull(inheritedWrapperDistribution(dir("bare/deep")))
+  }
+
+  @Test
+  fun `null for a wrapper whose distributionUrl is unusable`() {
+    val repo = dir("relative")
+    wrapper(repo, "gradle-9.7-bin.zip")
+    assertNull(inheritedWrapperDistribution(dir("relative/nested")))
+  }
+}

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
@@ -1,10 +1,12 @@
 package ee.schimke.composeai.previewdriver
 
 import java.io.File
+import java.net.URI
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -73,23 +75,83 @@ class InheritedWrapperDistributionTest {
   }
 
   @Test
-  fun `says so when the inherited wrapper pins a checksum it cannot carry over`() {
+  fun `a pinned checksum is refused rather than silently dropped`() {
+    // `useDistribution(URI)` carries a URL and nothing else, so inheriting a pinned distribution
+    // that is not already cached would download and run it with the repository's integrity pin
+    // gone. Refuse — a warning does not protect the invocation that is happening now.
     val repo = dir("pinned")
+    pinnedWrapper(repo)
+    val warnings = mutableListOf<String>()
+    val resolved =
+      inheritedWrapperDistribution(
+        dir("pinned/nested"),
+        warn = { warnings += it },
+        gradleUserHome = dir("empty-gradle-home"),
+      )
+    assertNull(resolved, "a distribution whose checksum cannot be honoured must not be inherited")
+    assertTrue(warnings.single().contains("distributionSha256Sum"), warnings.toString())
+  }
+
+  @Test
+  fun `a pinned distribution already in the wrapper cache is inherited`() {
+    // The wrapper downloaded and verified this copy; reusing it involves no download, so no
+    // unverified bytes reach the build.
+    val repo = dir("cached")
+    pinnedWrapper(repo)
+    val home = dir("cached-gradle-home")
+    val unpacked = File(home, "wrapper/dists/gradle-9.7-bin/a1b2c3")
+    unpacked.mkdirs()
+    File(unpacked, "gradle-9.7-bin.zip.ok").writeText("")
+
+    val warnings = mutableListOf<String>()
+    val resolved =
+      inheritedWrapperDistribution(
+        dir("cached/nested"),
+        warn = { warnings += it },
+        gradleUserHome = home,
+      )
+    assertEquals(
+      "https://services.gradle.org/distributions/gradle-9.7-bin.zip",
+      resolved?.toString(),
+    )
+    assertTrue(warnings.isEmpty(), "nothing to warn about when no download is needed: $warnings")
+  }
+
+  @Test
+  fun `the warning does not leak credentials from a private distribution URL`() {
+    val repo = dir("private")
+    File(repo, "gradle/wrapper").mkdirs()
+    File(repo, "gradle/wrapper/gradle-wrapper.properties")
+      .writeText(
+        "distributionUrl=https\\://ci:s3cr3t-token@dist.internal/gradle-9.7-bin.zip?sig=abc\n" +
+          "distributionSha256Sum=aaaabbbbccccdddd\n"
+      )
+    val warnings = mutableListOf<String>()
+    inheritedWrapperDistribution(
+      dir("private/nested"),
+      warn = { warnings += it },
+      gradleUserHome = dir("empty-home-2"),
+    )
+    val warning = warnings.single()
+    assertFalse(warning.contains("s3cr3t-token"), warning)
+    assertFalse(warning.contains("sig=abc"), warning)
+    assertTrue(warning.contains("dist.internal"), warning)
+  }
+
+  @Test
+  fun `redaction keeps the host and drops userinfo and query`() {
+    assertEquals(
+      "https://dist.internal/gradle-9.7-bin.zip?…",
+      redactedDistribution(URI("https://ci:s3cr3t@dist.internal/gradle-9.7-bin.zip?sig=abc")),
+    )
+  }
+
+  private fun pinnedWrapper(repo: File) {
     File(repo, "gradle/wrapper").mkdirs()
     File(repo, "gradle/wrapper/gradle-wrapper.properties")
       .writeText(
         "distributionUrl=https\\://services.gradle.org/distributions/gradle-9.7-bin.zip\n" +
           "distributionSha256Sum=aaaabbbbccccdddd\n"
       )
-    val warnings = mutableListOf<String>()
-    val resolved = inheritedWrapperDistribution(dir("pinned/nested")) { warnings += it }
-    assertEquals(
-      "https://services.gradle.org/distributions/gradle-9.7-bin.zip",
-      resolved?.toString(),
-    )
-    assertTrue(
-      warnings.single().contains("distributionSha256Sum"),
-      "expected the dropped checksum to be named; got $warnings",
-    )
   }
 }

--- a/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
+++ b/api/gradle-preview-driver/src/test/kotlin/ee/schimke/composeai/previewdriver/InheritedWrapperDistributionTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Which Gradle distribution drives a build root that has no wrapper of its own (issue #5031).
@@ -59,9 +60,36 @@ class InheritedWrapperDistributionTest {
   }
 
   @Test
-  fun `null for a wrapper whose distributionUrl is unusable`() {
+  fun `resolves a relative distributionUrl against the wrapper directory`() {
+    // The wrapper resolves a relative distributionUrl against the directory holding
+    // gradle-wrapper.properties, which is how a locally vendored distribution is normally written.
     val repo = dir("relative")
     wrapper(repo, "gradle-9.7-bin.zip")
-    assertNull(inheritedWrapperDistribution(dir("relative/nested")))
+    val resolved = inheritedWrapperDistribution(dir("relative/nested"))
+    assertEquals(
+      File(repo, "gradle/wrapper/gradle-9.7-bin.zip").toURI().normalize(),
+      resolved?.normalize(),
+    )
+  }
+
+  @Test
+  fun `says so when the inherited wrapper pins a checksum it cannot carry over`() {
+    val repo = dir("pinned")
+    File(repo, "gradle/wrapper").mkdirs()
+    File(repo, "gradle/wrapper/gradle-wrapper.properties")
+      .writeText(
+        "distributionUrl=https\\://services.gradle.org/distributions/gradle-9.7-bin.zip\n" +
+          "distributionSha256Sum=aaaabbbbccccdddd\n"
+      )
+    val warnings = mutableListOf<String>()
+    val resolved = inheritedWrapperDistribution(dir("pinned/nested")) { warnings += it }
+    assertEquals(
+      "https://services.gradle.org/distributions/gradle-9.7-bin.zip",
+      resolved?.toString(),
+    )
+    assertTrue(
+      warnings.single().contains("distributionSha256Sum"),
+      "expected the dropped checksum to be named; got $warnings",
+    )
   }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -13,6 +13,7 @@ import ee.schimke.composeai.previewdata.PreviewModule
 import ee.schimke.composeai.previewdata.PreviewResult
 import ee.schimke.composeai.previewdata.PreviewResultBuilder
 import ee.schimke.composeai.previewdata.previewSha256
+import ee.schimke.composeai.previewdriver.GradleAccessFailure
 import ee.schimke.composeai.previewdriver.GradleConnection
 import ee.schimke.composeai.previewdriver.GradleTaskOutcome
 import ee.schimke.composeai.previewdriver.ProjectDiscoveryFailure
@@ -344,9 +345,14 @@ abstract class Command(
     val root =
       findProjectRoot()
         ?: run {
-          System.err.println("Cannot find Gradle project root (no gradlew found)")
+          val here = File(".").absoluteFile.normalize().path
+          System.err.println(
+            "Cannot find Gradle project root: no settings.gradle[.kts] and no gradlew at or " +
+              "above $here"
+          )
           exitProcess(1)
         }
+    noteResolvedProjectRoot(root)
     val injectArgs = autoInjectInitScriptArgs(args, projectRoot = root)
     val connection =
       withGradleStdout(silenceStdout) {
@@ -361,6 +367,7 @@ abstract class Command(
           verbose,
           progress,
           extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
+          failureAdvice = ::buildFailureAdvice,
         )
       }
     connection.use(block)
@@ -390,15 +397,17 @@ abstract class Command(
           )
           System.err.println("Gradle ${it.operation} failed: ${it.message}")
           it.detail?.let { detail -> System.err.println("Caused by: $detail") }
-          System.err.println(
-            "Check Gradle wrapper/cache access, then rerun with --verbose for full output."
-          )
+          printModelAccessAdvice(it)
           exitProcess(1)
         }
         System.err.println(
           "Module '$explicitModule' not found or does not apply the compose-ai-tools plugin."
         )
-        printDiscoveryFailures(gradle.lastDiscoveryFailures)
+        printDiscoveryFailures(
+          gradle.lastDiscoveryFailures,
+          pluginVersion = injectedPluginVersion,
+          pluginVersionSource = injectedPluginVersionSource,
+        )
         exitProcess(1)
       }
       return listOf(one)
@@ -410,13 +419,15 @@ abstract class Command(
         System.err.println("Could not query Gradle project model.")
         System.err.println("Gradle ${it.operation} failed: ${it.message}")
         it.detail?.let { detail -> System.err.println("Caused by: $detail") }
-        System.err.println(
-          "Check Gradle wrapper/cache access, then rerun with --verbose for full output."
-        )
+        printModelAccessAdvice(it)
         exitProcess(1)
       }
       System.err.println("No preview modules discovered in this project.")
-      printDiscoveryFailures(gradle.lastDiscoveryFailures)
+      printDiscoveryFailures(
+        gradle.lastDiscoveryFailures,
+        pluginVersion = injectedPluginVersion,
+        pluginVersionSource = injectedPluginVersionSource,
+      )
       exitProcess(1)
     }
     if (verbose || modules.size > 1) {
@@ -1044,7 +1055,72 @@ abstract class Command(
   }
 
   protected fun findProjectRoot(): File? = findGradleProjectRoot()
+
+  /**
+   * The version pin in force for this run, resolved once. Read for two things that both need to
+   * name a version the user never typed: the auto-inject diagnosis in [buildFailureAdvice]
+   * (issue #5034) and the attribution in its message.
+   */
+  private val resolvedPin: ResolvedVersionPin? by lazy {
+    resolveVersionPin(findProjectRoot(), args)
+  }
+
+  /** The compose-preview plugin version this run injects — the pin when there is one, else ours. */
+  protected val injectedPluginVersion: String
+    get() = resolvedPin?.version ?: BUNDLE_VERSION
+
+  /** Where [injectedPluginVersion] came from, or null when it is simply the CLI's own version. */
+  protected val injectedPluginVersionSource: String?
+    get() = resolvedPin?.source?.display
+
+  /**
+   * The advice hook handed to every [GradleConnection] this command opens: recognises the
+   * compose-preview plugin marker failing to resolve and explains the publication window, so it is
+   * not diagnosed as a configuration problem in the user's own project (issue #5034).
+   */
+  protected fun buildFailureAdvice(failureText: String): String? =
+    pluginResolutionGuidance(failureText, injectedPluginVersion, injectedPluginVersionSource)
+
+  /**
+   * Prints what to do about a failed Gradle model query: the plugin-publication explanation when
+   * that is what it was, else the generic "check wrapper/cache access" pointer this always had.
+   */
+  private fun printModelAccessAdvice(failure: GradleAccessFailure) {
+    val text = listOfNotNull(failure.message, failure.detail).joinToString("\n")
+    val advice = buildFailureAdvice(text)
+    if (advice != null) {
+      System.err.println()
+      System.err.println(advice)
+    } else {
+      System.err.println(
+        "Check Gradle wrapper/cache access, then rerun with --verbose for full output."
+      )
+    }
+  }
+
+  /**
+   * Names the build the CLI resolved whenever that is **not** the directory it was invoked from —
+   * once per process, on stderr.
+   *
+   * This is the line issue #5031 was missing. When root resolution picks a build other than the one
+   * the user is standing in, every diagnostic that follows is a *true statement about a build they
+   * never named* — a project count, a set of configuration failures, an Isolated Projects error —
+   * and nothing anywhere says which build it is talking about. One line makes a mis-resolution
+   * legible instead of arriving as a wall of unrelated configuration failures. It is also correct
+   * and useful in the ordinary case of standing in a subproject: that is the build being driven.
+   */
+  private fun noteResolvedProjectRoot(root: File) {
+    val cwd = File(".").absoluteFile.normalize()
+    if (root.absoluteFile.normalize() == cwd) return
+    if (!projectRootNotePrinted.compareAndSet(false, true)) return
+    System.err.println(
+      "compose-preview: driving the Gradle build at ${root.path} (from ${cwd.path})."
+    )
+  }
 }
+
+/** One [Command.noteResolvedProjectRoot] line per process, however many connections it opens. */
+private val projectRootNotePrinted = AtomicBoolean(false)
 
 /**
  * Preview kinds whose render legitimately never emits a PNG, so a null `pngPath` is expected rather
@@ -1070,8 +1146,20 @@ internal fun printDiscoveryFailures(
   failures: List<ProjectDiscoveryFailure>,
   limit: Int = 10,
   err: (String) -> Unit = System.err::println,
+  pluginVersion: String? = null,
+  pluginVersionSource: String? = null,
 ) {
   if (failures.isEmpty()) return
+  // The plugin marker not resolving is never the consumer's build being wrong, so it pre-empts
+  // both the AGP guidance and the per-project list (issue #5034).
+  failures
+    .firstNotNullOfOrNull {
+      pluginResolutionGuidance(it.message, pluginVersion, pluginVersionSource)
+    }
+    ?.let {
+      err(it)
+      return
+    }
   // When the failures are dominated by the "auto-injected plugin can't see AGP" signature there's
   // a single actionable cause — emit the guidance instead of N cryptic NoClassDefFoundError stacks
   // (issue #1947).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -363,12 +363,12 @@ abstract class Command(
         // invisible to `findPreviewModules()` because its task only registers
         // when `-PcomposePreview.variant=demoDebug` is on the model query too.
         GradleConnection(
-          root,
-          verbose,
-          progress,
-          extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
-          failureAdvice = ::buildFailureAdvice,
-        )
+            root,
+            verbose,
+            progress,
+            extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
+          )
+          .apply { failureAdvice = ::buildFailureAdvice }
       }
     connection.use(block)
   }
@@ -1150,16 +1150,19 @@ internal fun printDiscoveryFailures(
   pluginVersionSource: String? = null,
 ) {
   if (failures.isEmpty()) return
-  // The plugin marker not resolving is never the consumer's build being wrong, so it pre-empts
-  // both the AGP guidance and the per-project list (issue #5034).
-  failures
-    .firstNotNullOfOrNull {
-      pluginResolutionGuidance(it.message, pluginVersion, pluginVersionSource)
-    }
-    ?.let {
-      err(it)
-      return
-    }
+  // The plugin marker not resolving is never the consumer's build being wrong, so it leads —
+  // ahead of the AGP guidance and the per-project list (issue #5034). It only *replaces* them
+  // when it accounts for at least half the failures, the same bar [agpClassloaderGuidance] uses:
+  // one project failing on the marker while others fail for their own reasons is not a reason to
+  // hide theirs and send the user away to wait for a publication.
+  val markerGuidance = failures.firstNotNullOfOrNull {
+    pluginResolutionGuidance(it.message, pluginVersion, pluginVersionSource)
+  }
+  if (markerGuidance != null) {
+    err(markerGuidance)
+    val matching = failures.count { isUnresolvedPluginMarkerFailure(it.message) }
+    if (matching * 2 >= failures.size) return
+  }
   // When the failures are dominated by the "auto-injected plugin can't see AGP" signature there's
   // a single actionable cause — emit the guidance instead of N cryptic NoClassDefFoundError stacks
   // (issue #1947).

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -341,6 +341,15 @@ class DoctorCommand(
 
   private fun runProjectChecks(projectDir: File) {
     var gradleAccessFailure: GradleAccessFailure? = null
+    // `doctor` is the command people run *because* something is wrong, so it is the last place
+    // that should print the generic "check wrapper/cache access" line when the real cause is that
+    // the plugin version this project asks for isn't published yet (issue #5034).
+    val pin = resolveVersionPin(projectDir, args, fileSystem = fileSystem)
+    val pluginVersion = pin?.version ?: BUNDLE_VERSION
+    val pluginVersionSource = pin?.source?.display
+    val diagnosePublicationRace = { text: String ->
+      pluginResolutionGuidance(text, pluginVersion, pluginVersionSource)
+    }
     // Cheap, disk-only, and independent of the Gradle model — so it runs first and still reports
     // when the model query below fails. A wrong pin is one of the reasons a query fails.
     checkVersionPin(projectDir)
@@ -353,6 +362,7 @@ class DoctorCommand(
             verbose = verbose,
             extraArguments = injectArgs + variantGradleArgs() + gradleWriteLocksArgs(),
           )
+          .apply { failureAdvice = diagnosePublicationRace }
           .use { gc ->
             // Daemon-JVM + Gradle-version snapshot. Runs first so other
             // project-scope checks can compare against the daemon's JDK
@@ -381,20 +391,29 @@ class DoctorCommand(
 
     if (model == null) {
       gradleAccessFailure?.let {
+        val raceGuidance =
+          diagnosePublicationRace(listOfNotNull(it.message, it.detail).joinToString("\n"))
         addCheck(
           DoctorCheck(
             id = "project.gradle-access",
             category = "project",
             status = "error",
-            message = "could not query Gradle project model",
+            message =
+              if (raceGuidance != null)
+                "could not query Gradle project model — the compose-preview plugin " +
+                  "$pluginVersion is not resolvable"
+              else "could not query Gradle project model",
             detail =
               "Gradle ${it.operation} failed: ${it.message}" +
                 (it.detail?.let { d -> " Caused by: $d" } ?: ""),
             remediation =
               DoctorRemediation(
                 summary =
-                  "Ensure the CLI can access the Gradle wrapper, distribution cache, and lock files, then rerun doctor.",
-                commands = listOf("./gradlew help"),
+                  raceGuidance
+                    ?: "Ensure the CLI can access the Gradle wrapper, distribution cache, and lock files, then rerun doctor.",
+                commands =
+                  if (raceGuidance != null) listOf("compose-preview pin <previous-version>")
+                  else listOf("./gradlew help"),
               ),
           )
         )
@@ -434,6 +453,7 @@ class DoctorCommand(
               fs.take(10).joinToString("; ") { "${it.path}: ${it.message}" } +
               if (fs.size > 10) " (… and ${fs.size - 10} more)" else ""
           }
+      val raceGuidance = model.failures.firstNotNullOfOrNull { diagnosePublicationRace(it.message) }
       addCheck(
         DoctorCheck(
           id = "project.plugin-applied",
@@ -444,7 +464,8 @@ class DoctorCommand(
           remediation =
             DoctorRemediation(
               summary =
-                if (failureDetail != null)
+                if (raceGuidance != null) raceGuidance
+                else if (failureDetail != null)
                   "Projects failed to configure during discovery — rerun with --verbose for full " +
                     "Gradle output. If the plugin is applied via a convention plugin, the CLI now " +
                     "skips auto-inject automatically; otherwise apply it in your module's " +

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PinCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PinCommand.kt
@@ -62,7 +62,10 @@ class PinCommand(
     val root =
       projectRoot
         ?: run {
-          stderr("compose-preview pin: cannot find a Gradle project root (no gradlew found).")
+          stderr(
+            "compose-preview pin: cannot find a Gradle project root " +
+              "(no settings.gradle[.kts] and no gradlew at or above this directory)."
+          )
           exitProcess(1)
         }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosis.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosis.kt
@@ -26,9 +26,10 @@ package ee.schimke.composeai.cli
  * and each was diagnosed as a problem with the imported project, because that is what the text
  * says. Nothing in it points at the CLI, and nothing suggests "come back in five minutes".
  *
- * Matching is deliberately narrow — the plugin's own coordinate, a resolution verb, and (when the
- * caller knows what it injected) that exact version — so an unrelated dependency failure in the
- * user's build never draws this explanation.
+ * Matching is deliberately narrow — the plugin's own coordinate, a *missing-artifact* verb, no
+ * transport or repository-configuration cause, and (when the caller knows what it injected) that
+ * exact version — so an unrelated dependency failure in the user's build never draws this
+ * explanation. See [isUnresolvedPluginMarkerFailure].
  */
 internal const val COMPOSE_PREVIEW_PLUGIN_ID = "ee.schimke.composeai.preview"
 
@@ -39,23 +40,54 @@ internal const val COMPOSE_PREVIEW_PLUGIN_MARKER =
   "$COMPOSE_PREVIEW_PLUGIN_ID:$COMPOSE_PREVIEW_PLUGIN_ID.gradle.plugin"
 
 /**
- * True when [message] is Gradle failing to resolve *our* plugin marker.
+ * True when [message] is Gradle reporting our plugin marker **missing from every repository it
+ * searched** — the shape a not-yet-published version takes.
  *
- * Requires all three of: the marker module (so a project that merely mentions the plugin id in an
- * unrelated failure doesn't match), one of Gradle's resolution-failure verbs, and — when [version]
- * is non-null — that version appearing as the coordinate's version. The version check is what makes
- * this "the release you just resolved isn't published yet" rather than "some compose-preview
- * version, somewhere, didn't resolve".
+ * Deliberately narrow, in three ways:
+ * - the marker module must appear, so a failure that merely mentions the plugin id doesn't match;
+ * - the verb must be a *missing-artifact* one. Gradle says `Could not find <coordinate>` for
+ *   dependency resolution and `could not resolve plugin artifact '<coordinate>'` for the plugins
+ *   DSL. The generic `Could not resolve` / `Cannot resolve external dependency` forms are **not**
+ *   accepted: they are also what an unreachable proxy, a TLS failure or a build with no
+ *   repositories declared produces, and telling someone in that state to wait for a publication
+ *   sends them the wrong way (and, in the discovery path, hides the other projects' failures);
+ * - and when [version] is given, that version must be the one in the coordinate — which is what
+ *   makes this "the release you just resolved isn't published yet" rather than "some
+ *   compose-preview version, somewhere, didn't resolve".
+ *
+ * [TRANSPORT_CAUSES] backs the second point up: a message carrying the marker *and* a
+ * missing-artifact verb but also naming a repository-configuration or transport cause is left
+ * alone, because that cause is the real one.
  */
 internal fun isUnresolvedPluginMarkerFailure(message: String, version: String? = null): Boolean {
   if (!message.contains(COMPOSE_PREVIEW_PLUGIN_MARKER)) return false
-  val unresolved =
+  val missingArtifact =
     message.contains("Could not find") ||
-      message.contains("Could not resolve") ||
-      message.contains("Cannot resolve external dependency")
-  if (!unresolved) return false
+      message.contains("could not resolve plugin artifact", ignoreCase = true)
+  if (!missingArtifact) return false
+  if (TRANSPORT_CAUSES.any { message.contains(it, ignoreCase = true) }) return false
   return version == null || message.contains("$COMPOSE_PREVIEW_PLUGIN_MARKER:$version")
 }
+
+/**
+ * Phrases that identify a resolution failure as a repository-configuration or transport problem
+ * rather than an absent artifact. Gradle can name the marker in any of these, and none of them is
+ * fixed by waiting for a publication.
+ */
+private val TRANSPORT_CAUSES =
+  listOf(
+    "no repositories are defined",
+    "Connection refused",
+    "Connection reset",
+    "UnknownHostException",
+    "SSLHandshakeException",
+    "certificate",
+    "Read timed out",
+    "connect timed out",
+    "407 Proxy",
+    "401 Unauthorized",
+    "403 Forbidden",
+  )
 
 /**
  * The message to print for [isUnresolvedPluginMarkerFailure], naming the version, where it came
@@ -91,15 +123,21 @@ internal fun unresolvedPluginMarkerGuidance(version: String, origin: String? = n
 
 /**
  * The version in an unresolvable marker coordinate, e.g. `1.66.1` out of `…gradle.plugin:1.66.1`.
- * Null when [message] names the marker without a version we can read.
+ * Null when [message] names the marker without a version.
+ *
+ * Takes the **whole** coordinate version, not a numeric-looking prefix of it: Gradle versions are
+ * not required to start with a digit or to avoid `+` (`dev-SNAPSHOT`, `1.2.3+build` are both legal,
+ * and the CLI's own pin normalisation accepts any non-blank string), and truncating one would name
+ * a different artifact in the message and in the availability URL. So it runs to the first
+ * character that cannot be part of a coordinate.
  */
 internal fun unresolvedPluginMarkerVersion(message: String): String? =
-  Regex("""${Regex.escape(COMPOSE_PREVIEW_PLUGIN_MARKER)}:([0-9][A-Za-z0-9._\-]*)""")
+  Regex("""${Regex.escape(COMPOSE_PREVIEW_PLUGIN_MARKER)}:([^\s,;)'"\]]+)""")
     .find(message)
     ?.groupValues
     ?.get(1)
     // Gradle ends the sentence right after the coordinate ("…gradle.plugin:1.66.1."), and a
-    // version never ends in a dot, so the trailing one is punctuation rather than part of it.
+    // version never ends in a dot, so a trailing one is punctuation rather than part of it.
     ?.trimEnd('.')
     ?.takeIf { it.isNotEmpty() }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosis.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosis.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Recognises the one Gradle failure that is never the consumer's fault — **the compose-preview
+ * plugin marker cannot be resolved at the version this run injected** — and says so, instead of
+ * letting it arrive as a configuration failure in the user's own project (issue #5034).
+ *
+ * # The failure
+ *
+ * ```
+ * :: ProjectConfigurationException: A problem occurred configuring root project '…'.
+ *    -> Could not resolve all dependencies for configuration 'classpath'.
+ *    -> Could not find ee.schimke.composeai.preview:
+ *       ee.schimke.composeai.preview.gradle.plugin:1.66.1
+ * ```
+ *
+ * # Why it is worth a message of its own
+ * A release makes the CLI available before the plugin: the GitHub release the `install` action
+ * resolves `latest` from goes public minutes — sometimes tens of minutes — before
+ * `ee.schimke.composeai.preview` is resolvable from plugins.gradle.org and Maven Central. The
+ * release workflow's `maven-readiness` gate exists to close that window, and issue #5029 widened
+ * its budget; this message covers what any gate leaves over, and the equivalent case with no gate
+ * at all — a pin or `--plugin-version` naming a version that was never published.
+ *
+ * The cost of *not* saying it is measured: three release rounds' worth of imports failed this way,
+ * and each was diagnosed as a problem with the imported project, because that is what the text
+ * says. Nothing in it points at the CLI, and nothing suggests "come back in five minutes".
+ *
+ * Matching is deliberately narrow — the plugin's own coordinate, a resolution verb, and (when the
+ * caller knows what it injected) that exact version — so an unrelated dependency failure in the
+ * user's build never draws this explanation.
+ */
+internal const val COMPOSE_PREVIEW_PLUGIN_ID = "ee.schimke.composeai.preview"
+
+/**
+ * The Maven coordinate Gradle resolves a `plugins { id(…) }` / buildscript classpath entry from.
+ */
+internal const val COMPOSE_PREVIEW_PLUGIN_MARKER =
+  "$COMPOSE_PREVIEW_PLUGIN_ID:$COMPOSE_PREVIEW_PLUGIN_ID.gradle.plugin"
+
+/**
+ * True when [message] is Gradle failing to resolve *our* plugin marker.
+ *
+ * Requires all three of: the marker module (so a project that merely mentions the plugin id in an
+ * unrelated failure doesn't match), one of Gradle's resolution-failure verbs, and — when [version]
+ * is non-null — that version appearing as the coordinate's version. The version check is what makes
+ * this "the release you just resolved isn't published yet" rather than "some compose-preview
+ * version, somewhere, didn't resolve".
+ */
+internal fun isUnresolvedPluginMarkerFailure(message: String, version: String? = null): Boolean {
+  if (!message.contains(COMPOSE_PREVIEW_PLUGIN_MARKER)) return false
+  val unresolved =
+    message.contains("Could not find") ||
+      message.contains("Could not resolve") ||
+      message.contains("Cannot resolve external dependency")
+  if (!unresolved) return false
+  return version == null || message.contains("$COMPOSE_PREVIEW_PLUGIN_MARKER:$version")
+}
+
+/**
+ * The message to print for [isUnresolvedPluginMarkerFailure], naming the version, where it came
+ * from, and the three things that actually resolve it. [origin] is a short phrase for why *this*
+ * version is in play ("pinned by gradle.properties (…)"), omitted when the caller can't say.
+ */
+internal fun unresolvedPluginMarkerGuidance(version: String, origin: String? = null): String {
+  val attribution = origin?.let { " ($it)" }.orEmpty()
+  return buildString {
+    appendLine(
+      "compose-preview: Gradle could not resolve the compose-preview Gradle plugin " +
+        "$COMPOSE_PREVIEW_PLUGIN_MARKER:$version$attribution. This is a problem with that " +
+        "version's availability, not with your project — the configuration failure above is the " +
+        "symptom."
+    )
+    appendLine()
+    appendLine(
+      "The usual cause is the publication window: a compose-preview release is downloadable as a " +
+        "CLI (and resolvable as `latest`) before the Gradle plugin of the same version is " +
+        "resolvable from plugins.gradle.org and Maven Central. Builds dispatched inside that " +
+        "window fail exactly like this, and it clears on its own."
+    )
+    appendLine()
+    appendLine("Options:")
+    appendLine("  * wait for the publication to land and re-run — nothing to change;")
+    appendLine(
+      "  * pin the previous release for now: `compose-preview pin <version>` (or " +
+        "`--plugin-version <version>` for a single run);"
+    )
+    append("  * check availability: ${pluginPortalMarkerUrl(version)}")
+  }
+}
+
+/**
+ * The version in an unresolvable marker coordinate, e.g. `1.66.1` out of `…gradle.plugin:1.66.1`.
+ * Null when [message] names the marker without a version we can read.
+ */
+internal fun unresolvedPluginMarkerVersion(message: String): String? =
+  Regex("""${Regex.escape(COMPOSE_PREVIEW_PLUGIN_MARKER)}:([0-9][A-Za-z0-9._\-]*)""")
+    .find(message)
+    ?.groupValues
+    ?.get(1)
+    // Gradle ends the sentence right after the coordinate ("…gradle.plugin:1.66.1."), and a
+    // version never ends in a dot, so the trailing one is punctuation rather than part of it.
+    ?.trimEnd('.')
+    ?.takeIf { it.isNotEmpty() }
+
+/**
+ * The whole diagnosis in one call: null when [message] is not our marker failing to resolve, else
+ * the guidance, attributed to [injectedVersion]'s [pinSource] when the version that failed is the
+ * one this run asked for.
+ *
+ * The version comes from the message when it is readable, so a build that resolves the plugin at a
+ * version the CLI did not choose (a module declaring the plugin itself) is still explained.
+ */
+internal fun pluginResolutionGuidance(
+  message: String,
+  injectedVersion: String?,
+  pinSource: String? = null,
+): String? {
+  if (!isUnresolvedPluginMarkerFailure(message)) return null
+  val version = unresolvedPluginMarkerVersion(message) ?: injectedVersion ?: return null
+  val origin =
+    when {
+      version != injectedVersion -> null
+      pinSource != null -> "pinned by $pinSource"
+      else -> "the version this CLI bundles"
+    }
+  return unresolvedPluginMarkerGuidance(version, origin)
+}
+
+/**
+ * Where the plugin marker for [version] lives on the Gradle Plugin Portal's Maven view — the URL
+ * that answers "is it published yet?" with a 200 or a 404, which is the only question worth asking
+ * when [unresolvedPluginMarkerGuidance] fires.
+ */
+internal fun pluginPortalMarkerUrl(version: String): String =
+  "https://plugins.gradle.org/m2/${COMPOSE_PREVIEW_PLUGIN_ID.replace('.', '/')}/" +
+    "$COMPOSE_PREVIEW_PLUGIN_ID.gradle.plugin/$version/"

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ProjectPreviewServer.kt
@@ -119,6 +119,18 @@ internal fun confirmProjectServeHost(
    * repo-scoped confirmation cannot match.
    */
   originRepo: String? = null,
+  /**
+   * The VCS checkout [projectRoot] belongs to — the boundary "outside the checkout" is measured
+   * against. Defaults to walking up from [projectRoot] for a `.git`, and falls back to
+   * [projectRoot] itself when there is none.
+   *
+   * **Not the same directory as [projectRoot], and that is the point.** The Gradle build root can
+   * be a nested build inside the checkout (`components/` with its own settings file, issue #5031),
+   * so measuring against it would put the repository's own committed `.gradle/gradle.properties`
+   * *outside* — and a branch that writes the same host into both files would be confirming itself,
+   * which is the one thing this mechanism exists to prevent.
+   */
+  checkoutRoot: File? = projectRoot?.let(::findVcsCheckoutRoot),
   env: (String) -> String? = System::getenv,
   userHome: String? = System.getProperty("user.home"),
   fileSystem: FileSystem = SystemFileSystem,
@@ -130,7 +142,7 @@ internal fun confirmProjectServeHost(
     // A URL rather than an allowlist entry, so it can only ever confirm its own host, for any
     // repo — it is the host this environment was built to talk to.
     env(SERVE_URL_ENV)?.let { hostOf(it)?.let { host -> add(Confirmation(host, null)) } }
-    userGradlePropertiesServeUrl(env, userHome, projectRoot, fileSystem)?.let {
+    userGradlePropertiesServeUrl(env, userHome, checkoutRoot ?: projectRoot, fileSystem)?.let {
       hostOf(it)?.let { host -> add(Confirmation(host, null)) }
     }
   }
@@ -218,7 +230,8 @@ internal fun gitOriginRepo(projectRoot: File?): String? {
 private fun userGradlePropertiesServeUrl(
   env: (String) -> String?,
   userHome: String?,
-  projectRoot: File?,
+  /** The checkout boundary — see `checkoutRoot` on [confirmProjectServeHost]. */
+  checkoutRoot: File?,
   fileSystem: FileSystem,
 ): String? {
   val gradleHome =
@@ -227,7 +240,7 @@ private fun userGradlePropertiesServeUrl(
   // both `gradle.properties` and `.gradle/gradle.properties` would be confirming itself — the
   // checkout supplying its own trust, which is the one thing this mechanism exists to prevent.
   // Compared canonically, so a symlink out of the tree and back in cannot launder it.
-  if (projectRoot != null && gradleHome.isInside(projectRoot)) return null
+  if (checkoutRoot != null && gradleHome.isInside(checkoutRoot)) return null
   return readGradleProperty(gradleHome, SERVE_URL_PROPERTY, fileSystem)?.normalizedUrl()
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
@@ -115,6 +115,27 @@ internal fun findGradleWrapperRoot(start: File = File(".").absoluteFile): File? 
   return null
 }
 
+/**
+ * The **VCS checkout root** for [start]: the nearest ancestor (inclusive) holding a `.git` entry,
+ * or null when [start] is not inside a Git checkout. Matches a file as well as a directory, so a
+ * worktree or submodule checkout (whose `.git` is a file) counts.
+ *
+ * This is a different question from [findGradleProjectRoot], and the difference is load-bearing for
+ * trust: the build root can be a *nested* directory inside the checkout, while "what may a pull
+ * request have written?" is bounded by the checkout. [confirmProjectServeHost] uses this to decide
+ * whether a `GRADLE_USER_HOME` is really outside the tree — against the build root alone, a
+ * repository whose nested build is the one being driven could confirm its own
+ * `composePreview.serveUrl` from a committed `.gradle/gradle.properties` one level up.
+ */
+internal fun findVcsCheckoutRoot(start: File = File(".").absoluteFile): File? {
+  var dir: File? = start.absoluteFile
+  while (dir != null) {
+    if (File(dir, ".git").exists()) return dir
+    dir = dir.parentFile
+  }
+  return null
+}
+
 /** Where a resolved pin came from. Ordered by precedence — first match wins. */
 internal enum class VersionPinSource(val display: String) {
   FLAG("--plugin-version"),

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/VersionPin.kt
@@ -70,14 +70,43 @@ internal const val VERSION_PIN_CATALOG_PATH = "gradle/libs.versions.toml"
 internal const val VERSION_PIN_CATALOG_KEY = "composePreviewCli"
 
 /**
- * Walks up from [start] looking for the Gradle wrapper, returning the first directory that has one
- * — the project root the pin is read from (and the directory `compose-preview pin <version>` writes
- * into). Null when there is no Gradle project above [start].
+ * The **build root** for [start]: the nearest ancestor (inclusive) holding a settings file, else
+ * the nearest ancestor holding a Gradle wrapper. Null when neither exists above [start].
  *
  * Shared by [Command.findProjectRoot] and [PinCommand] so "which directory is the project" has
  * exactly one answer across the CLI.
+ *
+ * # Why settings, not the wrapper (issue #5031)
+ * This used to walk up looking for `gradlew` alone, on the assumption that a wrapper marks a build.
+ * It does not — a `settings.gradle(.kts)` does. A **nested build that borrows its parent
+ * repository's wrapper** (thunderbird-android's `components/`: its own settings file,
+ * `rootProject.name = "components"`, three projects, no `gradlew` of its own) was therefore walked
+ * straight past, and the CLI silently drove the *enclosing* build instead — reporting the root
+ * build's project count and the root build's configuration failures for a build the user never
+ * named. The wrapper search stays as the fallback, for the rare build with no settings file at all.
+ *
+ * The wrapper is still what supplies the Gradle **distribution**; see [findGradleWrapperRoot],
+ * which `GradleConnection` uses to pick one up from an ancestor when the build root has no wrapper.
  */
 internal fun findGradleProjectRoot(start: File = File(".").absoluteFile): File? {
+  var dir: File? = start
+  while (dir != null) {
+    if (hasSettingsFile(dir)) return dir
+    dir = dir.parentFile
+  }
+  return findGradleWrapperRoot(start)
+}
+
+/** True when [dir] holds a Gradle settings file in either DSL — i.e. [dir] is a build root. */
+internal fun hasSettingsFile(dir: File): Boolean =
+  File(dir, "settings.gradle.kts").isFile || File(dir, "settings.gradle").isFile
+
+/**
+ * Walks up from [start] returning the first directory holding a `gradlew`. This is *not* "which
+ * build am I in" ([findGradleProjectRoot] answers that) — it is only "whose wrapper, and therefore
+ * whose Gradle distribution, applies here".
+ */
+internal fun findGradleWrapperRoot(start: File = File(".").absoluteFile): File? {
   var dir: File? = start
   while (dir != null) {
     if (File(dir, "gradlew").exists()) return dir

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/GradleBuildRootTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/GradleBuildRootTest.kt
@@ -1,0 +1,71 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Which build the CLI drives (issue #5031).
+ *
+ * The old rule — "the nearest ancestor with a `gradlew`" — walked straight past a nested build that
+ * borrows its parent repository's wrapper, and silently drove the enclosing build instead. These
+ * pin the rule that replaced it: **the nearest ancestor with a settings file**, with the wrapper
+ * search kept only as a fallback for a build that has no settings file at all.
+ */
+class GradleBuildRootTest {
+
+  private val tmp: File = Files.createTempDirectory("build-root").toFile()
+
+  @AfterTest
+  fun cleanUp() {
+    tmp.deleteRecursively()
+  }
+
+  private fun dir(path: String): File = File(tmp, path).apply { mkdirs() }
+
+  private fun touch(dir: File, name: String): File =
+    File(dir, name).apply {
+      parentFile.mkdirs()
+      writeText("")
+    }
+
+  @Test
+  fun `a nested build with its own settings and no wrapper is the root`() {
+    val repo = dir("repo").also { touch(it, "gradlew") }
+    touch(repo, "settings.gradle.kts")
+    val components = dir("repo/components").also { touch(it, "settings.gradle.kts") }
+
+    assertEquals(components, findGradleProjectRoot(components))
+    // …and the wrapper that drives it is still the repository's.
+    assertEquals(repo, findGradleWrapperRoot(components))
+  }
+
+  @Test
+  fun `a subproject resolves to the build that contains it`() {
+    val repo = dir("repo").also { touch(it, "gradlew") }
+    touch(repo, "settings.gradle.kts")
+    val app = dir("repo/app").also { touch(it, "build.gradle.kts") }
+
+    assertEquals(repo, findGradleProjectRoot(app))
+  }
+
+  @Test
+  fun `a groovy settings file counts`() {
+    val repo = dir("groovy").also { touch(it, "settings.gradle") }
+    assertEquals(repo, findGradleProjectRoot(dir("groovy/lib")))
+  }
+
+  @Test
+  fun `falls back to the wrapper when nothing declares settings`() {
+    val repo = dir("wrapper-only").also { touch(it, "gradlew") }
+    assertEquals(repo, findGradleProjectRoot(dir("wrapper-only/app")))
+  }
+
+  @Test
+  fun `null when there is neither settings nor a wrapper`() {
+    assertNull(findGradleProjectRoot(dir("bare/deep")))
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosisTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosisTest.kt
@@ -1,0 +1,140 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.previewdriver.ProjectDiscoveryFailure
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the publication-window diagnosis (issue #5034): the compose-preview plugin
+ * marker failing to resolve at the version this run injected is named as such, instead of being
+ * read as a configuration failure in the consumer's own project.
+ *
+ * The verbatim failure text below is the one from the issue — three release rounds' worth of
+ * imports died with it, and each was diagnosed as a problem with the imported project.
+ */
+class PluginResolutionDiagnosisTest {
+
+  private val raceFailure =
+    """
+    A problem occurred configuring root project 'thunderbird-android'.
+    > Could not resolve all dependencies for configuration 'classpath'.
+       > Could not find ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:1.66.1.
+    """
+      .trimIndent()
+
+  @Test
+  fun `recognises the marker failing to resolve at the injected version`() {
+    assertTrue(isUnresolvedPluginMarkerFailure(raceFailure, version = "1.66.1"))
+  }
+
+  @Test
+  fun `does not claim a failure at a different version is the one we injected`() {
+    assertFalse(isUnresolvedPluginMarkerFailure(raceFailure, version = "1.67.0"))
+    // …but the marker itself is still recognised, which is what lets the guidance report the
+    // version out of the message rather than the one the CLI chose.
+    assertTrue(isUnresolvedPluginMarkerFailure(raceFailure))
+  }
+
+  @Test
+  fun `ignores an unrelated dependency failure`() {
+    val unrelated = "Could not find com.squareup.okhttp3:okhttp:4.12.0. Required by: project ':app'"
+    assertFalse(isUnresolvedPluginMarkerFailure(unrelated))
+    assertNull(pluginResolutionGuidance(unrelated, injectedVersion = "1.66.1"))
+  }
+
+  @Test
+  fun `ignores a failure that merely mentions the plugin`() {
+    val applied =
+      "PluginApplicationException: Failed to apply plugin 'ee.schimke.composeai.preview'. " +
+        "Could not find method android() for arguments"
+    assertFalse(isUnresolvedPluginMarkerFailure(applied))
+  }
+
+  @Test
+  fun `reads the version out of the coordinate`() {
+    assertEquals("1.66.1", unresolvedPluginMarkerVersion(raceFailure))
+    assertNull(unresolvedPluginMarkerVersion("Could not find something else:1.0.0"))
+  }
+
+  @Test
+  fun `guidance names the version, the race and the way out`() {
+    val guidance = assertNotNull(pluginResolutionGuidance(raceFailure, injectedVersion = "1.66.1"))
+    assertTrue(guidance.contains("1.66.1"), guidance)
+    assertTrue(guidance.contains("not with your project"), guidance)
+    assertTrue(guidance.contains("publication window"), guidance)
+    assertTrue(guidance.contains("compose-preview pin"), guidance)
+    assertTrue(
+      guidance.contains(
+        "https://plugins.gradle.org/m2/ee/schimke/composeai/preview/" +
+          "ee.schimke.composeai.preview.gradle.plugin/1.66.1/"
+      ),
+      guidance,
+    )
+  }
+
+  @Test
+  fun `guidance attributes the version to the pin that chose it`() {
+    val guidance =
+      assertNotNull(
+        pluginResolutionGuidance(
+          raceFailure,
+          injectedVersion = "1.66.1",
+          pinSource = VersionPinSource.GRADLE_PROPERTIES.display,
+        )
+      )
+    assertTrue(guidance.contains("pinned by gradle.properties"), guidance)
+  }
+
+  @Test
+  fun `guidance says the CLI chose the version when nothing pinned it`() {
+    val guidance = assertNotNull(pluginResolutionGuidance(raceFailure, injectedVersion = "1.66.1"))
+    assertTrue(guidance.contains("the version this CLI bundles"), guidance)
+  }
+
+  @Test
+  fun `no attribution when the failing version is not the one this run injected`() {
+    // A module that declares the plugin itself keeps its own version — still worth explaining, but
+    // not as "pinned by …", which would name a pin that had nothing to do with it.
+    val guidance =
+      assertNotNull(
+        pluginResolutionGuidance(
+          raceFailure,
+          injectedVersion = "1.68.0",
+          pinSource = VersionPinSource.FLAG.display,
+        )
+      )
+    assertTrue(guidance.contains("1.66.1"), guidance)
+    assertFalse(guidance.contains("pinned by"), guidance)
+  }
+
+  @Test
+  fun `discovery reporting leads with the race instead of the per-project list`() {
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(
+      listOf(
+        ProjectDiscoveryFailure(":app", raceFailure),
+        ProjectDiscoveryFailure(":lib", raceFailure),
+      ),
+      err = { lines += it },
+      pluginVersion = "1.66.1",
+    )
+    assertEquals(1, lines.size, "expected one explanation, got $lines")
+    assertTrue(lines.single().contains("publication window"), lines.single())
+    assertFalse(lines.single().contains("failed to configure during discovery"), lines.single())
+  }
+
+  @Test
+  fun `discovery reporting is unchanged for ordinary failures`() {
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(
+      listOf(ProjectDiscoveryFailure(":app", "Cannot resolve external dependency")),
+      err = { lines += it },
+      pluginVersion = "1.66.1",
+    )
+    assertTrue(lines.first().contains("1 project(s) failed to configure"), "got $lines")
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosisTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PluginResolutionDiagnosisTest.kt
@@ -55,6 +55,36 @@ class PluginResolutionDiagnosisTest {
   }
 
   @Test
+  fun `a generic resolve failure naming the marker is not the race`() {
+    // "Could not resolve" / "Cannot resolve external dependency" is also what an unreachable
+    // proxy, a TLS failure or a build with no repositories produces — waiting does not fix those.
+    val noRepositories =
+      "Cannot resolve external dependency " +
+        "ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:1.66.1 " +
+        "because no repositories are defined."
+    assertFalse(isUnresolvedPluginMarkerFailure(noRepositories))
+    assertNull(pluginResolutionGuidance(noRepositories, injectedVersion = "1.66.1"))
+  }
+
+  @Test
+  fun `a missing artifact whose cause is transport is not the race`() {
+    val proxied =
+      "Could not find ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:" +
+        "1.66.1. Could not GET 'https://plugins.gradle.org/…'. Received status code 407 Proxy " +
+        "Authentication Required"
+    assertFalse(isUnresolvedPluginMarkerFailure(proxied))
+  }
+
+  @Test
+  fun `the plugins DSL form is recognised`() {
+    val pluginsDsl =
+      "Plugin [id: 'ee.schimke.composeai.preview', version: '1.66.1'] was not found in any of " +
+        "the following sources: could not resolve plugin artifact " +
+        "'ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin:1.66.1'"
+    assertTrue(isUnresolvedPluginMarkerFailure(pluginsDsl, version = "1.66.1"))
+  }
+
+  @Test
   fun `reads the version out of the coordinate`() {
     assertEquals("1.66.1", unresolvedPluginMarkerVersion(raceFailure))
     assertNull(unresolvedPluginMarkerVersion("Could not find something else:1.0.0"))
@@ -112,6 +142,18 @@ class PluginResolutionDiagnosisTest {
   }
 
   @Test
+  fun `reads a version that is not numeric or carries build metadata`() {
+    val snapshot =
+      "Could not find ee.schimke.composeai.preview:" +
+        "ee.schimke.composeai.preview.gradle.plugin:dev-SNAPSHOT."
+    assertEquals("dev-SNAPSHOT", unresolvedPluginMarkerVersion(snapshot))
+    val metadata =
+      "Could not find ee.schimke.composeai.preview:" +
+        "ee.schimke.composeai.preview.gradle.plugin:1.2.3+build, required by: project ':app'"
+    assertEquals("1.2.3+build", unresolvedPluginMarkerVersion(metadata))
+  }
+
+  @Test
   fun `discovery reporting leads with the race instead of the per-project list`() {
     val lines = mutableListOf<String>()
     printDiscoveryFailures(
@@ -125,6 +167,26 @@ class PluginResolutionDiagnosisTest {
     assertEquals(1, lines.size, "expected one explanation, got $lines")
     assertTrue(lines.single().contains("publication window"), lines.single())
     assertFalse(lines.single().contains("failed to configure during discovery"), lines.single())
+  }
+
+  @Test
+  fun `a lone marker failure among unrelated ones does not hide them`() {
+    // One project failing on the marker while others fail for their own reasons is not a reason
+    // to hide theirs and send the user away to wait for a publication.
+    val lines = mutableListOf<String>()
+    printDiscoveryFailures(
+      listOf(
+        ProjectDiscoveryFailure(":app", raceFailure),
+        ProjectDiscoveryFailure(":lib", "Cannot resolve external dependency"),
+        ProjectDiscoveryFailure(":data", "PluginApplicationException: boom"),
+      ),
+      err = { lines += it },
+      pluginVersion = "1.66.1",
+    )
+    assertTrue(lines.first().contains("publication window"), lines.first())
+    assertTrue(lines.any { it.contains("3 project(s) failed to configure") }, "got $lines")
+    assertTrue(lines.any { it.contains(":lib:") }, "got $lines")
+    assertTrue(lines.any { it.contains(":data:") }, "got $lines")
   }
 
   @Test

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ProjectPreviewServerTest.kt
@@ -229,6 +229,37 @@ class ProjectPreviewServerTest {
   }
 
   @Test
+  fun `a nested build root does not put the checkout's own gradle home outside it`() {
+    // The build root can be a nested build (issue #5031): `/project/components` has its own
+    // settings file and is what the CLI drives. Measuring "outside the checkout" against *that*
+    // would make `/project/.gradle/gradle.properties` — a file the same pull request can commit —
+    // count as external confirmation, which is precisely the self-confirmation this gate exists to
+    // stop. The boundary is the checkout, not the build.
+    val nested = File("/project/components")
+    val path = "/project/components/gradle.properties".toPath()
+    fs.createDirectories(path.parent!!)
+    fs.write(path) { writeUtf8("$SERVE_URL_PROPERTY=https://attacker.example\n") }
+    val inCheckout = "/project/.gradle/gradle.properties".toPath()
+    fs.createDirectories(inCheckout.parent!!)
+    fs.write(inCheckout) { writeUtf8("$SERVE_URL_PROPERTY=https://attacker.example\n") }
+
+    val resolved = resolveProjectServeUrl(nested, env = { null }, fileSystem = fs)!!
+    val env = { name: String -> if (name == "GRADLE_USER_HOME") "/project/.gradle" else null }
+    assertTrue(
+      confirmProjectServeHost(
+        resolved,
+        projectRoot = nested,
+        checkoutRoot = root,
+        env = env,
+        userHome = null,
+        fileSystem = fs,
+      )
+        is ServeUrlTrust.NeedsConfirmation,
+      "a .gradle inside the checkout is not a confirmation, whatever the build root is",
+    )
+  }
+
+  @Test
   fun `a gradle user home outside the checkout still confirms`() {
     writeProperties("$SERVE_URL_PROPERTY=https://preview.coo.ee\n")
     val outside = "/opt/ci-cache/gradle/gradle.properties".toPath()


### PR DESCRIPTION
Fixes #5031, fixes #5034 — two diagnosis bugs with the same shape: the failure text describes the consumer's project, and the cause is ours.

## Which build the CLI drives (#5031)

`findGradleProjectRoot` answered "which build am I in" with the nearest `gradlew`. A wrapper does not make a directory a build — a `settings.gradle(.kts)` does — so a nested build borrowing its parent repository's wrapper (thunderbird-android's `components/`) was walked straight past and the **enclosing** build was driven instead, reporting the root build's 206-project count and the root build's Isolated Projects failures for a build the user never named.

- The build root is now the nearest ancestor holding a settings file, with the wrapper search kept as the fallback for a build that has no settings file at all (`findGradleWrapperRoot`).
- The wrapper stays what it always was — where the Gradle **distribution** comes from. `GradleConnector.forProjectDirectory` reads it from that directory alone and silently falls back to the Tooling API default, so `GradleConnection` now inherits the nearest ancestor's `distributionUrl` when the build root has no wrapper: exactly the Gradle `../gradlew` would have used.
- The CLI says which build it resolved whenever that is not the directory it was invoked from, once per process, so a mis-resolution is legible instead of arriving as a wall of unrelated configuration failures.

`PinCommand` follows the same root, as the issue suggested — the two are the same directory for every project that has both.

## Naming the publication race (#5034)

Per the issue's follow-up comment, the readiness gate is #5029's business; what remained was the failure text. `Could not find ee.schimke.composeai.preview:…gradle.plugin:1.66.1` arrives as a configuration failure in the *imported project*, and that is where three release rounds of diagnosis time went.

A new `PluginResolutionDiagnosis.kt` recognises our own marker failing to resolve — narrowly: the marker coordinate, a resolution verb, and the version — and prints what the text never said: this is the version's availability, not your project; a release is downloadable as a CLI before the plugin of the same version is resolvable from plugins.gradle.org and Maven Central; wait, pin the previous release, or check the portal URL (given). The version is attributed to the pin that chose it when the failing version is the one this run injected.

Wired into all three places the failure can surface: discovery-failure reporting (it pre-empts the AGP guidance and the per-project list), the Gradle model-query failure path, and build failures via a new optional `failureAdvice` hook on `GradleConnection` — the driver stays ignorant of *why* a string is worth explaining; the CLI supplies the knowledge.

## Test plan

New unit coverage, all passing locally:

- `GradleBuildRootTest` — a nested build with settings and no wrapper is its own root (and the repository's wrapper still supplies the distribution); a subproject resolves to its containing build; Groovy settings count; wrapper-only fallback; null when neither exists.
- `InheritedWrapperDistributionTest` — inherits the ancestor's `distributionUrl` (including the properties-escaped `https\:` form), leaves a directory with its own wrapper alone, null for no ancestor and for an unusable URL.
- `PluginResolutionDiagnosisTest` — the verbatim failure from the issue is recognised at the injected version and not at another; unrelated dependency failures and "failed to apply plugin" messages are not; the version is read out of the coordinate; the guidance names the version, the race, the pin route and the portal URL; attribution is present for a pinned version and absent for one this run did not inject; discovery reporting leads with the explanation and is unchanged for ordinary failures.

Also ran `:cli:test` in full (green) and `ktfmtCheckAll`. Non-visual change, so no render evidence. One pre-existing failure in this sandbox — `DiscoverPreviewModulesIntegrationTest.discovery completes while GradleProject blows up on the poison module` — reproduces identically on a clean `origin/main` checkout here and is unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2JaJbzzWWJMRnLMwXdWkE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2JaJbzzWWJMRnLMwXdWkE)_