### PR TITLE
ci: move drift detectors and external integration cells to the nightly lane

### DIFF
--- a/.github/ci/test_affected_gradle_tests.py
+++ b/.github/ci/test_affected_gradle_tests.py
@@ -148,48 +148,57 @@ class ModuleUnitTestsGateTest(unittest.TestCase):
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
         self.assertIn("./gradlew test jvmTest desktopTest checkKotlinAbi --continue", ci)
 
-    def test_ci_gates_module_unit_tests_on_a_non_none_task_list(self):
-        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
-        self.assertIn("needs.module-test-scope.outputs.tasks != 'none'", ci)
+    def test_ci_absorbs_a_none_task_list_without_invoking_gradle(self):
+        """`none` is a real output of this script and must never reach `gradlew`.
 
-    def test_module_unit_tests_consumes_the_resolved_task_list(self):
-        """The gate and the task list must come from the same job.
-
-        `Resolve affected Gradle tests` lives in its own job so it stops blocking the ~11
-        jobs that never read it. That split is only safe while the `if:` gate above and
-        the `TEST_TASKS` the job actually runs both read `module-test-scope` — if one is
-        left pointing at a stale producer, the job passes its gate and then invokes a task
-        list it never resolved.
+        This used to be a job-level `if` on the resolver job's output. The resolver now runs
+        as a step inside Module Unit Tests, so there is no output to gate on before the job
+        starts — the `none` branch of the run step is what absorbs it instead. Assert the
+        branch exists and that the task list is only expanded on the `else`.
         """
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        self.assertIn('elif [ -z "$TEST_TASKS" ] || [ "$TEST_TASKS" = none ]; then', ci)
+        self.assertIn('read -r -a tasks <<< "$TEST_TASKS"', ci)
+
+    def test_module_unit_tests_consumes_the_task_list_it_resolved(self):
+        """The gate and the task list must come from the same place.
+
+        When `Resolve affected Gradle tests` was its own job, this guarded against the `if:`
+        gate and `TEST_TASKS` drifting onto different producers — the job would pass its gate
+        and then run a task list it never resolved. Folding the resolver into the consuming
+        job removes that class of bug by construction, so what is asserted now is that the
+        split is really gone: the step publishes `test-scope`, the run step reads it, and no
+        reference to the old `module-test-scope` job survives anywhere in the file.
+        """
+        ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
+        self.assertIn("id: test-scope", ci)
         self.assertIn(
             "TEST_TASKS: ${{ github.event_name == 'pull_request' "
-            "&& needs.module-test-scope.outputs.tasks || 'full' }}",
+            "&& steps.test-scope.outputs.tasks || 'full' }}",
             ci,
         )
-        self.assertIn("needs: [changes, module-test-scope]", ci)
+        self.assertNotIn("module-test-scope", ci)
         self.assertNotIn("module_test_tasks", ci)
 
     def test_non_pr_events_keep_module_coverage_without_a_resolver_hop(self):
-        """`main` and the nightly cron must not queue a job just to be told `full`.
+        """`main` and the nightly cron must not pay to be told `full`.
 
-        On non-PR events `path-scope.py` enables every group, so gating the resolver on
-        `module_unit_tests` alone would schedule it on every push — and since Module Unit
-        Tests `needs:` it, post-merge coverage would sit behind a second runner queue to
-        compute a constant. The resolver is therefore `pull_request`-only, which makes
-        `!cancelled()` load-bearing on the consumer: without it, the skipped resolver
-        would skip post-merge and nightly module tests outright.
+        On non-PR events `path-scope.py` enables every group, so a resolver gated on
+        `module_unit_tests` alone would run on every push to compute a constant. It used to
+        cost a whole extra job — and because Module Unit Tests `needs:` it, post-merge
+        coverage sat behind a second runner queue (measured p90 ~20 min under merge-burst
+        contention). It is now a `pull_request`-only step in the job that reads it, so a push
+        skips the step and falls through to `full` in the same runner.
+
+        `!cancelled()` stays load-bearing on the job: `changes` can be skipped rather than
+        failed, and a skipped `needs:` would otherwise delete post-merge and nightly module
+        coverage outright.
         """
         ci = (HERE.parents[1] / ".github" / "workflows" / "ci.yml").read_text()
