### PR TITLE
fix(focus): keep the resting capture, and pick a root when there are two

### DIFF
--- a/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
+++ b/gradle-plugin/preview-discovery/src/main/kotlin/ee/schimke/composeai/discovery/PreviewDiscovery.kt
@@ -3455,11 +3455,25 @@ object PreviewDiscovery {
     // keep the plain filename (matches the @ScrollingPreview single-mode
     // pattern). Empty → one (null, "") row, same shape as scroll/time
     // when their annotations are absent.
+    //
+    // A MULTI-capture fan-out also keeps the undriven row. Focus is a state a component passes
+    // through, not what the component IS, and a walk that replaced the resting capture left the
+    // preview with no picture of itself: m3-catalog annotated `TimePicker/Input` with a four-step
+    // traversal and its manifest came back listing four focus steps and nothing else, so the
+    // catalog would have published a focused hour field as that component's sticker and the parity
+    // lane would have diffed it against the kit's resting node (yschimke/m3-catalog#277).
+    //
+    // Only in multi-capture mode, because only there is the plain filename free: a single-capture
+    // annotation deliberately takes `renders/<id>.png` for its one focused still, and adding a
+    // resting row beside it would collide on that name — or, if the focus row were suffixed to make
+    // room, rename an output every existing consumer already links to.
     val focusRows: List<Pair<FocusCapture?, String>> =
       when {
         effectiveFocuses.isEmpty() -> listOf(null to "")
         effectiveFocuses.size == 1 -> listOf(effectiveFocuses[0] to "")
-        else -> effectiveFocuses.map { it to "_FOCUS_${focusSuffixOf(it)}" }
+        else ->
+          listOf<Pair<FocusCapture?, String>>(null to "") +
+            effectiveFocuses.map { it to "_FOCUS_${focusSuffixOf(it)}" }
       }
 
     // When ONLY @AnimatedPreview (or @FocusedPreview(gif = true)) is on the function, the

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -2593,6 +2593,15 @@ class DiscoveryFunctionalTest {
       fun FocusSettledPreview() {
           Box(modifier = Modifier.size(50.dp).background(Color.Gray))
       }
+
+      // A MULTI-capture focus fan-out. Every step is a state the component passes through, so the
+      // undriven capture has to survive alongside them — see the assertions below.
+      @Preview
+      @FocusedPreview(indices = [0, 1])
+      @Composable
+      fun FocusWalkPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Magenta))
+      }
       """
         .trimIndent()
     )
@@ -2651,6 +2660,23 @@ class DiscoveryFunctionalTest {
     // Above the floor nothing is touched — the clamp is a floor, not a rewrite.
     val focused = manifest.previews.single { it.functionName == "FocusSettledPreview" }
     assertThat(focused.captures.mapNotNull { it.settle?.afterMs }.toSet()).isEqualTo(setOf(200))
+
+    // A multi-capture walk keeps the preview's own picture. Without the undriven row the component
+    // would publish only states it passes through: m3-catalog's `TimePicker/Input` came back with
+    // four focus steps and no resting sticker, which the parity lane then diffs against the kit's
+    // resting node (yschimke/m3-catalog#277).
+    val walk = manifest.previews.single { it.functionName == "FocusWalkPreview" }
+    assertThat(walk.captures.count { it.focus == null }).isEqualTo(1)
+    assertThat(walk.captures.single { it.focus == null }.renderOutput).doesNotContain("_FOCUS_")
+    assertThat(walk.captures.count { it.focus != null }).isEqualTo(2)
+    assertThat(walk.captures.filter { it.focus != null }.map { it.renderOutput })
+      .comparingElementsUsing(
+        com.google.common.truth.Correspondence.from<String, String>(
+          { actual, expected -> actual!!.contains(expected!!) },
+          "contains",
+        )
+      )
+      .containsExactly("_FOCUS_0", "_FOCUS_1")
   }
 
   @Test

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -551,9 +551,9 @@ private fun SemanticsNodeInteractionsProvider.captureRoot(): SemanticsNodeIntera
   return onAllNodes(isRoot())[chosen.index]
 }
 
-private fun androidx.compose.ui.semantics.SemanticsNode.descendantCount(): Int = runCatching {
-  1 + children.sumOf { it.descendantCount() }
-}.getOrDefault(1)
+private fun androidx.compose.ui.semantics.SemanticsNode.descendantCount(): Int {
+  return runCatching { 1 + children.sumOf { it.descendantCount() } }.getOrDefault(1)
+}
 
 /**
  * Captures the root and writes it with the same wrap crop / round clip [renderPreview] applies, so

--- a/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
+++ b/renderers/desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopFocusRenderer.kt
@@ -15,9 +15,11 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.isFocused
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performMouseInput
@@ -516,6 +518,44 @@ private fun focusedNodeBounds(provider: SemanticsNodeInteractionsProvider): Rect
 }
 
 /**
+ * The root this capture should draw, chosen deliberately rather than asked for as "the" root.
+ *
+ * A preview that composes a `Popup`, `Dialog` or `ModalBottomSheet` installs a second semantics
+ * owner, and `isRoot()` matches every owner — so `onRoot()` resolves to two nodes and throws
+ * `Expected exactly '1' node but found '2' nodes that satisfy: (isRoot)`. That throw is not
+ * confined to the focused capture it happens in: it fails the whole preview, so the *undriven*
+ * captures of a `@FocusedPreview` function die with it and the preview publishes no PNG at all.
+ * m3-catalog's `DatePicker/Modal` hit exactly that (yschimke/m3-catalog#277), and so did its range
+ * picker, which composes no dialog — which is what rules out "dialogs" as the shape of the problem
+ * and leaves "more than one owner", whatever opened it.
+ *
+ * The rule is the portable half of Android's [DialogWindowCapture.selectCaptureRoot]: prefer the
+ * owner that actually holds the composition — most descendants, ties broken by area. Desktop has no
+ * decor view to ask about window ownership, and it does not need one, because the owner with the
+ * content is the owner worth capturing either way. A single-root preview keeps `onRoot()` exactly
+ * as before, so nothing that renders today changes shape.
+ */
+@OptIn(ExperimentalTestApi::class)
+private fun SemanticsNodeInteractionsProvider.captureRoot(): SemanticsNodeInteraction {
+  val roots = onAllNodes(isRoot()).fetchSemanticsNodes()
+  if (roots.size <= 1) return onRoot()
+  val chosen =
+    roots
+      .withIndex()
+      .maxWithOrNull(
+        compareBy(
+          { (_, node) -> node.descendantCount() },
+          { (_, node) -> node.size.width.toLong() * node.size.height.toLong() },
+        )
+      ) ?: return onRoot()
+  return onAllNodes(isRoot())[chosen.index]
+}
+
+private fun androidx.compose.ui.semantics.SemanticsNode.descendantCount(): Int = runCatching {
+  1 + children.sumOf { it.descendantCount() }
+}.getOrDefault(1)
+
+/**
  * Captures the root and writes it with the same wrap crop / round clip [renderPreview] applies, so
  * a focused capture and the resting one differ only in the state they document.
  */
@@ -533,7 +573,7 @@ private fun captureFocusFrame(
   captureGutter: PreviewCaptureGutter,
   fileSystem: FileSystem,
 ) {
-  val bitmap = provider.onRoot().captureToImage()
+  val bitmap = provider.captureRoot().captureToImage()
   val skiaImage = SkiaImage.makeFromBitmap(bitmap.asSkiaBitmap())
   val pngData = skiaImage.encodePngData() ?: error("Failed to encode focused capture to PNG")
   val bytes =
@@ -578,7 +618,7 @@ private fun captureFocusFrame(
 
 @OptIn(ExperimentalTestApi::class)
 private fun captureRootPngBytes(provider: SemanticsNodeInteractionsProvider): ByteArray {
-  val bitmap = provider.onRoot().captureToImage()
+  val bitmap = provider.captureRoot().captureToImage()
   val image = SkiaImage.makeFromBitmap(bitmap.asSkiaBitmap())
   val data = image.encodePngData() ?: error("Failed to encode interaction probe to PNG")
   return try {

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopFocusRendererTest.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/DesktopFocusRendererTest.kt
@@ -261,6 +261,31 @@ class DesktopFocusRendererTest {
    * Nothing focusable → decline, so the caller falls back to the undriven capture rather than
    * publishing a PNG under a focus label that no component could have taken.
    */
+  /**
+   * A preview with a popup in it has two semantics roots, and the capture has to pick one rather
+   * than asking for "the" root and throwing. Before this, the throw took down every capture of the
+   * preview — the undriven ones too — so the sticker published nothing at all.
+   */
+  @Test
+  fun capturesAPreviewThatOpensASecondRoot() {
+    val (plain, _) =
+      render("desktop-focus-popup-none", null, functionName = "FocusableRowBesidePopup")
+    val (focused, drove) =
+      render(
+        "desktop-focus-popup-0",
+        DesktopFocusIntent(tabIndex = 0),
+        functionName = "FocusableRowBesidePopup",
+      )
+    assertTrue("the walk must land on the row beside the popup", drove)
+    val image = decode(focused)
+    assertTrue("capture must have real pixels", image.width > 0 && image.height > 0)
+    assertNotEquals(
+      "focusing the first button must change pixels, popup or no popup",
+      bytes(plain),
+      bytes(focused),
+    )
+  }
+
   @Test
   fun declinesWhenNothingCanTakeFocus() {
     val (_, drove) =

--- a/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/FocusRenderTestFixtures.kt
+++ b/renderers/desktop/src/test/kotlin/ee/schimke/composeai/renderer/FocusRenderTestFixtures.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 
 /**
  * Fixture for [DesktopFocusRendererTest] — the CMP-desktop twin of `:samples:android-alpha`'s
@@ -63,6 +64,31 @@ fun ScrollableFocusableColumn() {
       items(20) { index ->
         Button(onClick = {}, modifier = Modifier.padding(8.dp)) { Text("Item " + (index + 1)) }
       }
+    }
+  }
+}
+
+/**
+ * A focusable row with a `Popup` open beside it — the **two-roots** fixture.
+ *
+ * A popup composes into its own semantics owner, so `isRoot()` matches twice and the naive
+ * `onRoot()` the focus capture used to call threw `Expected exactly '1' node but found '2' nodes
+ * that satisfy: (isRoot)`. That failure took the whole preview down, undriven captures included:
+ * m3-catalog's `DatePicker/Modal` published no PNG at all under `@FocusedPreview`
+ * (yschimke/m3-catalog#277), and its range picker — no dialog anywhere in it — did the same, which
+ * is what ruled the dialog out as the cause and left the extra owner as the real one.
+ *
+ * The popup is deliberately empty of focusables: the walk still belongs to the row, so a capture
+ * that resolves the wrong root would come back blank rather than merely differently framed.
+ */
+@Composable
+fun FocusableRowBesidePopup() {
+  MaterialTheme(colorScheme = lightColorScheme()) {
+    Row(modifier = Modifier.padding(16.dp)) {
+      listOf("Save", "Edit", "Share").forEach { label ->
+        Button(onClick = {}, modifier = Modifier.padding(end = 8.dp)) { Text(label) }
+      }
+      Popup { Text("elsewhere") }
     }
   }
 }


### PR DESCRIPTION
Two defects in `@FocusedPreview`, both found by putting it on a real catalog ([m3-catalog#277](https://github.com/yschimke/m3-catalog/pull/277)) and both fatal to that use. The annotation had to come back out of that PR; this is what it needs to go back in.

## A second semantics owner took the whole preview down

A preview that composes a `Popup`, `Dialog` or `ModalBottomSheet` installs a second semantics owner, and `isRoot()` matches every owner — so the desktop focus capture's `onRoot()` resolved to two nodes and threw:

```
Failed to capture a node to bitmap.
Reason: Expected exactly '1' node but found '2' nodes that satisfy: (isRoot)
  1) Node #1640 at (l=0.0, t=0.0, r=945.0, b=1491.0)px
  2) Node #1851 at (l=0.0, t=0.0, r=945.0, b=2100.0)px
```

The throw is not confined to the capture it happens in — **it fails every capture of that preview, the undriven ones included**. `DatePicker/Modal` published no PNG at all. The range picker beside it, which composes no dialog anywhere, failed identically, which is what rules out "dialogs" as the shape of the problem and leaves "more than one owner, whatever opened it".

Android already resolved this deliberately (issue #3048, `DialogWindowCapture.selectCaptureRoot`); desktop still asked for "the" root. It now picks the owner that holds the composition — most descendants, ties broken by area — which is the portable half of the rule Android applies (desktop has no decor view to ask about window ownership, and does not need one). A single-root preview keeps `onRoot()`, so nothing that renders today changes shape.

## A multi-capture walk replaced the preview's own picture

The focus rows in the capture fan-out carried no undriven row, so a traversal or multi-index annotation left the component with captures of states it *passes through* and none of itself. `TimePicker/Input` came back as:

```
ee.schimke.m3catalog.sections.TimePickersKt.TimeInputSticker_Light
    renders/TimeInputSticker_Light-c85b2ea4_FOCUS_step1_Next.png
    renders/…_FOCUS_step2_Next.png
    renders/…_FOCUS_step3_Next.png
    renders/…_FOCUS_step4_Next.png
```

A catalog cannot spend a component's sticker on a state: the parity lane diffs that render against the kit's **resting** node, and the sheet publishes a focused hour field as what the component looks like.

The undriven row comes back for **multi-capture fan-outs only**, because only there is the plain filename free. A single-capture annotation (`indices = [0]`, the default) deliberately takes `renders/<id>.png` for its one focused still — adding a resting row beside it would collide on that name, and suffixing the focus row to make room would rename an output every existing consumer already links to.

## Test plan

Both fixes are pinned by tests that fail without them, and I ran each against the unfixed code first:

- **`DesktopFocusRendererTest.capturesAPreviewThatOpensASecondRoot`** — new `FocusableRowBesidePopup` fixture: a focusable row with an open `Popup` beside it, so `isRoot()` matches twice. Without the fix it fails at `SemanticsNodeInteraction.kt:178`, the `Expected exactly '1' node` assertion; with it the capture succeeds and still differs from the undriven one, which is what proves the walk landed on the row rather than resolving to the popup's empty owner.
- **`DiscoveryFunctionalTest`, `@FocusedPreview(indices = [0, 1])`** — asserts exactly one capture with `focus == null` whose `renderOutput` carries no `_FOCUS_` suffix, plus the two suffixed rows. Without the fix: `expected: 1 but was: 0`.
- `:renderer-desktop:test` — full suite green.
- `:preview-discovery:test` and the plugin's `test` — green.
- `ktfmtFormat` clean.

What I have **not** established is what the second owner in the m3-catalog date pickers actually is. Neither picker composes a `Popup` directly; the fixture here reproduces the *failure mode* with an explicit one. The fix does not depend on knowing — it picks the owner with the content either way — but the cause is still open, and if it turns out to be something Material composes unconditionally it may be worth a look on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKa4vow5EnyW4mUz2yE4BU)_