### PR TITLE
fix: turn Isolated Projects off for auto-injected runs, and keep the S3.5 clone out of the fixture's static initializer

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1602,16 +1602,19 @@ jobs:
           GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
         run: |
           set -euo pipefail
-          if [ -f "$GRADLE_PROPERTIES" ] &&
-             grep -q '^[[:space:]]*org\.gradle\.unsafe\.isolated-projects[[:space:]]*=' "$GRADLE_PROPERTIES"; then
-            sed -i 's/^[[:space:]]*org\.gradle\.unsafe\.isolated-projects[[:space:]]*=.*/org.gradle.unsafe.isolated-projects=false/' \
-              "$GRADLE_PROPERTIES"
-            echo "turned Isolated Projects off in the throwaway checkout"
-          else
-            printf '\n# compose-preview import: auto-inject configures projects via allprojects {},\n# which Isolated Projects forbids.\norg.gradle.unsafe.isolated-projects=false\n' \
-              >> "$GRADLE_PROPERTIES"
-            echo "pinned Isolated Projects off in the throwaway checkout"
-          fi
+          # Gradle 9.7 graduated Isolated Projects and renamed the property from
+          # org.gradle.unsafe.isolated-projects to org.gradle.isolated-projects, so an upstream
+          # checkout can declare either name (nowinandroid uses the new one). Comment out whatever
+          # it declares, then pin both off — appending only the old name would leave IP on for a
+          # 9.7 checkout, and auto-inject's `allprojects { buildscript { ... } }` cannot run under
+          # IP at all (docs/isolated-projects-autoinject.md).
+          touch "$GRADLE_PROPERTIES"
+          sed -i -E \
+            's/^[[:space:]]*org\.gradle\.(unsafe\.)?isolated-projects[[:space:]]*=.*/# & (disabled by compose-preview import)/' \
+            "$GRADLE_PROPERTIES"
+          printf '\n# compose-preview import: auto-inject configures projects via allprojects {},\n# which Isolated Projects forbids.\norg.gradle.unsafe.isolated-projects=false\norg.gradle.isolated-projects=false\n' \
+            >> "$GRADLE_PROPERTIES"
+          echo "pinned Isolated Projects off (both property names) in the throwaway checkout"
 
       - name: Relax dependency verification in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}
@@ -2399,16 +2402,19 @@ jobs:
           GRADLE_PROPERTIES: ${{ env.RENDER_DIR }}/gradle.properties
         run: |
           set -euo pipefail
