### PR TITLE
feat(design-artifacts): preflight a catalog spec against a preview-id manifest

### DIFF
--- a/.github/workflows/design-artifacts-reusable.yml
+++ b/.github/workflows/design-artifacts-reusable.yml
@@ -1795,6 +1795,52 @@ jobs:
           compose-preview list --json "${variant[@]}" --module "$INPUT_MODULE" \
             > "$GITHUB_WORKSPACE/discovered-previews.json"
 
+      # Build-free preflight of the spec against the ids discovery just minted (issue #5066).
+      #
+      # Nearly every failed cycle is a config-shape error — a `preview` that names nothing, an
+      # `exclude-preview-ids` pattern in the wrong id shape, an exclusion that removes too few arms
+      # of a fan-out so two survivors fight over one sticker path — and each one otherwise costs the
+      # whole render to discover, because the completeness gate and `foldVariants` only speak at the
+      # end. Every one of them is decidable from a list of ids in seconds, and this is the last
+      # point before the render where saying so is still cheap. `validate-catalog-spec` above is the
+      # SOURCE-side half of the same idea; this is the manifest-side half, and it sees what
+      # discovery actually minted rather than what the Kotlin declares.
+      #
+      # Advisory — `--warn-only`, and never a failure. Two reasons, both deliberate:
+      #   * the output-axis report models what the join WOULD produce from manifest params, and an
+      #     axis it cannot see (one derived from pixels, or from an annotation the manifest does not
+      #     carry) would fail a spec that renders fine. The render's own guard stays the gate.
+      #   * an EXTERNAL caller runs the release-pinned export driver, so this script does not exist
+      #     for it until the next release moves `.github/design-artifacts-driver-pin.txt` — hence
+      #     the file guard rather than a hard `node` invocation.
+      # The findings are annotations on the run, minutes in, instead of a red gate 40 minutes in.
+      #
+      # Only the CALLER's `exclude-preview-ids` are checked, not the `activity__*`/`apptour__*`
+      # patterns import mode always appends: those are defensive by construction, and a module with
+      # no activity would otherwise report them as dead every single run.
+      - name: Preflight the spec against the discovered previews
+        env:
+          SPEC: ${{ inputs.spec }}
+          EXCLUDE_PREVIEW_IDS: ${{ inputs.exclude-preview-ids }}
+        run: |
+          set -euo pipefail
+          preflight=compose-ai-tools/scripts/design-artifacts/spec-preflight.mjs
+          manifest="$GITHUB_WORKSPACE/discovered-previews.json"
+          if [ ! -f "$preflight" ]; then
+            echo "::notice title=Driver too old for the spec preflight::This run's export driver predates spec-preflight.mjs, so the spec was not checked against the discovered preview ids. Nothing is lost — the render's own gates still run. External callers get it when the next release moves compose-ai-tools/.github/design-artifacts-driver-pin.txt."
+            exit 0
+          fi
+          if [ ! -s "$manifest" ]; then
+            echo "No discovered preview manifest in this job, so there is nothing to preflight the spec against."
+            exit 0
+          fi
+          exclude=()
+          if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then
+            exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS")
+          fi
+          node "$preflight" --spec "$GITHUB_WORKSPACE/$SPEC" --previews "$manifest" \
+            "${exclude[@]}" --warn-only
+
       - name: Derive per-mode render exclusions
         id: mode-filter
         if: ${{ steps.validate-spec.outputs.deferred-modes != '' }}
@@ -2856,6 +2902,52 @@ jobs:
           # A mode that carries no discovered id is a @PreviewParameter row axis: discovery never
           # sees those rows (the renderer expands the provider), so they're skipped by LABEL instead.
           echo "exclude-rows=$(cat "$GITHUB_WORKSPACE/mode-filter-rows.txt")" >> "$GITHUB_OUTPUT"
+
+      # Build-free preflight of the spec against the ids discovery just minted (issue #5066).
+      #
+      # Nearly every failed cycle is a config-shape error — a `preview` that names nothing, an
+      # `exclude-preview-ids` pattern in the wrong id shape, an exclusion that removes too few arms
+      # of a fan-out so two survivors fight over one sticker path — and each one otherwise costs the
+      # whole render to discover, because the completeness gate and `foldVariants` only speak at the
+      # end. Every one of them is decidable from a list of ids in seconds, and this is the last
+      # point before the render where saying so is still cheap. `validate-catalog-spec` above is the
+      # SOURCE-side half of the same idea; this is the manifest-side half, and it sees what
+      # discovery actually minted rather than what the Kotlin declares.
+      #
+      # Advisory — `--warn-only`, and never a failure. Two reasons, both deliberate:
+      #   * the output-axis report models what the join WOULD produce from manifest params, and an
+      #     axis it cannot see (one derived from pixels, or from an annotation the manifest does not
+      #     carry) would fail a spec that renders fine. The render's own guard stays the gate.
+      #   * an EXTERNAL caller runs the release-pinned export driver, so this script does not exist
+      #     for it until the next release moves `.github/design-artifacts-driver-pin.txt` — hence
+      #     the file guard rather than a hard `node` invocation.
+      # The findings are annotations on the run, minutes in, instead of a red gate 40 minutes in.
+      #
+      # Only the CALLER's `exclude-preview-ids` are checked, not the `activity__*`/`apptour__*`
+      # patterns import mode always appends: those are defensive by construction, and a module with
+      # no activity would otherwise report them as dead every single run.
+      - name: Preflight the spec against the discovered previews
+        env:
+          SPEC: ${{ inputs.spec }}
+          EXCLUDE_PREVIEW_IDS: ${{ inputs.exclude-preview-ids }}
+        run: |
+          set -euo pipefail
+          preflight=compose-ai-tools/scripts/design-artifacts/spec-preflight.mjs
+          manifest="$GITHUB_WORKSPACE/discovered-previews.json"
+          if [ ! -f "$preflight" ]; then
+            echo "::notice title=Driver too old for the spec preflight::This run's export driver predates spec-preflight.mjs, so the spec was not checked against the discovered preview ids. Nothing is lost — the render's own gates still run. External callers get it when the next release moves compose-ai-tools/.github/design-artifacts-driver-pin.txt."
+            exit 0
+          fi
+          if [ ! -s "$manifest" ]; then
+            echo "No discovered preview manifest in this job, so there is nothing to preflight the spec against."
+            exit 0
+          fi
+          exclude=()
+          if [ -n "${EXCLUDE_PREVIEW_IDS:-}" ]; then
+            exclude=(--exclude-preview-id "$EXCLUDE_PREVIEW_IDS")
+          fi
+          node "$preflight" --spec "$GITHUB_WORKSPACE/$SPEC" --previews "$manifest" \
+            "${exclude[@]}" --warn-only
 
       # Stage bundled fallback fonts into fontconfig before any render, so a
       # desktop (Skiko) render resolves glyphs a preview's FontFamily doesn't

