### PR TITLE
feat(remotecompose): record the player that actually drew each capture

### DIFF
--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -359,7 +359,24 @@ class S3_5RecompileSaveLoopRealModeTest {
     targetMethod: String,
   ): ByteArray {
     val reader = ClassReader(sourceBytes)
-    val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
+    // NO `COMPUTE_FRAMES`, deliberately. Computing stack map frames makes ASM merge reference
+    // types, and `ClassWriter.getCommonSuperClass` resolves both sides with `Class.forName` on the
+    // *writer's own* classloader — this test JVM's. But [sourceClassBytesFrom] reads these bytes
+    // off the spawned daemon's classpath precisely because that class is NOT on ours (see its
+    // KDoc), so the first method whose frames merge two of the fixture's own types dies:
+    //
+    //     TypeNotPresentException: Type …RedFixturePreviewsKt$GenericOutlineShapeSquare$diamond$1$1
+    //       at ClassWriter.getCommonSuperClass → SymbolTable.addMergedType → Frame.merge
+    //       → MethodWriter.computeAllFrames
+    //
+    // Recomputing them buys nothing here: this transformation is name-only — remap the internal
+    // name, rename one method, drop `<clinit>` — and none of that invalidates a frame, so
+    // [ClassRemapper] rewriting the existing frames' types keeps them correct. `COMPUTE_MAXS`
+    // stays: it recomputes stack/local sizes arithmetically, without loading a class.
+    //
+    // If a future change here *does* alter control flow, the copied frames stop matching and the
+    // JVM rejects the clone with `VerifyError` at define time — loud, not silent.
+    val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS)
     val remapper =
       object : Remapper(Opcodes.ASM9) {
         override fun map(internalName: String): String =

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -115,11 +115,17 @@ object RemoteComposeController {
    * The `rcPlayer` wire id of the player that actually drew the current capture, or null when
    * nothing recorded one this pass.
    *
+   * A **set**, not a last-write-wins string. `RemoteOverridablePreview` is public and a preview may
+   * call it more than once with different `player` arguments, each drawing part of the same PNG
+   * through a different player. Naming one of them would let the server satisfy a bare request for
+   * that player with pixels another player partly drew — so a mixed capture reads null instead, and
+   * the reader keeps its honest "unknown".
+   *
    * Plain `@Volatile`, not snapshot state: nobody composes against it and it is read once, after
    * the render, by [declarationsJson]. Recording it must not invalidate a composition — it happens
    * *during* one.
    */
-  @Volatile private var capturePlayerWire: String? = null
+  @Volatile private var capturePlayerWires: Set<String> = emptySet()
 
   /**
    * Record which player `RemoteOverridablePreview` actually composed the document with.
@@ -131,12 +137,13 @@ object RemoteComposeController {
    * inferred otherwise would answer `?rcPlayer=cmp-android` with those view-player pixels. So the
    * composable states it, and [RemoteComposeDeclarationsPayload.capturePlayer] carries it out.
    *
-   * Last write wins within a pass. A preview that composes the document more than once (a
-   * recomposition, a scroll capture) picks the same branch each time, because the condition depends
-   * on the classpath and the requested player rather than on anything that varies mid-pass.
+   * Idempotent per player: a recomposition or a scroll capture re-records the same branch, because
+   * the condition depends on the classpath and the requested player rather than on anything that
+   * varies mid-pass. Two *different* players in one pass are kept apart on purpose — see
+   * [capturePlayerWires].
    */
   fun recordCapturePlayer(wire: String) {
-    capturePlayerWire = wire
+    if (wire !in capturePlayerWires) capturePlayerWires = capturePlayerWires + wire
   }
 
   /**
@@ -226,16 +233,18 @@ object RemoteComposeController {
    */
   fun declarationsJson(): String? {
     val decls = declarations()
-    val player = capturePlayerWire
+    // Exactly one player, or nothing: a capture drawn through two of them has no true single
+    // answer, so it reads as unrecorded rather than naming whichever ran last.
+    val player = capturePlayerWires.singleOrNull()
     // A knob-less sticker is the common case and still has a player worth recording, so the
     // sidecar now exists for it too — the writer deletes the file when this returns null, which
     // before meant most Remote Compose captures carried no sidecar at all. Still null for a
     // preview that declared nothing AND drew through no player, so a non–Remote Compose render
     // writes no sidecar exactly as before.
-    if (decls.isEmpty() && player == null) return null
+    if (decls.isEmpty() && capturePlayerWires.isEmpty()) return null
     return json.encodeToString(
       RemoteComposeDeclarationsPayload.serializer(),
-      RemoteComposeDeclarationsPayload(decls, capturePlayer = player),
+      RemoteComposeDeclarationsPayload(decls).also { it.capturePlayer = player },
     )
   }
 
@@ -249,7 +258,7 @@ object RemoteComposeController {
   fun clearDeclarations() {
     // The player is per-capture, so it drops with the declarations: a pooled sandbox re-rendering a
     // different preview must not inherit the previous one's answer.
-    capturePlayerWire = null
+    capturePlayerWires = emptySet()
     // Always reset the bridge scope (even when the in-classloader set is already empty) so a
     // shrinking list's stale knobs drop from a reused sandbox's bridge entries — mirrors
     // `PreviewOverrideController.clearDeclarations`.
@@ -403,6 +412,9 @@ object RemoteComposeController {
     activePreviewId = null
     acceptedActionPayloads = null
     activeSeed = null
+    // The recorded capture player is per-session state like everything above it: leaving it would
+    // let a fresh session's sidecar claim a player the new session never composed through.
+    capturePlayerWires = emptySet()
     bridgeForwarder?.reset(scope)
   }
 

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteComposeController.kt
@@ -112,6 +112,34 @@ object RemoteComposeController {
     get() = playerState
 
   /**
+   * The `rcPlayer` wire id of the player that actually drew the current capture, or null when
+   * nothing recorded one this pass.
+   *
+   * Plain `@Volatile`, not snapshot state: nobody composes against it and it is read once, after
+   * the render, by [declarationsJson]. Recording it must not invalidate a composition — it happens
+   * *during* one.
+   */
+  @Volatile private var capturePlayerWire: String? = null
+
+  /**
+   * Record which player `RemoteOverridablePreview` actually composed the document with.
+   *
+   * The wrapper FQN cannot answer this: the selection is `player == EMBEDDED &&
+   * isEmbeddedPlayerAvailable`, and the second term is a property of the capturing app's classpath.
+   * A consumer shipping the connector without the optional embedded-player runtime draws through
+   * the view player with nothing in its annotations saying so, and a downstream reader that
+   * inferred otherwise would answer `?rcPlayer=cmp-android` with those view-player pixels. So the
+   * composable states it, and [RemoteComposeDeclarationsPayload.capturePlayer] carries it out.
+   *
+   * Last write wins within a pass. A preview that composes the document more than once (a
+   * recomposition, a scroll capture) picks the same branch each time, because the condition depends
+   * on the classpath and the requested player rather than on anything that varies mid-pass.
+   */
+  fun recordCapturePlayer(wire: String) {
+    capturePlayerWire = wire
+  }
+
+  /**
    * Record an editable knob the preview just declared (via a `LocalRemoteComposeHost` named-value
    * read, or an explicit `declareKnob`). Keyed by [RemoteComposeKnobDeclaration.name]; a repeat
    * declaration of the same name (recomposition) replaces the prior entry while keeping its
@@ -198,10 +226,16 @@ object RemoteComposeController {
    */
   fun declarationsJson(): String? {
     val decls = declarations()
-    if (decls.isEmpty()) return null
+    val player = capturePlayerWire
+    // A knob-less sticker is the common case and still has a player worth recording, so the
+    // sidecar now exists for it too — the writer deletes the file when this returns null, which
+    // before meant most Remote Compose captures carried no sidecar at all. Still null for a
+    // preview that declared nothing AND drew through no player, so a non–Remote Compose render
+    // writes no sidecar exactly as before.
+    if (decls.isEmpty() && player == null) return null
     return json.encodeToString(
       RemoteComposeDeclarationsPayload.serializer(),
-      RemoteComposeDeclarationsPayload(decls),
+      RemoteComposeDeclarationsPayload(decls, capturePlayer = player),
     )
   }
 
@@ -213,6 +247,9 @@ object RemoteComposeController {
    * `PreviewOverrideController.clearDeclarations`.
    */
   fun clearDeclarations() {
+    // The player is per-capture, so it drops with the declarations: a pooled sandbox re-rendering a
+    // different preview must not inherit the previous one's answer.
+    capturePlayerWire = null
     // Always reset the bridge scope (even when the in-classloader set is already empty) so a
     // shrinking list's stale knobs drop from a reused sandbox's bridge entries — mirrors
     // `PreviewOverrideController.clearDeclarations`.

--- a/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
+++ b/data/remotecompose/connector/src/main/kotlin/ee/schimke/composeai/daemon/RemoteOverridablePreview.kt
@@ -243,7 +243,17 @@ fun RemoteOverridablePreview(
   // controller's `MutableState`, so a follow-up render with a new override re-runs the bridge.
   val seededOverrides = RemoteComposeController.namedValues.value
 
-  if (player == RemoteComposePlayerKind.EMBEDDED && isEmbeddedPlayerAvailable) {
+  // Which branch this takes is the only place the *effective* player is known — the wrapper says
+  // what was asked for, `isEmbeddedPlayerAvailable` says what the classpath can actually do. A
+  // downstream reader inferring from the wrapper would answer `?rcPlayer=cmp-android` with the
+  // view player's pixels for any consumer that ships the connector without the optional embedded
+  // runtime. Recorded, not derived — see [RemoteComposeController.recordCapturePlayer].
+  val embedded = player == RemoteComposePlayerKind.EMBEDDED && isEmbeddedPlayerAvailable
+  androidx.compose.runtime.SideEffect {
+    RemoteComposeController.recordCapturePlayer(if (embedded) "cmp-android" else "java")
+  }
+
+  if (embedded) {
     ExperimentalRemoteDocumentPlayer(
       document = remoteDocument,
       modifier = modifier,

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -447,6 +447,53 @@ class RemoteComposeDataProductTest {
   }
 
   @Test
+  fun declarationsJson_reads_null_when_two_players_drew_one_capture() {
+    // `RemoteOverridablePreview` is public and a preview may call it twice with different `player`
+    // arguments, each drawing part of the same PNG. Naming one would let the server satisfy a bare
+    // request for that player with pixels the other partly drew, so a mixed capture has no single
+    // true answer and reads as unrecorded.
+    val controller = RemoteComposeController
+    controller.clearDeclarations()
+    controller.recordCapturePlayer("cmp-android")
+    controller.recordCapturePlayer("java")
+    controller.recordDeclaration(
+      RemoteComposeKnobDeclaration("label", RemoteNamedValue.StringValue("x"))
+    )
+    val payload =
+      Json.decodeFromString(
+        RemoteComposeDeclarationsPayload.serializer(),
+        controller.declarationsJson()!!,
+      )
+    assertNull("two players → no single answer", payload.capturePlayer)
+    assertEquals("…and the knobs still ride out", 1, payload.declarations.size)
+
+    // Re-recording the same player is not a conflict: a recomposition takes the same branch.
+    controller.clearDeclarations()
+    controller.recordCapturePlayer("cmp-android")
+    controller.recordCapturePlayer("cmp-android")
+    assertEquals(
+      "cmp-android",
+      Json.decodeFromString(
+          RemoteComposeDeclarationsPayload.serializer(),
+          controller.declarationsJson()!!,
+        )
+        .capturePlayer,
+    )
+    controller.clearDeclarations()
+  }
+
+  @Test
+  fun resetForNewSession_drops_the_recorded_capture_player() {
+    // Every other per-session facet is reset there; leaving this one would have a fresh session's
+    // sidecar claim a player it never composed through.
+    val controller = RemoteComposeController
+    controller.clearDeclarations()
+    controller.recordCapturePlayer("java")
+    controller.resetForNewSession()
+    assertNull("the player is per-session state too", controller.declarationsJson())
+  }
+
+  @Test
   fun document_fetch_before_any_render_returns_not_available() {
     val registry = RemoteComposeDataProductRegistry()
     assertEquals(

--- a/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
+++ b/data/remotecompose/connector/src/test/kotlin/ee/schimke/composeai/daemon/RemoteComposeDataProductTest.kt
@@ -409,6 +409,44 @@ class RemoteComposeDataProductTest {
   }
 
   @Test
+  fun declarationsJson_carries_the_capture_player_even_with_no_knobs() {
+    val controller = RemoteComposeController
+    controller.clearDeclarations()
+    assertNull("nothing declared and no player → still no sidecar", controller.declarationsJson())
+
+    // The common case this exists for: a sticker with no editable knobs. Before the player was
+    // recorded, `declarationsJson` returned null here and the renderer DELETED the sidecar, so most
+    // Remote Compose captures carried none — and there was nowhere for the player to ride out.
+    controller.recordCapturePlayer("cmp-android")
+    val jsonStr = controller.declarationsJson()
+    assertNotNull("a recorded player is worth a sidecar on its own", jsonStr)
+    val payload = Json.decodeFromString(RemoteComposeDeclarationsPayload.serializer(), jsonStr!!)
+    assertTrue("no knobs were declared", payload.declarations.isEmpty())
+    assertEquals("cmp-android", payload.capturePlayer)
+
+    // …and it is per-capture, so a pooled sandbox cannot hand the next preview a stale answer.
+    controller.clearDeclarations()
+    assertNull(controller.declarationsJson())
+  }
+
+  @Test
+  fun declarationsJson_records_the_view_player_when_that_is_what_drew_it() {
+    // The whole reason this is recorded rather than derived: a consumer shipping the connector
+    // without the optional embedded-player runtime draws through the view player, with nothing in
+    // its annotations saying so.
+    val controller = RemoteComposeController
+    controller.clearDeclarations()
+    controller.recordCapturePlayer("java")
+    val payload =
+      Json.decodeFromString(
+        RemoteComposeDeclarationsPayload.serializer(),
+        controller.declarationsJson()!!,
+      )
+    assertEquals("java", payload.capturePlayer)
+    controller.clearDeclarations()
+  }
+
+  @Test
   fun document_fetch_before_any_render_returns_not_available() {
     val registry = RemoteComposeDataProductRegistry()
     assertEquals(

--- a/data/remotecompose/core/api/data-remotecompose-core.api
+++ b/data/remotecompose/core/api/data-remotecompose-core.api
@@ -7,8 +7,10 @@ public final class ee/schimke/composeai/data/remotecompose/RemoteComposeDeclarat
 	public final fun copy (Ljava/util/List;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;
 	public static synthetic fun copy$default (Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;Ljava/util/List;ILjava/lang/Object;)Lee/schimke/composeai/data/remotecompose/RemoteComposeDeclarationsPayload;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCapturePlayer ()Ljava/lang/String;
 	public final fun getDeclarations ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun setCapturePlayer (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -74,11 +74,11 @@ public data class RemoteComposeKnobDeclaration(val name: String, val default: Re
  */
 @Serializable
 public data class RemoteComposeDeclarationsPayload(
-  val declarations: List<RemoteComposeKnobDeclaration> = emptyList(),
+  val declarations: List<RemoteComposeKnobDeclaration> = emptyList()
+) {
   /**
    * The `rcPlayer` wire id of the player that actually drew this capture — `"cmp-android"` for the
-   * embedded player, `"java"` for the view-backed one — or null when the capture predates this
-   * field.
+   * embedded player, `"java"` for the view-backed one — or null when the capture recorded none.
    *
    * Recorded rather than derived, because it cannot be derived. `RemoteOverridablePreview` selects
    * the player as `player == EMBEDDED && isEmbeddedPlayerAvailable`, and that second term is a
@@ -89,10 +89,18 @@ public data class RemoteComposeDeclarationsPayload(
    * (compose-preview-server#233 answers *unknown* instead, which is safe but costs the clean
    * default link — this is what lets it stop being unknown).
    *
-   * Null and absent mean the same thing: not recorded. Never "the default one".
+   * Null and absent mean the same thing: not recorded. Never "the default one". A capture that drew
+   * through more than one player also reads null, because no single answer would be true of it.
+   *
+   * **Declared in the body, not the primary constructor, deliberately.** Adding a parameter would
+   * have removed this published class's `<init>(List)` and `copy(List)` JVM signatures — Kotlin's
+   * default argument does not retain them — so an already-compiled consumer of
+   * `data-remotecompose-core` would hit `NoSuchMethodError`. A body `var` is serialized by
+   * kotlinx.serialization just the same and leaves both signatures intact; the committed ABI dump
+   * shows only additions.
    */
-  val capturePlayer: String? = null,
-)
+  var capturePlayer: String? = null
+}
 
 /**
  * Wire-shape returned by `data/fetch?kind=compose/remotecompose`.

--- a/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
+++ b/data/remotecompose/core/src/main/kotlin/ee/schimke/composeai/data/remotecompose/RemoteComposeModels.kt
@@ -74,7 +74,24 @@ public data class RemoteComposeKnobDeclaration(val name: String, val default: Re
  */
 @Serializable
 public data class RemoteComposeDeclarationsPayload(
-  val declarations: List<RemoteComposeKnobDeclaration> = emptyList()
+  val declarations: List<RemoteComposeKnobDeclaration> = emptyList(),
+  /**
+   * The `rcPlayer` wire id of the player that actually drew this capture — `"cmp-android"` for the
+   * embedded player, `"java"` for the view-backed one — or null when the capture predates this
+   * field.
+   *
+   * Recorded rather than derived, because it cannot be derived. `RemoteOverridablePreview` selects
+   * the player as `player == EMBEDDED && isEmbeddedPlayerAvailable`, and that second term is a
+   * property of the capturing app's own classpath at render time: a consumer shipping the connector
+   * without the optional embedded-player runtime draws through the view player while its
+   * `@PreviewWrapper` says nothing at all. A reader inferring from the wrapper would then answer
+   * `?rcPlayer=cmp-android` with view-player pixels under a confident 200
+   * (compose-preview-server#233 answers *unknown* instead, which is safe but costs the clean
+   * default link — this is what lets it stop being unknown).
+   *
+   * Null and absent mean the same thing: not recorded. Never "the default one".
+   */
+  val capturePlayer: String? = null,
 )
 
 /**

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -100,9 +100,13 @@ export function captureGutterPx(gutter, { density, locale } = {}) {
  * sticker states no device and no background, and a `previewParams: {}` on every image would be
  * pure noise. Kotlin reads a missing record back as null and keeps its existing behaviour.
  */
-function presentationParams(params) {
-  if (!params) return null;
+function presentationParams(params, capturePlayer) {
+  if (!params && !capturePlayer) return null;
   const out = {};
+  // The eighth, and the only one that is about the RENDERER rather than the render: which Remote
+  // Compose player drew these pixels. See `capturePlayerFor`.
+  if (capturePlayer) out.capturePlayer = capturePlayer;
+  if (!params) return Object.keys(out).length > 0 ? out : null;
   if (params.uiMode) out.uiMode = params.uiMode;
   if (params.showBackground === true) out.showBackground = true;
   if (params.backgroundColor) out.backgroundColor = params.backgroundColor;
@@ -121,6 +125,36 @@ function presentationParams(params) {
   const captureGutter = captureGutterPx(params.captureGutter, params);
   if (captureGutter) out.captureGutter = captureGutter;
   return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * FQN of the published wrapper that pins a preview to the view-backed Remote Compose player. A
+ * preview naming it composes through `RemoteComposePlayerKind.VIEW` instead of the
+ * `RemoteOverridablePreview` default.
+ */
+const REMOTE_VIEW_PREVIEW_WRAPPER = "ee.schimke.composeai.daemon.RemoteViewPreviewWrapper";
+
+/**
+ * The `rcPlayer` wire id of the player this preview's baked PNG was **captured** with, or null when
+ * the question does not apply.
+ *
+ * A published catalog stages no `previews.json`, so a server reading it back has nothing that
+ * records a `@PreviewWrapper` pin — and the only inference available to it, that
+ * `RemoteOverridablePreview` defaults to the embedded player, is wrong for exactly the previews
+ * that pin `RemoteViewPreviewWrapper`. Getting it wrong is not cosmetic: the server treats a
+ * request naming the capture's own player as satisfied by the baked pixels, so an inferred
+ * `cmp-android` would answer `?rcPlayer=cmp-android` on a view-pinned preview with the view
+ * player's capture, and the viewer would drop the parameter and label those pixels CMP Android.
+ *
+ * So it is recorded rather than inferred, and a catalog that predates this field reads back as
+ * "unknown" on the server rather than as the common answer (compose-preview-server#233).
+ *
+ * Only for a preview that carries a captured document: a plain Compose preview's PNG is not any
+ * player's output, and claiming one would invite the same false equivalence pointing the other way.
+ */
+function capturePlayerFor(bundle, preview) {
+  if (!bundle?.entries?.[`ir/${preview.id}.rc`]) return null;
+  return preview.params?.wrapperClassName === REMOTE_VIEW_PREVIEW_WRAPPER ? "java" : "cmp-android";
 }
 
 /** Metadata that must be visible on the browse surface before a preview daemon is opened. */
@@ -152,7 +186,7 @@ export function declarationsByPreviewId(bundles) {
       // per-preview backdrop falls back to the catalog's declared stage for all of them and the
       // device clip never resolves: a round Wear comparison is drawn on a square stage there and
       // nowhere else.
-      const previewParams = presentationParams(preview.params);
+      const previewParams = presentationParams(preview.params, capturePlayerFor(bundle, preview));
       if (
         overrides.length > 0 ||
         remoteComposeKnobs.length > 0 ||

--- a/scripts/design-artifacts/catalog-preview-declarations.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.mjs
@@ -21,6 +21,32 @@ function sidecarDeclarations(bundle, previewId, suffix) {
 }
 
 /**
+ * The `rcPlayer` wire id recorded by the capture itself, or null when it recorded none.
+ *
+ * Read off the same `previews/<id>.remotecompose.json` sidecar `sidecarDeclarations` parses, and
+ * deliberately NOT derived from the preview's `@PreviewWrapper`. `RemoteOverridablePreview` selects
+ * the player as `player == EMBEDDED && isEmbeddedPlayerAvailable`, and that second term is a
+ * property of the capturing app's classpath at render time — a consumer shipping the connector
+ * without the optional embedded-player runtime draws through the view player with nothing in its
+ * annotations saying so. An exporter reading a finished bundle cannot see that, so inferring here
+ * would record `cmp-android` over view-player pixels and have the server answer
+ * `?rcPlayer=cmp-android` with them under a confident 200 (compose-preview-server#233).
+ *
+ * Null keeps the server's honest "unknown", which costs a redundant query parameter rather than the
+ * wrong pixels. A capture from before the connector recorded this reads back null.
+ */
+function sidecarCapturePlayer(bundle, previewId) {
+  const bytes = bundle?.entries?.[`previews/${previewId}.remotecompose.json`];
+  if (!bytes) return null;
+  try {
+    const player = JSON.parse(decoder.decode(bytes))?.capturePlayer;
+    return typeof player === "string" && player !== "" ? player : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Whether a `@Preview(locale = …)` render was composed right-to-left — the direction the renderer
  * resolved a gutter's leading / trailing edges against.
  *
@@ -103,8 +129,9 @@ export function captureGutterPx(gutter, { density, locale } = {}) {
 function presentationParams(params, capturePlayer) {
   if (!params && !capturePlayer) return null;
   const out = {};
-  // The eighth, and the only one that is about the RENDERER rather than the render: which Remote
-  // Compose player drew these pixels. See `capturePlayerFor`.
+  // The eighth, and the only one about the RENDERER rather than the render: which Remote Compose
+  // player actually drew these pixels. Passed straight through from the capture's own sidecar —
+  // see `sidecarCapturePlayer` for why it cannot be derived here.
   if (capturePlayer) out.capturePlayer = capturePlayer;
   if (!params) return Object.keys(out).length > 0 ? out : null;
   if (params.uiMode) out.uiMode = params.uiMode;
@@ -125,36 +152,6 @@ function presentationParams(params, capturePlayer) {
   const captureGutter = captureGutterPx(params.captureGutter, params);
   if (captureGutter) out.captureGutter = captureGutter;
   return Object.keys(out).length > 0 ? out : null;
-}
-
-/**
- * FQN of the published wrapper that pins a preview to the view-backed Remote Compose player. A
- * preview naming it composes through `RemoteComposePlayerKind.VIEW` instead of the
- * `RemoteOverridablePreview` default.
- */
-const REMOTE_VIEW_PREVIEW_WRAPPER = "ee.schimke.composeai.daemon.RemoteViewPreviewWrapper";
-
-/**
- * The `rcPlayer` wire id of the player this preview's baked PNG was **captured** with, or null when
- * the question does not apply.
- *
- * A published catalog stages no `previews.json`, so a server reading it back has nothing that
- * records a `@PreviewWrapper` pin — and the only inference available to it, that
- * `RemoteOverridablePreview` defaults to the embedded player, is wrong for exactly the previews
- * that pin `RemoteViewPreviewWrapper`. Getting it wrong is not cosmetic: the server treats a
- * request naming the capture's own player as satisfied by the baked pixels, so an inferred
- * `cmp-android` would answer `?rcPlayer=cmp-android` on a view-pinned preview with the view
- * player's capture, and the viewer would drop the parameter and label those pixels CMP Android.
- *
- * So it is recorded rather than inferred, and a catalog that predates this field reads back as
- * "unknown" on the server rather than as the common answer (compose-preview-server#233).
- *
- * Only for a preview that carries a captured document: a plain Compose preview's PNG is not any
- * player's output, and claiming one would invite the same false equivalence pointing the other way.
- */
-function capturePlayerFor(bundle, preview) {
-  if (!bundle?.entries?.[`ir/${preview.id}.rc`]) return null;
-  return preview.params?.wrapperClassName === REMOTE_VIEW_PREVIEW_WRAPPER ? "java" : "cmp-android";
 }
 
 /** Metadata that must be visible on the browse surface before a preview daemon is opened. */
@@ -186,7 +183,10 @@ export function declarationsByPreviewId(bundles) {
       // per-preview backdrop falls back to the catalog's declared stage for all of them and the
       // device clip never resolves: a round Wear comparison is drawn on a square stage there and
       // nowhere else.
-      const previewParams = presentationParams(preview.params, capturePlayerFor(bundle, preview));
+      const previewParams = presentationParams(
+        preview.params,
+        sidecarCapturePlayer(bundle, preview.id),
+      );
       if (
         overrides.length > 0 ||
         remoteComposeKnobs.length > 0 ||

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -198,6 +198,39 @@ test("lifts the ground and device frame a browse surface needs before opening an
   });
 });
 
+test("records which Remote Compose player captured the render", () => {
+  // A published catalog stages no `previews.json`, so a server reading it back has nothing that
+  // records a `@PreviewWrapper` pin. It must be told, because the only inference available to it —
+  // that `RemoteOverridablePreview` defaults to the embedded player — would answer
+  // `?rcPlayer=cmp-android` on the pinned preview below with the VIEW player's own capture.
+  const bundle = {
+    previews: [
+      { id: "Card", params: {} },
+      {
+        id: "Pinned",
+        params: { wrapperClassName: "ee.schimke.composeai.daemon.RemoteViewPreviewWrapper" },
+      },
+    ],
+    entries: { "ir/Card.rc": new Uint8Array([1]), "ir/Pinned.rc": new Uint8Array([1]) },
+  };
+  const out = declarationsByPreviewId(bundle);
+  assert.deepEqual(out.get("Card"), { previewParams: { capturePlayer: "cmp-android" } });
+  assert.deepEqual(out.get("Pinned"), { previewParams: { capturePlayer: "java" } });
+});
+
+test("records no capture player for a preview with no captured document", () => {
+  // A plain Compose preview's PNG is not any player's output. Claiming one would invite the same
+  // false equivalence pointing the other way — an `rcPlayer` request read as satisfied by pixels
+  // no player drew.
+  const bundle = {
+    previews: [{ id: "PlainCompose", params: { showBackground: true } }],
+    entries: {},
+  };
+  assert.deepEqual(declarationsByPreviewId(bundle).get("PlainCompose"), {
+    previewParams: { showBackground: true },
+  });
+});
+
 test("records nothing for a preview that states no ground and no device", () => {
   // The ordinary component sticker. A `previewParams: {}` on every image would grow every catalog
   // for no reader, and Kotlin reads a missing record back as null — its existing behaviour.

--- a/scripts/design-artifacts/catalog-preview-declarations.test.mjs
+++ b/scripts/design-artifacts/catalog-preview-declarations.test.mjs
@@ -198,35 +198,51 @@ test("lifts the ground and device frame a browse surface needs before opening an
   });
 });
 
-test("records which Remote Compose player captured the render", () => {
-  // A published catalog stages no `previews.json`, so a server reading it back has nothing that
-  // records a `@PreviewWrapper` pin. It must be told, because the only inference available to it —
-  // that `RemoteOverridablePreview` defaults to the embedded player — would answer
-  // `?rcPlayer=cmp-android` on the pinned preview below with the VIEW player's own capture.
+test("passes through the capture player the render recorded", () => {
+  // Recorded by the capture, not derived here: `RemoteOverridablePreview` picks the player as
+  // `player == EMBEDDED && isEmbeddedPlayerAvailable`, and the second term is a property of the
+  // capturing app's classpath that a finished bundle does not otherwise expose.
+  const sidecar = (player) =>
+    new TextEncoder().encode(JSON.stringify({ declarations: [], capturePlayer: player }));
   const bundle = {
-    previews: [
-      { id: "Card", params: {} },
-      {
-        id: "Pinned",
-        params: { wrapperClassName: "ee.schimke.composeai.daemon.RemoteViewPreviewWrapper" },
-      },
-    ],
-    entries: { "ir/Card.rc": new Uint8Array([1]), "ir/Pinned.rc": new Uint8Array([1]) },
+    previews: [{ id: "Card", params: {} }, { id: "Pinned", params: {} }],
+    entries: {
+      "previews/Card.remotecompose.json": sidecar("cmp-android"),
+      "previews/Pinned.remotecompose.json": sidecar("java"),
+    },
   };
   const out = declarationsByPreviewId(bundle);
   assert.deepEqual(out.get("Card"), { previewParams: { capturePlayer: "cmp-android" } });
   assert.deepEqual(out.get("Pinned"), { previewParams: { capturePlayer: "java" } });
 });
 
-test("records no capture player for a preview with no captured document", () => {
-  // A plain Compose preview's PNG is not any player's output. Claiming one would invite the same
-  // false equivalence pointing the other way — an `rcPlayer` request read as satisfied by pixels
-  // no player drew.
+test("records no capture player when the sidecar recorded none", () => {
+  // A capture from before the connector recorded this, or a non-Remote-Compose preview. Null keeps
+  // the server's honest "unknown" rather than asserting the common answer.
   const bundle = {
-    previews: [{ id: "PlainCompose", params: { showBackground: true } }],
-    entries: {},
+    previews: [
+      { id: "Legacy", params: { showBackground: true } },
+      { id: "PlainCompose", params: { showBackground: true } },
+    ],
+    entries: {
+      "previews/Legacy.remotecompose.json": new TextEncoder().encode(
+        JSON.stringify({ declarations: [{ name: "label", default: "hi" }] }),
+      ),
+    },
   };
-  assert.deepEqual(declarationsByPreviewId(bundle).get("PlainCompose"), {
+  const out = declarationsByPreviewId(bundle);
+  assert.equal(out.get("Legacy").previewParams.capturePlayer, undefined);
+  assert.deepEqual(out.get("PlainCompose"), { previewParams: { showBackground: true } });
+});
+
+test("ignores a malformed sidecar rather than failing the export", () => {
+  const bundle = {
+    previews: [{ id: "Broken", params: { showBackground: true } }],
+    entries: {
+      "previews/Broken.remotecompose.json": new TextEncoder().encode("{ not json"),
+    },
+  };
+  assert.deepEqual(declarationsByPreviewId(bundle).get("Broken"), {
     previewParams: { showBackground: true },
   });
 });


### PR DESCRIPTION
Unblocks itself. The first attempt derived the capture player from the preview's `@PreviewWrapper`; Codex found that unsound, and it was. This replaces the derivation with a recording made where the answer is actually known.

## Why derivation cannot work

`RemoteOverridablePreview` selects the player like this:

```kotlin
if (player == RemoteComposePlayerKind.EMBEDDED && isEmbeddedPlayerAvailable) {
    ExperimentalRemoteDocumentPlayer(...)
} else {
    RemoteDocumentPlayer(...)   // view-backed
}
```

`isEmbeddedPlayerAvailable` is a property of the **capturing app's classpath at render time**. A consumer shipping the Remote Compose connector without the optional embedded-player runtime draws every preview through the *view* player, with nothing in its annotations saying so. An exporter reading a finished bundle cannot see that.

So deriving would have recorded `cmp-android` over view-player pixels — and the server treats a request naming the recorded player as satisfied by the baked bytes, so `?rcPlayer=cmp-android` would have answered with them under a confident `200`. That is the exact failure the compose-preview-server#226 → #233 chain exists to prevent, which #233 currently avoids by answering **unknown**.

## What it does instead

The composable states it, at the only point where the effective player is known, and it rides the sidecar the knob declarations already ride:

| step | where |
| --- | --- |
| record the branch taken | `RemoteOverridablePreview`, beside the existing declaration `SideEffect` |
| hold it for the pass | `RemoteComposeController.recordCapturePlayer`, dropped by `clearDeclarations` |
| carry it out | `RemoteComposeDeclarationsPayload.capturePlayer` via `declarationsJson`, which the renderer already calls reflectively to write `<stem>.remotecompose.json` |
| pass it through | `catalog-preview-declarations.mjs` → `previewParams.capturePlayer`, deriving nothing |
| read it | compose-preview-server#233, already merged |

Dropping it with the declarations matters: the controller is process-static and sandboxes are pooled, so a stale player would otherwise be handed to the next preview rendered in the same classloader.

Removing the derivation also removes the `ir/<id>.rc` entry lookup, and with it the **additional-module namespacing bug** Codex found on the first attempt — nothing resolves an `ir/` path by id any more.

## One behaviour change worth naming

`declarationsJson` used to return null for a preview that declared no knobs, and `RobolectricRenderTest.writeRemoteComposeSidecar` *deletes* the sidecar when it does. So most Remote Compose captures — every knob-less sticker — carried no sidecar at all, and there was nowhere for the player to ride out.

A recorded player is now enough to write one. Sidecars therefore appear for knob-less Remote Compose previews where they did not before; the payload reads `{"declarations":[],"capturePlayer":"cmp-android"}`, and every existing reader takes `declarations` as the empty list it already handled. Still null when a capture declared nothing *and* drew through no player, so a non-Remote-Compose render writes no sidecar exactly as before.

## Test plan

`./gradlew :data-remotecompose-connector:testDebugUnitTest --tests '*RemoteComposeDataProductTest*'` and `ktfmtCheckAll` green; `node --test scripts/design-artifacts/catalog-preview-declarations.test.mjs` — 22 passing.

Connector:
- `declarationsJson_carries_the_capture_player_even_with_no_knobs` — the case the whole change turns on: no declarations, a recorded player, a sidecar written anyway; then cleared, and null again.
- `declarationsJson_records_the_view_player_when_that_is_what_drew_it` — `java` round-trips, which is the case derivation got wrong.
- `declarationsJson_is_null_when_empty_and_a_payload_when_declared` — unchanged and still passing, pinning that a capture with neither still writes nothing.

Exporter:
- `passes through the capture player the render recorded` — `cmp-android` and `java` both reach `previewParams`.
- `records no capture player when the sidecar recorded none` — a pre-existing capture, and a non-Remote-Compose preview, both keep their old record and gain nothing.
- `ignores a malformed sidecar rather than failing the export`.

## After this

`remote-m3` regenerates daily, so once this releases and the catalog regenerates, published catalogs carry the field and compose-preview-server#233 stops answering unknown — which is what finally drops `?rcPlayer=cmp-android` from `preview.coo.ee` default links without anyone guessing.

The grant-gate 403 (`handleRender` classifying `rcPlayer` before leasing the host) is independent of this and still outstanding.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r