### PR TITLE
fix(compare): read a fractional root translate instead of dropping it

### DIFF
--- a/scripts/design-artifacts/render-compare-html.mjs
+++ b/scripts/design-artifacts/render-compare-html.mjs
@@ -285,11 +285,24 @@ const SCORER = String.raw`
   // DEFAULT_PADDING and draws the tree under translate(tx, ty) with tx = padding - minX,
   // in the same px scale as the render PNG (dp->px already applied). The render PNG is
   // padding-free with content at (0,0), so aligning means cropping that translate back
-  // out — matching the daemon's FigmaSvgFidelity.alignToRender. Integer-only, first match,
-  // exactly as the Kotlin harness parses it; defaults to (0,0) for an un-translated SVG.
+  // out — matching the daemon's FigmaSvgFidelity.alignToRender. First match, because the
+  // root group's transform is what the exporter writes first and inner transforms are the
+  // component's own geometry; defaults to (0,0) for an un-translated SVG.
+  //
+  // FRACTIONAL offsets are read. Figma emits them routinely, and an integer-only pattern does
+  // not merely round one — "translate(12.5, 40)" fails to match AT ALL, so the whole offset
+  // becomes the origin, integer part included. A component sitting at x=340.5 is then compared
+  // against a vector drawn 340px away from it, which reads as the component being wrong rather
+  // than as the two frames being in different places. compose-preview-server's scorer hit this
+  // and fixed it in scorer/svgTranslate.ts; this is the same pattern, for the same reason.
   function translateOf(svgText) {
-    const m = /translate\(\s*(-?\d+)\s*,\s*(-?\d+)\s*\)/.exec(svgText);
-    return m ? { tx: parseInt(m[1], 10), ty: parseInt(m[2], 10) } : { tx: 0, ty: 0 };
+    const m =
+      /translate\(\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*,\s*(-?(?:\d+(?:\.\d+)?|\.\d+))\s*\)/.exec(
+        svgText,
+      );
+    // Number, not parseFloat: the pattern has already established the shape, and parseFloat
+    // would quietly accept a trailing tail the pattern refused.
+    return m ? { tx: Number(m[1]), ty: Number(m[2]) } : { tx: 0, ty: 0 };
   }
 
   // The grounds a comparison is scored on, worst result winning. One opaque ground is not a

--- a/scripts/design-artifacts/render-compare-html.test.mjs
+++ b/scripts/design-artifacts/render-compare-html.test.mjs
@@ -652,3 +652,16 @@ test("only a frozen reading is announced", () => {
   // Off-screen rather than display:none, which would take it out of the accessibility tree.
   assert.match(html, /\.pick-live \{ position:absolute; width:1px; height:1px;/);
 });
+
+test("a fractional root translate is read, not dropped", () => {
+  // Figma emits fractional positions routinely. An integer-only pattern does not round one — it
+  // fails to match at all, so the whole offset becomes the origin, integer part included, and the
+  // two columns silently mis-register. The scorer then reports drift that is the alignment rather
+  // than the component, which is the most misleading answer this page can give.
+  // compose-preview-server's own scorer hit this and fixed it in scorer/svgTranslate.ts.
+  const html = renderCompareHtml(catalog, { figmaSvgSlugs: new Set(["button-filled"]) });
+  assert.match(html, /\(-\?\(\?:\\d\+\(\?:\\\.\\d\+\)\?\|\\\.\\d\+\)\)/);
+  assert.doesNotMatch(html, /translate\\\(\\s\*\(-\?\\d\+\)\\s\*,/);
+  // Number, not parseFloat: the pattern has established the shape already.
+  assert.match(html, /return m \? \{ tx: Number\(m\[1\]\), ty: Number\(m\[2\]\) \}/);
+});


### PR DESCRIPTION
## What

`translateOf` in `compare.html`'s scorer parsed the figma-svg's root translate with `(-?\d+)`. That doesn't *round* a fractional offset — `translate(12.5, 40)` fails to match **at all**, so the whole offset becomes the origin, integer part included.

## Why it matters

Figma emits fractional positions routinely. When it happens the render column is placed with no offset, the two columns silently mis-register, and both the SSIM score and the eyedropper report drift that is the alignment rather than the component — the most misleading answer this page can give, because it reads as the component being drawn wrongly.

## Reproduced first

A vector at `translate(4.5, 4.5)` over a render whose two tones match it exactly (left `#6750A4`, right `#7661AD`), so any disagreement is registration and nothing else:

| | render column placement | hover 5px from the tone boundary |
| --- | --- | --- |
| before | `left: 0px, top: 0px` | figma-svg `#6750a4` vs render `#7661ad` — **Δ 17 between two identical pictures** |
| after | `left: 5px, top: 5px` | `#6750a4` on both sides, `render px 45,19` |

## Provenance

Found by reading `compose-preview-server`'s own scorer while starting unrelated work there. It hit this exact bug and fixed it in [`scorer/svgTranslate.ts`](https://github.com/yschimke/compose-preview-server/blob/main/serve-web/src/scorer/svgTranslate.ts), whose comment spells out the failure mode. This is the same pattern for the same reason.

Worth noting the stale claim it replaces: the old comment said the integer-only form was "exactly as the Kotlin harness parses it". That is no longer true of the harness — the sibling repo reads fractional — so the comment was pinning this file to a contract that had already moved.

## Test plan

- `node --test scripts/design-artifacts/render-compare-html.test.mjs` — 54 pass (1 new, pinning the fractional pattern and asserting the integer-only form is gone).
- Browser, headless Chromium, before and after, with the fixture above — the table's numbers are measured, not described.
- The existing integer-translate fixtures are unchanged: the two-tone 240×100 row still reads `#6750a4` / `#7661ad` at 25% / 75%, the non-square fixture's 1px `#00C800` last row still reads on both sides at `render px 150,100`, and the row-to-row and rescore behaviours are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU)_