--- a/docs/design/DESIGN_CATALOGS.md
+++ b/docs/design/DESIGN_CATALOGS.md
@@ -941,6 +941,41 @@ gap by scanning the module's Kotlin source directly (no Gradle build, no render)
   so you know why they're absent. When there is no static sibling to point at, the
   entry can instead declare `"capture": "none"` — see below.
 
+- **Preflight against a preview-id manifest** — the manifest-side half of the same
+  idea, and the one that needs no source access at all. It reads a list of preview
+  **ids** (a module's `build/compose-previews/previews.json`, `compose-preview list
+  --json`, or a copy kept from the last good run) and reports, without rendering:
+
+  ```sh
+  node scripts/design-artifacts/spec-preflight.mjs \
+    --spec catalog.spec.json --previews previews.json \
+    --exclude-preview-id 'activity__*,Home_ja'
+  ```
+
+  - a spec `preview` (component or variant) that no manifest id's function answers to;
+  - each exclusion pattern with its match count, flagging any at **0** — the
+    underscores-vs-spaces mistake, where `@Preview(name = "Font scale 1.5x")` mints an
+    id carrying spaces and an underscored pattern silently excludes nothing;
+  - a claimed function whose *every* id is excluded, which can only publish as a
+    missing sticker;
+  - ids that survive exclusion and would **collide on output axes** — the three-arm
+    locale fan-out whose catalog declares no locale axis, where excluding one arm
+    leaves the other two fighting over one sticker path. `foldVariants` throws on this
+    at the very end of a render; here it is a report, and it names every colliding pair
+    rather than the first;
+  - as information, the surviving ids no spec component claims.
+
+  Exits non-zero on findings (`--warn-only` to report without failing, `--json` for the
+  machine-readable form). The manifest for a given import changes rarely while the spec
+  and its exclusions change constantly, so checking the fast-moving half against a
+  cached snapshot of the slow-moving one is where the time is: each of these otherwise
+  costs a full 20–40 minute render to discover. `design-artifacts-reusable.yml` runs it
+  before the render wherever discovery has already produced a manifest, as an advisory
+  step — the output-axis report models what the join *would* produce from manifest
+  params, so an axis it cannot see (one derived from pixels, or from an annotation the
+  manifest does not carry) must not be able to fail a spec that renders fine. The
+  render's own guards remain the gate.
+
 The spec shape is described by
 [`scripts/design-artifacts/catalog.spec.schema.json`](../../scripts/design-artifacts/catalog.spec.schema.json)
 (referenced via `$schema` in each sample spec for editor validation).

--- a/scripts/design-artifacts/catalog-variants.mjs
+++ b/scripts/design-artifacts/catalog-variants.mjs
@@ -143,21 +143,33 @@ function axisValueEquals(key, actual, expected) {
 }
 
 /**
+ * The effective output axes of one image, as the string the exporter would name its PNG from.
+ *
+ * Exported because the build-free spec preflight (`spec-preflight.mjs`, issue #5066) has to answer
+ * the same question against a preview-id manifest, before a render exists to fold. A second
+ * implementation there would drift from this one — and the direction it would drift in is a
+ * preflight that reports a collision the render does not have, or misses the one it does.
+ */
+export function outputAxisKey(image) {
+  const props = Object.fromEntries(
+    Object.entries(image?.props ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+  );
+  return JSON.stringify({
+    variant: image?.variant ?? "ideal",
+    state: image?.state ?? "default",
+    theme: image?.theme ?? null,
+    size: image?.size ?? null,
+    props,
+  });
+}
+
+/**
  * Refuse two images that the exporter would name from the same effective variant axes. Catching
  * this before `buildCatalog` writes either PNG prevents last-write-wins pixels paired with stale
  * manifest metadata.
  */
 function recordOutputKey(seen, image, componentId) {
-  const props = Object.fromEntries(
-    Object.entries(image.props ?? {}).sort(([a], [b]) => a.localeCompare(b)),
-  );
-  const key = JSON.stringify({
-    variant: image.variant ?? "ideal",
-    state: image.state ?? "default",
-    theme: image.theme ?? null,
-    size: image.size ?? null,
-    props,
-  });
+  const key = outputAxisKey(image);
   if (seen.has(key)) {
     throw new Error(
       `catalog component "${componentId}" produces duplicate output axes ${key}; ` +

--- a/scripts/design-artifacts/spec-preflight.mjs
+++ b/scripts/design-artifacts/spec-preflight.mjs
@@ -1,0 +1,521 @@
+/**
+ * Check a catalog spec against a **preview-id manifest**, without rendering (issue #5066).
+ *
+ * Nearly every failed import cycle is a config-shape error — a spec `preview` that names nothing,
+ * an `excludePreviewIds` pattern written in the wrong id shape, an exclusion that removes too few
+ * arms of a fan-out — and each one currently costs a full render (20–40 minutes on a real project)
+ * to discover. Every one of them is decidable in seconds from a list of preview ids, which is what
+ * this module does. Four reports, all from `(spec, previews[, exclusions])`:
+ *
+ *   - **`missing-preview`** — a spec `preview` (component or variant) that no manifest id's function
+ *     answers to. The offline half of the completeness gate's `missing`, and the same check
+ *     `validate-catalog-spec.mjs` runs against Kotlin *source* — except this one sees what discovery
+ *     actually minted, so it also catches a preview that exists but was never discovered.
+ *   - **`unmatched-exclusion`** — an exclusion pattern with a match count of 0 (issue #5064). The
+ *     underscores-vs-spaces mistake: `@Preview(name = "Font scale 1.5x")` mints an id carrying
+ *     spaces, and a pattern spelled with underscores silently excludes nothing.
+ *   - **`excluded-claimed`** — every id of a function the spec claims is excluded, so that component
+ *     can only publish as a missing sticker.
+ *   - **`duplicate-output-axes`** — ids that survive exclusion and would collide on output axes
+ *     (issue #5065): the three-arm locale fan-out whose catalog declares no locale axis, where an
+ *     exclusion covering only `_ja` leaves two arms fighting over one sticker path. `foldVariants`
+ *     throws on this at the very end of a render; here it is a report, and it names every colliding
+ *     pair rather than the first.
+ *
+ * Plus, as information, the manifest ids no spec component claims — the inverse view, for a catalog
+ * that is meant to cover a module.
+ *
+ * ## What a manifest is, and what the axis model can see
+ *
+ * Any `{ previews: [{ id, functionName, params, captures }] }` payload: a module's
+ * `build/compose-previews/previews.json`, `compose-preview list --json`, or a bundle's manifest.
+ * The manifest for a given import changes rarely while the spec and its exclusions change
+ * constantly, so a cached snapshot of the slow-moving half is enough to iterate the fast-moving one
+ * with no build at all.
+ *
+ * The output-axis check necessarily models what the render + candidate join WOULD produce, because
+ * the real axes are read off rendered images. The model derives, per manifest capture:
+ *
+ *   - `state` from an `_VARIANT_<name>` id suffix (`variantStateFromId`, the same reader the join
+ *     uses);
+ *   - `theme` from the declared mode a trailing id segment names (`modeOfPreviewId`), else a
+ *     `light`/`dark` id suffix, else `@Preview(uiMode = …)`'s night bits;
+ *   - `size` from the spec's `breakpoints` (`breakpointMatcher`, shared with the join);
+ *   - `props.fontScale` from a non-default `fontScale` param, mirroring `applyCatalogPreviewAxes`.
+ *
+ * An axis the join derives from pixels or from a source annotation this manifest does not carry is
+ * invisible here, so the collision report is a **report**, not the authority: the render's own
+ * `foldVariants` guard stays the gate. The bias is deliberately towards silence — two ids that
+ * differ only in something the model cannot see are the one shape it can get wrong, and it is worth
+ * saying that out loud rather than failing a spec that renders fine.
+ *
+ * Pure and dependency-free apart from its siblings (node built-ins only, no `@design-parity/*`, no
+ * I/O) so it unit-tests without an `npm ci`. The `--spec`/`--previews` CLI wrapper at the bottom
+ * only runs when this file is executed directly.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { breakpointMatcher, catalogBreakpoints } from "./catalog-breakpoints.mjs";
+import { modeOfPreviewId } from "./catalog-priority.mjs";
+import { selectImages, selectLabel, selectOf } from "./catalog-select.mjs";
+import { imageHasVariantAxes, outputAxisKey } from "./catalog-variants.mjs";
+import { previewsFromJson } from "./deferred-preview-ids.mjs";
+import { variantStateFromId } from "./variant-state.mjs";
+
+/** Mirror of `PackPreviewIdExclusions.ANCHOR` / `PreviewNameFilter.ANCHOR`. */
+export const ANCHOR = "=";
+
+/**
+ * Whether one `--exclude-preview-id` pattern matches one preview id.
+ *
+ * Mirrors `PackPreviewIdExclusions.matches` (CLI) and `PreviewNameFilter.matchesId` (plugin), which
+ * are what actually skip the render: an `=`-anchored pattern is exact, a pattern carrying `*`/`?` is
+ * an anchored glob, and a plain pattern matches by equality OR substring. Case-sensitive throughout.
+ * A fourth implementation is a liability, so keep it in step with those two — a preflight that
+ * matched more loosely than the render would report an exclusion as covered when the render will
+ * still burn the time, and one that matched more tightly would invent `unmatched-exclusion`
+ * findings for patterns that work.
+ */
+export function matchesExclusion(pattern, id) {
+  const text = String(id ?? "");
+  const glob = String(pattern ?? "");
+  if (glob.length === 0) return false;
+  if (glob.startsWith(ANCHOR)) return text === glob.slice(ANCHOR.length);
+  if (glob.includes("*") || glob.includes("?")) return globToRegExp(glob).test(text);
+  return text === glob || text.includes(glob);
+}
+
+/** Anchored regex for a `*`/`?` glob, every other character escaped so an id's `.` stays literal. */
+function globToRegExp(glob) {
+  const body = [...glob]
+    .map((c) => (c === "*" ? ".*" : c === "?" ? "." : c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")))
+    .join("");
+  return new RegExp(`^${body}$`);
+}
+
+/** Split a comma-separated exclusion list the way the CLI's `--exclude-preview-id` does. */
+export function exclusionPatterns(raw) {
+  return (Array.isArray(raw) ? raw : [raw])
+    .filter((value) => typeof value === "string")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+/**
+ * The `@Preview` function a manifest record belongs to. `functionName` when discovery recorded one
+ * (every current payload does), else the id — the same fallback the candidate join uses.
+ */
+export function functionOf(preview) {
+  return preview?.functionName ?? preview?.id;
+}
+
+/**
+ * Whether a spec's `preview` names [fn].
+ *
+ * Exact, with one concession: a repository-wide catalog rewrites a colliding function name to
+ * `<module>::<function>` (see multi-module-catalog.mjs), so a spec carrying the qualified spelling
+ * still resolves against a single-module manifest that only knows the bare one.
+ */
+function claims(specPreview, fn) {
+  if (typeof specPreview !== "string" || typeof fn !== "string") return false;
+  return specPreview === fn || specPreview.endsWith(`::${fn}`);
+}
+
+/** Every component a spec declares, in spec order. */
+function* specComponents(spec) {
+  for (const group of spec?.groups ?? []) {
+    for (const component of group?.components ?? []) {
+      if (component && typeof component === "object") yield component;
+    }
+  }
+}
+
+/** Every `(component, entry)` pair a spec declares, components and their variants alike. */
+function* specEntries(spec) {
+  for (const component of specComponents(spec)) {
+    yield { component, entry: component, kind: "component" };
+    for (const variant of component.variants ?? []) {
+      if (!variant || typeof variant !== "object") continue;
+      yield { component, entry: variant, kind: "variant" };
+    }
+  }
+}
+
+/** The captures of a preview, or one implicit capture for a preview that declares none. */
+function capturesOf(preview) {
+  const captures = preview?.captures;
+  return Array.isArray(captures) && captures.length > 0 ? captures : [{}];
+}
+
+/** UI_MODE_NIGHT mask / values from `android.content.res.Configuration`. */
+const UI_MODE_NIGHT_MASK = 0x30;
+const UI_MODE_NIGHT_NO = 0x10;
+const UI_MODE_NIGHT_YES = 0x20;
+
+/**
+ * The theme the join would tag this render with, or null.
+ *
+ * Three readers, most specific first, because two catalog shapes put the theme in different places:
+ * `@CatalogModes` mints a `Foo_Light`/`Foo_Dark` id (which `modeOfPreviewId` resolves against the
+ * spec's declared `modes`, and a bare light/dark suffix answers even for a spec that declares
+ * none — see `bridge-live-preview-ids.mjs`), while a hand-written `@Preview(uiMode = …)` carries it
+ * only in the annotation.
+ */
+function themeOf(id, params, modes) {
+  const declared = modeOfPreviewId(id, modes);
+  if (declared) return declared;
+  const lower = String(id ?? "").toLowerCase();
+  if (lower.endsWith("dark")) return "dark";
+  if (lower.endsWith("light")) return "light";
+  const night = Number(params?.uiMode) & UI_MODE_NIGHT_MASK;
+  if (night === UI_MODE_NIGHT_YES) return "dark";
+  if (night === UI_MODE_NIGHT_NO) return "light";
+  return null;
+}
+
+/**
+ * Params that decide pixels: everything but `name`/`group`, which only label an annotation, and an
+ * explicit `fontScale: 1`, which is the default written out.
+ *
+ * The `name`/`group` drop mirrors `applyCatalogPreviewAxes`. The `fontScale` normalisation is this
+ * module's own, and it is what keeps the Wear shape quiet: stacking `@WearPreviewDevices` on
+ * `@WearPreviewFontScales` emits the small-round render twice, once with the scale left implicit
+ * and once with it spelled `1.0`. Those are the same picture, the join collapses them, and treating
+ * the two spellings as different params would report every such catalog as colliding.
+ */
+function renderParams(params) {
+  const { name: _name, group: _group, ...rendering } = params ?? {};
+  if (Number(rendering.fontScale) === 1) delete rendering.fontScale;
+  return rendering;
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * The images one manifest record would contribute to a catalog entry: one per capture, carrying the
+ * axes the model can derive (see the file header for what it can and cannot see).
+ *
+ * `previewId` rides along for the report — a collision is only actionable if it names the ids that
+ * collided — and is ignored by `outputAxisKey`, which reads the axes alone.
+ */
+export function previewImages(preview, { modes, sizeOf }) {
+  const id = preview?.id;
+  const state = variantStateFromId(id);
+  return capturesOf(preview).map((capture) => {
+    const params = { ...(preview?.params ?? {}), ...(capture?.params ?? {}) };
+    const fontScale = params.fontScale;
+    const props =
+      typeof fontScale === "number" && Number.isFinite(fontScale) && fontScale !== 1
+        ? { fontScale: Number.isInteger(fontScale) ? fontScale.toFixed(1) : String(fontScale) }
+        : {};
+    const size = sizeOf ? sizeOf(params) : undefined;
+    return {
+      previewId: id,
+      variant: "ideal",
+      state: state ?? "default",
+      theme: themeOf(id, params, modes),
+      ...(size !== undefined ? { size } : {}),
+      props,
+      params: renderParams(params),
+    };
+  });
+}
+
+/**
+ * `functionName` → the images its surviving ids would contribute, exact duplicates collapsed.
+ *
+ * The collapse mirrors `applyCatalogPreviewAxes`: two renders with identical effective params AND
+ * identical derived axes are the same picture (Wear stacking `@WearPreviewDevices` on
+ * `@WearPreviewFontScales` produces one such pair per function), and the join drops the repeat
+ * rather than colliding on it. Skipping it here would report every such catalog as broken.
+ */
+export function imagesByFunction(previews, options) {
+  const byFunction = new Map();
+  const seen = new Map();
+  for (const preview of previews ?? []) {
+    const fn = functionOf(preview);
+    if (typeof fn !== "string" || fn.length === 0) continue;
+    const images = byFunction.get(fn) ?? [];
+    const claimed = seen.get(fn) ?? new Set();
+    for (const image of previewImages(preview, options)) {
+      const key = stableJson({ params: image.params, axes: outputAxisKey(image) });
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      images.push(image);
+    }
+    byFunction.set(fn, images);
+    seen.set(fn, claimed);
+  }
+  return byFunction;
+}
+
+/** Apply a variant's declared axes to an image, exactly as `foldVariants` re-tags it. */
+function tagged(image, variant) {
+  const out = { ...image };
+  if (variant.state !== undefined) out.state = variant.state;
+  if (variant.props) out.props = { ...image.props, ...variant.props };
+  if (variant.theme !== undefined) out.theme = variant.theme;
+  return out;
+}
+
+/**
+ * The output-axis collisions one component's surviving ids would produce.
+ *
+ * Walks the same fold as `foldVariants` — default images first, then each variant's re-tagged
+ * ones, a same-function variant already covered by a default image skipped — and keys them with the
+ * very same `outputAxisKey`. The difference is that it collects every collision instead of throwing
+ * on the first, which is what makes one preflight pass worth a render cycle.
+ */
+function collisionsOf(component, byFunction) {
+  const seen = new Map();
+  const collisions = [];
+  const record = (image, source) => {
+    const key = outputAxisKey(image);
+    const first = seen.get(key);
+    if (first === undefined) {
+      seen.set(key, { image, source });
+      return;
+    }
+    collisions.push({
+      componentId: component.componentId,
+      key,
+      previewIds: [first.image.previewId, image.previewId],
+      sources: [first.source, source],
+    });
+  };
+
+  const defaultImages = selectImages(byFunction.get(component.preview) ?? [], selectOf(component));
+  for (const image of defaultImages) record(image, component.preview);
+  for (const variant of component.variants ?? []) {
+    const images = selectImages(byFunction.get(variant.preview) ?? [], selectOf(variant));
+    if (images.length === 0) continue;
+    // A variant naming the component's OWN function whose axes the default images already carry is
+    // satisfied by them — `foldVariants` folds nothing in that case, so neither does this.
+    if (
+      variant.preview === component.preview &&
+      defaultImages.some((image) => imageHasVariantAxes(image, variant))
+    ) {
+      continue;
+    }
+    const label = `${variant.preview} [${variantLabelOf(variant)}]`;
+    for (const image of images) record(tagged(image, variant), label);
+  }
+  return collisions;
+}
+
+/** A short label for a variant in a finding — its declared axes, or its preview name. */
+function variantLabelOf(variant) {
+  const parts = [
+    ...(variant.state ? [`state=${variant.state}`] : []),
+    ...Object.entries(variant.props ?? {}).map(([k, v]) => `${k}=${v}`),
+    ...(variant.theme ? [`theme=${variant.theme}`] : []),
+    ...(selectOf(variant) ? [`select ${selectLabel(selectOf(variant))}`] : []),
+  ];
+  return parts.join(", ") || variant.preview;
+}
+
+/** Severity ordering for the report's own summary line. */
+export const ERROR = "error";
+export const INFO = "info";
+
+/**
+ * Check [spec] against a preview-id manifest.
+ *
+ * @param {object} spec parsed `catalog.spec.json`.
+ * @param {Array<{id: string, functionName?: string, params?: object, captures?: Array<object>}>} previews
+ *   the manifest's previews (see `previewsFromJson`).
+ * @param {{excludePatterns?: string[]}} [options] the `--exclude-preview-id` patterns the render
+ *   will be given, if any.
+ * @returns {{findings: Array<object>, patterns: Array<{pattern: string, matches: number}>,
+ *   unclaimed: string[], counts: object}} findings in reported order, every exclusion pattern with
+ *   its match count (whether or not it is a finding), the manifest ids no component claims, and the
+ *   id counts the summary line is built from.
+ */
+export function preflightSpec(spec, previews, options = {}) {
+  const patterns = exclusionPatterns(options.excludePatterns ?? []);
+  const all = (previews ?? []).filter((preview) => typeof preview?.id === "string");
+  const findings = [];
+
+  // Exclusions first: every later check runs against the SURVIVORS, which is the set the render
+  // actually produces. Counting matches per pattern (rather than over the union) is what makes a
+  // dead pattern visible when a sibling pattern covers the same ids.
+  const matchCounts = patterns.map((pattern) => ({
+    pattern,
+    matches: all.filter((preview) => matchesExclusion(pattern, preview.id)).length,
+  }));
+  const survivors = all.filter(
+    (preview) => !patterns.some((pattern) => matchesExclusion(pattern, preview.id)),
+  );
+  for (const { pattern, matches } of matchCounts) {
+    if (matches > 0) continue;
+    findings.push({
+      kind: "unmatched-exclusion",
+      severity: ERROR,
+      pattern,
+      message:
+        `exclusion pattern "${pattern}" matches none of the ${all.length} manifest id(s), so it ` +
+        `excludes nothing. Check the id shape — a @Preview(name = …) with spaces mints an id with ` +
+        `spaces, which an underscored pattern never matches.`,
+    });
+  }
+
+  const byFunction = imagesByFunction(survivors, {
+    modes: spec?.modes ?? [],
+    sizeOf: breakpointMatcher(catalogBreakpoints(spec)),
+  });
+  const functionsBefore = new Set(all.map(functionOf));
+  const claimed = new Set();
+
+  for (const { component, entry, kind } of specEntries(spec)) {
+    const preview = entry.preview;
+    if (typeof preview !== "string" || preview.length === 0) continue;
+    const resolved = [...byFunction.keys()].filter((fn) => claims(preview, fn));
+    for (const fn of resolved) claimed.add(fn);
+    if (resolved.length > 0) continue;
+    const wasExcluded = [...functionsBefore].some((fn) => claims(preview, fn));
+    findings.push({
+      kind: wasExcluded ? "excluded-claimed" : "missing-preview",
+      severity: ERROR,
+      componentId: component.componentId,
+      preview,
+      entry: kind,
+      message: wasExcluded
+        ? `${component.componentId} (${kind} "${preview}"): every discovered id of this function ` +
+          `is excluded, so the entry can only publish as a missing sticker. Narrow the exclusion ` +
+          `or drop the entry.`
+        : `${component.componentId} (${kind} "${preview}"): no manifest id belongs to a function ` +
+          `of this name.`,
+    });
+  }
+
+  for (const component of specComponents(spec)) {
+    for (const collision of collisionsOf(component, byFunction)) {
+      findings.push({
+        ...collision,
+        kind: "duplicate-output-axes",
+        severity: ERROR,
+        message:
+          `${collision.componentId}: ${collision.previewIds.join(" and ")} both fold onto output ` +
+          `axes ${collision.key} (from ${collision.sources.join(" / ")}), so one would overwrite ` +
+          `the other's sticker. Give the arms an axis the catalog declares, or exclude all but ` +
+          `one of them.`,
+      });
+    }
+  }
+
+  const unclaimed = [
+    ...new Set(
+      survivors.filter((preview) => !claimed.has(functionOf(preview))).map((preview) => preview.id),
+    ),
+  ].sort();
+
+  return {
+    findings,
+    patterns: matchCounts,
+    unclaimed,
+    counts: {
+      previews: all.length,
+      excluded: all.length - survivors.length,
+      survivors: survivors.length,
+      claimedFunctions: claimed.size,
+      unclaimed: unclaimed.length,
+    },
+  };
+}
+
+/** The findings that fail a run: everything the report is sure about. */
+export function errorsOf(report) {
+  return (report?.findings ?? []).filter((finding) => finding.severity === ERROR);
+}
+
+// --- CLI ----------------------------------------------------------------------
+// `node spec-preflight.mjs --spec catalog.spec.json --previews previews.json
+//    [--exclude-preview-id <patterns>…] [--exclude-preview-id-file <file>] [--warn-only] [--json]`
+//
+// Exit 0 when nothing is wrong, 1 on findings (0 with `--warn-only`), 2 on bad arguments. The
+// manifest is any `{ previews: [...] }` payload: a module's `build/compose-previews/previews.json`,
+// `compose-preview list --json`, or a bundle manifest — including one kept from the last good run,
+// which is the point: the manifest changes rarely, the spec and its exclusions change constantly.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { values } = parseArgs({
+    options: {
+      spec: { type: "string" },
+      previews: { type: "string" },
+      "exclude-preview-id": { type: "string", multiple: true },
+      "exclude-preview-id-file": { type: "string" },
+      // Report without failing — the posture of a shared pipeline adding this ahead of a render it
+      // is not yet ready to gate on, and the counterpart of the workflow's `allow-incomplete`.
+      "warn-only": { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help || !values.spec || !values.previews) {
+    const usage =
+      "usage: spec-preflight.mjs --spec <catalog.spec.json> --previews <previews.json> " +
+      "[--exclude-preview-id <patterns>]… [--exclude-preview-id-file <file>] [--warn-only] [--json]";
+    console.log(usage);
+    process.exit(values.help ? 0 : 2);
+  }
+  const spec = JSON.parse(readFileSync(values.spec, "utf8"));
+  const previews = previewsFromJson(JSON.parse(readFileSync(values.previews, "utf8")));
+  const fromFile = values["exclude-preview-id-file"]
+    ? readFileSync(values["exclude-preview-id-file"], "utf8").split("\n")
+    : [];
+  const report = preflightSpec(spec, previews, {
+    excludePatterns: [...(values["exclude-preview-id"] ?? []), ...fromFile],
+  });
+  const errors = errorsOf(report);
+  if (values.json) {
+    console.log(JSON.stringify({ ...report, ok: errors.length === 0 }, null, 2));
+  } else {
+    const { counts } = report;
+    console.log(
+      `Preflight ${values.spec} against ${counts.previews} manifest preview id(s): ` +
+        `${counts.excluded} excluded, ${counts.survivors} surviving, ` +
+        `${counts.claimedFunctions} @Preview function(s) claimed by the spec.`,
+    );
+    for (const { pattern, matches } of report.patterns) {
+      console.log(`  exclusion "${pattern}" matches ${matches} id(s)`);
+    }
+    for (const finding of report.findings) annotate(finding);
+    if (report.unclaimed.length > 0) {
+      // Information, not a finding: a catalog is allowed to curate, and a repository-wide publish
+      // generates entries for exactly these.
+      console.log(
+        `  info: ${report.unclaimed.length} surviving id(s) no spec component claims: ` +
+          `${report.unclaimed.slice(0, 10).join(", ")}${report.unclaimed.length > 10 ? ", …" : ""}`,
+      );
+    }
+    console.log(
+      errors.length === 0
+        ? "OK — no config-shape problems decidable from this manifest."
+        : `${values["warn-only"] ? "FINDINGS" : "FAILED"} — ${errors.length} finding(s).`,
+    );
+  }
+  process.exit(errors.length > 0 && !values["warn-only"] ? 1 : 0);
+
+  function annotate(finding) {
+    const sink = finding.severity === ERROR ? console.error : console.log;
+    if (process.env.GITHUB_ACTIONS === "true") {
+      const escape = (value) =>
+        String(value).replaceAll("%", "%25").replaceAll("\r", "%0D").replaceAll("\n", "%0A");
+      const level = finding.severity === ERROR && !values["warn-only"] ? "error" : "warning";
+      sink(`::${level} title=${escape(`Spec preflight: ${finding.kind}`)}::${escape(finding.message)}`);
+    } else {
+      sink(`  ${finding.severity}: ${finding.message}`);
+    }
+  }
+}

--- a/scripts/design-artifacts/spec-preflight.test.mjs
+++ b/scripts/design-artifacts/spec-preflight.test.mjs
@@ -1,0 +1,383 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ERROR,
+  errorsOf,
+  exclusionPatterns,
+  functionOf,
+  imagesByFunction,
+  matchesExclusion,
+  preflightSpec,
+  previewImages,
+} from "./spec-preflight.mjs";
+import { foldVariants } from "./catalog-variants.mjs";
+import { outputAxisKey } from "./catalog-variants.mjs";
+
+const preview = (id, extra = {}) => ({ id, functionName: id.split(".").pop(), ...extra });
+
+const spec = (components, extra = {}) => ({
+  system: "test",
+  groups: [{ name: "Components", components }],
+  ...extra,
+});
+
+const kinds = (report) => report.findings.map((finding) => finding.kind);
+
+test("matchesExclusion mirrors the CLI's anchored / glob / substring rules", () => {
+  // Anchored: exact, so a base id never drags its fan-out along.
+  assert.equal(matchesExclusion("=Switch_Dark", "Switch_Dark"), true);
+  assert.equal(matchesExclusion("=Switch_Dark", "Switch_Dark_VARIANT_off"), false);
+  // Glob: anchored at both ends, and a `.` in a package-qualified id stays literal.
+  assert.equal(matchesExclusion("activity__*", "activity__MainActivity"), true);
+  assert.equal(matchesExclusion("a?c", "abc"), true);
+  assert.equal(matchesExclusion("a?c", "abcd"), false);
+  assert.equal(matchesExclusion("com.a*", "comXa1"), false);
+  // Plain: equality OR substring.
+  assert.equal(matchesExclusion("Dark", "com.app.HomeKt.Home_Dark"), true);
+  assert.equal(matchesExclusion("Home_Dark", "com.app.HomeKt.Home_Dark"), true);
+  assert.equal(matchesExclusion("", "anything"), false);
+});
+
+test("exclusionPatterns splits and trims a comma list the way --exclude-preview-id does", () => {
+  assert.deepEqual(exclusionPatterns(["a, b", "", " c "]), ["a", "b", "c"]);
+  assert.deepEqual(exclusionPatterns("activity__*,apptour__*"), ["activity__*", "apptour__*"]);
+});
+
+test("functionOf prefers functionName and falls back to the id", () => {
+  assert.equal(functionOf({ id: "com.a.HomeKt.Home_Dark", functionName: "Home" }), "Home");
+  assert.equal(functionOf({ id: "Home" }), "Home");
+});
+
+test("a spec preview no manifest function answers to is reported as missing", () => {
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "HomeScren" }]), [
+    preview("com.a.HomeKt.HomeScreen", { functionName: "HomeScreen" }),
+  ]);
+  assert.deepEqual(kinds(report), ["missing-preview"]);
+  assert.match(report.findings[0].message, /Home \(component "HomeScren"\)/);
+});
+
+test("a variant's preview is resolved too, and a qualified multi-module name still matches", () => {
+  const previews = [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+    preview("com.a.HomeKt.HomePressed", { functionName: "HomePressed" }),
+  ];
+  const ok = preflightSpec(
+    spec([
+      {
+        componentId: "Home",
+        // The repository-wide catalog rewrites a colliding name to `<module>::<function>`.
+        preview: ":feature:home::Home",
+        variants: [{ preview: "HomePressed", state: "pressed" }],
+      },
+    ]),
+    previews,
+  );
+  assert.deepEqual(kinds(ok), []);
+
+  const typo = preflightSpec(
+    spec([
+      { componentId: "Home", preview: "Home", variants: [{ preview: "HomePressd", state: "pressed" }] },
+    ]),
+    previews,
+  );
+  assert.deepEqual(kinds(typo), ["missing-preview"]);
+  assert.equal(typo.findings[0].entry, "variant");
+});
+
+test("an exclusion pattern matching nothing is reported, with the id shape as the hint", () => {
+  // The underscores-vs-spaces mistake: the id carries the @Preview(name = …) verbatim.
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+    preview("com.a.HomeKt.Home Font scale 1.5x", { functionName: "Home" }),
+  ], { excludePatterns: ["Home_Font_scale"] });
+  assert.deepEqual(kinds(report), ["unmatched-exclusion"]);
+  assert.deepEqual(report.patterns, [{ pattern: "Home_Font_scale", matches: 0 }]);
+});
+
+test("a pattern's match count is reported per pattern, not over the union", () => {
+  // `Home` already covers every id `Home_Dark` would, so the union would hide the dead pattern.
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home_Light", { functionName: "Home" }),
+  ], { excludePatterns: ["Home", "Home_Dark"] });
+  assert.deepEqual(report.patterns, [
+    { pattern: "Home", matches: 1 },
+    { pattern: "Home_Dark", matches: 0 },
+  ]);
+  assert.ok(kinds(report).includes("unmatched-exclusion"));
+});
+
+test("a claimed function whose every id is excluded is reported apart from a missing one", () => {
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+  ], { excludePatterns: ["Home"] });
+  assert.deepEqual(kinds(report), ["excluded-claimed"]);
+  assert.match(report.findings[0].message, /every discovered id of this function is excluded/);
+});
+
+test("the three-arm locale fan-out collides on output axes once one arm is excluded", () => {
+  // The DroidKaigi case (#5059): a locale multipreview whose catalog declares no locale axis. Two
+  // cycles to discover from renders; decidable here in one pass.
+  const previews = ["ja", "en", "ar"].map((locale) =>
+    preview(`com.a.HomeKt.Home_${locale}`, {
+      functionName: "Home",
+      params: { locale, name: locale },
+    }),
+  );
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), previews, {
+    excludePatterns: ["=com.a.HomeKt.Home_ja"],
+  });
+  assert.deepEqual(kinds(report), ["duplicate-output-axes"]);
+  assert.deepEqual(report.findings[0].previewIds, [
+    "com.a.HomeKt.Home_en",
+    "com.a.HomeKt.Home_ar",
+  ]);
+  // Excluding two of the three arms leaves one sticker and nothing to report.
+  const narrowed = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), previews, {
+    excludePatterns: ["=com.a.HomeKt.Home_ja", "=com.a.HomeKt.Home_ar"],
+  });
+  assert.deepEqual(kinds(narrowed), []);
+});
+
+test("every collision is collected, not just the first", () => {
+  const previews = ["a", "b", "c"].map((tag) =>
+    preview(`com.a.HomeKt.Home_${tag}`, { functionName: "Home", params: { locale: tag } }),
+  );
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), previews);
+  assert.deepEqual(kinds(report), ["duplicate-output-axes", "duplicate-output-axes"]);
+});
+
+test("a declared mode, a light/dark suffix and a uiMode night bit each separate two arms", () => {
+  const declared = preflightSpec(
+    spec([{ componentId: "Home", preview: "Home" }], { modes: ["light", "dark"] }),
+    [
+      preview("com.a.HomeKt.Home_Light", { functionName: "Home" }),
+      preview("com.a.HomeKt.Home_Dark", { functionName: "Home" }),
+    ],
+  );
+  assert.deepEqual(kinds(declared), []);
+
+  // The same ids with no `modes` in the spec still separate on the light/dark suffix.
+  const undeclared = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home_Light", { functionName: "Home" }),
+    preview("com.a.HomeKt.Home_Dark", { functionName: "Home" }),
+  ]);
+  assert.deepEqual(kinds(undeclared), []);
+
+  // A hand-written `@Preview(uiMode = UI_MODE_NIGHT_YES)` carries the theme only in the annotation.
+  const uiMode = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home", { functionName: "Home", params: { uiMode: 0x11 } }),
+    preview("com.a.HomeKt.HomeNight", { functionName: "Home", params: { uiMode: 0x21 } }),
+  ]);
+  assert.deepEqual(kinds(uiMode), []);
+});
+
+test("a declared breakpoint separates two device arms; an undeclared one does not", () => {
+  const previews = [
+    preview("com.a.HomeKt.Home_small", {
+      functionName: "Home",
+      params: { device: "id:wearos_small_round", widthDp: 192 },
+    }),
+    preview("com.a.HomeKt.Home_large", {
+      functionName: "Home",
+      params: { device: "id:wearos_large_round", widthDp: 227 },
+    }),
+  ];
+  const declared = preflightSpec(
+    spec([{ componentId: "Home", preview: "Home" }], {
+      breakpoints: [
+        { size: "smallRound", device: "id:wearos_small_round" },
+        { size: "largeRound", device: "id:wearos_large_round" },
+      ],
+    }),
+    previews,
+  );
+  assert.deepEqual(kinds(declared), []);
+
+  // With no breakpoints the two renders land on one axis — the collapse `undeclaredBreakpointDevices`
+  // warns about at render time, decidable here before the render starts.
+  assert.deepEqual(
+    kinds(preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), previews)),
+    ["duplicate-output-axes"],
+  );
+});
+
+test("a `select` splits one fan-out across two components without colliding", () => {
+  const previews = [
+    preview("com.a.HomeKt.Home_small", { functionName: "Home", params: { widthDp: 192 } }),
+    preview("com.a.HomeKt.Home_large", { functionName: "Home", params: { widthDp: 227 } }),
+  ];
+  const report = preflightSpec(
+    spec(
+      [
+        { componentId: "Home/Small", preview: "Home", select: { size: "smallRound" } },
+        { componentId: "Home/Large", preview: "Home", select: { size: "largeRound" } },
+      ],
+      {
+        breakpoints: [
+          { size: "smallRound", widthDp: 192 },
+          { size: "largeRound", widthDp: 227 },
+        ],
+      },
+    ),
+    previews,
+  );
+  assert.deepEqual(kinds(report), []);
+});
+
+test("a same-function variant the default images already satisfy folds nothing in", () => {
+  // Mirrors foldVariants: re-tagging the very image it matched would invent a collision.
+  const previews = [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+    preview("com.a.HomeKt.Home_VARIANT_off", { functionName: "Home" }),
+  ];
+  const report = preflightSpec(
+    spec([
+      {
+        componentId: "Home",
+        preview: "Home",
+        variants: [{ preview: "Home", state: "off" }],
+      },
+    ]),
+    previews,
+  );
+  assert.deepEqual(kinds(report), []);
+});
+
+test("a state variant backed by its own function is re-tagged and does not collide", () => {
+  const report = preflightSpec(
+    spec([
+      {
+        componentId: "Home",
+        preview: "Home",
+        variants: [{ preview: "HomePressed", state: "pressed" }],
+      },
+    ]),
+    [
+      preview("com.a.HomeKt.Home", { functionName: "Home" }),
+      preview("com.a.HomeKt.HomePressed", { functionName: "HomePressed" }),
+    ],
+  );
+  assert.deepEqual(kinds(report), []);
+});
+
+test("two variants tagged with the same state collide on one sticker path", () => {
+  const report = preflightSpec(
+    spec([
+      {
+        componentId: "Home",
+        preview: "Home",
+        variants: [
+          { preview: "HomeOff", state: "off" },
+          { preview: "HomeUnchecked", state: "off" },
+        ],
+      },
+    ]),
+    [
+      preview("com.a.HomeKt.Home", { functionName: "Home" }),
+      preview("com.a.HomeKt.HomeOff", { functionName: "HomeOff" }),
+      preview("com.a.HomeKt.HomeUnchecked", { functionName: "HomeUnchecked" }),
+    ],
+  );
+  assert.deepEqual(kinds(report), ["duplicate-output-axes"]);
+});
+
+test("the preflight key agrees with the fold's own duplicate guard", () => {
+  // One assertion, two implementations: whatever `foldVariants` throws on, this reports.
+  const component = {
+    componentId: "Home",
+    preview: "Home",
+    variants: [
+      { preview: "HomeOff", state: "off" },
+      { preview: "HomeUnchecked", state: "off" },
+    ],
+  };
+  const image = (state) => ({ variant: "ideal", state, props: {} });
+  assert.throws(
+    () =>
+      foldVariants([image("default")], component, {
+        get: (fn) => ({ images: [image("default")] }),
+      }),
+    /produces duplicate output axes/,
+  );
+  assert.equal(outputAxisKey(image("off")), outputAxisKey({ state: "off" }));
+});
+
+test("exact render duplicates are collapsed the way applyCatalogPreviewAxes collapses them", () => {
+  // Wear stacking @WearPreviewDevices on @WearPreviewFontScales emits the same small-round /
+  // default-font render twice. The join drops the repeat; reporting it as a collision would fail
+  // every Wear catalog.
+  const previews = [
+    preview("com.a.HomeKt.Home_small", { functionName: "Home", params: { widthDp: 192 } }),
+    preview("com.a.HomeKt.Home_small_1x", {
+      functionName: "Home",
+      params: { widthDp: 192, fontScale: 1, name: "Font scale 1x" },
+    }),
+  ];
+  assert.deepEqual(kinds(preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), previews)), []);
+  // A non-default font scale becomes a props axis instead, so it stays a distinct sticker.
+  const scaled = [
+    previews[0],
+    preview("com.a.HomeKt.Home_small_2x", {
+      functionName: "Home",
+      params: { widthDp: 192, fontScale: 2 },
+    }),
+  ];
+  assert.deepEqual(kinds(preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), scaled)), []);
+});
+
+test("previewImages emits one image per capture", () => {
+  const images = previewImages(
+    preview("com.a.HomeKt.Home", {
+      params: { widthDp: 192 },
+      captures: [{ params: { fontScale: 1 } }, { params: { fontScale: 2 } }],
+    }),
+    { modes: [] },
+  );
+  assert.equal(images.length, 2);
+  assert.deepEqual(images[0].props, {});
+  assert.deepEqual(images[1].props, { fontScale: "2.0" });
+});
+
+test("imagesByFunction groups on the function, not the id", () => {
+  const byFunction = imagesByFunction(
+    [
+      preview("com.a.HomeKt.Home_Light", { functionName: "Home" }),
+      preview("com.a.HomeKt.Home_Dark", { functionName: "Home" }),
+      preview("com.a.OtherKt.Other", { functionName: "Other" }),
+    ],
+    { modes: ["light", "dark"] },
+  );
+  assert.deepEqual([...byFunction.keys()], ["Home", "Other"]);
+  assert.equal(byFunction.get("Home").length, 2);
+});
+
+test("ids no component claims are reported as information, never as a finding", () => {
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Home" }]), [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+    preview("com.a.OtherKt.Other", { functionName: "Other" }),
+  ]);
+  assert.deepEqual(kinds(report), []);
+  assert.deepEqual(report.unclaimed, ["com.a.OtherKt.Other"]);
+  assert.deepEqual(report.counts, {
+    previews: 2,
+    excluded: 0,
+    survivors: 2,
+    claimedFunctions: 1,
+    unclaimed: 1,
+  });
+});
+
+test("errorsOf keeps only what the report is sure about", () => {
+  const report = preflightSpec(spec([{ componentId: "Home", preview: "Nope" }]), [
+    preview("com.a.HomeKt.Home", { functionName: "Home" }),
+  ]);
+  assert.equal(errorsOf(report).length, 1);
+  assert.equal(errorsOf(report)[0].severity, ERROR);
+  assert.equal(errorsOf({ findings: [{ severity: "info" }] }).length, 0);
+});
+
+test("a spec with no groups and an empty manifest report nothing", () => {
+  assert.deepEqual(kinds(preflightSpec({ system: "test" }, [])), []);
+  assert.deepEqual(preflightSpec(undefined, undefined).counts.previews, 0);
+});


