### PR TITLE
feat(discovery): generate a compiling screen from a builder's document

### DIFF
--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -834,13 +834,21 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > compiler accepts. The exporter this path replaces asserted *balanced braces* on its
 > output.
 >
-> Building it immediately caught a defect in the opt-in markers below. The Compose
-> compiler stamps `@ComposableInferredTarget` and `@InternalComposeApi` onto the JVM
-> method; both carry `@RequiresOptIn`, so both were reported, and generated screens
-> told consumers to opt into Compose **internals** in order to place a `Card`.
-> Verified rather than argued — the same screen compiles with those annotations
-> stripped — so they are excluded and the gate now asserts stock Material 3 needs no
-> opt-in at all.
+> Building it immediately caught a defect in the opt-in markers below, and the first
+> fix for it was wrong in an instructive way. Generated screens told consumers to
+> `@OptIn(InternalComposeApi::class)` in order to place a `Card`. The cause is that
+> ClassGraph's `annotationInfo` is the **transitive closure of meta-annotations**, not
+> the annotations written on the element: `Card` carries `@Composable`,
+> `@ComposableInferredTarget` and `@FunctionKeyMeta`, and the closure of those three
+> drags in `InternalComposeApi`, `ComposeCompilerApi` and `kotlin.RequiresOptIn`
+> itself. Denylisting those names silenced the noise and *also* silenced a component an
+> author had deliberately marked `@InternalComposeApi`, whose callers really must opt
+> in. Reading `directOnly()` at both levels asks the actual Kotlin question — this
+> element, this marker — so a compiler-stamped annotation drops out because it is not
+> itself `@RequiresOptIn`, while an author's `@ExperimentalMaterial3Api` survives.
+> `ComposableSignatureTest` reproduces both halves on local fixtures shaped like the
+> Compose ones, and the functional gate asserts stock Material 3 needs no opt-in at
+> all.
 >
 > What is **not** done: `compose-preview-server`'s exporter still runs off an authored
 > `CapabilityCatalog` and a hand-written 29-entry `EMITTER_IDS` allowlist. Moving it

--- a/docs/design/COMPONENT_RECORD.md
+++ b/docs/design/COMPONENT_RECORD.md
@@ -811,6 +811,47 @@ gate over the corpora; retire the cleaner for migrated catalogs.
 > generator that worked in-process while the record persisted something else would have
 > passed the old test and failed every consumer.
 >
+> **From a call site to a screen.** `ComponentSnippets` prints one component with
+> placeholders — `Text(text = "")` — which proves a component is *reachable* and
+> renders nothing anyone designed. `ScreenGenerator` adds the half a UI builder needs:
+> the values its user set, and components nested into each other's slots.
+>
+> A node generates **only when its record carries an emitted `code`**. That single
+> check inherits every protection listed below without restating any of it — public,
+> no uninferable type parameters, no overload collision, a signature actually read, an
+> importable callable. `code.call` is the licence to call; the argument list is rebuilt
+> from `parameters` with the document's values, and `placeholderFor` plus the
+> qualified-type check are *shared* with `ComponentSnippets` rather than copied,
+> because "is this really `kotlin.String`?" is the question already got wrong twice.
+>
+> `ScreenDocument` is deliberately not the builder's own document model — it is the
+> narrow projection the generator needs, so the generator is testable without an
+> editor's undo stack and collaboration protocol. Projecting onto it is the builder's
+> job, and the interesting decisions are not in that projection.
+>
+> `ScreenGeneratorCompileFunctionalTest` closes the loop: a real project, real
+> discovery, and a screen assembled from the discovered catalog that the Kotlin
+> compiler accepts. The exporter this path replaces asserted *balanced braces* on its
+> output.
+>
+> Building it immediately caught a defect in the opt-in markers below. The Compose
+> compiler stamps `@ComposableInferredTarget` and `@InternalComposeApi` onto the JVM
+> method; both carry `@RequiresOptIn`, so both were reported, and generated screens
+> told consumers to opt into Compose **internals** in order to place a `Card`.
+> Verified rather than argued — the same screen compiles with those annotations
+> stripped — so they are excluded and the gate now asserts stock Material 3 needs no
+> opt-in at all.
+>
+> What is **not** done: `compose-preview-server`'s exporter still runs off an authored
+> `CapabilityCatalog` and a hand-written 29-entry `EMITTER_IDS` allowlist. Moving it
+> onto this path needs `ScreenGenerator` in a published artifact — that repo consumes
+> released jars and does not depend on `preview-discovery` — so the wiring is blocked
+> on a release rather than on a design question. Layout primitives (`Column`, `Row`,
+> `Box`) are also absent, because inference scopes library components to
+> `material3`/`material`/`wear`; the prototype nests inside `Card`'s `ColumnScope`
+> content slot instead, and widening that is a separate decision about what counts as
+> a component.
+>
 > **Six ways the compile claim was wider than the record could justify.** Persisting
 > the call site drew a review pass over the guarantee itself, and every one of these
 > was real. They share a root cause worth naming: `callSite` was deciding from a

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -109,6 +109,17 @@ data class ComponentRecord(
    * them.
    */
   val requiredOptIns: List<String> = emptyList(),
+  /**
+   * The subset of [requiredOptIns] whose markers are declared with
+   * `androidx.annotation.RequiresOptIn` rather than `kotlin.RequiresOptIn`.
+   *
+   * The two mechanisms are not interchangeable at the call site: `kotlin.OptIn` rejects an AndroidX
+   * marker outright ("this class is not an opt-in requirement marker"), and the AndroidX annotation
+   * takes its markers as `@androidx.annotation.OptIn(markerClass = [Foo::class])`. A generator that
+   * knows only the marker names cannot tell which to write, so the mechanism is recorded here at
+   * the one point that can see it — the annotation's own meta-annotations.
+   */
+  val androidxOptIns: List<String> = emptyList(),
 )
 
 /**
@@ -221,6 +232,17 @@ data class ComponentCode(
    * problem the caller fixes in one annotation.
    */
   val requiredOptIns: List<String> = emptyList(),
+  /**
+   * The subset of [requiredOptIns] whose markers are declared with
+   * `androidx.annotation.RequiresOptIn` rather than `kotlin.RequiresOptIn`.
+   *
+   * The two mechanisms are not interchangeable at the call site: `kotlin.OptIn` rejects an AndroidX
+   * marker outright ("this class is not an opt-in requirement marker"), and the AndroidX annotation
+   * takes its markers as `@androidx.annotation.OptIn(markerClass = [Foo::class])`. A generator that
+   * knows only the marker names cannot tell which to write, so the mechanism is recorded here at
+   * the one point that can see it — the annotation's own meta-annotations.
+   */
+  val androidxOptIns: List<String> = emptyList(),
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecord.kt
@@ -14,7 +14,18 @@ import kotlinx.serialization.Serializable
  * meaning changes, bumps this. A reader that does not know a major version refuses the file rather
  * than guessing at it.
  */
-const val COMPONENT_RECORD_SCHEMA_VERSION: Int = 1
+const val COMPONENT_RECORD_SCHEMA_VERSION: Int = 2
+
+/**
+ * The first schema that records **which opt-in mechanism** each marker in [ComponentCode] needs.
+ *
+ * Before it, `requiredOptIns` was a flat list and a consumer could only assume `kotlin.OptIn`,
+ * which is wrong for a marker declared with `androidx.annotation.RequiresOptIn` — the assumption
+ * that made this a meaning change rather than an addition, and so a version bump under the rule
+ * above. A generator reading an older record cannot classify its markers and should say so instead
+ * of guessing.
+ */
+const val COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA: Int = 2
 
 /**
  * `components.json` — the **components** a module's previews render, as opposed to
@@ -96,6 +107,11 @@ data class ComponentRecord(
   val callableFromAnotherFile: Boolean = true,
   /** See `PreviewTarget.hasTypeParameters`. */
   val hasTypeParameters: Boolean = false,
+  /**
+   * Whether the composable declares a context receiver or context parameter, which a generated
+   * wrapper cannot supply — see `ComposableSignatureInfo.hasContextReceivers`.
+   */
+  val hasContextReceivers: Boolean = false,
   /**
    * True when overloads collided into this record — they share [canonicalId], so `collect` merged
    * them and kept one signature. No call site can be printed for the merged pair: two fully

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -67,6 +67,7 @@ object ComponentRecords {
             callableFromAnotherFile = target.callableFromAnotherFile,
             hasTypeParameters = target.hasTypeParameters,
             requiredOptIns = target.requiredOptIns,
+            androidxOptIns = target.androidxOptIns,
           )
         }
       // Overloads share a canonical id and merge into this one record. Both JVM handles identify
@@ -101,6 +102,7 @@ object ComponentRecords {
         existing.callableFromAnotherFile = target.callableFromAnotherFile
         existing.hasTypeParameters = target.hasTypeParameters
         existing.requiredOptIns = target.requiredOptIns
+        existing.androidxOptIns = target.androidxOptIns
       } else if (
         target.signatureKnown == existing.signatureKnown &&
           target.parameters.size > existing.parameters.size
@@ -176,6 +178,7 @@ object ComponentRecords {
     var callableFromAnotherFile: Boolean = true,
     var hasTypeParameters: Boolean = false,
     var requiredOptIns: List<String> = emptyList(),
+    var androidxOptIns: List<String> = emptyList(),
   ) {
     /**
      * Set when two targets under this id disagreed about which method they are. Distinct from a
@@ -205,6 +208,7 @@ object ComponentRecords {
           hasTypeParameters = hasTypeParameters,
           overloadsCollided = overloadsCollided,
           requiredOptIns = requiredOptIns,
+          androidxOptIns = androidxOptIns,
         )
       // Printed from the finished record, so the snippet is answering the same symbol, parameters
       // and receiver a consumer will read beside it.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentRecords.kt
@@ -66,6 +66,7 @@ object ComponentRecords {
             descriptor = target.descriptor,
             callableFromAnotherFile = target.callableFromAnotherFile,
             hasTypeParameters = target.hasTypeParameters,
+            hasContextReceivers = target.hasContextReceivers,
             requiredOptIns = target.requiredOptIns,
             androidxOptIns = target.androidxOptIns,
           )
@@ -101,6 +102,7 @@ object ComponentRecords {
         existing.signatureKnown = true
         existing.callableFromAnotherFile = target.callableFromAnotherFile
         existing.hasTypeParameters = target.hasTypeParameters
+        existing.hasContextReceivers = target.hasContextReceivers
         existing.requiredOptIns = target.requiredOptIns
         existing.androidxOptIns = target.androidxOptIns
       } else if (
@@ -177,6 +179,7 @@ object ComponentRecords {
     var descriptor: String? = null,
     var callableFromAnotherFile: Boolean = true,
     var hasTypeParameters: Boolean = false,
+    var hasContextReceivers: Boolean = false,
     var requiredOptIns: List<String> = emptyList(),
     var androidxOptIns: List<String> = emptyList(),
   ) {
@@ -207,6 +210,7 @@ object ComponentRecords {
           callableFromAnotherFile = callableFromAnotherFile,
           hasTypeParameters = hasTypeParameters,
           overloadsCollided = overloadsCollided,
+          hasContextReceivers = hasContextReceivers,
           requiredOptIns = requiredOptIns,
           androidxOptIns = androidxOptIns,
         )

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -66,6 +66,14 @@ object ComponentSnippets {
         "declares type parameters that a call omitting defaulted arguments cannot infer"
       )
     }
+    // The same reason as an extension receiver, one the parameter list cannot show: a context is
+    // not a value parameter, so nothing in the printed call would hint that a `Theme` has to be in
+    // scope around it.
+    if (record.hasContextReceivers) {
+      return ComponentSnippet.Refused(
+        "declares a context receiver or parameter, which a generated wrapper cannot supply"
+      )
+    }
     record.symbol.receiver?.let { receiver ->
       return ComponentSnippet.Refused(
         "declared on $receiver, so a call site needs that scope around it"

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -172,13 +172,25 @@ object ComponentSnippets {
       "while",
     )
 
-  private fun escapeIfKeyword(name: String): String = if (name in HARD_KEYWORDS) "`$name`" else name
+  /**
+   * The parameter's qualified type, falling back to the rendered spelling under `kotlin.` when the
+   * record predates [TargetParameter.typeFqn].
+   *
+   * Shared with [ScreenGenerator] rather than duplicated: both have to decide "is this actually
+   * `kotlin.String`?", and two implementations of that question is how one of them starts emitting
+   * `""` for `com.example.String` again.
+   */
+  internal fun qualifiedTypeOf(parameter: TargetParameter): String =
+    parameter.typeFqn ?: "kotlin.${parameter.type}"
+
+  internal fun escapeIfKeyword(name: String): String =
+    if (name in HARD_KEYWORDS) "`$name`" else name
 
   /** Escapes each segment of an import path, since any one of them may be a keyword. */
-  private fun escapeCallableIfKeyword(callable: String): String =
+  internal fun escapeCallableIfKeyword(callable: String): String =
     callable.split('.').joinToString(".") { escapeIfKeyword(it) }
 