-        scope_gate = "if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.module_unit_tests == 'true'"
-        self.assertIn(scope_gate, ci)
+        self.assertIn("      - name: Resolve affected Gradle tests\n        id: test-scope\n        if: github.event_name == 'pull_request'\n", ci)
         self.assertIn("!cancelled()", ci)
         self.assertIn("needs.changes.result == 'success'", ci)
-        self.assertIn("needs.module-test-scope.result != 'failure'", ci)
-        self.assertIn(
-            "(github.event_name != 'pull_request' || needs.module-test-scope.outputs.tasks != 'none')",
-            ci,
-        )
+        self.assertIn("needs: changes\n", ci)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
   # without making every PR wait on them.
   schedule:
     - cron: "23 4 * * *"
+  # Manual full run, including the nightly-only drift detectors above.
+  workflow_dispatch:
 
 # Workflow-level default: minimum viable scope. Individual jobs can widen if
 # they need it (none here do — all jobs are read-only builds + artifact upload,
@@ -60,9 +62,10 @@ jobs:
   # time added to all ~12 downstream jobs. Resolving the affected Gradle tests
   # (a full `./.github/actions/setup` + a Gradle model query, ~4 min) used to sit
   # in this job and blocked all of them, though only Module Unit Tests consumes
-  # the result. It now lives in `module-test-scope` below, which runs alongside
-  # the other jobs instead of in front of them. Keep this job cheap: anything
-  # added here delays the entire workflow.
+  # the result. It now runs as a step inside `module-unit-tests` itself, which
+  # already has the checkout and the Gradle cache warm — so it costs that job ~2 min
+  # and costs no other job anything. Keep this job cheap: anything added here delays
+  # the entire workflow.
   changes:
     name: Determine CI scope
     runs-on: ubuntu-latest
@@ -107,37 +110,6 @@ jobs:
   # too. On a saturated queue that is another 40-70 min in front of post-merge
   # module coverage: the exact cost this split exists to remove. Non-PR events
   # skip the job and the consumer defaults to `full` directly.
-  module-test-scope:
-    name: Resolve affected module tests
-    needs: changes
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.module_unit_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
-    runs-on: ubuntu-latest
-    outputs:
-      tasks: ${{ steps.test-scope.outputs.tasks }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      # `changes` fetched this into its own checkout; the split means this job
-      # has to fetch it again for `affected-gradle-tests.py` to diff against.
-      - name: Fetch the PR base commit
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        run: git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
-      - uses: ./.github/actions/setup
-      - uses: ./.github/actions/buildfetch-cache
-        with:
-          rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
-          ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
-      - name: Resolve affected Gradle tests
-        id: test-scope
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.sha }}
-        run: |
-          tasks=$(python3 .github/ci/affected-gradle-tests.py)
-          echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
-
   plugin-tests:
     name: Plugin Unit Tests
     needs: changes
@@ -169,7 +141,13 @@ jobs:
     # figma-svg export change, so it has to run on PRs, where the export changes land.
     name: Renderer Android Unit Tests
     needs: changes
