### PR TITLE
fix(harness): clone S3.5's fixture without recomputing frames

### DIFF
--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -359,7 +359,24 @@ class S3_5RecompileSaveLoopRealModeTest {
     targetMethod: String,
   ): ByteArray {
     val reader = ClassReader(sourceBytes)
-    val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS or ClassWriter.COMPUTE_FRAMES)
+    // NO `COMPUTE_FRAMES`, deliberately. Computing stack map frames makes ASM merge reference
+    // types, and `ClassWriter.getCommonSuperClass` resolves both sides with `Class.forName` on the
+    // *writer's own* classloader — this test JVM's. But [sourceClassBytesFrom] reads these bytes
+    // off the spawned daemon's classpath precisely because that class is NOT on ours (see its
+    // KDoc), so the first method whose frames merge two of the fixture's own types dies:
+    //
+    //     TypeNotPresentException: Type …RedFixturePreviewsKt$GenericOutlineShapeSquare$diamond$1$1
+    //       at ClassWriter.getCommonSuperClass → SymbolTable.addMergedType → Frame.merge
+    //       → MethodWriter.computeAllFrames
+    //
+    // Recomputing them buys nothing here: this transformation is name-only — remap the internal
+    // name, rename one method, drop `<clinit>` — and none of that invalidates a frame, so
+    // [ClassRemapper] rewriting the existing frames' types keeps them correct. `COMPUTE_MAXS`
+    // stays: it recomputes stack/local sizes arithmetically, without loading a class.
+    //
+    // If a future change here *does* alter control flow, the copied frames stop matching and the
+    // JVM rejects the clone with `VerifyError` at define time — loud, not silent.
+    val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS)
     val remapper =
       object : Remapper(Opcodes.ASM9) {
         override fun map(internalName: String): String =


### PR DESCRIPTION
`Daemon Harness (android, real renderer)` has been red on `main` all day — every run today that wasn't superseded, including the `1.70.0` release commit. One line fixes it.

## The failure

Every run dies identically, in the ASM clone S3.5 builds before its first render:

```
java.lang.TypeNotPresentException: Type ee/schimke/composeai/daemon/
  RedFixturePreviewsKt$GenericOutlineShapeSquare$diamond$1$1 not present
  at org.objectweb.asm.ClassWriter.getCommonSuperClass(ClassWriter.java:1062)
  at org.objectweb.asm.SymbolTable.addMergedType(SymbolTable.java:1286)
  at org.objectweb.asm.Frame.merge(Frame.java:1312)
  at org.objectweb.asm.MethodWriter.computeAllFrames(MethodWriter.java:1612)
  at org.objectweb.asm.MethodWriter.visitMaxs(MethodWriter.java:1548)
```

`COMPUTE_FRAMES` makes ASM merge reference types when computing stack map frames, and `ClassWriter.getCommonSuperClass` resolves both sides with `Class.forName` **on the writer's own classloader** — this test JVM's.

But `sourceClassBytesFrom` reads those bytes off the *spawned daemon's* classpath precisely because the class is **not** on ours. Its KDoc spells out why: taking the android fixture from the harness's own classpath would return the *desktop* fixture and drag desktop-only references into the sandbox. So the first method whose frames merge two of that fixture's own types cannot resolve them, and the clone throws before a render is ever attempted.

That also explains the shape of the breakage: `Daemon Harness (desktop, real renderer)` is **green** on the same code, because the desktop fixture's types *are* on the harness classpath.

## The fix

Drop `COMPUTE_FRAMES`. Recomputing frames buys nothing here — the transformation is name-only (remap the internal name, rename one method, drop `<clinit>`), and none of that invalidates a frame, so `ClassRemapper` rewriting the existing frames' types keeps them correct. `COMPUTE_MAXS` stays: it recomputes stack/local sizes arithmetically, without loading a class.

If a future change here *does* alter control flow, the copied frames stop matching and the JVM rejects the clone with `VerifyError` at define time — loud, not silent. That's in a comment at the call site.

## Verification

Reproduced and fixed on the same machine, running exactly what CI runs (`-Pharness.host=real -Pharness.target=android`):

| | before | after |
| --- | --- | --- |
| android-real leg | 45 tests, **1 failed**, 22 skipped | 45 tests, **0 failed**, 22 skipped |
| `S3_5RecompileSaveLoopRealModeTest` | fails in `0.127s`, inside the clone | **passes in `45.958s`**, running the full save loop |
| `Daemon Harness (desktop, real renderer)` | green | green |

The before-tally matches CI's `45 tests completed, 1 failed, 22 skipped` exactly, so the local reproduction is the same failure and not a lookalike.

The mechanism was also confirmed in isolation before touching the test — an ASM `ClassWriter` cloning a class whose referenced type is off-classpath throws `TypeNotPresentException` caused by `ClassNotFoundException` under `COMPUTE_MAXS | COMPUTE_FRAMES` and succeeds under `COMPUTE_MAXS`; the class it then produces loads and executes, so the copied frames are JVM-valid rather than merely writable.

`ktfmtCheckAll` green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r)_