### PR TITLE
feat(discovery): widen a screen value past the four literals

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
@@ -92,6 +92,27 @@ sealed interface ScreenValue {
   val typeFqn: String?
     get() = null
 
+  /**
+   * `@RequiresOptIn` markers the expression needs, declared with `kotlin.RequiresOptIn`.
+   *
+   * The generator unions these into the wrapper's `@OptIn` exactly as it does for a component's
+   * [ComponentCode.requiredOptIns]. It has to be declared rather than derived: a component's
+   * markers come from the record, which discovery read off the class file, but a value names an
+   * arbitrary allowed callable and nothing here has that callable's annotations. So a projection
+   * reaching for an experimental accessor says so, and one that forgets gets a file the compiler
+   * rejects — the same trade as [typeFqn], and the same reason it is written down here.
+   */
+  val requiredOptIns: List<String>
+    get() = emptyList()
+
+  /**
+   * The subset of [requiredOptIns] declared with `androidx.annotation.RequiresOptIn`, which needs
+   * `@androidx.annotation.OptIn(markerClass = […])` rather than `@kotlin.OptIn` — see
+   * [ComponentCode.androidxOptIns] for why the two are not interchangeable.
+   */
+  val androidxOptIns: List<String>
+    get() = emptyList()
+
   @Serializable data class Text(val value: String) : ScreenValue
 
   @Serializable data class Bool(val value: Boolean) : ScreenValue
@@ -118,6 +139,8 @@ sealed interface ScreenValue {
     val rootFqn: String,
     val members: List<String> = emptyList(),
     override val typeFqn: String,
+    override val requiredOptIns: List<String> = emptyList(),
+    override val androidxOptIns: List<String> = emptyList(),
   ) : ScreenValue
 
   /**
@@ -138,6 +161,8 @@ sealed interface ScreenValue {
     val positional: List<ScreenValue> = emptyList(),
     val named: Map<String, ScreenValue> = emptyMap(),
     override val typeFqn: String,
+    override val requiredOptIns: List<String> = emptyList(),
+    override val androidxOptIns: List<String> = emptyList(),
   ) : ScreenValue
 
   /**
@@ -158,6 +183,8 @@ sealed interface ScreenValue {
     val receiver: ScreenValue,
     val links: List<ChainLink>,
     override val typeFqn: String,
+    override val requiredOptIns: List<String> = emptyList(),
+    override val androidxOptIns: List<String> = emptyList(),
   ) : ScreenValue
 }
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenDocument.kt
@@ -22,9 +22,15 @@ data class ScreenDocument(
  * One placed component: which one, the arguments the user set, and what they dropped into its
  * slots.
  *
- * @property componentId the [ComponentRecord.canonicalId] this node places. An id with no matching
- *   record is a refusal, never a guess — a builder pinned to a catalog it no longer has is exactly
- *   the case where inventing a call site produces confident nonsense.
+ * @property componentId a [ComponentRecord.canonicalId], or one of its
+ *   [ComponentRecord.componentIds] catalog aliases. Both are accepted because the two sides name
+ *   components differently and neither can be made to give: discovery's key is derived
+ *   (`app/androidx.compose.material3.TextKt.Text`) precisely so an ordinary preview that carries no
+ *   catalog identity still gets one, while a builder's document holds the authored id its palette
+ *   was built from (`m3/text`). The record already carries that mapping, so resolving it here beats
+ *   asking every builder to rebuild it. An alias claimed by two records is a refusal rather than a
+ *   pick, and an id matching nothing is a refusal too — a builder pinned to a catalog it no longer
+ *   has is exactly the case where inventing a call site produces confident nonsense.
  * @property arguments values the user set, by **source parameter name**. A name the component does
  *   not declare is a refusal: silently dropping it would generate a screen that compiles and is not
  *   the one that was designed.
@@ -40,13 +46,52 @@ data class ScreenNode(
 /**
  * A value a builder can set on a parameter.
  *
- * A closed set on purpose. Every case here has an unambiguous Kotlin literal *and* an unambiguous
- * type to check against the parameter's [TargetParameter.typeFqn], which is what lets the generator
- * reject `text = true` instead of emitting it. Widening this set means widening the type check with
- * it — a value kind whose type cannot be checked is a call site nobody can prove compiles.
+ * ## Two halves, with different guarantees
+ *
+ * [Text], [Bool], [Whole] and [Fractional] are **self-evidently typed**: the generator knows what
+ * `"hello"` and `false` are without being told, so it can reject `text = true` from the record
+ * alone. That is the whole reason the first version of this interface held nothing else.
+ *
+ * It held nothing else for one release. A real builder document sets colours, dimensions, theme
+ * tokens, enum entries, paddings and modifier chains, and measured against one — 19 `m3/text`
+ * nodes, 18 colour tokens, 14 typography tokens, 11 paddings, 10 layout modifiers — the four
+ * literal kinds covered under a third of the values placed. A generator that refuses two thirds of
+ * a screen is not a generator anybody uses, so the vocabulary widened to the three shapes below:
+ * [Reference] (`MaterialTheme.colorScheme.primary`), [Construct] (`PaddingValues(16.dp)`) and
+ * [Chain] (`Modifier.fillMaxWidth()`).
+ *
+ * ## What the widening costs, stated plainly
+ *
+ * Those three carry a **claimed** [ScreenValue.typeFqn] rather than an evident one. The generator
+ * still checks it against [TargetParameter.typeFqn] and still refuses a mismatch, so a colour
+ * handed to a `String` parameter is caught exactly as `text = true` was — but it cannot check that
+ * `MaterialTheme.colorScheme.primary` really *is* a `Color`. It takes the projection's word for
+ * that one fact.
+ *
+ * That trade is deliberate and it is the smaller of two evils. The alternative was a table of
+ * Material 3's token names inside a library that knows nothing about Material 3, maintained by
+ * hand, wrong the first time a design system renamed a token. Instead the design system's own
+ * knowledge stays with whoever has it, and what arrives here is a **restricted expression shape**:
+ * a dotted path, a call, a chain of extension links. Not free text — every name is checked as
+ * writable Kotlin and every reference is emitted fully qualified, so a projection cannot smuggle in
+ * `run { System.exit(0) }` or shadow an import.
+ *
+ * A projection that gets a claimed type wrong produces source that does not compile. That failure
+ * is loud, local and lands on the projection — which is the right place for it, and is why the
+ * server-side compile check exists.
  */
 @Serializable
 sealed interface ScreenValue {
+
+  /**
+   * The fully-qualified classifier this value has, or null when the value is its own evidence.
+   *
+   * Null for the four literal kinds — nothing sensible could be claimed for `Whole(1)`, which fits
+   * `Int` and `Long` alike and is checked against whichever the parameter declares.
+   */
+  val typeFqn: String?
+    get() = null
+
   @Serializable data class Text(val value: String) : ScreenValue
 
   @Serializable data class Bool(val value: Boolean) : ScreenValue
@@ -54,4 +99,79 @@ sealed interface ScreenValue {
   @Serializable data class Whole(val value: Long) : ScreenValue
 
   @Serializable data class Fractional(val value: Double) : ScreenValue
+
+  /**
+   * A read through a fully-qualified path — `androidx.compose.material3.MaterialTheme.colorScheme
+   * .primary`, `androidx.compose.ui.text.style.TextAlign.Center`.
+   *
+   * Emitted fully qualified and therefore imported nowhere. That is not tidiness: an import can be
+   * shadowed by a same-named declaration in the package the caller chose for the generated file,
+   * and a qualified path cannot. It is also what keeps this case honest — there is no receiver to
+   * infer and no overload to resolve, so the only thing the generator is trusting is [typeFqn].
+   *
+   * @property rootFqn the qualified name the path starts from. A class (`…MaterialTheme`), an
+   *   object, or a top-level property.
+   * @property members further members read from it, in order. Empty for a bare object read.
+   */
+  @Serializable
+  data class Reference(
+    val rootFqn: String,
+    val members: List<String> = emptyList(),
+    override val typeFqn: String,
+  ) : ScreenValue
+
+  /**
+   * A call to a fully-qualified callable — `androidx.compose.ui.graphics.Color(0xFF6750A4)`,
+   * `androidx.compose.foundation.layout.PaddingValues(16.dp)`.
+   *
+   * Qualified for the same reason [Reference] is. A constructor and a top-level factory function
+   * are the same shape here on purpose: `Color(…)` is a function and `PaddingValues(…)` a
+   * constructor, the distinction is invisible at the call site, and a record that made a projection
+   * declare which one would only give it a second thing to get wrong.
+   *
+   * @property positional arguments in declaration order.
+   * @property named arguments by parameter name, appended after [positional].
+   */
+  @Serializable
+  data class Construct(
+    val callableFqn: String,
+    val positional: List<ScreenValue> = emptyList(),
+    val named: Map<String, ScreenValue> = emptyMap(),
+    override val typeFqn: String,
+  ) : ScreenValue
+
+  /**
+   * A receiver followed by extension links — `Modifier.fillMaxWidth().padding(16.dp)`, `16.dp`.
+   *
+   * The one case that **must** import, and the reason it is a case of its own rather than a
+   * [Reference] with a longer path: an extension is resolved from the importing file's scope, so
+   * `Modifier.androidx.compose.foundation.layout.fillMaxWidth()` is not a spelling of anything.
+   * Each link's callable is imported and called by its simple name, and two links claiming one
+   * simple name from different packages are refused — Kotlin calls that a conflicting import, and
+   * picking one would silently generate a chain nobody wrote.
+   *
+   * @property receiver what the links apply to. `Modifier` as a [Reference], or a literal for the
+   *   `16` in `16.dp`.
+   */
+  @Serializable
+  data class Chain(
+    val receiver: ScreenValue,
+    val links: List<ChainLink>,
+    override val typeFqn: String,
+  ) : ScreenValue
 }
+
+/**
+ * One link in a [ScreenValue.Chain].
+ *
+ * @property callableFqn the extension's fully-qualified name. Imported, then called by simple name.
+ * @property property a property read (`.dp`) rather than a call (`.padding(8.dp)`). A link that is
+ *   both — a property with arguments — is a refusal, not a call.
+ */
+@Serializable
+data class ChainLink(
+  val callableFqn: String,
+  val positional: List<ScreenValue> = emptyList(),
+  val named: Map<String, ScreenValue> = emptyMap(),
+  val property: Boolean = false,
+)

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -514,6 +514,12 @@ object ScreenGenerator {
         reasons += "$where nests values more than $MAX_VALUE_DEPTH deep"
         return null
       }
+      // Collected for every nesting level, not just the outermost, because a construct's argument
+      // is as capable of naming a gated API as the construct itself. Unioned into the same two
+      // sets a component's markers go into, so the wrapper carries one `@OptIn` of each mechanism
+      // however many places asked for it.
+      optIns += value.requiredOptIns
+      androidxOptIns += value.androidxOptIns
       return when (value) {
         is ScreenValue.Text -> string(value.value, where)
         is ScreenValue.Bool -> value.value.toString()
@@ -557,6 +563,31 @@ object ScreenGenerator {
               // file this generator had already called compilable.
               val imported = qualifiedName(link.callableFqn, where) ?: return null
               val simple = link.callableFqn.substringAfterLast('.')
+              // A chain link is *imported* and called by its simple name, so it has to be a
+              // top-level declaration. `RowScope.weight` is not: it is a member extension of the
+              // scope, supplied by an implicit receiver, and neither
+              // `import …layout.RowScope.weight` nor a package-level `…layout.weight` resolves.
+              // Emitted anyway it produces a file that fails on the import line.
+              //
+              // The qualifier's case is the evidence available here. Kotlin packages are lower
+              // case and classifiers are capitalised by universal convention, so a capitalised
+              // penultimate segment names a classifier and therefore a member. That is a
+              // convention rather than a rule — a top-level callable in a package with a
+              // capitalised segment is legal and would be refused — and refusing the legal
+              // oddity beats emitting the common one broken.
+              if (
+                link.callableFqn
+                  .substringBeforeLast('.')
+                  .substringAfterLast('.')
+                  .firstOrNull()
+                  ?.isUpperCase() == true
+              ) {
+                reasons +=
+                  "$where links `${link.callableFqn}`, whose qualifier names a classifier rather " +
+                    "than a package — a member extension comes from an implicit receiver and " +
+                    "cannot be imported"
+                return null
+              }
               if (!link.property && simple == screenName) {
                 // An extension imported under the screen's own name is shadowed by the function
                 // being generated, so the chain would call the screen — or fail to resolve.

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -54,6 +54,15 @@ package ee.schimke.composeai.discovery
  * trade is readability against a narrow hazard, and it is recorded here so it is a decision rather
  * than an oversight.
  *
+ * ## The one thing a caller must decide
+ *
+ * `expressionPackages` is not a convenience. A [ScreenDocument] is wire data, and
+ * [ScreenValue.Construct] emits a qualified call with document-supplied arguments — so without a
+ * declared vocabulary this object would happily generate
+ * `java.nio.file.Files.readString(java.nio.file.Path.of("/etc/passwd"))` for a `String` parameter,
+ * and a host that compiles and renders what it generated would run it. The set is empty by default,
+ * so a caller that has not thought about it gets refusals rather than arbitrary code.
+ *
  * A third gap arrived with the widened value vocabulary and is a different animal:
  * [ScreenValue.Reference], [ScreenValue.Construct] and [ScreenValue.Chain] carry a **claimed**
  * type. It is checked against the parameter, so a colour handed to a `String` is still refused, but
@@ -90,6 +99,7 @@ object ScreenGenerator {
     document: ScreenDocument,
     components: ComponentRecordFile,
     packageName: String = "generated.screen",
+    expressionPackages: Set<String> = emptySet(),
   ): Result {
     if (components.schemaVersion > COMPONENT_RECORD_SCHEMA_VERSION) {
       // A record from a newer producer may mean things by fields this build has never seen.
@@ -150,7 +160,13 @@ object ScreenGenerator {
         }
         .map { it.canonicalId }
         .toSet()
-    val context = Emission(ComponentIndex(components.components), simplyImportable, document.name)
+    val context =
+      Emission(
+        ComponentIndex(components.components),
+        simplyImportable,
+        document.name,
+        expressionPackages,
+      )
     val body = context.node(document.root, depth = 1)
     if (context.reasons.isNotEmpty()) return Result.Refused(context.reasons.toList())
 
@@ -271,6 +287,7 @@ object ScreenGenerator {
     val index: ComponentIndex,
     val simplyImportable: Set<String>,
     val screenName: String,
+    val expressionPackages: Set<String>,
   ) {
     val imports = mutableSetOf<String>()
     /**
@@ -601,8 +618,32 @@ object ScreenGenerator {
       // unchecked, `Construct("Color", …)` emitted a bare `Color(…)` into `package
       // generated.screen`
       // and this returned `Emitted` for it.
+      //
+      // Shape before trust, deliberately: a malformed name is malformed whatever vocabulary is
+      // declared, and "this is not a qualified name" is the more actionable of the two answers.
       if (fqn.isEmpty() || segments.size < 2 || segments.any { !isWritableName(it) }) {
         reasons += "$where refers to `$fqn`, which is not a qualified Kotlin name"
+        return null
+      }
+      // **The trust boundary.** Everything else in this file asks whether a name can be *written*;
+      // this asks whether it may be *called*, and the two are not the same question once a
+      // document arrives over the wire.
+      //
+      // `Construct` emits a fully-qualified call with the arguments the document supplies, so a
+      // spelling-only check admits any accessible JVM method:
+      // `Files.readString(Path.of("/etc/passwd"))` is a well-formed qualified call whose claimed
+      // type is `kotlin.String`, matches a `String` parameter, and generates without complaint. A
+      // host that then compiles and renders the screen — which is the point of generating it —
+      // has executed it.
+      //
+      // So a caller declares the vocabulary its projection is allowed to name, and the default is
+      // **empty**: a caller who never thought about this gets refusals rather than arbitrary code.
+      // A prefix matches the package itself or a name under it, never a longer sibling package,
+      // which is why the `.` is required rather than a bare `startsWith`.
+      if (expressionPackages.none { fqn == it || fqn.startsWith("$it.") }) {
+        reasons +=
+          "$where names `$fqn`, which is outside the packages this screen may call " +
+            "(${expressionPackages.sorted().joinToString(", ").ifEmpty { "none are allowed" }})"
         return null
       }
       return segments.joinToString(".") { ComponentSnippets.escapeIfKeyword(it) }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -41,6 +41,19 @@ package ee.schimke.composeai.discovery
  * `code.call` promises, or compiling a candidate call in the producer — not a boolean per
  * restriction, which is how this list would keep growing.
  *
+ * A third restriction belongs to [ScreenValue.Chain] rather than to `code.call`: an imported
+ * extension **loses to a member of the same simple name on the receiver**. A link naming
+ * `com.example.pad` is emitted as `.pad()`, and a receiver that declares its own `pad` gets the
+ * call instead — a different expression from the one the document asked for, emitted as though it
+ * were the right one. The only mechanism that forces the link's own callable is a *renaming* import
+ * alias (`import com.example.pad as generatedPad`, called as `.generatedPad()`); an alias to the
+ * same name does not help, since resolution keys off the name at the call site. That is declined
+ * for now, deliberately: it renames every link in every generated file — `Modifier
+ * .generatedFillMaxWidth()` — to close a case that needs a link named after a member of `Any`,
+ * `Number` or `Modifier.Companion`, and a probe over material3 1.11 found no such collision. The
+ * trade is readability against a narrow hazard, and it is recorded here so it is a decision rather
+ * than an oversight.
+ *
  * A third gap arrived with the widened value vocabulary and is a different animal:
  * [ScreenValue.Reference], [ScreenValue.Construct] and [ScreenValue.Chain] carry a **claimed**
  * type. It is checked against the parameter, so a colour handed to a `String` is still refused, but
@@ -511,7 +524,13 @@ object ScreenGenerator {
             reasons += "$where is a chain with no links, which is a plain reference"
             return null
           }
-          val receiver = expression(value.receiver, where, depth + 1) ?: return null
+          val rendered = expression(value.receiver, where, depth + 1) ?: return null
+          // `-1.dp` is `-(1.dp)`, not `(-1).dp`: Kotlin binds the selector tighter than unary
+          // minus. Verified with the compiler — `-1.toString()` is rejected outright, because
+          // there is no `unaryMinus` on `String`. For a receiver whose result *does* have one the
+          // failure is worse than a compile error: it silently applies the extension to the
+          // positive value and negates afterwards.
+          val receiver = if (rendered.startsWith("-")) "($rendered)" else rendered
           buildString {
             append(receiver)
             for (link in value.links) {
@@ -575,7 +594,14 @@ object ScreenGenerator {
     /** A dotted path, each segment escaped, or null having said why. */
     private fun qualifiedName(fqn: String, where: String): String? {
       val segments = fqn.split('.')
-      if (fqn.isEmpty() || segments.any { !isWritableName(it) }) {
+      // A **qualifier is required**, not just a writable name. Every path this validates is either
+      // emitted fully qualified with no import (a reference, a construct) or imported by its full
+      // name (a chain link), and a single segment can be neither: it names a declaration in the
+      // default package, which a file in a named package can neither import nor refer to. Left
+      // unchecked, `Construct("Color", …)` emitted a bare `Color(…)` into `package
+      // generated.screen`
+      // and this returned `Emitted` for it.
+      if (fqn.isEmpty() || segments.size < 2 || segments.any { !isWritableName(it) }) {
         reasons += "$where refers to `$fqn`, which is not a qualified Kotlin name"
         return null
       }

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -209,9 +209,14 @@ object ScreenGenerator {
    */
   private class ComponentIndex(records: List<ComponentRecord>) {
     private val byCanonical = records.groupBy { it.canonicalId }
+    // `distinct()` inside the record, never across records. A record listing one alias twice says
+    // nothing twice; two *records* claiming one alias is the ambiguity this refuses, and they can
+    // share a canonical id — so collapsing by canonical id here would let an alias resolve to
+    // whichever of the two came first in the file, while `resolve` refuses the same pair when
+    // asked by canonical id. Catalog-order-dependent, and silently so.
     private val byAlias =
       records
-        .flatMap { record -> record.componentIds.map { it to record } }
+        .flatMap { record -> record.componentIds.distinct().map { it to record } }
         .groupBy(
           { it.first },
           { it.second },
@@ -227,7 +232,7 @@ object ScreenGenerator {
               "identifies none of them"
           )
       }
-      val aliased = byAlias[id]?.distinctBy { it.canonicalId } ?: return Outcome.Missing
+      val aliased = byAlias[id] ?: return Outcome.Missing
       return if (aliased.size == 1) Outcome.Found(aliased.single())
       else
         Outcome.Ambiguous(
@@ -510,15 +515,19 @@ object ScreenGenerator {
           buildString {
             append(receiver)
             for (link in value.links) {
+              // The **whole** callable, not just the simple name it ends in. Validating only the
+              // last segment let `foo..padding` through: `padding` is a fine name, so the link
+              // was accepted and imported as `foo.``.padding` — an empty backticked segment, in a
+              // file this generator had already called compilable.
+              val imported = qualifiedName(link.callableFqn, where) ?: return null
               val simple = link.callableFqn.substringAfterLast('.')
-              if (name(simple, where) == null) return null
               if (!link.property && simple == screenName) {
                 // An extension imported under the screen's own name is shadowed by the function
                 // being generated, so the chain would call the screen — or fail to resolve.
                 reasons += "$where imports `$simple`, which is the screen's own name"
                 return null
               }
-              extensionImports += ComponentSnippets.escapeCallableIfKeyword(link.callableFqn)
+              extensionImports += imported
               append(".")
               append(ComponentSnippets.escapeIfKeyword(simple))
               if (link.property) {
@@ -645,7 +654,13 @@ object ScreenGenerator {
    * contain the characters that would close the quoting or reparse as structure.
    */
   private fun isWritableName(name: String): Boolean =
-    name.isNotEmpty() && name.none { it in FORBIDDEN_IN_A_NAME }
+    name.isNotEmpty() &&
+      // Reserved, and reserved past backticks. `_`, `__` and friends match every identifier rule
+      // ever written, so nothing else here rejects them, and `receiver._` would be returned as
+      // successfully generated source that does not compile. The same rule `isUsableIdentifier`
+      // applies to a declaration's name applies to a name we merely refer to.
+      name.any { it != '_' } &&
+      name.none { it in FORBIDDEN_IN_A_NAME }
 
   private val FORBIDDEN_IN_A_NAME = ".;:\\/[]<>`\n\r".toSet()
 

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -331,8 +331,8 @@ object ScreenGenerator {
       }
       val qualified = ComponentSnippets.escapeCallableIfKeyword(record.symbol.callable)
       if (record.canonicalId in simplyImportable && !inReceiverScope) imports += qualified
-      optIns += code.requiredOptIns
-      androidxOptIns += code.androidxOptIns
+      markers(code.requiredOptIns, optIns, "`${record.symbol.name}`")
+      markers(code.androidxOptIns, androidxOptIns, "`${record.symbol.name}`")
 
       val byName = record.parameters.associateBy { it.name }
       node.arguments.keys.filterNot(byName::containsKey).forEach {
@@ -518,8 +518,8 @@ object ScreenGenerator {
       // is as capable of naming a gated API as the construct itself. Unioned into the same two
       // sets a component's markers go into, so the wrapper carries one `@OptIn` of each mechanism
       // however many places asked for it.
-      optIns += value.requiredOptIns
-      androidxOptIns += value.androidxOptIns
+      markers(value.requiredOptIns, optIns, where)
+      markers(value.androidxOptIns, androidxOptIns, where)
       return when (value) {
         is ScreenValue.Text -> string(value.value, where)
         is ScreenValue.Bool -> value.value.toString()
@@ -629,6 +629,29 @@ object ScreenGenerator {
     }
 
     /**
+     * Accepts each `@RequiresOptIn` marker that can be written as a qualified name, refusing the
+     * rest.
+     *
+     * A marker reaches the file as annotation source through `markerReference`, which only
+     * keyword-escapes. That was safe while every marker came from `ComponentRecord` — discovery
+     * read those off a class file — and stopped being safe the moment a [ScreenValue] could carry
+     * its own, because a `ScreenDocument` is wire data. A marker holding a backtick and a newline
+     * closes the generated `@OptIn(…)` and opens a top-level declaration: arbitrary code in the
+     * file **without naming anything `expressionPackages` would have checked**.
+     *
+     * The shape check alone, deliberately. A marker is an inert type reference inside an annotation
+     * and executes nothing, so restricting *which* markers may be named would refuse a project's
+     * own experimental annotation for no safety gained. What has to hold is that it cannot stop
+     * being a name.
+     */
+    private fun markers(names: List<String>, into: MutableSet<String>, where: String) {
+      for (name in names) {
+        if (isQualifiedName(name)) into += name
+        else reasons += "$where needs opt-in marker `$name`, which is not a qualified Kotlin name"
+      }
+    }
+
+    /**
      * A single name, backticked when it has to be, or null having said why it cannot be written.
      */
     private fun name(name: String, where: String): String? {
@@ -652,7 +675,7 @@ object ScreenGenerator {
       //
       // Shape before trust, deliberately: a malformed name is malformed whatever vocabulary is
       // declared, and "this is not a qualified name" is the more actionable of the two answers.
-      if (fqn.isEmpty() || segments.size < 2 || segments.any { !isWritableName(it) }) {
+      if (!isQualifiedName(fqn)) {
         reasons += "$where refers to `$fqn`, which is not a qualified Kotlin name"
         return null
       }
@@ -751,6 +774,18 @@ object ScreenGenerator {
    * escape's own limit rather than the identifier's: a backticked name may not be empty and may not
    * contain the characters that would close the quoting or reparse as structure.
    */
+  /**
+   * Whether [fqn] is a dotted path of writable names carrying a qualifier.
+   *
+   * Shared by the callable check and the marker check so the two cannot drift. Both put a
+   * projection-supplied string into generated source, and a string that is not a name is how one
+   * stops being a reference and starts being syntax.
+   */
+  private fun isQualifiedName(fqn: String): Boolean {
+    val segments = fqn.split('.')
+    return fqn.isNotEmpty() && segments.size >= 2 && segments.all(::isWritableName)
+  }
+
   private fun isWritableName(name: String): Boolean =
     name.isNotEmpty() &&
       // Reserved, and reserved past backticks. `_`, `__` and friends match every identifier rule

--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/ScreenGenerator.kt
@@ -41,6 +41,12 @@ package ee.schimke.composeai.discovery
  * `code.call` promises, or compiling a candidate call in the producer — not a boolean per
  * restriction, which is how this list would keep growing.
  *
+ * A third gap arrived with the widened value vocabulary and is a different animal:
+ * [ScreenValue.Reference], [ScreenValue.Construct] and [ScreenValue.Chain] carry a **claimed**
+ * type. It is checked against the parameter, so a colour handed to a `String` is still refused, but
+ * the claim itself is taken on trust. [ScreenValue] says why that trade was worth making and where
+ * the failure lands when a projection gets it wrong.
+ *
  * ## Refusing, again
  *
  * The discipline is the same one that makes the call-site generator worth anything: emit only what
@@ -116,7 +122,6 @@ object ScreenGenerator {
         )
       )
     }
-    val byId = components.components.associateBy { it.canonicalId }
     // Two components can share a simple name (`com.a.Badge`, `com.b.Badge`), and a screen can share
     // one with a component it calls — `fun HomeScreen()` calling a `HomeScreen` component would
     // shadow the import and recurse into itself. Neither is exotic once a catalog spans libraries.
@@ -132,7 +137,7 @@ object ScreenGenerator {
         }
         .map { it.canonicalId }
         .toSet()
-    val context = Emission(byId, simplyImportable)
+    val context = Emission(ComponentIndex(components.components), simplyImportable, document.name)
     val body = context.node(document.root, depth = 1)
     if (context.reasons.isNotEmpty()) return Result.Refused(context.reasons.toList())
 
@@ -140,7 +145,23 @@ object ScreenGenerator {
     // written twice under two annotations that would each reject the other's markers.
     val androidxOptIns = context.androidxOptIns.toSortedSet().toList()
     val optIns = (context.optIns - context.androidxOptIns).toSortedSet().toList()
-    val imports = (context.imports + "androidx.compose.runtime.Composable").toSortedSet()
+    val imports =
+      (context.imports + context.extensionImports + "androidx.compose.runtime.Composable")
+        .toSortedSet()
+    // Kotlin calls two imports of one simple name a conflicting import and compiles neither. The
+    // component half of this can't collide — `simplyImportable` already withholds a simple name two
+    // records want — but an extension link is imported from wherever a projection said, so
+    // `foundation.layout.padding` and `some.other.padding` in one screen have to be caught here.
+    val conflicts =
+      imports.groupBy { it.substringAfterLast('.') }.filterValues { it.size > 1 }.toSortedMap()
+    if (conflicts.isNotEmpty()) {
+      return Result.Refused(
+        conflicts.map { (name, fqns) ->
+          "`$name` would be imported from ${fqns.sorted().joinToString(" and ")}, which Kotlin " +
+            "rejects as a conflicting import"
+        }
+      )
+    }
     val source = buildString {
       appendLine("package $packageName")
       appendLine()
@@ -179,22 +200,85 @@ object ScreenGenerator {
   }
 
   /**
+   * Resolves a document's component id, by canonical key or by catalog alias.
+   *
+   * Two indexes rather than one flat map, because they are not equally authoritative:
+   * [ComponentRecord.canonicalId] is the file's key and an alias is a label several records may
+   * carry. Merging them would let an alias on one record mask another record's key — a silent
+   * substitution, which is the one outcome worth more care than either lookup.
+   */
+  private class ComponentIndex(records: List<ComponentRecord>) {
+    private val byCanonical = records.groupBy { it.canonicalId }
+    private val byAlias =
+      records
+        .flatMap { record -> record.componentIds.map { it to record } }
+        .groupBy(
+          { it.first },
+          { it.second },
+        )
+
+    /** The record, or the reason there isn't exactly one. */
+    fun resolve(id: String): Outcome {
+      byCanonical[id]?.let { matches ->
+        return if (matches.size == 1) Outcome.Found(matches.single())
+        else
+          Outcome.Ambiguous(
+            "canonical id `$id` is claimed by ${matches.size} components in this catalog, so it " +
+              "identifies none of them"
+          )
+      }
+      val aliased = byAlias[id]?.distinctBy { it.canonicalId } ?: return Outcome.Missing
+      return if (aliased.size == 1) Outcome.Found(aliased.single())
+      else
+        Outcome.Ambiguous(
+          "catalog id `$id` maps to ${aliased.size} components " +
+            "(${aliased.joinToString(", ") { "`${it.canonicalId}`" }}), so it identifies none of " +
+            "them"
+        )
+    }
+
+    sealed interface Outcome {
+      data class Found(val record: ComponentRecord) : Outcome
+
+      data class Ambiguous(val reason: String) : Outcome
+
+      data object Missing : Outcome
+    }
+  }
+
+  /**
    * Accumulates one generation pass: the text, the imports it needs, and every reason it failed.
    */
   private class Emission(
-    val byId: Map<String, ComponentRecord>,
+    val index: ComponentIndex,
     val simplyImportable: Set<String>,
+    val screenName: String,
   ) {
     val imports = mutableSetOf<String>()
+    /**
+     * Kept apart from [imports] only so the conflict message can say an *extension* collided. They
+     * are unioned before anything is written.
+     */
+    val extensionImports = mutableSetOf<String>()
     val optIns = mutableSetOf<String>()
     val androidxOptIns = mutableSetOf<String>()
     val reasons = mutableListOf<String>()
 
     fun node(node: ScreenNode, depth: Int, inReceiverScope: Boolean = false): String {
       val pad = INDENT.repeat(depth)
-      val record = byId[node.componentId]
+      val record =
+        when (val outcome = index.resolve(node.componentId)) {
+          is ComponentIndex.Outcome.Found -> outcome.record
+          is ComponentIndex.Outcome.Ambiguous -> {
+            reasons += outcome.reason
+            null
+          }
+          ComponentIndex.Outcome.Missing -> {
+            reasons += "no component `${node.componentId}` in this catalog"
+            null
+          }
+        }
       if (record == null) {
-        reasons += "no component `${node.componentId}` in this catalog"
         // Keep walking its children: a catalog that dropped a whole subtree should name every node
         // it can no longer place, not just the outermost one. `reasons` is what a caller acts on,
         // and the text returned here is discarded the moment anything has failed.
@@ -244,11 +328,11 @@ object ScreenGenerator {
         val children = node.slots[parameter.name]
         when {
           supplied != null -> {
-            literal(supplied, parameter, record.symbol.name)?.let {
+            argument(supplied, parameter, record.symbol.name)?.let {
               arguments += "${ComponentSnippets.escapeIfKeyword(parameter.name)} = $it"
             }
             // A conflicted document can set both an argument and a slot for one parameter. The
-            // scalar loses (a literal cannot be a function type, so `literal` refuses it), but the
+            // scalar loses (a literal cannot be a function type, so `argument` refuses it), but the
             // slot's children would never be visited otherwise — the fourth branch that rejects a
             // node and would drop its subtree.
             //
@@ -306,30 +390,38 @@ object ScreenGenerator {
     }
 
     /**
-     * The Kotlin literal for [value], or null having recorded why it does not fit [parameter].
+     * The Kotlin expression for [value] as an argument to [parameter], or null having recorded why
+     * it does not fit.
      *
-     * Checked against the **qualified** type, so a `com.example.String` property is rejected rather
+     * Two rules, because [ScreenValue] has two halves. A literal is checked by *rendering it
+     * against the parameter's type*, so `Whole(1)` is an `Int` for an `Int` parameter and a `Long`
+     * for a `Long` one — the parameter decides, which is what lets one document value serve either.
+     * A [ScreenValue.Reference], [ScreenValue.Construct] or [ScreenValue.Chain] is checked the
+     * other way round: it renders once, on its own terms, and its claimed type must equal the
+     * parameter's.
+     *
+     * Both compare the **qualified** type, so a `com.example.String` property is rejected rather
      * than handed a string literal — the trap the call-site generator was caught by twice.
      */
-    fun literal(value: ScreenValue, parameter: TargetParameter, owner: String): String? {
+    fun argument(value: ScreenValue, parameter: TargetParameter, owner: String): String? {
       val type = ComponentSnippets.qualifiedTypeOf(parameter)
+      val where = "`$owner`.`${parameter.name}`"
+      if (value.typeFqn != null) {
+        val rendered = expression(value, where, depth = 0) ?: return null
+        if (value.typeFqn != type) {
+          reasons += "$where is $type, and this value is a ${value.typeFqn}"
+          return null
+        }
+        return rendered
+      }
+      // `string` refuses an over-long value by *recording* the reason, so the count is read either
+      // side of the render: a null literal that already explained itself must not draw the generic
+      // "is not a String" on top of it, and comparing message text instead would silence the
+      // second of two identical parameters on two nodes.
+      val before = reasons.size
       val literal =
         when (value) {
-          is ScreenValue.Text ->
-            when {
-              type != "kotlin.String" -> null
-              // A JVM constant-pool string is length-prefixed with an unsigned short, so a value
-              // over 65535 modified-UTF-8 bytes cannot be a literal at all — the backend fails
-              // late, on a file this generator has already called compilable. Nothing bounds a
-              // pasted document value, so it is measured and refused rather than assumed small.
-              modifiedUtf8Length(value.value) > MAX_CONSTANT_POOL_STRING -> {
-                reasons +=
-                  "`$owner`.`${parameter.name}` is ${modifiedUtf8Length(value.value)} bytes, past " +
-                    "the $MAX_CONSTANT_POOL_STRING a JVM string constant can hold"
-                return null
-              }
-              else -> quote(value.value)
-            }
+          is ScreenValue.Text -> if (type != "kotlin.String") null else string(value.value, where)
           is ScreenValue.Bool -> if (type == "kotlin.Boolean") value.value.toString() else null
           is ScreenValue.Whole ->
             when (type) {
@@ -339,15 +431,7 @@ object ScreenGenerator {
                 if (value.value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong())
                   value.value.toString()
                 else null
-              // `-9223372036854775808L` does not compile: Kotlin reads the positive token first
-              // and rejects it as out of range, then applies unary minus. Verified with the
-              // compiler, which is also why `Int.MIN_VALUE` is left as a plain literal — the same
-              // spelling one type down *is* accepted.
-              "kotlin.Long" ->
-                // Qualified for the same reason `@kotlin.OptIn` is: the generated file sits in a
-                // package the caller chose, and a same-package declaration named `Long` shadows
-                // the default import.
-                if (value.value == Long.MIN_VALUE) "kotlin.Long.MIN_VALUE" else "${value.value}L"
+              "kotlin.Long" -> long(value.value)
               else -> null
             }
           is ScreenValue.Fractional ->
@@ -367,13 +451,157 @@ object ScreenGenerator {
               type == "kotlin.Double" -> value.value.toString()
               else -> null
             }
+          // Every case with a claimed type left through the branch above.
+          else -> null
         }
-      if (literal == null) {
-        reasons += "`$owner`.`${parameter.name}` is $type, which ${value::class.simpleName} is not"
+      if (literal == null && reasons.size == before) {
+        reasons += "$where is $type, which ${value::class.simpleName} is not"
       }
       return literal
     }
+
+    /**
+     * [value] rendered on its own terms — no parameter to lean on — or null having said why.
+     *
+     * This is the rule for every **nested** position (a constructor argument, a chain receiver),
+     * where there is no declared type to render against. A literal therefore gets one fixed
+     * spelling: a whole number is an `Int` when it fits and a `Long` otherwise, and a fraction is
+     * always a `Double`. That is a real restriction — `Dp` takes a `Float`, so `Dp(16.0)` does not
+     * compile and a projection wanting `16.dp` writes the idiomatic [ScreenValue.Chain] instead.
+     * Documented rather than papered over: a rule a projection can read beats a coercion it cannot
+     * predict.
+     */
+    fun expression(value: ScreenValue, where: String, depth: Int): String? {
+      // A document arrives over the wire and nothing on that path bounds how deeply a value nests.
+      // Recursion here is depth-first over attacker-shaped data, so the cap is a refusal rather
+      // than a `StackOverflowError` thrown out of a generator that promised a `Result`.
+      if (depth > MAX_VALUE_DEPTH) {
+        reasons += "$where nests values more than $MAX_VALUE_DEPTH deep"
+        return null
+      }
+      return when (value) {
+        is ScreenValue.Text -> string(value.value, where)
+        is ScreenValue.Bool -> value.value.toString()
+        is ScreenValue.Whole ->
+          if (value.value in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) value.value.toString()
+          else long(value.value)
+        is ScreenValue.Fractional ->
+          if (value.value.isFinite()) value.value.toString()
+          else {
+            reasons += "$where is ${value.value}, which is not a Kotlin literal"
+            null
+          }
+        is ScreenValue.Reference -> {
+          val root = qualifiedName(value.rootFqn, where) ?: return null
+          val members = value.members.map { name(it, where) ?: return null }
+          (listOf(root) + members).joinToString(".")
+        }
+        is ScreenValue.Construct -> {
+          val callable = qualifiedName(value.callableFqn, where) ?: return null
+          val arguments = arguments(value.positional, value.named, where, depth) ?: return null
+          "$callable($arguments)"
+        }
+        is ScreenValue.Chain -> {
+          if (value.links.isEmpty()) {
+            reasons += "$where is a chain with no links, which is a plain reference"
+            return null
+          }
+          val receiver = expression(value.receiver, where, depth + 1) ?: return null
+          buildString {
+            append(receiver)
+            for (link in value.links) {
+              val simple = link.callableFqn.substringAfterLast('.')
+              if (name(simple, where) == null) return null
+              if (!link.property && simple == screenName) {
+                // An extension imported under the screen's own name is shadowed by the function
+                // being generated, so the chain would call the screen — or fail to resolve.
+                reasons += "$where imports `$simple`, which is the screen's own name"
+                return null
+              }
+              extensionImports += ComponentSnippets.escapeCallableIfKeyword(link.callableFqn)
+              append(".")
+              append(ComponentSnippets.escapeIfKeyword(simple))
+              if (link.property) {
+                if (link.positional.isNotEmpty() || link.named.isNotEmpty()) {
+                  reasons += "$where reads `$simple` as a property and also passes it arguments"
+                  return null
+                }
+              } else {
+                val arguments = arguments(link.positional, link.named, where, depth) ?: return null
+                append("(").append(arguments).append(")")
+              }
+            }
+          }
+        }
+      }
+    }
+
+    /** `a, b, name = c` for a call, or null having said why one of them could not be written. */
+    private fun arguments(
+      positional: List<ScreenValue>,
+      named: Map<String, ScreenValue>,
+      where: String,
+      depth: Int,
+    ): String? {
+      val rendered = mutableListOf<String>()
+      for (argument in positional) rendered += expression(argument, where, depth + 1) ?: return null
+      for ((parameter, argument) in named) {
+        val escaped = name(parameter, where) ?: return null
+        rendered += "$escaped = ${expression(argument, where, depth + 1) ?: return null}"
+      }
+      return rendered.joinToString(", ")
+    }
+
+    /**
+     * A single name, backticked when it has to be, or null having said why it cannot be written.
+     */
+    private fun name(name: String, where: String): String? {
+      if (!isWritableName(name)) {
+        reasons += "$where names `$name`, which cannot be written as a Kotlin identifier"
+        return null
+      }
+      return ComponentSnippets.escapeIfKeyword(name)
+    }
+
+    /** A dotted path, each segment escaped, or null having said why. */
+    private fun qualifiedName(fqn: String, where: String): String? {
+      val segments = fqn.split('.')
+      if (fqn.isEmpty() || segments.any { !isWritableName(it) }) {
+        reasons += "$where refers to `$fqn`, which is not a qualified Kotlin name"
+        return null
+      }
+      return segments.joinToString(".") { ComponentSnippets.escapeIfKeyword(it) }
+    }
+
+    /** A string literal, or null when it is too long to be one. */
+    private fun string(value: String, where: String): String? {
+      // A JVM constant-pool string is length-prefixed with an unsigned short, so a value over 65535
+      // modified-UTF-8 bytes cannot be a literal at all — the backend fails late, on a file this
+      // generator has already called compilable. Nothing bounds a pasted document value, so it is
+      // measured and refused rather than assumed small.
+      val length = modifiedUtf8Length(value)
+      if (length > MAX_CONSTANT_POOL_STRING) {
+        reasons +=
+          "$where is $length bytes, past the $MAX_CONSTANT_POOL_STRING a JVM string constant " +
+            "can hold"
+        return null
+      }
+      return quote(value)
+    }
   }
+
+  /**
+   * A `Long` literal.
+   *
+   * `-9223372036854775808L` does not compile: Kotlin reads the positive token first and rejects it
+   * as out of range, then applies unary minus. Verified with the compiler, which is also why
+   * `Int.MIN_VALUE` is left as a plain literal — the same spelling one type down *is* accepted.
+   *
+   * Qualified for the same reason `@kotlin.OptIn` is: the generated file sits in a package the
+   * caller chose, and a same-package declaration named `Long` shadows the default import.
+   */
+  private fun long(value: Long): String =
+    if (value == Long.MIN_VALUE) "kotlin.Long.MIN_VALUE" else "${value}L"
 
   /**
    * A Kotlin string literal for [value].
@@ -405,6 +633,21 @@ object ScreenGenerator {
     ComponentSnippets.isIdentifier(name) &&
       !ComponentSnippets.isHardKeyword(name) &&
       name.any { it != '_' }
+
+  /**
+   * Whether [name] can be written as a Kotlin name at all — bare or in backticks.
+   *
+   * Wider than [isUsableIdentifier] on purpose, and for a different question. That one asks whether
+   * a *declaration* can be named this; this one asks whether a name a projection handed us can be
+   * *referred to*, and Kotlin's backticks admit far more than its identifier rule does — a real
+   * marker in this repo's own fixtures is spelled `` `Api${'$'}Experimental` ``. So the rule is the
+   * escape's own limit rather than the identifier's: a backticked name may not be empty and may not
+   * contain the characters that would close the quoting or reparse as structure.
+   */
+  private fun isWritableName(name: String): Boolean =
+    name.isNotEmpty() && name.none { it in FORBIDDEN_IN_A_NAME }
+
+  private val FORBIDDEN_IN_A_NAME = ".;:\\/[]<>`\n\r".toSet()
 
   /**
    * An opt-in marker, spelled for source.
@@ -449,6 +692,14 @@ object ScreenGenerator {
   private const val MAX_CONSTANT_POOL_STRING = 65535
 
   /**
+   * How deeply one argument's value may nest.
+   *
+   * Sixteen is far past anything a builder produces — `Modifier.padding(PaddingValues(16.dp))` is
+   * three — and far short of what overflows a stack. The number is not the point; having one is.
+   */
+  private const val MAX_VALUE_DEPTH = 16
+
+  /**
    * Simple names the generated file has already spent on its own scaffolding.
    *
    * The wrapper always imports `androidx.compose.runtime.Composable`, so a catalog component that
@@ -457,17 +708,4 @@ object ScreenGenerator {
    * the screen's own name and a two-package collision already get.
    */
   private val RESERVED_BY_THE_WRAPPER = setOf("Composable")
-
-  /**
-   * Kotlin's own identifier rule: `(Letter | '_') (Letter | '_' | UnicodeDigit)*`.
-   *
-   * Not `[A-Za-z_][A-Za-z0-9_]*`. `Übersicht`, `画面` and `généré` are identifiers Kotlin accepts
-   * without backticks, and an ASCII-only rule refused documents that were never wrong — a refusal
-   * costs nothing to the compiler and everything to whoever named their screen in their own
-   * language.
-   */
-  private fun isIdentifier(name: String): Boolean =
-    name.isNotEmpty() &&
-      (name[0].isLetter() || name[0] == '_') &&
-      name.all { it.isLetter() || it.isDigit() || it == '_' }
 }

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ComposableSignatureTest.kt
@@ -35,6 +35,16 @@ class ComposableSignatureTest {
   }
 
   @Test
+  fun `a type alias is recorded as the class it expands to, not as the alias`() {
+    // `typealias AliasedLabel = String` on a parameter. Kotlin's metadata expands aliases, so the
+    // classifier is `kotlin.String` and a value claiming `kotlin.String` matches — there is no
+    // fabricated `kotlin.AliasedLabel` for a claimed value to be refused against.
+    val parameter = parametersOf("aliasedComponent").single()
+    assertThat(parameter.typeFqn).isEqualTo("kotlin.String")
+    assertThat(ComponentSnippets.qualifiedTypeOf(parameter)).isEqualTo("kotlin.String")
+  }
+
+  @Test
   fun `reads parameter names, types and defaults from metadata`() {
     val params = parametersOf("sampleComponent")
 

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -399,6 +399,89 @@ class ScreenValueVocabularyTest {
   }
 
   @Test
+  fun `a chain link with a malformed qualified name is refused, not imported`() {
+    // Only the last segment used to be checked, so `padding` passed and the link was imported as
+    // `foo.``.padding` — an empty backticked segment in source this generator had called
+    // compilable.
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = listOf(ChainLink("foo..padding")),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` refers to `foo..padding`, which is not a qualified Kotlin name"
+      )
+  }
+
+  @Test
+  fun `an all-underscore name is refused wherever a projection supplies one`() {
+    assertThat(
+        refusal(
+          textNode("color" to ScreenValue.Reference(color, listOf("__"), color)),
+          catalog(text),
+        )
+      )
+      .containsExactly("`Text`.`color` names `__`, which cannot be written as a Kotlin identifier")
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = listOf(ChainLink("com.example.decor._")),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` refers to `com.example.decor._`, which is not a qualified Kotlin name"
+      )
+  }
+
+  @Test
+  fun `two records sharing a canonical id and an alias identify neither through the alias`() {
+    // The canonical lookup already refuses this pair. Collapsing the alias list by canonical id
+    // made the alias resolve to whichever came first in the file instead — the same question
+    // answered two ways depending on which spelling the document happened to use.
+    val twin =
+      component(
+        "Label",
+        "androidx.compose.material3.Label",
+        emptyList(),
+        componentIds = listOf("m3/text"),
+        canonicalId = text.canonicalId,
+      )
+    assertThat(refusal(textNode(), catalog(text, twin)))
+      .contains(
+        "catalog id `m3/text` maps to 2 components " +
+          "(`app/androidx.compose.material3.TextKt.Text`, " +
+          "`app/androidx.compose.material3.TextKt.Text`), so it identifies none of them"
+      )
+  }
+
+  @Test
+  fun `one record listing an alias twice still resolves through it`() {
+    val twice =
+      component(
+        "Text",
+        "androidx.compose.material3.Text",
+        text.parameters,
+        componentIds = listOf("m3/text", "m3/text"),
+      )
+    assertThat(emitted(textNode(), catalog(twice)).source).contains("Text(text = \"hi\")")
+  }
+
+  @Test
   fun `a canonical id wins over another record's alias for the same string`() {
     val shadow =
       component(

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -1,0 +1,417 @@
+package ee.schimke.composeai.discovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * The value kinds beyond the four literals: a qualified read, a qualified call, an extension chain
+ * — and the identity aliasing that lets a builder's own component ids resolve.
+ *
+ * Kept apart from [ScreenGeneratorTest] because the questions are different. That file asks whether
+ * a screen is *assembled* correctly (slots, scopes, imports, opt-ins); this one asks whether a
+ * *value* is written correctly, which is where the widening put the new ways to be wrong.
+ */
+class ScreenValueVocabularyTest {
+
+  private fun component(
+    name: String,
+    callable: String,
+    parameters: List<TargetParameter>,
+    componentIds: List<String> = emptyList(),
+    canonicalId: String = "app/androidx.compose.material3.${name}Kt.$name",
+  ) =
+    ComponentRecord(
+      canonicalId = canonicalId,
+      componentIds = componentIds,
+      symbol =
+        ComponentSymbol(
+          jvmOwner = "androidx.compose.material3.${name}Kt",
+          callable = callable,
+          name = name,
+          origin = ComponentOrigin.LIBRARY,
+        ),
+      parameters = parameters,
+      signatureKnown = true,
+      code = ComponentCode(call = "$name()", imports = listOf(callable)),
+    )
+
+  private val colorParameter =
+    TargetParameter(
+      "color",
+      "Color",
+      typeFqn = "androidx.compose.ui.graphics.Color",
+      hasDefault = true,
+    )
+
+  private val modifierParameter =
+    TargetParameter(
+      "modifier",
+      "Modifier",
+      typeFqn = "androidx.compose.ui.Modifier",
+      hasDefault = true,
+    )
+
+  private val text =
+    component(
+      "Text",
+      "androidx.compose.material3.Text",
+      listOf(
+        TargetParameter("text", "String", typeFqn = "kotlin.String"),
+        modifierParameter,
+        colorParameter,
+      ),
+      componentIds = listOf("m3/text"),
+    )
+
+  private fun catalog(vararg records: ComponentRecord) =
+    ComponentRecordFile(module = "app", variant = "debug", components = records.toList())
+
+  private fun generate(root: ScreenNode, catalog: ComponentRecordFile, name: String = "Screen") =
+    ScreenGenerator.generate(ScreenDocument(name = name, root = root), catalog)
+
+  private fun emitted(root: ScreenNode, catalog: ComponentRecordFile, name: String = "Screen") =
+    generate(root, catalog, name) as ScreenGenerator.Result.Emitted
+
+  private fun refusal(root: ScreenNode, catalog: ComponentRecordFile, name: String = "Screen") =
+    (generate(root, catalog, name) as ScreenGenerator.Result.Refused).reasons
+
+  private fun textNode(vararg arguments: Pair<String, ScreenValue>) =
+    ScreenNode(
+      componentId = "m3/text",
+      arguments = mapOf("text" to ScreenValue.Text("hi")) + arguments,
+    )
+
+  private val color = "androidx.compose.ui.graphics.Color"
+  private val modifier = "androidx.compose.ui.Modifier"
+
+  @Test
+  fun `a reference is emitted fully qualified and imported nowhere`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Reference(
+              rootFqn = "androidx.compose.material3.MaterialTheme",
+              members = listOf("colorScheme", "primary"),
+              typeFqn = color,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source)
+      .contains("color = androidx.compose.material3.MaterialTheme.colorScheme.primary")
+    assertThat(result.source).doesNotContain("import androidx.compose.material3.MaterialTheme")
+  }
+
+  @Test
+  fun `a reference with no members is a bare qualified read`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to ScreenValue.Reference("androidx.compose.ui.graphics.Color", typeFqn = color)
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("color = androidx.compose.ui.graphics.Color")
+  }
+
+  @Test
+  fun `a reference claiming the wrong type is refused, as a literal of the wrong type is`() {
+    assertThat(
+        refusal(
+          textNode(
+            "color" to
+              ScreenValue.Reference(
+                "androidx.compose.ui.text.style.TextAlign",
+                listOf("Center"),
+                typeFqn = "androidx.compose.ui.text.style.TextAlign",
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`color` is androidx.compose.ui.graphics.Color, and this value is a " +
+          "androidx.compose.ui.text.style.TextAlign"
+      )
+  }
+
+  @Test
+  fun `a construct is a qualified call with positional then named arguments`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Construct(
+              callableFqn = "androidx.compose.ui.graphics.Color",
+              positional = listOf(ScreenValue.Fractional(0.5)),
+              named = mapOf("alpha" to ScreenValue.Fractional(1.0)),
+              typeFqn = color,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source)
+      .contains("color = androidx.compose.ui.graphics.Color(0.5, alpha = 1.0)")
+  }
+
+  @Test
+  fun `a chain imports each link and calls it by simple name`() {
+    val result =
+      emitted(
+        textNode(
+          "modifier" to
+            ScreenValue.Chain(
+              receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+              links =
+                listOf(
+                  ChainLink("androidx.compose.foundation.layout.fillMaxWidth"),
+                  ChainLink(
+                    "androidx.compose.foundation.layout.padding",
+                    positional =
+                      listOf(
+                        ScreenValue.Chain(
+                          receiver = ScreenValue.Whole(16),
+                          links = listOf(ChainLink("androidx.compose.ui.unit.dp", property = true)),
+                          typeFqn = "androidx.compose.ui.unit.Dp",
+                        )
+                      ),
+                  ),
+                ),
+              typeFqn = modifier,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source)
+      .contains("modifier = androidx.compose.ui.Modifier.fillMaxWidth().padding(16.dp)")
+    assertThat(result.source).contains("import androidx.compose.foundation.layout.fillMaxWidth")
+    assertThat(result.source).contains("import androidx.compose.foundation.layout.padding")
+    assertThat(result.source).contains("import androidx.compose.ui.unit.dp")
+  }
+
+  @Test
+  fun `two links claiming one simple name are refused rather than resolved`() {
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links =
+                  listOf(
+                    ChainLink("androidx.compose.foundation.layout.padding"),
+                    ChainLink("com.example.decor.padding"),
+                  ),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`padding` would be imported from androidx.compose.foundation.layout.padding and " +
+          "com.example.decor.padding, which Kotlin rejects as a conflicting import"
+      )
+  }
+
+  @Test
+  fun `an extension colliding with an imported component is refused too`() {
+    val padding =
+      component(
+        "padding",
+        "com.example.decor.padding",
+        listOf(TargetParameter("content", "() -> Unit", composableSlot = true)),
+        canonicalId = "app/com.example.decor.PaddingKt.padding",
+      )
+    assertThat(
+        refusal(
+          ScreenNode(
+            componentId = padding.canonicalId,
+            slots =
+              mapOf(
+                "content" to
+                  listOf(
+                    textNode(
+                      "modifier" to
+                        ScreenValue.Chain(
+                          receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                          links = listOf(ChainLink("androidx.compose.foundation.layout.padding")),
+                          typeFqn = modifier,
+                        )
+                    )
+                  )
+              ),
+          ),
+          catalog(text, padding),
+        )
+      )
+      .containsExactly(
+        "`padding` would be imported from androidx.compose.foundation.layout.padding and " +
+          "com.example.decor.padding, which Kotlin rejects as a conflicting import"
+      )
+  }
+
+  @Test
+  fun `a link named after the screen is refused, because the screen would shadow it`() {
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = listOf(ChainLink("com.example.decor.Screen")),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+          name = "Screen",
+        )
+      )
+      .containsExactly("`Text`.`modifier` imports `Screen`, which is the screen's own name")
+  }
+
+  @Test
+  fun `a chain with no links is refused as the reference it actually is`() {
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = emptyList(),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly("`Text`.`modifier` is a chain with no links, which is a plain reference")
+  }
+
+  @Test
+  fun `a property link that also passes arguments is refused`() {
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links =
+                  listOf(
+                    ChainLink(
+                      "androidx.compose.ui.unit.dp",
+                      positional = listOf(ScreenValue.Whole(1)),
+                      property = true,
+                    )
+                  ),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly("`Text`.`modifier` reads `dp` as a property and also passes it arguments")
+  }
+
+  @Test
+  fun `a nested whole past Int range is a Long literal, and a nested fraction a Double`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Construct(
+              "androidx.compose.ui.graphics.Color",
+              positional = listOf(ScreenValue.Whole(0xFF6750A4), ScreenValue.Fractional(2.0)),
+              typeFqn = color,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source)
+      .contains("color = androidx.compose.ui.graphics.Color(4284960932L, 2.0)")
+  }
+
+  @Test
+  fun `a name that cannot be written as Kotlin is refused rather than emitted`() {
+    assertThat(
+        refusal(
+          textNode(
+            "color" to
+              ScreenValue.Reference("androidx.compose.ui.graphics.Color", listOf("a b`c"), color)
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`color` names `a b`c`, which cannot be written as a Kotlin identifier"
+      )
+  }
+
+  @Test
+  fun `a hard keyword in a qualified name is backticked, not refused`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to ScreenValue.Reference("com.example.in.Palette", listOf("brand"), color)
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("color = com.example.`in`.Palette.brand")
+  }
+
+  @Test
+  fun `values nested past the depth cap are refused instead of overflowing the stack`() {
+    var value: ScreenValue = ScreenValue.Whole(1)
+    repeat(20) {
+      value =
+        ScreenValue.Construct(
+          "androidx.compose.ui.graphics.Color",
+          positional = listOf(value),
+          typeFqn = color,
+        )
+    }
+    assertThat(refusal(textNode("color" to value), catalog(text)))
+      .containsExactly("`Text`.`color` nests values more than 16 deep")
+  }
+
+  @Test
+  fun `a node resolves by catalog alias as well as by canonical id`() {
+    val byAlias = emitted(textNode(), catalog(text))
+    val byCanonical =
+      emitted(
+        ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Text("hi"))),
+        catalog(text),
+      )
+    assertThat(byAlias.source).isEqualTo(byCanonical.source)
+  }
+
+  @Test
+  fun `an alias two components claim identifies neither`() {
+    val label =
+      component("Label", "androidx.compose.material3.Label", emptyList(), listOf("m3/text"))
+    assertThat(refusal(textNode(), catalog(text, label)))
+      .contains(
+        "catalog id `m3/text` maps to 2 components " +
+          "(`app/androidx.compose.material3.TextKt.Text`, " +
+          "`app/androidx.compose.material3.LabelKt.Label`), so it identifies none of them"
+      )
+  }
+
+  @Test
+  fun `a canonical id wins over another record's alias for the same string`() {
+    val shadow =
+      component(
+        "Label",
+        "androidx.compose.material3.Label",
+        emptyList(),
+        componentIds = listOf(text.canonicalId),
+      )
+    val result =
+      emitted(
+        ScreenNode(text.canonicalId, arguments = mapOf("text" to ScreenValue.Text("hi"))),
+        catalog(text, shadow),
+      )
+    assertThat(result.source).contains("Text(text = \"hi\")")
+  }
+}

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -637,6 +637,44 @@ class ScreenValueVocabularyTest {
   }
 
   @Test
+  fun `an opt-in marker that is not a name is refused, because it becomes annotation source`() {
+    // A marker is printed straight into `@OptIn(…)`, so a backtick and a newline close the
+    // annotation and open a top-level declaration — arbitrary code in the generated file that
+    // names nothing `expressionPackages` would have looked at.
+    val injected =
+      "com.example.Marker`::class)\nval pwned = System.exit(0)\n@kotlin.OptIn(kotlin.Any"
+    assertThat(
+        refusal(
+          textNode(
+            "color" to
+              ScreenValue.Reference(
+                "androidx.compose.ui.graphics.Color",
+                listOf("Unspecified"),
+                typeFqn = color,
+                requiredOptIns = listOf(injected),
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`color` needs opt-in marker `$injected`, which is not a qualified Kotlin name"
+      )
+  }
+
+  @Test
+  fun `a component's markers are checked too, since one printer serves both`() {
+    val gated =
+      component("Gated", "androidx.compose.material3.Gated", emptyList()).let {
+        it.copy(code = it.code!!.copy(requiredOptIns = listOf("not a name")))
+      }
+    assertThat(refusal(ScreenNode(gated.canonicalId), catalog(gated)))
+      .containsExactly(
+        "`Gated` needs opt-in marker `not a name`, which is not a qualified Kotlin name"
+      )
+  }
+
+  @Test
   fun `a node resolves by catalog alias as well as by canonical id`() {
     val byAlias = emitted(textNode(), catalog(text))
     val byCanonical =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -557,6 +557,86 @@ class ScreenValueVocabularyTest {
   }
 
   @Test
+  fun `a value's opt-in markers reach the wrapper, at any nesting depth`() {
+    val result =
+      emitted(
+        textNode(
+          "color" to
+            ScreenValue.Construct(
+              "androidx.compose.material3.ExperimentalColor",
+              positional =
+                listOf(
+                  ScreenValue.Reference(
+                    "androidx.compose.material3.MaterialTheme",
+                    listOf("colorScheme", "primary"),
+                    typeFqn = color,
+                    androidxOptIns = listOf("androidx.compose.material3.ExperimentalMaterial3Api"),
+                  )
+                ),
+              typeFqn = color,
+              requiredOptIns = listOf("com.example.ExperimentalPalette"),
+            )
+        ),
+        catalog(text),
+      )
+    // The outer construct's marker uses the Kotlin mechanism and the nested reference's uses the
+    // AndroidX one, so both annotations appear and neither marker lands under the wrong one.
+    assertThat(result.source).contains("@kotlin.OptIn(com.example.ExperimentalPalette::class)")
+    assertThat(result.source)
+      .contains(
+        "@androidx.annotation.OptIn(markerClass = " +
+          "[androidx.compose.material3.ExperimentalMaterial3Api::class])"
+      )
+    assertThat(result.requiredOptIns)
+      .containsExactly(
+        "com.example.ExperimentalPalette",
+        "androidx.compose.material3.ExperimentalMaterial3Api",
+      )
+  }
+
+  @Test
+  fun `a member extension is refused, because a chain link has to be importable`() {
+    // `RowScope.weight` is a member of the scope, handed over by an implicit receiver. Neither
+    // `import …layout.RowScope.weight` nor a package-level `…layout.weight` resolves, so importing
+    // it produces a file that fails on the import line.
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = listOf(ChainLink("androidx.compose.foundation.layout.RowScope.weight")),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` links `androidx.compose.foundation.layout.RowScope.weight`, whose " +
+          "qualifier names a classifier rather than a package — a member extension comes from an " +
+          "implicit receiver and cannot be imported"
+      )
+  }
+
+  @Test
+  fun `a top-level extension in a lower-case package is still accepted`() {
+    val result =
+      emitted(
+        textNode(
+          "modifier" to
+            ScreenValue.Chain(
+              receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+              links = listOf(ChainLink("androidx.compose.foundation.layout.fillMaxWidth")),
+              typeFqn = modifier,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("import androidx.compose.foundation.layout.fillMaxWidth")
+  }
+
+  @Test
   fun `a node resolves by catalog alias as well as by canonical id`() {
     val byAlias = emitted(textNode(), catalog(text))
     val byCanonical =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -376,6 +376,89 @@ class ScreenValueVocabularyTest {
   }
 
   @Test
+  fun `a single-segment name is refused wherever a qualified one is required`() {
+    // A default-package declaration is what a single segment names, and a file in a named package
+    // can neither import nor refer to one. Before this, `Construct("Color", …)` emitted a bare
+    // `Color(…)` into `package generated.screen` and reported success.
+    assertThat(
+        refusal(
+          textNode("color" to ScreenValue.Construct("Color", typeFqn = color)),
+          catalog(text),
+        )
+      )
+      .containsExactly("`Text`.`color` refers to `Color`, which is not a qualified Kotlin name")
+    assertThat(
+        refusal(textNode("color" to ScreenValue.Reference("Color", typeFqn = color)), catalog(text))
+      )
+      .containsExactly("`Text`.`color` refers to `Color`, which is not a qualified Kotlin name")
+    assertThat(
+        refusal(
+          textNode(
+            "modifier" to
+              ScreenValue.Chain(
+                receiver = ScreenValue.Reference(modifier, typeFqn = modifier),
+                links = listOf(ChainLink("padding")),
+                typeFqn = modifier,
+              )
+          ),
+          catalog(text),
+        )
+      )
+      .containsExactly(
+        "`Text`.`modifier` refers to `padding`, which is not a qualified Kotlin name"
+      )
+  }
+
+  @Test
+  fun `a negative chain receiver is parenthesised, because the selector binds tighter`() {
+    // `-1.dp` parses as `-(1.dp)`. Proven with the compiler on the same shape one type down:
+    // `-1.toString()` is rejected outright, since `String` has no `unaryMinus`.
+    val whole =
+      emitted(
+        textNode(
+          "modifier" to
+            ScreenValue.Chain(
+              receiver = ScreenValue.Whole(-1),
+              links = listOf(ChainLink("androidx.compose.ui.unit.dp", property = true)),
+              typeFqn = modifier,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(whole.source).contains("modifier = (-1).dp")
+    val fractional =
+      emitted(
+        textNode(
+          "modifier" to
+            ScreenValue.Chain(
+              receiver = ScreenValue.Fractional(-1.5),
+              links = listOf(ChainLink("androidx.compose.ui.unit.dp", property = true)),
+              typeFqn = modifier,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(fractional.source).contains("modifier = (-1.5).dp")
+  }
+
+  @Test
+  fun `a positive chain receiver is left bare`() {
+    val result =
+      emitted(
+        textNode(
+          "modifier" to
+            ScreenValue.Chain(
+              receiver = ScreenValue.Whole(16),
+              links = listOf(ChainLink("androidx.compose.ui.unit.dp", property = true)),
+              typeFqn = modifier,
+            )
+        ),
+        catalog(text),
+      )
+    assertThat(result.source).contains("modifier = 16.dp")
+  }
+
+  @Test
   fun `a node resolves by catalog alias as well as by canonical id`() {
     val byAlias = emitted(textNode(), catalog(text))
     val byCanonical =

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/ScreenValueVocabularyTest.kt
@@ -66,8 +66,19 @@ class ScreenValueVocabularyTest {
   private fun catalog(vararg records: ComponentRecord) =
     ComponentRecordFile(module = "app", variant = "debug", components = records.toList())
 
+  /**
+   * The vocabulary these fixtures name. Passed explicitly in every case, because the generator
+   * refuses a claimed value under a package the caller never declared — see the trusted-vocabulary
+   * test below for what that protects against.
+   */
+  private val allowed = setOf("androidx.compose", "com.example")
+
   private fun generate(root: ScreenNode, catalog: ComponentRecordFile, name: String = "Screen") =
-    ScreenGenerator.generate(ScreenDocument(name = name, root = root), catalog)
+    ScreenGenerator.generate(
+      ScreenDocument(name = name, root = root),
+      catalog,
+      expressionPackages = allowed,
+    )
 
   private fun emitted(root: ScreenNode, catalog: ComponentRecordFile, name: String = "Screen") =
     generate(root, catalog, name) as ScreenGenerator.Result.Emitted
@@ -456,6 +467,93 @@ class ScreenValueVocabularyTest {
         catalog(text),
       )
     assertThat(result.source).contains("modifier = 16.dp")
+  }
+
+  @Test
+  fun `a callable outside the declared vocabulary is refused, however well spelled`() {
+    // A document is wire data and a construct emits a qualified call with the arguments it carries,
+    // so spelling is not the question — a host that compiles and renders what it generated would
+    // have run this one.
+    val exploit =
+      ScreenValue.Construct(
+        callableFqn = "java.nio.file.Files.readString",
+        positional =
+          listOf(
+            ScreenValue.Construct(
+              callableFqn = "java.nio.file.Path.of",
+              positional = listOf(ScreenValue.Text("/etc/passwd")),
+              typeFqn = "java.nio.file.Path",
+            )
+          ),
+        typeFqn = "kotlin.String",
+      )
+    assertThat(
+        (ScreenGenerator.generate(
+            ScreenDocument("Screen", ScreenNode("m3/text", mapOf("text" to exploit))),
+            catalog(text),
+            expressionPackages = allowed,
+          ) as ScreenGenerator.Result.Refused)
+          .reasons
+      )
+      .contains(
+        "`Text`.`text` names `java.nio.file.Files.readString`, which is outside the packages this " +
+          "screen may call (androidx.compose, com.example)"
+      )
+  }
+
+  @Test
+  fun `an undeclared vocabulary refuses every claimed value, because the default is empty`() {
+    // Fail closed: a caller who never thought about the boundary gets refusals, not a wider one.
+    val result =
+      ScreenGenerator.generate(
+        ScreenDocument(
+          "Screen",
+          ScreenNode(
+            "m3/text",
+            mapOf(
+              "text" to ScreenValue.Text("hi"),
+              "color" to
+                ScreenValue.Reference(
+                  "androidx.compose.material3.MaterialTheme",
+                  listOf("colorScheme", "primary"),
+                  typeFqn = color,
+                ),
+            ),
+          ),
+        ),
+        catalog(text),
+      )
+    assertThat((result as ScreenGenerator.Result.Refused).reasons)
+      .containsExactly(
+        "`Text`.`color` names `androidx.compose.material3.MaterialTheme`, which is outside the " +
+          "packages this screen may call (none are allowed)"
+      )
+  }
+
+  @Test
+  fun `a longer sibling package does not satisfy a prefix`() {
+    assertThat(
+        (ScreenGenerator.generate(
+            ScreenDocument(
+              "Screen",
+              ScreenNode(
+                "m3/text",
+                mapOf(
+                  "text" to ScreenValue.Text("hi"),
+                  "color" to
+                    ScreenValue.Reference("androidx.composeevil.Exfiltrate", typeFqn = color),
+                ),
+              ),
+            ),
+            catalog(text),
+            expressionPackages = setOf("androidx.compose"),
+          ) as ScreenGenerator.Result.Refused)
+          .reasons
+      )
+      .contains(
+        "`Text`.`color` names `androidx.composeevil.Exfiltrate`, which is outside the packages " +
+          "this screen may call (androidx.compose)"
+      )
   }
 
   @Test

--- a/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
+++ b/gradle-plugin/preview-discovery/src/test/kotlin/ee/schimke/composeai/discovery/SignatureFixtures.kt
@@ -122,3 +122,15 @@ annotation class `Api$Experimental`
 // (`context(Foo)` needs -Xcontext-receivers, `context(f: Foo)` needs language version 2.4). The
 // refusal a recorded context produces is covered in ComponentSnippetsTest instead; the metadata
 // read itself has no fixture here, which ComposableSignature.hasContextRequirement says plainly.
+
+/**
+ * A parameter written through a type alias, for the question of what `typeFqn` records for one.
+ *
+ * Kotlin's metadata **expands** an alias — the docs for `KmType.abbreviatedType` say so outright —
+ * so the recorded classifier should be the aliased class rather than the alias, and a value
+ * claiming that class should match. Asserted rather than assumed, because a review finding claimed
+ * the opposite and the difference is a whole category of false refusals.
+ */
+typealias AliasedLabel = String
+
+@Suppress("unused", "UNUSED_PARAMETER") fun aliasedComponent(label: AliasedLabel = "") {}


### PR DESCRIPTION
## Why

`ScreenGenerator` landed in #5076 able to bind four kinds of value: a string, a boolean, a whole number and a fraction. Measured against the frozen UI-builder document at `docs/design/fixtures/ui-builder/confetti-schedule-operations-v1.json` in the sibling repo, that covers **under a third** of the values a real screen places — 19 enum values, 18 colour tokens, 14 typography tokens, 11 paddings, 6 raw colours and 10 layout modifiers had no expression at all.

A generator that refuses two thirds of a screen is not one anybody uses, so the vocabulary widens.

## What

Three new `ScreenValue` kinds, each emitting a **restricted expression shape** rather than free text:

- `Reference` — a qualified read: `androidx.compose.material3.MaterialTheme.colorScheme.primary`.
- `Construct` — a qualified call: `androidx.compose.ui.graphics.Color(4284960932L)`, `androidx.compose.foundation.layout.PaddingValues(16.dp)`.
- `Chain` — a receiver plus extension links: `androidx.compose.ui.Modifier.fillMaxWidth().padding(16.dp)`, `16.dp`.

Everything is emitted **fully qualified** except an extension link, which cannot be — so that one case imports, and two links claiming one simple name from different packages are refused rather than resolved.

Each kind also carries its own `requiredOptIns` / `androidxOptIns`, mirroring `ComponentCode`, since an expression can name a `@RequiresOptIn` API as readily as a component can.

A node also resolves by **catalog alias**, not only by canonical id. The record already carries `componentIds`, so a document holding `m3/text` needs no second mapping on the builder's side.

## The trust boundary

`generate` takes **`expressionPackages`**, and every FQN a projection supplies — a reference's root, a construct's callable, a chain link's callable, and recursively every nested argument — must sit under one of them.

This is not a nicety. A `ScreenDocument` is wire data, and before the boundary this generated cleanly:

```kotlin
Construct("java.nio.file.Files.readString",
          [Construct("java.nio.file.Path.of", ["/etc/passwd"])],
          typeFqn = "kotlin.String")
```

A well-formed qualified call, claiming a type that matches any `String` parameter, with the nested argument never type-checked at all — emitted into source a host compiles and renders. **The default is empty**, so a caller who has not thought about this generates nothing rather than anything, and a prefix never admits a longer sibling package (`androidx.compose` ≠ `androidx.composeevil`).

The invariant underneath it is not "callables are checked" but **"every projection-supplied string that reaches source is still a name"** — enforced per-property rather than per-site, after round 6 found the second door (below).

## What the widening costs

Stated in the KDoc where it lands: the three new kinds carry a **claimed** type rather than an evident one. It is still checked against `TargetParameter.typeFqn`, so a colour handed to a `String` parameter is refused exactly as `text = true` was — but the generator cannot check that `MaterialTheme.colorScheme.primary` really *is* a `Color`. It takes the projection's word for that one fact, and for the opt-in markers an expression declares.

The alternative was a hand-maintained table of Material 3's token names inside a library that knows nothing about Material 3. This keeps the design system's knowledge with whoever has it and admits the trust boundary out loud. The class KDoc carries the full list of admitted gaps, and names the structural answer to all of them: compiling a candidate in the producer, which would close the list rather than lengthen it.

## Six rounds of review

Every finding below was verified against a primary source — the compiler, a fixture, or the checked-in documents — before being acted on or refuted.

**Round 2 (`1744bbb`).** A chain link's callable was validated by its *last segment only*, so `foo..padding` imported as ``foo.`.padding``. All-underscore names were accepted and left bare, so `receiver._` came back as successful output that does not compile. Alias resolution collapsed claimants with `distinctBy { canonicalId }`, so two records sharing a canonical id resolved by file order while the canonical lookup refused the same pair.

**Round 3 (`4534c8a`).** `qualifiedName` accepted a single segment — a default-package name a file in a named package can neither import nor refer to. A negative chain receiver mis-parsed: `-1.dp` is `-(1.dp)`, proven with the compiler on `-1.toString()`, which is rejected outright because `String` has no `unaryMinus`.

**Round 4 (`c1f2cc7`, `1fc31d8`).** The trust boundary above. And one finding **refuted with a test**: a claim that a type-aliased parameter records `typeFqn = null` and gets a fabricated `kotlin.<Alias>`. Kotlin's metadata expands aliases (`KmType.abbreviatedType` documents it), so a real fixture — `typealias AliasedLabel = String`, read through the same ClassGraph scan as every other signature test — records `kotlin.String`. The test is kept so that if a future Kotlin stops expanding, this fails loudly instead of silently refusing a category of valid values.

**Round 5 (`c295012`).** A member extension — `RowScope`'s `Modifier.weight` — was imported top-level, which no import spells. It is refused now, on the evidence of the qualifier's case: Kotlin packages are lower case and classifiers are capitalised. **That is a convention, not a rule**, and the comment says so — a top-level callable in a package with a capitalised segment is legal and is now refused. Same round: a value's opt-in markers reached no annotation, so an experimental accessor generated a file the compiler rejects. Markers are now declared by the value and unioned at every nesting depth into the same two annotations a component's go into.

**Round 6 (`1434c19`).** The marker lists opened a second door into the room the vocabulary check had just locked, one commit after locking it: a marker is not a callable, so a wire-supplied string reached `markerReference`, which only keyword-escapes. A backtick and newline closed the generated `@OptIn(…)`, injected a top-level initializer and commented out the suffix — **bypassing `expressionPackages` entirely**. Both marker lists are now shape-checked as qualified names on both paths, the component's from the record and the value's from the document, through the same `isQualifiedName` the callables use.

**Two findings declined, with the patch or the reasoning offered, and both threads left open.**

*Extension shadowing.* An imported extension loses to a same-named member on the receiver, so a link naming `com.example.pad` can invoke the receiver's own `pad`. The only fix is a *renaming* import alias — an alias to the same name changes nothing, since resolution keys off the call-site name — which renames every link in every generated file (`Modifier.generatedFillMaxWidth()`). Readable output is load-bearing here, the hazard needs a link named after a member of `Any`, `Number` or `Modifier.Companion`, and a probe over material3 1.11 found no such collision.

*The casing heuristic's other edge.* Round 6 also pointed out that `interface rowScope { fun Modifier.weight() }` is legal and slips through the capitalisation test. Correct, and the asymmetry was mine to spot — I documented the false-refusal edge and never wrote down the false-accept one. The suggested remedy is not reachable: it needs recorded declaration info for the *chain link's* callable, and a `ChainLink` is an arbitrary string with no classpath and no scan behind it. The casing check stays as a partial catch, in the KDoc's list of admitted gaps.

## Test plan

- `./gradlew :gradle-plugin:preview-discovery:test` — **338 tests pass**: 32 `ScreenValueVocabularyTest`, 14 `ComposableSignatureTest`, and all 37 pre-existing `ScreenGeneratorTest` cases unchanged, which is the evidence the widening is additive at the top level.
- Coverage includes both exploits **as the reviewer wrote them** — the `Files.readString` construct and the marker-injection string — plus the empty-default case, a longer-sibling package, both signs of a chain receiver, all three qualified-name paths, a conflicting simple name across two packages, an extension colliding with an imported *component*, a link named after the screen, an empty chain, a property link that also passes arguments, a member extension and a top-level one in a lower-case package, markers at two nesting depths under both mechanisms, nested `Int`-vs-`Long` selection, the depth cap, alias resolution and its two failure modes.
- **Every idiom the new kinds emit was compiled against real Compose** — a qualified companion with imported extensions, a qualified `MaterialTheme` read, a qualified top-level `Color(…)` call, a qualified `PaddingValues` constructor, `clip(MaterialTheme.shapes.medium)`, `.width(…)`, and all 47 Material 3 colour accessors. The durable version of that check is the consumer-side evidence in yschimke/compose-preview-server#236, which generates a whole screen from this and compiles it.

Text-only evidence is correct here: this is a code generator's data model and printing rules, with no rendered surface.

## Status

- [x] `ktfmt`, plugin unit, actions-script, consumer-contract, XR pin, serve-wasm drift — green
- [ ] `Module Unit Tests`, `Plugin Functional Tests`, `Build Samples` — running on `1434c195`
- [ ] `Daemon Harness (android, real renderer)` — red on every head, and not this PR's: `S3_5RecompileSaveLoopRealModeTest` fails with `ClassNotFoundException`, the same signature seen on every head of #5076, on `main` at that merge base, and on a KDoc-only commit. Stood down on in one comment; the re-run allowance is unspent.
- [ ] One preview changed (`Remote theme colours`, `samples:remotecompose`) — no code path from this diff reaches it; noted in the same comment.
- [x] Codex review — twelve findings across six rounds: nine fixed, one refuted with a test, two declined with their reasoning on the thread. The recurring P1 attribution finding is not real on any round: `.github/scripts/agent-attribution-scan.sh --range 'origin/main..HEAD'` exits 0, and the commits it has cited (`2dd85d5`, `12bf0e1`, `73e9cf2`, `1d7641f`, `f4dcf8d`) do not exist in this repository.

**Correction:** `c1f2cc7`'s commit message says "335 pass"; the real count at that commit was 333. Not worth a force-push on a branch under active review, so it is corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115HdUftUrZaiswsvUXtj2o