### PR TITLE
fix(discovery): close six ways an emitted call site could fail to compile

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -811,6 +811,33 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > generator that worked in-process while the record persisted something else would have
 > passed the old test and failed every consumer.
 >
+> **Six ways the compile claim was wider than the record could justify.** Persisting
+> the call site drew a review pass over the guarantee itself, and every one of these
+> was real. They share a root cause worth naming: `callSite` was deciding from a
+> *rendered* view of the signature, which is the same trap `nullable` was introduced
+> for one level down.
+>
+> | What broke | Now |
+> | --- | --- |
+> | ``fun `when`(`is`: String)`` printed `when(is = "")` and an import ending `.when` | hard keywords backtick-escaped in the call and every import segment |
+> | merged overloads emitted `Chip()`, which resolves to neither | `overloadsCollided` refuses — the signal was already computed and discarded |
+> | a `@RequiresOptIn` component compiled in its preview and not in a generated wrapper | `code.requiredOptIns` travels with the call; the wrapper applies them |
+> | a `private` composable was advertised as importable | visibility read from metadata; non-public refuses |
+> | `fun <T> Picker(items: List<T> = emptyList())` emitted `Picker()` | a declaration with type parameters refuses |
+> | `com.example.String` got `""`, because it renders exactly like `kotlin.String` | placeholders match `TargetParameter.typeFqn`, never the spelling |
+>
+> The opt-in one is the only one not answered by refusing. Refusing would drop most of
+> Material 3 over something a caller fixes with one annotation on the wrapper it
+> already has to write, so the call is emitted and the markers travel beside it — and
+> the compile gate generates `@OptIn(…)` wrappers, so that half of the contract is
+> compiler-checked rather than asserted.
+>
+> Two of these defaulted permissively on purpose. `callableFromAnotherFile` defaults
+> to true and `typeFqn` falls back to the rendered spelling, because a record written
+> before those fields existed carries neither, and reading "not recorded" as "private"
+> or "not a Kotlin scalar" would silently retract call sites that were already being
+> published.
+>
 > **Measured reach.** Over a 28-component Material 3 surface (buttons, cards, chips,
 > toggles, progress, scaffolding, list and navigation items, dialogs), **26 emit a
 > call site and 2 refuse** — the two being `TextField` / `OutlinedTextField`, whose

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -92,6 +92,23 @@ data class ComponentRecord(
    * must not.
    */
   val signatureKnown: Boolean = false,
+  /** See `PreviewTarget.callableFromAnotherFile`. Defaults to the permissive reading. */
+  val callableFromAnotherFile: Boolean = true,
+  /** See `PreviewTarget.hasTypeParameters`. */
+  val hasTypeParameters: Boolean = false,
+  /**
+   * True when overloads collided into this record — they share [canonicalId], so `collect` merged
+   * them and kept one signature. No call site can be printed for the merged pair: two fully
+   * defaulted overloads make `Chip()` ambiguous, and the record no longer says which one the
+   * signature belongs to.
+   */
+  val overloadsCollided: Boolean = false,
+  /**
+   * Fully-qualified `@RequiresOptIn` markers the declaration carries. Copied onto
+   * [ComponentCode.requiredOptIns] for the emitted call; see that field for what a caller does with
+   * them.
+   */
+  val requiredOptIns: List<String> = emptyList(),
 )
 
 /**
@@ -194,6 +211,16 @@ data class ComponentCode(
   val call: String? = null,
   val imports: List<String> = emptyList(),
   val refusedReason: String? = null,
+  /**
+   * Fully-qualified `@RequiresOptIn` markers the wrapper around [call] must apply.
+   *
+   * This is the one part of the contract the caller has to act on rather than paste. [call] already
+   * only compiles inside a `@Composable` body the caller supplies; when this is non-empty that body
+   * also needs `@OptIn(Marker::class)` and an import for each marker. Emitting the call and saying
+   * so beats refusing: opting in is mechanical, and refusing would drop most of Material 3 over a
+   * problem the caller fixes in one annotation.
+   */
+  val requiredOptIns: List<String> = emptyList(),
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -64,6 +64,9 @@ object ComponentRecords {
             signatureKnown = target.signatureKnown,
             jvmName = target.jvmName,
             descriptor = target.descriptor,
+            callableFromAnotherFile = target.callableFromAnotherFile,
+            hasTypeParameters = target.hasTypeParameters,
+            requiredOptIns = target.requiredOptIns,
           )
         }
       // Overloads share a canonical id and merge into this one record. Both JVM handles identify
