### PR TITLE
feat(discovery): persist each component's call site in components.json

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -790,6 +790,27 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > with you. Both fixtures I picked by hand happened to avoid the one construct that
 > breaks the path, and only compiling something real found it.
 >
+> **The call site is persisted, not recomputed.** `ComponentRecord.code` carries what
+> `ComponentSnippets` printed — either a `call` plus its `imports`, or a `refusedReason`.
+> That is a deliberate choice about where the rule lives. The consumer this record
+> exists for (compose-preview-server's Compose exporter and playground) depends on
+> published compose-ai-tools artifacts but **not** on `preview-discovery`, so a
+> consumer-side call site would mean either a new dependency on a module that drags
+> ClassGraph, ASM and kotlin-metadata in to produce one string, or a second
+> implementation of the three rules that make a refusal sound — `signatureKnown`,
+> `symbol.receiver`, and the `…Kt`-facade evidence in `symbol.callable`. A second
+> implementation of a rule this exacting is how two sides of a contract start
+> disagreeing, which is the drift §1.4 already records once.
+>
+> `codeFor` is a projection of `callSite`, never a parallel path, so the persisted answer
+> and the in-process one cannot differ: there is one decision.
+>
+> The compile gate was moved onto the persisted field for the same reason. It now reads
+> `record.code` off the written `components.json` instead of calling `ComponentSnippets`
+> itself, so what the Kotlin compiler accepts is the exact bytes a consumer receives — a
+> generator that worked in-process while the record persisted something else would have
+> passed the old test and failed every consumer.
+>
 > **Measured reach.** Over a 28-component Material 3 surface (buttons, cards, chips,
 > toggles, progress, scaffolding, list and navigation items, dialogs), **26 emit a
 > call site and 2 refuse** — the two being `TextField` / `OutlinedTextField`, whose

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -68,6 +68,21 @@ data class ComponentRecord(
   val slots: List<ComponentSlot> = emptyList(),
   val bindings: List<ComponentBinding> = emptyList(),
   /**
+   * The Kotlin call site for this component, printed by `ComponentSnippets` — or the reason there
+   * isn't one.
+   *
+   * Persisted rather than left for a consumer to compute, because the three things that make a
+   * refusal sound ([signatureKnown], [ComponentSymbol.receiver], and the `…Kt`-facade evidence in
+   * [ComponentSymbol.callable]) are producer-side knowledge. A consumer re-deriving the call site
+   * would have to rediscover all three, and a second implementation of a rule this exacting is how
+   * two sides of a contract start disagreeing. It also makes this file answerable on its own: a
+   * reader gets the call site without linking the discovery library that produced it.
+   *
+   * Null only in a record written before this field existed — never "no call site", which
+   * [ComponentCode.refusedReason] says explicitly.
+   */
+  val code: ComponentCode? = null,
+  /**
    * Whether [parameters], [slots] and [ComponentSymbol.receiver] were read from `@kotlin.Metadata`
    * rather than defaulted away.
    *
@@ -149,6 +164,36 @@ data class ComponentSlot(
   val name: String,
   val required: Boolean,
   val receiverScope: String? = null,
+)
+
+/**
+ * How to call this component — exactly one of [call] and [refusedReason] is set.
+ *
+ * The refusal is the load-bearing half. A generator handed a call site it cannot prove will produce
+ * source that looks right and does not build, which is worse than an admitted gap: a consumer given
+ * a [refusedReason] can ask a human or a model for the one missing value, while a consumer handed
+ * broken source has to discover the breakage itself.
+ *
+ * It is also a **tier signal**, and a mechanical one. A component whose call site cannot be printed
+ * cannot reach a Compose exporter, so the question "which components can this pipeline actually
+ * generate code for?" is answered by this field rather than by an authored allowlist that someone
+ * has to remember to extend.
+ *
+ * @property call the call expression — `Button(onClick = {}, content = {})`. An **expression**, not
+ *   a file: it calls a `@Composable`, so it compiles only inside a `@Composable` body, and the
+ *   caller supplies that wrapper.
+ * @property imports the FQNs [call] needs. Today always exactly the callable, because every
+ *   placeholder written is a literal or an empty lambda — a property of the placeholder table
+ *   rather than a coincidence, and one that stops holding the moment the table admits a constructor
+ *   call.
+ * @property refusedReason why there is no call site, phrased for a human or a model to act on,
+ *   since supplying the missing value is exactly what a consumer would escalate.
+ */
+@Serializable
+data class ComponentCode(
+  val call: String? = null,
+  val imports: List<String> = emptyList(),
+  val refusedReason: String? = null,
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -172,18 +172,22 @@ object ComponentRecords {
 
     fun toRecord(): ComponentRecord {
       val resolvedBindings = bindings.distinctBy { it.previewId }.sortedBy { it.previewId }
-      return ComponentRecord(
-        canonicalId = canonicalId,
-        // Every alias any preview published this symbol under, not whichever the manifest listed
-        // first — a shared component such as `Card` is rendered by several previews and would
-        // otherwise take an arbitrary, order-dependent id.
-        componentIds = resolvedBindings.mapNotNull { it.componentId }.distinct().sorted(),
-        symbol = symbol.copy(receiver = receiver, jvmName = jvmName, descriptor = descriptor),
-        parameters = parameters,
-        slots = slotsOf(parameters),
-        bindings = resolvedBindings,
-        signatureKnown = signatureKnown,
-      )
+      val record =
+        ComponentRecord(
+          canonicalId = canonicalId,
+          // Every alias any preview published this symbol under, not whichever the manifest listed
+          // first — a shared component such as `Card` is rendered by several previews and would
+          // otherwise take an arbitrary, order-dependent id.
+          componentIds = resolvedBindings.mapNotNull { it.componentId }.distinct().sorted(),
+          symbol = symbol.copy(receiver = receiver, jvmName = jvmName, descriptor = descriptor),
+          parameters = parameters,
+          slots = slotsOf(parameters),
+          bindings = resolvedBindings,
+          signatureKnown = signatureKnown,
+        )
+      // Printed from the finished record, so the snippet is answering the same symbol, parameters
+      // and receiver a consumer will read beside it.
+      return record.copy(code = ComponentSnippets.codeFor(record))
     }
   }
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -80,6 +80,19 @@ object ComponentSnippets {
   }
 
   /**
+   * [callSite] as the wire shape `components.json` carries, so the record answers "how do I call
+   * this?" without a consumer linking this library.
+   *
+   * Deliberately a projection of [callSite] rather than a second implementation: the two cannot
+   * disagree about what is emittable, because there is only one decision.
+   */
+  fun codeFor(record: ComponentRecord): ComponentCode =
+    when (val snippet = callSite(record)) {
+      is ComponentSnippet.Emitted -> ComponentCode(call = snippet.code, imports = snippet.imports)
+      is ComponentSnippet.Refused -> ComponentCode(refusedReason = snippet.reason)
+    }
+
+  /**
    * A literal for [parameter] that is guaranteed to type-check, or null to refuse.
    *
    * The nullable test comes first and needs no per-type knowledge, because `null` satisfies every

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentRecordsTest.kt
@@ -12,6 +12,7 @@ class ComponentRecordsTest {
     sourceFile: String? = null,
     jvmName: String? = null,
     descriptor: String? = null,
+    signatureKnown: Boolean = false,
   ) =
     PreviewTarget(
       className = className,
@@ -21,6 +22,7 @@ class ComponentRecordsTest {
       sourceFile = sourceFile,
       confidence = TargetConfidence.HIGH,
       parameters = parameters,
+      signatureKnown = signatureKnown,
     )
 
   private fun preview(
@@ -292,5 +294,83 @@ class ComponentRecordsTest {
     val symbol = file.components.single().symbol
     assertThat(symbol.descriptor).isEqualTo("(I)V")
     assertThat(symbol.jvmName).isEqualTo("Card")
+  }
+
+  @Test
+  fun `a record carries the printed call site, so a consumer needs no generator`() {
+    // `components.json` has to answer "how do I call this?" on its own: the server that consumes it
+    // depends on published compose-ai-tools artifacts but not on this module, and re-deriving the
+    // call site there would mean a second implementation of the refusal rules.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            componentTargets =
+              listOf(
+                target(
+                  "androidx.compose.material3.ButtonKt",
+                  "Button",
+                  parameters =
+                    listOf(
+                      TargetParameter("onClick", "() -> Unit"),
+                      TargetParameter("modifier", "Modifier", hasDefault = true),
+                      TargetParameter("content", "RowScope.() -> Unit", composableSlot = true),
+                    ),
+                  signatureKnown = true,
+                )
+              ),
+          )
+        )
+      )
+
+    val code = file.components.single().code
+    assertThat(code?.call).isEqualTo("Button(onClick = {}, content = {})")
+    assertThat(code?.imports).containsExactly("androidx.compose.material3.Button")
+    assertThat(code?.refusedReason).isNull()
+  }
+
+  @Test
+  fun `a component with no writable call site records why, not silence`() {
+    // The refusal is the half that makes the field trustworthy, and it doubles as the mechanical
+    // tier signal: no printable call site means the component cannot reach a Compose exporter.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            componentTargets =
+              listOf(
+                target(
+                  "androidx.compose.material3.IconKt",
+                  "Icon",
+                  parameters = listOf(TargetParameter("imageVector", "ImageVector")),
+                  signatureKnown = true,
+                )
+              ),
+          )
+        )
+      )
+
+    val code = file.components.single().code
+    assertThat(code?.call).isNull()
+    assertThat(code?.refusedReason).contains("imageVector: ImageVector")
+  }
+
+  @Test
+  fun `an unread signature refuses rather than printing a parameterless call`() {
+    // `signatureKnown = false` is "we could not look", which reads identically to "takes nothing".
+    // Printing `Card()` from the first is a compile error in someone else's build.
+    val file =
+      ComponentRecords.from(
+        manifest(
+          preview(
+            "p1",
+            componentTargets = listOf(target("androidx.compose.material3.CardKt", "Card")),
+          )
+        )
+      )
+
+    assertThat(file.components.single().code?.refusedReason).contains("not recovered")
   }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -2,9 +2,8 @@ package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.discovery.ComponentCode
 import ee.schimke.composeai.discovery.ComponentRecordFile
-import ee.schimke.composeai.discovery.ComponentSnippet
-import ee.schimke.composeai.discovery.ComponentSnippets
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
@@ -23,6 +22,11 @@ import org.junit.rules.TemporaryFolder
  * defaults, produces a green test and source that does not build. This test removes me from the
  * loop. It discovers real `androidx.compose.material3` components out of a real project, prints
  * their call sites, writes them into that project, and compiles them.
+ *
+ * It reads `ComponentRecord.code` off the written `components.json` rather than calling
+ * `ComponentSnippets` itself, so what is compiled here is the exact bytes a consumer receives. A
+ * generator that worked in-process while the record persisted something else would pass a test that
+ * called the generator, and fail every consumer.
  *
  * **The vacuity guard is the important assertion.** A generator that refused everything would emit
  * an empty file that compiles perfectly, so "the build passed" alone proves nothing. The test
@@ -162,12 +166,16 @@ class ComponentCallSiteCompileFunctionalTest {
     val components =
       json.decodeFromString(ComponentRecordFile.serializer(), componentsFile.readText())
 
-    val emitted = mutableMapOf<String, ComponentSnippet.Emitted>()
+    val emitted = mutableMapOf<String, ComponentCode>()
     val refused = mutableMapOf<String, String>()
     for (record in components.components) {
-      when (val snippet = ComponentSnippets.callSite(record)) {
-        is ComponentSnippet.Emitted -> emitted[record.symbol.name] = snippet
-        is ComponentSnippet.Refused -> refused[record.symbol.name] = snippet.reason
+      val code = record.code
+      // A record with no `code` at all is a producer bug, not a refusal, so it is reported as one
+      // rather than counted among the components that legitimately have no writable call site.
+      when {
+        code == null -> refused[record.symbol.name] = "record carried no `code` field"
+        code.call != null -> emitted[record.symbol.name] = code
+        else -> refused[record.symbol.name] = code.refusedReason ?: "refused without a reason"
       }
     }
 
@@ -200,19 +208,16 @@ class ComponentCallSiteCompileFunctionalTest {
    * fails with the name of the component that produced it, instead of the first compile error
    * hiding the rest.
    */
-  private fun writeGeneratedCallSites(
-    projectDir: File,
-    emitted: Map<String, ComponentSnippet.Emitted>,
-  ) {
+  private fun writeGeneratedCallSites(projectDir: File, emitted: Map<String, ComponentCode>) {
     val imports = emitted.values.flatMap { it.imports }.toSortedSet()
     val body =
       emitted.entries
         .sortedBy { it.key }
-        .joinToString("\n\n") { (name, snippet) ->
+        .joinToString("\n\n") { (name, code) ->
           """
           |@Composable
           |fun Generated$name() {
-          |    ${snippet.code}
+          |    ${code.call}
           |}
           """
             .trimMargin()


### PR DESCRIPTION
## Summary

`ComponentSnippets` can print a call site, but only in-process — so the consumer that needs one could not reach it. This puts the answer on the record.

`ComponentRecord.code` now carries either a `call` with its `imports`, or a `refusedReason`:

```json
"code": {
  "call": "Button(onClick = {}, content = {})",
  "imports": ["androidx.compose.material3.Button"]
}
```

```json
"code": { "refusedReason": "no placeholder can be written for required parameter `imageVector: ImageVector`" }
```

## Why persist rather than let the consumer compute it

I checked before assuming. compose-preview-server consumes ~10 published compose-ai-tools artifacts and **`preview-discovery` is not one of them**, so a consumer-side call site meant one of two bad options: take a dependency on a module that drags ClassGraph, ASM and kotlin-metadata in to produce one string, or reimplement the three rules that make a refusal sound — `signatureKnown`, `symbol.receiver`, and the `…Kt`-facade evidence in `symbol.callable`.

A second implementation of a rule that exacting is how two sides of a contract start disagreeing, and [compose-preview-server#208](https://github.com/yschimke/compose-preview-server/pull/208) already says this side should not re-derive it. `codeFor` is a **projection** of `callSite`, never a parallel path, so the persisted answer and the in-process one cannot differ — there is one decision.

It also makes `components.json` answerable on its own: a reader gets the call site without linking the library that produced it.

## The gate now tests what consumers receive

`ComponentCallSiteCompileFunctionalTest` reads `record.code` off the written `components.json` instead of calling `ComponentSnippets` itself. So the Kotlin compiler accepts the exact bytes a consumer gets. A generator that worked in-process while the record persisted something else would have passed the old test and failed every consumer — that gap is now closed rather than assumed shut.

A record carrying no `code` at all is reported as a producer bug, not counted among the legitimate refusals.

## What this unblocks

The consumer side, in two places, neither in this PR:

- **Playground seeding.** `components.json` already travels inside every bundle (`BundlePreviewTask.kt:1571`), and nothing on the server reads it today — I grepped, and the only hit is an unrelated wasm protocol marker. With `code` present, seeding the playground from a component is: read the record, wrap `call` in the `@Preview` the adapter already adds, submit to `PlaygroundCompileService`. No unsolved problem in the path.
- **The ui-builder's `CodeCapability(symbol, imports)`**, which is the same shape this emits.

And the refusal is a **mechanical tier signal**: a component whose call site cannot be printed cannot reach a Compose exporter. That is the gate the exporter currently spells as `EMITTER_IDS`, a hand-written allowlist of 29 component ids that someone has to remember to extend.

What it does **not** unblock is argument binding. A printed call site has placeholders; the exporter needs the user's values. That is still Phase 2, and it is the same wall as [#5067](https://github.com/yschimke/compose-ai-tools/issues/5067).

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test --rerun-tasks` — **BUILD SUCCESSFUL**.
- `./gradlew :gradle-plugin:functionalTest` — the **whole** suite, **BUILD SUCCESSFUL in 5m16s**, run alone from a cleared results dir (two runs sharing `build/test-results` is how I broke it on a previous PR).
- New `ComponentRecordsTest` cases: a record carries the printed call site and its import; a component with no writable literal records *why* rather than falling silent; an unread signature refuses instead of printing `Card()`.
- `ktfmtCheck` on all three touched source sets — clean.
- Wire compatibility: `code` defaults to null, so a `components.json` written by an older plugin still deserialises. Null means "not recorded", never "no call site" — that case is `refusedReason`.
- Non-visual change: no render evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_