-          if [ -f "$GRADLE_PROPERTIES" ] &&
-             grep -q '^[[:space:]]*org\.gradle\.unsafe\.isolated-projects[[:space:]]*=' "$GRADLE_PROPERTIES"; then
-            sed -i 's/^[[:space:]]*org\.gradle\.unsafe\.isolated-projects[[:space:]]*=.*/org.gradle.unsafe.isolated-projects=false/' \
-              "$GRADLE_PROPERTIES"
-            echo "turned Isolated Projects off in the throwaway checkout"
-          else
-            printf '\n# compose-preview import: auto-inject configures projects via allprojects {},\n# which Isolated Projects forbids.\norg.gradle.unsafe.isolated-projects=false\n' \
-              >> "$GRADLE_PROPERTIES"
-            echo "pinned Isolated Projects off in the throwaway checkout"
-          fi
+          # Gradle 9.7 graduated Isolated Projects and renamed the property from
+          # org.gradle.unsafe.isolated-projects to org.gradle.isolated-projects, so an upstream
+          # checkout can declare either name (nowinandroid uses the new one). Comment out whatever
+          # it declares, then pin both off — appending only the old name would leave IP on for a
+          # 9.7 checkout, and auto-inject's `allprojects { buildscript { ... } }` cannot run under
+          # IP at all (docs/isolated-projects-autoinject.md).
+          touch "$GRADLE_PROPERTIES"
+          sed -i -E \
+            's/^[[:space:]]*org\.gradle\.(unsafe\.)?isolated-projects[[:space:]]*=.*/# & (disabled by compose-preview import)/' \
+            "$GRADLE_PROPERTIES"
+          printf '\n# compose-preview import: auto-inject configures projects via allprojects {},\n# which Isolated Projects forbids.\norg.gradle.unsafe.isolated-projects=false\norg.gradle.isolated-projects=false\n' \
+            >> "$GRADLE_PROPERTIES"
+          echo "pinned Isolated Projects off (both property names) in the throwaway checkout"
 
       - name: Relax dependency verification in the upstream checkout
         if: ${{ inputs.upstream-repository != '' }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,8 +30,8 @@ name: Integration
 # cheapest real cell and the widest one: measured on recent PR runs it takes
 # ~2.6 min (discover 53s + render 23s + daemon round-trip 34s) against
 # androidify ~3.4-4.1 min, nowinandroid ~3.4-3.6 min and agp8-min ~3.3-4.2 min,
-# while covering the full render pipeline, the daemon, and isolated-projects +
-# configuration-cache end-to-end. Every other cell still spins up on a PR (so
+# while covering the full render pipeline, the daemon, and the configuration
+# cache end-to-end. Every other cell still spins up on a PR (so
 # its check reports) but skips the expensive steps. The daily cron and pushes
 # to `main` run the full matrix, so consumer/AGP-floor drift still surfaces
 # within a day — it just doesn't sit on the PR critical path.
@@ -325,18 +325,24 @@ jobs:
             # It earns the slot on both axes: cheapest real cell (~2.6 min
             # measured, vs ~3.4-4.2 for androidify / nowinandroid / agp8-min)
             # AND the widest coverage — full render pipeline + daemon
-            # round-trip + IP/CC end-to-end. Before adding a second
-            # `pr_blocking` cell, check it buys signal this one can't.
+            # round-trip + configuration cache end-to-end. Before adding a
+            # second `pr_blocking` cell, check it buys signal this one can't.
             pr_blocking: true
-            # ComposeStarter enables isolated-projects + configuration-cache. The plugin used to
-            # need `-Dorg.gradle.unsafe.isolated-projects=false -Dorg.gradle.isolated-projects
-            # =false --no-configuration-cache` here because of `rootProject.findProject` walks +
-            # `rootProject.layout` reads; both were removed in #1546's IP-cleanup pass (#1549
-            # tracks the cross-project-metadata follow-up). Leave the field empty so this cell
-            # exercises IP + CC end-to-end. Re-add specific opt-outs below (with a fresh comment
-            # naming the regression) if the consumer's own build script surfaces an IP problem
-            # we haven't seen before.
-            extra_gradle_args: ""
+            # Configuration cache on, Isolated Projects off. ComposeStarter's gradle.properties
+            # asks for both, but its 9.4.1 wrapper predates Gradle 9.7's graduation of IP, so the
+            # `org.gradle.isolated-projects` name it uses is inert there and this cell has never
+            # actually run under IP — the flags below just make that explicit and keep the cell
+            # green through a wrapper bump. Auto-inject cannot run under IP at all: the init
+            # script configures projects via `allprojects { buildscript { ... } }`, which IP
+            # rejects (docs/isolated-projects-autoinject.md), and the CLI itself passes these same
+            # two flags on every auto-injected invocation (ISOLATED_PROJECTS_OFF_ARGS in
+            # AutoInject.kt) — these steps drive `./gradlew --init-script` directly, so they carry
+            # them here. IP coverage for the plugin's own code lives in the gradle-plugin
+            # functional tests (CrossProjectMetadataFunctionalTest et al), which enable IP and
+            # apply the plugin manually. The `--no-configuration-cache` this cell once needed for
+            # `rootProject.findProject` walks + `rootProject.layout` reads is gone for good after
+            # #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata follow-up).
+            extra_gradle_args: "-Dorg.gradle.isolated-projects=false -Dorg.gradle.unsafe.isolated-projects=false"
             # Exercise the full render pipeline on at least one matrix entry
             # so the `renderer-android` AAR resolution + Robolectric launch
             # path is covered against the locally-published snapshot. The
@@ -369,8 +375,9 @@ jobs:
               - Exercises the full Android render pipeline end-to-end
                 (renderer-android AAR resolution + Robolectric launch) plus
                 the daemon round-trip (spawn → render → edit → re-render).
-              - Runs with isolated-projects + configuration-cache enabled, so
-                it doubles as the IP/CC end-to-end cell. No build-script
+              - Runs with the configuration cache enabled, so it doubles as
+                the CC end-to-end cell. Isolated Projects is turned off, as
+                the CLI does on every auto-injected run. No build-script
                 workarounds applied.
               - The gallery below is the clean baseline render, captured
                 *before* the daemon round-trip edits a source file, so the
@@ -513,10 +520,20 @@ jobs:
               p.write_text(t)
               print(f"patched {p}")
               PY
-            # No opt-outs after #1546's IP-cleanup pass (#1549 tracks the cross-project-metadata
-            # follow-up). Re-add specific flags here (with a fresh comment naming the regression)
-            # if the consumer's build surfaces a new CC / IP gap.
-            extra_gradle_args: ""
+            # Isolated Projects off. nowinandroid's gradle.properties carries
+            # `org.gradle.isolated-projects=true` — the name the feature took when Gradle 9.7
+            # graduated it out of `org.gradle.unsafe.*` — and its wrapper is on 9.7.1, so IP is
+            # genuinely active there. The auto-inject init script configures every project through
+            # `allprojects { buildscript { ... } }`, which IP rejects outright ("Project ':' cannot
+            # access 'Project.buildscript' functionality on subprojects via 'allprojects'"), and no
+            # IP-safe injection mechanism exists — docs/isolated-projects-autoinject.md has the
+            # three we tested. This is NOT the #1546 IP-cleanup pass regressing: it is the
+            # documented opt-out, and the CLI now passes the same two flags itself on every
+            # auto-injected invocation (ISOLATED_PROJECTS_OFF_ARGS in AutoInject.kt). These steps
+            # drive `./gradlew --init-script` directly rather than through the CLI, so they carry
+            # the flags themselves. Both spellings, so the cell survives a wrapper bump in either
+            # direction.
+            extra_gradle_args: "-Dorg.gradle.isolated-projects=false -Dorg.gradle.unsafe.isolated-projects=false"
           - name: homeassistant-remotecompose
             slug: homeassistant-remotecompose
             repo: yschimke/homeassistant-remotecompose

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt
@@ -347,16 +347,22 @@ gradle.settingsEvaluated {
     // BEFORE the allprojects violation, so a warning here is the one place reliably delivered to
     // the user driving the CLI / MCP / VS Code workflow. `BuildFeatures` (Gradle 8.5+) is the
     // supported active-IP probe; runCatching keeps older Gradle from breaking the script.
+    //
+    // The CLI itself passes ISOLATED_PROJECTS_OFF_ARGS on every auto-injected invocation, so this
+    // warning is for the caller who runs `./gradlew --init-script <this>` by hand (CI matrices,
+    // the docs' manual repro) and hasn't turned IP off.
     val composeAiPreviewIpActive =
         runCatching { gradle.serviceOf<BuildFeatures>().isolatedProjects.active.get() }
             .getOrDefault(false)
     if (composeAiPreviewIpActive) {
         logger.warn(
             "compose-preview: Isolated Projects is enabled " +
-                "(org.gradle.unsafe.isolated-projects=true). Auto-inject configures projects via " +
+                "(org.gradle.isolated-projects / org.gradle.unsafe.isolated-projects). " +
+                "Auto-inject configures projects via " +
                 "`allprojects { }`, which Isolated Projects rejects, so discovery/render will fail. " +
                 "Disable Isolated Projects for compose-preview runs " +
-                "(e.g. -Dorg.gradle.unsafe.isolated-projects=false), or apply " +
+                "(-Dorg.gradle.isolated-projects=false on Gradle 9.7+, " +
+                "-Dorg.gradle.unsafe.isolated-projects=false before that), or apply " +
                 "id(\"ee.schimke.composeai.preview\") manually in each module's build script."
         )
     }
@@ -599,8 +605,31 @@ internal fun gradleWriteLocksArgs(env: (String) -> String? = System::getenv): Li
   if (env("COMPOSE_PREVIEW_WRITE_LOCKS") == "1") listOf("--write-locks") else emptyList()
 
 /**
- * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation, or an empty
- * list when auto-inject is disabled. Materialises the script on first call.
+ * Every Gradle invocation the CLI drives with auto-inject on also turns Isolated Projects **off**
+ * for that build.
+ *
+ * The init script applies the plugin through `allprojects { buildscript { … } }`, which IP rejects
+ * outright ("Project ':' cannot access 'Project.buildscript' functionality on subprojects via
+ * 'allprojects'"), and no IP-safe injection mechanism exists — the docs page
+ * `docs/isolated-projects-autoinject.md` records the three we tested and why each fails. A
+ * consumer's own `gradle.properties` decides whether IP is on and the Tooling API daemon honours
+ * it, so without this the CLI simply fails on any build that opted in. Passing the flag here is the
+ * same opt-out that page tells a human to type by hand; a command-line `-D` outranks
+ * `gradle.properties`.
+ *
+ * Both spellings go out because Gradle 9.7 graduated the feature and renamed
+ * `org.gradle.unsafe.isolated-projects` to `org.gradle.isolated-projects`. Consumer builds carry
+ * either name (nowinandroid moved to the new one, which is what turned its integration cell red the
+ * moment its wrapper reached 9.7.1 — the old name alone no longer covers it), and a name the
+ * running Gradle doesn't recognise is an inert system property.
+ */
+internal val ISOLATED_PROJECTS_OFF_ARGS: List<String> =
+  listOf("-Dorg.gradle.unsafe.isolated-projects=false", "-Dorg.gradle.isolated-projects=false")
+
+/**
+ * Returns the `--init-script <path>` arguments to prepend to every Gradle invocation — followed by
+ * [ISOLATED_PROJECTS_OFF_ARGS], since the injected script cannot run under Isolated Projects — or
+ * an empty list when auto-inject is disabled. Materialises the script on first call.
  *
  * The injected plugin version is the **project's version pin** when it has one —
  * `--plugin-version`, `COMPOSE_PREVIEW_VERSION`, `gradle.properties`' `composePreview.version`, or
@@ -655,7 +684,7 @@ internal fun autoInjectInitScriptArgs(
   val dir = storageDir ?: defaultInitScriptStorageDir(effectiveVersion)
   return try {
     val path = materializeInitScript(dir, effectiveVersion, fileSystem)
-    listOf("--init-script", path.absolutePath)
+    listOf("--init-script", path.absolutePath) + ISOLATED_PROJECTS_OFF_ARGS
   } catch (e: Exception) {
     stderr(
       "compose-preview: auto-inject disabled — could not materialise init script in $dir: ${e.message}"

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/AutoInjectTest.kt
@@ -158,10 +158,33 @@ class AutoInjectTest {
         storageDir = storage,
         env = { null },
       )
-    assertEquals(2, args.size)
-    assertEquals("--init-script", args[0])
-    assertEquals(File(storage, INIT_SCRIPT_FILENAME).absolutePath, args[1])
-    assertTrue(File(args[1]).isFile)
+    val scriptPath = File(storage, INIT_SCRIPT_FILENAME).absolutePath
+    assertEquals(listOf("--init-script", scriptPath) + ISOLATED_PROJECTS_OFF_ARGS, args)
+    assertTrue(File(scriptPath).isFile)
+  }
+
+  @Test
+  fun `autoInjectInitScriptArgs turns Isolated Projects off under both property names`() {
+    val storage = tempDir()
+    val args =
+      autoInjectInitScriptArgs(
+        args = emptyList(),
+        pluginVersion = "1.0.0",
+        storageDir = storage,
+        env = { null },
+      )
+    // The injected `allprojects { buildscript { ... } }` cannot run under IP, and a consumer's own
+    // gradle.properties is what turns IP on, so every auto-injected invocation opts back out.
+    // Gradle 9.7 renamed the property when IP graduated (nowinandroid sets the new name), and the
+    // pre-9.7 name still has to be covered for older wrappers — hence both.
+    assertTrue(
+      args.contains("-Dorg.gradle.isolated-projects=false"),
+      "expected the Gradle 9.7+ property name to be disabled",
+    )
+    assertTrue(
+      args.contains("-Dorg.gradle.unsafe.isolated-projects=false"),
+      "expected the pre-9.7 property name to be disabled",
+    )
   }
 
   @Test
@@ -238,7 +261,11 @@ class AutoInjectTest {
         env = { null },
         projectRoot = projectRoot,
       )
-    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+    assertEquals(
+      listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath) +
+        ISOLATED_PROJECTS_OFF_ARGS,
+      out,
+    )
 
     // Same root with parens — should skip.
     File(projectRoot, "settings.gradle").writeText("includeBuild('gradle-plugin')\n")
@@ -274,7 +301,11 @@ class AutoInjectTest {
         env = { null },
         projectRoot = projectRoot,
       )
-    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+    assertEquals(
+      listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath) +
+        ISOLATED_PROJECTS_OFF_ARGS,
+      out,
+    )
   }
 
   @Test
@@ -1080,6 +1111,10 @@ class AutoInjectTest {
         env = { null },
         projectRoot = projectRoot,
       )
-    assertEquals(listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath), out)
+    assertEquals(
+      listOf("--init-script", File(storage, INIT_SCRIPT_FILENAME).absolutePath) +
+        ISOLATED_PROJECTS_OFF_ARGS,
+      out,
+    )
   }
 }

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.commons.ClassRemapper
 import org.objectweb.asm.commons.Remapper
@@ -319,6 +320,22 @@ class S3_5RecompileSaveLoopRealModeTest {
     // [targetMethod]; all other methods retain their original names but live on the new FQN. Any
     // collisions between renamed and original methods are deliberately avoided by picking
     // [targetMethod] = `MutableSquare` which doesn't exist on the source.
+    //
+    // The one method that is NOT copied is the static initializer. The bytes always come from
+    // `:daemon:desktop`'s fixture (the harness's *test* classpath carries that testFixtures jar;
+    // the Android daemon's classpath arrives as a text file the subprocess reads, so it is never
+    // the source of these bytes), while under `-Ptarget=android` the clone is loaded inside the
+    // Robolectric sandbox over `:daemon:android`'s classpath — which carries that module's own
+    // copy of the fixture. `<clinit>` wires the file's top-level properties, none of which
+    // [sourceMethod] touches: `RedSquare` / `BlueSquare` are a `Box` with a background colour and
+    // read no static state. Copying it made this test fail the moment a top-level property in the
+    // desktop fixture named a type the Android fixture does not have — #5002's
+    // `val insetFocusRing: InsetFocusRingTheme? by lazy { … }`, whose initialisation resolves
+    // `InsetFocusRingTheme`, a class only the desktop fixture declares. The sandbox has nothing to
+    // resolve it against, so initialising the clone fails, the render never completes, and this
+    // test reports it as a bare `renderFinished` timeout — which is how the Android leg went red
+    // on `main` from #5002 onwards while the desktop leg stayed green. Dropping the initializer
+    // keeps the clone to what it is for: one composable, loaded from a directory the daemon swaps.
     val filter =
       object : ClassVisitor(Opcodes.ASM9, ClassRemapper(writer, remapper)) {
         override fun visitMethod(
@@ -327,14 +344,16 @@ class S3_5RecompileSaveLoopRealModeTest {
           descriptor: String,
           signature: String?,
           exceptions: Array<out String>?,
-        ) =
-          super.visitMethod(
+        ): MethodVisitor? {
+          if (name == "<clinit>") return null
+          return super.visitMethod(
             access,
             if (name == sourceMethod) targetMethod else name,
             descriptor,
             signature,
             exceptions,
           )
+        }
       }
     reader.accept(filter, 0)
     return writer.toByteArray()

--- a/docs/isolated-projects-autoinject.md
+++ b/docs/isolated-projects-autoinject.md
@@ -13,8 +13,22 @@ that would actually fix it.
 - The auto-inject init script applies the plugin to every project via
   `allprojects { buildscript { … } }`. That is a cross-project configuration
   IP rejects outright, and the Tooling API daemon honours whatever a project's
-  `gradle.properties` sets — so enabling IP (here **or** in a consumer's build)
-  breaks every tooling-driven run, not just CI.
+  `gradle.properties` sets — so a consumer who enables IP would break every
+  tooling-driven run, not just CI.
+- **So the CLI turns IP off for its own invocations.** Every auto-injected
+  Gradle build the CLI / MCP server / VS Code extension drives carries
+  `-Dorg.gradle.isolated-projects=false -Dorg.gradle.unsafe.isolated-projects=false`
+  (`ISOLATED_PROJECTS_OFF_ARGS` in
+  [AutoInject.kt](../cli/src/main/kotlin/ee/schimke/composeai/cli/AutoInject.kt)),
+  which outranks the consumer's `gradle.properties`. Both spellings, because
+  **Gradle 9.7 graduated IP and renamed `org.gradle.unsafe.isolated-projects`
+  to `org.gradle.isolated-projects`** — a build on 9.7+ that sets the new name
+  (nowinandroid does) is unaffected by the old one. Anything driving
+  `./gradlew --init-script <script>` by hand — the integration matrix, the
+  repros below — has to pass the same flags itself.
+- `--no-auto-inject` (or a build that applies the plugin in its own
+  `plugins { }` blocks) does not need any of this: the plugin itself is
+  IP-clean, which the gradle-plugin functional tests pin with IP on.
 - We attempted an IP-safe redesign. The blocker is fundamental: there is no
   Gradle mechanism that is simultaneously **(a)** IP-clean, **(b)** injects a
   plugin without editing build files, and **(c)** puts that plugin on the same

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -149,10 +149,12 @@ constructor(
   private fun warnIfIsolatedProjectsEnabled(project: Project) {
     if (!buildFeatures.isolatedProjects.active.get()) return
     project.logger.warn(
-      "compose-preview: Isolated Projects is enabled (org.gradle.unsafe.isolated-projects=true). " +
+      "compose-preview: Isolated Projects is enabled (org.gradle.isolated-projects on Gradle 9.7+, " +
+        "org.gradle.unsafe.isolated-projects before that). " +
         "The compose-preview CLI, MCP server, and VS Code extension auto-inject this plugin through " +
         "an init script that configures projects via `allprojects { }`, which Isolated Projects " +
-        "rejects — those runs will fail. Disable Isolated Projects when using compose-preview tooling."
+        "rejects — so those tools turn Isolated Projects off for their own invocations. A build you " +
+        "drive yourself with the init script has to do the same."
     )
   }
 }


### PR DESCRIPTION
Two red checks on `main`, unrelated to each other.

## nowinandroid integration — Isolated Projects (Gradle 9.7 renamed the property)

`Integration / nowinandroid` fails with `Project ':' cannot access 'Project.buildscript' functionality on subprojects via 'allprojects'`. That is the documented auto-inject/IP incompatibility ([docs/isolated-projects-autoinject.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/isolated-projects-autoinject.md)), and what changed is not the plugin: **Gradle 9.7 graduated Isolated Projects and renamed `org.gradle.unsafe.isolated-projects` to `org.gradle.isolated-projects`.** nowinandroid's `gradle.properties` sets the new name and its wrapper is 9.7.1, so IP is genuinely active there, while every opt-out in this repository still named the old property only. The failing job's own log confirms it: the init script's IP warning fires, then the build aborts.

- **The CLI now turns IP off itself.** `ISOLATED_PROJECTS_OFF_ARGS` (`-Dorg.gradle.isolated-projects=false -Dorg.gradle.unsafe.isolated-projects=false`) goes out on every auto-injected invocation. A consumer's `gradle.properties` is what turns IP on and the Tooling API daemon honours it, so this is the difference between "works" and "fails" for any consumer that opted in — the same opt-out the docs told a human to type by hand. `--no-auto-inject` runs are untouched: the plugin itself is IP-clean.
- **The integration matrix** drives `./gradlew --init-script` directly rather than through the CLI, so the nowinandroid cell carries the two flags itself. The `wear-os-samples (ComposeStarter)` cell gets them too — and its comments are corrected: it asks for IP under the new name but runs Gradle 9.4.1, which predates the rename, so that cell has never actually run under IP. The flags make that explicit and keep the PR-blocking cell green through a wrapper bump. Real IP coverage for the plugin's own code stays in the gradle-plugin functional tests, which enable IP and apply the plugin manually.
- **The design-artifacts import step** wrote only the old property name into the throwaway checkout, which leaves IP on for a 9.7 upstream. It now comments out whichever name the checkout declares and pins both off.
- Both IP warnings (init script and plugin) name both properties; the docs page records what the CLI now does.

## Daemon Harness (android, real renderer) — the S3.5 clone

Red on `main` since #5002, not caused by #5052 (it fails identically on that PR's base commit and on today's `main`): `S3_5RecompileSaveLoopRealModeTest` times out waiting for `renderFinished`, only on the Android leg.

The test ASM-clones one composable out of `RedFixturePreviewsKt`. Those bytes always come from `:daemon:desktop`'s fixture — that is the testFixtures jar on the harness's own test classpath — while under `-Ptarget=android` the clone is loaded inside the Robolectric sandbox over `:daemon:android`'s classpath, which carries that module's separate copy of the fixture. The clone copied the file class's `<clinit>` too, so it inherited every top-level property of the desktop fixture, and #5002 added `val insetFocusRing: InsetFocusRingTheme? by lazy { … }` — whose initialisation resolves `InsetFocusRingTheme`, a class only the desktop fixture declares. The sandbox has nothing to resolve it against, the render never completes, and the harness reports a bare poll timeout.

The initializer was never wanted: `RedSquare` / `BlueSquare` are a `Box` with a background colour and read no static state. The cloner now skips `<clinit>`, so the clone carries the one composable it exists for.

## Test plan

- `:cli:test --tests '*AutoInjectTest*'` — green, including new coverage that both property names are disabled and that the init-script args carry them.
- `ktfmtFormat` clean on `:cli`, `:gradle-plugin`, `:daemon:harness`; `:daemon:harness:compileTestKotlin` green.
- Two unrelated `:cli:test` cases (`GradleWriteLocksTest`, `InitScriptExclusiveContentReproducerTest`) fail in this sandbox: their TestKit builds get HTTP 429 from Maven Central. Same cause blocked running the daemon harness locally (Skiko/Robolectric could not resolve), so the Daemon Harness workflow on this PR is the check for the second fix, and the wear-os ComposeStarter integration cell is the check that the two `-D` flags are accepted on Gradle 9.4.1.
- Non-visual change, so no render evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhPBfxNKL3JrqYkkjWbCb3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhPBfxNKL3JrqYkkjWbCb3)_