-  private fun placeholderFor(parameter: TargetParameter): String? {
+  internal fun placeholderFor(parameter: TargetParameter): String? {
     if (parameter.nullable) return "null"
     val type = parameter.type
     // A record written before `nullable` existed defaults it to `false`, so a persisted v1
@@ -192,7 +204,7 @@ object ComponentSnippets {
     // `String` exactly like `kotlin.String`, and answering `""` for the first emits source that
     // does not compile. A record written before `typeFqn` existed has null here and falls back to
     // the spelling, which is what it always did — no worse, and no silent retraction.
-    return when (parameter.typeFqn ?: "kotlin.$type") {
+    return when (qualifiedTypeOf(parameter)) {
       "kotlin.String" -> "\"\""
       "kotlin.Boolean" -> "false"
       "kotlin.Int" -> "0"

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -195,10 +195,31 @@ object ComponentSnippets {
 
   internal fun isHardKeyword(name: String): Boolean = name in HARD_KEYWORDS
 
-  internal fun escapeIfKeyword(name: String): String =
-    if (name in HARD_KEYWORDS) "`$name`" else name
+  /**
+   * Kotlin's own identifier rule: `(Letter | '_') (Letter | '_' | UnicodeDigit)*`.
+   *
+   * Not `[A-Za-z_][A-Za-z0-9_]*` — `Übersicht` and `画面` are identifiers Kotlin accepts without
+   * backticks. Kept here, next to the escaping it decides, so there is one answer to "can this be
+   * written bare?" rather than one per generator.
+   */
+  internal fun isIdentifier(name: String): Boolean =
+    name.isNotEmpty() &&
+      (name[0].isLetter() || name[0] == '_') &&
+      name.all { it.isLetter() || it.isDigit() || it == '_' }
 
-  /** Escapes each segment of an import path, since any one of them may be a keyword. */
+  /**
+   * Backticks [name] unless it can be written bare.
+   *
+   * Two reasons it cannot, and a keyword is only the obvious one: a declaration's *source* name can
+   * hold characters no bare identifier may, because it was written in backticks to begin with —
+   * ``annotation class `Api${'$'}Experimental` ``. Printing that unquoted is as broken as printing
+   * `when` unquoted, and the second case is the one that survived a round of review by looking
+   * unremarkable.
+   */
+  internal fun escapeIfKeyword(name: String): String =
+    if (name in HARD_KEYWORDS || !isIdentifier(name)) "`$name`" else name
+
+  /** Escapes each segment of an import path, since any one of them may need it. */
   internal fun escapeCallableIfKeyword(callable: String): String =
     callable.split('.').joinToString(".") { escapeIfKeyword(it) }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -228,7 +228,33 @@ object ComponentSnippets {
    * String` accepts children in neither generator, and two answers to that would let one of them
    * emit a lambda the compiler rejects.
    */
-  internal fun acceptsBareLambda(type: String): Boolean = emptyLambda(type) != null
+  internal fun acceptsBareLambda(type: String): Boolean =
+    // A nullable slot renders as `(() -> Unit)?` — parenthesised so the `?` cannot read as part of
+    // the return type. Kotlin accepts a non-null `{ … }` for a nullable function type, so the
+    // outer nullability is stripped before asking about the lambda's shape. Only
+    // `acceptsBareLambda`
+    // unwraps: `emptyLambda` still answers null for a nullable parameter, because `placeholderFor`
+    // reaches `null` first and that is the better answer when there are no children to place.
+    emptyLambda(unwrapNullable(type)) != null
+
+  /** `(() -> Unit)?` to `() -> Unit`; anything else unchanged. */
+  private fun unwrapNullable(type: String): String {
+    if (!type.startsWith("(") || !type.endsWith(")?")) return type
+    val inner = type.substring(1, type.length - 2)
+    // Only strip when the opening paren really is the one the `?` closes, so `(A) -> B` — whose
+    // first paren belongs to the parameter list — is left alone.
+    return if (topLevelCommaCount(inner) >= 0 && balanced(inner)) inner else type
+  }
+
+  private fun balanced(text: String): Boolean {
+    var depth = 0
+    for (c in text) {
+      if (c == '(') depth++
+      if (c == ')') depth--
+      if (depth < 0) return false
+    }
+    return depth == 0
+  }
 
   /**
    * `"{}"` when a bare empty-lambda literal satisfies the function type [type], else null.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -97,6 +97,7 @@ object ComponentSnippets {
       imports = listOf(escapeCallableIfKeyword(record.symbol.callable)),
       code = "${escapeIfKeyword(record.symbol.name)}(${arguments.joinToString(", ")})",
       requiredOptIns = record.requiredOptIns,
+      androidxOptIns = record.androidxOptIns,
     )
   }
 
@@ -114,6 +115,7 @@ object ComponentSnippets {
           call = snippet.code,
           imports = snippet.imports,
           requiredOptIns = snippet.requiredOptIns,
+          androidxOptIns = snippet.androidxOptIns,
         )
       is ComponentSnippet.Refused -> ComponentCode(refusedReason = snippet.reason)
     }
@@ -310,6 +312,7 @@ sealed interface ComponentSnippet {
     val code: String,
     /** Markers the caller's `@Composable` wrapper must `@OptIn` to — see `ComponentCode`. */
     val requiredOptIns: List<String> = emptyList(),
+    val androidxOptIns: List<String> = emptyList(),
   ) : ComponentSnippet
 
   /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComponentSnippets.kt
@@ -183,6 +183,8 @@ object ComponentSnippets {
   internal fun qualifiedTypeOf(parameter: TargetParameter): String =
     parameter.typeFqn ?: "kotlin.${parameter.type}"
 
+  internal fun isHardKeyword(name: String): Boolean = name in HARD_KEYWORDS
+
   internal fun escapeIfKeyword(name: String): String =
     if (name in HARD_KEYWORDS) "`$name`" else name
 
@@ -217,6 +219,16 @@ object ComponentSnippets {
       else -> null
     }
   }
+
+  /**
+   * Whether a bare `{ … }` satisfies the function type [type] — the question a slot has to answer
+   * before children can be dropped into it.
+   *
+   * Shared with [ScreenGenerator] because a slot whose type is `(Int, Int) -> Unit` or `() ->
+   * String` accepts children in neither generator, and two answers to that would let one of them
+   * emit a lambda the compiler rejects.
+   */
+  internal fun acceptsBareLambda(type: String): Boolean = emptyLambda(type) != null
 
   /**
    * `"{}"` when a bare empty-lambda literal satisfies the function type [type], else null.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -74,6 +74,17 @@ internal data class ComposableSignatureInfo(
    * be identified, and is indistinguishable here from a declaration that needs no opt-in.
    */
   val requiredOptIns: List<String>,
+  /**
+   * The subset of [requiredOptIns] whose markers are declared with
+   * `androidx.annotation.RequiresOptIn` rather than `kotlin.RequiresOptIn`.
+   *
+   * The two mechanisms are not interchangeable at the call site: `kotlin.OptIn` rejects an AndroidX
+   * marker outright ("this class is not an opt-in requirement marker"), and the AndroidX annotation
+   * takes its markers as `@androidx.annotation.OptIn(markerClass = [Foo::class])`. A generator that
+   * knows only the marker names cannot tell which to write, so the mechanism is recorded here at
+   * the one point that can see it — the annotation's own meta-annotations.
+   */
+  val androidxOptIns: List<String>,
 )
 
 internal object ComposableSignature {
@@ -131,7 +142,8 @@ internal object ComposableSignature {
         callableFromAnotherFile =
           fn.visibility == Visibility.PUBLIC || fn.visibility == Visibility.INTERNAL,
         hasTypeParameters = fn.typeParameters.isNotEmpty(),
-        requiredOptIns = requiredOptInsOf(method),
+        requiredOptIns = requiredOptInsOf(method, OPT_IN_MARKER_ANNOTATIONS),
+        androidxOptIns = requiredOptInsOf(method, setOf("androidx.annotation.RequiresOptIn")),
         receiver =
           fn.receiverParameterType?.let { receiver ->
             (receiver.classifier as? KmClassifier.Class)?.name?.replace('/', '.')?.replace('$', '.')
@@ -226,14 +238,12 @@ internal object ComposableSignature {
    * `ComposableInferredTarget` drops out because it is not itself `@RequiresOptIn`, while an
    * author's `@ExperimentalMaterial3Api` or `@InternalComposeApi` survives.
    */
-  private fun requiredOptInsOf(method: MethodInfo): List<String> =
+  private fun requiredOptInsOf(method: MethodInfo, mechanisms: Set<String>): List<String> =
     method.annotationInfo
       ?.directOnly()
       .orEmpty()
       .filter { annotation ->
-        annotation.classInfo?.annotationInfo?.directOnly()?.any {
-          it.name in OPT_IN_MARKER_ANNOTATIONS
-        } == true
+        annotation.classInfo?.annotationInfo?.directOnly()?.any { it.name in mechanisms } == true
       }
       .map { it.name }
       .distinct()

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -215,6 +215,7 @@ internal object ComposableSignature {
   private fun requiredOptInsOf(method: MethodInfo): List<String> =
     method.annotationInfo
       .orEmpty()
+      .filterNot { it.name in COMPILER_INSERTED_MARKERS }
       .filter { annotation ->
         annotation.classInfo?.annotationInfo?.any { it.name in OPT_IN_MARKER_ANNOTATIONS } == true
       }
@@ -224,6 +225,31 @@ internal object ComposableSignature {
 
   private val OPT_IN_MARKER_ANNOTATIONS =
     setOf("kotlin.RequiresOptIn", "androidx.annotation.RequiresOptIn")
+
+  /**
+   * Opt-in markers the **Compose compiler** stamps onto a JVM method, which no source caller has to
+   * apply.
+   *
+   * These carry `@RequiresOptIn` and so pass the check above, but ordinary code calls `Card` and
+   * `Text` without opting into anything — the annotations describe how the compiler tracked the
+   * function's composable target, not a contract the author asked callers to accept. Reporting them
+   * put `@OptIn(InternalComposeApi::class)` on generated screens, which is worse than noise: it
+   * tells a consumer to opt into Compose's internals to place a button.
+   *
+   * Verified rather than assumed — a generated screen calling `Card`, `Text` and `Button` compiles
+   * with these annotations stripped, which is what says they were never required.
+   *
+   * A denylist because no shape rule separates them: an author-written `@ExperimentalMaterial3Api`
+   * and a compiler-written `@ComposableInferredTarget` are both `@RequiresOptIn` annotations on the
+   * same method, and only their provenance differs.
+   */
+  private val COMPILER_INSERTED_MARKERS =
+    setOf(
+      "androidx.compose.runtime.ComposableInferredTarget",
+      "androidx.compose.runtime.ComposableOpenTarget",
+      "androidx.compose.runtime.ComposableTarget",
+      "androidx.compose.runtime.InternalComposeApi",
+    )
 
   /** Match the metadata function to [method] by JVM signature (name + descriptor). */
   private fun matchFunction(functions: List<KmFunction>, method: MethodInfo): KmFunction? {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.discovery
 
+import io.github.classgraph.AnnotationInfo
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import kotlin.metadata.KmClassifier
@@ -61,6 +62,14 @@ internal data class ComposableSignatureInfo(
    * emptyList())` cannot be called as `Picker()`.
    */
   val hasTypeParameters: Boolean,
+  /**
+   * Whether the composable declares a context receiver or context parameter.
+   *
+   * `context(Theme) @Composable fun Widget()` is callable only where a `Theme` is in scope, and a
+   * generated wrapper supplies none. Nothing in the rendered parameter list says so — the context
+   * is not a value parameter — so a call site would be printed and would not compile.
+   */
+  val hasContextReceivers: Boolean,
   /**
    * Fully-qualified `@RequiresOptIn` marker annotations on the declaration
    * (`androidx.compose.material3.ExperimentalMaterial3Api`).
@@ -142,6 +151,7 @@ internal object ComposableSignature {
         callableFromAnotherFile =
           fn.visibility == Visibility.PUBLIC || fn.visibility == Visibility.INTERNAL,
         hasTypeParameters = fn.typeParameters.isNotEmpty(),
+        hasContextReceivers = hasContextRequirement(fn),
         requiredOptIns = requiredOptInsOf(method, OPT_IN_MARKER_ANNOTATIONS),
         androidxOptIns = requiredOptInsOf(method, setOf("androidx.annotation.RequiresOptIn")),
         receiver =
@@ -245,9 +255,45 @@ internal object ComposableSignature {
       .filter { annotation ->
         annotation.classInfo?.annotationInfo?.directOnly()?.any { it.name in mechanisms } == true
       }
-      .map { it.name }
+      .map { sourceNameOf(it) }
       .distinct()
       .sorted()
+
+  /**
+   * Whether [fn] can only be called where some context is in scope.
+   *
+   * **Partial, and deliberately so.** `context(Theme)` compiled by an older toolchain lands in
+   * `contextReceiverTypes`, which is what this reads. Kotlin 2.2 onwards records the same
+   * declaration as a context *parameter* instead, and `KmFunction.contextParameters` is gated on an
+   * opt-in marker that itself requires API version 2.2 — this module targets 2.0, so the accessor
+   * cannot be referenced here at all.
+   *
+   * So a component compiled by a 2.2+ toolchain with a context parameter is still admitted and
+   * still produces a call that does not compile. That is a real gap, named here rather than hidden
+   * behind a check that looks total: closing it needs this module's API version raised, which is a
+   * build-wide decision and not this change's to make.
+   */
+  @OptIn(kotlin.metadata.ExperimentalContextReceivers::class)
+  @Suppress("DEPRECATION", "DEPRECATION_ERROR")
+  private fun hasContextRequirement(fn: KmFunction): Boolean = fn.contextReceiverTypes.isNotEmpty()
+
+  /**
+   * An annotation class's name as Kotlin source spells it.
+   *
+   * ClassGraph reports the **binary** name, where `$` separates a nested class from its outer one —
+   * but `$` is also legal inside a backticked top-level name (``annotation class
+   * `Api${'$'}Experimental` ``), so replacing every `$` with `.` corrupts the second case while
+   * fixing the first. The nesting chain says which is which, so the source name is rebuilt from it
+   * here, once, and the emitter gets a name it can print verbatim.
+   */
+  private fun sourceNameOf(annotation: AnnotationInfo): String {
+    val info = annotation.classInfo ?: return annotation.name
+    val outers = info.outerClasses?.reversed().orEmpty()
+    if (outers.isEmpty()) return annotation.name
+    val packageName = annotation.name.substringBeforeLast('.', "")
+    val nesting = (outers.map { it.simpleName } + info.simpleName).joinToString(".")
+    return if (packageName.isEmpty()) nesting else "$packageName.$nesting"
+  }
 
   private val OPT_IN_MARKER_ANNOTATIONS =
     setOf("kotlin.RequiresOptIn", "androidx.annotation.RequiresOptIn")

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ComposableSignature.kt
@@ -205,19 +205,35 @@ internal object ComposableSignature {
   }
 
   /**
-   * The `@RequiresOptIn`-marked annotations applied to [method].
+   * The `@RequiresOptIn`-marked annotations a caller of [method] has to opt into.
    *
    * An opt-in marker is an annotation whose own class carries `@RequiresOptIn`, so this resolves
    * one level up rather than pattern-matching names like `Experimental…` — a convention plenty of
    * annotations follow without gating anything. An annotation class outside the scan resolves to
    * null and is skipped: unrecognised, not assumed.
+   *
+   * **`directOnly()` at both levels is what makes this correct, and its absence is what made the
+   * first version wrong.** ClassGraph's `annotationInfo` is the transitive closure of
+   * meta-annotations, not the annotations written on the element: `Card` carries `@Composable`,
+   * `@ComposableInferredTarget` and `@FunctionKeyMeta`, and the closure of those three drags in
+   * `InternalComposeApi`, `ComposeCompilerApi` and `kotlin.RequiresOptIn` itself. Reading the
+   * closure therefore reported `@OptIn(InternalComposeApi::class)` for placing a `Card` — telling
+   * consumers to opt into Compose's internals to draw a container.
+   *
+   * Filtering those names out was the first fix and the wrong one: it also silenced a component an
+   * author had *deliberately* marked `@InternalComposeApi`, whose callers really must opt in.
+   * Direct annotations answer the actual Kotlin rule — this element, this marker — so
+   * `ComposableInferredTarget` drops out because it is not itself `@RequiresOptIn`, while an
+   * author's `@ExperimentalMaterial3Api` or `@InternalComposeApi` survives.
    */
   private fun requiredOptInsOf(method: MethodInfo): List<String> =
     method.annotationInfo
+      ?.directOnly()
       .orEmpty()
-      .filterNot { it.name in COMPILER_INSERTED_MARKERS }
       .filter { annotation ->
-        annotation.classInfo?.annotationInfo?.any { it.name in OPT_IN_MARKER_ANNOTATIONS } == true
+        annotation.classInfo?.annotationInfo?.directOnly()?.any {
+          it.name in OPT_IN_MARKER_ANNOTATIONS
+        } == true
       }
       .map { it.name }
       .distinct()
@@ -225,31 +241,6 @@ internal object ComposableSignature {
 
   private val OPT_IN_MARKER_ANNOTATIONS =
     setOf("kotlin.RequiresOptIn", "androidx.annotation.RequiresOptIn")
-
-  /**
-   * Opt-in markers the **Compose compiler** stamps onto a JVM method, which no source caller has to
-   * apply.
-   *
-   * These carry `@RequiresOptIn` and so pass the check above, but ordinary code calls `Card` and
-   * `Text` without opting into anything — the annotations describe how the compiler tracked the
-   * function's composable target, not a contract the author asked callers to accept. Reporting them
-   * put `@OptIn(InternalComposeApi::class)` on generated screens, which is worse than noise: it
-   * tells a consumer to opt into Compose's internals to place a button.
-   *
-   * Verified rather than assumed — a generated screen calling `Card`, `Text` and `Button` compiles
-   * with these annotations stripped, which is what says they were never required.
-   *
-   * A denylist because no shape rule separates them: an author-written `@ExperimentalMaterial3Api`
-   * and a compiler-written `@ComposableInferredTarget` are both `@RequiresOptIn` annotations on the
-   * same method, and only their provenance differs.
-   */
-  private val COMPILER_INSERTED_MARKERS =
-    setOf(
-      "androidx.compose.runtime.ComposableInferredTarget",
-      "androidx.compose.runtime.ComposableOpenTarget",
-      "androidx.compose.runtime.ComposableTarget",
-      "androidx.compose.runtime.InternalComposeApi",
-    )
 
   /** Match the metadata function to [method] by JVM signature (name + descriptor). */
   private fun matchFunction(functions: List<KmFunction>, method: MethodInfo): KmFunction? {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1463,6 +1463,17 @@ data class PreviewTarget(
    * must apply itself — see `ComposableSignatureInfo.requiredOptIns`.
    */
   val requiredOptIns: List<String> = emptyList(),
+  /**
+   * The subset of [requiredOptIns] whose markers are declared with
+   * `androidx.annotation.RequiresOptIn` rather than `kotlin.RequiresOptIn`.
+   *
+   * The two mechanisms are not interchangeable at the call site: `kotlin.OptIn` rejects an AndroidX
+   * marker outright ("this class is not an opt-in requirement marker"), and the AndroidX annotation
+   * takes its markers as `@androidx.annotation.OptIn(markerClass = [Foo::class])`. A generator that
+   * knows only the marker names cannot tell which to write, so the mechanism is recorded here at
+   * the one point that can see it — the annotation's own meta-annotations.
+   */
+  val androidxOptIns: List<String> = emptyList(),
 )
 
 /**

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewData.kt
@@ -1459,6 +1459,11 @@ data class PreviewTarget(
    */
   val hasTypeParameters: Boolean = false,
   /**
+   * Whether the composable declares a context receiver or context parameter, which a generated
+   * wrapper cannot supply — see `ComposableSignatureInfo.hasContextReceivers`.
+   */
+  val hasContextReceivers: Boolean = false,
+  /**
    * Fully-qualified `@RequiresOptIn` markers the declaration carries, which a generated wrapper
    * must apply itself — see `ComposableSignatureInfo.requiredOptIns`.
    */

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -226,6 +226,7 @@ object PreviewTargetInference {
         signatureKnown = true,
         callableFromAnotherFile = signature.callableFromAnotherFile,
         hasTypeParameters = signature.hasTypeParameters,
+        hasContextReceivers = signature.hasContextReceivers,
         requiredOptIns = signature.requiredOptIns,
         androidxOptIns = signature.androidxOptIns,
       )
@@ -347,6 +348,7 @@ object PreviewTargetInference {
         // Null metadata keeps the permissive defaults: "not recovered" must not read as "private".
         callableFromAnotherFile = signature?.callableFromAnotherFile ?: true,
         hasTypeParameters = signature?.hasTypeParameters ?: false,
+        hasContextReceivers = signature?.hasContextReceivers ?: false,
         requiredOptIns = signature?.requiredOptIns.orEmpty(),
         androidxOptIns = signature?.androidxOptIns.orEmpty(),
       )

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewTargetInference.kt
@@ -227,6 +227,7 @@ object PreviewTargetInference {
         callableFromAnotherFile = signature.callableFromAnotherFile,
         hasTypeParameters = signature.hasTypeParameters,
         requiredOptIns = signature.requiredOptIns,
+        androidxOptIns = signature.androidxOptIns,
       )
     }
   }
@@ -347,6 +348,7 @@ object PreviewTargetInference {
         callableFromAnotherFile = signature?.callableFromAnotherFile ?: true,
         hasTypeParameters = signature?.hasTypeParameters ?: false,
         requiredOptIns = signature?.requiredOptIns.orEmpty(),
+        androidxOptIns = signature?.androidxOptIns.orEmpty(),
       )
     )
   }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.discovery
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A screen a builder composed out of components, in the shape a code generator can consume.
+ *
+ * This is deliberately **not** the UI builder's own document model. It is the narrow subset
+ * [ScreenGenerator] needs — which component, what the user set, what went in each slot — so that
+ * the generator can be tested and reasoned about without dragging an editor's undo stack, presence
+ * state and collaboration protocol along with it. A builder projects its document onto this; the
+ * projection is the builder's job and the interesting decisions are not in it.
+ */
+@Serializable
+data class ScreenDocument(
+  /** The generated composable's name. Must be a valid Kotlin identifier — the generator checks. */
+  val name: String,
+  val root: ScreenNode,
+)
+
+/**
+ * One placed component: which one, the arguments the user set, and what they dropped into its
+ * slots.
+ *
+ * @property componentId the [ComponentRecord.canonicalId] this node places. An id with no matching
+ *   record is a refusal, never a guess — a builder pinned to a catalog it no longer has is exactly
+ *   the case where inventing a call site produces confident nonsense.
+ * @property arguments values the user set, by **source parameter name**. A name the component does
+ *   not declare is a refusal: silently dropping it would generate a screen that compiles and is not
+ *   the one that was designed.
+ * @property slots children by slot name. A slot the component does not declare is likewise refused.
+ */
+@Serializable
+data class ScreenNode(
+  val componentId: String,
+  val arguments: Map<String, ScreenValue> = emptyMap(),
+  val slots: Map<String, List<ScreenNode>> = emptyMap(),
+)
+
+/**
+ * A value a builder can set on a parameter.
+ *
+ * A closed set on purpose. Every case here has an unambiguous Kotlin literal *and* an unambiguous
+ * type to check against the parameter's [TargetParameter.typeFqn], which is what lets the generator
+ * reject `text = true` instead of emitting it. Widening this set means widening the type check with
+ * it — a value kind whose type cannot be checked is a call site nobody can prove compiles.
+ */
+@Serializable
+sealed interface ScreenValue {
+  @Serializable data class Text(val value: String) : ScreenValue
+
+  @Serializable data class Bool(val value: Boolean) : ScreenValue
+
+  @Serializable data class Whole(val value: Long) : ScreenValue
+
+  @Serializable data class Fractional(val value: Double) : ScreenValue
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -104,9 +104,7 @@ object ScreenGenerator {
           // Qualified, not imported and shortened: two markers can share a simple name from
           // different packages, and `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` is
           // ambiguous rather than merely ugly. Same reasoning as the component calls below.
-          optIns.joinToString(", ", "@OptIn(", ")") {
-            "${ComponentSnippets.escapeCallableIfKeyword(it)}::class"
-          }
+          optIns.joinToString(", ", "@OptIn(", ")") { "${markerReference(it)}::class" }
         )
       }
       appendLine("@Composable")
@@ -128,7 +126,7 @@ object ScreenGenerator {
     val optIns = mutableSetOf<String>()
     val reasons = mutableListOf<String>()
 
-    fun node(node: ScreenNode, depth: Int): String {
+    fun node(node: ScreenNode, depth: Int, inReceiverScope: Boolean = false): String {
       val pad = INDENT.repeat(depth)
       val record = byId[node.componentId]
       if (record == null) {
@@ -136,7 +134,7 @@ object ScreenGenerator {
         // Keep walking its children: a catalog that dropped a whole subtree should name every node
         // it can no longer place, not just the outermost one. `reasons` is what a caller acts on,
         // and the text returned here is discarded the moment anything has failed.
-        node.slots.values.flatten().forEach { node(it, depth + 1) }
+        node.slots.values.flatten().forEach { node(it, depth + 1, inReceiverScope) }
         return "$pad// unresolved: ${node.componentId}"
       }
       // The licence to call at all. Everything a refusal protects against — private, generic,
@@ -145,11 +143,11 @@ object ScreenGenerator {
       if (code?.call == null) {
         reasons +=
           "`${node.componentId}` has no call site: ${code?.refusedReason ?: "no code was recorded"}"
-        node.slots.values.flatten().forEach { node(it, depth + 1) }
+        node.slots.values.flatten().forEach { node(it, depth + 1, inReceiverScope) }
         return "$pad// unusable: ${node.componentId}"
       }
       val qualified = ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
-      if (record.canonicalId in simplyImportable) imports += qualified
+      if (record.canonicalId in simplyImportable && !inReceiverScope) imports += qualified
       optIns += code.requiredOptIns
 
       val byName = record.parameters.associateBy { it.name }
@@ -171,7 +169,7 @@ object ScreenGenerator {
           // never reached and its subtree would go unreported — the same gap as an unresolved
           // node's children, one level in. A renamed slot is exactly when a document is most
           // likely to be stale further down, so those children are the ones worth naming.
-          children.forEach { node(it, depth + 1) }
+          children.forEach { node(it, depth + 1, inReceiverScope) }
         }
       }
 
@@ -192,9 +190,15 @@ object ScreenGenerator {
             reasons +=
               "`${record.symbol.name}`.`${parameter.name}` is `${parameter.type}`, which children " +
                 "in a bare lambda cannot satisfy"
+            // The third branch that rejects a node and would otherwise drop its subtree, after an
+            // unresolved id and a slot the component never declared. All three now walk on.
+            children.forEach { node(it, depth + 1, inReceiverScope) }
           }
           children != null && parameter.composableSlot -> {
-            val nested = children.joinToString("\n") { node(it, depth + 1) }
+            val nested =
+              children.joinToString("\n") {
+                node(it, depth + 1, inReceiverScope || hasReceiver(parameter.type))
+              }
             arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = {\n$nested\n$pad}"
           }
           // Untouched by the document. A default may be omitted; anything else still has to be
@@ -213,7 +217,7 @@ object ScreenGenerator {
         }
       }
       val name =
-        if (record.canonicalId in simplyImportable)
+        if (record.canonicalId in simplyImportable && !inReceiverScope)
           ComponentSnippets.escapeIfKeyword(record.symbol.name)
         else qualified
       return "$pad$name(${arguments.joinToString(", ")})"
@@ -229,7 +233,21 @@ object ScreenGenerator {
       val type = ComponentSnippets.qualifiedTypeOf(parameter)
       val literal =
         when (value) {
-          is ScreenValue.Text -> if (type == "kotlin.String") quote(value.value) else null
+          is ScreenValue.Text ->
+            when {
+              type != "kotlin.String" -> null
+              // A JVM constant-pool string is length-prefixed with an unsigned short, so a value
+              // over 65535 modified-UTF-8 bytes cannot be a literal at all — the backend fails
+              // late, on a file this generator has already called compilable. Nothing bounds a
+              // pasted document value, so it is measured and refused rather than assumed small.
+              modifiedUtf8Length(value.value) > MAX_CONSTANT_POOL_STRING -> {
+                reasons +=
+                  "`$owner`.`${parameter.name}` is ${modifiedUtf8Length(value.value)} bytes, past " +
+                    "the $MAX_CONSTANT_POOL_STRING a JVM string constant can hold"
+                return null
+              }
+              else -> quote(value.value)
+            }
           is ScreenValue.Bool -> if (type == "kotlin.Boolean") value.value.toString() else null
           is ScreenValue.Whole ->
             when (type) {
@@ -302,6 +320,36 @@ object ScreenGenerator {
     KOTLIN_IDENTIFIER.matches(name) &&
       !ComponentSnippets.isHardKeyword(name) &&
       name.any { it != '_' }
+
+  /**
+   * The source spelling of an opt-in marker's class name.
+   *
+   * ClassGraph reports a nested annotation by its **binary** name — `com.example.Api$Experimental`
+   * — and `$` is not a nesting separator in Kotlin source, so emitting it verbatim produces an
+   * annotation the compiler rejects. The segments are then keyword-escaped like any other path,
+   * because a marker under `com.`when`` is spelled without the backticks in the binary name too.
+   */
+  private fun markerReference(marker: String): String =
+    ComponentSnippets.escapeCallableIfKeyword(marker.replace('$', '.'))
+
+  /** Whether the function type [type] declares a receiver, as `ColumnScope.() -> Unit` does. */
+  private fun hasReceiver(type: String): Boolean = type.substringBefore('(').contains('.')
+
+  /**
+   * The bytes [value] occupies as a JVM constant-pool string.
+   *
+   * Modified UTF-8, not UTF-8: `NUL` is two bytes rather than one, and a supplementary character is
+   * six (both halves of the surrogate pair encoded separately) rather than four.
+   */
+  private fun modifiedUtf8Length(value: String): Int = value.sumOf { c ->
+    when {
+      c.code in 1..0x7F -> 1
+      c.code <= 0x7FF -> 2
+      else -> 3
+    }
+  }
+
+  private const val MAX_CONSTANT_POOL_STRING = 65535
 
   private val KOTLIN_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -76,6 +76,23 @@ object ScreenGenerator {
         listOf("screen name `${document.name}` is not a usable Kotlin function name")
       )
     }
+    // A record older than `androidxOptIns` carries every marker in `requiredOptIns` with no way to
+    // say which mechanism declared it, and guessing `kotlin.OptIn` is what this whole split exists
+    // to stop. Refused only when such a record actually carries markers — an old catalog with no
+    // opt-ins at all is unambiguous and still generates.
+    if (components.schemaVersion < COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA) {
+      val unclassifiable =
+        components.components.filter { it.code?.requiredOptIns?.isNotEmpty() == true }
+      if (unclassifiable.isNotEmpty()) {
+        return Result.Refused(
+          unclassifiable.map {
+            "`${it.canonicalId}` carries opt-in markers from schema ${components.schemaVersion}, " +
+              "which did not record whether each needs `kotlin.OptIn` or " +
+              "`androidx.annotation.OptIn`"
+          }
+        )
+      }
+    }
     val byId = components.components.associateBy { it.canonicalId }
     // Two components can share a simple name (`com.a.Badge`, `com.b.Badge`), and a screen can share
     // one with a component it calls — `fun HomeScreen()` calling a `HomeScreen` component would
@@ -209,10 +226,17 @@ object ScreenGenerator {
             // scalar loses (a literal cannot be a function type, so `literal` refuses it), but the
             // slot's children would never be visited otherwise — the fourth branch that rejects a
             // node and would drop its subtree.
+            //
+            // Only when the slot loop above did not already walk them. It walks the children of
+            // any slot it rejected, so for a parameter that is not a composable slot both paths
+            // fire, every reason below is duplicated, and a document conflicted at each level
+            // doubles the work per level.
             if (children != null) {
               reasons +=
                 "`${record.symbol.name}`.`${parameter.name}` is set as both a value and a slot"
-              children.forEach { node(it, depth + 1, inReceiverScope || hasReceiver(parameter)) }
+              if (parameter.composableSlot) {
+                children.forEach { node(it, depth + 1, inReceiverScope || hasReceiver(parameter)) }
+              }
             }
           }
           children != null &&
@@ -350,20 +374,19 @@ object ScreenGenerator {
    * reserved in Kotlin".
    */
   private fun isUsableIdentifier(name: String): Boolean =
-    KOTLIN_IDENTIFIER.matches(name) &&
-      !ComponentSnippets.isHardKeyword(name) &&
-      name.any { it != '_' }
+    isIdentifier(name) && !ComponentSnippets.isHardKeyword(name) && name.any { it != '_' }
 
   /**
-   * The source spelling of an opt-in marker's class name.
+   * An opt-in marker, spelled for source.
    *
-   * ClassGraph reports a nested annotation by its **binary** name — `com.example.Api$Experimental`
-   * — and `$` is not a nesting separator in Kotlin source, so emitting it verbatim produces an
-   * annotation the compiler rejects. The segments are then keyword-escaped like any other path,
-   * because a marker under `com.`when`` is spelled without the backticks in the binary name too.
+   * The name arrives already in source notation — the producer rebuilds a nested marker's name from
+   * its nesting chain, because `$` is a nesting separator in a binary name and an ordinary
+   * character inside a backticked one, and only the chain tells them apart. All that is left here
+   * is keyword escaping, since a marker under `com.`when`` is spelled without backticks anywhere it
+   * is recorded.
    */
   private fun markerReference(marker: String): String =
-    ComponentSnippets.escapeCallableIfKeyword(marker.replace('$', '.'))
+    ComponentSnippets.escapeCallableIfKeyword(marker)
 
   /**
    * The bytes [value] occupies as a JVM constant-pool string.
@@ -405,5 +428,16 @@ object ScreenGenerator {
    */
   private val RESERVED_BY_THE_WRAPPER = setOf("Composable")
 
-  private val KOTLIN_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
+  /**
+   * Kotlin's own identifier rule: `(Letter | '_') (Letter | '_' | UnicodeDigit)*`.
+   *
+   * Not `[A-Za-z_][A-Za-z0-9_]*`. `Übersicht`, `画面` and `généré` are identifiers Kotlin accepts
+   * without backticks, and an ASCII-only rule refused documents that were never wrong — a refusal
+   * costs nothing to the compiler and everything to whoever named their screen in their own
+   * language.
+   */
+  private fun isIdentifier(name: String): Boolean =
+    name.isNotEmpty() &&
+      (name[0].isLetter() || name[0] == '_') &&
+      name.all { it.isLetter() || it.isDigit() || it == '_' }
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -96,7 +96,10 @@ object ScreenGenerator {
     val body = context.node(document.root, depth = 1)
     if (context.reasons.isNotEmpty()) return Result.Refused(context.reasons.toList())
 
-    val optIns = context.optIns.toSortedSet().toList()
+    // An AndroidX-mechanism marker is reported by both scans, so it is subtracted here rather than
+    // written twice under two annotations that would each reject the other's markers.
+    val androidxOptIns = context.androidxOptIns.toSortedSet().toList()
+    val optIns = (context.optIns - context.androidxOptIns).toSortedSet().toList()
     val imports = (context.imports + "androidx.compose.runtime.Composable").toSortedSet()
     val source = buildString {
       appendLine("package $packageName")
@@ -111,12 +114,26 @@ object ScreenGenerator {
           optIns.joinToString(", ", "@OptIn(", ")") { "${markerReference(it)}::class" }
         )
       }
+      if (androidxOptIns.isNotEmpty()) {
+        // A different annotation, not a stylistic variant: `kotlin.OptIn` rejects a marker declared
+        // with `androidx.annotation.RequiresOptIn` ("this class is not an opt-in requirement
+        // marker"), and the AndroidX one takes an array under a named `markerClass`.
+        appendLine(
+          androidxOptIns.joinToString(
+            ", ",
+            "@androidx.annotation.OptIn(markerClass = [",
+            "])",
+          ) {
+            "${markerReference(it)}::class"
+          }
+        )
+      }
       appendLine("@Composable")
       appendLine("fun ${document.name}() {")
       appendLine(body)
       appendLine("}")
     }
-    return Result.Emitted(source = source, requiredOptIns = optIns)
+    return Result.Emitted(source = source, requiredOptIns = optIns + androidxOptIns)
   }
 
   /**
@@ -128,6 +145,7 @@ object ScreenGenerator {
   ) {
     val imports = mutableSetOf<String>()
     val optIns = mutableSetOf<String>()
+    val androidxOptIns = mutableSetOf<String>()
     val reasons = mutableListOf<String>()
 
     fun node(node: ScreenNode, depth: Int, inReceiverScope: Boolean = false): String {
@@ -153,6 +171,7 @@ object ScreenGenerator {
       val qualified = ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
       if (record.canonicalId in simplyImportable && !inReceiverScope) imports += qualified
       optIns += code.requiredOptIns
+      androidxOptIns += code.androidxOptIns
 
       val byName = record.parameters.associateBy { it.name }
       node.arguments.keys.filterNot(byName::containsKey).forEach {
@@ -182,10 +201,20 @@ object ScreenGenerator {
         val supplied = node.arguments[parameter.name]
         val children = node.slots[parameter.name]
         when {
-          supplied != null ->
+          supplied != null -> {
             literal(supplied, parameter, record.symbol.name)?.let {
               arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $it"
             }
+            // A conflicted document can set both an argument and a slot for one parameter. The
+            // scalar loses (a literal cannot be a function type, so `literal` refuses it), but the
+            // slot's children would never be visited otherwise — the fourth branch that rejects a
+            // node and would drop its subtree.
+            if (children != null) {
+              reasons +=
+                "`${record.symbol.name}`.`${parameter.name}` is set as both a value and a slot"
+              children.forEach { node(it, depth + 1, inReceiverScope || hasReceiver(parameter)) }
+            }
+          }
           children != null &&
             parameter.composableSlot &&
             !ComponentSnippets.acceptsBareLambda(parameter.type) -> {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -1,0 +1,207 @@
+package ee.schimke.composeai.discovery
+
+/**
+ * Generates a compilable `@Composable` screen from a [ScreenDocument] and the components a build
+ * discovered.
+ *
+ * ## What this adds over [ComponentSnippets]
+ *
+ * [ComponentSnippets] prints one component's call site with **placeholders** — `Text(text = "")` —
+ * which proves a component is reachable but renders nothing anyone designed. This binds the values
+ * a builder actually set, and nests components into each other's slots, so the output is the screen
+ * rather than a specimen of its parts.
+ *
+ * ## What it inherits, and why that matters
+ *
+ * A node is generated only when its record carries an emitted [ComponentCode]. That single check
+ * carries every protection the call-site generator learned the hard way: the component is public,
+ * has no uninferable type parameters, did not collide with an overload, is a top-level function
+ * with an importable callable, and has a signature that was actually read rather than defaulted
+ * away. None of that is re-derived here — a second implementation of those rules is how two halves
+ * of a contract start disagreeing.
+ *
+ * What is *not* inherited is the argument list: `code.call` fills required parameters with
+ * placeholders, and this replaces them with the document's values. So the emitted call is built
+ * here from [ComponentRecord.parameters], with `code.call` used as the licence to call at all.
+ *
+ * ## Refusing, again
+ *
+ * The discipline is the same one that makes the call-site generator worth anything: emit only what
+ * can be proven, and say why otherwise. A builder pinned to a catalog it no longer has, a property
+ * the component never declared, a string handed to a `Boolean` — each is a refusal naming the node,
+ * because a screen that compiles and is not the one designed is worse than an error message.
+ */
+object ScreenGenerator {
+
+  /** The generated file, or the reasons it could not be generated. */
+  sealed interface Result {
+    data class Emitted(
+      /** A complete Kotlin file: package, imports, opt-ins and the screen composable. */
+      val source: String,
+      /**
+       * Every `@RequiresOptIn` marker the screen's components need, already applied to [source].
+       */
+      val requiredOptIns: List<String>,
+    ) : Result
+
+    /** Every problem found, not just the first — a builder wants the whole list to act on. */
+    data class Refused(val reasons: List<String>) : Result
+  }
+
+  private const val INDENT = "    "
+
+  fun generate(
+    document: ScreenDocument,
+    components: ComponentRecordFile,
+    packageName: String = "generated.screen",
+  ): Result {
+    if (!KOTLIN_IDENTIFIER.matches(document.name)) {
+      return Result.Refused(listOf("screen name `${document.name}` is not a Kotlin identifier"))
+    }
+    val byId = components.components.associateBy { it.canonicalId }
+    val context = Emission(byId)
+    val body = context.node(document.root, depth = 1)
+    if (context.reasons.isNotEmpty()) return Result.Refused(context.reasons.toList())
+
+    val optIns = context.optIns.toSortedSet().toList()
+    val imports = (context.imports + optIns + "androidx.compose.runtime.Composable").toSortedSet()
+    val source = buildString {
+      appendLine("package $packageName")
+      appendLine()
+      imports.forEach { appendLine("import $it") }
+      appendLine()
+      if (optIns.isNotEmpty()) {
+        appendLine(
+          optIns.joinToString(", ", "@OptIn(", ")") { "${it.substringAfterLast('.')}::class" }
+        )
+      }
+      appendLine("@Composable")
+      appendLine("fun ${document.name}() {")
+      appendLine(body)
+      appendLine("}")
+    }
+    return Result.Emitted(source = source, requiredOptIns = optIns)
+  }
+
+  /**
+   * Accumulates one generation pass: the text, the imports it needs, and every reason it failed.
+   */
+  private class Emission(val byId: Map<String, ComponentRecord>) {
+    val imports = mutableSetOf<String>()
+    val optIns = mutableSetOf<String>()
+    val reasons = mutableListOf<String>()
+
+    fun node(node: ScreenNode, depth: Int): String {
+      val pad = INDENT.repeat(depth)
+      val record = byId[node.componentId]
+      if (record == null) {
+        reasons += "no component `${node.componentId}` in this catalog"
+        return "$pad// unresolved: ${node.componentId}"
+      }
+      // The licence to call at all. Everything a refusal protects against — private, generic,
+      // collided, unreadable, not importable — is already decided here, once, by the producer.
+      val code = record.code
+      if (code?.call == null) {
+        reasons +=
+          "`${node.componentId}` has no call site: ${code?.refusedReason ?: "no code was recorded"}"
+        return "$pad// unusable: ${node.componentId}"
+      }
+      imports += ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
+      optIns += code.requiredOptIns
+
+      val byName = record.parameters.associateBy { it.name }
+      node.arguments.keys.filterNot(byName::containsKey).forEach {
+        reasons += "`${record.symbol.name}` has no parameter `$it`"
+      }
+      node.slots.keys.forEach { slot ->
+        val parameter = byName[slot]
+        when {
+          parameter == null -> reasons += "`${record.symbol.name}` has no slot `$slot`"
+          !parameter.composableSlot ->
+            reasons += "`${record.symbol.name}`.`$slot` is a parameter, not a @Composable slot"
+        }
+      }
+
+      val arguments = mutableListOf<String>()
+      for (parameter in record.parameters) {
+        val supplied = node.arguments[parameter.name]
+        val children = node.slots[parameter.name]
+        when {
+          supplied != null ->
+            literal(supplied, parameter, record.symbol.name)?.let {
+              arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $it"
+            }
+          children != null && parameter.composableSlot -> {
+            val nested = children.joinToString("\n") { node(it, depth + 1) }
+            arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = {\n$nested\n$pad}"
+          }
+          // Untouched by the document. A default may be omitted; anything else still has to be
+          // filled, and the placeholder table is the same one the call-site generator uses.
+          parameter.hasDefault -> Unit
+          else -> {
+            val placeholder = ComponentSnippets.placeholderFor(parameter)
+            if (placeholder == null) {
+              reasons +=
+                "`${record.symbol.name}` needs `${parameter.name}: ${parameter.type}` and the " +
+                  "document does not set it"
+            } else {
+              arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $placeholder"
+            }
+          }
+        }
+      }
+      val name = ComponentSnippets.escapeIfKeyword(record.symbol.name)
+      return "$pad$name(${arguments.joinToString(", ")})"
+    }
+
+    /**
+     * The Kotlin literal for [value], or null having recorded why it does not fit [parameter].
+     *
+     * Checked against the **qualified** type, so a `com.example.String` property is rejected rather
+     * than handed a string literal — the trap the call-site generator was caught by twice.
+     */
+    fun literal(value: ScreenValue, parameter: TargetParameter, owner: String): String? {
+      val type = ComponentSnippets.qualifiedTypeOf(parameter)
+      val literal =
+        when (value) {
+          is ScreenValue.Text -> if (type == "kotlin.String") quote(value.value) else null
+          is ScreenValue.Bool -> if (type == "kotlin.Boolean") value.value.toString() else null
+          is ScreenValue.Whole ->
+            when (type) {
+              "kotlin.Int" -> value.value.toInt().toString()
+              "kotlin.Long" -> "${value.value}L"
+              else -> null
+            }
+          is ScreenValue.Fractional ->
+            when (type) {
+              "kotlin.Float" -> "${value.value}f"
+              "kotlin.Double" -> value.value.toString()
+              else -> null
+            }
+        }
+      if (literal == null) {
+        reasons += "`$owner`.`${parameter.name}` is $type, which ${value::class.simpleName} is not"
+      }
+      return literal
+    }
+  }
+
+  /**
+   * A Kotlin string literal for [value].
+   *
+   * `$` needs escaping as much as `"` does: a user typing `$name` into a label would otherwise
+   * generate a template referring to a variable that does not exist, which is a compile error
+   * produced by ordinary text.
+   */
+  private fun quote(value: String): String =
+    value
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("$", "\\$")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+      .replace("\t", "\\t")
+      .let { "\"$it\"" }
+
+  private val KOTLIN_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
+}

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -374,7 +374,9 @@ object ScreenGenerator {
    * reserved in Kotlin".
    */
   private fun isUsableIdentifier(name: String): Boolean =
-    isIdentifier(name) && !ComponentSnippets.isHardKeyword(name) && name.any { it != '_' }
+    ComponentSnippets.isIdentifier(name) &&
+      !ComponentSnippets.isHardKeyword(name) &&
+      name.any { it != '_' }
 
   /**
    * An opt-in marker, spelled for source.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -55,16 +55,50 @@ object ScreenGenerator {
     components: ComponentRecordFile,
     packageName: String = "generated.screen",
   ): Result {
-    if (!KOTLIN_IDENTIFIER.matches(document.name)) {
-      return Result.Refused(listOf("screen name `${document.name}` is not a Kotlin identifier"))
+    if (components.schemaVersion > COMPONENT_RECORD_SCHEMA_VERSION) {
+      // A record from a newer producer may mean things by fields this build has never seen.
+      // Reading it as the current schema is exactly the guess the version exists to prevent.
+      return Result.Refused(
+        listOf(
+          "components.json is schema ${components.schemaVersion}, newer than the " +
+            "$COMPONENT_RECORD_SCHEMA_VERSION this generator understands"
+        )
+      )
+    }
+    val badSegment =
+      packageName.split('.').firstOrNull {
+        !KOTLIN_IDENTIFIER.matches(it) || ComponentSnippets.isHardKeyword(it)
+      }
+    if (badSegment != null) {
+      return Result.Refused(
+        listOf("package segment `$badSegment` is not a usable Kotlin identifier")
+      )
+    }
+    if (
+      !KOTLIN_IDENTIFIER.matches(document.name) || ComponentSnippets.isHardKeyword(document.name)
+    ) {
+      return Result.Refused(
+        listOf("screen name `${document.name}` is not a usable Kotlin function name")
+      )
     }
     val byId = components.components.associateBy { it.canonicalId }
-    val context = Emission(byId)
+    // Two components can share a simple name (`com.a.Badge`, `com.b.Badge`), and a screen can share
+    // one with a component it calls — `fun HomeScreen()` calling a `HomeScreen` component would
+    // shadow the import and recurse into itself. Neither is exotic once a catalog spans libraries.
+    // A simple name is only used when exactly one component wants it and the screen does not; the
+    // rest are called fully qualified, which is always unambiguous and needs no import.
+    val claimants = components.components.groupBy { it.symbol.name }
+    val simplyImportable =
+      components.components
+        .filter { claimants.getValue(it.symbol.name).size == 1 && it.symbol.name != document.name }
+        .map { it.canonicalId }
+        .toSet()
+    val context = Emission(byId, simplyImportable)
     val body = context.node(document.root, depth = 1)
     if (context.reasons.isNotEmpty()) return Result.Refused(context.reasons.toList())
 
     val optIns = context.optIns.toSortedSet().toList()
-    val imports = (context.imports + optIns + "androidx.compose.runtime.Composable").toSortedSet()
+    val imports = (context.imports + "androidx.compose.runtime.Composable").toSortedSet()
     val source = buildString {
       appendLine("package $packageName")
       appendLine()
@@ -72,7 +106,10 @@ object ScreenGenerator {
       appendLine()
       if (optIns.isNotEmpty()) {
         appendLine(
-          optIns.joinToString(", ", "@OptIn(", ")") { "${it.substringAfterLast('.')}::class" }
+          // Qualified, not imported and shortened: two markers can share a simple name from
+          // different packages, and `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` is
+          // ambiguous rather than merely ugly. Same reasoning as the component calls below.
+          optIns.joinToString(", ", "@OptIn(", ")") { "$it::class" }
         )
       }
       appendLine("@Composable")
@@ -86,7 +123,10 @@ object ScreenGenerator {
   /**
    * Accumulates one generation pass: the text, the imports it needs, and every reason it failed.
    */
-  private class Emission(val byId: Map<String, ComponentRecord>) {
+  private class Emission(
+    val byId: Map<String, ComponentRecord>,
+    val simplyImportable: Set<String>,
+  ) {
     val imports = mutableSetOf<String>()
     val optIns = mutableSetOf<String>()
     val reasons = mutableListOf<String>()
@@ -96,6 +136,10 @@ object ScreenGenerator {
       val record = byId[node.componentId]
       if (record == null) {
         reasons += "no component `${node.componentId}` in this catalog"
+        // Keep walking its children: a catalog that dropped a whole subtree should name every node
+        // it can no longer place, not just the outermost one. `reasons` is what a caller acts on,
+        // and the text returned here is discarded the moment anything has failed.
+        node.slots.values.flatten().forEach { node(it, depth + 1) }
         return "$pad// unresolved: ${node.componentId}"
       }
       // The licence to call at all. Everything a refusal protects against — private, generic,
@@ -104,9 +148,11 @@ object ScreenGenerator {
       if (code?.call == null) {
         reasons +=
           "`${node.componentId}` has no call site: ${code?.refusedReason ?: "no code was recorded"}"
+        node.slots.values.flatten().forEach { node(it, depth + 1) }
         return "$pad// unusable: ${node.componentId}"
       }
-      imports += ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
+      val qualified = ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
+      if (record.canonicalId in simplyImportable) imports += qualified
       optIns += code.requiredOptIns
 
       val byName = record.parameters.associateBy { it.name }
@@ -131,6 +177,15 @@ object ScreenGenerator {
             literal(supplied, parameter, record.symbol.name)?.let {
               arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $it"
             }
+          children != null &&
+            parameter.composableSlot &&
+            !ComponentSnippets.acceptsBareLambda(parameter.type) -> {
+            // `code.call` may have been emittable only because this slot was defaulted away. A
+            // `(Int, Int) -> Unit` or `() -> String` slot cannot be satisfied by `{ children }`.
+            reasons +=
+              "`${record.symbol.name}`.`${parameter.name}` is `${parameter.type}`, which children " +
+                "in a bare lambda cannot satisfy"
+          }
           children != null && parameter.composableSlot -> {
             val nested = children.joinToString("\n") { node(it, depth + 1) }
             arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = {\n$nested\n$pad}"
@@ -150,7 +205,10 @@ object ScreenGenerator {
           }
         }
       }
-      val name = ComponentSnippets.escapeIfKeyword(record.symbol.name)
+      val name =
+        if (record.canonicalId in simplyImportable)
+          ComponentSnippets.escapeIfKeyword(record.symbol.name)
+        else qualified
       return "$pad$name(${arguments.joinToString(", ")})"
     }
 
@@ -168,14 +226,30 @@ object ScreenGenerator {
           is ScreenValue.Bool -> if (type == "kotlin.Boolean") value.value.toString() else null
           is ScreenValue.Whole ->
             when (type) {
-              "kotlin.Int" -> value.value.toInt().toString()
+              "kotlin.Int" ->
+                // `toInt()` wraps silently: 2147483648 would be emitted as -2147483648, which
+                // compiles and is not the number anyone entered.
+                if (value.value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
+                  value.value.toString()
+                else null
               "kotlin.Long" -> "${value.value}L"
               else -> null
             }
           is ScreenValue.Fractional ->
-            when (type) {
-              "kotlin.Float" -> "${value.value}f"
-              "kotlin.Double" -> value.value.toString()
+            when {
+              // Neither `NaN` nor `Infinity` is a Kotlin literal, so both would emit source the
+              // compiler rejects.
+              !value.value.isFinite() -> null
+              type == "kotlin.Float" -> {
+                // The same narrowing rule as `Int`, which the first pass missed one type down: a
+                // `Double` past `Float`'s range becomes `Infinity`, and one below it collapses to
+                // zero. The float's own rendering is emitted, so the literal is exactly the value
+                // the parameter will hold rather than a `Double` spelling with an `f` stapled on.
+                val narrowed = value.value.toFloat()
+                val lost = !narrowed.isFinite() || (narrowed == 0.0f && value.value != 0.0)
+                if (lost) null else "${narrowed}f"
+              }
+              type == "kotlin.Double" -> value.value.toString()
               else -> null
             }
         }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -76,22 +76,28 @@ object ScreenGenerator {
         listOf("screen name `${document.name}` is not a usable Kotlin function name")
       )
     }
-    // A record older than `androidxOptIns` carries every marker in `requiredOptIns` with no way to
-    // say which mechanism declared it, and guessing `kotlin.OptIn` is what this whole split exists
-    // to stop. Refused only when such a record actually carries markers — an old catalog with no
-    // opt-ins at all is unambiguous and still generates.
+    // **Schema 1 is refused outright**, rather than read with a growing list of exceptions.
+    //
+    // The first attempt kept reading it and refused only the one thing it could name — markers
+    // whose opt-in mechanism it could not classify. That was too clever twice over: it scanned the
+    // whole catalog, so one gated component nobody placed refused a screen built entirely from
+    // stable ones; and it protected only the field it happened to be about, while a schema-1 record
+    // also cannot say whether a component needs a context receiver, so those still slipped through
+    // with a persisted `code.call` and produced a call the compiler rejects.
+    //
+    // Both are the same shape: this generator's guarantee rests on fields schema 1 does not have,
+    // and every one of them would need its own exception here. One rule instead of a table of them
+    // — a producer emits schema 2, and a catalog older than that is regenerated rather than
+    // squinted at.
     if (components.schemaVersion < COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA) {
-      val unclassifiable =
-        components.components.filter { it.code?.requiredOptIns?.isNotEmpty() == true }
-      if (unclassifiable.isNotEmpty()) {
-        return Result.Refused(
-          unclassifiable.map {
-            "`${it.canonicalId}` carries opt-in markers from schema ${components.schemaVersion}, " +
-              "which did not record whether each needs `kotlin.OptIn` or " +
-              "`androidx.annotation.OptIn`"
-          }
+      return Result.Refused(
+        listOf(
+          "components.json is schema ${components.schemaVersion}; this generator needs at least " +
+            "$COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA, which is the first to record whether a " +
+            "component needs a context receiver and which opt-in mechanism each marker uses. " +
+            "Re-run discovery to regenerate the catalog."
         )
-      }
+      )
     }
     val byId = components.components.associateBy { it.canonicalId }
     // Two components can share a simple name (`com.a.Badge`, `com.b.Badge`), and a screen can share
@@ -125,10 +131,12 @@ object ScreenGenerator {
       appendLine()
       if (optIns.isNotEmpty()) {
         appendLine(
-          // Qualified, not imported and shortened: two markers can share a simple name from
-          // different packages, and `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` is
-          // ambiguous rather than merely ugly. Same reasoning as the component calls below.
-          optIns.joinToString(", ", "@OptIn(", ")") { "${markerReference(it)}::class" }
+          // Both halves qualified. The markers because two can share a simple name from different
+          // packages, and `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` is ambiguous
+          // rather than merely ugly; the annotation itself because the generated file sits in a
+          // package the caller chose, and a package declaring its own `OptIn` would capture the
+          // bare name — the AndroidX branch below was already written qualified.
+          optIns.joinToString(", ", "@kotlin.OptIn(", ")") { "${markerReference(it)}::class" }
         )
       }
       if (androidxOptIns.isNotEmpty()) {

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -85,7 +85,11 @@ object ScreenGenerator {
     val claimants = components.components.groupBy { it.symbol.name }
     val simplyImportable =
       components.components
-        .filter { claimants.getValue(it.symbol.name).size == 1 && it.symbol.name != document.name }
+        .filter {
+          claimants.getValue(it.symbol.name).size == 1 &&
+            it.symbol.name != document.name &&
+            it.symbol.name !in RESERVED_BY_THE_WRAPPER
+        }
         .map { it.canonicalId }
         .toSet()
     val context = Emission(byId, simplyImportable)
@@ -197,7 +201,7 @@ object ScreenGenerator {
           children != null && parameter.composableSlot -> {
             val nested =
               children.joinToString("\n") {
-                node(it, depth + 1, inReceiverScope || hasReceiver(parameter.type))
+                node(it, depth + 1, inReceiverScope || hasReceiver(parameter))
               }
             arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = {\n$nested\n$pad}"
           }
@@ -332,9 +336,6 @@ object ScreenGenerator {
   private fun markerReference(marker: String): String =
     ComponentSnippets.escapeCallableIfKeyword(marker.replace('$', '.'))
 
-  /** Whether the function type [type] declares a receiver, as `ColumnScope.() -> Unit` does. */
-  private fun hasReceiver(type: String): Boolean = type.substringBefore('(').contains('.')
-
   /**
    * The bytes [value] occupies as a JVM constant-pool string.
    *
@@ -349,7 +350,31 @@ object ScreenGenerator {
     }
   }
 
+  /**
+   * Whether children placed in [parameter] execute inside an implicit receiver.
+   *
+   * The **recorded** receiver is the answer, because the rendered type is a lossy spelling: a
+   * nullable extension slot renders as `(ColumnScope.() -> Unit)?`, which has nothing at all before
+   * its first `(`, so reading the receiver off the text answered "none" for exactly the slots most
+   * likely to have one. The text is kept only as a fallback for a record written before
+   * `composableSlotReceiver` existed, where null means "not recorded" rather than "no receiver" —
+   * and there it is unwrapped first, so the same nullable case does not slip through twice.
+   */
+  private fun hasReceiver(parameter: TargetParameter): Boolean =
+    parameter.composableSlotReceiver != null ||
+      parameter.type.removePrefix("(").removeSuffix(")?").substringBefore('(').contains('.')
+
   private const val MAX_CONSTANT_POOL_STRING = 65535
+
+  /**
+   * Simple names the generated file has already spent on its own scaffolding.
+   *
+   * The wrapper always imports `androidx.compose.runtime.Composable`, so a catalog component that
+   * happens to be called `Composable` would be imported alongside it and `Composable()` would be
+   * ambiguous between the two. Such a component is called fully qualified instead — the same answer
+   * the screen's own name and a two-package collision already get.
+   */
+  private val RESERVED_BY_THE_WRAPPER = setOf("Composable")
 
   private val KOTLIN_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -65,18 +65,13 @@ object ScreenGenerator {
         )
       )
     }
-    val badSegment =
-      packageName.split('.').firstOrNull {
-        !KOTLIN_IDENTIFIER.matches(it) || ComponentSnippets.isHardKeyword(it)
-      }
+    val badSegment = packageName.split('.').firstOrNull { !isUsableIdentifier(it) }
     if (badSegment != null) {
       return Result.Refused(
         listOf("package segment `$badSegment` is not a usable Kotlin identifier")
       )
     }
-    if (
-      !KOTLIN_IDENTIFIER.matches(document.name) || ComponentSnippets.isHardKeyword(document.name)
-    ) {
+    if (!isUsableIdentifier(document.name)) {
       return Result.Refused(
         listOf("screen name `${document.name}` is not a usable Kotlin function name")
       )
@@ -109,7 +104,9 @@ object ScreenGenerator {
           // Qualified, not imported and shortened: two markers can share a simple name from
           // different packages, and `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` is
           // ambiguous rather than merely ugly. Same reasoning as the component calls below.
-          optIns.joinToString(", ", "@OptIn(", ")") { "$it::class" }
+          optIns.joinToString(", ", "@OptIn(", ")") {
+            "${ComponentSnippets.escapeCallableIfKeyword(it)}::class"
+          }
         )
       }
       appendLine("@Composable")
@@ -159,12 +156,22 @@ object ScreenGenerator {
       node.arguments.keys.filterNot(byName::containsKey).forEach {
         reasons += "`${record.symbol.name}` has no parameter `$it`"
       }
-      node.slots.keys.forEach { slot ->
+      node.slots.forEach { (slot, children) ->
         val parameter = byName[slot]
-        when {
-          parameter == null -> reasons += "`${record.symbol.name}` has no slot `$slot`"
-          !parameter.composableSlot ->
-            reasons += "`${record.symbol.name}`.`$slot` is a parameter, not a @Composable slot"
+        val rejected =
+          when {
+            parameter == null -> "`${record.symbol.name}` has no slot `$slot`"
+            !parameter.composableSlot ->
+              "`${record.symbol.name}`.`$slot` is a parameter, not a @Composable slot"
+            else -> null
+          }
+        if (rejected != null) {
+          reasons += rejected
+          // The loop below walks `record.parameters`, so a slot the component never declared is
+          // never reached and its subtree would go unreported — the same gap as an unresolved
+          // node's children, one level in. A renamed slot is exactly when a document is most
+          // likely to be stale further down, so those children are the ones worth naming.
+          children.forEach { node(it, depth + 1) }
         }
       }
 
@@ -232,7 +239,12 @@ object ScreenGenerator {
                 if (value.value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
                   value.value.toString()
                 else null
-              "kotlin.Long" -> "${value.value}L"
+              // `-9223372036854775808L` does not compile: Kotlin reads the positive token first
+              // and rejects it as out of range, then applies unary minus. Verified with the
+              // compiler, which is also why `Int.MIN_VALUE` is left as a plain literal — the same
+              // spelling one type down *is* accepted.
+              "kotlin.Long" ->
+                if (value.value == Long.MIN_VALUE) "Long.MIN_VALUE" else "${value.value}L"
               else -> null
             }
           is ScreenValue.Fractional ->
@@ -276,6 +288,20 @@ object ScreenGenerator {
       .replace("\r", "\\r")
       .replace("\t", "\\t")
       .let { "\"$it\"" }
+
+  /**
+   * Whether [name] can be written into generated source as a bare declaration name.
+   *
+   * Three ways it cannot, and all three produce source the compiler rejects rather than a warning:
+   * it is not an identifier at all (`my screen`), it is a hard keyword (`when`), or it is
+   * all-underscore. The last is the least obvious — `_`, `__` and friends match every identifier
+   * regex ever written and Kotlin reserves them, so `fun _()` fails with "Names _, __, ___, … are
+   * reserved in Kotlin".
+   */
+  private fun isUsableIdentifier(name: String): Boolean =
+    KOTLIN_IDENTIFIER.matches(name) &&
+      !ComponentSnippets.isHardKeyword(name) &&
+      name.any { it != '_' }
 
   private val KOTLIN_IDENTIFIER = Regex("[A-Za-z_][A-Za-z0-9_]*")
 }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -344,7 +344,10 @@ object ScreenGenerator {
               // compiler, which is also why `Int.MIN_VALUE` is left as a plain literal — the same
               // spelling one type down *is* accepted.
               "kotlin.Long" ->
-                if (value.value == Long.MIN_VALUE) "Long.MIN_VALUE" else "${value.value}L"
+                // Qualified for the same reason `@kotlin.OptIn` is: the generated file sits in a
+                // package the caller chose, and a same-package declaration named `Long` shadows
+                // the default import.
+                if (value.value == Long.MIN_VALUE) "kotlin.Long.MIN_VALUE" else "${value.value}L"
               else -> null
             }
           is ScreenValue.Fractional ->

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -24,6 +24,23 @@ package ee.schimke.composeai.discovery
  * placeholders, and this replaces them with the document's values. So the emitted call is built
  * here from [ComponentRecord.parameters], with `code.call` used as the licence to call at all.
  *
+ * ## Where that licence is wider than it should be
+ *
+ * `code.call != null` is treated as proof that nothing stops a caller writing this call. That is
+ * not quite true, and the gap is one problem rather than a list of them: **the record cannot
+ * express every source-level restriction on calling a declaration**, so each one found has to be
+ * recorded as its own field, and one not yet found is silently admitted. Two are known and open:
+ *
+ * - `@Deprecated(level = DeprecationLevel.ERROR)`. A preview can call such a component under
+ *   `@Suppress("DEPRECATION_ERROR")`, which persists a call site the generated file — carrying no
+ *   such suppression — cannot compile.
+ * - A context *parameter* (Kotlin 2.2 onwards). `ComposableSignature.hasContextRequirement` reads
+ *   the older `contextReceiverTypes` only, and says there why it cannot read the other.
+ *
+ * Both are admitted today. Closing them properly means either an explicit closed list of what
+ * `code.call` promises, or compiling a candidate call in the producer — not a boolean per
+ * restriction, which is how this list would keep growing.
+ *
  * ## Refusing, again
  *
  * The discipline is the same one that makes the call-site generator worth anything: emit only what

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComponentSnippetsTest.kt
@@ -15,6 +15,7 @@ class ComponentSnippetsTest {
     callableFromAnotherFile: Boolean = true,
     hasTypeParameters: Boolean = false,
     overloadsCollided: Boolean = false,
+    hasContextReceivers: Boolean = false,
     requiredOptIns: List<String> = emptyList(),
   ) =
     ComponentRecord(
@@ -32,6 +33,7 @@ class ComponentSnippetsTest {
       callableFromAnotherFile = callableFromAnotherFile,
       hasTypeParameters = hasTypeParameters,
       overloadsCollided = overloadsCollided,
+      hasContextReceivers = hasContextReceivers,
       requiredOptIns = requiredOptIns,
     )
 
@@ -139,6 +141,15 @@ class ComponentSnippetsTest {
     // `Button()` from it would emit source that does not compile.
     assertThat(refusal(record(signatureKnown = false, parameters = emptyList())))
       .contains("not recovered")
+  }
+
+  @Test
+  fun `a composable with a context requirement is refused`() {
+    // The same reason as an extension receiver, and invisible in the parameter list: a context is
+    // not a value parameter, so a printed call would carry no hint that something has to be in
+    // scope around it.
+    assertThat(refusal(record(hasContextReceivers = true)))
+      .contains("context receiver or parameter")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -92,6 +92,15 @@ class ComposableSignatureTest {
       .containsExactly("ee.schimke.composeai.discovery.InternalFixtureApi")
   }
 
+  @Test
+  fun `a nested marker is reported by its binary name, which is not its source spelling`() {
+    // Not a wish: this is what ClassGraph hands the producer, and `$` is not a nesting separator
+    // in Kotlin source. `ScreenGenerator` converts it back before emitting `@OptIn`, and this is
+    // the test that says the conversion has something real to convert.
+    assertThat(optInsOf("nestedMarkerComponent"))
+      .containsExactly("ee.schimke.composeai.discovery.MarkerHolder\$NestedApi")
+  }
+
   /** As [parametersOf], for the knob view of the same fixtures. */
   private fun knobsOf(simpleName: String): List<PreviewKnob> {
     ClassGraph()

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -53,6 +53,45 @@ class ComposableSignatureTest {
     assertThat(params.first { it.name == "state" }.composableSlot).isFalse()
   }
 
+  /** As [parametersOf], for the opt-in markers a caller of the fixture has to apply. */
+  private fun optInsOf(simpleName: String): List<String> {
+    ClassGraph()
+      .enableClassInfo()
+      .enableMethodInfo()
+      // The producer enables this too; without it no annotation is visible and every method would
+      // trivially report no markers, which is a green test that proves nothing.
+      .enableAnnotationInfo()
+      .acceptPackages("ee.schimke.composeai.discovery")
+      .scan()
+      .use { scan ->
+        val classInfo =
+          scan.getClassInfo("ee.schimke.composeai.discovery.SignatureFixturesKt")
+            ?: error("fixture facade class not found")
+        val m: MethodInfo = classInfo.methodInfo.first { it.name == simpleName }
+        return ComposableSignature.signatureOf(classInfo, m)?.requiredOptIns
+          ?: error("no signature for $simpleName")
+      }
+  }
+
+  @Test
+  fun `only markers written on the method are reported, not their meta-annotations`() {
+    // `optInComponent` carries `@ExperimentalFixtureApi` (a real requirement) and
+    // `@FixtureInferredTarget` (the shape the Compose compiler stamps on, itself guarded by
+    // `@InternalFixtureApi`). Reading ClassGraph's annotation closure rather than the direct
+    // annotations reported `InternalFixtureApi` — and `kotlin.RequiresOptIn` itself — telling a
+    // caller to opt into internals in order to place a component.
+    assertThat(optInsOf("optInComponent"))
+      .containsExactly("ee.schimke.composeai.discovery.ExperimentalFixtureApi")
+  }
+
+  @Test
+  fun `a marker the author wrote on their own component survives`() {
+    // The other half, and why a name denylist was the wrong fix: `InternalFixtureApi` is noise as a
+    // meta-annotation of a compiler marker and a real requirement when an author applies it.
+    assertThat(optInsOf("deliberatelyInternalComponent"))
+      .containsExactly("ee.schimke.composeai.discovery.InternalFixtureApi")
+  }
+
   /** As [parametersOf], for the knob view of the same fixtures. */
   private fun knobsOf(simpleName: String): List<PreviewKnob> {
     ClassGraph()

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -93,12 +93,20 @@ class ComposableSignatureTest {
   }
 
   @Test
-  fun `a nested marker is reported by its binary name, which is not its source spelling`() {
-    // Not a wish: this is what ClassGraph hands the producer, and `$` is not a nesting separator
-    // in Kotlin source. `ScreenGenerator` converts it back before emitting `@OptIn`, and this is
-    // the test that says the conversion has something real to convert.
+  fun `a nested marker is recorded in source notation, not by its binary name`() {
+    // ClassGraph hands over `MarkerHolder$NestedApi`. The source name is rebuilt from the nesting
+    // chain here, at the one place that can see it — an emitter replacing every `$` with `.` would
+    // also corrupt a top-level marker whose backticked name legitimately contains one.
     assertThat(optInsOf("nestedMarkerComponent"))
-      .containsExactly("ee.schimke.composeai.discovery.MarkerHolder\$NestedApi")
+      .containsExactly("ee.schimke.composeai.discovery.MarkerHolder.NestedApi")
+  }
+
+  @Test
+  fun `a top-level marker whose name contains a dollar keeps it`() {
+    // The other half of the nesting question, and why replacing every `$` was wrong: this marker
+    // has no outer class, so its name is already what source spells.
+    assertThat(optInsOf("dollarMarkerComponent"))
+      .containsExactly("ee.schimke.composeai.discovery.Api\$Experimental")
   }
 
   /** As [parametersOf], for the knob view of the same fixtures. */

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -657,6 +657,69 @@ class ScreenGeneratorTest {
   }
 
   @Test
+  fun `a component named Composable is qualified, so it cannot collide with the wrapper's import`() {
+    // The generated file always imports `androidx.compose.runtime.Composable` for its own
+    // `@Composable`
+    // annotation. Importing a catalog component of the same simple name alongside it makes
+    // `Composable()` ambiguous between the two.
+    val clash =
+      component("Composable", "com.example.Composable", emptyList()).let {
+        it.copy(
+          canonicalId = "app/com.example.ComposableKt.Composable",
+          symbol = it.symbol.copy(callable = "com.example.Composable"),
+        )
+      }
+
+    val source =
+      emitted(ScreenDocument("Screen", ScreenNode(clash.canonicalId)), catalog(clash)).source
+
+    assertThat(source).contains("com.example.Composable()")
+    assertThat(source).doesNotContain("import com.example.Composable")
+    // The wrapper's own import is untouched.
+    assertThat(source).contains("import androidx.compose.runtime.Composable")
+  }
+
+  @Test
+  fun `a nullable receiver slot still qualifies its children`() {
+    // `(ColumnScope.() -> Unit)?` has nothing before its first `(`, so reading the receiver off the
+    // rendered type answered "no receiver" and the children went back to simple names. The record
+    // carries the receiver structurally; that is what is read.
+    val optional =
+      component(
+        "Optional",
+        "com.example.Optional",
+        listOf(
+          TargetParameter(
+            "content",
+            "(ColumnScope.() -> Unit)?",
+            hasDefault = true,
+            composableSlot = true,
+            composableSlotReceiver = "androidx.compose.foundation.layout.ColumnScope",
+          )
+        ),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          optional.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Text("Hi")))
+                )
+            ),
+        ),
+      )
+
+    val source = emitted(screen, catalog(optional, text)).source
+
+    assertThat(source).contains("androidx.compose.material3.Text(text = \"Hi\")")
+    assertThat(source).doesNotContain("import androidx.compose.material3.Text")
+  }
+
+  @Test
   fun `children of an unresolved node are still reported`() {
     // A catalog that dropped a whole subtree should name every node it can no longer place.
     val holder =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -200,7 +200,7 @@ class ScreenGeneratorTest {
     // Qualified, not imported: two markers can share a simple name across packages, so the
     // shortened form is ambiguous rather than merely ugly.
     assertThat(emitted.source)
-      .contains("@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)")
+      .contains("@kotlin.OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)")
     assertThat(emitted.source)
       .doesNotContain("import androidx.compose.material3.ExperimentalMaterial3Api")
     assertThat(emitted.requiredOptIns)
@@ -398,7 +398,7 @@ class ScreenGeneratorTest {
 
     // `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` would not compile.
     assertThat(source)
-      .contains("@OptIn(com.a.ExperimentalApi::class, com.b.ExperimentalApi::class)")
+      .contains("@kotlin.OptIn(com.a.ExperimentalApi::class, com.b.ExperimentalApi::class)")
   }
 
   @Test
@@ -488,7 +488,7 @@ class ScreenGeneratorTest {
     val source =
       emitted(ScreenDocument("Screen", ScreenNode(fancy.canonicalId)), catalog(fancy)).source
 
-    assertThat(source).contains("@OptIn(com.`when`.Api::class)")
+    assertThat(source).contains("@kotlin.OptIn(com.`when`.Api::class)")
   }
 
   @Test
@@ -641,9 +641,9 @@ class ScreenGeneratorTest {
       )
 
     assertThat(emitted(ScreenDocument("A", ScreenNode(nested.canonicalId)), catalog(nested)).source)
-      .contains("@OptIn(com.example.Api.Experimental::class)")
+      .contains("@kotlin.OptIn(com.example.Api.Experimental::class)")
     assertThat(emitted(ScreenDocument("B", ScreenNode(dollar.canonicalId)), catalog(dollar)).source)
-      .contains("@OptIn(com.example.`Api${'$'}Experimental`::class)")
+      .contains("@kotlin.OptIn(com.example.`Api${'$'}Experimental`::class)")
   }
 
   @Test
@@ -667,42 +667,26 @@ class ScreenGeneratorTest {
   }
 
   @Test
-  fun `a record older than the opt-in mechanism split is refused when it carries markers`() {
-    val guarded =
-      component(
-        "Guarded",
-        "com.example.Guarded",
-        emptyList(),
-        requiredOptIns = listOf("com.example.SomeApi"),
-      )
+  fun `a catalog older than the current schema is refused outright`() {
+    // Not "refused when it carries markers": a schema-1 record also cannot say whether a component
+    // needs a context receiver, and every field added since would need its own exception here. One
+    // rule, and a stale catalog is regenerated rather than squinted at.
     val plain = component("Plain", "com.example.Plain", emptyList())
-    fun legacy(vararg records: ComponentRecord) =
+    val legacy =
       ComponentRecordFile(
         schemaVersion = COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA - 1,
         module = "app",
         variant = "debug",
-        components = records.toList(),
+        components = listOf(plain),
       )
 
-    // Such a record cannot say whether its marker needs `kotlin.OptIn` or the AndroidX one, and
-    // guessing is what the split exists to stop.
-    assertThat(
-        (ScreenGenerator.generate(
-            ScreenDocument("Screen", ScreenNode(guarded.canonicalId)),
-            legacy(guarded),
-          ) as ScreenGenerator.Result.Refused)
-          .reasons
-          .first()
-      )
-      .contains("did not record whether")
-    // An old catalog with no opt-ins at all is unambiguous, and still generates.
-    assertThat(
-        ScreenGenerator.generate(
-          ScreenDocument("Screen", ScreenNode(plain.canonicalId)),
-          legacy(plain),
-        )
-      )
-      .isInstanceOf(ScreenGenerator.Result.Emitted::class.java)
+    val reasons =
+      (ScreenGenerator.generate(ScreenDocument("Screen", ScreenNode(plain.canonicalId)), legacy)
+          as ScreenGenerator.Result.Refused)
+        .reasons
+
+    assertThat(reasons).hasSize(1)
+    assertThat(reasons.single()).contains("Re-run discovery")
   }
 
   @Test
@@ -833,13 +817,13 @@ class ScreenGeneratorTest {
     val emitted =
       emitted(ScreenDocument("Screen", ScreenNode(guarded.canonicalId)), catalog(guarded))
 
-    assertThat(emitted.source).contains("@OptIn(com.example.KotlinApi::class)")
+    assertThat(emitted.source).contains("@kotlin.OptIn(com.example.KotlinApi::class)")
     assertThat(emitted.source)
       .contains(
         "@androidx.annotation.OptIn(markerClass = [androidx.camera.core.ExperimentalLens::class])"
       )
     // The AndroidX marker is not also written under `kotlin.OptIn`, which would reject it.
-    assertThat(emitted.source).doesNotContain("@OptIn(androidx.camera")
+    assertThat(emitted.source).doesNotContain("@kotlin.OptIn(androidx.camera")
     assertThat(emitted.source).doesNotContain("ExperimentalLens::class, ")
     // Both are still reported to the caller: the split is about which annotation carries them.
     assertThat(emitted.requiredOptIns)

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -1,0 +1,220 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ScreenGeneratorTest {
+
+  private fun component(
+    name: String,
+    callable: String,
+    parameters: List<TargetParameter>,
+    call: String = "$name()",
+    requiredOptIns: List<String> = emptyList(),
+  ) =
+    ComponentRecord(
+      canonicalId = "app/androidx.compose.material3.${name}Kt.$name",
+      symbol =
+        ComponentSymbol(
+          jvmOwner = "androidx.compose.material3.${name}Kt",
+          callable = callable,
+          name = name,
+          origin = ComponentOrigin.LIBRARY,
+        ),
+      parameters = parameters,
+      signatureKnown = true,
+      code =
+        ComponentCode(call = call, imports = listOf(callable), requiredOptIns = requiredOptIns),
+    )
+
+  private val text =
+    component(
+      "Text",
+      "androidx.compose.material3.Text",
+      listOf(TargetParameter("text", "String", typeFqn = "kotlin.String")),
+    )
+
+  private val card =
+    component(
+      "Card",
+      "androidx.compose.material3.Card",
+      listOf(
+        TargetParameter(
+          "modifier",
+          "Modifier",
+          typeFqn = "androidx.compose.ui.Modifier",
+          hasDefault = true,
+        ),
+        TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true),
+      ),
+    )
+
+  private fun catalog(vararg records: ComponentRecord) =
+    ComponentRecordFile(module = "app", variant = "debug", components = records.toList())
+
+  private fun emitted(document: ScreenDocument, catalog: ComponentRecordFile) =
+    ScreenGenerator.generate(document, catalog) as ScreenGenerator.Result.Emitted
+
+  private fun refusal(document: ScreenDocument, catalog: ComponentRecordFile) =
+    (ScreenGenerator.generate(document, catalog) as ScreenGenerator.Result.Refused).reasons
+
+  @Test
+  fun `a screen binds the document's values and nests children into slots`() {
+    val screen =
+      ScreenDocument(
+        name = "HomeScreen",
+        root =
+          ScreenNode(
+            componentId = card.canonicalId,
+            slots =
+              mapOf(
+                "content" to
+                  listOf(
+                    ScreenNode(
+                      text.canonicalId,
+                      arguments = mapOf("text" to ScreenValue.Text("Hello")),
+                    )
+                  )
+              ),
+          ),
+      )
+
+    val source = emitted(screen, catalog(card, text)).source
+
+    // The user's value, not the placeholder `Text(text = "")` the call-site generator prints.
+    assertThat(source).contains("""Text(text = "Hello")""")
+    assertThat(source).contains("Card(content = {")
+    assertThat(source).contains("fun HomeScreen()")
+    assertThat(source).contains("import androidx.compose.material3.Card")
+    assertThat(source).contains("import androidx.compose.material3.Text")
+    // `modifier` is defaulted and untouched, so it is omitted rather than guessed at.
+    assertThat(source).doesNotContain("modifier =")
+  }
+
+  @Test
+  fun `a component the catalog no longer has is refused, not invented`() {
+    val screen = ScreenDocument("Screen", ScreenNode("app/com.example.GoneKt.Gone"))
+
+    assertThat(refusal(screen, catalog(text)).single())
+      .contains("no component `app/com.example.GoneKt.Gone`")
+  }
+
+  @Test
+  fun `a component whose call site was refused stays refused here`() {
+    // The whole point of gating on `code`: every protection the call-site generator learned — the
+    // private, the generic, the collided — arrives here without being re-derived.
+    val private =
+      component("Secret", "com.example.Secret", emptyList(), call = "Secret()")
+        .copy(
+          code =
+            ComponentCode(
+              refusedReason = "not public or internal, so a generated file cannot call it"
+            )
+        )
+    val screen = ScreenDocument("Screen", ScreenNode(private.canonicalId))
+
+    assertThat(refusal(screen, catalog(private)).single()).contains("not public or internal")
+  }
+
+  @Test
+  fun `a property the component does not declare is refused rather than dropped`() {
+    // Dropping it silently would generate a screen that compiles and is not the one designed.
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(text.canonicalId, arguments = mapOf("caption" to ScreenValue.Text("x"))),
+      )
+
+    assertThat(refusal(screen, catalog(text)).first()).contains("has no parameter `caption`")
+  }
+
+  @Test
+  fun `a value of the wrong type is refused`() {
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Bool(true))),
+      )
+
+    assertThat(refusal(screen, catalog(text)).first()).contains("kotlin.String, which Bool is not")
+  }
+
+  @Test
+  fun `a domain type that renders like a Kotlin scalar does not accept a literal`() {
+    // The trap that bit the call-site generator twice: `com.example.String` renders as `String`.
+    val odd =
+      component(
+        "Odd",
+        "com.example.Odd",
+        listOf(TargetParameter("value", "String", typeFqn = "com.example.String")),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(odd.canonicalId, arguments = mapOf("value" to ScreenValue.Text("x"))),
+      )
+
+    assertThat(refusal(screen, catalog(odd)).first()).contains("com.example.String")
+  }
+
+  @Test
+  fun `text is escaped so ordinary characters cannot break the generated file`() {
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          text.canonicalId,
+          arguments = mapOf("text" to ScreenValue.Text("""a "quote", a ${'$'}var and a \ slash""")),
+        ),
+      )
+
+    val source = emitted(screen, catalog(text)).source
+
+    // `$` matters as much as `"`: unescaped it becomes a template for a variable that is not there.
+    assertThat(source).contains("""\"quote\"""")
+    assertThat(source).contains("""\${'$'}var""")
+    assertThat(source).contains("""\\ slash""")
+  }
+
+  @Test
+  fun `required opt-ins are applied to the generated file, not left to the caller`() {
+    val experimental =
+      component(
+        "Fancy",
+        "androidx.compose.material3.Fancy",
+        emptyList(),
+        requiredOptIns = listOf("androidx.compose.material3.ExperimentalMaterial3Api"),
+      )
+    val screen = ScreenDocument("Screen", ScreenNode(experimental.canonicalId))
+
+    val emitted = emitted(screen, catalog(experimental))
+
+    assertThat(emitted.source).contains("@OptIn(ExperimentalMaterial3Api::class)")
+    assertThat(emitted.source)
+      .contains("import androidx.compose.material3.ExperimentalMaterial3Api")
+    assertThat(emitted.requiredOptIns)
+      .containsExactly("androidx.compose.material3.ExperimentalMaterial3Api")
+  }
+
+  @Test
+  fun `every problem is reported, not just the first`() {
+    // A builder wants the whole list to act on; fixing one error at a time is a bad loop.
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          card.canonicalId,
+          arguments = mapOf("nope" to ScreenValue.Text("x")),
+          slots = mapOf("content" to listOf(ScreenNode("app/com.example.GoneKt.Gone"))),
+        ),
+      )
+
+    assertThat(refusal(screen, catalog(card))).hasSize(2)
+  }
+
+  @Test
+  fun `a screen name that is not an identifier is refused`() {
+    assertThat(refusal(ScreenDocument("my screen", ScreenNode(text.canonicalId)), catalog(text)))
+      .containsExactly("screen name `my screen` is not a Kotlin identifier")
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -420,6 +420,95 @@ class ScreenGeneratorTest {
   }
 
   @Test
+  fun `Long MIN_VALUE is emitted by name, because its literal does not compile`() {
+    // `-9223372036854775808L` is rejected: Kotlin reads the positive token first and it is out of
+    // range, then applies unary minus. Confirmed against the compiler — and `Int.MIN_VALUE`, the
+    // same spelling one type down, *is* accepted, so it stays a plain literal.
+    val counted =
+      component(
+        "Counted",
+        "com.example.Counted",
+        listOf(TargetParameter("total", "Long", typeFqn = "kotlin.Long")),
+      )
+    fun screen(v: Long) =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(counted.canonicalId, arguments = mapOf("total" to ScreenValue.Whole(v))),
+      )
+
+    assertThat(emitted(screen(Long.MIN_VALUE), catalog(counted)).source)
+      .contains("Counted(total = Long.MIN_VALUE)")
+    assertThat(emitted(screen(Long.MAX_VALUE), catalog(counted)).source)
+      .contains("Counted(total = 9223372036854775807L)")
+    assertThat(emitted(screen(7L), catalog(counted)).source).contains("Counted(total = 7L)")
+  }
+
+  @Test
+  fun `an all-underscore screen name is refused`() {
+    // `_` and `__` match every identifier regex and Kotlin reserves them: "Names _, __, ___, ...
+    // are reserved in Kotlin".
+    assertThat(refusal(ScreenDocument("_", ScreenNode(text.canonicalId)), catalog(text)).first())
+      .contains("not a usable Kotlin function name")
+    assertThat(refusal(ScreenDocument("__", ScreenNode(text.canonicalId)), catalog(text)).first())
+      .contains("not a usable Kotlin function name")
+    // A leading underscore on an otherwise ordinary name is legal and must still be accepted.
+    assertThat(
+        emitted(ScreenDocument("_Screen", ScreenNode(text.canonicalId)), catalog(text)).source
+      )
+      .contains("fun _Screen()")
+  }
+
+  @Test
+  fun `an all-underscore package segment is refused`() {
+    val result =
+      ScreenGenerator.generate(
+        ScreenDocument("Screen", ScreenNode(text.canonicalId)),
+        catalog(text),
+        packageName = "com._.example",
+      )
+
+    assertThat((result as ScreenGenerator.Result.Refused).reasons.first()).contains("`_`")
+  }
+
+  @Test
+  fun `an opt-in marker under a keyword package is escaped`() {
+    // ClassGraph reports the FQN unescaped, so a marker in a package Kotlin source spells
+    // ``com.`when``` arrives as `com.when` and would emit an annotation that does not compile.
+    val fancy =
+      component("Fancy", "com.example.Fancy", emptyList(), requiredOptIns = listOf("com.when.Api"))
+
+    val source =
+      emitted(ScreenDocument("Screen", ScreenNode(fancy.canonicalId)), catalog(fancy)).source
+
+    assertThat(source).contains("@OptIn(com.`when`.Api::class)")
+  }
+
+  @Test
+  fun `children of a slot the component never declared are still reported`() {
+    // The argument loop walks the component's own parameters, so a renamed slot is never reached
+    // and its subtree would go unreported — the unresolved-node gap, one level in.
+    val holder =
+      card.copy(
+        parameters =
+          listOf(TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true))
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          holder.canonicalId,
+          slots = mapOf("body" to listOf(ScreenNode("app/com.example.GoneKt.Gone"))),
+        ),
+      )
+
+    val reasons = refusal(screen, catalog(holder))
+
+    assertThat(reasons).hasSize(2)
+    assertThat(reasons.joinToString()).contains("has no slot `body`")
+    assertThat(reasons.joinToString()).contains("Gone")
+  }
+
+  @Test
   fun `children of an unresolved node are still reported`() {
     // A catalog that dropped a whole subtree should name every node it can no longer place.
     val holder =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -11,6 +11,7 @@ class ScreenGeneratorTest {
     parameters: List<TargetParameter>,
     call: String = "$name()",
     requiredOptIns: List<String> = emptyList(),
+    androidxOptIns: List<String> = emptyList(),
   ) =
     ComponentRecord(
       canonicalId = "app/androidx.compose.material3.${name}Kt.$name",
@@ -24,7 +25,12 @@ class ScreenGeneratorTest {
       parameters = parameters,
       signatureKnown = true,
       code =
-        ComponentCode(call = call, imports = listOf(callable), requiredOptIns = requiredOptIns),
+        ComponentCode(
+          call = call,
+          imports = listOf(callable),
+          requiredOptIns = requiredOptIns,
+          androidxOptIns = androidxOptIns,
+        ),
     )
 
   private val text =
@@ -717,6 +723,59 @@ class ScreenGeneratorTest {
 
     assertThat(source).contains("androidx.compose.material3.Text(text = \"Hi\")")
     assertThat(source).doesNotContain("import androidx.compose.material3.Text")
+  }
+
+  @Test
+  fun `an AndroidX marker is emitted under the AndroidX annotation, not kotlin OptIn`() {
+    // Not interchangeable: `kotlin.OptIn` rejects a marker declared with
+    // `androidx.annotation.RequiresOptIn` outright, and the AndroidX annotation takes an array
+    // under a named `markerClass`. Emitting one for the other is source the compiler refuses.
+    val guarded =
+      component(
+        "Guarded",
+        "com.example.Guarded",
+        emptyList(),
+        requiredOptIns = listOf("com.example.KotlinApi", "androidx.camera.core.ExperimentalLens"),
+        androidxOptIns = listOf("androidx.camera.core.ExperimentalLens"),
+      )
+
+    val emitted =
+      emitted(ScreenDocument("Screen", ScreenNode(guarded.canonicalId)), catalog(guarded))
+
+    assertThat(emitted.source).contains("@OptIn(com.example.KotlinApi::class)")
+    assertThat(emitted.source)
+      .contains(
+        "@androidx.annotation.OptIn(markerClass = [androidx.camera.core.ExperimentalLens::class])"
+      )
+    // The AndroidX marker is not also written under `kotlin.OptIn`, which would reject it.
+    assertThat(emitted.source).doesNotContain("@OptIn(androidx.camera")
+    assertThat(emitted.source).doesNotContain("ExperimentalLens::class, ")
+    // Both are still reported to the caller: the split is about which annotation carries them.
+    assertThat(emitted.requiredOptIns)
+      .containsExactly("com.example.KotlinApi", "androidx.camera.core.ExperimentalLens")
+  }
+
+  @Test
+  fun `a parameter set as both a value and a slot is reported, and its children too`() {
+    val holder =
+      card.copy(
+        parameters =
+          listOf(TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true))
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          holder.canonicalId,
+          arguments = mapOf("content" to ScreenValue.Text("oops")),
+          slots = mapOf("content" to listOf(ScreenNode("app/com.example.GoneKt.Gone"))),
+        ),
+      )
+
+    val reasons = refusal(screen, catalog(holder))
+
+    assertThat(reasons.joinToString()).contains("both a value and a slot")
+    assertThat(reasons.joinToString()).contains("Gone")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -621,9 +621,10 @@ class ScreenGeneratorTest {
   @Test
   fun `an opt-in marker is emitted exactly as recorded, dollars and all`() {
     // The producer rebuilds a nested marker's name from its nesting chain, so what arrives here is
-    // already source notation. The emitter must not second-guess it: a top-level marker whose
-    // backticked name contains a `$` is spelled with the `$`, and rewriting every one to `.` would
-    // reference a class that does not exist. `ComposableSignatureTest` covers both producer halves.
+    // already source notation. The emitter must not rewrite it — turning every `$` into `.` would
+    // reference a class that does not exist — but it must still quote a segment that cannot be
+    // written bare, which is how such a name came to hold a `$` in the first place.
+    // `ComposableSignatureTest` covers both producer halves.
     val nested =
       component(
         "Nested",
@@ -642,7 +643,7 @@ class ScreenGeneratorTest {
     assertThat(emitted(ScreenDocument("A", ScreenNode(nested.canonicalId)), catalog(nested)).source)
       .contains("@OptIn(com.example.Api.Experimental::class)")
     assertThat(emitted(ScreenDocument("B", ScreenNode(dollar.canonicalId)), catalog(dollar)).source)
-      .contains("@OptIn(com.example.Api${'$'}Experimental::class)")
+      .contains("@OptIn(com.example.`Api${'$'}Experimental`::class)")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -86,7 +86,9 @@ class ScreenGeneratorTest {
     assertThat(source).contains("Card(content = {")
     assertThat(source).contains("fun HomeScreen()")
     assertThat(source).contains("import androidx.compose.material3.Card")
-    assertThat(source).contains("import androidx.compose.material3.Text")
+    // `Text` is nested inside `Card`'s `ColumnScope` slot, so it is qualified rather than imported
+    // — an implicit receiver's members outrank an import in Kotlin. See the dedicated test.
+    assertThat(source).contains("androidx.compose.material3.Text(text = ")
     // `modifier` is defaulted and untouched, so it is omitted rather than guessed at.
     assertThat(source).doesNotContain("modifier =")
   }
@@ -506,6 +508,152 @@ class ScreenGeneratorTest {
     assertThat(reasons).hasSize(2)
     assertThat(reasons.joinToString()).contains("has no slot `body`")
     assertThat(reasons.joinToString()).contains("Gone")
+  }
+
+  @Test
+  fun `children of an unsatisfiable slot are still reported`() {
+    // The third branch that rejects a node and could drop its subtree, after an unresolved id and
+    // a slot the component never declared.
+    val dragging =
+      component(
+        "Dragging",
+        "com.example.Dragging",
+        listOf(
+          TargetParameter(
+            "onDrag",
+            "(Float, Float) -> Unit",
+            hasDefault = true,
+            composableSlot = true,
+          )
+        ),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          dragging.canonicalId,
+          slots = mapOf("onDrag" to listOf(ScreenNode("app/com.example.GoneKt.Gone"))),
+        ),
+      )
+
+    val reasons = refusal(screen, catalog(dragging))
+
+    assertThat(reasons).hasSize(2)
+    assertThat(reasons.joinToString()).contains("bare lambda cannot satisfy")
+    assertThat(reasons.joinToString()).contains("Gone")
+  }
+
+  @Test
+  fun `a child inside a receiver slot is qualified, because the receiver outranks an import`() {
+    // Kotlin resolves a simple name against implicit receivers before imports, so a `ColumnScope`
+    // with a member `Text` would win over `import androidx.compose.material3.Text` — source that
+    // compiles and draws something else. The receiver's members are not in the record, so this
+    // cannot be checked, only avoided.
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          card.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  ScreenNode(
+                    text.canonicalId,
+                    arguments = mapOf("text" to ScreenValue.Text("Hi")),
+                  )
+                )
+            ),
+        ),
+      )
+
+    val source = emitted(screen, catalog(card, text)).source
+
+    assertThat(source).contains("androidx.compose.material3.Text(text = \"Hi\")")
+    // No import either: nothing uses the simple name, and an unused import is noise in generated
+    // source that a linter will flag.
+    assertThat(source).doesNotContain("import androidx.compose.material3.Text")
+    // The root is not inside any receiver, so it keeps the readable spelling.
+    assertThat(source).contains("    Card(")
+    assertThat(source).contains("import androidx.compose.material3.Card")
+  }
+
+  @Test
+  fun `a nullable composable slot accepts children`() {
+    // `(@Composable () -> Unit)?` renders as `(() -> Unit)?`, which has no ` -> Unit` suffix for
+    // the lambda-shape check to find — so an optional slot was refused even though Kotlin accepts
+    // a non-null `{ … }` for it.
+    val optional =
+      component(
+        "Optional",
+        "com.example.Optional",
+        listOf(
+          TargetParameter("content", "(() -> Unit)?", hasDefault = true, composableSlot = true)
+        ),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          optional.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Text("Hi")))
+                )
+            ),
+        ),
+      )
+
+    val source = emitted(screen, catalog(optional, text)).source
+
+    assertThat(source).contains("content = {")
+    assertThat(source).contains("Text(text = \"Hi\")")
+  }
+
+  @Test
+  fun `a nested opt-in marker is emitted in source notation, not its binary name`() {
+    // ClassGraph reports a marker declared inside a class as `com.example.Api${'$'}Experimental`,
+    // and
+    // `${'$'}` is not a nesting separator in Kotlin source. `ComposableSignatureTest` proves that
+    // is
+    // really the shape the producer records.
+    val fancy =
+      component(
+        "Fancy",
+        "com.example.Fancy",
+        emptyList(),
+        requiredOptIns = listOf("com.example.Api${'$'}Experimental"),
+      )
+
+    val source =
+      emitted(ScreenDocument("Screen", ScreenNode(fancy.canonicalId)), catalog(fancy)).source
+
+    assertThat(source).contains("@OptIn(com.example.Api.Experimental::class)")
+  }
+
+  @Test
+  fun `a string too large for the constant pool is refused`() {
+    val labelled =
+      component(
+        "Labelled",
+        "com.example.Labelled",
+        listOf(TargetParameter("label", "String", typeFqn = "kotlin.String")),
+      )
+    fun screen(value: String) =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(labelled.canonicalId, arguments = mapOf("label" to ScreenValue.Text(value))),
+      )
+
+    // A JVM string constant is length-prefixed with an unsigned short, so 65536 bytes cannot be a
+    // literal. The backend, not this generator, would have been the one to say so.
+    assertThat(refusal(screen("a".repeat(65536)), catalog(labelled)).first()).contains("65535")
+    // Measured in modified UTF-8, not characters: a 3-byte character reaches the limit in a third
+    // of the count.
+    assertThat(refusal(screen("\u4e2d".repeat(21846)), catalog(labelled)).first()).contains("65535")
+    assertThat(emitted(screen("a".repeat(65535)), catalog(labelled)).source).contains("label = \"")
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -619,24 +619,114 @@ class ScreenGeneratorTest {
   }
 
   @Test
-  fun `a nested opt-in marker is emitted in source notation, not its binary name`() {
-    // ClassGraph reports a marker declared inside a class as `com.example.Api${'$'}Experimental`,
-    // and
-    // `${'$'}` is not a nesting separator in Kotlin source. `ComposableSignatureTest` proves that
-    // is
-    // really the shape the producer records.
-    val fancy =
+  fun `an opt-in marker is emitted exactly as recorded, dollars and all`() {
+    // The producer rebuilds a nested marker's name from its nesting chain, so what arrives here is
+    // already source notation. The emitter must not second-guess it: a top-level marker whose
+    // backticked name contains a `$` is spelled with the `$`, and rewriting every one to `.` would
+    // reference a class that does not exist. `ComposableSignatureTest` covers both producer halves.
+    val nested =
       component(
-        "Fancy",
-        "com.example.Fancy",
+        "Nested",
+        "com.example.Nested",
+        emptyList(),
+        requiredOptIns = listOf("com.example.Api.Experimental"),
+      )
+    val dollar =
+      component(
+        "Dollar",
+        "com.example.Dollar",
         emptyList(),
         requiredOptIns = listOf("com.example.Api${'$'}Experimental"),
       )
 
-    val source =
-      emitted(ScreenDocument("Screen", ScreenNode(fancy.canonicalId)), catalog(fancy)).source
+    assertThat(emitted(ScreenDocument("A", ScreenNode(nested.canonicalId)), catalog(nested)).source)
+      .contains("@OptIn(com.example.Api.Experimental::class)")
+    assertThat(emitted(ScreenDocument("B", ScreenNode(dollar.canonicalId)), catalog(dollar)).source)
+      .contains("@OptIn(com.example.Api${'$'}Experimental::class)")
+  }
 
-    assertThat(source).contains("@OptIn(com.example.Api.Experimental::class)")
+  @Test
+  fun `a non-ASCII but valid Kotlin name is accepted`() {
+    // `Übersicht` and `画面` need no backticks in Kotlin. An ASCII-only rule refused documents that
+    // were never wrong.
+    assertThat(
+        emitted(ScreenDocument("Übersicht", ScreenNode(text.canonicalId)), catalog(text)).source
+      )
+      .contains("fun Übersicht()")
+    assertThat(emitted(ScreenDocument("画面", ScreenNode(text.canonicalId)), catalog(text)).source)
+      .contains("fun 画面()")
+    assertThat(
+        ScreenGenerator.generate(
+          ScreenDocument("Screen", ScreenNode(text.canonicalId)),
+          catalog(text),
+          packageName = "généré.écran",
+        )
+      )
+      .isInstanceOf(ScreenGenerator.Result.Emitted::class.java)
+  }
+
+  @Test
+  fun `a record older than the opt-in mechanism split is refused when it carries markers`() {
+    val guarded =
+      component(
+        "Guarded",
+        "com.example.Guarded",
+        emptyList(),
+        requiredOptIns = listOf("com.example.SomeApi"),
+      )
+    val plain = component("Plain", "com.example.Plain", emptyList())
+    fun legacy(vararg records: ComponentRecord) =
+      ComponentRecordFile(
+        schemaVersion = COMPONENT_RECORD_OPT_IN_MECHANISM_SCHEMA - 1,
+        module = "app",
+        variant = "debug",
+        components = records.toList(),
+      )
+
+    // Such a record cannot say whether its marker needs `kotlin.OptIn` or the AndroidX one, and
+    // guessing is what the split exists to stop.
+    assertThat(
+        (ScreenGenerator.generate(
+            ScreenDocument("Screen", ScreenNode(guarded.canonicalId)),
+            legacy(guarded),
+          ) as ScreenGenerator.Result.Refused)
+          .reasons
+          .first()
+      )
+      .contains("did not record whether")
+    // An old catalog with no opt-ins at all is unambiguous, and still generates.
+    assertThat(
+        ScreenGenerator.generate(
+          ScreenDocument("Screen", ScreenNode(plain.canonicalId)),
+          legacy(plain),
+        )
+      )
+      .isInstanceOf(ScreenGenerator.Result.Emitted::class.java)
+  }
+
+  @Test
+  fun `a conflicted non-slot parameter reports its children once, not twice`() {
+    // Both the slot-validation loop and the argument branch can reach these children. Walking them
+    // in both duplicates every reason and doubles the work per conflicted level.
+    val labelled =
+      component(
+        "Labelled",
+        "com.example.Labelled",
+        listOf(TargetParameter("label", "String", typeFqn = "kotlin.String")),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          labelled.canonicalId,
+          arguments = mapOf("label" to ScreenValue.Text("hi")),
+          slots = mapOf("label" to listOf(ScreenNode("app/com.example.GoneKt.Gone"))),
+        ),
+      )
+
+    val reasons = refusal(screen, catalog(labelled))
+
+    assertThat(reasons.filter { it.contains("Gone") }).hasSize(1)
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -189,9 +189,12 @@ class ScreenGeneratorTest {
 
     val emitted = emitted(screen, catalog(experimental))
 
-    assertThat(emitted.source).contains("@OptIn(ExperimentalMaterial3Api::class)")
+    // Qualified, not imported: two markers can share a simple name across packages, so the
+    // shortened form is ambiguous rather than merely ugly.
     assertThat(emitted.source)
-      .contains("import androidx.compose.material3.ExperimentalMaterial3Api")
+      .contains("@OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)")
+    assertThat(emitted.source)
+      .doesNotContain("import androidx.compose.material3.ExperimentalMaterial3Api")
     assertThat(emitted.requiredOptIns)
       .containsExactly("androidx.compose.material3.ExperimentalMaterial3Api")
   }
@@ -215,6 +218,237 @@ class ScreenGeneratorTest {
   @Test
   fun `a screen name that is not an identifier is refused`() {
     assertThat(refusal(ScreenDocument("my screen", ScreenNode(text.canonicalId)), catalog(text)))
-      .containsExactly("screen name `my screen` is not a Kotlin identifier")
+      .containsExactly("screen name `my screen` is not a usable Kotlin function name")
+  }
+
+  @Test
+  fun `two components sharing a simple name are called fully qualified`() {
+    // `com.a.Badge` and `com.b.Badge` both reduced to `Badge()` under two conflicting imports.
+    fun badge(pkg: String) =
+      component("Badge", "$pkg.Badge", emptyList()).let {
+        it.copy(
+          canonicalId = "app/$pkg.BadgeKt.Badge",
+          symbol = it.symbol.copy(jvmOwner = "$pkg.BadgeKt", callable = "$pkg.Badge"),
+        )
+      }
+    val a = badge("com.a")
+    val b = badge("com.b")
+    val card2 =
+      card.copy(
+        parameters =
+          listOf(TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true))
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          card2.canonicalId,
+          slots = mapOf("content" to listOf(ScreenNode(a.canonicalId), ScreenNode(b.canonicalId))),
+        ),
+      )
+
+    val source = emitted(screen, catalog(card2, a, b)).source
+
+    assertThat(source).contains("com.a.Badge()")
+    assertThat(source).contains("com.b.Badge()")
+    assertThat(source).doesNotContain("import com.a.Badge")
+    assertThat(source).doesNotContain("import com.b.Badge")
+  }
+
+  @Test
+  fun `a component sharing the screen's own name is qualified, so the screen cannot recurse`() {
+    // `fun HomeScreen()` calling an imported `HomeScreen()` would shadow the import and call
+    // itself — a stack overflow that compiles.
+    val same =
+      component("HomeScreen", "com.example.HomeScreen", emptyList()).let {
+        it.copy(
+          canonicalId = "app/com.example.HomeScreenKt.HomeScreen",
+          symbol = it.symbol.copy(callable = "com.example.HomeScreen"),
+        )
+      }
+    val screen = ScreenDocument("HomeScreen", ScreenNode(same.canonicalId))
+
+    val source = emitted(screen, catalog(same)).source
+
+    assertThat(source).contains("com.example.HomeScreen()")
+    assertThat(source).doesNotContain("import com.example.HomeScreen")
+  }
+
+  @Test
+  fun `an Int value that does not fit is refused rather than silently wrapped`() {
+    // `Long.toInt()` turns 2147483648 into -2147483648: source that compiles carrying a number
+    // nobody entered.
+    val counted =
+      component(
+        "Counted",
+        "com.example.Counted",
+        listOf(TargetParameter("count", "Int", typeFqn = "kotlin.Int")),
+      )
+    val tooBig =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          counted.canonicalId,
+          arguments = mapOf("count" to ScreenValue.Whole(2147483648L)),
+        ),
+      )
+    val fits =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(counted.canonicalId, arguments = mapOf("count" to ScreenValue.Whole(7L))),
+      )
+
+    assertThat(refusal(tooBig, catalog(counted)).first()).contains("count")
+    assertThat(emitted(fits, catalog(counted)).source).contains("Counted(count = 7)")
+  }
+
+  @Test
+  fun `children are refused for a slot a bare lambda cannot satisfy`() {
+    // A defaulted slot can be absent from `code.call` and still be uncallable with `{ children }`:
+    // two parameters have nothing to bind, and a non-Unit return has nothing to return.
+    val dragging =
+      component(
+        "Dragging",
+        "com.example.Dragging",
+        listOf(
+          TargetParameter(
+            "onDrag",
+            "(Float, Float) -> Unit",
+            hasDefault = true,
+            composableSlot = true,
+          )
+        ),
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          dragging.canonicalId,
+          slots = mapOf("onDrag" to listOf(ScreenNode(text.canonicalId))),
+        ),
+      )
+
+    assertThat(refusal(screen, catalog(dragging, text)).first())
+      .contains("bare lambda cannot satisfy")
+  }
+
+  @Test
+  fun `a screen named after a Kotlin keyword is refused`() {
+    assertThat(refusal(ScreenDocument("when", ScreenNode(text.canonicalId)), catalog(text)).first())
+      .contains("not a usable Kotlin function name")
+  }
+
+  @Test
+  fun `a Float value that cannot survive narrowing is refused`() {
+    val sized =
+      component(
+        "Sized",
+        "com.example.Sized",
+        listOf(TargetParameter("scale", "Float", typeFqn = "kotlin.Float")),
+      )
+    fun screen(v: Double) =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(sized.canonicalId, arguments = mapOf("scale" to ScreenValue.Fractional(v))),
+      )
+
+    // Past Float's range it becomes Infinity; below it, zero. Neither is the designed value.
+    assertThat(refusal(screen(Double.MAX_VALUE), catalog(sized)).first()).contains("scale")
+    assertThat(refusal(screen(1.0e-60), catalog(sized)).first()).contains("scale")
+    // Non-finite is not a Kotlin literal at all.
+    assertThat(refusal(screen(Double.NaN), catalog(sized)).first()).contains("scale")
+    assertThat(emitted(screen(0.5), catalog(sized)).source).contains("Sized(scale = 0.5f)")
+    // Zero is legitimate and must not be mistaken for an underflow.
+    assertThat(emitted(screen(0.0), catalog(sized)).source).contains("Sized(scale = 0.0f)")
+  }
+
+  @Test
+  fun `opt-in markers are qualified, so two of the same simple name stay distinct`() {
+    val a =
+      component("A", "com.a.A", emptyList(), requiredOptIns = listOf("com.a.ExperimentalApi")).let {
+        it.copy(canonicalId = "app/com.a.AKt.A", symbol = it.symbol.copy(callable = "com.a.A"))
+      }
+    val b =
+      component("B", "com.b.B", emptyList(), requiredOptIns = listOf("com.b.ExperimentalApi")).let {
+        it.copy(canonicalId = "app/com.b.BKt.B", symbol = it.symbol.copy(callable = "com.b.B"))
+      }
+    val holder =
+      card.copy(
+        parameters =
+          listOf(TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true))
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          holder.canonicalId,
+          slots = mapOf("content" to listOf(ScreenNode(a.canonicalId), ScreenNode(b.canonicalId))),
+        ),
+      )
+
+    val source = emitted(screen, catalog(holder, a, b)).source
+
+    // `@OptIn(ExperimentalApi::class, ExperimentalApi::class)` would not compile.
+    assertThat(source)
+      .contains("@OptIn(com.a.ExperimentalApi::class, com.b.ExperimentalApi::class)")
+  }
+
+  @Test
+  fun `a record from a newer schema is refused rather than read as this one`() {
+    val newer =
+      ComponentRecordFile(
+        schemaVersion = COMPONENT_RECORD_SCHEMA_VERSION + 1,
+        module = "app",
+        variant = "debug",
+        components = listOf(text),
+      )
+
+    assertThat(refusal(ScreenDocument("Screen", ScreenNode(text.canonicalId)), newer).first())
+      .contains("newer than")
+  }
+
+  @Test
+  fun `a package segment that is not a usable identifier is refused`() {
+    val result =
+      ScreenGenerator.generate(
+        ScreenDocument("Screen", ScreenNode(text.canonicalId)),
+        catalog(text),
+        packageName = "com.example.when",
+      )
+
+    assertThat((result as ScreenGenerator.Result.Refused).reasons.first()).contains("`when`")
+  }
+
+  @Test
+  fun `children of an unresolved node are still reported`() {
+    // A catalog that dropped a whole subtree should name every node it can no longer place.
+    val holder =
+      card.copy(
+        parameters =
+          listOf(TargetParameter("content", "ColumnScope.() -> Unit", composableSlot = true))
+      )
+    val screen =
+      ScreenDocument(
+        "Screen",
+        ScreenNode(
+          holder.canonicalId,
+          slots =
+            mapOf(
+              "content" to
+                listOf(
+                  ScreenNode(
+                    "app/com.example.GoneKt.Gone",
+                    slots =
+                      mapOf("content" to listOf(ScreenNode("app/com.example.AlsoGoneKt.AlsoGone"))),
+                  )
+                )
+            ),
+        ),
+      )
+
+    val reasons = refusal(screen, catalog(holder))
+
+    assertThat(reasons).hasSize(2)
+    assertThat(reasons.joinToString()).contains("AlsoGone")
   }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenGeneratorTest.kt
@@ -445,7 +445,7 @@ class ScreenGeneratorTest {
       )
 
     assertThat(emitted(screen(Long.MIN_VALUE), catalog(counted)).source)
-      .contains("Counted(total = Long.MIN_VALUE)")
+      .contains("Counted(total = kotlin.Long.MIN_VALUE)")
     assertThat(emitted(screen(Long.MAX_VALUE), catalog(counted)).source)
       .contains("Counted(total = 9223372036854775807L)")
     assertThat(emitted(screen(7L), catalog(counted)).source).contains("Counted(total = 7L)")

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -97,3 +97,15 @@ fun optInComponent(label: String) {}
 
 /** An author opting *their own* declaration into internals — the caller really must opt in. */
 @Suppress("unused", "UNUSED_PARAMETER") @InternalFixtureApi fun deliberatelyInternalComponent() {}
+
+/**
+ * A marker declared inside a class, so its binary name carries a `$` the source spelling has not.
+ */
+class MarkerHolder {
+  @RequiresOptIn("Fixture-only marker.")
+  @Retention(AnnotationRetention.BINARY)
+  @Target(AnnotationTarget.FUNCTION)
+  annotation class NestedApi
+}
+
+@Suppress("unused") @MarkerHolder.NestedApi fun nestedMarkerComponent() {}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -109,3 +109,16 @@ class MarkerHolder {
 }
 
 @Suppress("unused") @MarkerHolder.NestedApi fun nestedMarkerComponent() {}
+
+/** A top-level marker whose backticked name legitimately contains a `$`. */
+@RequiresOptIn("Fixture-only marker.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+annotation class `Api$Experimental`
+
+@Suppress("unused") @`Api$Experimental` fun dollarMarkerComponent() {}
+
+// No context-receiver fixture: this module's language version cannot express either spelling
+// (`context(Foo)` needs -Xcontext-receivers, `context(f: Foo)` needs language version 2.4). The
+// refusal a recorded context produces is covered in ComponentSnippetsTest instead; the metadata
+// read itself has no fixture here, which ComposableSignature.hasContextRequirement says plainly.

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -62,3 +62,38 @@ fun nullableKnobComponent(label: String? = null, enabled: Boolean = true) {}
 // ambiguous with a non-null callback returning `Unit?`.
 @Suppress("unused")
 fun nullableCallbackComponent(onCheckedChange: ((Boolean) -> Unit)?, onClick: (() -> Unit)?) {}
+
+// --- Opt-in marker fixtures ------------------------------------------------------------------
+
+/** An author-written opt-in marker, the shape `@ExperimentalMaterial3Api` has. */
+@RequiresOptIn("Fixture-only marker.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+annotation class ExperimentalFixtureApi
+
+/** An author-written marker guarding internals, the shape `@InternalComposeApi` has. */
+@RequiresOptIn("Fixture-only marker.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+annotation class InternalFixtureApi
+
+/**
+ * A marker that is **not itself** an opt-in requirement but whose class is guarded by one — exactly
+ * `@ComposableInferredTarget`, which the Compose compiler stamps onto every composable and which is
+ * declared `@InternalComposeApi`. Reading the meta-annotation closure of a method carrying this
+ * reports [InternalFixtureApi], which no caller has to opt into.
+ */
+@InternalFixtureApi
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+annotation class FixtureInferredTarget
+
+/** The trap: one real marker, one compiler-shaped marker that must not contribute its own. */
+@OptIn(InternalFixtureApi::class)
+@ExperimentalFixtureApi
+@FixtureInferredTarget
+@Suppress("unused", "UNUSED_PARAMETER")
+fun optInComponent(label: String) {}
+
+/** An author opting *their own* declaration into internals — the caller really must opt in. */
+@Suppress("unused", "UNUSED_PARAMETER") @InternalFixtureApi fun deliberatelyInternalComponent() {}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
@@ -1,0 +1,222 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import ee.schimke.composeai.discovery.ComponentRecordFile
+import ee.schimke.composeai.discovery.ScreenDocument
+import ee.schimke.composeai.discovery.ScreenGenerator
+import ee.schimke.composeai.discovery.ScreenNode
+import ee.schimke.composeai.discovery.ScreenValue
+import java.io.File
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * The end-to-end prototype: a builder's document, the components a real build discovered, and a
+ * screen the Kotlin compiler accepts.
+ *
+ * `ComponentCallSiteCompileFunctionalTest` proves one component can be *called*. This proves a
+ * screen can be *composed* — values bound, components nested into slots — which is the thing a UI
+ * builder is for and the thing no test covered. The exporter it replaces asserted balanced braces
+ * on its output; balanced braces are not a compiler.
+ *
+ * Nothing here is hand-fed. The catalog is whatever `composePreviewDiscover` wrote for a project of
+ * ordinary previews, addressed by canonical id, so a change that stops a component being
+ * discoverable — or stops its call site being printable — fails here rather than in a consumer.
+ */
+class ScreenGeneratorCompileFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-screen-generator"
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "Components.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.material3.Button
+        import androidx.compose.material3.Card
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.tooling.preview.Preview
+
+        @Preview
+        @Composable
+        fun LabelPreview() {
+            Text(text = "Hello")
+        }
+
+        @Preview
+        @Composable
+        fun ActionPreview() {
+            Button(onClick = {}) { Text(text = "Go") }
+        }
+
+        @Preview
+        @Composable
+        fun ContainerPreview() {
+            Card { Text(text = "Inside") }
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  private fun runGradle(projectDir: File, vararg arguments: String) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments(*arguments)
+      .withPluginClasspath()
+      .build()
+
+  /** `<module>/<jvmOwner>.<name>`, the id a builder stores when a component is placed. */
+  private fun idOf(components: ComponentRecordFile, name: String): String {
+    val record =
+      components.components.firstOrNull { it.symbol.name == name && it.code?.call != null }
+    assertWithMessage(
+        "no usable `%s` in the discovered catalog; components were %s",
+        name,
+        components.components.map {
+          "${it.symbol.name}=${it.code?.call ?: it.code?.refusedReason}"
+        },
+      )
+      .that(record)
+      .isNotNull()
+    return record!!.canonicalId
+  }
+
+  @Test
+  fun `a screen composed from discovered components compiles`() {
+    val projectDir = createTestProject()
+
+    val discover = runGradle(projectDir, "composePreviewDiscover")
+    assertThat(discover.task(":composePreviewDiscover")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    val components =
+      json.decodeFromString(
+        ComponentRecordFile.serializer(),
+        File(projectDir, "build/compose-previews/components.json").readText(),
+      )
+
+    // The document a builder would hold after someone dropped a Card on the canvas, typed a
+    // heading into a Text, and put a Button under it with its own label.
+    val screen =
+      ScreenDocument(
+        name = "HomeScreen",
+        root =
+          ScreenNode(
+            componentId = idOf(components, "Card"),
+            slots =
+              mapOf(
+                "content" to
+                  listOf(
+                    ScreenNode(
+                      componentId = idOf(components, "Text"),
+                      arguments = mapOf("text" to ScreenValue.Text("Good morning")),
+                    ),
+                    ScreenNode(
+                      componentId = idOf(components, "Button"),
+                      slots =
+                        mapOf(
+                          "content" to
+                            listOf(
+                              ScreenNode(
+                                componentId = idOf(components, "Text"),
+                                arguments = mapOf("text" to ScreenValue.Text("Continue")),
+                              )
+                            )
+                        ),
+                    ),
+                  )
+              ),
+          ),
+      )
+
+    val result = ScreenGenerator.generate(screen, components)
+    val emitted =
+      assertWithMessage(
+          "generation refused: %s",
+          (result as? ScreenGenerator.Result.Refused)?.reasons,
+        )
+        .that(result)
+        .isInstanceOf(ScreenGenerator.Result.Emitted::class.java)
+        .let { result as ScreenGenerator.Result.Emitted }
+
+    // The designed values reached the source, rather than the placeholders a call site prints.
+    assertThat(emitted.source).contains("""Text(text = "Good morning")""")
+    assertThat(emitted.source).contains("""Text(text = "Continue")""")
+    // Stock Material 3 needs no opt-in at a call site. Compose's compiler stamps its own markers
+    // onto the JVM method, and reporting those told consumers to opt into Compose internals to use
+    // a `Card` — verified by stripping the annotations and watching this same screen still compile.
+    assertThat(emitted.requiredOptIns).isEmpty()
+    assertThat(emitted.source).doesNotContain("@OptIn")
+
+    val generated = File(projectDir, "src/main/kotlin/generated")
+    generated.mkdirs()
+    File(generated, "HomeScreen.kt").writeText(emitted.source)
+
+    // `GradleRunner.build()` throws on failure, so reaching this line is the gate: the Kotlin
+    // compiler accepted a screen assembled entirely from the discovered catalog.
+    val compile = runGradle(projectDir, "compileKotlin")
+    assertThat(compile.task(":compileKotlin")?.outcome)
+      .isIn(listOf(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE))
+  }
+}

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ScreenGeneratorCompileFunctionalTest.kt
@@ -203,9 +203,11 @@ class ScreenGeneratorCompileFunctionalTest {
     // The designed values reached the source, rather than the placeholders a call site prints.
     assertThat(emitted.source).contains("""Text(text = "Good morning")""")
     assertThat(emitted.source).contains("""Text(text = "Continue")""")
-    // Stock Material 3 needs no opt-in at a call site. Compose's compiler stamps its own markers
-    // onto the JVM method, and reporting those told consumers to opt into Compose internals to use
-    // a `Card` — verified by stripping the annotations and watching this same screen still compile.
+    // Stock Material 3 needs no opt-in at a call site. The markers the Compose compiler stamps
+    // onto the JVM method are not themselves opt-in requirements, and reading the meta-annotation
+    // closure rather than the direct annotations reported them anyway — which told consumers to
+    // opt into Compose internals to place a `Card`. This is the gate on that against a real
+    // library; `ComposableSignatureTest` covers the same trap on fixtures.
     assertThat(emitted.requiredOptIns).isEmpty()
     assertThat(emitted.source).doesNotContain("@OptIn")
 


### PR DESCRIPTION
## Summary

A working prototype of the UI-builder code path: a builder's document, the components a real build discovered, and a screen the Kotlin compiler accepts.

`ComponentSnippets` prints one component's call site with **placeholders** — `Text(text = "")`. That proves a component is reachable and renders nothing anyone designed. This adds the other half: the values the user set, and components nested into each other's slots.

Generated by the functional test, from a catalog `composePreviewDiscover` produced, and compiled:

```kotlin
package generated.screen

import androidx.compose.material3.Card
import androidx.compose.runtime.Composable

@Composable
fun HomeScreen() {
    Card(content = {
        androidx.compose.material3.Text(text = "Good morning")
        androidx.compose.material3.Button(onClick = {}, content = {
            androidx.compose.material3.Text(text = "Continue")
        })
    })
}
```

`onClick` fell back to the placeholder table because the document did not set it; everything else is the document's. Nested calls are qualified rather than imported — see the receiver-shadowing note below, which is the one deliberate readability cost in here.

## What it inherits rather than re-derives

A node generates **only when its record carries an emitted `ComponentCode`**. That one check carries every protection the call-site generator learned the hard way — public, no uninferable type parameters, no overload collision, a signature actually read rather than defaulted away, a top-level function with an importable callable. None of it is restated here.

`code.call` is the *licence to call*; the argument list is rebuilt from `ComponentRecord.parameters` with the document's values. `placeholderFor` and the qualified-type check are shared with `ComponentSnippets` rather than copied, because "is this really `kotlin.String`?" is exactly the question that has already been got wrong twice.

## Refusing

A screen that compiles and is not the one designed is worse than an error:

| Case | Why not just emit |
| --- | --- |
| component id not in the catalog | a builder pinned to a catalog it no longer has is where inventing produces confident nonsense |
| a `components.json` newer than this schema, or older than schema 2 | this generator's guarantee rests on fields schema 1 lacks; re-run discovery rather than squint at it |
| property the component never declared | dropping it silently generates the wrong screen |
| `com.example.String` given a string literal | the trap that bit the call-site generator twice |
| a number that cannot survive narrowing | `2147483648` wraps to `-2147483648`; a `Double` past `Float`'s range becomes `Infinity` — both compile, neither is the value anyone entered |
| a screen or package segment named `_` or `__` | Kotlin reserves all-underscore names, and they match every identifier regex ever written |
| children in a slot a bare lambda cannot satisfy | `(Float, Float) -> Unit` has nothing to bind |
| a component needing a context receiver | a context is not a value parameter, so a printed call gives no hint one is required |
| a string past 65535 modified-UTF-8 bytes | not expressible as a JVM string constant at all |

Every problem is reported, not just the first — including inside a subtree whose parent is unresolvable, attached to a slot the component no longer declares, or in a slot no bare lambda can satisfy.

**Names are handled where they are emitted.** Components and opt-in markers are written fully qualified, every segment quoted when it cannot be written bare, and `@kotlin.OptIn` / `@androidx.annotation.OptIn` are chosen by the mechanism that declared each marker — the two are not interchangeable, and Kotlin's rejects an AndroidX marker outright. `kotlin.Long.MIN_VALUE` is emitted by name because `-9223372036854775808L` does not compile; `Int.MIN_VALUE` stays a literal because the same spelling one type down *is* accepted. The compiler was asked in both cases.

## The bug the prototype found, and the wrong first fix for it

Building it surfaced a defect in the opt-in markers added in [#5073](https://github.com/yschimke/compose-ai-tools/pull/5073): generated screens carried `@OptIn(InternalComposeApi::class)` just to place a `Card`.

My first fix was a name denylist. That was wrong, and the reviewer was right that it would also silence a component an author had *deliberately* marked `@InternalComposeApi`. Chasing it found the real cause: **ClassGraph's `MethodInfo.annotationInfo` is the transitive closure of meta-annotations, not the annotations written on the method.** `Card` carries three, and the closure of those three drags in `InternalComposeApi`, `ComposeCompilerApi` and `kotlin.RequiresOptIn` itself. The marker was never on `Card`.

`directOnly()` at both levels asks the actual Kotlin question. Verified against the real `material3-desktop` jar with a standalone ClassGraph probe:

| Method | Reported |
| --- | --- |
| `CardKt.Card` | *(nothing)* |
| `ButtonKt.Button` | `ExperimentalMaterial3ExpressiveApi` |
| `AppBarKt.BottomAppBar` | `ExperimentalMaterial3Api` |

## One trade-off worth a second opinion

A child inside a receiver slot is called **fully qualified**, because Kotlin resolves a simple name against implicit receivers before imports — a `ColumnScope` declaring a member `Text` would beat the import and the screen would compile while drawing something else. The receiver's members are not in the record, so this is undetectable, not merely unlikely.

I measured the hazard before accepting the cost: material3 1.11.0-alpha07 has 197 top-level composables, one scope type with composable members, and **zero collisions**. So it guards a future or project-local collision, not one the catalog exhibits today, and it makes every nested call verbose. Kept because the failure it prevents is the one this generator refuses everywhere else — but a reasonable call to make differently, and a one-line revert. [Thread](https://github.com/yschimke/compose-ai-tools/pull/5076#discussion_r3923730630).

## Scope

- `ScreenDocument` is deliberately **not** the builder's document model — it is the narrow projection the generator needs, so it can be tested without an editor's undo stack. Projecting onto it is the builder's job.
- Producer half only. Wiring `compose-preview-server`'s exporter onto it, replacing the authored `CapabilityCatalog` and 29-entry `EMITTER_IDS` allowlist, is next and not here.
- Layout primitives are absent because inference scopes library components to `material3`/`material`/`wear`; the screen nests inside `Card`'s `ColumnScope` instead.

## Test plan

- `./gradlew :gradle-plugin:functionalTest --rerun` — the **whole** suite, run alone from a cleared results directory: **BUILD SUCCESSFUL**, 105 tests, 0 failures. `--rerun` matters: a plain invocation reports success in under a second because Gradle holds the task UP-TO-DATE.
- `./gradlew ktfmtCheckAll :gradle-plugin:preview-discovery:test :gradle-plugin:test` — **BUILD SUCCESSFUL**.
- 37 `ScreenGeneratorTest`, 13 `ComposableSignatureTest`, 25 `ComponentSnippetsTest` — most of the growth is review rounds.
- **Every fix was confirmed failing on the immediately preceding commit before being restored.** A test that passes both before and after is not a regression net, and one round proved the point: a test written in round 7 asserted the *broken* output and held that bug in place until round 8 caught it.
- Claims about the language were checked by compiling them, never asserted. Rejected: `-9223372036854775808L`, `fun _()`, and `@Target(AnnotationTarget.FILE)` on a `@RequiresOptIn` marker. Accepted: `-2147483648`, `fun catch()`, `fun finally()`, `package com.import`.
- `ScreenGeneratorCompileFunctionalTest` end to end: discover, generate, write into the project, compile.
- **Non-visual change, and both preview lanes now agree.** `Preview Changes` reports *"No visual changes detected — 511 preview(s) unchanged"*, and `Notification Previews` reports *"No notification preview changes in this PR's latest render"*. An earlier "22 removed" from the notifications lane was a stale-baseline artifact and has since corrected itself in place.

## Status

Ten review rounds, 38 findings — 35 real. Per round: 5, 6, 4, 5, 2, 2, 5, 1, 4, 4.

- [x] Rounds 1–6 — fixed
- [x] Round 7 (5) — fixed; **two were defects my own round-6 commit introduced**
- [x] Round 8 (1) — fixed; a defect round 7 introduced, whose test had asserted the broken form
- [x] Round 9 (3 of 4) — two collapsed into *deleting* the schema-1 compatibility path rather than adding an exception per field, which is less code than it replaced
- [x] Round 10 (1 of 4) — one real fix; **two findings were false and shown so with the compiler**, which is a first for this PR: `catch`/`finally`/`import` are soft keywords, and a `@RequiresOptIn` marker cannot target `FILE`. Replied with the evidence rather than resolved on my own say-so.
- [ ] **Stopped fixing forward at round 9, deliberately.** What remains is one unsolved problem, not a list: the record cannot express every source-level restriction on calling a declaration, and `code.call != null` is read as proof there are none. Two are open and documented in `ScreenGenerator`'s KDoc — `@Deprecated(level = ERROR)` components, and context *parameters* (Kotlin 2.2+), which this module's API version cannot read. The fix is an explicit statement of what `code.call` promises, or a compile check in the producer — not a boolean per restriction, which is how that list would keep growing. That thread is left open rather than resolved.
- [ ] `Daemon Harness (android, real renderer)` — red on `main` at this PR's exact merge base ([run 33736575795](https://github.com/yschimke/compose-ai-tools/actions/runs/33736575795)); [not this PR's, with no fix to port](https://github.com/yschimke/compose-ai-tools/pull/5076#issuecomment-5524010574). Same test, same exception, same line 402 on all ten heads — including one that changed only a KDoc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o