@@ -78,9 +81,11 @@ object ComponentRecords {
       // `Chip-a1b2c3d`.
       if (existing.jvmName != target.jvmName) {
         existing.jvmName = null
+        existing.overloadsCollided = true
       }
       if (existing.descriptor != target.descriptor) {
         existing.descriptor = null
+        existing.overloadsCollided = true
       }
       // One component, many previews: keep the richest signature seen. A target resolved through a
       // path that could not read metadata reports no parameters, and letting that overwrite a
@@ -93,6 +98,9 @@ object ComponentRecords {
         existing.parameters = target.parameters
         existing.receiver = target.receiver
         existing.signatureKnown = true
+        existing.callableFromAnotherFile = target.callableFromAnotherFile
+        existing.hasTypeParameters = target.hasTypeParameters
+        existing.requiredOptIns = target.requiredOptIns
       } else if (
         target.signatureKnown == existing.signatureKnown &&
           target.parameters.size > existing.parameters.size
@@ -165,7 +173,16 @@ object ComponentRecords {
     var signatureKnown: Boolean = false,
     var jvmName: String? = null,
     var descriptor: String? = null,
+    var callableFromAnotherFile: Boolean = true,
+    var hasTypeParameters: Boolean = false,
+    var requiredOptIns: List<String> = emptyList(),
   ) {
+    /**
+     * Set when two targets under this id disagreed about which method they are. Distinct from a
+     * null [descriptor], which is also what an unrecorded one looks like.
+     */
+    var overloadsCollided: Boolean = false
+
     var receiver: String? = symbol.receiver
 
     var bindings: List<ComponentBinding> = emptyList()
@@ -184,6 +201,10 @@ object ComponentRecords {
           slots = slotsOf(parameters),
           bindings = resolvedBindings,
           signatureKnown = signatureKnown,
+          callableFromAnotherFile = callableFromAnotherFile,
+          hasTypeParameters = hasTypeParameters,
+          overloadsCollided = overloadsCollided,
+          requiredOptIns = requiredOptIns,
         )
       // Printed from the finished record, so the snippet is answering the same symbol, parameters
       // and receiver a consumer will read beside it.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -46,6 +46,26 @@ object ComponentSnippets {
     if (!record.signatureKnown) {
       return ComponentSnippet.Refused("signature was not recovered from @kotlin.Metadata")
     }
+    // Overloads share a canonical id, so `ComponentRecords` merged them and kept one signature.
+    // Even when that signature prints, the call is ambiguous: two fully defaulted overloads both
+    // accept `Chip()`, and Kotlin resolves neither.
+    if (record.overloadsCollided) {
+      return ComponentSnippet.Refused(
+        "overloads collided under this canonical id, so no single call site identifies one"
+      )
+    }
+    // A generator writes its wrapper into a new file. `private` and `protected` declarations are
+    // not reachable from there however correct the call text is.
+    if (!record.callableFromAnotherFile) {
+      return ComponentSnippet.Refused("not public or internal, so a generated file cannot call it")
+    }
+    // Every defaulted argument is omitted, which leaves a generic function with nothing to infer
+    // its type parameters from — `fun <T> Picker(items: List<T> = emptyList())` has no `Picker()`.
+    if (record.hasTypeParameters) {
+      return ComponentSnippet.Refused(
+        "declares type parameters that a call omitting defaulted arguments cannot infer"
+      )
+    }
     record.symbol.receiver?.let { receiver ->
       return ComponentSnippet.Refused(
         "declared on $receiver, so a call site needs that scope around it"
@@ -71,11 +91,12 @@ object ComponentSnippets {
             "no placeholder can be written for required parameter " +
               "`${parameter.name}: ${parameter.type}`"
           )
-      arguments += "${parameter.name} = $placeholder"
+      arguments += "${escapeIfKeyword(parameter.name)} = $placeholder"
     }
     return ComponentSnippet.Emitted(
-      imports = listOf(record.symbol.callable),
-      code = "${record.symbol.name}(${arguments.joinToString(", ")})",
+      imports = listOf(escapeCallableIfKeyword(record.symbol.callable)),
+      code = "${escapeIfKeyword(record.symbol.name)}(${arguments.joinToString(", ")})",
+      requiredOptIns = record.requiredOptIns,
     )
   }
 
@@ -88,7 +109,12 @@ object ComponentSnippets {
    */
   fun codeFor(record: ComponentRecord): ComponentCode =
     when (val snippet = callSite(record)) {
-      is ComponentSnippet.Emitted -> ComponentCode(call = snippet.code, imports = snippet.imports)
+      is ComponentSnippet.Emitted ->
+        ComponentCode(
+          call = snippet.code,
+          imports = snippet.imports,
+          requiredOptIns = snippet.requiredOptIns,
+        )
       is ComponentSnippet.Refused -> ComponentCode(refusedReason = snippet.reason)
     }
 
@@ -105,6 +131,53 @@ object ComponentSnippets {
    * That test is what lets `Checkbox`, `RadioButton` and `Switch` through: material3 declares their
    * `onCheckedChange` / `onClick` as `((Boolean) -> Unit)?`, which no lambda-shaped rule accepts.
    */
+  /**
+   * Kotlin's **hard** keywords — the ones that are never valid as a plain identifier and so must be
+   * backtick-escaped wherever they appear as a name.
+   *
+   * Soft and modifier keywords (`by`, `data`, `value`, `where`, …) are deliberately absent: they
+   * are legal identifiers, and escaping them would be noise. `` fun `when`(`is`: String) `` is a
+   * legal declaration whose metadata hands back the bare names `when` and `is`, which pass the
+   * import-identifier filter and would otherwise be printed as `when(is = "")`.
+   */
+  private val HARD_KEYWORDS =
+    setOf(
+      "as",
+      "break",
+      "class",
+      "continue",
+      "do",
+      "else",
+      "false",
+      "for",
+      "fun",
+      "if",
+      "in",
+      "interface",
+      "is",
+      "null",
+      "object",
+      "package",
+      "return",
+      "super",
+      "this",
+      "throw",
+      "true",
+      "try",
+      "typealias",
+      "typeof",
+      "val",
+      "var",
+      "when",
+      "while",
+    )
+
+  private fun escapeIfKeyword(name: String): String = if (name in HARD_KEYWORDS) "`$name`" else name
+
+  /** Escapes each segment of an import path, since any one of them may be a keyword. */
+  private fun escapeCallableIfKeyword(callable: String): String =
+    callable.split('.').joinToString(".") { escapeIfKeyword(it) }
+
   private fun placeholderFor(parameter: TargetParameter): String? {
     if (parameter.nullable) return "null"
     val type = parameter.type
@@ -115,13 +188,17 @@ object ComponentSnippets {
     // deliberately get no fallback: `(Int) -> String?` ends in `?` and is *not* nullable.
     if (!type.contains("->") && type.endsWith("?")) return "null"
     if (parameter.composableSlot || type.contains("->")) return emptyLambda(type)
-    return when (type) {
-      "String" -> "\"\""
-      "Boolean" -> "false"
-      "Int" -> "0"
-      "Long" -> "0L"
-      "Float" -> "0f"
-      "Double" -> "0.0"
+    // Matched on the QUALIFIED type, never the rendered spelling: `com.example.String` renders as
+    // `String` exactly like `kotlin.String`, and answering `""` for the first emits source that
+    // does not compile. A record written before `typeFqn` existed has null here and falls back to
+    // the spelling, which is what it always did — no worse, and no silent retraction.
+    return when (parameter.typeFqn ?: "kotlin.$type") {
+      "kotlin.String" -> "\"\""
+      "kotlin.Boolean" -> "false"
+      "kotlin.Int" -> "0"
+      "kotlin.Long" -> "0L"
+      "kotlin.Float" -> "0f"
+      "kotlin.Double" -> "0.0"
       // Everything else — `Modifier`, `ImageVector`, an enum, a domain type — has no literal that
       // is correct without knowing the type, and inventing one is how generated code stops
       // compiling.
@@ -178,7 +255,12 @@ sealed interface ComponentSnippet {
    *   placeholder is a literal or an empty lambda, so nothing else has to resolve.
    * @property code the call expression, for a caller to place inside a `@Composable` body.
    */
-  data class Emitted(val imports: List<String>, val code: String) : ComponentSnippet
+  data class Emitted(
+    val imports: List<String>,
+    val code: String,
+    /** Markers the caller's `@Composable` wrapper must `@OptIn` to — see `ComponentCode`. */
+    val requiredOptIns: List<String> = emptyList(),
+  ) : ComponentSnippet
 
   /**
    * No call site, and why — phrased for a human or a model to act on, since supplying the missing

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -7,11 +7,13 @@ import kotlin.metadata.KmFunction
 import kotlin.metadata.KmType
 import kotlin.metadata.KmTypeProjection
 import kotlin.metadata.KmValueParameter
+import kotlin.metadata.Visibility
 import kotlin.metadata.declaresDefaultValue
 import kotlin.metadata.isNullable
 import kotlin.metadata.jvm.KotlinClassMetadata
 import kotlin.metadata.jvm.annotations
 import kotlin.metadata.jvm.signature
+import kotlin.metadata.visibility
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
@@ -47,6 +49,31 @@ internal data class ComposableSignatureInfo(
   val name: String,
   val parameters: List<TargetParameter>,
   val receiver: String?,
+  /**
+   * True when the declaration is `public` (or `internal`, which is still callable from the same
+   * module). A `private` or `protected` composable cannot be called from a file a generator writes,
+   * so a call site for one is a compile error waiting to happen.
+   */
+  val callableFromAnotherFile: Boolean,
+  /**
+   * True when the function declares type parameters. A call that omits every defaulted argument
+   * supplies nothing for the compiler to infer them from — `fun <T> Picker(items: List<T> =
+   * emptyList())` cannot be called as `Picker()`.
+   */
+  val hasTypeParameters: Boolean,
+  /**
+   * Fully-qualified `@RequiresOptIn` marker annotations on the declaration
+   * (`androidx.compose.material3.ExperimentalMaterial3Api`).
+   *
+   * A preview calling one of these compiles because its own file or function carries `@OptIn`. A
+   * generated wrapper inherits nothing, so the same call fails there unless the wrapper opts in
+   * too. Recorded rather than used to refuse, because opting in is mechanical and refusing would
+   * drop much of Material 3 for a problem the caller can fix in one annotation.
+   *
+   * Empty also means "none we could resolve": a marker whose own class was outside the scan cannot
+   * be identified, and is indistinguishable here from a declaration that needs no opt-in.
+   */
+  val requiredOptIns: List<String>,
 )
 
 internal object ComposableSignature {
@@ -101,6 +128,10 @@ internal object ComposableSignature {
         // amount of string surgery on the JVM name distinguishes those two.
         name = fn.name,
         parameters = fn.valueParameters.map { it.toTargetParameter() },
+        callableFromAnotherFile =
+          fn.visibility == Visibility.PUBLIC || fn.visibility == Visibility.INTERNAL,
+        hasTypeParameters = fn.typeParameters.isNotEmpty(),
+        requiredOptIns = requiredOptInsOf(method),
         receiver =
           fn.receiverParameterType?.let { receiver ->
             (receiver.classifier as? KmClassifier.Class)?.name?.replace('/', '.')?.replace('$', '.')
@@ -173,6 +204,27 @@ internal object ComposableSignature {
     }
   }
 
+  /**
+   * The `@RequiresOptIn`-marked annotations applied to [method].
+   *
+   * An opt-in marker is an annotation whose own class carries `@RequiresOptIn`, so this resolves
+   * one level up rather than pattern-matching names like `Experimental…` — a convention plenty of
+   * annotations follow without gating anything. An annotation class outside the scan resolves to
+   * null and is skipped: unrecognised, not assumed.
+   */
+  private fun requiredOptInsOf(method: MethodInfo): List<String> =
+    method.annotationInfo
+      .orEmpty()
+      .filter { annotation ->
+        annotation.classInfo?.annotationInfo?.any { it.name in OPT_IN_MARKER_ANNOTATIONS } == true
+      }
+      .map { it.name }
+      .distinct()
+      .sorted()
+
+  private val OPT_IN_MARKER_ANNOTATIONS =
+    setOf("kotlin.RequiresOptIn", "androidx.annotation.RequiresOptIn")
+
   /** Match the metadata function to [method] by JVM signature (name + descriptor). */
   private fun matchFunction(functions: List<KmFunction>, method: MethodInfo): KmFunction? {
     val name = method.name
@@ -189,6 +241,8 @@ internal object ComposableSignature {
     return TargetParameter(
       name = name,
       type = renderType(type),
+      typeFqn =
+        (type.classifier as? KmClassifier.Class)?.name?.replace('/', '.')?.replace('$', '.'),
       hasDefault = declaresDefaultValue,
       composableSlot = slot,
       composableSlotReceiver = if (slot) receiverFqnOf(type) else null,

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1445,6 +1445,24 @@ data class PreviewTarget(
    * told apart here rather than left to be guessed at.
    */
   val signatureKnown: Boolean = false,
+  /**
+   * Whether the composable is `public`/`internal`, and so callable from a file a generator writes.
+   *
+   * Defaults to true — the permissive reading — because a target recorded before this field existed
+   * carried no visibility at all, and treating "not recorded" as "private" would silently retract
+   * call sites that were being published. Only meaningful when [signatureKnown].
+   */
+  val callableFromAnotherFile: Boolean = true,
+  /**
+   * Whether the composable declares type parameters, which a call omitting every defaulted argument
+   * gives the compiler nothing to infer. Only meaningful when [signatureKnown].
+   */
+  val hasTypeParameters: Boolean = false,
+  /**
+   * Fully-qualified `@RequiresOptIn` markers the declaration carries, which a generated wrapper
+   * must apply itself — see `ComposableSignatureInfo.requiredOptIns`.
+   */
+  val requiredOptIns: List<String> = emptyList(),
 )
 
 /**
@@ -1456,6 +1474,16 @@ data class PreviewTarget(
 data class TargetParameter(
   val name: String,
   val type: String,
+  /**
+   * The parameter's **fully-qualified** classifier (`kotlin.String`), or null when not recorded or
+   * not a class type.
+   *
+   * [type] is a deliberately lossy rendering — it prints the simple name so a human can read it —
+   * and `com.example.String` and `kotlin.String` render identically as `String`. A generator that
+   * picks a placeholder literal off that spelling writes `""` for a domain type and produces source
+   * that does not compile, which is the same trap [nullable] exists for one level down.
+   */
+  val typeFqn: String? = null,
   /** True when the parameter declares a default value (so a call site may legally omit it). */
   val hasDefault: Boolean = false,
   /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -224,6 +224,9 @@ object PreviewTargetInference {
         parameters = signature.parameters,
         receiver = signature.receiver,
         signatureKnown = true,
+        callableFromAnotherFile = signature.callableFromAnotherFile,
+        hasTypeParameters = signature.hasTypeParameters,
+        requiredOptIns = signature.requiredOptIns,
       )
     }
   }
@@ -340,6 +343,10 @@ object PreviewTargetInference {
         parameters = signature?.parameters.orEmpty(),
         receiver = signature?.receiver,
         signatureKnown = signature != null,
+        // Null metadata keeps the permissive defaults: "not recovered" must not read as "private".
+        callableFromAnotherFile = signature?.callableFromAnotherFile ?: true,
+        hasTypeParameters = signature?.hasTypeParameters ?: false,
+        requiredOptIns = signature?.requiredOptIns.orEmpty(),
       )
     )
   }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
@@ -12,6 +12,10 @@ class ComponentSnippetsTest {
     receiver: String? = null,
     signatureKnown: Boolean = true,
     parameters: List<TargetParameter> = emptyList(),
+    callableFromAnotherFile: Boolean = true,
+    hasTypeParameters: Boolean = false,
+    overloadsCollided: Boolean = false,
+    requiredOptIns: List<String> = emptyList(),
   ) =
     ComponentRecord(
       canonicalId = "app/$jvmOwner.$name",
@@ -25,6 +29,10 @@ class ComponentSnippetsTest {
         ),
       parameters = parameters,
       signatureKnown = signatureKnown,
+      callableFromAnotherFile = callableFromAnotherFile,
+      hasTypeParameters = hasTypeParameters,
+      overloadsCollided = overloadsCollided,
+      requiredOptIns = requiredOptIns,
     )
 
   private fun parameter(
@@ -33,10 +41,12 @@ class ComponentSnippetsTest {
     hasDefault: Boolean = false,
     composableSlot: Boolean = false,
     nullable: Boolean = false,
+    typeFqn: String? = null,
   ) =
     TargetParameter(
       name = name,
       type = type,
+      typeFqn = typeFqn,
       hasDefault = hasDefault,
       composableSlot = composableSlot,
       nullable = nullable,
@@ -255,5 +265,90 @@ class ComponentSnippetsTest {
 
     assertThat(snippet.code)
       .isEqualTo("Button(count = 0, id = 0L, fraction = 0f, ratio = 0.0, selected = false)")
+  }
+
+  @Test
+  fun `a keyword name is backtick-escaped in both the call and the import`() {
+    // ``fun `when`(`is`: String)`` is a legal declaration, and metadata hands back the bare names.
+    // They pass the import-identifier filter, so without escaping this prints `when(is = "")` and
+    // an import ending `.when` — neither of which parses.
+    val snippet =
+      emitted(
+        record(
+          jvmOwner = "com.example.ControlsKt",
+          name = "when",
+          callable = "com.example.when",
+          parameters = listOf(parameter("is", "String", typeFqn = "kotlin.String")),
+        )
+      )
+
+    assertThat(snippet.code).isEqualTo("`when`(`is` = \"\")")
+    assertThat(snippet.imports).containsExactly("com.example.`when`")
+  }
+
+  @Test
+  fun `a soft keyword is left alone`() {
+    // `data`, `value`, `by` and friends are legal identifiers; escaping them would be noise.
+    val snippet =
+      emitted(
+        record(
+          name = "Card",
+          callable = "androidx.compose.material3.Card",
+          parameters = listOf(parameter("value", "String", typeFqn = "kotlin.String")),
+        )
+      )
+
+    assertThat(snippet.code).isEqualTo("Card(value = \"\")")
+  }
+
+  @Test
+  fun `a domain type that happens to be named String is refused, not given a string literal`() {
+    // `com.example.String` and `kotlin.String` both render as `String`. Choosing the literal off
+    // that spelling emits `value = ""` for a type that does not accept it.
+    val reason =
+      refusal(
+        record(parameters = listOf(parameter("value", "String", typeFqn = "com.example.String")))
+      )
+
+    assertThat(reason).contains("value: String")
+  }
+
+  @Test
+  fun `a real Kotlin scalar is still matched by its qualified name`() {
+    val snippet =
+      emitted(record(parameters = listOf(parameter("count", "Int", typeFqn = "kotlin.Int"))))
+
+    assertThat(snippet.code).isEqualTo("Button(count = 0)")
+  }
+
+  @Test
+  fun `a private composable is refused because a generated file cannot reach it`() {
+    assertThat(refusal(record(callableFromAnotherFile = false))).contains("public or internal")
+  }
+
+  @Test
+  fun `a generic composable is refused because the call cannot infer its type parameters`() {
+    // `fun <T> Picker(items: List<T> = emptyList())` omits every default, leaving nothing to infer
+    // `T` from, and the record carries no type argument a consumer could supply instead.
+    assertThat(refusal(record(hasTypeParameters = true))).contains("type parameters")
+  }
+
+  @Test
+  fun `collided overloads are refused because no single call site identifies one`() {
+    assertThat(refusal(record(overloadsCollided = true))).contains("overloads collided")
+  }
+
+  @Test
+  fun `required opt-ins travel with the emitted call rather than refusing it`() {
+    // Refusing would drop most of Material 3 over something the caller fixes with one annotation
+    // on the wrapper it already has to write.
+    val snippet =
+      emitted(
+        record(requiredOptIns = listOf("androidx.compose.material3.ExperimentalMaterial3Api"))
+      )
+
+    assertThat(snippet.code).isEqualTo("Button()")
+    assertThat(snippet.requiredOptIns)
+      .containsExactly("androidx.compose.material3.ExperimentalMaterial3Api")
   }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ComponentCallSiteCompileFunctionalTest.kt
@@ -209,13 +209,29 @@ class ComponentCallSiteCompileFunctionalTest {
    * hiding the rest.
    */
   private fun writeGeneratedCallSites(projectDir: File, emitted: Map<String, ComponentCode>) {
-    val imports = emitted.values.flatMap { it.imports }.toSortedSet()
+    // The markers each call needs, imported once and applied per function below. A component
+    // guarded by `@ExperimentalMaterial3Api` compiles in its own preview because that file opted
+    // in; a generated wrapper inherits nothing, so this is the half of the contract the caller
+    // owns — and compiling it here is what stops `requiredOptIns` being an unchecked claim.
+    val imports =
+      (emitted.values.flatMap { it.imports } + emitted.values.flatMap { it.requiredOptIns })
+        .toSortedSet()
     val body =
       emitted.entries
         .sortedBy { it.key }
         .joinToString("\n\n") { (name, code) ->
+          val optIn =
+            if (code.requiredOptIns.isEmpty()) ""
+            else
+              code.requiredOptIns.joinToString(
+                prefix = "@OptIn(",
+                postfix = "::class)\n",
+                separator = "::class, ",
+              ) {
+                it.substringAfterLast('.')
+              }
           """
-          |@Composable
+          |$optIn@Composable
           |fun Generated$name() {
           |    ${code.call}
           |}


### PR DESCRIPTION
## Summary

Follow-up to [#5068](https://github.com/yschimke/compose-ai-tools/pull/5068), which merged before these fixes were pushed. That PR started publishing `ComponentRecord.code` — a call site labelled as compiling — and the review pass it drew found **six ways that label could be wrong**. All six were real; `main` currently publishes them.

They share one root cause worth naming: `callSite` decided from a **rendered** view of the signature. That is the same trap `TargetParameter.nullable` was introduced for one level down, and it recurred, so placeholders now match the qualified classifier and never the spelling.

| What broke | Now |
| --- | --- |
| ``fun `when`(`is`: String)`` printed `when(is = "")` and an import ending `.when` | hard keywords backtick-escaped in the call and in **every import segment** |
| merged overloads emitted `Chip()`, which resolves to neither | `overloadsCollided` refuses — the signal was already computed in `ComponentRecords` and thrown away |
| a `@RequiresOptIn` component compiled in its own preview, not in a generated wrapper | `code.requiredOptIns` travels with the call; the wrapper applies them |
| a `private` composable was advertised as importable | visibility read from `@kotlin.Metadata`; non-public refuses |
| `fun <T> Picker(items: List<T> = emptyList())` emitted `Picker()` | a declaration with type parameters refuses — omitting every default leaves nothing to infer from |
| `com.example.String` got `""`, because it renders exactly like `kotlin.String` | placeholders match `TargetParameter.typeFqn` |

## The one that is not answered by refusing

Opt-in. Refusing would drop much of Material 3 over something a caller fixes with one annotation on the wrapper it already has to write, so the call is emitted and the markers travel beside it. `code.call` was always an expression needing a `@Composable` wrapper the caller supplies; when `requiredOptIns` is non-empty that wrapper also needs `@OptIn(Marker::class)`.

**The compile gate now generates those wrappers**, so this half of the contract is compiler-checked rather than asserted — `ComponentCallSiteCompileFunctionalTest` imports each marker and emits `@OptIn(...)` above the function.

An opt-in marker is identified by its own class carrying `@RequiresOptIn`, resolved one level up — not by pattern-matching names like `Experimental…`, which plenty of annotations use without gating anything. A marker class outside the scan resolves to null and is skipped: unrecognised, never assumed.

## Two deliberate permissive defaults

`callableFromAnotherFile` defaults to **true** and `typeFqn` falls back to the rendered spelling. A record written before these fields existed carries neither, and reading "not recorded" as "private" or "not a Kotlin scalar" would silently retract call sites already being published — the same backward-compatibility trap the `nullable` field hit in #5036.

## Test plan

- `./gradlew :gradle-plugin:functionalTest --rerun` — **BUILD SUCCESSFUL in 3m42s**, run alone. The `--rerun` matters: a plain invocation reported success in 933ms because Gradle held the task UP-TO-DATE, which is not a test result.
- `./gradlew :gradle-plugin:preview-discovery:test :gradle-plugin:test` — **BUILD SUCCESSFUL**.
- `ktfmtCheck` on all three touched source sets — clean.
- Eight new `ComponentSnippetsTest` cases, one per finding plus the two that must *not* change: a soft keyword (`value`) is left unescaped, and a real `kotlin.Int` still resolves to `0`.
- The 26-of-28 reach is unchanged: no expected component is private, generic or collided, and the gate's vacuity guard still passes.

## Note on sequencing

The fixes were committed before #5068 merged but validated after, so they could not be pushed to that branch. This is a fresh branch from `origin/main` with the commit cherry-picked; the source tree is byte-identical to the one the 5m01s suite passed on, re-validated on the new base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o


---
_Generated by [Claude Code](https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o)_