### PR TITLE
fix(semantics): match Font's style getter on its decoration, not a prefix

### DIFF
--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -713,13 +713,35 @@ object ComposeSemanticsDataProducer {
     return candidates.firstOrNull { it.weight.weight == chosenWeight } ?: candidates.firstOrNull()
   }
 
+  /**
+   * Whether this face is the italic one, read reflectively because `Font.style` is a value-class
+   * getter whose JVM name carries a signature hash (`getStyle-_-LCdwA`). Compiling a direct call
+   * would pin that hash, and the daemon runs against the *consumer's* compose-ui, so the tolerance
+   * is the point.
+   *
+   * Matched on the decoration rather than on a bare prefix. `getStyle` is a prefix of any longer
+   * `getStyleXxx` a future `Font` subtype might declare, and `Class.getMethods()` returns its
+   * elements in no specified order, so a prefix match would pick between them per run — silently,
+   * since a non-`Int` return just reads as "not italic" and mis-selects the face whose family and
+   * variation axes get reported. That is the defect `RemoteCatalogValues` shipped with, where
+   * `getPrimary` matched `getPrimaryDim`; nothing collides here today, and this keeps it that way.
+   * `-` (inline-class mangling) and `$` (an `internal` member's module suffix) are the only things
+   * that may follow, since neither can occur in a Kotlin property name.
+   */
   private fun Font.isItalic(): Boolean =
     runCatching {
       javaClass.methods
-        .firstOrNull { it.name.startsWith("getStyle") && it.parameterCount == 0 }
+        .filter { it.parameterCount == 0 && isStyleGetter(it.name) }
+        .minByOrNull { it.name }
         ?.invoke(this) as? Int
     }
       .getOrNull() == 1
+
+  private fun isStyleGetter(methodName: String): Boolean =
+    methodName == "getStyle" ||
+      (methodName.length > "getStyle".length &&
+        methodName.startsWith("getStyle") &&
+        methodName["getStyle".length].let { it == '-' || it == '$' })
 
   /**
    * Stable identity for a resolved [Font]: a downloadable face's Google-Fonts name, then the

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeInternalFieldContractTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeInternalFieldContractTest.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertTrue
@@ -180,6 +183,39 @@ class ComposeInternalFieldContractTest {
       "CutCornerShape renamed to ${shape.javaClass.simpleName}; ModifierTokenResolver would " +
         "now report a cut-corner shape as rounded.",
       shape.javaClass.simpleName == "CutCornerShape",
+    )
+  }
+
+  @Test
+  fun `a real Font offers exactly one zero-arg getStyle accessor`() {
+    // `ComposeSemanticsDataProducer.isItalic` reads `Font.style` reflectively, because it is a
+    // value-class getter whose JVM name carries a signature hash (`getStyle-_-LCdwA`) and the
+    // daemon runs against the consumer's compose-ui, not ours. The reflection therefore cannot
+    // match the name exactly — it matches `getStyle` plus a decoration.
+    //
+    // That is only unambiguous while `getStyle` is no other accessor's prefix. The day androidx
+    // adds a second zero-arg `getStyleXxx` to a Font implementation, the lookup has two candidates
+    // and `Class.getMethods()` orders them however it likes — the face whose family and variation
+    // axes get reported would then change between runs, silently, because a non-Int return just
+    // reads as "not italic". This is the canary for that day; the same collision, on
+    // `getPrimary`/`getPrimaryDim`, is what made a colour catalog render four different PNGs.
+    val bytes = checkNotNull(javaClass.getResourceAsStream("/fonts/DroidSansMono.ttf")).readBytes()
+    val font: Any = Font("DroidSansMono", bytes, FontWeight.Normal, FontStyle.Italic)
+
+    val styleAccessors =
+      font.javaClass.methods.filter { it.parameterCount == 0 && it.name.startsWith("getStyle") }
+
+    assertTrue(
+      "Expected exactly one zero-arg getStyle* accessor on ${font.javaClass.name}, found " +
+        styleAccessors.map { it.name } +
+        "; ComposeSemanticsDataProducer.isItalic now has to choose between them.",
+      styleAccessors.size == 1,
+    )
+    // And the decoration is the mangling the loose match exists for, not a plain name.
+    assertTrue(
+      "Font.style is no longer a mangled value-class getter (${styleAccessors.single().name}); " +
+        "isItalic could read it by exact name now.",
+      styleAccessors.single().name.startsWith("getStyle-"),
     )
   }
 


### PR DESCRIPTION
The one other place in this repository with the reflection shape #5080 fixed. Hardening rather than a live bug — and the test is written so that stays checkable rather than asserted.

## The shape

`ComposeSemanticsDataProducer.isItalic` picks `Font.style` out of `javaClass.methods` with `startsWith("getStyle")`. `getStyle` is a prefix of any `getStyleXxx` a future `Font` implementation might declare, and `Class.getMethods()` returns its elements in no specified order — so two candidates would be chosen between per run.

It would not look like a bug. A non-`Int` return just reads as "not italic", so `matchingFont` would pick the wrong face and the family label and variation axes reported for that text would follow it, silently. That is exactly how the colour catalog behaved for weeks: `getPrimary` matching `getPrimaryDim` produced four different PNGs from unchanged code, with nothing failing.

## Why the loose match was right to exist

`Font.style` is a value-class getter, so its JVM name carries a signature hash — `getStyle-_-LCdwA`. The daemon runs against the **consumer's** compose-ui, not the one this module compiled against, so a direct call would pin a hash that a version bump can change. Keeping the read reflective and tolerant is deliberate and stays.

What narrows is *what* may follow the getter: `-` (inline-class mangling) or `$` (an `internal` member's module suffix), neither of which is legal in a Kotlin property name. A longer role no longer matches, and the surviving candidates are sorted rather than taken in `getMethods()` order.

The three sibling reflective reads in the same file — `getVariationSettings`, `getIdentity`, `getResId` — already compare for equality and are untouched; none of their return types is a value class, so none needs the tolerance.

## Test plan

`./gradlew :data-layoutinspector-connector:test --tests '*ComposeInternalFieldContractTest*'` — **BUILD SUCCESSFUL**, and `ktfmtFormat` run on the module.

The test is the part worth reviewing. Testing the predicate would prove nothing about the risk, so instead the canary goes in `ComposeInternalFieldContractTest` — the file that exists for precisely this, reflected androidx names that can change under us without breaking our compile. Against a **real** `Font` built from the pinned Compose it asserts:

- there is exactly **one** zero-arg `getStyle*` accessor — the collision this guards against does not exist today; and
- that accessor is still **mangled** (`getStyle-…`) — the reason the match must stay loose at all.

Both hold today, which is what makes this hardening and not a fix. The first fails the day androidx adds a second `getStyleXxx`, which is the day the old code would have started choosing between them; the second fails if `style` ever stops being a value class, at which point the tolerance could go entirely. Either way the failure names what changed instead of quietly reporting the wrong face.

That file's own KDoc makes the case better than I can: hand-written fakes "stay green precisely when the assumption has broken", so the assertion has to run against the real dependency.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVCHoRJakBpHkycZxKAV9r)_