### PR TITLE
feat(discovery): give a target its source name, JVM name and descriptor

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -739,17 +739,52 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 >
 > The same mangling drops the project's *own* composables from `targets`:
 > `AppTile(padding: Dp)` compiles to `AppTile-<hash>`, so its preview reports
-> `targets = []` for a composable the preview does nothing but render. **That half is
-> deliberately left alone**, because `DiscoveryFunctionalTest` pins it with a
-> purpose-built `@JvmInline` fixture — a decision, not an oversight — and the two
-> paths can legitimately differ: `ComponentSymbol` separates `callable` (the
-> source-level name an import needs) from `jvmOwner` (the reflection handle), while a
-> `targets` entry has a single name that consumers may be using as a JVM lookup key,
-> and `ComponentsKt.Screen` does not exist at runtime when the method is
-> `Screen-<hash>`. Whether `targets` should demangle is a question for whoever owns
-> that contract; if it should, `Dp` and `Color` parameters are ordinary enough in app
-> code that this is §1's "detect components from previews in typical projects"
-> failing on the typical projects.
+> `targets = []` for a composable the preview does nothing but render. That half was
+> left alone at first, on two arguments that did not survive being checked.
+>
+> The first was that `DiscoveryFunctionalTest` pins the rejection with a
+> purpose-built `@JvmInline` fixture, so someone had decided it. The assertion
+> arrived whole in `feat(mcp): add remote UI builder tools` (#4929) — a feature
+> commit — pinning what the code did at the time. Someone noticed enough to extend
+> the test's *name*; nothing designed the behaviour.
+>
+> The second was that a `targets` entry has a single name which consumers may be
+> using as a JVM lookup key, so demangling it would break them. Across both
+> repositories `PreviewInfo.targets` has exactly **one** non-test consumer,
+> `ComponentRecords.from`, which folds it into this record. Nothing reflects on it.
+> The consumer being deferred to did not exist.
+>
+> What was true is the shape underneath: `ComponentSymbol` already separates
+> `callable` (the source-level name an import needs) from `jvmOwner` (the reflection
+> handle) — its own KDoc opens *"three ways, because one name cannot serve all three
+> readers"* — and `PreviewTarget` had one name for all of them. **So the fix is not
+> to choose which name to publish but to stop making it a choice**: `functionName` is
+> the source name, `jvmName` is the JVM name, and `descriptor` is what actually says
+> *which* method is meant, since two overloads mentioning no value class share both
+> names exactly. Discovery already had the descriptor — the bytecode walk matches
+> call sites by name **and** descriptor — and was discarding it at the last step;
+> `ComponentSymbol.descriptor` had been declared and left null since v1 waiting for
+> it.
+>
+> Scoring was reading the mangled name too. `nameMatches` compared `ScreenPreview`
+> against `Screen-<hash>`, so the clearest naming convention a preview can follow was
+> the one case where the `NAME_MATCH` signal could never fire — a scoring bug hiding
+> behind the naming bug, invisible while the target was being dropped anyway.
+>
+> One thing this does **not** fix: overloads still share a canonical id and merge
+> into a single record. Recording a descriptor does not un-merge them, and putting
+> the id on a descriptor basis would rewrite every id in the file for a case no
+> consumer has asked to resolve. `ComponentSymbol.descriptor` is therefore null when
+> merged targets disagreed, rather than naming whichever one the manifest listed
+> first — a null descriptor with `signatureKnown` true is how a collision announces
+> itself.
+>
+> Cost worth stating rather than hiding: `infer` now reads `@kotlin.Metadata` once
+> per surviving candidate instead of once per preview, because the source name has to
+> be in hand before any name-based filter can run. That is the shape `inferComponents`
+> already had, the parse is `SKIP_CODE`, and candidate counts after filtering are
+> small — but it is more class-file reads than before and has not been measured on a
+> large corpus.
 >
 > The lesson generalises past this bug: a corpus you chose is a corpus that agrees
 > with you. Both fixtures I picked by hand happened to avoid the one construct that

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -42,11 +42,15 @@ data class ComponentRecordFile(
  *   preview does not carry, so it is absent for exactly the typical-app records this file exists to
  *   publish, and several absent ids would collide as a key.
  *
- *   **Overloads collide here, and that is a known v1 limitation.** Distinguishing them needs the
- *   JVM descriptor, which discovery does not record yet — the same gap `:renderer-android`'s
- *   `findDefaultedComposableMethod` names when it refuses to guess between two fully-defaulted
- *   overloads. [ComponentSymbol.descriptor] is where it lands; until then a reader that finds two
- *   records with one id should treat the pair as unresolved rather than pick one.
+ *   **Overloads still collide here.** Two overloads share this id, so they merge into one record
+ *   rather than appearing as two. Discovery now records the JVM descriptor that tells them apart
+ *   ([ComponentSymbol.descriptor]) — the gap `:renderer-android`'s `findDefaultedComposableMethod`
+ *   names when it refuses to guess between two fully-defaulted overloads — but recording it does
+ *   not un-merge the records, and putting the id itself on a descriptor basis would rewrite every
+ *   id in the file for a case no consumer has asked to resolve. So the merge is what a reader sees,
+ *   and [ComponentSymbol.descriptor] is deliberately **null** when the merged targets disagreed: a
+ *   single descriptor on a merged symbol would claim a precision the record does not have. Null
+ *   descriptor with `signatureKnown` true is how a collision announces itself.
  *
  * @property componentIds every published catalog identity associated with this symbol, deduplicated
  *   and ordered. A **list**, not a scalar: one symbol is routinely rendered by several catalog
@@ -83,8 +87,15 @@ data class ComponentRecord(
  * @property callable the **source-level** FQN generated Kotlin imports
  *   (`androidx.compose.material3.Button`). Deriving an import from [jvmOwner] would print `import
  *   androidx.compose.material3.ButtonKt`, which does not resolve.
- * @property descriptor the JVM method descriptor, once discovery records one. Null in v1 — see
- *   [ComponentRecord.canonicalId] for what that costs.
+ * @property jvmName the JVM method name — what `Class.forName(jvmOwner).getMethod(…)` needs, and
+ *   not the same string as [name] whenever Kotlin mangled it (a signature mentioning a value class
+ *   gives `AppTile-a1b2c3d`). Null when not recorded, and — like [descriptor] — when overloads
+ *   merged into this record disagreed: mangling is per-signature, so `Chip(label: String)` and
+ *   `Chip(width: Dp)` share a source name and a canonical id while their JVM names differ.
+ * @property descriptor the JVM method descriptor, which is what actually identifies *which* method
+ *   is meant: two overloads mentioning no value class share both [name] and [jvmName] exactly. Null
+ *   when not recorded, and also when overloads merged into this record disagreed — see
+ *   [ComponentRecord.canonicalId].
  * @property origin where the symbol lives. Explicit rather than inferred from [sourceFile] being
  *   null, which also happens for a project-local file discovery could not resolve (a generated
  *   source, say) — reading that null as "library" would send a local component down the sources-jar
@@ -105,6 +116,7 @@ data class ComponentSymbol(
   val callable: String,
   val name: String,
   val origin: ComponentOrigin,
+  val jvmName: String? = null,
   val descriptor: String? = null,
   val sourceFile: String? = null,
   val docs: String = "unavailable",

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -55,13 +55,33 @@ object ComponentRecords {
                 callable = callableFqn(target),
                 name = target.functionName,
                 origin = origin,
+                jvmName = target.jvmName,
+                descriptor = target.descriptor,
                 sourceFile = target.sourceFile,
                 receiver = target.receiver,
               ),
             parameters = target.parameters,
             signatureKnown = target.signatureKnown,
+            jvmName = target.jvmName,
+            descriptor = target.descriptor,
           )
         }
+      // Overloads share a canonical id and merge into this one record. Both JVM handles identify
+      // ONE method, so keeping the first seen would label the merged record with whichever preview
+      // the manifest happened to list first. Disagreement drops each to null instead — the record
+      // then says "several methods, and I cannot tell you which", which is true, rather than
+      // naming one of them.
+      //
+      // `jvmName` needs the same rule as `descriptor` and not merely the same rule as `name`:
+      // overloads always agree on the source name, and can disagree on the JVM one, because
+      // mangling is per-signature. `Chip(label: String)` and `Chip(width: Dp)` are `Chip` and
+      // `Chip-a1b2c3d`.
+      if (existing.jvmName != target.jvmName) {
+        existing.jvmName = null
+      }
+      if (existing.descriptor != target.descriptor) {
+        existing.descriptor = null
+      }
       // One component, many previews: keep the richest signature seen. A target resolved through a
       // path that could not read metadata reports no parameters, and letting that overwrite a
       // populated signature would lose the API for everyone.
@@ -143,6 +163,8 @@ object ComponentRecords {
     val symbol: ComponentSymbol,
     var parameters: List<TargetParameter>,
     var signatureKnown: Boolean = false,
+    var jvmName: String? = null,
+    var descriptor: String? = null,
   ) {
     var receiver: String? = symbol.receiver
 
@@ -156,7 +178,7 @@ object ComponentRecords {
         // first — a shared component such as `Card` is rendered by several previews and would
         // otherwise take an arbitrary, order-dependent id.
         componentIds = resolvedBindings.mapNotNull { it.componentId }.distinct().sorted(),
-        symbol = symbol.copy(receiver = receiver),
+        symbol = symbol.copy(receiver = receiver, jvmName = jvmName, descriptor = descriptor),
         parameters = parameters,
         slots = slotsOf(parameters),
         bindings = resolvedBindings,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1379,8 +1379,44 @@ data class PreviewInfo(
 data class PreviewTarget(
   /** Owner class FQN (synthetic `…Kt` for top-level functions). */
   val className: String,
-  /** Composable function name on [className]. */
+  /**
+   * The composable's **source-level** name — what a human reads and what generated Kotlin calls.
+   *
+   * Not the JVM method name, which [jvmName] carries. Kotlin mangles the JVM name of any function
+   * whose signature mentions a value class, so a perfectly ordinary `fun AppTile(padding: Dp)`
+   * compiles to `AppTile-a1b2c3d`. Publishing that as the name meant a consumer generating a call
+   * site emitted an identifier that does not exist, which is why this is read from
+   * `@kotlin.Metadata` rather than from the class file's method table.
+   *
+   * Falls back to the JVM name when metadata could not be read — see [signatureKnown], which is
+   * what says which of the two this is.
+   */
   val functionName: String,
+  /**
+   * The JVM method name, for a consumer that has to *find* this method rather than write a call to
+   * it — `Class.forName(className).getMethod(jvmName, …)`.
+   *
+   * Differs from [functionName] only under mangling (`AppTile-a1b2c3d`, `internalFun$module`), but
+   * it is recorded unconditionally rather than "only when it differs": a consumer that has to
+   * remember `jvmName ?: functionName` gets it right in every case it tests and wrong on exactly
+   * the mangled one this field exists for.
+   *
+   * Null means "not recorded" — a manifest written before this field existed — never "same as
+   * [functionName]".
+   */
+  val jvmName: String? = null,
+  /**
+   * The JVM method descriptor (`(ILandroidx/compose/runtime/Composer;I)V`), which is what actually
+   * identifies *which* method is meant.
+   *
+   * Neither name settles that on its own. Two overloads that mention no value class share their JVM
+   * name exactly, and their source name always; only the descriptor tells them apart. It is
+   * recorded here because inference already has it in hand — the bytecode walk matches call sites
+   * by name **and** descriptor — and was discarding it at the last step.
+   *
+   * Null means "not recorded", as for [jvmName].
+   */
+  val descriptor: String? = null,
   /** Module-relative source path of the target's owning file, when resolvable. */
   val sourceFile: String? = null,
   val confidence: TargetConfidence,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -214,6 +214,8 @@ object PreviewTargetInference {
       PreviewTarget(
         className = candidate.ownerFqn,
         functionName = signature.name,
+        jvmName = candidate.method.name,
+        descriptor = candidate.method.typeDescriptorStr,
         // A library symbol has no source file in this build; `sourceFile` stays null and
         // [PreviewTarget.origin] is what says so, rather than the null being read as "library".
         sourceFile = null,
@@ -261,23 +263,37 @@ object PreviewTargetInference {
         .filterNot { isWrapperFqn(it.ownerFqn) }
         .filter { it.ownerFqn in projectClassFqns }
         .mapNotNull { resolveCandidate(it, scanResult) }
-        .filterNot { candidate ->
-          !isValidKotlinImportIdentifier(candidate.method.name) ||
-            isPreviewOnlyWrapper(candidate.method.name, resolveSourceFile(candidate.ownerFqn))
+        // Pair each candidate with its metadata before judging its name, because every decision
+        // below is about the *source* name and only metadata carries it. Unlike `inferComponents`,
+        // a candidate whose metadata cannot be read is kept rather than dropped: `signatureKnown`
+        // already models "we could not look", `infer` has always emitted such targets, and
+        // dropping them here would trade a wrong name for a missing target.
+        .map { candidate ->
+          candidate to ComposableSignature.signatureOf(candidate.classInfo, candidate.method)
         }
-        .distinctBy { it.ownerFqn to it.method.name }
+        .filterNot { (candidate, signature) ->
+          // No metadata means no source name, so the JVM name is all there is — and then the
+          // import filter below is the only guard, exactly as it was before this pairing existed.
+          val sourceName = signature?.name ?: candidate.method.name
+          !isValidKotlinImportIdentifier(sourceName) ||
+            isPreviewOnlyWrapper(sourceName, resolveSourceFile(candidate.ownerFqn))
+        }
+        .distinctBy { (candidate, signature) ->
+          candidate.ownerFqn to (signature?.name ?: candidate.method.name)
+        }
         .toList()
 
     if (candidates.isEmpty()) return emptyList()
 
     val survivors = candidates.size
-    // Keep each candidate paired with its score so the winner's resolved ClassInfo/MethodInfo is in
-    // hand for signature extraction (params come from the target's Kotlin metadata, below).
-    val scored = candidates.map { candidate ->
-      candidate to
+    // Keep each candidate paired with its score so the winner's resolved metadata is in hand below
+    // rather than read a second time.
+    val scored = candidates.map { (candidate, signature) ->
+      (candidate to signature) to
         score(
           callerOwner = candidate.ownerFqn,
           callerMethod = candidate.method,
+          callerSourceName = signature?.name ?: candidate.method.name,
           callerClassInfo = candidate.classInfo,
           previewClassFqn = previewFqn,
           previewMethodName = previewMethodName,
@@ -298,7 +314,7 @@ object PreviewTargetInference {
         )
     }
 
-    val (bestCandidate, best) = scored.maxByOrNull { it.second.score } ?: return emptyList()
+    val (winner, best) = scored.maxByOrNull { it.second.score } ?: return emptyList()
     if (best.score < MIN_EMIT_SCORE) return emptyList()
 
     val confidence =
@@ -307,11 +323,14 @@ object PreviewTargetInference {
         best.score >= MEDIUM_THRESHOLD -> TargetConfidence.MEDIUM
         else -> TargetConfidence.LOW
       }
-    val signature = ComposableSignature.signatureOf(bestCandidate.classInfo, bestCandidate.method)
+    val signature = winner.second
     return listOf(
       PreviewTarget(
         className = best.classFqn,
+        // The source name when metadata gave one, else the JVM name — `signatureKnown` says which.
         functionName = best.methodName,
+        jvmName = best.jvmName,
+        descriptor = best.descriptor,
         sourceFile = best.sourceFile,
         confidence = confidence,
         signals = best.signals,
@@ -537,16 +556,11 @@ object PreviewTargetInference {
   /**
    * Whether a resolved call in a component library is the **component a sticker demonstrates**.
    *
-   * Three rules, each earning its place against `:samples:cmp`:
-   * * the name must be usable as a Kotlin import — a mangled or synthetic member is not a call site
-   *   anyone can write;
-   * * [returnsUnit] — a component *emits*, it does not return a value. `MaterialTheme.colorScheme`
-   *   and `MaterialTheme.typography` are `@Composable` property getters that pass every other test
-   *   here, and reporting them would describe a sticker's theme lookup as its subject;
-   * * not a [THEME_ENTRY_POINTS] member — the frame a sticker is drawn in rather than its subject.
-   */
-  /**
-   * Whether a resolved call in a component library is the **component a sticker demonstrates**.
+   * Three rules, each earning its place against `:samples:cmp`: the name must be usable as a Kotlin
+   * import; [returnsUnit], because a component *emits* rather than returning a value
+   * (`MaterialTheme.colorScheme` is a `@Composable` property getter that passes every other test
+   * here, and reporting it would describe a sticker's theme lookup as its subject); and not a
+   * [THEME_ENTRY_POINTS] member, which is the frame a sticker is drawn in rather than its subject.
    *
    * [methodName] must be the **source** name from `@kotlin.Metadata`, never the JVM one. Kotlin
    * mangles the JVM name of any function whose signature mentions a value class, so
@@ -591,7 +605,10 @@ object PreviewTargetInference {
 
   private data class ScoredCandidate(
     val classFqn: String,
+    /** Source-level name, or the JVM name when metadata could not be read. */
     val methodName: String,
+    val jvmName: String,
+    val descriptor: String,
     val sourceFile: String?,
     val score: Int,
     val signals: List<TargetSignal>,
@@ -601,6 +618,7 @@ object PreviewTargetInference {
   private fun score(
     callerOwner: String,
     callerMethod: MethodInfo,
+    callerSourceName: String,
     callerClassInfo: ClassInfo,
     previewClassFqn: String,
     previewMethodName: String,
@@ -626,7 +644,10 @@ object PreviewTargetInference {
     }
 
     // +2 if `FooPreview` / `PreviewFoo` / `Foo_*_Preview` strips down to the candidate's name.
-    if (nameMatches(previewMethodName, callerMethod.name)) {
+    // Against the SOURCE name: `ScreenPreview` matches `Screen`, never `Screen-a1b2c3d`, so
+    // scoring a mangled candidate on its JVM name silently withheld this signal from exactly the
+    // previews whose naming convention was clearest.
+    if (nameMatches(previewMethodName, callerSourceName)) {
       score += 2
       signals += TargetSignal.NAME_MATCH
     }
@@ -668,7 +689,9 @@ object PreviewTargetInference {
 
     return ScoredCandidate(
       classFqn = callerOwner,
-      methodName = callerMethod.name,
+      methodName = callerSourceName,
+      jvmName = callerMethod.name,
+      descriptor = callerMethod.typeDescriptorStr,
       sourceFile = resolveSourceFile(callerOwner) ?: packageQualifiedSourcePath(callerClassInfo),
       score = score,
       signals = signals,

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
@@ -10,10 +10,14 @@ class ComponentRecordsTest {
     functionName: String,
     parameters: List<TargetParameter> = emptyList(),
     sourceFile: String? = null,
+    jvmName: String? = null,
+    descriptor: String? = null,
   ) =
     PreviewTarget(
       className = className,
       functionName = functionName,
+      jvmName = jvmName,
+      descriptor = descriptor,
       sourceFile = sourceFile,
       confidence = TargetConfidence.HIGH,
       parameters = parameters,
@@ -209,5 +213,84 @@ class ComponentRecordsTest {
 
     assertThat(file.components).isEmpty()
     assertThat(file.module).isEqualTo("app")
+  }
+
+  @Test
+  fun `the symbol carries the JVM name and descriptor alongside the source name`() {
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            componentTargets =
+              listOf(
+                target(
+                  "androidx.compose.material3.TextKt",
+                  "Text",
+                  jvmName = "Text-Nvy7gAk",
+                  descriptor = "(Ljava/lang/String;JLandroidx/compose/runtime/Composer;I)V",
+                )
+              ),
+          )
+        )
+      )
+
+    val symbol = file.components.single().symbol
+    // Three answers to three different questions, none of which the others can serve: what to
+    // import, what to reflect on, and which method this actually is.
+    assertThat(symbol.callable).isEqualTo("androidx.compose.material3.Text")
+    assertThat(symbol.jvmName).isEqualTo("Text-Nvy7gAk")
+    assertThat(symbol.descriptor)
+      .isEqualTo("(Ljava/lang/String;JLandroidx/compose/runtime/Composer;I)V")
+  }
+
+  @Test
+  fun `overloads merging into one record drop the descriptor rather than name one of them`() {
+    // Two overloads share `<module>/<jvmOwner>.<name>`, so they merge. Keeping the first
+    // descriptor would label the merged record with whichever preview the manifest listed first —
+    // a precise-looking answer that is wrong half the time.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            targets =
+              listOf(target("com.example.ChipKt", "Chip", descriptor = "(Ljava/lang/String;)V")),
+          ),
+          preview(
+            "p2",
+            targets = listOf(target("com.example.ChipKt", "Chip", descriptor = "(I)V")),
+          ),
+        )
+      )
+
+    val symbol = file.components.single().symbol
+    assertThat(symbol.descriptor).isNull()
+    assertThat(symbol.name).isEqualTo("Chip")
+  }
+
+  @Test
+  fun `one component seen by several previews keeps its descriptor`() {
+    // The common case, and the reason the rule above is "disagree" rather than "seen twice":
+    // `Card` is rendered by many previews and every one of them reports the same method.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            targets =
+              listOf(target("com.example.CardKt", "Card", jvmName = "Card", descriptor = "(I)V")),
+          ),
+          preview(
+            "p2",
+            targets =
+              listOf(target("com.example.CardKt", "Card", jvmName = "Card", descriptor = "(I)V")),
+          ),
+        )
+      )
+
+    val symbol = file.components.single().symbol
+    assertThat(symbol.descriptor).isEqualTo("(I)V")
+    assertThat(symbol.jvmName).isEqualTo("Card")
   }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/PreviewTargetInferenceTest.kt
@@ -165,4 +165,14 @@ class PreviewTargetInferenceTest {
       )
       .isFalse()
   }
+
+  @Test
+  fun `a mangled JVM name only matches its preview once scored on the source name`() {
+    // `ScreenPreview` is the clearest naming convention a preview can follow, and it was the one
+    // this signal never fired for: `Screen(padding: Dp)` compiles to `Screen-a1b2c3d`, and the
+    // scorer compared against that. Scoring on the source name is what makes NAME_MATCH reachable
+    // for a composable taking a value-class parameter.
+    assertThat(PreviewTargetInference.nameMatches("ScreenPreview", "Screen-a1b2c3d")).isFalse()
+    assertThat(PreviewTargetInference.nameMatches("ScreenPreview", "Screen")).isTrue()
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -3868,7 +3868,7 @@ class DiscoveryFunctionalTest {
   }
 
   @Test
-  fun `composePreviewDiscover looks through theme and catalog lambdas and rejects mangled targets`() {
+  fun `composePreviewDiscover looks through theme and catalog lambdas and names mangled targets`() {
     val projectDir = createCmpTestProject()
 
     val srcDir = File(projectDir, "src/main/kotlin/test")
@@ -3955,7 +3955,24 @@ class DiscoveryFunctionalTest {
     assertThat(wrapTarget.sourceFile).contains("Components.kt")
     assertThat(themeTarget.signals).contains(TargetSignal.WRAPPER_UNWRAPPED)
     assertThat(wrapTarget.signals).contains(TargetSignal.WRAPPER_UNWRAPPED)
-    assertThat(manifest.previews.single { it.functionName == "MangledPreview" }.targets).isEmpty()
+    // `Screen(value: ScreenValue)` mentions a value class, so Kotlin mangles its JVM name to
+    // `Screen-<hash>`. This used to report `targets = []`: the name was judged as a Kotlin import
+    // identifier, a mangled one is not, and the target was dropped — so an ordinary app composable
+    // taking a `Dp` or a `Color` was invisible to inference. The rejection was the right call while
+    // a target had one name field and that field held the JVM name; with the source name recorded
+    // separately there is nothing left to be wrong about, and dropping the target is now the only
+    // wrong answer available.
+    val mangled = manifest.previews.single { it.functionName == "MangledPreview" }.targets.single()
+    assertThat(mangled.functionName).isEqualTo("Screen")
+    assertThat(mangled.jvmName).startsWith("Screen-")
+    assertThat(mangled.jvmName).isNotEqualTo(mangled.functionName)
+    assertThat(mangled.descriptor).isNotNull()
+    assertThat(mangled.signatureKnown).isTrue()
+
+    // The unmangled targets carry both names too, and there they agree — recorded rather than
+    // left null so a consumer never has to write `jvmName ?: functionName`.
+    assertThat(themeTarget.jvmName).isEqualTo("HomeScreen")
+    assertThat(themeTarget.descriptor).isNotNull()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Answers the question #5036 left open — should the `targets` path demangle value-class JVM names the way the component path now does? — with **both names and the descriptor**, rather than by picking one.

`PreviewTarget` had a single `functionName` serving three different readers, and it held the JVM name. Kotlin mangles that for any function whose signature mentions a value class, so an ordinary `AppTile(padding: Dp)` compiles to `AppTile-<hash>`, failed the "is this a usable Kotlin import?" filter, and its preview reported `targets = []` for a composable the preview does nothing but render. `Dp` and `Color` parameters are ordinary in app code, so this was §1's *"detect components from previews in typical projects"* failing on the typical projects.

## Both arguments for leaving it alone turned out not to hold

I backed this out of #5036 on two grounds. Checking them:

**"A `@JvmInline` fixture pins the rejection, so someone decided it."** The `targets).isEmpty()` assertion arrived whole in [#4929](https://github.com/yschimke/compose-ai-tools/pull/4929) (`feat(mcp): add remote UI builder tools`) — a feature commit, characterising what the code did at the time. Someone noticed enough to extend the *test's name*; nothing designed the behaviour.

**"Consumers may be using that name as a JVM lookup key."** Across both repositories, `PreviewInfo.targets` has exactly **one** non-test consumer — `ComponentRecords.from`, which folds it into the component record. Nothing reflects on it. The consumer I deferred to does not exist.

What *was* true is the shape underneath, and `ComponentSymbol` already had it — its KDoc opens *"three ways, because one name cannot serve all three readers."* `PreviewTarget` had one name for all of them.

## The shape

| field | reader | why nothing else serves it |
| --- | --- | --- |
| `functionName` | a human; generated Kotlin | the source name from `@kotlin.Metadata`. Falls back to the JVM name when metadata is unreadable — `signatureKnown` says which |
| `jvmName` | `Class.forName(className).getMethod(…)` | recorded unconditionally, not "only when it differs": a consumer writing `jvmName ?: functionName` gets it right in every case they test and wrong on exactly the mangled one |
| `descriptor` | *which* method this is | two overloads mentioning no value class share their JVM name exactly and their source name always |

The descriptor was already in hand — the bytecode walk matches call sites by name **and** descriptor — and was discarded at the last step. `ComponentSymbol.descriptor` has been declared and left null since v1 waiting for exactly it, and gains `jvmName` alongside.

## A scoring bug hiding behind the naming bug

`nameMatches` compared `ScreenPreview` against `Screen-<hash>`, so the clearest naming convention a preview can follow was the one case where the `NAME_MATCH` signal could never fire. Invisible while the target was being dropped anyway.

## What this does not fix

Overloads still share a canonical id and merge into one record; recording a descriptor does not un-merge them, and putting the id on a descriptor basis would rewrite every id in the file for a case no consumer has asked to resolve. So **both JVM handles go null when merged targets disagree** rather than naming whichever preview the manifest happened to list first — a null descriptor with `signatureKnown` true is how a collision announces itself. `jvmName` needs that rule and not the source name's, because mangling is per-signature: `Chip(label: String)` and `Chip(width: Dp)` share a source name and differ in JVM name.

## Costs, stated rather than hidden

- `infer` now reads `@kotlin.Metadata` **once per surviving candidate** instead of once per preview, because the source name must be in hand before any name-based filter runs. That is the shape `inferComponents` already had and the parse is `SKIP_CODE`, but it is more class-file reads and is unmeasured on a large corpus.
- `DiscoveryFunctionalTest` now asserts the mangled target is **named** rather than dropped — a deliberate change to a published wire format, replacing a characterisation assertion with a designed one. Sanctioned by the repo owner before I wrote it.
- Both new fields default to null, so a manifest written by an older plugin still deserialises.

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test` — **BUILD SUCCESSFUL**.
- `./gradlew :gradle-plugin:functionalTest` — the **whole** suite, **BUILD SUCCESSFUL in 3m48s**.
- Two earlier runs of that suite failed and neither was this change: the first hit `NoClassDefFoundError` because I ran the formatter concurrently and swapped the jar underneath it, the second `NoSuchFileException: in-progress-results-generic.bin` because two runs overlapped on `build/test-results`. Re-run alone from a cleared results dir: green. Recorded because "it was concurrency" is exactly the excuse that should be checked rather than asserted.
- New coverage: `ComponentRecordsTest` for the three-handles symbol, for overloads dropping both JVM handles on disagreement, and for the common case where several previews of one component keep them; `PreviewTargetInferenceTest` for scoring against the source name; `DiscoveryFunctionalTest` asserting the mangled target's source name, JVM name and descriptor end to end against a real `@JvmInline` fixture.
- `ktfmtCheck` on all three touched source sets — clean.
- Non-visual change: no render evidence applies.

Also removes a duplicated KDoc block on `isComponentLibraryTarget` that I left behind in #5036.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_