### PR TITLE
style(harness): ktfmt S3.5's new KDoc

### DIFF
--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -311,13 +311,13 @@ class S3_5RecompileSaveLoopRealModeTest {
    * carries `:daemon:desktop`'s testFixtures, so under `-Ptarget=android` that lookup returns the
    * *desktop* fixture's `RedFixturePreviewsKt` — a class the Robolectric sandbox then has to link
    * against `:daemon:android`'s runtime. The two fixtures share only the composables the scenarios
-   * name; everything else drifted apart long ago (desktop-only `RangeSlider`, `ripple`,
-   * key-event and `InsetFocusRingTheme` code; Android-only Wear, resources and Material-icon code).
-   * Cloning the desktop file class into the sandbox therefore drags desktop-only references into a
-   * class the sandbox has to resolve, and a render that cannot link its preview class never
-   * completes — which is how the Android leg reported this as a bare `renderFinished` timeout after
-   * #5002 added `InsetFocusRingTheme` to the desktop fixture. Taking the bytes off the daemon's own
-   * classpath keeps the clone on one Compose line, whichever target is under test.
+   * name; everything else drifted apart long ago (desktop-only `RangeSlider`, `ripple`, key-event
+   * and `InsetFocusRingTheme` code; Android-only Wear, resources and Material-icon code). Cloning
+   * the desktop file class into the sandbox therefore drags desktop-only references into a class
+   * the sandbox has to resolve, and a render that cannot link its preview class never completes —
+   * which is how the Android leg reported this as a bare `renderFinished` timeout after #5002 added
+   * `InsetFocusRingTheme` to the desktop fixture. Taking the bytes off the daemon's own classpath
+   * keeps the clone on one Compose line, whichever target is under test.
    */
   private fun sourceClassBytesFrom(classpath: List<File>, resourceName: String): ByteArray {
     for (entry in classpath) {


### PR DESCRIPTION
## What

#5069 merged before its follow-up formatting commit landed, so `main` carries an unformatted KDoc
paragraph in `S3_5RecompileSaveLoopRealModeTest` — the `ktfmt (Google style)` job was red on that
PR's head for exactly this, and `ktfmtCheck` aborts on the first unformatted file, so it stays red
on `main` and on every PR branched from it until this lands.

## Changes

Reflow the one KDoc paragraph exactly as `ktfmt 0.64 --google-style` emits it. Comment rewrap only —
no code change.

## Test plan

`ktfmt 0.64` (google style) run directly against the file; it now reports no changes. The `format`
job on this PR is the check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3EmFQhmxGZoGsNtTs19vg

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3EmFQhmxGZoGsNtTs19vg)_