### PR DESCRIPTION
Closes #5066.

Nearly every failed import cycle is a **config-shape** error, and each one currently costs a full 20–40 minute render to discover even though all of them are decidable in seconds from a list of preview ids. This adds the manifest-side pre-flight the issue asks for.

## What it does

`scripts/design-artifacts/spec-preflight.mjs` takes a spec plus any `{ previews: [...] }` manifest — a module's `build/compose-previews/previews.json`, `compose-preview list --json`, or a copy kept from the last good run — and reports, without rendering:

| finding | the mistake it catches |
| --- | --- |
| `missing-preview` | a spec `preview` (component or variant) no manifest function answers to — the offline half of the completeness gate's `missing`, against what discovery actually minted rather than what the Kotlin declares |
| `unmatched-exclusion` | an exclusion pattern with a match count of 0 (#5064) — the underscores-vs-spaces mistake, where `@Preview(name = "Font scale 1.5x")` mints an id carrying spaces |
| `excluded-claimed` | every id of a claimed function excluded, so the entry can only publish as a missing sticker |
| `duplicate-output-axes` | ids that survive exclusion and would collide on output axes (#5065, #5059) — the three-arm locale fan-out where excluding `_ja` leaves two arms fighting over one sticker path |

Plus, as information, the surviving ids no spec component claims. Exits non-zero on findings; `--warn-only` reports without failing, `--json` gives the machine-readable form.

```
$ node scripts/design-artifacts/spec-preflight.mjs --spec spec.json --previews previews.json \
    --exclude-preview-id 'activity__*,HomeScreen_ja,apptour__*'
Preflight spec.json against 4 manifest preview id(s): 2 excluded, 2 surviving, 1 @Preview function(s) claimed by the spec.
  exclusion "activity__*" matches 1 id(s)
  exclusion "HomeScreen_ja" matches 1 id(s)
  exclusion "apptour__*" matches 0 id(s)
  error: exclusion pattern "apptour__*" matches none of the 4 manifest id(s), so it excludes nothing. …
  error: Gone (component "MissingScreen"): no manifest id belongs to a function of this name.
  error: Home: com.demo.HomeKt.HomeScreen_en and com.demo.HomeKt.HomeScreen_ar both fold onto output axes … so one would overwrite the other's sticker.
FAILED — 3 finding(s).
```

## Sharing, not restating

- Exclusion matching mirrors `PackPreviewIdExclusions.matches` / `PreviewNameFilter.matchesId` (anchored `=`, anchored glob, else equality-or-substring) — a preflight that matched more loosely would report an exclusion as covered when the render still burns the time.
- The collision check walks the same fold as `foldVariants` and keys images with `outputAxisKey`, **now exported from `catalog-variants.mjs`** so the guard and the preflight cannot disagree. The difference is that it collects every collision instead of throwing on the first.
- Size comes from `breakpointMatcher`, state from `variantStateFromId`, theme from `modeOfPreviewId` (falling back to a light/dark suffix, then `uiMode`'s night bits), `props.fontScale` mirroring `applyCatalogPreviewAxes` — including its collapse of exact render duplicates, without which every Wear catalog stacking `@WearPreviewDevices` on `@WearPreviewFontScales` would report as broken.

## Workflow wiring

`design-artifacts-reusable.yml` runs it before the render in both the shard job and the single job, wherever discovery has already produced `discovered-previews.json` — no extra Gradle invocation. It is **advisory** (`--warn-only`), deliberately:

- the axis model works from manifest params, so an axis it cannot see (derived from pixels, or from an annotation the manifest does not carry) must not be able to fail a spec that renders fine — the render's own gates stay authoritative;
- an external caller runs the release-pinned export driver, where this script does not exist yet, so the step is guarded on the file and says so rather than dying on a missing `node` argument.

Only the caller's `exclude-preview-ids` are checked, not the `activity__*`/`apptour__*` patterns import mode always appends — those are defensive by construction, and a module with no activity would otherwise report them as dead every run.

## Test plan

- `node --test spec-preflight.test.mjs` — 23 new tests: the matcher's three modes, per-pattern match counts (a dead pattern that a sibling's coverage would hide), the qualified `<module>::<function>` spelling, the three-arm locale collision and its narrowing, every collision collected rather than the first, the three theme readers, declared vs undeclared breakpoints, `select` splitting one fan-out across two components, the same-function variant short-circuit, the Wear duplicate collapse, and one test asserting the preflight key agrees with `foldVariants`' own guard.
- `node --test` over every dependency-free suite that touches `catalog-variants.mjs` (`catalog-variants`, `design-references`, `catalog-select`, `catalog-inventory`, `catalog-priority`, `catalog-preview-axes`, `design-pages`, `parity-activity`, …) — 284 passing, 0 failing.
- Workflow parsed and both inserted steps reviewed in place; docs added to `docs/design/DESIGN_CATALOGS.md` beside the two existing build-free helpers.

Text-only PR: no rendered surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fq5CpC5uG2NyHFHGT8acJU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fq5CpC5uG2NyHFHGT8acJU)_