### PR TITLE
docs(parity): record that D4's crude form landed with the viewer's locator

### DIFF
--- a/docs/design/COMPONENT_PARITY_WORKFLOW.md
+++ b/docs/design/COMPONENT_PARITY_WORKFLOW.md
@@ -209,7 +209,10 @@ knows the frame it was served and writes the value outright. The **viewer** re-r
 its controls stop describing the served frame the moment one moves: the server writes the key and
 leaves the value as an `{{overrides}}` placeholder, which `refreshReportLink()` fills from live
 control state on the same pass that fills `{{render}}` — one pass, one source, so the identity the
-block states and the pixels the body links cannot name two frames. The viewer emitted no block at all
+block states and the pixels the body links cannot name two frames. **And that pass runs only when
+the landed frame is the one the controls are asking for** (§D4): the links move a fetch and a decode
+ahead of the image, so between a knob and its pixels the report is left holding the body that
+describes the frame still on the stage, and it catches up the moment the new one lands. The viewer emitted no block at all
 until [#5000](https://github.com/yschimke/compose-ai-tools/issues/5000), which cost every issue filed
 from a preview page its row in the index while the form went on promising one.
 

--- a/docs/design/parity-batches/01-locator-and-report.md
+++ b/docs/design/parity-batches/01-locator-and-report.md
@@ -99,6 +99,16 @@ href"** rule.
 > repository publishes it and reaches this repository's own bundled `serve` when
 > `composeai-preview-serve` is bumped to a release carrying it — the block is not on any deployed
 > viewer until then.
+>
+> **D4's crude form landed with it, on the viewer.** The trap below is not hypothetical on a page
+> whose controls re-render in place: the copyable links move the instant a knob does and the image
+> lands a fetch and a decode later, so a report composed on every change would describe a frame the
+> reporter never saw. `refreshReportLink()` therefore recomposes only while the landed frame is the
+> one the controls are asking for, and again the moment a frame lands; in between, the field keeps
+> the body that described the previous frame — which is the frame still on the stage. That is the
+> "disable the affordance until the requested frame has loaded" option, spelled without a disabled
+> affordance, and it covers the failed-render case for the same reason it covers the pending one:
+> what decides is which pixels are up, not why the newer ones are missing.
 
 ## Traps
 


### PR DESCRIPTION
Follow-up to #5057 (merged as 1be2f59), which recorded that the viewer emits a `compose-parity-locator/v1` block. This records the other half of that change: the D4 gate it needed.

Review on the server PR ([yschimke/compose-preview-server#220](https://github.com/yschimke/compose-preview-server/pull/220)) raised it and it was right. The viewer's controls and its copyable links move the instant a knob does; the image lands a fetch and a decode later — `viewer.ts` says so where it records the landed frame's provenance, and `specBaseline.ts` relies on the same gap from the other side. For a copyable link that is harmless. For a report it is the defect batch 01 lists under **Done when**: *"reporting while a requested frame is still in flight, and reporting after that render has failed, must both either be refused or produce a locator describing the frame actually on screen."* A reporter submitting inside that window would file a locator and an embedded render URL that agree with each other and with neither the screen nor themselves — and nothing downstream can tell, because the body looks complete and the index takes it.

The implementation ([compose-preview-server#220](https://github.com/yschimke/compose-preview-server/pull/220), commit `6631030`) recomposes only while the landed frame is the one the controls are asking for, and again the moment a frame lands. Skipping leaves the field holding the body that described the previous frame — which is the frame still on the stage — so it needs no disabled affordance and adds no UI state. That is the option batch 01 calls *"explicitly acceptable and explicitly preferred"* over a subtly-wrong derivation, and it covers the failed-render case for the same reason it covers the pending one: what decides is which pixels are up, not why the newer ones are missing.

## What this PR changes

- **`docs/design/parity-batches/01-locator-and-report.md`** — extends the erratum added in #5057 to say D4's crude form landed with it, so a reader can tell the trap was walked around rather than into.
- **`docs/design/COMPONENT_PARITY_WORKFLOW.md` §2** — the sentence about the viewer's `{{overrides}}` pass now says when that pass runs.

## Test plan

Docs only; no code in this repository. The behaviour is tested in the server PR by `serve-web/test/viewerReportFrame.test.ts` (7 cases: nothing landed yet, landed and matching, relative-vs-absolute, in flight, after a failed render, a lane switch, an unparseable URL) with a fixture assertion pinning that the gate is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011piAXfYfYUhf6g3Nyq5mZR

---
_Generated by [Claude Code](https://claude.ai/code/session_011piAXfYfYUhf6g3Nyq5mZR)_