-    if: ${{ needs.changes.outputs.renderer_android_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
+    # `pull_request` only. `:renderer-android` is in the root build (settings.gradle.kts),
+    # so `module-unit-tests`' `full` branch — the one every non-PR event takes — already runs
+    # `:renderer-android:test`, which for an Android library depends on `testDebugUnitTest`.
+    # On push this job was a 3.7-min re-run of work happening in parallel two jobs over.
+    # It stays on PRs, where `module-unit-tests` is scoped to affected modules and may not
+    # reach `:renderer-android` at all.
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.renderer_android_tests == 'true' && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -211,27 +189,22 @@ jobs:
   # of masking them — the point of the job is to know the true state, not to stop at the first red.
   module-unit-tests:
     name: Module Unit Tests
-    needs: [changes, module-test-scope]
-    # `tasks != 'none'` is load-bearing, not belt-and-braces: the two scopes are
-    # resolved from different configs and can disagree. `path-scope.py` fails OPEN on a path it
-    # doesn't recognise (turning every group on, this job included), while
-    # `affected-gradle-tests.py` reads `gradle-test-scope.json`, where e.g. `.github/**` is
-    # ignored — so a PR touching only such a path enabled the job with `tasks=none` and it died
-    # on `gradlew none` ("Task 'none' not found"). `none` means there is nothing to run: skip.
-    # It is scoped to `pull_request` because that is the only event that produces it.
+    needs: changes
+    # The two scopes are resolved from different configs and can disagree. `path-scope.py`
+    # fails OPEN on a path it doesn't recognise (turning every group on, this job included),
+    # while `affected-gradle-tests.py` reads `gradle-test-scope.json`, where e.g. `.github/**`
+    # is ignored — so a PR touching only such a path enables the job with `tasks=none`. That
+    # used to reach `gradlew none` and die ("Task 'none' not found"); the `none` branch of the
+    # run step below absorbs it as a no-op, which is why the job `if` no longer has to.
     #
-    # `!cancelled()` is required, not decoration: `module-test-scope` deliberately does not run
-    # on push/schedule, and a skipped `needs:` skips the dependent by default — which would
-    # silently delete post-merge and nightly module coverage. The explicit
-    # `needs.changes.result == 'success'` and `module-test-scope.result != 'failure'` restore
-    # the propagation that `!cancelled()` switches off, so a broken scope job still stops this
-    # one rather than running it against an empty task list.
+    # `!cancelled()` is required, not decoration: it keeps the job alive when an upstream is
+    # skipped rather than failed, which would otherwise silently delete post-merge and nightly
+    # module coverage. The explicit `needs.changes.result == 'success'` restores the failure
+    # propagation that `!cancelled()` switches off.
     if: >-
       ${{ !cancelled()
           && needs.changes.result == 'success'
           && needs.changes.outputs.module_unit_tests == 'true'
-          && needs.module-test-scope.result != 'failure'
-          && (github.event_name != 'pull_request' || needs.module-test-scope.outputs.tasks != 'none')
           && !(startsWith(github.head_ref, 'release-please--') && github.event.pull_request.user.login == 'github-actions[bot]') }}
     runs-on: ubuntu-latest
     steps:
@@ -243,10 +216,30 @@ jobs:
         with:
           rw-token: ${{ github.event_name == 'push' && (secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN) || '' }}
           ro-token: ${{ secrets.BUILDFETCH_COMPOSEAI_GRADLE_REMOTE_CACHE_TOKEN_RO || secrets.BUILDFETCH_GRADLE_REMOTE_CACHE_TOKEN_RO }}
+      # Resolved here rather than in a `needs:` job. As a separate job this cost a
+      # second checkout, a second Gradle setup and — because a `needs:` edge is a full
+      # scheduling round-trip — a fresh spell in the runner queue, measured at a p90 of
+      # ~20 min under merge-burst contention, to hand 17 min of tests a one-line output.
+      # `module-unit-tests` already has the checkout and the cache warm, so the resolver
+      # is ~2 min of work that now overlaps nothing instead of gating everything.
+      - name: Fetch the PR base commit
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+      - name: Resolve affected Gradle tests
+        id: test-scope
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          tasks=$(python3 .github/ci/affected-gradle-tests.py)
+          echo "tasks=$tasks" >> "$GITHUB_OUTPUT"
       - name: Run affected module tests (full suite off PRs)
         env:
-          # Non-PR events skip the resolver job, so default to the full suite here.
-          TEST_TASKS: ${{ github.event_name == 'pull_request' && needs.module-test-scope.outputs.tasks || 'full' }}
+          # Non-PR events skip the resolver step above, so default to the full suite here.
+          TEST_TASKS: ${{ github.event_name == 'pull_request' && steps.test-scope.outputs.tasks || 'full' }}
         run: |
           if [ "$TEST_TASKS" = full ]; then
             # `checkKotlinAbi` unqualified, so Gradle runs it in every project that HAS it — the
@@ -476,7 +469,18 @@ jobs:
     # smoke job and routinely make Build Samples the slowest CI leg. Run them
     # on main and nightly instead. Because this is a distinct, new check name it
     # is not part of the existing branch-protection required-check set.
-    if: ${{ github.event_name != 'pull_request' }}
+    # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
+    # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
+    # merge before they finish. Running it on push therefore paid a runner slot on 100% of
+    # merges to get a result on ~25% of them — and the ones that did land were rarely the
+    # commit that broke anything. The nightly cron already catches the drift these guard
+    # against within 24h, which is the cadence they were designed for.
+    #
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
+    # required check that never reports blocks every PR forever. `workflow_dispatch` is the
+    # manual escape hatch for running one on demand.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -600,7 +604,18 @@ jobs:
     # Heavy (Xvfb software-GL render, several minutes). Drift detector, not a PR
     # gate — runs on push-to-main + nightly, skipped on PRs (a skipped required
     # check counts as passing for branch protection).
-    if: ${{ github.event_name != 'pull_request' }}
+    # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
+    # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
+    # merge before they finish. Running it on push therefore paid a runner slot on 100% of
+    # merges to get a result on ~25% of them — and the ones that did land were rarely the
+    # commit that broke anything. The nightly cron already catches the drift these guard
+    # against within 24h, which is the cadence they were designed for.
+    #
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
+    # required check that never reports blocks every PR forever. `workflow_dispatch` is the
+    # manual escape hatch for running one on demand.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -682,7 +697,18 @@ jobs:
     # Heavy E2E (~7 min, cold-starts Compose Desktop per preview). Drift
     # detector — runs on push-to-main + nightly, skipped on PRs (skipped
     # required check == passing).
-    if: ${{ github.event_name != 'pull_request' }}
+    # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
+    # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
+    # merge before they finish. Running it on push therefore paid a runner slot on 100% of
+    # merges to get a result on ~25% of them — and the ones that did land were rarely the
+    # commit that broke anything. The nightly cron already catches the drift these guard
+    # against within 24h, which is the cadence they were designed for.
+    #
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
+    # required check that never reports blocks every PR forever. `workflow_dispatch` is the
+    # manual escape hatch for running one on demand.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -721,7 +747,18 @@ jobs:
     # Heavy E2E (~9 min, cold-starts a daemon JVM per bundle). Drift detector —
     # runs on push-to-main + nightly, skipped on PRs (skipped required check ==
     # passing).
-    if: ${{ github.event_name != 'pull_request' }}
+    # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
+    # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
+    # merge before they finish. Running it on push therefore paid a runner slot on 100% of
+    # merges to get a result on ~25% of them — and the ones that did land were rarely the
+    # commit that broke anything. The nightly cron already catches the drift these guard
+    # against within 24h, which is the cadence they were designed for.
+    #
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
+    # required check that never reports blocks every PR forever. `workflow_dispatch` is the
+    # manual escape hatch for running one on demand.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -787,7 +824,18 @@ jobs:
     # Longest single job (~12 min; one external-fetched audit script). Drift
     # detector — runs on push-to-main + nightly, skipped on PRs (skipped
     # required check == passing).
-    if: ${{ github.event_name != 'pull_request' }}
+    # Drift detector, not a PR gate. Measured: `main` merges land a median 4 min apart
+    # while this workflow takes 20-25 min, so 75% of push runs are cancelled by the next
+    # merge before they finish. Running it on push therefore paid a runner slot on 100% of
+    # merges to get a result on ~25% of them — and the ones that did land were rarely the
+    # commit that broke anything. The nightly cron already catches the drift these guard
+    # against within 24h, which is the cadence they were designed for.
+    #
+    # The job stays DEFINED rather than deleted so it keeps reporting `skipped` on PRs:
+    # `Agent Audit Samples` below is a required check in the `Protect Main` ruleset, and a
+    # required check that never reports blocks every PR forever. `workflow_dispatch` is the
+    # manual escape hatch for running one on demand.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,13 +20,21 @@ name: CodeQL
 # Settings → Code security → Code scanning for this workflow to take effect.
 
 on:
-  push:
-    branches: [main]
+  # Deliberately NOT on `push: [main]`. `path-scope.py` enables every language group on any
+  # non-`pull_request` event (it only diffs a PR against its base), so the push lane ran a full
+  # 13.7-min `java-kotlin` Kotlin compile on every merge — unscoped, and measured 72% cancelled
+  # by the next merge before it finished, because `main` merges land a median 4 min apart.
+  #
+  # Everything reaches `main` through a pull request, so the PR lane below already analyses the
+  # exact tree that lands, and does it scoped (0.8 min median when no Kotlin changed). The weekly
+  # cron re-establishes the full-tree baseline in the security tab, which is what the push lane
+  # was really providing.
   pull_request:
     branches: [main]
   schedule:
-    # Weekly, off-peak.
+    # Weekly, off-peak. Also the full-tree baseline for code scanning now that push is off.
     - cron: '27 7 * * 3'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -303,6 +303,23 @@ jobs:
     # gate on PR merges. Other cells default to `false` (blocking) when the
     # field is absent.
     continue-on-error: ${{ matrix.continue_on_error == true }}
+    # Which cells do real work on this event. Every cell still *materialises* as a job
+    # regardless — `wear-os-samples (ComposeStarter)` and `(WearTilesKotlin)` are required
+    # checks in the `Protect Main` ruleset, and the others' names are cheap to keep reporting —
+    # but a cell that is not active skips every expensive step below and costs ~0.1 min.
+    #
+    # PRs already worked this way: only `pr_blocking` cells built anything. What changed is the
+    # push-to-main lane, which used to run the full external matrix on every merge — 8 cells,
+    # ~25 job-min. Measured, 72% of those push runs were cancelled by the next merge before they
+    # finished (`main` merges land a median 4 min apart), so the lane was paying for the full
+    # matrix on every merge and completing it on roughly one in four. These cells guard against
+    # *upstream* drift — an external repo bumping AGP / Kotlin / the Compose BOM — which is
+    # correlated with time, not with our commits, so the nightly cron is the cadence that
+    # actually fits them and the one the workflow header already describes.
+    #
+    # The two `pr_blocking` cells stay on push for immediate post-merge signal.
+    env:
+      CELL_ACTIVE: ${{ (matrix.pr_blocking || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
     strategy:
       fail-fast: false
       matrix:
@@ -730,7 +747,7 @@ jobs:
           #   java_version: "21"
     steps:
       - name: Checkout ${{ matrix.repo }}
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ matrix.repo }}
@@ -739,7 +756,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout ${{ matrix.secondary_repo }} (secondary)
-        if: ${{ matrix.secondary_repo != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.secondary_repo != '' && env.CELL_ACTIVE == '1' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ matrix.secondary_repo }}
@@ -749,7 +766,7 @@ jobs:
           persist-credentials: false
 
       - name: Wire androidx symlink in androidchka workspace
-        if: ${{ matrix.wire_androidx_symlink && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.wire_androidx_symlink && env.CELL_ACTIVE == '1' }}
         run: |
           set -euo pipefail
           target="$GITHUB_WORKSPACE/${{ matrix.secondary_path }}"
@@ -761,7 +778,7 @@ jobs:
           ls -ld "$link"
 
       - name: Write local.properties for ${{ matrix.name }}
-        if: ${{ matrix.local_properties != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.local_properties != '' && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           LOCAL_PROPERTIES: ${{ matrix.local_properties }}
@@ -772,7 +789,7 @@ jobs:
           cat local.properties
 
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         with:
           distribution: temurin
           # Matrix entries can override (e.g. androidchka needs 21 for
@@ -780,7 +797,7 @@ jobs:
           java-version: ${{ matrix.java_version || '17' }}
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         with:
           cache-provider: basic
 
@@ -815,7 +832,7 @@ jobs:
       # from a foreign coordinate costs a quarter-gig restore and still needs the
       # real download.
       - name: Restore Robolectric android-all cache
-        if: ${{ (matrix.render || matrix.render_xr || matrix.daemon) && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ (matrix.render || matrix.render_xr || matrix.daemon) && env.CELL_ACTIVE == '1' }}
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository/org/robolectric/android-all-instrumented
@@ -829,7 +846,7 @@ jobs:
       # android-all instead of re-fetching. Structural check only (central
       # directory, no full decompress) — drop anything that fails it.
       - name: Drop corrupt android-all jars
-        if: ${{ (matrix.render || matrix.render_xr || matrix.daemon) && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ (matrix.render || matrix.render_xr || matrix.daemon) && env.CELL_ACTIVE == '1' }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -849,13 +866,13 @@ jobs:
           PY
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         with:
           name: compose-ai-bundle
           path: .
 
       - name: Install plugin and CLI
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         run: |
           set -euo pipefail
           mkdir -p bundle
@@ -870,7 +887,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bundle/cli/bin" >> "$GITHUB_PATH"
 
       - name: Materialise the bundled auto-inject init script
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         env:
           # Tell the rendered init script to look at the snapshot we just
           # seeded into ~/.m2 in addition to the public plugin/Maven Central
@@ -884,11 +901,11 @@ jobs:
           echo "COMPOSE_AI_INIT_SCRIPT=$init_script" >> "$GITHUB_ENV"
 
       - name: Sanity check CLI
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         run: compose-preview help
 
       - name: Make external gradlew executable
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: chmod +x ./gradlew
 
@@ -898,7 +915,7 @@ jobs:
         # non-representative drift cell. The discover/render steps that consume
         # the patch are already PR-gated the same way, so there's nothing to
         # patch for on a skipped cell. (Drift still surfaces on cron/push.)
-        if: ${{ matrix.patch_file != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.patch_file != '' && env.CELL_ACTIVE == '1' }}
         # Runs from the external checkout root so each patch's
         # repo-root-relative paths (e.g. AdaptiveJetStream/jetstream/...)
         # line up with `git apply -p1`. The bundle was extracted into
@@ -928,7 +945,7 @@ jobs:
           done
 
       - name: Add preview-annotations dependency for the XR overlay
-        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render_xr && env.CELL_ACTIVE == '1' }}
         # The @XrSubspacePreview overlay needs the preview-annotations artifact
         # (which defines @XrSubspacePreview) on the module's compile classpath.
         # That's an ordinary library dependency, not plugin configuration: the
@@ -979,7 +996,7 @@ jobs:
           PY
 
       - name: Repo-specific pre-Gradle patches
-        if: ${{ matrix.pre_gradle_script != '' && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.pre_gradle_script != '' && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: ${{ matrix.pre_gradle_script }}
 
@@ -988,7 +1005,7 @@ jobs:
         # are covered by the daily cron + push-to-main. `matrix` is available at
         # step level (unlike at `jobs.<id>.if`), so the cell still reports its
         # check — it just skips the build.
-        if: ${{ !matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ !matrix.use_cli && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1002,7 +1019,7 @@ jobs:
             --stacktrace
 
       - name: CLI — list previews (${{ matrix.module }})
-        if: ${{ matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.use_cli && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1017,7 +1034,7 @@ jobs:
       - name: Verify previews.json was produced
         # Skip the assertion on cells whose discovery was skipped above, else it
         # would fail on a missing manifest.
-        if: ${{ github.event_name != 'pull_request' || matrix.pr_blocking }}
+        if: ${{ env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1039,7 +1056,7 @@ jobs:
           fi
 
       - name: Render previews via Gradle
-        if: ${{ matrix.render && !matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render && !matrix.use_cli && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1054,7 +1071,7 @@ jobs:
             --stacktrace
 
       - name: CLI — render previews (${{ matrix.module }})
-        if: ${{ matrix.render && matrix.use_cli && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render && matrix.use_cli && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1066,7 +1083,7 @@ jobs:
           compose-preview render --module "${{ matrix.module }}"
 
       - name: Verify PNGs were produced
-        if: ${{ matrix.render && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1092,7 +1109,7 @@ jobs:
           printf '  %s\n' "${pngs[@]}"
 
       - name: Render XR subspace previews (composePreviewRenderXr)
-        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render_xr && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1109,7 +1126,7 @@ jobs:
             --stacktrace
 
       - name: Verify XR scene.json was produced
-        if: ${{ matrix.render_xr && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render_xr && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1138,7 +1155,7 @@ jobs:
         # Staged before the daemon round-trip below: that step edits a
         # source file and re-renders, which would otherwise leak into the
         # published gallery.
-        if: matrix.render && github.event_name != 'pull_request'
+        if: matrix.render && github.event_name != 'pull_request' && env.CELL_ACTIVE == '1'
         working-directory: external/${{ matrix.workdir }}
         # Matrix-derived strings go through env, not inline `${{ }}` in the
         # script body: `pre_gradle_script` / `notes` are multi-line and
@@ -1236,7 +1253,7 @@ jobs:
         # staged gallery README so the spatial previews are browsable on the
         # published branch alongside the flat ones. No-op when the gallery
         # wasn't staged (README absent) or no scene.json was produced.
-        if: matrix.render_xr && github.event_name != 'pull_request'
+        if: matrix.render_xr && github.event_name != 'pull_request' && env.CELL_ACTIVE == '1'
         working-directory: external/${{ matrix.workdir }}
         env:
           GALLERY_DIR: ${{ github.workspace }}/_integration_baselines
@@ -1251,7 +1268,7 @@ jobs:
             --search-root .
 
       - name: Upload browsable preview gallery payload
-        if: matrix.render && github.event_name != 'pull_request' && hashFiles('_integration_baselines/baselines.json') != ''
+        if: matrix.render && github.event_name != 'pull_request' && env.CELL_ACTIVE == '1' && hashFiles('_integration_baselines/baselines.json') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-previews-${{ matrix.slug }}
@@ -1260,7 +1277,7 @@ jobs:
           retention-days: 7
 
       - name: Configure daemon in consumer build
-        if: matrix.daemon && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: matrix.daemon && env.CELL_ACTIVE == '1'
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1310,7 +1327,7 @@ jobs:
           MATRIX_BACKGROUND_BOOT: ${{ matrix.daemon_background_boot }}
 
       - name: Emit daemon launch descriptor (composePreviewDaemonStart)
-        if: matrix.daemon && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: matrix.daemon && env.CELL_ACTIVE == '1'
         working-directory: external/${{ matrix.workdir }}
         env:
           COMPOSE_PREVIEW_INIT_USE_MAVEN_LOCAL: "1"
@@ -1323,7 +1340,7 @@ jobs:
             --stacktrace
 
       - name: Daemon round-trip (spawn → render → edit → re-render)
-        if: matrix.daemon && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: matrix.daemon && env.CELL_ACTIVE == '1'
         working-directory: external/${{ matrix.workdir }}
         env:
           # The recompile step inside daemon-roundtrip.py runs `./gradlew
@@ -1364,7 +1381,7 @@ jobs:
             --gradle-args "--init-script $COMPOSE_AI_INIT_SCRIPT ${{ matrix.extra_gradle_args }}"
 
       - name: Upload daemon launch descriptor
-        if: always() && matrix.daemon && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: always() && matrix.daemon && env.CELL_ACTIVE == '1'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: daemon-launch-${{ matrix.slug }}
@@ -1373,7 +1390,7 @@ jobs:
           retention-days: 7
 
       - name: Verify at least one TILE preview was rendered
-        if: ${{ matrix.render && matrix.require_tile_render && (github.event_name != 'pull_request' || matrix.pr_blocking) }}
+        if: ${{ matrix.render && matrix.require_tile_render && env.CELL_ACTIVE == '1' }}
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
@@ -1405,7 +1422,7 @@ jobs:
           PY
 
       - name: Upload previews.json
-        if: always() && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: always() && env.CELL_ACTIVE == '1'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previews-${{ matrix.slug }}
@@ -1414,7 +1431,7 @@ jobs:
           retention-days: 7
 
       - name: Upload rendered PNGs
-        if: always() && (matrix.render || matrix.render_xr) && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: always() && (matrix.render || matrix.render_xr) && env.CELL_ACTIVE == '1'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renders-${{ matrix.slug }}
@@ -1448,7 +1465,7 @@ jobs:
       # below call that one script; they must not drift apart.
       - name: Resolve android-all cache key
         id: android-all
-        if: always() && (matrix.render || matrix.render_xr || matrix.daemon) && (github.event_name != 'pull_request' || matrix.pr_blocking)
+        if: always() && (matrix.render || matrix.render_xr || matrix.daemon) && env.CELL_ACTIVE == '1'
         run: |
           set -euo pipefail
           # Ships in the bundle (these legs have no checkout of this repo). The
@@ -1830,6 +1847,11 @@ jobs:
     # external consumer code — it just downloads the staged galleries from
     # the matrix job and `git push` them. The untrusted external builds all
     # ran in the `integration` job under a read-only token.
+    #
+    # Cadence note: since the non-`pr_blocking` cells moved to the nightly cron, a push to
+    # main refreshes only the `pr_blocking` cells' gallery branches. The rest refresh on the
+    # nightly run instead of per-merge — in practice fresher than before, because 72% of the
+    # per-merge runs were cancelled before ever reaching this job.
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why

`main` merges land a **median 4 minutes apart** (89% within 25 min of the previous one) while CI takes 20–25 minutes. The consequence, measured over the last 100 runs per workflow:

| Workflow | push-to-main runs cancelled |
| --- | --- |
| ci.yml | **75%** |
| integration.yml | 72% |
| codeql.yml | 72% |
| compose-preview.yml | 64% |

Only **15%** of pushes to `main` ever get a green CI run. Everything gated to the push lane was paying a runner slot on 100% of merges to produce a result on roughly one in four — and those slots are what PR jobs queue behind. The p90 queue wait for a `ci.yml` push job is **18–25 minutes**; 11% of all jobs wait over 5 minutes to start.

Measured baseline (last 15 successful runs of each workflow — 195 runs, 993 jobs): **~198 job-minutes and ~50 jobs per merge**, and a commit on `main` carries **93 check-runs, 58 of them under a minute**.

## What changed

**Deferred to the nightly cron** (each reachable on demand via `workflow_dispatch`):

- **ci.yml** — `Build Samples (full render suite)`, `Render XR composite`, `Bundle Render E2E`, `Android Bundle Daemon E2E`, `Agent Audit Samples`. These are drift detectors; the nightly run already catches what they guard within 24h, and at 75% cancellation the push lane was not reliably catching it "within minutes of landing" as intended. The jobs stay **defined** rather than deleted so `Agent Audit Samples` keeps reporting `skipped` on PRs — it is a required check in the `Protect Main` ruleset, and a required check that never reports blocks every PR forever.
- **integration.yml** — the seven non-`pr_blocking` external-consumer cells. They guard against upstream repos bumping AGP / Kotlin / the Compose BOM, which correlates with time rather than with our commits. PRs already skipped their expensive steps; this extends the same gate to push through one job-level `CELL_ACTIVE`, replacing 32 hand-repeated step conditions.
- **codeql.yml** — the `push` leg. `path-scope.py` enables every language group on any non-`pull_request` event, so push ran an unscoped 13.7-min Kotlin compile on every merge. Everything reaches `main` through a PR, where the scoped analysis (0.8 min median when no Kotlin changed) already covers the tree that lands; the weekly cron keeps the full-tree code-scanning baseline.

**Duplicate and serialised work removed:**

- `Renderer Android Unit Tests` is now `pull_request`-only. `:renderer-android` is in the root build (`settings.gradle.kts`), so `module-unit-tests`' `full` branch — which every non-PR event takes — already runs it. It stays on PRs, where `module-unit-tests` is scoped and may not reach it.
- `module-test-scope` is folded into `module-unit-tests` as a step. A `needs:` edge is a full scheduling round-trip, so a 2.4-min resolver was gating a 17-min job from a separate queue position; the consuming job already has the checkout and Gradle cache warm.

`agp8-min` deliberately **stays** on push: it builds an in-repo fixture, so it tracks our own compatibility floor rather than external drift.

## Expected effect

Per merge to `main`: **~198 → ~110 job-minutes**, and ~50 → ~30 jobs. PR-lane behaviour is unchanged except that `Renderer Android Unit Tests` and the folded resolver stop costing a queue round-trip.

## Things to look at

- **CodeQL losing its push leg** is a security-posture call. Alerts on `main` now refresh from the weekly cron plus every PR analysis rather than per-merge. Easy to revert if you'd rather keep it.
- **`wear-os-samples (WearTilesKotlin)`** is a required check but is not `pr_blocking`, so it was already a no-op shell on PRs; it now also defers its real work (including the `require_tile_render` guard) to nightly. Required-check behaviour is unchanged.
- **`publish-previews`** refreshes only the `pr_blocking` cells' gallery branches on push; the rest refresh nightly. In practice fresher than before, since 72% of per-merge runs were cancelled before reaching that job.

## Not done

Two items from the original analysis are deliberately absent:

- **Splitting the 24.3-min `A11y + notification previews` job** — this is the PR critical path, but the workflow header documents that notifications *must* run after a11y in the same job (its staging globs the workspace the a11y re-render populates). Splitting was tried and reverted in #2195, where it "falsely reports every daemon-produced capture as removed". Left alone.
- **Collapsing the 58 sub-minute check-runs** into a shared hygiene job — `Conventional Commit title` and `Reject agent attribution` are required checks, and renaming a required check hangs every PR. Needs a ruleset edit, which this session can't make.

The structural fix — a merge queue — is tracked in #5063.

## Test plan

- All 19 Python action/CI test suites pass locally, including `test_affected_gradle_tests.py`, `test_path_scope.py`, `test_change_scope.py`, `test_compute_scope.py`.
- The three `ModuleUnitTestsGateTest` cases are **re-pointed** at the new wiring rather than dropped. Each invariant still holds by a different mechanism: a `none` task list never reaching `gradlew` (now the run step's `none` branch), the gate and task list sharing a producer (now the same job, by construction), and non-PR events not paying to be told `full` (now a `pull_request`-gated step, not a job).
- All 39 workflow files parse as YAML; verified the eight required checks in `Protect Main` are still produced.
- Non-visual change — no render evidence applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UR7ueGkeJnabqchqVJTVHk